### PR TITLE
Add removal reason to EntityRemoveFromWorldEvent

### DIFF
--- a/patches/api/0031-Entity-AddTo-RemoveFrom-World-Events.patch
+++ b/patches/api/0031-Entity-AddTo-RemoveFrom-World-Events.patch
@@ -59,13 +59,14 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..5ad5632d4d47d8b42e4f2af19c0fe6cf94ac5643
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityRemoveFromWorldEvent.java
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,169 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.World;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.bukkit.event.player.PlayerQuitEvent;
 +import org.jetbrains.annotations.ApiStatus;
 +import org.jspecify.annotations.NullMarked;
 +
@@ -79,11 +80,14 @@ index 0000000000000000000000000000000000000000..5ad5632d4d47d8b42e4f2af19c0fe6cf
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    private final World world;
++    private final Cause cause;
 +
 +    @ApiStatus.Internal
-+    public EntityRemoveFromWorldEvent(final Entity entity, final World world) {
++    public EntityRemoveFromWorldEvent(final Entity entity, final World world, final Cause cause) {
 +        super(entity);
++
 +        this.world = world;
++        this.cause = cause;
 +    }
 +
 +    /**
@@ -91,6 +95,14 @@ index 0000000000000000000000000000000000000000..5ad5632d4d47d8b42e4f2af19c0fe6cf
 +     */
 +    public World getWorld() {
 +        return this.world;
++    }
++
++    /**
++     * Gets the reason the entity is being removed from the world.
++     * @return the removal reason
++     */
++    public Cause getCause() {
++        return cause;
 +    }
 +
 +    @Override
@@ -101,6 +113,121 @@ index 0000000000000000000000000000000000000000..5ad5632d4d47d8b42e4f2af19c0fe6cf
 +    public static HandlerList getHandlerList() {
 +        return HANDLER_LIST;
 +    }
++
++    public enum Cause {
++
++        /**
++         * When an entity dies.
++         */
++        DEATH(true, false),
++        /**
++         * When an entity does despawn. This includes mobs which are too far away,
++         * items or arrows which lay to long on the ground or area effect cloud.
++         */
++        DESPAWN(true, false),
++        /**
++         * When an entity gets removed because it drops as an item.
++         * For example, trident or falling sand.
++         * <p>
++         * <b>Note:</b> Depending on other factors, such as gamerules, no item will actually drop,
++         * the cause, however, will still be drop.
++         */
++        DROP(true, false),
++        /**
++         * When an entity gets removed because it enters a block.
++         * For example, bees or silverfish.
++         */
++        ENTER_BLOCK(true, false),
++        /**
++         * When an entity gets removed because it exploded.
++         * For example, creepers, tnt or firework.
++         */
++        EXPLODE(true, false),
++        /**
++         * When an entity gets removed because it hit something. This mainly applies to projectiles.
++         */
++        HIT(true, false),
++        /**
++         * When an entity gets removed because it merges with another one.
++         * For example, items or xp.
++         */
++        MERGE(true, false),
++        /**
++         * When an entity gets removed because it is too far below the world.
++         * This only applies to entities which get removed immediately,
++         * some entities get damage instead.
++         */
++        OUT_OF_WORLD(true, false),
++        /**
++         * When an entity gets removed because it got pickup.
++         * For example, items, arrows, xp or parrots which get on a player shoulder.
++         */
++        PICKUP(true, false),
++        /**
++         * When an entity gets removed with a player because the player quits the game.
++         * For example, a boat which gets removed with the player when he quits.
++         */
++        PLAYER_QUIT(false, false),
++        /**
++         * When a plugin manually removes an entity.
++         */
++        PLUGIN(true, false),
++        /**
++         * When an entity gets removed because it transforms into another one.
++         */
++        TRANSFORMATION(true, false),
++        /**
++         * When the chunk an entity is in gets unloaded.
++         */
++        UNLOAD(false, true),
++        /**
++         * When an entity is discarded, and a more specific cause does not exist.
++         */
++        DISCARD(true, false),
++        /**
++         * When an entity changes dimensions.
++         */
++        CHANGED_DIMENSION(false, false),
++        /**
++         * When the chunk an entity is in is no longer accessible, but not yet fully unloaded.
++         */
++        INACCESSIBLE(false, false),
++        /**
++         * Used when the cause of the removal is unknown.
++         */
++        UNKNOWN(false, false);
++
++        private final boolean destroy;
++        private final boolean save;
++
++        Cause(boolean destroy, boolean save) {
++            this.destroy = destroy;
++            this.save = save;
++        }
++
++        /**
++         * Whether the entity instance being removed will be destroyed.
++         *
++         * @return whether the entity will be destroyed
++         */
++        public boolean willDestroy() {
++            return this.destroy;
++        }
++
++        /**
++         * Whether the entity instance being removed will be saved. This does not account for the value of
++         * {@link Entity#isPersistent}. Entities removed with {@link Cause#PLAYER_QUIT} are saved
++         * prior to the event firing, and thus should be modified prior to this using another event, such as
++         * with {@link PlayerQuitEvent}.
++         *
++         * @return whether the entity will be saved
++         */
++        public boolean willSave() {
++            return this.save;
++        }
++
++    }
++
 +}
 diff --git a/src/main/java/org/bukkit/event/entity/EntityRemoveEvent.java b/src/main/java/org/bukkit/event/entity/EntityRemoveEvent.java
 index e32df91d911bae42c8137c6f952a6ac6a94d27e0..8ed5d1ccc44951089999db360219b556db89b4ba 100644

--- a/patches/removed/1.21/0994-Rewrite-chunk-system.patch
+++ b/patches/removed/1.21/0994-Rewrite-chunk-system.patch
@@ -15006,12 +15006,13 @@ index 73e83d56a340f0c7dcb8ff737d621003e72c6de4..bdaf062f9b66ceab303a0807eca30134
      }
 diff --git a/src/main/java/io/papermc/paper/world/ChunkEntitySlices.java b/src/main/java/io/papermc/paper/world/ChunkEntitySlices.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c78cbec447032de9fe69748591bef6be300160ed
+index 0000000000000000000000000000000000000000..0d00940d9eb724afc9f2d44d697fbd40832bfabd
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/world/ChunkEntitySlices.java
 @@ -0,0 +1,607 @@
 +package io.papermc.paper.world;
 +
++import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 +import com.destroystokyo.paper.util.maplist.EntityList;
 +import io.papermc.paper.chunk.system.entity.EntityLookup;
 +import io.papermc.paper.util.TickThread;
@@ -15036,7 +15037,6 @@ index 0000000000000000000000000000000000000000..c78cbec447032de9fe69748591bef6be
 +import java.util.Iterator;
 +import java.util.List;
 +import java.util.function.Predicate;
-+import org.bukkit.event.entity.EntityRemoveEvent;
 +
 +public final class ChunkEntitySlices {
 +
@@ -15132,12 +15132,12 @@ index 0000000000000000000000000000000000000000..c78cbec447032de9fe69748591bef6be
 +                continue;
 +            }
 +            if (entity.shouldBeSaved()) {
-+                entity.setRemoved(Entity.RemovalReason.UNLOADED_TO_CHUNK, EntityRemoveEvent.Cause.UNLOAD);
++                entity.setRemoved(Entity.RemovalReason.UNLOADED_TO_CHUNK, EntityRemoveFromWorldEvent.Cause.UNLOAD);
 +                if (entity.isVehicle()) {
 +                    // we cannot assume that these entities are contained within this chunk, because entities can
 +                    // desync - so we need to remove them all
 +                    for (final Entity passenger : entity.getIndirectPassengers()) {
-+                        passenger.setRemoved(Entity.RemovalReason.UNLOADED_TO_CHUNK, EntityRemoveEvent.Cause.UNLOAD);
++                        passenger.setRemoved(Entity.RemovalReason.UNLOADED_TO_CHUNK, EntityRemoveFromWorldEvent.Cause.UNLOAD);
 +                    }
 +                }
 +            }
@@ -16486,7 +16486,7 @@ index 88729d92878f98729eb5669cce5ae5b1418865a1..13d15a135dd0373bef4a5ac9ffb56dbb
      // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index d3f63185edd1db9fab3887ea3f08982435b3a23c..d6ecee1db17cb9eaeffa94b3d8dd150238fdefe5 100644
+index a5734fd84e863d72489f3eef4c352f5ba324f448..bb623c041c64bfac6a66a493ae5f05a1c7fa98d6 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -122,10 +122,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -18344,7 +18344,7 @@ index 0e89cf0742b9443f5256081987242554de24d893..802e9d266c01eaf8a83e78fe8dbe881e
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index b33bf957b1541756e3b983b87b1c83629757739a..0ccdc8d135dd3edb410fbc1d248c20a4a45b37fa 100644
+index b8f313d60e76203986669dffecc3323e6f38019a..dcdc82461df0f5cb7ef8894bebd2be83e07bc0cd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -199,7 +199,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -19293,7 +19293,7 @@ index c502d9b85eb68b277ae17dfea34e0475f0156647..27d0f1ed58948039004f8f1eba2f7f96
          this.desiredChunksPerTick = Double.isNaN((double)desiredBatchSize) ? 0.01F : Mth.clamp(desiredBatchSize, 0.01F, 64.0F);
          if (this.unacknowledgedBatches == 0) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0aa28caa1254137c0bae8e213bd08c9a654f5335..c4b4e5f5c9366b241686e881cda34568a57b4877 100644
