### PR TITLE
Add CropBlock API

### DIFF
--- a/patches/api/0457-CropBlock-API.patch
+++ b/patches/api/0457-CropBlock-API.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: leguan <longboard.noah@gmail.com>
+Date: Sun, 14 Jan 2024 21:26:35 +0100
+Subject: [PATCH] CropBlock API
+
+
+diff --git a/src/main/java/io/papermc/paper/block/CropBlock.java b/src/main/java/io/papermc/paper/block/CropBlock.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..9bbf45d4ef2c4cad81a092af7296e31f8b33a139
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/block/CropBlock.java
+@@ -0,0 +1,18 @@
++package io.papermc.paper.block;
++
++import org.bukkit.Material;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Represents a CropBlock.
++ */
++public interface CropBlock {
++
++    /**
++     * Gets the seed of the planted block. E.g. WHEAT_SEEDS for WHEAT.
++     *
++     * @return The seed of the planted block.
++     */
++    @NotNull Material getBaseSeedId();
++
++}

--- a/patches/server/1062-CropBlock-API.patch
+++ b/patches/server/1062-CropBlock-API.patch
@@ -1,0 +1,146 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: leguan <longboard.noah@gmail.com>
+Date: Sun, 14 Jan 2024 21:26:15 +0100
+Subject: [PATCH] CropBlock API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftBeetroot.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftBeetroot.java
+index 90b4883f3e9748212ae7d6a09781d846a88c5abf..b94a56a676c065c9f31796eae08e23e30bd75d5e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftBeetroot.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftBeetroot.java
+@@ -3,7 +3,10 @@
+  */
+ package org.bukkit.craftbukkit.block.impl;
+ 
+-public final class CraftBeetroot extends org.bukkit.craftbukkit.block.data.CraftBlockData implements org.bukkit.block.data.Ageable {
++import org.bukkit.Material;
++import org.jetbrains.annotations.NotNull;
++
++public final class CraftBeetroot extends org.bukkit.craftbukkit.block.data.CraftBlockData implements org.bukkit.block.data.Ageable, io.papermc.paper.block.CropBlock { // Paper - CropBlock API
+ 
+     public CraftBeetroot() {
+         super();
+@@ -31,4 +34,11 @@ public final class CraftBeetroot extends org.bukkit.craftbukkit.block.data.Craft
+     public int getMaximumAge() {
+         return getMax(CraftBeetroot.AGE);
+     }
++
++    // Paper start - CropBlock API
++    @Override
++    public @NotNull Material getBaseSeedId() {
++        return org.bukkit.craftbukkit.inventory.CraftItemStack.asNewCraftStack(((net.minecraft.world.level.block.CropBlock) getState().getBlock()).getBaseSeedId().asItem()).getType();
++    }
++    // Paper end - CropBlock API
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCarrots.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCarrots.java
+index 270416eb51c4aac676969bf51d8a719f2d5da0ac..05d83f7821177c4a2c6c25757fad3249421f25e5 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCarrots.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCarrots.java
+@@ -3,7 +3,10 @@
+  */
+ package org.bukkit.craftbukkit.block.impl;
+ 
+-public final class CraftCarrots extends org.bukkit.craftbukkit.block.data.CraftBlockData implements org.bukkit.block.data.Ageable {
++import org.bukkit.Material;
++import org.jetbrains.annotations.NotNull;
++
++public final class CraftCarrots extends org.bukkit.craftbukkit.block.data.CraftBlockData implements org.bukkit.block.data.Ageable, io.papermc.paper.block.CropBlock { // Paper - CropBlock API
+ 
+     public CraftCarrots() {
+         super();
+@@ -31,4 +34,11 @@ public final class CraftCarrots extends org.bukkit.craftbukkit.block.data.CraftB
+     public int getMaximumAge() {
+         return getMax(CraftCarrots.AGE);
+     }
++
++    // Paper start - CropBlock API
++    @Override
++    public @NotNull Material getBaseSeedId() {
++        return org.bukkit.craftbukkit.inventory.CraftItemStack.asNewCraftStack(((net.minecraft.world.level.block.CropBlock) getState().getBlock()).getBaseSeedId().asItem()).getType();
++    }
++    // Paper end - CropBlock API
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCrops.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCrops.java
+index d186de7098a63a8667c39ff1749f65d6ab82e4e8..4d7c78c51242dcd85457ed07f1ca596e1fb9ef4d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCrops.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCrops.java
+@@ -3,7 +3,10 @@
+  */
+ package org.bukkit.craftbukkit.block.impl;
+ 
+-public final class CraftCrops extends org.bukkit.craftbukkit.block.data.CraftBlockData implements org.bukkit.block.data.Ageable {
++import org.bukkit.Material;
++import org.jetbrains.annotations.NotNull;
++
++public final class CraftCrops extends org.bukkit.craftbukkit.block.data.CraftBlockData implements org.bukkit.block.data.Ageable, io.papermc.paper.block.CropBlock { // Paper - CropBlock API
+ 
+     public CraftCrops() {
+         super();
+@@ -31,4 +34,11 @@ public final class CraftCrops extends org.bukkit.craftbukkit.block.data.CraftBlo
+     public int getMaximumAge() {
+         return getMax(CraftCrops.AGE);
+     }
++
++    // Paper start - CropBlock API
++    @Override
++    public @NotNull Material getBaseSeedId() {
++        return org.bukkit.craftbukkit.inventory.CraftItemStack.asNewCraftStack(((net.minecraft.world.level.block.CropBlock) getState().getBlock()).getBaseSeedId().asItem()).getType();
++    }
++    // Paper end - CropBlock API
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftPotatoes.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftPotatoes.java
+index ee3faab6b3d2371579dfdb619c1aae2109e22211..601dcad4ea0dea38233fac8bb239e790ecfcff68 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftPotatoes.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftPotatoes.java
+@@ -3,7 +3,10 @@
+  */
+ package org.bukkit.craftbukkit.block.impl;
+ 
+-public final class CraftPotatoes extends org.bukkit.craftbukkit.block.data.CraftBlockData implements org.bukkit.block.data.Ageable {
++import org.bukkit.Material;
++import org.jetbrains.annotations.NotNull;
++
++public final class CraftPotatoes extends org.bukkit.craftbukkit.block.data.CraftBlockData implements org.bukkit.block.data.Ageable, io.papermc.paper.block.CropBlock { // Paper - CropBlock API
+ 
+     public CraftPotatoes() {
+         super();
+@@ -31,4 +34,11 @@ public final class CraftPotatoes extends org.bukkit.craftbukkit.block.data.Craft
+     public int getMaximumAge() {
+         return getMax(CraftPotatoes.AGE);
+     }
++
++    // Paper start - CropBlock API
++    @Override
++    public @NotNull Material getBaseSeedId() {
++        return org.bukkit.craftbukkit.inventory.CraftItemStack.asNewCraftStack(((net.minecraft.world.level.block.CropBlock) getState().getBlock()).getBaseSeedId().asItem()).getType();
++    }
++    // Paper end - CropBlock API
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftTorchflowerCrop.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftTorchflowerCrop.java
+index 2a4ade3518b60ea97d6dbb6c66cf2f40aaf4ab7d..3be17b1bb627313e593af2179f0e193b77be4293 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftTorchflowerCrop.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftTorchflowerCrop.java
+@@ -3,7 +3,10 @@
+  */
+ package org.bukkit.craftbukkit.block.impl;
+ 
+-public final class CraftTorchflowerCrop extends org.bukkit.craftbukkit.block.data.CraftBlockData implements org.bukkit.block.data.Ageable {
++import org.bukkit.Material;
++import org.jetbrains.annotations.NotNull;
++
++public final class CraftTorchflowerCrop extends org.bukkit.craftbukkit.block.data.CraftBlockData implements org.bukkit.block.data.Ageable, io.papermc.paper.block.CropBlock { // Paper - CropBlock API
+ 
+     public CraftTorchflowerCrop() {
+         super();
+@@ -31,4 +34,11 @@ public final class CraftTorchflowerCrop extends org.bukkit.craftbukkit.block.dat
+     public int getMaximumAge() {
+         return getMax(CraftTorchflowerCrop.AGE);
+     }
++
++    // Paper start - CropBlock API
++    @Override
++    public @NotNull Material getBaseSeedId() {
++        return org.bukkit.craftbukkit.inventory.CraftItemStack.asNewCraftStack(((net.minecraft.world.level.block.CropBlock) getState().getBlock()).getBaseSeedId().asItem()).getType();
++    }
++    // Paper end - CropBlock API
+ }


### PR DESCRIPTION
This pull request exposes the `getBaseSeedId` methods from crop blocks. 
This makes it possible to get the corresponding seed to its block representation. 
E.g. `Material.POTATO` for `minecraft:potatoes`

I don't know about the name `getBaseSeedId`. I named it like that cause its the same as the name from the server. Maybe there is a better name for it tho.  