### PR TITLE
Properly check if a loot table exists

### DIFF
--- a/patches/server/0008-CB-fixes.patch
+++ b/patches/server/0008-CB-fixes.patch
@@ -87,17 +87,15 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index 5f12fce84e0ec001dc43523753883a098434fcb6..d6a1b9bbf9737ed884ecf4af31e1521f46807405 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2454,7 +2454,13 @@ public final class CraftServer implements Server {
+@@ -2454,7 +2454,11 @@ public final class CraftServer implements Server {
          Preconditions.checkArgument(key != null, "NamespacedKey key cannot be null");
  
          LootDataManager registry = this.getServer().getLootData();
 -        return new CraftLootTable(key, registry.getLootTable(CraftNamespacedKey.toMinecraft(key)));
 +        // Paper start - honor method contract
 +        final ResourceLocation lootTableKey = CraftNamespacedKey.toMinecraft(key);
-+        if (registry.getLootTable(lootTableKey) == net.minecraft.world.level.storage.loot.LootTable.EMPTY) {
-+            return null;
-+        }
-+        return new CraftLootTable(key, registry.getLootTable(lootTableKey));
++        final Optional<net.minecraft.world.level.storage.loot.LootTable> table = registry.getElementOptional(net.minecraft.world.level.storage.loot.LootDataType.TABLE, lootTableKey);
++        return table.map(lootTable -> new CraftLootTable(key, lootTable)).orElse(null);
 +        // Paper end
      }
  

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -7740,7 +7740,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index d6a1b9bbf9737ed884ecf4af31e1521f46807405..5ee460d5d6e017a52bf26cfd56ca2cfeb82d3343 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2533,4 +2533,9 @@ public final class CraftServer implements Server {
+@@ -2531,4 +2531,9 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -3484,7 +3484,7 @@ index 5ee460d5d6e017a52bf26cfd56ca2cfeb82d3343..a381673d2397bcb3569e0b24eb071d86
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2538,4 +2595,57 @@ public final class CraftServer implements Server {
+@@ -2536,4 +2593,57 @@ public final class CraftServer implements Server {
      public double[] getTPS() {
          return new double[]{0, 0, 0}; // TODO
      }

--- a/patches/server/0011-Paper-command.patch
+++ b/patches/server/0011-Paper-command.patch
@@ -617,7 +617,7 @@ index c56c7293261ec2601ab02d051b37e820f023f0ff..faab5e8c952a2af6a286043617cded4e
          this.setPvpAllowed(dedicatedserverproperties.pvp);
          this.setFlightAllowed(dedicatedserverproperties.allowFlight);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1079476a3b327d668cf3d98f0a0659c81c120443..6c6a2a1eb9a02bf14b6b851f5d0aaba8528a8fec 100644
+index 4c75f630ff99259bd1d0e116fa20d0f625a3cf30..e9aa6a3c7710ed0c4685c5d8661d5de3fabb0a0d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -939,6 +939,7 @@ public final class CraftServer implements Server {
@@ -628,7 +628,7 @@ index 1079476a3b327d668cf3d98f0a0659c81c120443..6c6a2a1eb9a02bf14b6b851f5d0aaba8
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2639,6 +2640,34 @@ public final class CraftServer implements Server {
+@@ -2637,6 +2638,34 @@ public final class CraftServer implements Server {
      // Paper end
  
      // Paper start

--- a/patches/server/0014-Timings-v2.patch
+++ b/patches/server/0014-Timings-v2.patch
@@ -1617,7 +1617,7 @@ index ab7f7246ee7cd456dbf016aa4b3eed974cd0bca2..eccca51b91f3c8afeab19fe11b3e60df
          this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
-@@ -2547,12 +2547,31 @@ public final class CraftServer implements Server {
+@@ -2545,12 +2545,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  

--- a/patches/server/0016-Further-improve-server-tick-loop.patch
+++ b/patches/server/0016-Further-improve-server-tick-loop.patch
@@ -146,10 +146,10 @@ index a6a8b5079ceaad90a79a09cab5c38a6fde6d33ee..f32aa4e03ae02d1449101c4aa89c8e0c
                  this.startMetricsRecordingTick();
                  this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b1d0e9caed38b6a264b7ea8e508be103d3d0664e..33b6605d1139e83a09054b6ed140e129e65a954d 100644
+index ac036223ca386a48caf1796ea65c3bbde4d6ed08..2e42f297ad27d9dea4b09cf19e9b4f00e4fc5a21 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2600,7 +2600,11 @@ public final class CraftServer implements Server {
+@@ -2598,7 +2598,11 @@ public final class CraftServer implements Server {
  
      @Override
      public double[] getTPS() {

--- a/patches/server/0066-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0066-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b473527d5ccfa4ab196b4c94601dea5b694034b1..dc98b67f462e6d055d9098903a3ee59ff1e04000 100644
+index 7203f9b281305e83d7a31e49aab5fb73d603789b..58cf842c3bdc91233404ce907e3652abb1187e03 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2718,5 +2718,23 @@ public final class CraftServer implements Server {
+@@ -2716,5 +2716,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0109-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0109-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 49a0cb59ae1ad6b5f45c15c71ccf9680e2d2b764..f120e614ab3d4e646ddc675f76f0a637deae598a 100644
+index edf6fb3db243e4c9b28641504e383f0b03e672d2..1983650dbbb634472e81984960b857f1e87b26b8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2744,5 +2744,24 @@ public final class CraftServer implements Server {
+@@ -2742,5 +2742,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0128-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0128-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f120e614ab3d4e646ddc675f76f0a637deae598a..30ef05974f5645e0769cb1604290a4c8045501c8 100644
+index 1983650dbbb634472e81984960b857f1e87b26b8..fd8733b602e4711a3b57fb3c8c313a9035f15df0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2763,5 +2763,10 @@ public final class CraftServer implements Server {
+@@ -2761,5 +2761,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0135-Basic-PlayerProfile-API.patch
+++ b/patches/server/0135-Basic-PlayerProfile-API.patch
@@ -612,7 +612,7 @@ index adb472c175cc6f6ced7075a37423d6c898fd5ccb..1ec0f3a7148c2f412421772f6e1dff0b
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e7ad8c2d40568a243b6d3b2a28065083802afe5d..5c9415a5771191b7e3fec02f5a9ad569e735c4aa 100644
+index b9c23e03577724459b87bf9f0c5b93f593515b5a..11111b1015d362b35cbb6d35bee91c3c130e7cc7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -260,6 +260,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -633,7 +633,7 @@ index e7ad8c2d40568a243b6d3b2a28065083802afe5d..5c9415a5771191b7e3fec02f5a9ad569
          CraftItemFactory.instance();
      }
  
-@@ -2772,5 +2776,42 @@ public final class CraftServer implements Server {
+@@ -2770,5 +2774,42 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }

--- a/patches/server/0273-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0273-Make-the-default-permission-message-configurable.patch
@@ -18,10 +18,10 @@ index 6d06b772ffb9d47d6a717462a4b2b494544e80ae..69ffd6ea2ce7c6d4f211c6081fcea79a
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a880bc79f139633d5a6aa9a0fa290c691abdcf98..663ad8d391d81e7bbdf8b4ec4a8232b5b10954b7 100644
+index b942d5efdde98c3367833fc1863ee196a1920d3b..41c9c8957e81c492891fda79f68262ba402dddee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2805,6 +2805,16 @@ public final class CraftServer implements Server {
+@@ -2803,6 +2803,16 @@ public final class CraftServer implements Server {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }
  

--- a/patches/server/0301-Expose-the-internal-current-tick.patch
+++ b/patches/server/0301-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 663ad8d391d81e7bbdf8b4ec4a8232b5b10954b7..b26199cdd8a09cef6e873fd8ffccaec97f6bc7c4 100644
+index 41c9c8957e81c492891fda79f68262ba402dddee..7e765fcdf4cb302c8eae2b4b6a86adfc038505ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2851,5 +2851,10 @@ public final class CraftServer implements Server {
+@@ -2849,5 +2849,10 @@ public final class CraftServer implements Server {
          profile.getProperties().putAll(((CraftPlayer) player).getHandle().getGameProfile().getProperties());
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
      }

--- a/patches/server/0338-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0338-Add-tick-times-API-and-mspt-command.patch
@@ -187,7 +187,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index b26199cdd8a09cef6e873fd8ffccaec97f6bc7c4..d4231c9c22d3014702d856cb3b329ba3c4c6d0ce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2619,6 +2619,16 @@ public final class CraftServer implements Server {
+@@ -2617,6 +2617,16 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0339-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0339-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d4231c9c22d3014702d856cb3b329ba3c4c6d0ce..070fba9322c5f8dd4f217685d8157d05cc78c95b 100644
+index 04788b844ddd7f33216f05642850edbe58021697..8d65ed46f3ab22b18bf7d54368d744d9084dad1b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2866,5 +2866,10 @@ public final class CraftServer implements Server {
+@@ -2864,5 +2864,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0368-Implement-Mob-Goal-API.patch
+++ b/patches/server/0368-Implement-Mob-Goal-API.patch
@@ -768,10 +768,10 @@ index 6667ecc4b7eded4e20a415cef1e1b1179e6710b8..16f9a98b8a939e5ca7e2dc04f87134a7
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 967627073ce7f7670cdfea4c54434e17b7648664..c8147b9481f79806ec64941169f2ef552c165baa 100644
+index a40c30be9923da16f84f11e6678f1d380ad5bc69..9c27232b680e42c08a37347ed84669686a0cb2d1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2879,5 +2879,11 @@ public final class CraftServer implements Server {
+@@ -2877,5 +2877,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0558-Add-basic-Datapack-API.patch
+++ b/patches/server/0558-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cf508b4ddd21d006b88eac6588a0f56eb20c5ec7..eb9c34864a3ad86f79b344211864429f13c3b06f 100644
+index 4c84e41e12ab81e374a6ba831e078bd538d7afbc..50a79cefb97a33bc59d7c706a45bbdb0e739147c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -301,6 +301,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index cf508b4ddd21d006b88eac6588a0f56eb20c5ec7..eb9c34864a3ad86f79b344211864429f
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2947,5 +2949,11 @@ public final class CraftServer implements Server {
+@@ -2945,5 +2947,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0715-Custom-Potion-Mixes.patch
+++ b/patches/server/0715-Custom-Potion-Mixes.patch
@@ -32,7 +32,7 @@ index 0000000000000000000000000000000000000000..7ea357ac2f3a93db4ebdf24b5072be7d
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 831594402c2c7d6aa72b303fb73fde62160c95e3..c0353463f59ae4d3fe94ee15feb95a4ec1a064f4 100644
+index d81fa8c7049bb6284865f249cc808caac7d5f65e..011d688fc0be45a8d1f65ebedcc5291bb109def2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2081,6 +2081,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -172,7 +172,7 @@ index 424406d2692856cfd82b6f3b7b6228fa3bd20c2f..bc01481ac5990ad1cfd1def5a16dd0ed
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b578f3666291bf0ec9b9620e6212d39c33399a9e..506145875fae3da90662315a71eddda9aaabb0c3 100644
+index ab5e98c3b7c7b3d5b2108be87e6465cc7a6f3d2c..2bc4cfb1abd8a82228d1958fde2fd92e10c199b1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -304,6 +304,7 @@ public final class CraftServer implements Server {
@@ -192,7 +192,7 @@ index b578f3666291bf0ec9b9620e6212d39c33399a9e..506145875fae3da90662315a71eddda9
          // Ugly hack :(
  
          if (!Main.useConsole) {
-@@ -3069,5 +3070,10 @@ public final class CraftServer implements Server {
+@@ -3067,5 +3068,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/10189

When the loot table registry system was changed, this wasn't update to actually check if the loot table didn't exist to return null. As a result, LootTables.EMPTY#getLootTable returned null when it shouldn't have.