+index 2860c8e7df49655bd0f8832ec8362f43e22a1488..62013378c1925134682e7a7c406a398baf2d0358 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -296,7 +296,7 @@ public abstract class PlayerList {
@@ -19552,7 +19552,7 @@ index 62363c09111aaa31220fb260940744c097af7b3c..ff497f0e80889508dd8c183b48cd33bc
 @@ -4519,6 +4584,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
-     public final void setRemoved(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
+     public final void setRemoved(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
 +        // Paper start - rewrite chunk system
 +        io.papermc.paper.util.TickThread.ensureTickThread(this, "Cannot remove entity off-main");
 +        if (!((ServerLevel)this.level).getEntityLookup().canRemoveEntity(this)) {
@@ -19560,7 +19560,7 @@ index 62363c09111aaa31220fb260940744c097af7b3c..ff497f0e80889508dd8c183b48cd33bc
 +            return;
 +        }
 +        // Paper end - rewrite chunk system
-         CraftEventFactory.callEntityRemoveEvent(this, cause);
+         CraftEventFactory.callEntityRemoveEvent(this, entity_removalreason, cause); // Paper - EntityRemoveFromWorldEvent
          // CraftBukkit end
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
 @@ -4530,7 +4602,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -19867,7 +19867,7 @@ index bd20bea7f76a7307f1698fb2dfef37125032d166..9a28912f52824acdc80a62243b136e6f
  
      <T extends Entity> List<T> getEntities(EntityTypeTest<Entity, T> filter, AABB box, Predicate<? super T> predicate);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 975fcd4b8f93cb8c602ddeb165c485214eac10a4..d3137c9e5cc42ef191ea233b0d37eafeffc6f82c 100644
+index f2f8f7b1356b0e7fe7010eca2fc55b46b0bcb1dc..75deea9c9b02feea2fb57556e48d97a6f460deb6 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -547,6 +547,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -21685,7 +21685,7 @@ index 7aee9f6b143c89cf8d65ca55eeda808152b4dd26..9c06c3729b09726e1da6ff8fb975cef2
  
      // Paper start - implement pointers
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 68a0b6b8650e9e80e8e8c4037d92389cae899d72..9aec6efef4094bbdb920101df1a7a5a2a6070dde 100644
+index c6c9199e88cd25f2ba8155cea77365f05979c07d..ba6c42530e5995dee4f693fd5d560f21bb8fde7e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -3463,31 +3463,31 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0078-Entity-AddTo-RemoveFrom-World-Events.patch
+++ b/patches/server/0078-Entity-AddTo-RemoveFrom-World-Events.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity AddTo/RemoveFrom World Events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 1e5b42fc3903b14537d232c8adbbaf79078d8d8e..e6cf145fa7a2968c70e9e467e3927fd38e199e06 100644
+index 1e5b42fc3903b14537d232c8adbbaf79078d8d8e..b3a25ad2f3a184b3ba6f54d18119b3e80566522b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2153,6 +2153,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -16,11 +16,1487 @@ index 1e5b42fc3903b14537d232c8adbbaf79078d8d8e..e6cf145fa7a2968c70e9e467e3927fd3
          }
  
          public void onTrackingEnd(Entity entity) {
-@@ -2223,6 +2224,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2223,6 +2224,15 @@ public class ServerLevel extends Level implements WorldGenLevel {
                  }
              }
              // CraftBukkit end
-+            new com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent(entity.getBukkitEntity(), ServerLevel.this.getWorld()).callEvent(); // Paper - fire while valid
++            // Paper start - fire if tracking ends without calling Entity#setRemoved
++            if (entity.getRemovalReason() == null) {
++                com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause;
++                if (entity.moonrise$getChunkStatus() == FullChunkStatus.INACCESSIBLE) cause = com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.INACCESSIBLE;
++                else cause = com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.UNKNOWN;
++
++                new com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent(entity.getBukkitEntity(), ServerLevel.this.getWorld(), cause).callEvent();
++            }
++            // Paper end
          }
  
          public void onSectionChange(Entity entity) {
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index 8a91a44e46a2d49e2f4b9e9970c2b77f2e87767e..70827e926b470e6b9e1ea8903dca034034baa0b6 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -520,7 +520,7 @@ public abstract class PlayerList {
+                 PlayerList.LOGGER.debug("Removing player mount");
+                 entityplayer.stopRiding();
+                 entity.getPassengersAndSelf().forEach((entity1) -> {
+-                    entity1.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, EntityRemoveEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause
++                    entity1.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 });
+             }
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/AreaEffectCloud.java b/src/main/java/net/minecraft/world/entity/AreaEffectCloud.java
+index 1859477e96709368683fe5707327e92f56fbfc8e..9976f49df5bd4a15f804e636e6f373632a8388c0 100644
+--- a/src/main/java/net/minecraft/world/entity/AreaEffectCloud.java
++++ b/src/main/java/net/minecraft/world/entity/AreaEffectCloud.java
+@@ -156,7 +156,7 @@ public class AreaEffectCloud extends Entity implements TraceableEntity {
+         super.inactiveTick();
+ 
+         if (this.tickCount >= this.waitTime + this.duration) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             return;
+         }
+     }
+@@ -206,7 +206,7 @@ public class AreaEffectCloud extends Entity implements TraceableEntity {
+             }
+         } else {
+             if (this.tickCount >= this.waitTime + this.duration) {
+-                this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 return;
+             }
+ 
+@@ -223,7 +223,7 @@ public class AreaEffectCloud extends Entity implements TraceableEntity {
+             if (this.radiusPerTick != 0.0F) {
+                 f += this.radiusPerTick;
+                 if (f < 0.5F) {
+-                    this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                    this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                     return;
+                 }
+ 
+@@ -300,7 +300,7 @@ public class AreaEffectCloud extends Entity implements TraceableEntity {
+                                         if (this.radiusOnUse != 0.0F) {
+                                             f += this.radiusOnUse;
+                                             if (f < 0.5F) {
+-                                                this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                                                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                                                 return;
+                                             }
+ 
+@@ -310,7 +310,7 @@ public class AreaEffectCloud extends Entity implements TraceableEntity {
+                                         if (this.durationOnUse != 0) {
+                                             this.duration += this.durationOnUse;
+                                             if (this.duration <= 0) {
+-                                                this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                                                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                                                 return;
+                                             }
+                                         }
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index ff1c6e5af0645305fd2047b5696cc3b0dc9d4009..3104ef9f18cac0fa564b1f81ce8268d34448db40 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -548,7 +548,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+     }
+ 
+     public void kill() {
+-        this.remove(Entity.RemovalReason.KILLED, EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
++        this.remove(Entity.RemovalReason.KILLED, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         this.gameEvent(GameEvent.ENTITY_DIE);
+     }
+ 
+@@ -557,7 +557,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+         this.discard(null);
+     }
+ 
+-    public final void discard(EntityRemoveEvent.Cause cause) {
++    public final void discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
+         this.remove(Entity.RemovalReason.DISCARDED, cause);
+         // CraftBukkit end
+     }
+@@ -591,7 +591,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+         this.setRemoved(reason, null);
+     }
+ 
+-    public void remove(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
++    public void remove(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) {
+         this.setRemoved(entity_removalreason, cause);
+         // CraftBukkit end
+     }
+@@ -878,7 +878,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+     }
+ 
+     protected void onBelowWorld() {
+-        this.discard(EntityRemoveEvent.Cause.OUT_OF_WORLD); // CraftBukkit - add Bukkit remove cause
++        this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.OUT_OF_WORLD); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+     }
+ 
+     public boolean isFree(double offsetX, double offsetY, double offsetZ) {
+@@ -4268,8 +4268,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+     }
+ 
+     @Override
+-    public final void setRemoved(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
+-        CraftEventFactory.callEntityRemoveEvent(this, cause);
++    public final void setRemoved(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
++        CraftEventFactory.callEntityRemoveEvent(this, entity_removalreason, cause); // Paper - EntityRemoveFromWorldEvent
+         // CraftBukkit end
+         if (this.removalReason == null) {
+             this.removalReason = entity_removalreason;
+diff --git a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
+index 56402312e44d12c859e2c4b39902d31b7cfd1573..789192579b5c0adfb1fbb84c200fdd351a3820f3 100644
+--- a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
++++ b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
+@@ -141,7 +141,7 @@ public class ExperienceOrb extends Entity {
+ 
+         ++this.age;
+         if (this.age >= 6000) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+@@ -210,7 +210,7 @@ public class ExperienceOrb extends Entity {
+     private void merge(ExperienceOrb other) {
+         this.count += other.count;
+         this.age = Math.min(this.age, other.age);
+-        other.discard(EntityRemoveEvent.Cause.MERGE); // CraftBukkit - add Bukkit remove cause
++        other.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.MERGE); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+     }
+ 
+     private void setUnderwaterMovement() {
+@@ -232,7 +232,7 @@ public class ExperienceOrb extends Entity {
+             this.markHurt();
+             this.health = (int) ((float) this.health - amount);
+             if (this.health <= 0) {
+-                this.discard(EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+ 
+             return true;
+@@ -269,7 +269,7 @@ public class ExperienceOrb extends Entity {
+ 
+                 --this.count;
+                 if (this.count == 0) {
+-                    this.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++                    this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 }
+             }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/LightningBolt.java b/src/main/java/net/minecraft/world/entity/LightningBolt.java
+index bf5015c4bb68e5c46313bab1e59c0a4d45053b73..d8b7f80107b61ba3c6591d13d40c03ee931c5425 100644
+--- a/src/main/java/net/minecraft/world/entity/LightningBolt.java
++++ b/src/main/java/net/minecraft/world/entity/LightningBolt.java
+@@ -125,7 +125,7 @@ public class LightningBolt extends Entity {
+                     }
+                 }
+ 
+-                this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             } else if (this.life < -this.random.nextInt(10)) {
+                 --this.flashes;
+                 this.life = 1;
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 270c1aa3c43764a7463f571e2735fdfb37fe8169..72c8a0d7f9187a9a86b12a7fd1186479beecae72 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -610,7 +610,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+         ++this.deathTime;
+         if (this.deathTime >= 20 && !this.level().isClientSide() && !this.isRemoved()) {
+             this.level().broadcastEntityEvent(this, (byte) 60);
+-            this.remove(Entity.RemovalReason.KILLED, EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
++            this.remove(Entity.RemovalReason.KILLED, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+@@ -747,7 +747,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+     }
+ 
+     @Override
+-    public void remove(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
++    public void remove(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
+         // CraftBukkit end
+         if (entity_removalreason == Entity.RemovalReason.KILLED || entity_removalreason == Entity.RemovalReason.DISCARDED) {
+             this.triggerOnDeathMobEffects(entity_removalreason);
+diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
+index 69eddc7fb0af1d2b024ca9fff41ace6050e25181..3ca22fc51958c4cb3148e886cbb3aba73b2423ed 100644
+--- a/src/main/java/net/minecraft/world/entity/Mob.java
++++ b/src/main/java/net/minecraft/world/entity/Mob.java
+@@ -694,7 +694,7 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+             this.take(item, itemstack1.getCount());
+             itemstack.shrink(itemstack1.getCount());
+             if (itemstack.isEmpty()) {
+-                item.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++                item.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+         }
+ 
+@@ -858,7 +858,7 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+     @Override
+     public void checkDespawn() {
+         if (this.level().getDifficulty() == Difficulty.PEACEFUL && this.shouldDespawnInPeaceful()) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else if (!this.isPersistenceRequired() && !this.requiresCustomPersistence()) {
+             Player entityhuman = this.level().findNearbyPlayer(this, -1.0D, EntitySelector.PLAYER_AFFECTS_SPAWNING); // Paper - Affects Spawning API
+ 
+@@ -873,11 +873,11 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+                 final double distanceSquared = dxSqr + dzSqr + dySqr;
+                 // Despawn if hard/soft limit is exceeded
+                 if (despawnRangePair.hard().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy) && this.removeWhenFarAway(distanceSquared)) {
+-                    this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                    this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 }
+                 if (despawnRangePair.soft().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy)) {
+                     if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && this.removeWhenFarAway(distanceSquared)) {
+-                        this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                        this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                     }
+                 } else {
+                 // Paper end - Configurable despawn distances
+@@ -1561,7 +1561,7 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+                     t0.startRiding(entity, true);
+                 }
+ 
+-                this.discard(EntityRemoveEvent.Cause.TRANSFORMATION); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.TRANSFORMATION); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 return t0;
+             }
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/warden/Digging.java b/src/main/java/net/minecraft/world/entity/ai/behavior/warden/Digging.java
+index 9e155ce2f19586fb12dad20ce138ea44ec4c88bb..ab05521df3e7f562b56fb8087f63bd2e1b1888aa 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/behavior/warden/Digging.java
++++ b/src/main/java/net/minecraft/world/entity/ai/behavior/warden/Digging.java
+@@ -41,7 +41,7 @@ public class Digging<E extends Warden> extends Behavior<E> {
+ 
+     protected void stop(ServerLevel worldserver, E e0, long i) {
+         if (e0.getRemovalReason() == null) {
+-            e0.remove(Entity.RemovalReason.DISCARDED, EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - Add bukkit remove cause
++            e0.remove(Entity.RemovalReason.DISCARDED, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - Add bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Bucketable.java b/src/main/java/net/minecraft/world/entity/animal/Bucketable.java
+index b586116d8cca1585f9c9e618ed4d0cb2ef2747be..15d5b8ccf29d93885fe25b914203b4cb160675cd 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Bucketable.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Bucketable.java
+@@ -123,7 +123,7 @@ public interface Bucketable {
+                 CriteriaTriggers.FILLED_BUCKET.trigger((ServerPlayer) player, itemstack1);
+             }
+ 
+-            entity.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++            entity.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             return Optional.of(InteractionResult.sidedSuccess(world.isClientSide));
+         } else {
+             return Optional.empty();
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Dolphin.java b/src/main/java/net/minecraft/world/entity/animal/Dolphin.java
+index 08823651b0a81b15bc33f86c96d6cc1dc72770f4..7dc1d038b444c9f3ba68bc95682ab642c2b8db32 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Dolphin.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Dolphin.java
+@@ -233,7 +233,7 @@ public class Dolphin extends WaterAnimal {
+                 this.setItemSlot(EquipmentSlot.MAINHAND, itemstack);
+                 this.setGuaranteedDrop(EquipmentSlot.MAINHAND);
+                 this.take(item, itemstack.getCount());
+-                item.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++                item.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+         }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Fox.java b/src/main/java/net/minecraft/world/entity/animal/Fox.java
+index de2a25db9465bc4ae3cbf7ff6d3af756df679f4a..9f6f9c0ac330fefde906ac8efddb5ffd81193953 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Fox.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Fox.java
+@@ -534,7 +534,7 @@ public class Fox extends Animal implements VariantHolder<Fox.Type> {
+             this.setItemSlot(EquipmentSlot.MAINHAND, itemstack.split(1));
+             this.setGuaranteedDrop(EquipmentSlot.MAINHAND);
+             this.take(item, itemstack.getCount());
+-            item.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++            item.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             this.ticksSinceEaten = 0;
+         }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/animal/MushroomCow.java b/src/main/java/net/minecraft/world/entity/animal/MushroomCow.java
+index aa125e3043b120935aaa015803f065f99eb8d050..514b961f94e9239b7879a98df789c8fa396d25bf 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/MushroomCow.java
++++ b/src/main/java/net/minecraft/world/entity/animal/MushroomCow.java
+@@ -190,7 +190,7 @@ public class MushroomCow extends Cow implements Shearable, VariantHolder<Mushroo
+                 }
+                 this.level().addFreshEntity(entitycow, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.SHEARED);
+ 
+-                this.discard(EntityRemoveEvent.Cause.TRANSFORMATION); // CraftBukkit - from above and add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.TRANSFORMATION); // CraftBukkit - from above and add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 // CraftBukkit end
+ 
+                 for (int i = 0; i < 5; ++i) {
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Panda.java b/src/main/java/net/minecraft/world/entity/animal/Panda.java
+index 228cfb77e12ed5979e422dc5dbb5e8dcf363b509..fb3ec5f4148dd0d4bf8c52636d966e2f4205bdd8 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Panda.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Panda.java
+@@ -570,7 +570,7 @@ public class Panda extends Animal {
+             this.setItemSlot(EquipmentSlot.MAINHAND, itemstack);
+             this.setGuaranteedDrop(EquipmentSlot.MAINHAND);
+             this.take(item, itemstack.getCount());
+-            item.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++            item.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Pig.java b/src/main/java/net/minecraft/world/entity/animal/Pig.java
+index 03d29d5114237f5700c188510a12f26507844c3d..3f8ee6870153a28b36ed9a8ff2022c377dffdfa4 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Pig.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Pig.java
+@@ -264,7 +264,7 @@ public class Pig extends Animal implements ItemSteerable, Saddleable {
+                 // CraftBukkit - added a reason for spawning this creature
+                 world.addFreshEntity(entitypigzombie, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.LIGHTNING);
+                 // CraftBukkit end
+-                this.discard(EntityRemoveEvent.Cause.TRANSFORMATION); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.TRANSFORMATION); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             } else {
+                 super.thunderHit(world, lightning);
+             }
+diff --git a/src/main/java/net/minecraft/world/entity/animal/ShoulderRidingEntity.java b/src/main/java/net/minecraft/world/entity/animal/ShoulderRidingEntity.java
+index fdc7106d64949294cdfdfd60b51042bc9c6c767b..d335a34f8a867c5e394ca79b82eb086cf589aacf 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/ShoulderRidingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/animal/ShoulderRidingEntity.java
+@@ -24,7 +24,7 @@ public abstract class ShoulderRidingEntity extends TamableAnimal {
+         nbttagcompound.putString("id", this.getEncodeId());
+         this.saveWithoutId(nbttagcompound);
+         if (player.setEntityOnShoulder(nbttagcompound)) {
+-            this.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             return true;
+         } else {
+             return false;
+diff --git a/src/main/java/net/minecraft/world/entity/animal/frog/ShootTongue.java b/src/main/java/net/minecraft/world/entity/animal/frog/ShootTongue.java
+index 103cf941b33e0c2389c0cda73c19ccde36d20b71..5559640cafbb1a761f65a69cd87ed50db1fd5dbd 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/frog/ShootTongue.java
++++ b/src/main/java/net/minecraft/world/entity/animal/frog/ShootTongue.java
+@@ -88,7 +88,7 @@ public class ShootTongue extends Behavior<Frog> {
+             if (entity.isAlive()) {
+                 frog.doHurtTarget(entity);
+                 if (!entity.isAlive()) {
+-                    entity.remove(Entity.RemovalReason.KILLED, EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
++                    entity.remove(Entity.RemovalReason.KILLED, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 }
+             }
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/animal/frog/Tadpole.java b/src/main/java/net/minecraft/world/entity/animal/frog/Tadpole.java
+index b06d39d3bd39a4dc4f273a359a89592d3b8cf184..14953e3d7339cc66d83adbebedca5981742a7dd0 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/frog/Tadpole.java
++++ b/src/main/java/net/minecraft/world/entity/animal/frog/Tadpole.java
+@@ -244,7 +244,7 @@ public class Tadpole extends AbstractFish {
+                 frog.fudgePositionAfterSizeChange(this.getDimensions(this.getPose()));
+                 this.playSound(SoundEvents.TADPOLE_GROW_UP, 0.15F, 1.0F);
+                 worldserver.addFreshEntityWithPassengers(frog, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.METAMORPHOSIS); // CraftBukkit - add SpawnReason
+-                this.discard(EntityRemoveEvent.Cause.TRANSFORMATION); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.TRANSFORMATION); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+         }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/animal/horse/SkeletonHorse.java b/src/main/java/net/minecraft/world/entity/animal/horse/SkeletonHorse.java
+index c12086c50bb9b5923c179108e92674b2b26d27f2..215247e5b134efe31679cd7a110eab8c793e280b 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/horse/SkeletonHorse.java
++++ b/src/main/java/net/minecraft/world/entity/animal/horse/SkeletonHorse.java
+@@ -125,7 +125,7 @@ public class SkeletonHorse extends AbstractHorse {
+     public void aiStep() {
+         super.aiStep();
+         if (this.isTrap() && this.trapTime++ >= 18000) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/animal/horse/TraderLlama.java b/src/main/java/net/minecraft/world/entity/animal/horse/TraderLlama.java
+index bbfc94237bbd546361cc4a7bde773c810e8c5d49..3fd77d5b23286416409ec2692fbff7a11729b3c5 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/horse/TraderLlama.java
++++ b/src/main/java/net/minecraft/world/entity/animal/horse/TraderLlama.java
+@@ -90,7 +90,7 @@ public class TraderLlama extends Llama {
+             this.despawnDelay = this.isLeashedToWanderingTrader() ? ((WanderingTrader) this.getLeashHolder()).getDespawnDelay() - 1 : this.despawnDelay - 1;
+             if (this.despawnDelay <= 0) {
+                 this.dropLeash(true, false);
+-                this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+ 
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EndCrystal.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EndCrystal.java
+index 6f8d4584aae56fc7fbcbc38b1291ea415208fd5e..70bfeead1ecb23d68ea8c449a3f75cbb4061dbbd 100644
+--- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EndCrystal.java
++++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EndCrystal.java
+@@ -117,10 +117,10 @@ public class EndCrystal extends Entity {
+                         return false;
+                     }
+ 
+-                    this.remove(Entity.RemovalReason.KILLED, EntityRemoveEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause
++                    this.remove(Entity.RemovalReason.KILLED, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                     this.level().explode(this, damagesource1, (ExplosionDamageCalculator) null, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.BLOCK);
+                 } else {
+-                    this.remove(Entity.RemovalReason.KILLED, EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
++                    this.remove(Entity.RemovalReason.KILLED, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 }
+                 // CraftBukkit end
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+index 0be5ae83d2fa86142e3404393729039c51ae0639..fd003bed9f30214c3dde1f881e6187bcfbb9a2b6 100644
+--- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
++++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+@@ -635,7 +635,7 @@ public class EnderDragon extends Mob implements Enemy {
+ 
+     @Override
+     public void kill() {
+-        this.remove(Entity.RemovalReason.KILLED, EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
++        this.remove(Entity.RemovalReason.KILLED, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         this.gameEvent(GameEvent.ENTITY_DIE);
+         if (this.dragonFight != null) {
+             this.dragonFight.updateDragon(this);
+@@ -723,7 +723,7 @@ public class EnderDragon extends Mob implements Enemy {
+                 this.dragonFight.setDragonKilled(this);
+             }
+ 
+-            this.remove(Entity.RemovalReason.KILLED, EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
++            this.remove(Entity.RemovalReason.KILLED, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             this.gameEvent(GameEvent.ENTITY_DIE);
+         }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonSittingFlamingPhase.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonSittingFlamingPhase.java
+index 3eaf64a6f66c6a844e30967e6b87432e559a59e7..32ab046a98ed888e98fc0174b7315c8c79b76ebd 100644
+--- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonSittingFlamingPhase.java
++++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonSittingFlamingPhase.java
+@@ -102,7 +102,7 @@ public class DragonSittingFlamingPhase extends AbstractDragonSittingPhase {
+     @Override
+     public void end() {
+         if (this.flame != null) {
+-            this.flame.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.flame.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             this.flame = null;
+         }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
+index d288bc209a0b0fdf2d73197a8e7d179e8e8c31e7..d91d7992f78da7d5997a0772683238784b710bb7 100644
+--- a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
++++ b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
+@@ -543,7 +543,7 @@ public class WitherBoss extends Monster implements PowerableMob, RangedAttackMob
+     @Override
+     public void checkDespawn() {
+         if (this.level().getDifficulty() == Difficulty.PEACEFUL && this.shouldDespawnInPeaceful()) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else {
+             this.noActionTime = 0;
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
+index af954b2c0c7106a231fb15172da3fa8e1d281d56..74036bb104bf23e07033fef8e2bed9455da9ca56 100644
+--- a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
++++ b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
+@@ -534,7 +534,7 @@ public class ArmorStand extends LivingEntity {
+                                 } else {
+                                     this.brokenByPlayer(worldserver, source);
+                                     this.showBreakingParticles();
+-                                    this.discard(EntityRemoveEvent.Cause.DEATH); // CraftBukkit - SPIGOT-4890: remain as this.discard() since above damagesource method will call death event
++                                    this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - SPIGOT-4890: remain as this.discard() since above damagesource method will call death event // Paper - EntityRemoveFromWorldEvent
+                                 }
+ 
+                                 return true;
+@@ -732,7 +732,7 @@ public class ArmorStand extends LivingEntity {
+ 
+     public void kill(DamageSource damageSource) {
+         org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this, (damageSource == null ? this.damageSources().genericKill() : damageSource), this.drops); // CraftBukkit - call event
+-        this.remove(Entity.RemovalReason.KILLED, EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
++        this.remove(Entity.RemovalReason.KILLED, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         // CraftBukkit end
+         this.gameEvent(GameEvent.ENTITY_DIE);
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/decoration/BlockAttachedEntity.java b/src/main/java/net/minecraft/world/entity/decoration/BlockAttachedEntity.java
+index cf65d8ef8d69a24ceb44d2a5d84c83dfee322a1d..aacf03f4985c7fa5231d4c1d7850889b3c285ba9 100644
+--- a/src/main/java/net/minecraft/world/entity/decoration/BlockAttachedEntity.java
++++ b/src/main/java/net/minecraft/world/entity/decoration/BlockAttachedEntity.java
+@@ -65,7 +65,7 @@ public abstract class BlockAttachedEntity extends Entity {
+                         return;
+                     }
+                     // CraftBukkit end
+-                    this.discard(EntityRemoveEvent.Cause.DROP); // CraftBukkit - add Bukkit remove cause
++                    this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DROP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                     this.dropItem((Entity) null);
+                 }
+             }
+diff --git a/src/main/java/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java b/src/main/java/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java
+index 3c0af74ed65610b1d5e3b72fdcf28c5a3423f0da..cdc454055306b7a2e2a4be24207137b99b555d7d 100644
+--- a/src/main/java/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java
++++ b/src/main/java/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java
+@@ -131,7 +131,7 @@ public class LeashFenceKnotEntity extends BlockAttachedEntity {
+                     }
+                     // CraftBukkit start
+                     if (die) {
+-                        this.discard(EntityRemoveEvent.Cause.DROP); // CraftBukkit - add Bukkit remove cause
++                        this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DROP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                     }
+                     // CraftBukkit end
+                 }
+diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
+index c3a16691e8a843c02e0aea6469822cd8869ad593..88892ab16fe711e80220b5222db410e6504f22ff 100644
+--- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
++++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
+@@ -142,7 +142,7 @@ public class FallingBlockEntity extends Entity {
+     @Override
+     public void tick() {
+         if (this.blockState.isAir()) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else {
+             Block block = this.blockState.getBlock();
+ 
+@@ -155,7 +155,7 @@ public class FallingBlockEntity extends Entity {
+                     this.spawnAtLocation(block);
+                 }
+ 
+-                this.discard(EntityRemoveEvent.Cause.OUT_OF_WORLD);
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.OUT_OF_WORLD); // Paper - EntityRemoveFromWorldEvent
+                 return;
+             }
+             // Paper end - Configurable falling blocks height nerf
+@@ -181,7 +181,7 @@ public class FallingBlockEntity extends Entity {
+                             this.spawnAtLocation((ItemLike) block);
+                         }
+ 
+-                        this.discard(EntityRemoveEvent.Cause.DROP); // CraftBukkit - add Bukkit remove cause
++                        this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DROP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                     }
+                 } else {
+                     BlockState iblockdata = this.level().getBlockState(blockposition);
+@@ -200,13 +200,13 @@ public class FallingBlockEntity extends Entity {
+ 
+                                 // CraftBukkit start
+                                 if (!CraftEventFactory.callEntityChangeBlockEvent(this, blockposition, this.blockState)) {
+-                                    this.discard(EntityRemoveEvent.Cause.DESPAWN); // SPIGOT-6586 called before the event in previous versions
++                                    this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // SPIGOT-6586 called before the event in previous versions // Paper - EntityRemoveFromWorldEvent
+                                     return;
+                                 }
+                                 // CraftBukkit end
+                                 if (this.level().setBlock(blockposition, this.blockState, 3)) {
+                                     ((ServerLevel) this.level()).getChunkSource().chunkMap.broadcast(this, new ClientboundBlockUpdatePacket(blockposition, this.level().getBlockState(blockposition)));
+-                                    this.discard(EntityRemoveEvent.Cause.DESPAWN);
++                                    this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // Paper - EntityRemoveFromWorldEvent
+                                     if (block instanceof Fallable) {
+                                         ((Fallable) block).onLand(this.level(), blockposition, this.blockState, iblockdata, this);
+                                     }
+@@ -234,19 +234,19 @@ public class FallingBlockEntity extends Entity {
+                                         }
+                                     }
+                                 } else if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
+-                                    this.discard(EntityRemoveEvent.Cause.DROP); // CraftBukkit - add Bukkit remove cause
++                                    this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DROP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                                     this.callOnBrokenAfterFall(block, blockposition);
+                                     this.spawnAtLocation((ItemLike) block);
+                                 }
+                             } else {
+-                                this.discard(EntityRemoveEvent.Cause.DROP); // CraftBukkit - add Bukkit remove cause
++                                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DROP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                                 if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
+                                     this.callOnBrokenAfterFall(block, blockposition);
+                                     this.spawnAtLocation((ItemLike) block);
+                                 }
+                             }
+                         } else {
+-                            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                             this.callOnBrokenAfterFall(block, blockposition);
+                         }
+                     }
+diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
+index c4cd7cf1567cdf57bfe9f2d80cd4a613efe10dc7..a4a83400d01dc37446a13d7b85e648cb26819ee0 100644
+--- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
++++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
+@@ -141,7 +141,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
+     @Override
+     public void tick() {
+         if (this.getItem().isEmpty()) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else {
+             super.tick();
+             // CraftBukkit start - Use wall time for pickup and despawn timers
+@@ -220,7 +220,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
+                     return;
+                 }
+                 // CraftBukkit end
+-                this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+ 
+         }
+@@ -243,7 +243,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
+                 return;
+             }
+             // CraftBukkit end
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+     }
+     // Spigot end
+@@ -337,7 +337,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
+         targetEntity.pickupDelay = Math.max(targetEntity.pickupDelay, sourceEntity.pickupDelay);
+         targetEntity.age = Math.min(targetEntity.age, sourceEntity.age);
+         if (sourceStack.isEmpty()) {
+-            sourceEntity.discard(EntityRemoveEvent.Cause.MERGE); // CraftBukkit - add Bukkit remove cause);
++            sourceEntity.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.MERGE); // CraftBukkit - add Bukkit remove cause); // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+@@ -368,7 +368,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
+             this.gameEvent(GameEvent.ENTITY_DAMAGE, source.getEntity());
+             if (this.health <= 0) {
+                 this.getItem().onDestroyed(this);
+-                this.discard(EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+ 
+             return true;
+@@ -475,7 +475,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
+             if (this.pickupDelay == 0 && (this.target == null || this.target.equals(player.getUUID())) && player.getInventory().add(itemstack)) {
+                 player.take(this, i);
+                 if (itemstack.isEmpty()) {
+-                    this.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++                    this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                     itemstack.setCount(i);
+                 }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java b/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
+index 15432b512fc0d0d38bf28499e2afa5e48fec7aaa..935610e9b384854102536a2befb0eac24c83d1e2 100644
+--- a/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
++++ b/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
+@@ -101,7 +101,7 @@ public class PrimedTnt extends Entity implements TraceableEntity {
+         this.move(MoverType.SELF, this.getDeltaMovement());
+         // Paper start - Configurable TNT height nerf
+         if (this.level().paperConfig().fixes.tntEntityHeightNerf.test(v -> this.getY() > v)) {
+-            this.discard(EntityRemoveEvent.Cause.OUT_OF_WORLD);
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.OUT_OF_WORLD); // Paper - EntityRemoveFromWorldEvent
+             return;
+         }
+         // Paper end - Configurable TNT height nerf
+@@ -119,7 +119,7 @@ public class PrimedTnt extends Entity implements TraceableEntity {
+             if (!this.level().isClientSide) {
+                 this.explode();
+             }
+-            this.discard(EntityRemoveEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             // CraftBukkit end
+         } else {
+             this.updateInWaterStateAndDoFluidPushing();
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Creeper.java b/src/main/java/net/minecraft/world/entity/monster/Creeper.java
+index 976de2547f654bec58f53a4eff54df5176e815aa..f50dabeeaad9561cad15ed36ea7e49990d5f439e 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Creeper.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Creeper.java
+@@ -274,7 +274,7 @@ public class Creeper extends Monster implements PowerableMob {
+             this.level().explode(this, net.minecraft.world.level.Explosion.getDefaultDamageSource(this.level(), this).customCausingEntityDamager(this.entityIgniter), null, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.MOB); // CraftBukkit
+             this.spawnLingeringCloud();
+             this.triggerOnDeathMobEffects(Entity.RemovalReason.KILLED);
+-            this.discard(EntityRemoveEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             // CraftBukkit start
+             } else {
+                 this.swell = 0;
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Endermite.java b/src/main/java/net/minecraft/world/entity/monster/Endermite.java
+index 9c78905762d9a484878fa9cf03a2ca3850e7e613..187f9109babae4aeb9e5aeaa61c9b7a32e48c6f7 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Endermite.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Endermite.java
+@@ -116,7 +116,7 @@ public class Endermite extends Monster {
+             }
+ 
+             if (this.life >= 2400) {
+-                this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+         }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Pillager.java b/src/main/java/net/minecraft/world/entity/monster/Pillager.java
+index 4b4dcee6abe7a6db43638d04665125eec560496e..c821afb569d419f30da629827aac155b0cea871a 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Pillager.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Pillager.java
+@@ -198,7 +198,7 @@ public class Pillager extends AbstractIllager implements CrossbowAttackMob, Inve
+             ItemStack itemstack1 = this.inventory.addItem(itemstack);
+ 
+             if (itemstack1.isEmpty()) {
+-                item.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++                item.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             } else {
+                 itemstack.setCount(itemstack1.getCount());
+             }
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Silverfish.java b/src/main/java/net/minecraft/world/entity/monster/Silverfish.java
+index 9ff42b0ae2b82dc3092e38e1439d89b4ab554b17..1264e7b33e476c61489cbc10f3becc60eece3c36 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Silverfish.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Silverfish.java
+@@ -242,7 +242,7 @@ public class Silverfish extends Monster {
+                     // CraftBukkit end
+                     world.setBlock(blockposition, InfestedBlock.infestedStateByHost(iblockdata), 3);
+                     this.mob.spawnAnim();
+-                    this.mob.discard(EntityRemoveEvent.Cause.ENTER_BLOCK); // CraftBukkit - add Bukkit remove cause
++                    this.mob.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.ENTER_BLOCK); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 }
+ 
+             }
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Slime.java b/src/main/java/net/minecraft/world/entity/monster/Slime.java
+index b1f7ea02e533660322675e1bddb070f0a41084f2..10b100cb60c0c65b78ea857b6637625b4123ace6 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Slime.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Slime.java
+@@ -213,7 +213,7 @@ public class Slime extends Mob implements Enemy {
+     }
+ 
+     @Override
+-    public void remove(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
++    public void remove(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
+         // CraftBukkit end
+         int i = this.getSize();
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java b/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java
+index 545e20e558d3bb934ec4bf32847c9fd83edfd85e..6e32e5dd277c95025cc92a9bbb5f267867644d32 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java
++++ b/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java
+@@ -245,7 +245,7 @@ public class PiglinAi {
+         if (drop.getItem().is(Items.GOLD_NUGGET) && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityPickupItemEvent(piglin, drop, 0, false).isCancelled()) {
+             piglin.take(drop, drop.getItem().getCount());
+             itemstack = drop.getItem();
+-            drop.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++            drop.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityPickupItemEvent(piglin, drop, drop.getItem().getCount() - 1, false).isCancelled()) {
+             piglin.take(drop, 1);
+             itemstack = PiglinAi.removeOneItemFromItemEntity(drop);
+@@ -282,7 +282,7 @@ public class PiglinAi {
+         ItemStack itemstack1 = itemstack.split(1);
+ 
+         if (itemstack.isEmpty()) {
+-            stack.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++            stack.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else {
+             stack.setItem(itemstack);
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/npc/InventoryCarrier.java b/src/main/java/net/minecraft/world/entity/npc/InventoryCarrier.java
+index 7e1a533f545d35b2fc55805e26f574461fe7899f..704079decc6e92cf5e9f84c1cf9fb451ea5d90c3 100644
+--- a/src/main/java/net/minecraft/world/entity/npc/InventoryCarrier.java
++++ b/src/main/java/net/minecraft/world/entity/npc/InventoryCarrier.java
+@@ -41,7 +41,7 @@ public interface InventoryCarrier {
+ 
+             entity.take(item, i - itemstack1.getCount());
+             if (itemstack1.isEmpty()) {
+-                item.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++                item.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             } else {
+                 itemstack.setCount(itemstack1.getCount());
+             }
+diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
+index 63c10be6eacd7108b8b4795d76bf624e0614440a..016adc00352a0401d316b9d584eca8fa12011cd1 100644
+--- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
++++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
+@@ -866,7 +866,7 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+                 world.addFreshEntityWithPassengers(entitywitch, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.LIGHTNING);
+                 // CraftBukkit end
+                 this.releaseAllPois();
+-                this.discard(EntityRemoveEvent.Cause.TRANSFORMATION); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.TRANSFORMATION); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             } else {
+                 super.thunderHit(world, lightning);
+             }
+diff --git a/src/main/java/net/minecraft/world/entity/npc/WanderingTrader.java b/src/main/java/net/minecraft/world/entity/npc/WanderingTrader.java
+index 0f2e2e42e732e942664d70a72dd9c4e47c7e95b6..911ca85baa6b81eb61603ce64d09f5519451f0ac 100644
+--- a/src/main/java/net/minecraft/world/entity/npc/WanderingTrader.java
++++ b/src/main/java/net/minecraft/world/entity/npc/WanderingTrader.java
+@@ -261,7 +261,7 @@ public class WanderingTrader extends net.minecraft.world.entity.npc.AbstractVill
+ 
+     private void maybeDespawn() {
+         if (this.despawnDelay > 0 && !this.isTrading() && --this.despawnDelay == 0) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
+index ba279ab6ec0ab41309607333b62a941e35dbf581..25f492450eb76813738d15320d75dbf4cc519572 100644
+--- a/src/main/java/net/minecraft/world/entity/player/Player.java
++++ b/src/main/java/net/minecraft/world/entity/player/Player.java
+@@ -1480,7 +1480,7 @@ public abstract class Player extends LivingEntity {
+     }
+ 
+     @Override
+-    public void remove(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
++    public void remove(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
+         super.remove(entity_removalreason, cause);
+         // CraftBukkit end
+         this.inventoryMenu.removed(this);
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
+index 230040bef7d2cf9a463cfd9cb3b1b1aa208a7119..dd7f74855d42d8cd18d9ce0274b5c9055b3f6a82 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
+@@ -357,7 +357,7 @@ public abstract class AbstractArrow extends Projectile {
+     protected void tickDespawn() {
+         ++this.life;
+         if (this.life >= (pickup == Pickup.CREATIVE_ONLY ? this.level().paperConfig().entities.spawning.creativeArrowDespawnRate.value() : (pickup == Pickup.DISALLOWED ? this.level().paperConfig().entities.spawning.nonPlayerArrowDespawnRate.value() : ((this instanceof ThrownTrident) ? this.level().spigotConfig.tridentDespawnRate : this.level().spigotConfig.arrowDespawnRate)))) { // Spigot // Paper - Configurable non-player arrow despawn rate; TODO: Extract this to init?
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+@@ -404,7 +404,7 @@ public abstract class AbstractArrow extends Projectile {
+             }
+ 
+             if (this.piercingIgnoreEntityIds.size() >= this.getPierceLevel() + 1) {
+-                this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 return;
+             }
+ 
+@@ -477,7 +477,7 @@ public abstract class AbstractArrow extends Projectile {
+ 
+             this.playSound(this.soundEvent, 1.0F, 1.2F / (this.random.nextFloat() * 0.2F + 0.9F));
+             if (this.getPierceLevel() <= 0) {
+-                this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+         } else {
+             entity.setRemainingFireTicks(k);
+@@ -488,7 +488,7 @@ public abstract class AbstractArrow extends Projectile {
+                     this.spawnAtLocation(this.getPickupItem(), 0.1F);
+                 }
+ 
+-                this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+         }
+ 
+@@ -707,7 +707,7 @@ public abstract class AbstractArrow extends Projectile {
+             if ((this.pickup == AbstractArrow.Pickup.ALLOWED && player.getInventory().add(itemstack)) || (this.pickup == AbstractArrow.Pickup.CREATIVE_ONLY && player.getAbilities().instabuild)) {
+                 // CraftBukkit end
+                 player.take(this, 1);
+-                this.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+ 
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractHurtingProjectile.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractHurtingProjectile.java
+index f79fc0ed58af2cf55e8642b6d7fc9e4f57d0ba20..8e7d154f6854d657f993684a69e58ea783479918 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/AbstractHurtingProjectile.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractHurtingProjectile.java
+@@ -76,7 +76,7 @@ public abstract class AbstractHurtingProjectile extends Projectile {
+         Entity entity = this.getOwner();
+ 
+         if (!this.level().isClientSide && (entity != null && entity.isRemoved() || !this.level().hasChunkAt(this.blockPosition()))) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else {
+             super.tick();
+             if (this.shouldBurn()) {
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/DragonFireball.java b/src/main/java/net/minecraft/world/entity/projectile/DragonFireball.java
+index 3c77515f6b7f1ff89325afba214e9a8e5f536158..3d721282b1ffdea891c28f01525f8e7f7e887302 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/DragonFireball.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/DragonFireball.java
+@@ -65,7 +65,7 @@ public class DragonFireball extends AbstractHurtingProjectile {
+ 
+                 this.level().levelEvent(2006, this.blockPosition(), this.isSilent() ? -1 : 1);
+                 this.level().addFreshEntity(entityareaeffectcloud);
+-                this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+ 
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/EvokerFangs.java b/src/main/java/net/minecraft/world/entity/projectile/EvokerFangs.java
+index c75433bb0fcd4264148950467bf6b700296aca7b..932c2f8681e7a6a88bd1c66d8d498b24a3eb12a7 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/EvokerFangs.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/EvokerFangs.java
+@@ -124,7 +124,7 @@ public class EvokerFangs extends Entity implements TraceableEntity {
+             }
+ 
+             if (--this.lifeTicks < 0) {
+-                this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             }
+         }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/EyeOfEnder.java b/src/main/java/net/minecraft/world/entity/projectile/EyeOfEnder.java
+index 8b0ccd1aa0f2f1d2326c6071f16e641afc101751..f2ed31407347e61c6d31eec8d4eb4f3a639734bd 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/EyeOfEnder.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/EyeOfEnder.java
+@@ -149,7 +149,7 @@ public class EyeOfEnder extends Entity implements ItemSupplier {
+             ++this.life;
+             if (this.life > 80 && !this.level().isClientSide) {
+                 this.playSound(SoundEvents.ENDER_EYE_DEATH, 1.0F, 1.0F);
+-                this.discard(this.surviveAfterDeath ? EntityRemoveEvent.Cause.DROP : EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                this.discard(this.surviveAfterDeath ? com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DROP : com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 if (this.surviveAfterDeath) {
+                     this.level().addFreshEntity(new ItemEntity(this.level(), this.getX(), this.getY(), this.getZ(), this.getItem()));
+                 } else {
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/FireworkRocketEntity.java b/src/main/java/net/minecraft/world/entity/projectile/FireworkRocketEntity.java
+index cc99d67bc52c89b50171b6c808c6e3bf293999f5..66c139ee89b0c22b9a61cc07963855aae8987b69 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/FireworkRocketEntity.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/FireworkRocketEntity.java
+@@ -195,7 +195,7 @@ public class FireworkRocketEntity extends Projectile implements ItemSupplier {
+         this.level().broadcastEntityEvent(this, (byte) 17);
+         this.gameEvent(GameEvent.EXPLODE, this.getOwner());
+         this.dealExplosionDamage();
+-        this.discard(EntityRemoveEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause
++        this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
+index ed43ad94ca007a54e3c32d5e17c141048eeb5835..41ddf812971638999a73fdc0bca3c5f4c1bee617 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
+@@ -170,12 +170,12 @@ public class FishingHook extends Projectile {
+         net.minecraft.world.entity.player.Player entityhuman = this.getPlayerOwner();
+ 
+         if (entityhuman == null) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else if (this.level().isClientSide || !this.shouldStopFishing(entityhuman)) {
+             if (this.onGround()) {
+                 ++this.life;
+                 if (this.life >= 1200) {
+-                    this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                    this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                     return;
+                 }
+             } else {
+@@ -276,7 +276,7 @@ public class FishingHook extends Projectile {
+         if (!player.isRemoved() && player.isAlive() && (flag || flag1) && this.distanceToSqr((Entity) player) <= 1024.0D) {
+             return false;
+         } else {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             return true;
+         }
+     }
+@@ -557,7 +557,7 @@ public class FishingHook extends Projectile {
+             }
+             // CraftBukkit end
+ 
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             return i;
+         } else {
+             return 0;
+@@ -595,7 +595,7 @@ public class FishingHook extends Projectile {
+     }
+ 
+     @Override
+-    public void remove(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
++    public void remove(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
+         // CraftBukkit end
+         this.updateOwnerInfo((FishingHook) null);
+         super.remove(entity_removalreason, cause); // CraftBukkit - add Bukkit remove cause
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/LargeFireball.java b/src/main/java/net/minecraft/world/entity/projectile/LargeFireball.java
+index 28a65f2a9ef441ae96a7a635e0695b14ce2ee367..575f24a3c4601fb8d77cb216552028ffc7ae6293 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/LargeFireball.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/LargeFireball.java
+@@ -47,7 +47,7 @@ public class LargeFireball extends Fireball {
+                 this.level().explode(this, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.MOB);
+             }
+             // CraftBukkit end
+-            this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/LlamaSpit.java b/src/main/java/net/minecraft/world/entity/projectile/LlamaSpit.java
+index 8575941fd238750c5d56843989a48bcbde2d8a88..3280d68bb5ebe446e9cc264678bc5a7c71ee0d2c 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/LlamaSpit.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/LlamaSpit.java
+@@ -53,9 +53,9 @@ public class LlamaSpit extends Projectile {
+         float f = 0.99F;
+ 
+         if (this.level().getBlockStates(this.getBoundingBox()).noneMatch(BlockBehaviour.BlockStateBase::isAir)) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else if (this.isInWaterOrBubble()) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else {
+             this.setDeltaMovement(vec3d.scale(0.9900000095367432D));
+             this.applyGravity();
+@@ -89,7 +89,7 @@ public class LlamaSpit extends Projectile {
+     protected void onHitBlock(BlockHitResult blockHitResult) {
+         super.onHitBlock(blockHitResult);
+         if (!this.level().isClientSide) {
+-            this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/ShulkerBullet.java b/src/main/java/net/minecraft/world/entity/projectile/ShulkerBullet.java
+index 7fde1807640d0b02d417f48f1f6758f8ae32e04b..27f20def170072dc2cec2e0368b4ff79bad45a04 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/ShulkerBullet.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/ShulkerBullet.java
+@@ -210,7 +210,7 @@ public class ShulkerBullet extends Projectile {
+     @Override
+     public void checkDespawn() {
+         if (this.level().getDifficulty() == Difficulty.PEACEFUL) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+@@ -341,7 +341,7 @@ public class ShulkerBullet extends Projectile {
+         this.destroy(null);
+     }
+ 
+-    private void destroy(EntityRemoveEvent.Cause cause) {
++    private void destroy(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
+         this.discard(cause);
+         // CraftBukkit end
+         this.level().gameEvent((Holder) GameEvent.ENTITY_DAMAGE, this.position(), GameEvent.Context.of((Entity) this));
+@@ -350,7 +350,7 @@ public class ShulkerBullet extends Projectile {
+     @Override
+     protected void onHit(HitResult hitResult) {
+         super.onHit(hitResult);
+-        this.destroy(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++        this.destroy(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+     }
+ 
+     @Override
+@@ -368,7 +368,7 @@ public class ShulkerBullet extends Projectile {
+         if (!this.level().isClientSide) {
+             this.playSound(SoundEvents.SHULKER_BULLET_HURT, 1.0F, 1.0F);
+             ((ServerLevel) this.level()).sendParticles(ParticleTypes.CRIT, this.getX(), this.getY(), this.getZ(), 15, 0.2D, 0.2D, 0.2D, 0.0D);
+-            this.destroy(EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
++            this.destroy(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+         return true;
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/SmallFireball.java b/src/main/java/net/minecraft/world/entity/projectile/SmallFireball.java
+index 1711ad457e7d1233fd32edc3e9e3b9f1e3be9980..b86f8c60961c6465d8b05c83d89cc3ebc4415c68 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/SmallFireball.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/SmallFireball.java
+@@ -89,7 +89,7 @@ public class SmallFireball extends Fireball {
+     protected void onHit(HitResult hitResult) {
+         super.onHit(hitResult);
+         if (!this.level().isClientSide) {
+-            this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/Snowball.java b/src/main/java/net/minecraft/world/entity/projectile/Snowball.java
+index 2b4d206c0d31ba38d7b2af654bd420e85145d441..3f548b8ccf61b5f5c956583f7c6d75ca281101e4 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/Snowball.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/Snowball.java
+@@ -68,7 +68,7 @@ public class Snowball extends ThrowableItemProjectile {
+         super.onHit(hitResult);
+         if (!this.level().isClientSide) {
+             this.level().broadcastEntityEvent(this, (byte) 3);
+-            this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownEgg.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownEgg.java
+index 62850e899955732afdd255ea1e55fc84b7c6c96b..e2c4c5113069ba56774a84c398bc193f1b41a22c 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/ThrownEgg.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownEgg.java
+@@ -107,7 +107,7 @@ public class ThrownEgg extends ThrowableItemProjectile {
+             }
+ 
+             this.level().broadcastEntityEvent(this, (byte) 3);
+-            this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
+index f43dd56182ced23cf1cf65c149c532a611cc933a..8570ebb0bf42f4bdf9aa8f811a2d3cadf0f4780e 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
+@@ -73,7 +73,7 @@ public class ThrownEnderpearl extends ThrowableItemProjectile {
+                             // CraftBukkit start
+                             Entity tp = entity.changeDimension(new DimensionTransition(worldserver, this.position(), entity.getDeltaMovement(), entity.getYRot(), entity.getXRot(), DimensionTransition.DO_NOTHING, PlayerTeleportEvent.TeleportCause.ENDER_PEARL));
+                             if (tp == null) {
+-                                this.discard(EntityRemoveEvent.Cause.HIT);
++                                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // Paper - EntityRemoveFromWorldEvent
+                                 return;
+                             }
+                             // CraftBukkit end
+@@ -98,11 +98,11 @@ public class ThrownEnderpearl extends ThrowableItemProjectile {
+                         this.playSound(worldserver, this.position());
+                     }
+ 
+-                    this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++                    this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                     return;
+                 }
+ 
+-                this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 return;
+             }
+         }
+@@ -128,7 +128,7 @@ public class ThrownEnderpearl extends ThrowableItemProjectile {
+         Entity entity = this.getOwner();
+ 
+         if (entity instanceof ServerPlayer && !entity.isAlive() && this.level().getGameRules().getBoolean(GameRules.RULE_ENDER_PEARLS_VANISH_ON_DEATH)) {
+-            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else {
+             super.tick();
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownExperienceBottle.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownExperienceBottle.java
+index 9963db38420b91ae817a18ff084311cb45c0edee..ac8d4a1cc047b76cdaa93931282fbf1c3b07c15b 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/ThrownExperienceBottle.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownExperienceBottle.java
+@@ -55,7 +55,7 @@ public class ThrownExperienceBottle extends ThrowableItemProjectile {
+             // CraftBukkit end
+ 
+             ExperienceOrb.award((ServerLevel) this.level(), this.position(), i);
+-            this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
+index be787a5b52e90796d4f06e17e564f4324807c3e6..f45600ad48224e37da14b7a6b589a3eaf95a1aca 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
+@@ -119,7 +119,7 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
+             int i = potioncontents.potion().isPresent() && ((Potion) ((Holder) potioncontents.potion().get()).value()).hasInstantEffects() ? 2007 : 2002;
+ 
+             this.level().levelEvent(i, this.blockPosition(), potioncontents.getColor());
+-            this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+     }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownTrident.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownTrident.java
+index 46b67c38dccf911973e6a7643f06972019073eb2..6140f397acb5c70bd9eeb2c017918cd3a6cbccdf 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/ThrownTrident.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownTrident.java
+@@ -72,7 +72,7 @@ public class ThrownTrident extends AbstractArrow {
+                     this.spawnAtLocation(this.getPickupItem(), 0.1F);
+                 }
+ 
+-                this.discard(EntityRemoveEvent.Cause.DROP); // CraftBukkit - add Bukkit remove cause
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DROP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             } else {
+                 this.setNoPhysics(true);
+                 Vec3 vec3d = entity.getEyePosition().subtract(this.position());
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/WitherSkull.java b/src/main/java/net/minecraft/world/entity/projectile/WitherSkull.java
+index 315610e95c91a0db096bf572789a40e746e72ebe..2ed2fe4ad3a25ae693c9946ba1f9bd67d316b4b8 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/WitherSkull.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/WitherSkull.java
+@@ -110,7 +110,7 @@ public class WitherSkull extends AbstractHurtingProjectile {
+                 this.level().explode(this, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.MOB);
+             }
+             // CraftBukkit end
+-            this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/windcharge/AbstractWindCharge.java b/src/main/java/net/minecraft/world/entity/projectile/windcharge/AbstractWindCharge.java
+index de2bc78415ab4efb651030be6560d9c9778a1d17..50d359df6059cbb41f02ff996e93db644ded91b6 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/windcharge/AbstractWindCharge.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/windcharge/AbstractWindCharge.java
+@@ -116,7 +116,7 @@ public abstract class AbstractWindCharge extends AbstractHurtingProjectile imple
+             Vec3 vec3d1 = blockHitResult.getLocation().add(vec3d);
+ 
+             this.explode(vec3d1);
+-            this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+@@ -125,7 +125,7 @@ public abstract class AbstractWindCharge extends AbstractHurtingProjectile imple
+     protected void onHit(HitResult hitResult) {
+         super.onHit(hitResult);
+         if (!this.level().isClientSide) {
+-            this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+@@ -160,7 +160,7 @@ public abstract class AbstractWindCharge extends AbstractHurtingProjectile imple
+     public void tick() {
+         if (!this.level().isClientSide && this.getBlockY() > this.level().getMaxBuildHeight() + 30) {
+             this.explode(this.position());
+-            this.discard(EntityRemoveEvent.Cause.OUT_OF_WORLD); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.OUT_OF_WORLD); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else {
+             super.tick();
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/raid/Raider.java b/src/main/java/net/minecraft/world/entity/raid/Raider.java
+index 6fb56c826f0eaf76ab7896f784084b4fb1b3d105..6b0231c8a8b640c671563fe75021dd2569afe876 100644
+--- a/src/main/java/net/minecraft/world/entity/raid/Raider.java
++++ b/src/main/java/net/minecraft/world/entity/raid/Raider.java
+@@ -236,7 +236,7 @@ public abstract class Raider extends PatrollingMonster {
+             this.onItemPickup(item);
+             this.setItemSlot(enumitemslot, itemstack);
+             this.take(item, itemstack.getCount());
+-            item.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++            item.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             this.getCurrentRaid().setLeader(this.getWave(), this);
+             this.setPatrolLeader(true);
+         } else {
+diff --git a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java
+index 67840327e934b631a85cf2d64911f5cfab4402b1..07059329125e35fdcff649601f594670843f32e2 100644
+--- a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java
++++ b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java
+@@ -132,7 +132,7 @@ public abstract class AbstractMinecartContainer extends AbstractMinecart impleme
+     }
+ 
+     @Override
+-    public void remove(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
++    public void remove(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
+         // CraftBukkit end
+         if (!this.level().isClientSide && entity_removalreason.shouldDestroy()) {
+             Containers.dropContents(this.level(), (Entity) this, (Container) this);
+diff --git a/src/main/java/net/minecraft/world/entity/vehicle/Boat.java b/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
+index 26dd7c9f48f15f66a326901259ee89f4ab911526..5cee57e22a66e4b7978bd5a234c30d02db2204fd 100644
+--- a/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
++++ b/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
+@@ -896,7 +896,7 @@ public class Boat extends VehicleEntity implements Leashable, VariantHolder<Boat
+     }
+ 
+     @Override
+-    public void remove(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
++    public void remove(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
+         // CraftBukkit end
+         if (!this.level().isClientSide && entity_removalreason.shouldDestroy() && this.isLeashed()) {
+             this.dropLeash(true, true);
+diff --git a/src/main/java/net/minecraft/world/entity/vehicle/ChestBoat.java b/src/main/java/net/minecraft/world/entity/vehicle/ChestBoat.java
+index 42f8e2d961f83c3e9ce384158b9dfc4014eb0a5f..a2b925d09601aa2e1021f29b9ba7f6f85e82189d 100644
+--- a/src/main/java/net/minecraft/world/entity/vehicle/ChestBoat.java
++++ b/src/main/java/net/minecraft/world/entity/vehicle/ChestBoat.java
+@@ -92,7 +92,7 @@ public class ChestBoat extends Boat implements HasCustomInventoryScreen, Contain
+     }
+ 
+     @Override
+-    public void remove(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
++    public void remove(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
+         // CraftBukkit end
+         if (!this.level().isClientSide && entity_removalreason.shouldDestroy()) {
+             Containers.dropContents(this.level(), (Entity) this, (Container) this);
+diff --git a/src/main/java/net/minecraft/world/entity/vehicle/MinecartTNT.java b/src/main/java/net/minecraft/world/entity/vehicle/MinecartTNT.java
+index b7036f8399e2500ba01736c6006b972f7ca4838e..e4f3f5671208ff9b40f41b2ad0d145f51e60101e 100644
+--- a/src/main/java/net/minecraft/world/entity/vehicle/MinecartTNT.java
++++ b/src/main/java/net/minecraft/world/entity/vehicle/MinecartTNT.java
+@@ -56,7 +56,7 @@ public class MinecartTNT extends AbstractMinecart {
+         if (this.fuse > 0) {
+             // Paper start - Configurable TNT height nerf
+             if (this.level().paperConfig().fixes.tntEntityHeightNerf.test(v -> this.getY() > v)) {
+-                this.discard(EntityRemoveEvent.Cause.OUT_OF_WORLD);
++                this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.OUT_OF_WORLD); // Paper - EntityRemoveFromWorldEvent
+                 return;
+             }
+             // Paper end - Configurable TNT height nerf
+@@ -132,7 +132,7 @@ public class MinecartTNT extends AbstractMinecart {
+             }
+             this.level().explode(this, damageSource, (ExplosionDamageCalculator) null, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.TNT);
+             // CraftBukkit end
+-            this.discard(EntityRemoveEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause
++            this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/vehicle/VehicleEntity.java b/src/main/java/net/minecraft/world/entity/vehicle/VehicleEntity.java
+index 869caeca756e4d75157cb22566d915fafba4d708..d9d83633965046eb2e6c472948b57f31d3c195dc 100644
+--- a/src/main/java/net/minecraft/world/entity/vehicle/VehicleEntity.java
++++ b/src/main/java/net/minecraft/world/entity/vehicle/VehicleEntity.java
+@@ -67,7 +67,7 @@ public abstract class VehicleEntity extends Entity {
+                             return true;
+                         }
+                         // CraftBukkit end
+-                        this.discard(EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
++                        this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                     }
+                 } else {
+                     // CraftBukkit start
+diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
+index 024da1029baecae639d7c05b5f7c30dbaa67b006..9cf436aa3a160841256ad937531bcdddecc080d0 100644
+--- a/src/main/java/net/minecraft/world/level/Level.java
++++ b/src/main/java/net/minecraft/world/level/Level.java
+@@ -750,7 +750,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+             final String msg = String.format("Entity threw exception at %s:%s,%s,%s", entity.level().getWorld().getName(), entity.getX(), entity.getY(), entity.getZ());
+             MinecraftServer.LOGGER.error(msg, throwable);
+             getCraftServer().getPluginManager().callEvent(new com.destroystokyo.paper.event.server.ServerExceptionEvent(new com.destroystokyo.paper.exception.ServerInternalException(msg, throwable))); // Paper - ServerExceptionEvent
+-            entity.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DISCARD);
++            entity.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DISCARD); // Paper - EntityRemoveFromWorldEvent
+             // Paper end - Prevent block entity and entity crashes
+         }
+     }
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/BeehiveBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BeehiveBlockEntity.java
+index 4ee7a4e5637fe36eb50e8ec9186d72d1253bfd98..0f1821eed3263f931adec3e669148a3069487487 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/BeehiveBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/BeehiveBlockEntity.java
+@@ -192,7 +192,7 @@ public class BeehiveBlockEntity extends BlockEntity {
+                 this.level.gameEvent((Holder) GameEvent.BLOCK_CHANGE, blockposition, GameEvent.Context.of(entity, this.getBlockState()));
+             }
+ 
+-            entity.discard(EntityRemoveEvent.Cause.ENTER_BLOCK); // CraftBukkit - add Bukkit remove cause
++            entity.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.ENTER_BLOCK); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+             super.setChanged();
+         }
+     }
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
+index 1c8a08e317591413426285874de74f4de54efa07..8859726e7662cfeaa999d0fedcd6393c7e661ea7 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
+@@ -414,7 +414,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+         if (itemstack1.isEmpty()) {
+             flag = true;
+             itemEntity.setItem(ItemStack.EMPTY);
+-            itemEntity.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
++            itemEntity.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         } else {
+             itemEntity.setItem(itemstack1);
+         }
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/trialspawner/TrialSpawnerData.java b/src/main/java/net/minecraft/world/level/block/entity/trialspawner/TrialSpawnerData.java
+index 055f4b87c01ee7ecf7d2a111b72cc5aa85d9fbe8..416198471d3f6873a6f7a95ab69cfccf54ff215b 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/trialspawner/TrialSpawnerData.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/trialspawner/TrialSpawnerData.java
+@@ -218,7 +218,7 @@ public class TrialSpawnerData {
+                     entityinsentient.dropPreservedEquipment();
+                 }
+ 
+-                entity.remove(Entity.RemovalReason.DISCARDED, org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - Add bukkit remove cause;
++                entity.remove(Entity.RemovalReason.DISCARDED, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - Add bukkit remove cause; // Paper - EntityRemoveFromWorldEvent
+             }
+         });
+         if (!logic.getOminousConfig().spawnPotentialsDefinition().isEmpty()) {
+diff --git a/src/main/java/net/minecraft/world/level/dimension/end/DragonRespawnAnimation.java b/src/main/java/net/minecraft/world/level/dimension/end/DragonRespawnAnimation.java
+index 7bbe93966fa00b7001da53bf2f22f4d942b7cc22..ee1988f3a7dccd16f423b8512bdcdbf0ee8d5c37 100644
+--- a/src/main/java/net/minecraft/world/level/dimension/end/DragonRespawnAnimation.java
++++ b/src/main/java/net/minecraft/world/level/dimension/end/DragonRespawnAnimation.java
+@@ -105,7 +105,7 @@ public enum DragonRespawnAnimation {
+                     entityendercrystal = (EndCrystal) iterator.next();
+                     entityendercrystal.setBeamTarget((BlockPos) null);
+                     world.explode(entityendercrystal, entityendercrystal.getX(), entityendercrystal.getY(), entityendercrystal.getZ(), 6.0F, Level.ExplosionInteraction.NONE);
+-                    entityendercrystal.discard(EntityRemoveEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause
++                    entityendercrystal.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+                 }
+             } else if (tick >= 80) {
+                 world.levelEvent(3001, new BlockPos(0, 128, 0), 0);
+diff --git a/src/main/java/net/minecraft/world/level/entity/EntityAccess.java b/src/main/java/net/minecraft/world/level/entity/EntityAccess.java
+index d06d36867c6724bc5840ba7cd9287f49f6249d7b..671f78a5113aad9205a52c4110e18209e3ece3fe 100644
+--- a/src/main/java/net/minecraft/world/level/entity/EntityAccess.java
++++ b/src/main/java/net/minecraft/world/level/entity/EntityAccess.java
+@@ -28,7 +28,7 @@ public interface EntityAccess {
+     void setRemoved(Entity.RemovalReason reason);
+ 
+     // CraftBukkit start - add Bukkit remove cause
+-    default void setRemoved(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
++    default void setRemoved(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) {
+         this.setRemoved(entity_removalreason);
+     }
+     // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
+index 1cfc906317f07a44f06a4adf021c44e34a2f1d07..270c98bf13168bf452ba1c8bac36a9e582a30ca6 100644
+--- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
++++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
+@@ -284,7 +284,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+     }
+ 
+     private void unloadEntity(EntityAccess entity) {
+-        entity.setRemoved(Entity.RemovalReason.UNLOADED_TO_CHUNK, EntityRemoveEvent.Cause.UNLOAD); // CraftBukkit - add Bukkit remove cause
++        entity.setRemoved(Entity.RemovalReason.UNLOADED_TO_CHUNK, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.UNLOAD); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
+         entity.setLevelCallback(EntityInLevelCallback.NULL);
+     }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractWindCharge.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractWindCharge.java
+index 59df9031e8b4466c8687671d745318e7ee83d271..7efbe24b9954367a7e102fcf1049d110bc14f25c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractWindCharge.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractWindCharge.java
+@@ -12,7 +12,7 @@ public abstract class CraftAbstractWindCharge extends CraftFireball implements A
+     @Override
+     public void explode() {
+         this.getHandle().explode(this.getHandle().position());
+-        this.getHandle().discard(EntityRemoveEvent.Cause.EXPLODE); // SPIGOT-7577 - explode doesn't discard the entity, this happens only in tick and onHitBlock
++        this.getHandle().discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.EXPLODE); // SPIGOT-7577 - explode doesn't discard the entity, this happens only in tick and onHitBlock // Paper - EntityRemoveFromWorldEvent
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+index df6da730134da754d0ff23bd1b57c82486b9ab73..8f5aff9f9622a531136acfbae9bb2b8c573aa7f1 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+@@ -45,7 +45,6 @@ import org.bukkit.entity.Player;
+ import org.bukkit.entity.Pose;
+ import org.bukkit.entity.SpawnCategory;
+ import org.bukkit.event.entity.EntityDamageEvent;
+-import org.bukkit.event.entity.EntityRemoveEvent;
+ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+ import org.bukkit.metadata.MetadataValue;
+ import org.bukkit.permissions.PermissibleBase;
+@@ -326,7 +325,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+     @Override
+     public void remove() {
+         this.entity.pluginRemoved = true;
+-        this.entity.discard(this.getHandle().generation ? null : EntityRemoveEvent.Cause.PLUGIN);
++        this.entity.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PLUGIN); // Paper - EntityRemoveFromWorldEvent
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 34636f7a05d868c4df86316a65c4e008f54db634..1b9ea4990ca03a48b26457d0e42d97eca39d703c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1916,19 +1916,32 @@ public class CraftEventFactory {
+         return event;
+     }
+ 
+-    public static void callEntityRemoveEvent(Entity entity, EntityRemoveEvent.Cause cause) {
+-        if (entity instanceof ServerPlayer) {
+-            return; // Don't call for player
+-        }
++    // Paper start - EntityRemoveFromWorldEvent
++    public static void callEntityRemoveEvent(Entity entity, Entity.RemovalReason removalReason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) {
++        if (entity.generation) return;
+ 
+         if (cause == null) {
+-            // Don't call if cause is null
+-            // This can happen when an entity changes dimension,
+-            // the entity gets removed during world gen or
+-            // the entity is removed before it is even spawned (when the spawn event is cancelled for example)
+-            return;
++            cause = switch (removalReason) {
++                case KILLED -> com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH;
++                case DISCARDED -> com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DISCARD;
++                case UNLOADED_TO_CHUNK -> com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.UNLOAD;
++                case UNLOADED_WITH_PLAYER -> com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PLAYER_QUIT;
++                case CHANGED_DIMENSION -> com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.CHANGED_DIMENSION;
++            };
++        }
++
++        EntityRemoveEvent.Cause legacyCause;
++        try {
++            legacyCause = EntityRemoveEvent.Cause.valueOf(cause.name());
++        } catch (IllegalArgumentException e) {
++            legacyCause = null;
++        }
++
++        if (!(entity instanceof ServerPlayer) && legacyCause != null) {
++            Bukkit.getPluginManager().callEvent(new EntityRemoveEvent(entity.getBukkitEntity(), legacyCause));
+         }
+ 
+-        Bukkit.getPluginManager().callEvent(new EntityRemoveEvent(entity.getBukkitEntity(), cause));
++        new com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent(entity.getBukkitEntity(), entity.level().getWorld(), cause).callEvent();
+     }
++    // Paper end - EntityRemoveFromWorldEvent
+ }
+diff --git a/src/test/java/org/bukkit/event/EntityRemoveEventTest.java b/src/test/java/org/bukkit/event/EntityRemoveEventTest.java
+index fa2c47a25ada4eb38a2077afac37bd595ed6157a..3a2528e5e8fab3129a2bfa66280e062fec95a04e 100644
+--- a/src/test/java/org/bukkit/event/EntityRemoveEventTest.java
++++ b/src/test/java/org/bukkit/event/EntityRemoveEventTest.java
+@@ -119,7 +119,7 @@ public class EntityRemoveEventTest extends AbstractTestingBase {
+ 
+             for (MethodNode methodNode : classNode.methods) {
+                 if (methodNode.name.equals("remove") && methodNode.desc.contains("Lnet/minecraft/world/entity/Entity$RemovalReason;")) {
+-                    if (methodNode.desc.contains("Lorg/bukkit/event/entity/EntityRemoveEvent$Cause;")) {
++                    if (methodNode.desc.contains("Lcom/destroystokyo/paper/event/entity/EntityRemoveFromWorldEvent$Cause;")) { // Paper - EntityRemoveFromWorldEvent
+                         bukkitCause = true;
+                     } else {
+                         minecraftCause = true;
+@@ -189,7 +189,7 @@ public class EntityRemoveEventTest extends AbstractTestingBase {
+             }
+         }
+ 
+-        if (desc.contains("Lorg/bukkit/event/entity/EntityRemoveEvent$Cause;")) {
++        if (desc.contains("Lcom/destroystokyo/paper/event/entity/EntityRemoveFromWorldEvent$Cause;")) { // Paper - EntityRemoveFromWorldEvent
+             return false;
+         }
+ 

--- a/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
@@ -59,14 +59,14 @@ index 02b9e1ed57f5d65698c461387ff7d48450e6a70f..0d18b12d0755c14bd041e0f981774696
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8f468a3bfa8ef381eabb45ebb3dd9a4942e98dd5..96e0fc5c8a018fd579f24529175decdac634cfa1 100644
+index 1b9ea4990ca03a48b26457d0e42d97eca39d703c..147c4cb3460fa7d46b8c1e20aeaec3e4f1b215f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1931,4 +1931,13 @@ public class CraftEventFactory {
- 
-         Bukkit.getPluginManager().callEvent(new EntityRemoveEvent(entity.getBukkitEntity(), cause));
+@@ -1944,4 +1944,13 @@ public class CraftEventFactory {
+         new com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent(entity.getBukkitEntity(), entity.level().getWorld(), cause).callEvent();
      }
-+    // Paper start - PlayerUseUnknownEntityEvent
+     // Paper end - EntityRemoveFromWorldEvent
++        // Paper start - PlayerUseUnknownEntityEvent
 +    public static void callPlayerUseUnknownEntityEvent(net.minecraft.world.entity.player.Player player, net.minecraft.network.protocol.game.ServerboundInteractPacket packet, InteractionHand hand, @Nullable net.minecraft.world.phys.Vec3 vector) {
 +        new com.destroystokyo.paper.event.player.PlayerUseUnknownEntityEvent(
 +            (Player) player.getBukkitEntity(), packet.getEntityId(), packet.isAttack(),

--- a/patches/server/0125-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0125-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -21,7 +21,7 @@ index 99771070840a545537fe352bda1c4aaeedd638ca..2fab84c5e2dc4de39281956390588a9a
  
                  return true;
 diff --git a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
-index 25a45e680f9fdea90f43d59de87a3a500f4ee8c0..0330a62a6a0060d2a96de191db68774588fc7ae5 100644
+index eb1fcd73600db3c040f8700c822157333d4e7f00..2d70e18de483d72b637e08286627a7f9a8199dff 100644
 --- a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 +++ b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 @@ -44,9 +44,63 @@ public class ExperienceOrb extends Entity {
@@ -172,7 +172,7 @@ index 48d0cbe7859c62bbf281a7b43ef9af658667cb7b..b46352b328178df2a48d1c9e895bed3f
              // CraftBukkit end
          }
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Fox.java b/src/main/java/net/minecraft/world/entity/animal/Fox.java
-index de2a25db9465bc4ae3cbf7ff6d3af756df679f4a..a6788da1505f9e119c03b94488f5e006da13e918 100644
+index c7e5d4279df924ed4067f4b74c36e1a4dd0ccbad..dd04f885d1a9ecb9ad9fc743792fa32df7e7e1c4 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Fox.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Fox.java
 @@ -897,7 +897,7 @@ public class Fox extends Animal implements VariantHolder<Fox.Type> {
@@ -220,7 +220,7 @@ index 25a429a2d1725d562a28b9d07dba630cfe49d32a..f8283405b3c5bd43746a5738be55f600
  
              if (this.dragonFight != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-index 243eb1e54293c763a06febff551c051398d43535..79fdc8284f57a4f11e1954936ad574f7b8df5435 100644
+index ec2f1f1a2e12048a6c8b38cf787374218509306f..ae149663ecd46489066223bf325bc2fb8a37e4af 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
 @@ -634,7 +634,7 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
@@ -233,7 +233,7 @@ index 243eb1e54293c763a06febff551c051398d43535..79fdc8284f57a4f11e1954936ad574f7
  
      }
 diff --git a/src/main/java/net/minecraft/world/entity/npc/WanderingTrader.java b/src/main/java/net/minecraft/world/entity/npc/WanderingTrader.java
-index 0f2e2e42e732e942664d70a72dd9c4e47c7e95b6..e51cb9c96e1bd13c00bf938436f4fc26d80055a1 100644
+index 922e8bdc52ce9e5720396406f97478730dc23c9c..5841aec10a9b0c102c64ecc45cef2967ceda6824 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/WanderingTrader.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/WanderingTrader.java
 @@ -207,7 +207,7 @@ public class WanderingTrader extends net.minecraft.world.entity.npc.AbstractVill
@@ -246,7 +246,7 @@ index 0f2e2e42e732e942664d70a72dd9c4e47c7e95b6..e51cb9c96e1bd13c00bf938436f4fc26
  
      }
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
-index ed43ad94ca007a54e3c32d5e17c141048eeb5835..0b4c67b9de6893601f032a8fae103e8a98f2c767 100644
+index 37f4120add02737e6efdc8979ab3a841abe2148a..ad3b9af306313060b8f2ccbd4874e8d0aee6135b 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 @@ -525,7 +525,7 @@ public class FishingHook extends Projectile {
@@ -259,7 +259,7 @@ index ed43ad94ca007a54e3c32d5e17c141048eeb5835..0b4c67b9de6893601f032a8fae103e8a
                      // CraftBukkit end
                      if (itemstack1.is(ItemTags.FISHES)) {
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownExperienceBottle.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownExperienceBottle.java
-index 9963db38420b91ae817a18ff084311cb45c0edee..70ceef96c6305324aef3b006f6603817ef187e9f 100644
+index ac8d4a1cc047b76cdaa93931282fbf1c3b07c15b..02377b4bbd4f3f11212bf8c372d3c86a6be443b6 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownExperienceBottle.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownExperienceBottle.java
 @@ -54,7 +54,7 @@ public class ThrownExperienceBottle extends ThrowableItemProjectile {
@@ -268,7 +268,7 @@ index 9963db38420b91ae817a18ff084311cb45c0edee..70ceef96c6305324aef3b006f6603817
  
 -            ExperienceOrb.award((ServerLevel) this.level(), this.position(), i);
 +            ExperienceOrb.award((ServerLevel) this.level(), this.position(), i, org.bukkit.entity.ExperienceOrb.SpawnReason.EXP_BOTTLE, this.getOwner(), this); // Paper
-             this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
+             this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
          }
  
 diff --git a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java

--- a/patches/server/0133-PlayerPickupItemEvent-setFlyAtPlayer.patch
+++ b/patches/server/0133-PlayerPickupItemEvent-setFlyAtPlayer.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] PlayerPickupItemEvent#setFlyAtPlayer
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index 759c246540bbd5cb99c78a722c39b72fbc1951d4..f51f04758e135294bab5c7d1f891a8d67fea78f5 100644
+index 3aed8b373d8e923d2c3fbb3528c68cdf3d62dfda..78865d3a8fe07f40d53155506a6a75b2c4349720 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 @@ -436,6 +436,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
@@ -38,4 +38,4 @@ index 759c246540bbd5cb99c78a722c39b72fbc1951d4..f51f04758e135294bab5c7d1f891a8d6
 +                if (flyAtPlayer) // Paper - PlayerPickupItemEvent
                  player.take(this, i);
                  if (itemstack.isEmpty()) {
-                     this.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
+                     this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent

--- a/patches/server/0141-Entity-fromMobSpawner.patch
+++ b/patches/server/0141-Entity-fromMobSpawner.patch
@@ -64,7 +64,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index df6da730134da754d0ff23bd1b57c82486b9ab73..69b5946625a53a1351ffc4bdf61c6874949bbeae 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1010,4 +1010,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1009,4 +1009,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return originVector.toLocation(world);
      }
      // Paper end - entity origin API

--- a/patches/server/0163-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0163-Ability-to-apply-mending-to-XP-API.patch
@@ -42,7 +42,7 @@ index f53504221e660bfe86220a8cc1ae28750794f0cf..93550342c6f181b7622f5d649cd3e507
 +            int i = Math.min(possibleDurabilityFromXp, itemstack.getDamageValue());
 +            org.bukkit.event.player.PlayerItemMendEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerItemMendEvent(handle, orb, itemstack, stackEntry.get().inSlot(), i);
 +            i = event.getRepairAmount();
-+            orb.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN);
++            orb.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN);
 +            if (!event.isCancelled()) {
 +                amount -= i * amount / possibleDurabilityFromXp;
 +                itemstack.setDamageValue(itemstack.getDamageValue() - i);

--- a/patches/server/0192-WitchReadyPotionEvent.patch
+++ b/patches/server/0192-WitchReadyPotionEvent.patch
@@ -25,7 +25,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b
 index 91180d7ad705ca97c0df43debc14b204127165d0..e3af0db8082e4e90902197f96f1c833405bf5f63 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1976,4 +1976,14 @@ public class CraftEventFactory {
+@@ -1989,4 +1989,14 @@ public class CraftEventFactory {
          ).callEvent();
      }
      // Paper end - PlayerUseUnknownEntityEvent

--- a/patches/server/0196-Fix-CraftEntity-hashCode.patch
+++ b/patches/server/0196-Fix-CraftEntity-hashCode.patch
@@ -21,10 +21,10 @@ check is essentially the same as this.getHandle() == other.getHandle()
 However, replaced it too to make it clearer of intent.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 69b5946625a53a1351ffc4bdf61c6874949bbeae..bddf98bdf60473eb1d2e533cf533ed7eee797aaa 100644
+index 2ab879c05604312199126c0f51902f37742b2712..e46b0c85798a194a7e928999faf7a5776ebf27ef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -502,14 +502,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -501,14 +501,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
              return false;
          }
          final CraftEntity other = (CraftEntity) obj;

--- a/patches/server/0202-Add-entity-knockback-events.patch
+++ b/patches/server/0202-Add-entity-knockback-events.patch
@@ -225,7 +225,7 @@ index d6bbeaf3833a4c44ed05243445edd813e3f15dcb..1b13096da1f0bc49efe25677ec24e6ab
                                      Level world = this.level();
  
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-index 230040bef7d2cf9a463cfd9cb3b1b1aa208a7119..6c79997ba46e641de5aa12ff8a3d790d04a5a475 100644
+index 8b79944f80279339a27f64001572a87dca93d01a..49c339d84f7f8d4ffa11504bed24553af2cc0435 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 @@ -519,7 +519,7 @@ public abstract class AbstractArrow extends Projectile {
@@ -238,7 +238,7 @@ index 230040bef7d2cf9a463cfd9cb3b1b1aa208a7119..6c79997ba46e641de5aa12ff8a3d790d
          }
  
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/windcharge/AbstractWindCharge.java b/src/main/java/net/minecraft/world/entity/projectile/windcharge/AbstractWindCharge.java
-index de2bc78415ab4efb651030be6560d9c9778a1d17..1e00df3fa3c3b61daa3d59ee1173269a6eae3a43 100644
+index bea9ef6fdd9a45ef1f4893643035d9fd9d3e967b..03de16a6024dbdffcf2efc4a5add79fa16b5eb9b 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/windcharge/AbstractWindCharge.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/windcharge/AbstractWindCharge.java
 @@ -103,7 +103,7 @@ public abstract class AbstractWindCharge extends AbstractHurtingProjectile imple
@@ -315,5 +315,5 @@ index e3af0db8082e4e90902197f96f1c833405bf5f63..3059a21b554db99af96c76f72dd08591
      }
 +    // Paper end - replace knockback events
  
-     public static void callEntityRemoveEvent(Entity entity, EntityRemoveEvent.Cause cause) {
-         if (entity instanceof ServerPlayer) {
+     // Paper start - EntityRemoveFromWorldEvent
+     public static void callEntityRemoveEvent(Entity entity, Entity.RemovalReason removalReason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) {

--- a/patches/server/0211-EnderDragon-Events.patch
+++ b/patches/server/0211-EnderDragon-Events.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] EnderDragon Events
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonSittingFlamingPhase.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonSittingFlamingPhase.java
-index 3eaf64a6f66c6a844e30967e6b87432e559a59e7..5c5c71db73a2bfebbb33cebd6325a0f4fef1f239 100644
+index 32ab046a98ed888e98fc0174b7315c8c79b76ebd..870bb6d252981fccebc02605b859dce513aa21ea 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonSittingFlamingPhase.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonSittingFlamingPhase.java
 @@ -88,7 +88,13 @@ public class DragonSittingFlamingPhase extends AbstractDragonSittingPhase {
@@ -37,7 +37,7 @@ index e5c896409536b7fb908590d02e40923d5979841f..a28e6b6a50cfd9191732ad2e4aca5f63
                          if (this.currentPath != null) {
                              while (!this.currentPath.isDone()) {
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/DragonFireball.java b/src/main/java/net/minecraft/world/entity/projectile/DragonFireball.java
-index 3c77515f6b7f1ff89325afba214e9a8e5f536158..1dade7a4fbdf190661e4431496349444467509cc 100644
+index 68b51a30587d00bb2bcbb645710e93ccd79fba46..89c8aae3dbd77fd07299159155fca3d4f8cf265c 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/DragonFireball.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/DragonFireball.java
 @@ -63,8 +63,10 @@ public class DragonFireball extends AbstractHurtingProjectile {
@@ -48,6 +48,6 @@ index 3c77515f6b7f1ff89325afba214e9a8e5f536158..1dade7a4fbdf190661e4431496349444
                  this.level().levelEvent(2006, this.blockPosition(), this.isSilent() ? -1 : 1);
                  this.level().addFreshEntity(entityareaeffectcloud);
 +                } else entityareaeffectcloud.discard(null); // Paper - EnderDragon Events
-                 this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
+                 this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
              }
  

--- a/patches/server/0242-Improve-death-events.patch
+++ b/patches/server/0242-Improve-death-events.patch
@@ -268,7 +268,7 @@ index 25a71cc5ca8cf8a5070cd24eb56fe0d79e765669..b46572f6e3b52f498b395d3b8c5def2a
              }
          }
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Fox.java b/src/main/java/net/minecraft/world/entity/animal/Fox.java
-index a6788da1505f9e119c03b94488f5e006da13e918..e46c8231ee318eda0512afbb6343b426b4838643 100644
+index dd04f885d1a9ecb9ad9fc743792fa32df7e7e1c4..2fa31978a4f181608b2b6c540de7db1635a5cef5 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Fox.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Fox.java
 @@ -704,16 +704,38 @@ public class Fox extends Animal implements VariantHolder<Fox.Type> {
@@ -336,7 +336,7 @@ index 767817fb1418958c89d0db9da4ae7eb8a5a16076..5654c614f07f07ff642ba4851b0cb6fa
      @Override
      public void addAdditionalSaveData(CompoundTag nbt) {
 diff --git a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
-index ee3902cbada46ffb78c42dbf6f00c859546c76e1..92bb0c63330ad3a4cb13b2dc655020714e9b1ffd 100644
+index 7f5c374f13ba86acb3e12bedb92665753842bcf5..16ec47a4b47e25a34304fe8ca58d6cd659d01222 100644
 --- a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
 +++ b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
 @@ -505,8 +505,10 @@ public class ArmorStand extends LivingEntity {
@@ -359,7 +359,7 @@ index ee3902cbada46ffb78c42dbf6f00c859546c76e1..92bb0c63330ad3a4cb13b2dc65502071
 -                                    this.brokenByPlayer(worldserver, source);
 +                                    org.bukkit.event.entity.EntityDeathEvent event = this.brokenByPlayer(worldserver, source); // Paper
                                      this.showBreakingParticles();
--                                    this.discard(EntityRemoveEvent.Cause.DEATH); // CraftBukkit - SPIGOT-4890: remain as this.discard() since above damagesource method will call death event
+-                                    this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - SPIGOT-4890: remain as this.discard() since above damagesource method will call death event // Paper - EntityRemoveFromWorldEvent
 +                                    if (!event.isCancelled()) this.kill(source, false); // Paper - we still need to kill to follow vanilla logic (emit the game event etc...)
                                  }
  
@@ -419,7 +419,7 @@ index ee3902cbada46ffb78c42dbf6f00c859546c76e1..92bb0c63330ad3a4cb13b2dc65502071
 +            if (event.isCancelled()) return;
 +        }
 +        // Paper end
-         this.remove(Entity.RemovalReason.KILLED, EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
+         this.remove(Entity.RemovalReason.KILLED, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
          // CraftBukkit end
          this.gameEvent(GameEvent.ENTITY_DIE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java

--- a/patches/server/0280-Fixes-and-additions-to-the-spawn-reason-API.patch
+++ b/patches/server/0280-Fixes-and-additions-to-the-spawn-reason-API.patch
@@ -138,7 +138,7 @@ index 146cbec9e64b6c77759aadd0d0c4e989018e9aef..4c4545b3732d4c08afdb7bc1913169a9
              level.gameEvent(entity, GameEvent.ENTITY_PLACE, this.position());
              this.setItem(ItemStack.EMPTY);
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/DragonFireball.java b/src/main/java/net/minecraft/world/entity/projectile/DragonFireball.java
-index 1dade7a4fbdf190661e4431496349444467509cc..3e869620db35d38db39fbeed715b898ef9d2743c 100644
+index 8d2a9cb0a4dc6d8f134213abf3a094e55e67474b..65ab90ec9a24e12225be57c6b10b93a8d65438f9 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/DragonFireball.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/DragonFireball.java
 @@ -65,7 +65,7 @@ public class DragonFireball extends AbstractHurtingProjectile {
@@ -148,7 +148,7 @@ index 1dade7a4fbdf190661e4431496349444467509cc..3e869620db35d38db39fbeed715b898e
 -                this.level().addFreshEntity(entityareaeffectcloud);
 +                this.level().addFreshEntity(entityareaeffectcloud, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.EXPLOSION); // Paper - use correct spawn reason
                  } else entityareaeffectcloud.discard(null); // Paper - EnderDragon Events
-                 this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
+                 this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
              }
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
 index ee897b8c9462dbb3d7be9a2994753155065ce205..1d0964a7f544735a0213d5c7832c71f53db139a9 100644
@@ -214,10 +214,10 @@ index c3f6522a7dc0777c5b3fa2bac63a8901f96d9f38..9b336f651ead8111a0b2c0fedad9331f
                              if (org.bukkit.craftbukkit.event.CraftEventFactory.callTrialSpawnerSpawnEvent(entity, pos).isCancelled()) {
                                  return Optional.empty();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index bddf98bdf60473eb1d2e533cf533ed7eee797aaa..ce70c8fddbe63d0af2b1f988ce9a2b40c5d48066 100644
+index e46b0c85798a194a7e928999faf7a5776ebf27ef..8f8ff10ec0e3543dbd3baa9529241819caf2441f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1018,4 +1018,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1017,4 +1017,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.getHandle().spawnedViaMobSpawner;
      }
      // Paper end - Entity#fromMobSpawner

--- a/patches/server/0300-Duplicate-UUID-Resolve-Option.patch
+++ b/patches/server/0300-Duplicate-UUID-Resolve-Option.patch
@@ -77,7 +77,7 @@ index 82fc5133325a127890984d51c1381883759eb444..ae16cf5c803caae636860dd9b1a83abe
 +                    break;
 +                }
 +                case DELETE: {
-+                    entity.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DISCARD);
++                    entity.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DISCARD);
 +                    return true;
 +                }
 +                default:

--- a/patches/server/0355-ExperienceOrb-merging-stacking-API-and-fixes.patch
+++ b/patches/server/0355-ExperienceOrb-merging-stacking-API-and-fixes.patch
@@ -21,7 +21,7 @@ Co-authored-by: Aikar <aikar@aikar.co>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
-index 0916e24271d07ad5db51c5bc68791722b0f69c2b..a758b2456acac23095fe4619ae10300a034cb460 100644
+index 3957988d213716258e72b4708acc08ec1cdf0f27..2b3ecec18a1e0a1ac4057b4f72e6b45488f9aa06 100644
 --- a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 +++ b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 @@ -244,6 +244,7 @@ public class ExperienceOrb extends Entity {
@@ -43,7 +43,7 @@ index 0916e24271d07ad5db51c5bc68791722b0f69c2b..a758b2456acac23095fe4619ae10300a
 +        // Paper end - call orb merge event
          this.count += other.count;
          this.age = Math.min(this.age, other.age);
-         other.discard(EntityRemoveEvent.Cause.MERGE); // CraftBukkit - add Bukkit remove cause
+         other.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.MERGE); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
 @@ -360,7 +366,7 @@ public class ExperienceOrb extends Entity {
                  int l = amount - k * amount / j;
  

--- a/patches/server/0381-Add-entity-liquid-API.patch
+++ b/patches/server/0381-Add-entity-liquid-API.patch
@@ -8,10 +8,10 @@ public net.minecraft.world.entity.Entity isInRain()Z
 public net.minecraft.world.entity.Entity isInBubbleColumn()Z
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index ce70c8fddbe63d0af2b1f988ce9a2b40c5d48066..34321f095e12ea0cca34ff1ec00819c6350205a8 100644
+index c5f15ff7f6af20a1c068a7068e54c21f34ab685a..ac0b1cbb6c8356061757673f868912dcc80d234d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1025,4 +1025,41 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1024,4 +1024,41 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return getHandle().spawnReason;
      }
      // Paper end - entity spawn reason API

--- a/patches/server/0407-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0407-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -81,10 +81,10 @@ index b90127f9f805fdb5bb43a4b8ad2b10499b0b6b78..8efc06d29c62fa2be8515ed3359d52a6
                          if (entity instanceof Mob) {
                              Mob entityinsentient = (Mob) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 34321f095e12ea0cca34ff1ec00819c6350205a8..5f5788a502642463091fb76e98703aaec7a86836 100644
+index ac0b1cbb6c8356061757673f868912dcc80d234d..6b27f7c2d2120cbefe9a05a2e5d56e0c6fa571db 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -240,7 +240,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -239,7 +239,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          }
  
          // entity.setLocation() throws no event, and so cannot be cancelled

--- a/patches/server/0413-Entity-isTicking.patch
+++ b/patches/server/0413-Entity-isTicking.patch
@@ -19,10 +19,10 @@ index c01a9305eb1c3e2ee5effab1e11980c2540d3c2a..6ab665efcac4c2543bab9d95472026e0
      // Paper end - Expose entity id counter
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 5f5788a502642463091fb76e98703aaec7a86836..98e8ad81b8c9c0636abe59f70ce891fe926a37fe 100644
+index 6b27f7c2d2120cbefe9a05a2e5d56e0c6fa571db..0dbcca0080b8e9dceafc57acd7fbcac78c208c0c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1062,4 +1062,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1061,4 +1061,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return getHandle().isInLava();
      }
      // Paper end - entity liquid API

--- a/patches/server/0463-Add-BlockFailedDispenseEvent.patch
+++ b/patches/server/0463-Add-BlockFailedDispenseEvent.patch
@@ -35,7 +35,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b
 index 24fcb0eb139174671ffb7a8e5222ec9833835f87..9e67dc35ea12149265517b951a96828460b2ca67 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2127,4 +2127,12 @@ public class CraftEventFactory {
+@@ -2140,4 +2140,12 @@ public class CraftEventFactory {
          return org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getPotion());
      }
      // Paper end - WitchReadyPotionEvent

--- a/patches/server/0469-Fix-villager-boat-exploit.patch
+++ b/patches/server/0469-Fix-villager-boat-exploit.patch
@@ -20,6 +20,6 @@ index 98eb00a8ee23543714d424d3ff5ca19887d6db19..9436a9614dea81d14c4f77cc21ca91f8
 +                        }
 +                    }
 +                    // Paper end - Fix villager boat exploit
-                     entity1.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, EntityRemoveEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause
+                     entity1.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
                  });
              }

--- a/patches/server/0477-Add-BlockPreDispenseEvent.patch
+++ b/patches/server/0477-Add-BlockPreDispenseEvent.patch
@@ -32,7 +32,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b
 index 9e67dc35ea12149265517b951a96828460b2ca67..251b605396b77b0c449972c1da75978f57587e1a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2134,5 +2134,11 @@ public class CraftEventFactory {
+@@ -2147,5 +2147,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0481-Expand-EntityUnleashEvent.patch
+++ b/patches/server/0481-Expand-EntityUnleashEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expand EntityUnleashEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7d131f3b3f5739468aa3115e97ed28b6bfeca33d..da184893d617311a43f9ce176a965f8417a2876d 100644
+index ce56ccbb116623f2803aed5f43f4be5d04f20fc5..76d83911dd1410520ba63d6a85da9dd17fe94c2b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2574,12 +2574,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -80,7 +80,7 @@ index 5c51dd5229689cba459655d488aee59bd159a414..e7535f15be3cc1537aafee53779ccfb4
  
      default void closeRangeLeashBehaviour(Entity entity) {}
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index b46572f6e3b52f498b395d3b8c5def2aa799ff03..e87360e21e6eb7b0161c34a3ac6cb83d18bcd1e8 100644
+index 14678e655da654cef8cb8f9faff6372b7c03b17f..dd1ede91e65f3b2301cac3bdec39b76e0078b453 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -1621,8 +1621,11 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
@@ -115,7 +115,7 @@ index bf2c9134c7d9d5926add36b55e3cfea79e8c8243..7b7bc1a205dfacbe5709011b6b6799e7
  
              return false;
 diff --git a/src/main/java/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java b/src/main/java/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java
-index 3c0af74ed65610b1d5e3b72fdcf28c5a3423f0da..01173fc7177d78588978e087e63efda0b0527c2f 100644
+index cdc454055306b7a2e2a4be24207137b99b555d7d..30deb6f319983b0a4899fce3976927c92debb341 100644
 --- a/src/main/java/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java
 @@ -118,13 +118,18 @@ public class LeashFenceKnotEntity extends BlockAttachedEntity {
@@ -140,7 +140,7 @@ index 3c0af74ed65610b1d5e3b72fdcf28c5a3423f0da..01173fc7177d78588978e087e63efda0
                              flag1 = true;
                          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 251b605396b77b0c449972c1da75978f57587e1a..c48a9026c4db2005b67c5f70e9e1fa95b7820bc0 100644
+index a3613495df7c712fdcc2a97b06132e1483556fcc..97a9db439699a35bc1858c14cc4d6b7a3e953a83 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1598,8 +1598,10 @@ public class CraftEventFactory {

--- a/patches/server/0492-Expose-Tracked-Players.patch
+++ b/patches/server/0492-Expose-Tracked-Players.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index 98e8ad81b8c9c0636abe59f70ce891fe926a37fe..96201ea45f8b53dcadb1a8732b1d49b1e8d1d7df 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1069,4 +1069,21 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1068,4 +1068,21 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return getHandle().isTicking();
      }
      // Paper end - isTicking API

--- a/patches/server/0554-Fix-potions-splash-events.patch
+++ b/patches/server/0554-Fix-potions-splash-events.patch
@@ -8,7 +8,7 @@ Fixes SPIGOT-6221: https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-6
 Fix splash events cancellation that still show particles/sound
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
-index be787a5b52e90796d4f06e17e564f4324807c3e6..cb34cc9443da56c0497c7a0192c8b8363c3426fe 100644
+index f3c008de4ac3def173b63059e71b03ff1a001f6b..b3a4756ded5e48261b5cfa91af9d80e3b46506f0 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 @@ -106,55 +106,76 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
@@ -34,7 +34,7 @@ index be787a5b52e90796d4f06e17e564f4324807c3e6..cb34cc9443da56c0497c7a0192c8b836
  
              this.level().levelEvent(i, this.blockPosition(), potioncontents.getColor());
 +            } // Paper - Fix potions splash events
-             this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
+             this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
          }
      }
  

--- a/patches/server/0557-Missing-Entity-API.patch
+++ b/patches/server/0557-Missing-Entity-API.patch
@@ -146,7 +146,7 @@ index 615b57fac9def18d9dcaefcfe397c74c11cac627..f933654b66f7474dc071da5f10cf1684
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/animal/frog/Tadpole.java b/src/main/java/net/minecraft/world/entity/animal/frog/Tadpole.java
-index b06d39d3bd39a4dc4f273a359a89592d3b8cf184..43046f4a0cff620834ac4647efdcde227185b2ff 100644
+index 81abf1ce26432afa1598f3b8f5e34c80289f639d..bd1f01deec9b0842fff67d7e25d4569c42316be4 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/frog/Tadpole.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/frog/Tadpole.java
 @@ -50,6 +50,7 @@ public class Tadpole extends AbstractFish {
@@ -264,7 +264,7 @@ index 8afd453deda455bd486c9a4a69790151f5012f62..33b7e578f39608d522a9c270cac69be4
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
-index 3ee24382ef3614ff0c5d5cdc614a41286ba4af5e..3cd4a744c3e3aeba90f342de9dea67ef2f3de626 100644
+index 6f079d4d344d3421bccfe60ad8b014687b79c061..76b4340e9c7988c23967f53a495043a2abfb9622 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 @@ -88,6 +88,11 @@ public class WitherBoss extends Monster implements PowerableMob, RangedAttackMob
@@ -353,7 +353,7 @@ index 9cf453248b6ee9e1af9f5945b1e515a9ad7ff236..f8c733961015ace508bfe14fd61d5188
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownTrident.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownTrident.java
-index 46b67c38dccf911973e6a7643f06972019073eb2..e45c3a9805d9fac1fabe6d891c817743acd9969e 100644
+index 41b9c8bbb3f31cd29ad4c0ba524311a253123cbe..08447cf5e0f978c52f1413bf5a9cc991e38f8e5c 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownTrident.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownTrident.java
 @@ -106,6 +106,20 @@ public class ThrownTrident extends AbstractArrow {
@@ -708,7 +708,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index 96201ea45f8b53dcadb1a8732b1d49b1e8d1d7df..7c04eb9e7eb5ff728465b46e3739eb2598ef1204 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1086,4 +1086,27 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1085,4 +1085,27 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return set;
      }
      // Paper end - tracked players API

--- a/patches/server/0593-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0593-Add-Raw-Byte-Entity-Serialization.patch
@@ -30,7 +30,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index 7c04eb9e7eb5ff728465b46e3739eb2598ef1204..6fab713531665298d3b03e7960a17ecb1471a6d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1087,6 +1087,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1086,6 +1086,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      }
      // Paper end - tracked players API
  

--- a/patches/server/0638-Entity-powdered-snow-API.patch
+++ b/patches/server/0638-Entity-powdered-snow-API.patch
@@ -10,7 +10,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index 6fab713531665298d3b03e7960a17ecb1471a6d7..4ed5647101bbace0005b1ebfb824e4aed48e43cb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1099,6 +1099,13 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1098,6 +1098,13 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      }
      // Paper end - raw entity serialization API
  

--- a/patches/server/0639-Add-API-for-item-entity-health.patch
+++ b/patches/server/0639-Add-API-for-item-entity-health.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add API for item entity health
 public net.minecraft.world.entity.item.ItemEntity health
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
-index 4a15c3786edbfeae3367c0b20fb6aee11d62aea6..1a291dd8a287db30e71dcb315599fc4b038764c4 100644
+index 4a15c3786edbfeae3367c0b20fb6aee11d62aea6..dc0656ceec4e77f38ab7a9f2de8a7b24deec4837 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
 @@ -98,6 +98,21 @@ public class CraftItem extends CraftEntity implements Item {
@@ -24,7 +24,7 @@ index 4a15c3786edbfeae3367c0b20fb6aee11d62aea6..1a291dd8a287db30e71dcb315599fc4b
 +    public void setHealth(int health) {
 +        if (health <= 0) {
 +            this.getHandle().getItem().onDestroyed(this.getHandle());
-+            this.getHandle().discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.PLUGIN);
++            this.getHandle().discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PLUGIN);
 +        } else {
 +            this.getHandle().health = health;
 +        }

--- a/patches/server/0655-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0655-Freeze-Tick-Lock-API.patch
@@ -62,7 +62,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index 4ed5647101bbace0005b1ebfb824e4aed48e43cb..4c09f2529dd8eb7ac7d260d177f5292ff2339442 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -323,6 +323,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -322,6 +322,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.getHandle().isFullyFrozen();
      }
  

--- a/patches/server/0721-More-Teleport-API.patch
+++ b/patches/server/0721-More-Teleport-API.patch
@@ -32,7 +32,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index 4c09f2529dd8eb7ac7d260d177f5292ff2339442..94051ae8ea93ab144f3767345b1cda0438d2afc6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -221,15 +221,36 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -220,15 +220,36 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
  
      @Override
      public boolean teleport(Location location, TeleportCause cause) {
@@ -71,7 +71,7 @@ index 4c09f2529dd8eb7ac7d260d177f5292ff2339442..94051ae8ea93ab144f3767345b1cda04
  
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
-@@ -975,6 +996,39 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -974,6 +995,39 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return CraftEntity.perm;
      }
  

--- a/patches/server/0728-Collision-API.patch
+++ b/patches/server/0728-Collision-API.patch
@@ -25,7 +25,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index 94051ae8ea93ab144f3767345b1cda0438d2afc6..f950102a324d07aeba260bfa82fe88728f2362e5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1193,4 +1193,20 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1192,4 +1192,20 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.getHandle().noPhysics;
      }
      // Paper end - missing entity api

--- a/patches/server/0748-EntityPickupItemEvent-fixes.patch
+++ b/patches/server/0748-EntityPickupItemEvent-fixes.patch
@@ -40,7 +40,7 @@ index d3d50ec0f4466464c048449d8a844569c447d59b..b9810a1f6ac91ae9631dd1ebc225f009
 +            // Paper end - EntityPickupItemEvent fixes
              piglin.take(drop, drop.getItem().getCount());
              itemstack = drop.getItem();
-             drop.discard(EntityRemoveEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause
+             drop.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.PICKUP); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
          } else if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityPickupItemEvent(piglin, drop, drop.getItem().getCount() - 1, false).isCancelled()) {
 +            piglin.onItemPickup(drop); // Paper - EntityPickupItemEvent fixes; moved from Piglin#pickUpItem - call prior to item entity modification
              piglin.take(drop, 1);
@@ -56,7 +56,7 @@ index d3d50ec0f4466464c048449d8a844569c447d59b..b9810a1f6ac91ae9631dd1ebc225f009
              if (!flag) {
                  PiglinAi.putInInventory(piglin, itemstack);
 diff --git a/src/main/java/net/minecraft/world/entity/raid/Raider.java b/src/main/java/net/minecraft/world/entity/raid/Raider.java
-index 174d246b0a4d0fc9d769aad08da627ca8487bdf2..bbf21ea433f9e3963aac0ede597ed8d3c8e50ed8 100644
+index b319ce7d8e09ed8325e3ba0d1ab0c84574938d92..c5d584922b0924e7cd5550637a2d30741c18e64d 100644
 --- a/src/main/java/net/minecraft/world/entity/raid/Raider.java
 +++ b/src/main/java/net/minecraft/world/entity/raid/Raider.java
 @@ -225,6 +225,11 @@ public abstract class Raider extends PatrollingMonster {

--- a/patches/server/0766-check-global-player-list-where-appropriate.patch
+++ b/patches/server/0766-check-global-player-list-where-appropriate.patch
@@ -10,7 +10,7 @@ diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/mai
 index 4bf6281a75597072b19658208e4447c4d1ee8ba2..688f9f13ae06337250e2e9ac2ddf9ad90d049f9b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2302,4 +2302,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2310,4 +2310,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
              entity.updateDynamicGameEventListener(DynamicGameEventListener::move);
          }
      }

--- a/patches/server/0779-Add-Sneaking-API-for-Entities.patch
+++ b/patches/server/0779-Add-Sneaking-API-for-Entities.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index f950102a324d07aeba260bfa82fe88728f2362e5..ac513d3162a0794f226abc80bff21c799fe5802c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -874,6 +874,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -873,6 +873,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return Pose.values()[this.getHandle().getPose().ordinal()];
      }
  

--- a/patches/server/0793-Add-Entity-Body-Yaw-API.patch
+++ b/patches/server/0793-Add-Entity-Body-Yaw-API.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index ac513d3162a0794f226abc80bff21c799fe5802c..7c7501b4b21530d0641774f64e87d7d1ca71a33c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1183,6 +1183,33 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1182,6 +1182,33 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      }
      // Paper end - entity powdered snow API
  

--- a/patches/server/0795-Add-EntityFertilizeEggEvent.patch
+++ b/patches/server/0795-Add-EntityFertilizeEggEvent.patch
@@ -72,7 +72,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b
 index b6cca72b4785d5cf009077c81c1cca718d8cfe28..a0b387ddf3cc1e3473c6b35175ac8b68c717cfbe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2197,4 +2197,28 @@ public class CraftEventFactory {
+@@ -2210,4 +2210,28 @@ public class CraftEventFactory {
          return event.callEvent();
      }
      // Paper end

--- a/patches/server/0815-Expand-PlayerItemMendEvent.patch
+++ b/patches/server/0815-Expand-PlayerItemMendEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expand PlayerItemMendEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
-index a758b2456acac23095fe4619ae10300a034cb460..a58ff67052fb5f33782f8b5c83465ec03ef1d073 100644
+index 2b3ecec18a1e0a1ac4057b4f72e6b45488f9aa06..ed17a307b050d7ccaef02a027d28ce1a9983e484 100644
 --- a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 +++ b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 @@ -354,7 +354,10 @@ public class ExperienceOrb extends Entity {
@@ -41,7 +41,7 @@ index 06a3ccb90f23fc357e5cbc6e9173baab4b218955..3945a6ab723deee3ec3ebb5fbc726ce1
 +            final int consumedExperience = i * amount / possibleDurabilityFromXp; // Paper - taken from ExperienceOrb#repairPlayerItems
 +            org.bukkit.event.player.PlayerItemMendEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerItemMendEvent(handle, orb, itemstack, stackEntry.get().inSlot(), i, consumedExperience);
              i = event.getRepairAmount();
-             orb.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN);
+             orb.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN);
              if (!event.isCancelled()) {
 -                amount -= i * amount / possibleDurabilityFromXp;
 +                amount -= consumedExperience; // Use previously computed variable to reduce diff on change.

--- a/patches/server/0830-Call-missing-BlockDispenseEvent.patch
+++ b/patches/server/0830-Call-missing-BlockDispenseEvent.patch
@@ -53,7 +53,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b
 index 9586837f25464396c0695e87fa278c91ca90183a..9b3023fdda9d08c0f5489542f644e2ea311af191 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2198,6 +2198,32 @@ public class CraftEventFactory {
+@@ -2211,6 +2211,32 @@ public class CraftEventFactory {
      }
      // Paper end
  

--- a/patches/server/0843-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/server/0843-Folia-scheduler-and-owned-region-API.patch
@@ -1214,8 +1214,8 @@ index 37f37df8b4185c92c13e43eb89d19514e360059e..33ac5c816c98c2dfa99898279ed74d42
      public CommandSender getBukkitSender(CommandSourceStack wrapper) {
          return this.getBukkitEntity();
 @@ -4486,6 +4498,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
-     public final void setRemoved(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
-         CraftEventFactory.callEntityRemoveEvent(this, cause);
+     public final void setRemoved(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
+         CraftEventFactory.callEntityRemoveEvent(this, entity_removalreason, cause); // Paper - EntityRemoveFromWorldEvent
          // CraftBukkit end
 +        final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
          if (this.removalReason == null) {
@@ -1335,7 +1335,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index 7c7501b4b21530d0641774f64e87d7d1ca71a33c..d3ff8015b2f713451b0aeb50e1b4cf81f2bcb7bc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -70,6 +70,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -69,6 +69,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      private EntityDamageEvent lastDamageEvent;
      private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftEntity.DATA_TYPE_REGISTRY);
      protected net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
@@ -1351,7 +1351,7 @@ index 7c7501b4b21530d0641774f64e87d7d1ca71a33c..d3ff8015b2f713451b0aeb50e1b4cf81
  
      public CraftEntity(final CraftServer server, final Entity entity) {
          this.server = server;
-@@ -486,6 +495,12 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -485,6 +494,12 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.entity;
      }
  

--- a/patches/server/0856-API-for-an-entity-s-scoreboard-name.patch
+++ b/patches/server/0856-API-for-an-entity-s-scoreboard-name.patch
@@ -10,7 +10,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index d3ff8015b2f713451b0aeb50e1b4cf81f2bcb7bc..3626fea17527da69e6fbee26f018f52ef036cf90 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1263,4 +1263,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1262,4 +1262,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return !this.getHandle().level().noCollision(this.getHandle(), aabb);
      }
      // Paper end - Collision API

--- a/patches/server/0860-Fire-entity-death-event-for-ender-dragon.patch
+++ b/patches/server/0860-Fire-entity-death-event-for-ender-dragon.patch
@@ -21,6 +21,6 @@ index 6306f7925ac4852d8eed7508a11764c636dd7d36..5868d2e9e05a698c77117cf87c79b636
 +        }
 +        // Paper end - Fire entity death event
 +
-         this.remove(Entity.RemovalReason.KILLED, EntityRemoveEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause
+         this.remove(Entity.RemovalReason.KILLED, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DEATH); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
          this.gameEvent(GameEvent.ENTITY_DIE);
          if (this.dragonFight != null) {

--- a/patches/server/0866-Expand-Pose-API.patch
+++ b/patches/server/0866-Expand-Pose-API.patch
@@ -28,7 +28,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index 3626fea17527da69e6fbee26f018f52ef036cf90..580427bf1521ac9fef37f7464e12a7bfe4fbfb10 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -899,6 +899,20 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -898,6 +898,20 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean isSneaking() {
          return this.getHandle().isShiftKeyDown();
      }

--- a/patches/server/0905-Fix-missing-event-call-for-entity-teleport-API.patch
+++ b/patches/server/0905-Fix-missing-event-call-for-entity-teleport-API.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index 580427bf1521ac9fef37f7464e12a7bfe4fbfb10..9ca1fee03bfa557f1df7388c6043c9ec6d02a79a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -258,6 +258,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -257,6 +257,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
              return false;
          }
  

--- a/patches/server/0916-Add-drops-to-shear-events.patch
+++ b/patches/server/0916-Add-drops-to-shear-events.patch
@@ -44,7 +44,7 @@ index 5e8cc5cfac8888628c6d513148f41be09ca65a2c..2ee48ac3b665db2b02bcb1a30ec972d4
 +    // Paper end - custom shear drops
  }
 diff --git a/src/main/java/net/minecraft/world/entity/animal/MushroomCow.java b/src/main/java/net/minecraft/world/entity/animal/MushroomCow.java
-index aa125e3043b120935aaa015803f065f99eb8d050..0c21959f57ae88fcd0a4d6dc911c1ce347c96528 100644
+index 514b961f94e9239b7879a98df789c8fa396d25bf..dac0a9d5118cf5f1f7c74c087c35b527c6e2dec0 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/MushroomCow.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/MushroomCow.java
 @@ -123,11 +123,18 @@ public class MushroomCow extends Cow implements Shearable, VariantHolder<Mushroo
@@ -93,7 +93,7 @@ index aa125e3043b120935aaa015803f065f99eb8d050..0c21959f57ae88fcd0a4d6dc911c1ce3
          if (!this.level().isClientSide()) {
              Cow entitycow = (Cow) EntityType.COW.create(this.level());
 @@ -193,17 +216,12 @@ public class MushroomCow extends Cow implements Shearable, VariantHolder<Mushroo
-                 this.discard(EntityRemoveEvent.Cause.TRANSFORMATION); // CraftBukkit - from above and add Bukkit remove cause
+                 this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.TRANSFORMATION); // CraftBukkit - from above and add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
                  // CraftBukkit end
  
 -                for (int i = 0; i < 5; ++i) {

--- a/patches/server/0942-Fix-DamageSource-API.patch
+++ b/patches/server/0942-Fix-DamageSource-API.patch
@@ -123,7 +123,7 @@ index 7bc612890f941177da11da0ce047d5a74d8ebb33..270acce7411e5ada71eaa04c05efc888
                  if (damager != null) {
                      event = new HangingBreakByEntityEvent((Hanging) this.getBukkitEntity(), damager.getBukkitEntity(), source.is(DamageTypeTags.IS_EXPLOSION) ? HangingBreakEvent.RemoveCause.EXPLOSION : HangingBreakEvent.RemoveCause.ENTITY);
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Creeper.java b/src/main/java/net/minecraft/world/entity/monster/Creeper.java
-index 9bf11a8b44e696b6587bc775904a836d390e437b..d1041f2a4f1b3ea29ad532006e18cdc30c5019fa 100644
+index 6ec47383b62b869f063368ff2088636c3f59ac08..64355b3ff97209961739a2671f60320271478ec8 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Creeper.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Creeper.java
 @@ -271,7 +271,7 @@ public class Creeper extends Monster implements PowerableMob {
@@ -134,9 +134,9 @@ index 9bf11a8b44e696b6587bc775904a836d390e437b..d1041f2a4f1b3ea29ad532006e18cdc3
 +            this.level().explode(this, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.MOB); // CraftBukkit // Paper - fix DamageSource API (revert to vanilla, no, just no, don't change this)
              this.spawnLingeringCloud();
              this.triggerOnDeathMobEffects(Entity.RemovalReason.KILLED);
-             this.discard(EntityRemoveEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause
+             this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/EvokerFangs.java b/src/main/java/net/minecraft/world/entity/projectile/EvokerFangs.java
-index c75433bb0fcd4264148950467bf6b700296aca7b..820965950c8b6c868ee261cf9613665e583f092e 100644
+index 932c2f8681e7a6a88bd1c66d8d498b24a3eb12a7..9c44d35c7b8d67b00c19c427cf2a3e5f5129aa35 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/EvokerFangs.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/EvokerFangs.java
 @@ -135,7 +135,7 @@ public class EvokerFangs extends Entity implements TraceableEntity {
@@ -149,7 +149,7 @@ index c75433bb0fcd4264148950467bf6b700296aca7b..820965950c8b6c868ee261cf9613665e
                  if (entityliving1.isAlliedTo((Entity) target)) {
                      return;
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
-index f43dd56182ced23cf1cf65c149c532a611cc933a..1aa5e57a4e6a4be60514d8808a2e6c973d93e798 100644
+index e53d9109d9033031d7f0f14281da3a190ab0146f..cdc0331b923a4099dc66d02f2333a1bcc4b699ae 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
 @@ -89,7 +89,7 @@ public class ThrownEnderpearl extends ThrowableItemProjectile {
@@ -162,7 +162,7 @@ index f43dd56182ced23cf1cf65c149c532a611cc933a..1aa5e57a4e6a4be60514d8808a2e6c97
                          }
                      } else {
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/WitherSkull.java b/src/main/java/net/minecraft/world/entity/projectile/WitherSkull.java
-index 60eac9df10a9a395a1568925515d010eb51a64e5..55fd997a4e894eeab24de269d59e486196ffbe8d 100644
+index 1ee5176e6e485898c57c2bab8f3cf718807b1f46..f2c4c2edd1f308acaa7a75f98eaba880c4b31c09 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/WitherSkull.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/WitherSkull.java
 @@ -77,7 +77,7 @@ public class WitherSkull extends AbstractHurtingProjectile {

--- a/patches/server/0981-Moonrise-optimisation-patches.patch
+++ b/patches/server/0981-Moonrise-optimisation-patches.patch
@@ -2177,7 +2177,7 @@ index 0000000000000000000000000000000000000000..5b092bca7027e37aeee8f4b852ad896d
 +}
 diff --git a/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..997b05167c19472acb98edac32d4548cc65efa8e
+index 0000000000000000000000000000000000000000..a94ad978faee586d1bc73fc5a438b7bb1b5a3c8d
 --- /dev/null
 +++ b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
 @@ -0,0 +1,819 @@
@@ -2185,6 +2185,7 @@ index 0000000000000000000000000000000000000000..997b05167c19472acb98edac32d4548c
 +
 +import ca.spottedleaf.moonrise.common.list.EntityList;
 +import ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity;
++import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 +import com.google.common.collect.ImmutableList;
 +import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 +import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
@@ -2209,7 +2210,6 @@ index 0000000000000000000000000000000000000000..997b05167c19472acb98edac32d4548c
 +import java.util.Iterator;
 +import java.util.List;
 +import java.util.function.Predicate;
-+import org.bukkit.event.entity.EntityRemoveEvent;
 +
 +public final class ChunkEntitySlices {
 +
@@ -2330,12 +2330,12 @@ index 0000000000000000000000000000000000000000..997b05167c19472acb98edac32d4548c
 +                continue;
 +            }
 +            if (entity.shouldBeSaved()) {
-+                entity.setRemoved(Entity.RemovalReason.UNLOADED_TO_CHUNK, EntityRemoveEvent.Cause.UNLOAD);
++                entity.setRemoved(Entity.RemovalReason.UNLOADED_TO_CHUNK, EntityRemoveFromWorldEvent.Cause.UNLOAD);
 +                if (entity.isVehicle()) {
 +                    // we cannot assume that these entities are contained within this chunk, because entities can
 +                    // desync - so we need to remove them all
 +                    for (final Entity passenger : entity.getIndirectPassengers()) {
-+                        passenger.setRemoved(Entity.RemovalReason.UNLOADED_TO_CHUNK, EntityRemoveEvent.Cause.UNLOAD);
++                        passenger.setRemoved(Entity.RemovalReason.UNLOADED_TO_CHUNK, EntityRemoveFromWorldEvent.Cause.UNLOAD);
 +                    }
 +                }
 +            }
@@ -27282,14 +27282,14 @@ index 76e9d34e5219fbae0095cf735b58833c29343573..6fe90b281c95062c0be14650c00b21b6
 @@ -4529,6 +4730,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
-     public final void setRemoved(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
+     public final void setRemoved(Entity.RemovalReason entity_removalreason, com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause cause) { // Paper - EntityRemoveFromWorldEvent
 +        // Paper start - rewrite chunk system
 +        if (!((ca.spottedleaf.moonrise.patches.chunk_system.level.ChunkSystemLevel)this.level).moonrise$getEntityLookup().canRemoveEntity((Entity)(Object)this)) {
 +            LOGGER.warn("Entity " + this + " is currently prevented from being removed from the world since it is processing section status updates", new Throwable());
 +            return;
 +        }
 +        // Paper end - rewrite chunk system
-         CraftEventFactory.callEntityRemoveEvent(this, cause);
+         CraftEventFactory.callEntityRemoveEvent(this, entity_removalreason, cause); // Paper - EntityRemoveFromWorldEvent
          // CraftBukkit end
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
 @@ -4540,7 +4747,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -27565,7 +27565,7 @@ index 971fb29a2c3dc713cb8ab1d2eed054cc16f9c93c..a6c0e89cb645693034f8e90ac2de8f2d
          this(updateListener, true, ImmutableList.of());
      }
 diff --git a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
-index 2f398750bfee5758ad8b1367b6fc14364e4de776..c292f58ba4b29395484dbbf8591e455f449581d8 100644
+index e2462d46d3994ec4cf65c8fe4794c577e8eb54a6..a7296b5a9f0e5a2b41c2cddc6b4b794763d0b085 100644
 --- a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
 +++ b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
 @@ -359,7 +359,7 @@ public class ArmorStand extends LivingEntity {
@@ -28754,7 +28754,7 @@ index 16e721ac80ba21511bdeccfccd055f7700bda61f..7a592a3c5491fc19ab33287e1e60b869
          }
          this.blockEntityTickers.removeAll(toRemove); // Paper - Fix MC-117075
 @@ -850,12 +1340,20 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
-             entity.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DISCARD);
+             entity.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DISCARD); // Paper - EntityRemoveFromWorldEvent
              // Paper end - Prevent block entity and entity crashes
          }
 +        this.moonrise$midTickTasks(); // Paper - rewrite chunk system
@@ -29877,7 +29877,7 @@ index 0baa4adf2a4401f9c955352f27e6f99957d1dff4..3723c07183e7b894cccf4d01bedf1d0d
          this.chunkType = chunkType;
          this.heightmapsAfter = heightMapTypes;
 diff --git a/src/main/java/net/minecraft/world/level/chunk/status/ChunkStatusTasks.java b/src/main/java/net/minecraft/world/level/chunk/status/ChunkStatusTasks.java
-index ae16cf5c803caae636860dd9b1a83abe479ca5a4..b993c4b2595e2879b25753c2e34530f3622c18fa 100644
+index 99077982cd61e2c4436d94a7283487c3e154cf65..fc288ff79a567ab8d2cd55e4ac6b277670e7d94f 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/status/ChunkStatusTasks.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/status/ChunkStatusTasks.java
 @@ -154,7 +154,7 @@ public class ChunkStatusTasks {

--- a/patches/server/1013-Properly-resend-entities.patch
+++ b/patches/server/1013-Properly-resend-entities.patch
@@ -202,7 +202,7 @@ index 05dae689ada8d96009e81aabf95a626bae90ecd3..3b15995efc65a351da8dac009b969849
          if (this.isUsingItem()) {
              if (ItemStack.isSameItem(this.getItemInHand(this.getUsedItemHand()), this.useItem)) {
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Bucketable.java b/src/main/java/net/minecraft/world/entity/animal/Bucketable.java
-index b586116d8cca1585f9c9e618ed4d0cb2ef2747be..acf38ef6d8de8b15cf2b09eb7bda390c4e446e9a 100644
+index 80c1c1096b88040e17b2fa373cf1fa8bfacddc46..60b7edcf6139abc8c292b7f62fb8576148cb0d09 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Bucketable.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Bucketable.java
 @@ -108,8 +108,7 @@ public interface Bucketable {
@@ -240,7 +240,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/
 index 9ca1fee03bfa557f1df7388c6043c9ec6d02a79a..cd789c235acf740ec29c30b180e7fbe1a140caa9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1012,7 +1012,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1011,7 +1011,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
              return;
          }
  

--- a/patches/server/1056-Remove-wall-time-unused-skip-tick-protection.patch
+++ b/patches/server/1056-Remove-wall-time-unused-skip-tick-protection.patch
@@ -30,7 +30,7 @@ completely unnecessary, which also rids paper of the previous described
 incompatibility with non-ticking chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index 03cfa29bdb426a9fb6b1b6be6e897da48d4f2f3e..4423973d4d9a2c3879d98d1d4c8b8c117c677ac5 100644
+index c0ab6a1f95dd49b77914534faeeca3f686084a77..4a872c1987dde64809fafc5948139966fe643685 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 @@ -60,7 +60,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
@@ -43,7 +43,7 @@ index 03cfa29bdb426a9fb6b1b6be6e897da48d4f2f3e..4423973d4d9a2c3879d98d1d4c8b8c11
      private int despawnRate = -1; // Paper - Alternative item-despawn-rate
      public net.kyori.adventure.util.TriState frictionState = net.kyori.adventure.util.TriState.NOT_SET; // Paper - Friction API
 @@ -153,12 +153,11 @@ public class ItemEntity extends Entity implements TraceableEntity {
-             this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
+             this.discard(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause // Paper - EntityRemoveFromWorldEvent
          } else {
              super.tick();
 -            // CraftBukkit start - Use wall time for pickup and despawn timers

--- a/patches/server/1060-Improve-entity-effect-API.patch
+++ b/patches/server/1060-Improve-entity-effect-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Improve entity effect API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index cd789c235acf740ec29c30b180e7fbe1a140caa9..89c8713d2c2206d1b0d8c0a392c9d13b3e736f0c 100644
+index f0ffb262c9ae0d60c8dd5e3b11312e79506db038..1362f28ae79f1c859a46520f6457eab7df98ecbf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1299,4 +1299,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1298,4 +1298,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.getHandle().getScoreboardName();
      }
      // Paper end - entity scoreboard name
@@ -25,7 +25,7 @@ index cd789c235acf740ec29c30b180e7fbe1a140caa9..89c8713d2c2206d1b0d8c0a392c9d13b
 +    // Paper end - broadcast hurt animation
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ad740739437be632fc7fedec488a7d0c49534688..42d7660efe5baa6f796f2a7606686c765b6f2478 100644
+index cb7232ef3a8f142c43cc6a6780bf2815f799df95..82bdf534129ac26907a5fbd9dcb4aca04872b0b5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1277,6 +1277,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {


### PR DESCRIPTION
Adds a removal reason to `EntityRemoveFromWorldEvent`. The `RemovalReason` enum mirrors the NMS `Entity.RemovalReason`, except that the methods `shouldDestroy`/`shouldSave` are renamed to `willDestroy`/`willSave`. Due to the chunk system rewrite, unloaded entities are not set as removed with `RemovalReason.UNLOAD_TO_CHUNK`, so currently if the removal reason is not set and the entity is inaccessible, it'll default to `RemovalReason.UNLOAD_TO_CHUNK` as the removal reason.