### PR TITLE
Add world to Entity AddTo/RemoveFrom Events

### DIFF
--- a/patches/api/0033-Entity-AddTo-RemoveFrom-World-Events.patch
+++ b/patches/api/0033-Entity-AddTo-RemoveFrom-World-Events.patch
@@ -6,28 +6,36 @@ Subject: [PATCH] Entity AddTo/RemoveFrom World Events
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityAddToWorldEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityAddToWorldEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..07660202e41ee86f1b66bad3335cf6fe126e7f9c
+index 0000000000000000000000000000000000000000..bf5fec2451244ed863f86a113a7e1de94c39c03a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityAddToWorldEvent.java
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,40 @@
 +package com.destroystokyo.paper.event.entity;
 +
++import org.bukkit.World;
 +import org.bukkit.entity.Entity;
-+import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Fired any time an entity is being added to the world for any reason.
++ * Fired any time an entity is being added to the world for any reason (including a chunk loading).
 + *
 + * Not to be confused with {@link org.bukkit.event.entity.CreatureSpawnEvent}
-+ * This will fire anytime a chunk is reloaded too.
 + */
 +public class EntityAddToWorldEvent extends EntityEvent {
++    @NotNull private final World world;
 +
-+    public EntityAddToWorldEvent(@NotNull Entity entity) {
++    public EntityAddToWorldEvent(@NotNull Entity entity, @NotNull World world) {
 +        super(entity);
++        this.world = world;
++    }
++
++    /**
++     * @return The world that the entity is being added to
++     */
++    public World getWorld() {
++        return world;
 +    }
 +
 +    private static final HandlerList handlers = new HandlerList();
@@ -44,25 +52,34 @@ index 0000000000000000000000000000000000000000..07660202e41ee86f1b66bad3335cf6fe
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityRemoveFromWorldEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityRemoveFromWorldEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e5dbbd660409bae0d3b96e83390511d3a423a52e
+index 0000000000000000000000000000000000000000..a7c7ac5bce970604b18ec12c5f438648731d04c6
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityRemoveFromWorldEvent.java
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,38 @@
 +package com.destroystokyo.paper.event.entity;
 +
++import org.bukkit.World;
 +import org.bukkit.entity.Entity;
-+import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Fired any time an entity is being removed from a world for any reason
++ * Fired any time an entity is being removed from a world for any reason (including a chunk unloading).
 + */
 +public class EntityRemoveFromWorldEvent extends EntityEvent {
++    @NotNull private final World world;
 +
-+    public EntityRemoveFromWorldEvent(@NotNull Entity entity) {
++    public EntityRemoveFromWorldEvent(@NotNull Entity entity, @NotNull World world) {
 +        super(entity);
++        this.world = world;
++    }
++
++    /**
++     * @return The world that the entity is being removed from
++     */
++    public World getWorld() {
++        return world;
 +    }
 +
 +    private static final HandlerList handlers = new HandlerList();

--- a/patches/server/0078-Entity-AddTo-RemoveFrom-World-Events.patch
+++ b/patches/server/0078-Entity-AddTo-RemoveFrom-World-Events.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Entity AddTo/RemoveFrom World Events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f95d4fc714b98a86d732d16f0b783cd943ce0c15..ab55b028239f75b23a3e3fee10305a7896c2522b 100644
+index 404193d1a674ae8e92b4fcf5efdec6052fff21b4..c2e5bebd086d4afc86786a0d39cf84ce32863151 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2415,6 +2415,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
                  entity.setOrigin(entity.getOriginVector().toLocation(getWorld()));
              }
              // Paper end
-+            new com.destroystokyo.paper.event.entity.EntityAddToWorldEvent(entity.getBukkitEntity()).callEvent(); // Paper - fire while valid
++            new com.destroystokyo.paper.event.entity.EntityAddToWorldEvent(entity.getBukkitEntity(), ServerLevel.this.getWorld()).callEvent(); // Paper - fire while valid
          }
  
          public void onTrackingEnd(Entity entity) {
@@ -20,7 +20,7 @@ index f95d4fc714b98a86d732d16f0b783cd943ce0c15..ab55b028239f75b23a3e3fee10305a78
                  }
              }
              // CraftBukkit end
-+            new com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent(entity.getBukkitEntity()).callEvent(); // Paper - fire while valid
++            new com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent(entity.getBukkitEntity(), ServerLevel.this.getWorld()).callEvent(); // Paper - fire while valid
          }
  
          public void onSectionChange(Entity entity) {


### PR DESCRIPTION
When a plugin listens to the EntityAddToWorld and EntityRemoveFromWorld events, I don't believe there is currently any method of directly obtaining which world the entity was actually added to/removed from. Using `event.getEntity().getWorld()` works in many cases, but not all. Specifically, when an entity is teleported from one world to another, the location of the entity is updated prior to the removal event being called. This means that when an entity goes through a nether/end portal or is teleported between worlds with a command, a plugin listening to the EntityRemoveFromWorldEvent has no way of determining which world the entity was actually removed from (without relying on other events).

To resolve this, I've added the world as a field in the events along with a getter to retrieve it. I also removed an unused import and made the documentation more clear on the event behaviour when chunks load/unload.