### PR TITLE
Call EntityChangeBlockEvent for extinguishing (cake) candles

### DIFF
--- a/patches/server/0784-Fire-EntityChangeBlockEvent-in-more-places.patch
+++ b/patches/server/0784-Fire-EntityChangeBlockEvent-in-more-places.patch
@@ -198,6 +198,22 @@ index 32995cb5efdad0bc34ecacacb78cccd21220ba8d..21212462e6b415e96536a27b2c009d15
                      level.setBlock(blockPos, blockState3, 11);
                      level.gameEvent(GameEvent.BLOCK_CHANGE, blockPos, GameEvent.Context.of(player, blockState3));
                      if (player != null) {
+diff --git a/src/main/java/net/minecraft/world/level/block/AbstractCandleBlock.java b/src/main/java/net/minecraft/world/level/block/AbstractCandleBlock.java
+index f24b8c0c581873672a45f3deee77160a1ae3e2e9..8c35a9554b32ceda251363eaecc948e5b705a418 100644
+--- a/src/main/java/net/minecraft/world/level/block/AbstractCandleBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/AbstractCandleBlock.java
+@@ -82,6 +82,11 @@ public abstract class AbstractCandleBlock extends Block {
+     }
+ 
+     public static void extinguish(@Nullable Player player, BlockState state, LevelAccessor world, BlockPos pos) {
++        // Paper start - Call EntityChangeBlockEvent for extinguishing candles
++        if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, pos, state.setValue(AbstractCandleBlock.LIT, false))) {
++            return;
++        }
++        // Paper end - Call EntityChangeBlockEvent for extinguishing candles
+         AbstractCandleBlock.setLit(world, state, pos, false);
+         if (state.getBlock() instanceof AbstractCandleBlock) {
+             ((AbstractCandleBlock) state.getBlock()).getParticleOffsets(state).forEach((vec3d) -> {
 diff --git a/src/main/java/net/minecraft/world/level/block/CakeBlock.java b/src/main/java/net/minecraft/world/level/block/CakeBlock.java
 index 49fe91a8eaeb2580c8ad0166e72540168af605f6..ca1ccedb5a551328ebfad907f39594b220efaefe 100644
 --- a/src/main/java/net/minecraft/world/level/block/CakeBlock.java


### PR DESCRIPTION
Calls the EntityChangeBlockEvent for when candles, normal ones and the ones on cakes, are extinguished as described in #10112 