### PR TITLE
Use a ConcurrentHashMap for enum mappings for BlockData

### DIFF
--- a/patches/server/0454-Cache-block-data-strings.patch
+++ b/patches/server/0454-Cache-block-data-strings.patch
@@ -17,9 +17,18 @@ index a82f7dd2cbc2f6311b810f117f0970a47db85818..2616d771a8a95dac4440b74933c8aa7b
  
          if (this.isSameThread()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-index cf379f7da8d8e6db0d74f1ca0e4b42e017a8191e..c1506afacb6a73ef4a4692c0ae0722b240f01606 100644
+index cf379f7da8d8e6db0d74f1ca0e4b42e017a8191e..cab13044a3c827256967632a1769f4aec3b11839 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
+@@ -153,7 +153,7 @@ public class CraftBlockData implements BlockData {
+         return exactMatch;
+     }
+ 
+-    private static final Map<Class<? extends Enum<?>>, Enum<?>[]> ENUM_VALUES = new HashMap<>();
++    private static final Map<Class<? extends Enum<?>>, Enum<?>[]> ENUM_VALUES = new java.util.concurrent.ConcurrentHashMap<>(); // Paper - make thread safe
+ 
+     /**
+      * Convert an NMS Enum (usually a BlockStateEnum) to its appropriate Bukkit
 @@ -536,9 +536,39 @@ public class CraftBlockData implements BlockData {
          Preconditions.checkState(CraftBlockData.MAP.put(nms, bukkit) == null, "Duplicate mapping %s->%s", nms, bukkit);
      }


### PR DESCRIPTION
This API should be thread-safe as there is no world state

Reported in https://forums.papermc.io/threads/concurrentmodificationexception-on-chunkgenerator.1022/