### PR TITLE
Cleanup events

### DIFF
--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -206,10 +206,10 @@ index 0000000000000000000000000000000000000000..2ad76b1751ba707f7ae0d283aa1cbaf6
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/AbstractChatEvent.java b/src/main/java/io/papermc/paper/event/player/AbstractChatEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ed8e885f226b02b9875b23ae2294a9056d2e8b29
+index 0000000000000000000000000000000000000000..a0fd845bc9b2540c398fe1dbbf821803a7017a28
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/AbstractChatEvent.java
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,127 @@
 +package io.papermc.paper.event.player;
 +
 +import io.papermc.paper.chat.ChatRenderer;
@@ -231,12 +231,14 @@ index 0000000000000000000000000000000000000000..ed8e885f226b02b9875b23ae2294a905
 + */
 +@ApiStatus.NonExtendable
 +public abstract class AbstractChatEvent extends PlayerEvent implements Cancellable {
++
 +    private final Set<Audience> viewers;
 +    private final Component originalMessage;
 +    private final SignedMessage signedMessage;
 +    private ChatRenderer renderer;
 +    private Component message;
-+    private boolean cancelled = false;
++
++    private boolean cancelled;
 +
 +    AbstractChatEvent(final boolean async, final @NotNull Player player, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message, final @NotNull Component originalMessage, final @NotNull SignedMessage signedMessage) {
 +        super(player, async);
@@ -331,8 +333,8 @@ index 0000000000000000000000000000000000000000..ed8e885f226b02b9875b23ae2294a905
 +    }
 +
 +    @Override
-+    public final void setCancelled(final boolean cancelled) {
-+        this.cancelled = cancelled;
++    public final void setCancelled(final boolean cancel) {
++        this.cancelled = cancel;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/AsyncChatCommandDecorateEvent.java b/src/main/java/io/papermc/paper/event/player/AsyncChatCommandDecorateEvent.java
@@ -371,16 +373,17 @@ index 0000000000000000000000000000000000000000..feece00981ebf932e64760e7a10a04ad
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/AsyncChatDecorateEvent.java b/src/main/java/io/papermc/paper/event/player/AsyncChatDecorateEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..667bfa6afc35f8a8f475431171ee474af4e10afd
+index 0000000000000000000000000000000000000000..9e1eb774d841e2c7ffa8bef688d832bdffaa0944
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/AsyncChatDecorateEvent.java
-@@ -0,0 +1,117 @@
+@@ -0,0 +1,120 @@
 +package io.papermc.paper.event.player;
 +
 +import net.kyori.adventure.text.Component;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.AsyncPlayerChatPreviewEvent;
 +import org.bukkit.event.server.ServerEvent;
 +import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.Contract;
@@ -393,7 +396,8 @@ index 0000000000000000000000000000000000000000..667bfa6afc35f8a8f475431171ee474a
 + * message here, and use the chat events for modifying receivers and later the chat type. If you
 + * want to keep the message as "signed" for the clients who get it, be sure to include the entire
 + * original message somewhere in the final message.
-+ * @see AsyncChatCommandDecorateEvent for the decoration of messages sent via commands
++ * <br>
++ * See {@link AsyncChatCommandDecorateEvent} for the decoration of messages sent via commands
 + */
 +@ApiStatus.Experimental
 +public class AsyncChatDecorateEvent extends ServerEvent implements Cancellable {
@@ -403,6 +407,7 @@ index 0000000000000000000000000000000000000000..667bfa6afc35f8a8f475431171ee474a
 +    private final Player player;
 +    private final Component originalMessage;
 +    private Component result;
++
 +    private boolean cancelled;
 +
 +    @ApiStatus.Internal
@@ -419,7 +424,7 @@ index 0000000000000000000000000000000000000000..667bfa6afc35f8a8f475431171ee474a
 +     * Certain commands request decorations without a player context
 +     * which is why this is possibly null.
 +     *
-+     * @return the player or null
++     * @return the player or {@code null}
 +     */
 +    public @Nullable Player player() {
 +        return this.player;
@@ -437,7 +442,7 @@ index 0000000000000000000000000000000000000000..667bfa6afc35f8a8f475431171ee474a
 +    /**
 +     * Gets the decoration result. This may already be different from
 +     * {@link #originalMessage()} if some other listener to this event
-+     * <b>OR</b> the legacy preview event ({@link org.bukkit.event.player.AsyncPlayerChatPreviewEvent}
++     * <b>OR</b> the legacy preview event ({@link AsyncPlayerChatPreviewEvent})
 +     * changed the result.
 +     *
 +     * @return the result
@@ -458,10 +463,10 @@ index 0000000000000000000000000000000000000000..667bfa6afc35f8a8f475431171ee474a
 +    /**
 +     * If this decorating is part of a preview request/response.
 +     *
-+     * @return true if part of previewing
++     * @return {@code true} if part of previewing
 +     * @deprecated chat preview was removed in 1.19.3
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19.3")
 +    @ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    @Contract(value = "-> false", pure = true)
 +    public boolean isPreview() {
@@ -494,10 +499,10 @@ index 0000000000000000000000000000000000000000..667bfa6afc35f8a8f475431171ee474a
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/AsyncChatEvent.java b/src/main/java/io/papermc/paper/event/player/AsyncChatEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4d2eddba7dc88ba23b241ac7849114a30af968d3
+index 0000000000000000000000000000000000000000..4adae8b8a8640ffbd6a86b0908ca21fded737b88
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/AsyncChatEvent.java
-@@ -0,0 +1,47 @@
+@@ -0,0 +1,45 @@
 +package io.papermc.paper.event.player;
 +
 +import java.util.Set;
@@ -524,11 +529,9 @@ index 0000000000000000000000000000000000000000..4d2eddba7dc88ba23b241ac7849114a3
 + * appropriately.
 + */
 +public final class AsyncChatEvent extends AbstractChatEvent {
-+    private static final HandlerList HANDLERS = new HandlerList();
 +
-+    /**
-+     * @param viewers A mutable set of viewers
-+     */
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @ApiStatus.Internal
 +    public AsyncChatEvent(final boolean async, final @NotNull Player player, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message, final @NotNull Component originalMessage, final @NotNull SignedMessage signedMessage) {
 +        super(async, player, viewers, renderer, message, originalMessage, signedMessage);
@@ -537,20 +540,20 @@ index 0000000000000000000000000000000000000000..4d2eddba7dc88ba23b241ac7849114a3
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/ChatEvent.java b/src/main/java/io/papermc/paper/event/player/ChatEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..af025704e978dc0b11be277ab4646da77eb3a60b
+index 0000000000000000000000000000000000000000..7411f58f9f36beaadcc47c2264a4af313956ee03
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/ChatEvent.java
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,41 @@
 +package io.papermc.paper.event.player;
 +
 +import java.util.Set;
@@ -567,16 +570,15 @@ index 0000000000000000000000000000000000000000..af025704e978dc0b11be277ab4646da7
 +/**
 + * An event fired when a {@link Player} sends a chat message to the server.
 + *
-+ * @deprecated Listening to this event forces chat to wait for the main thread, delaying chat messages. It is recommended to use {@link AsyncChatEvent} instead, wherever possible.
++ * @deprecated Listening to this event forces chat to wait for the main thread, delaying chat messages.
++ * It is recommended to use {@link AsyncChatEvent} instead, wherever possible.
 + */
 +@Deprecated
 +@Warning(reason = "Listening to this event forces chat to wait for the main thread, delaying chat messages.")
 +public final class ChatEvent extends AbstractChatEvent {
-+    private static final HandlerList HANDLERS = new HandlerList();
 +
-+    /**
-+     * @param viewers A mutable set of viewers
-+     */
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @ApiStatus.Internal
 +    public ChatEvent(final @NotNull Player player, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message, final @NotNull Component originalMessage, final @NotNull SignedMessage signedMessage) {
 +        super(false, player, viewers, renderer, message, originalMessage, signedMessage);
@@ -585,12 +587,12 @@ index 0000000000000000000000000000000000000000..af025704e978dc0b11be277ab4646da7
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/text/PaperComponents.java b/src/main/java/io/papermc/paper/text/PaperComponents.java

--- a/patches/api/0008-Use-ASM-for-event-executors.patch
+++ b/patches/api/0008-Use-ASM-for-event-executors.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use ASM for event executors.
 Uses method handles for private or static methods.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index cbe75dc937409af36528e4eef6f257f323cd4d12..7fbb782ccf17e581a759429ffac6db608c08e3cf 100644
+index b577114c2b89fe2053123d1a542d37dff7fa8d5a..af6c528ccc4356f5bba3ce0b9bf6de237d77376e 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -47,6 +47,9 @@ dependencies {
@@ -69,10 +69,10 @@ index 0000000000000000000000000000000000000000..5b28e9b1daba7834af67dbc193dd656b
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/executor/StaticMethodHandleEventExecutor.java b/src/main/java/com/destroystokyo/paper/event/executor/StaticMethodHandleEventExecutor.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c83672427324bd068ed52916f700b68446a226f6
+index 0000000000000000000000000000000000000000..827f2b27f70a7ec0bc11d039305c3e58c02a4ef4
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/executor/StaticMethodHandleEventExecutor.java
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,42 @@
 +package com.destroystokyo.paper.event.executor;
 +
 +import java.lang.invoke.MethodHandle;
@@ -83,7 +83,6 @@ index 0000000000000000000000000000000000000000..c83672427324bd068ed52916f700b684
 +import com.destroystokyo.paper.util.SneakyThrow;
 +import com.google.common.base.Preconditions;
 +
-+import org.bukkit.Bukkit;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.EventException;
 +import org.bukkit.event.Listener;
@@ -218,20 +217,18 @@ index 0000000000000000000000000000000000000000..f79685b48bb581277a6891927988b6f7
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/executor/asm/SafeClassDefiner.java b/src/main/java/com/destroystokyo/paper/event/executor/asm/SafeClassDefiner.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ac99477e9f2c08041aeff31abc1d1edee58d0a67
+index 0000000000000000000000000000000000000000..abcc966d8ee01d73c1d1480237ab46fa0ab55fdc
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/executor/asm/SafeClassDefiner.java
-@@ -0,0 +1,66 @@
+@@ -0,0 +1,64 @@
 +package com.destroystokyo.paper.event.executor.asm;
 +
-+import java.util.concurrent.ConcurrentHashMap;
 +import java.util.concurrent.ConcurrentMap;
 +
 +import com.google.common.base.Preconditions;
 +
 +import com.google.common.collect.MapMaker;
 +import org.jetbrains.annotations.NotNull;
-+import org.objectweb.asm.Type;
 +
 +public class SafeClassDefiner implements ClassDefiner {
 +    /* default */ static final SafeClassDefiner INSTANCE = new SafeClassDefiner();

--- a/patches/api/0017-Add-PlayerLocaleChangeEvent.patch
+++ b/patches/api/0017-Add-PlayerLocaleChangeEvent.patch
@@ -6,16 +6,18 @@ Subject: [PATCH] Add PlayerLocaleChangeEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerLocaleChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerLocaleChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..bb7baa91fd4ba763fd8ce216bc9043c5e2c4b7b7
+index 0000000000000000000000000000000000000000..57f6c47e4e759abf0af9aa8962551225cc12246c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerLocaleChangeEvent.java
-@@ -0,0 +1,51 @@
+@@ -0,0 +1,60 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
 +
 +/**
 + * Called when the locale of the player is changed.
@@ -24,11 +26,14 @@ index 0000000000000000000000000000000000000000..bb7baa91fd4ba763fd8ce216bc9043c5
 + */
 +@Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +public class PlayerLocaleChangeEvent extends PlayerEvent {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final String oldLocale;
 +    private final String newLocale;
 +
-+    public PlayerLocaleChangeEvent(final Player player, final String oldLocale, final String newLocale) {
++    @ApiStatus.Internal
++    public PlayerLocaleChangeEvent(final @NotNull Player player, final @Nullable String oldLocale, final @NotNull String newLocale) {
 +        super(player);
 +        this.oldLocale = oldLocale;
 +        this.newLocale = newLocale;
@@ -39,8 +44,9 @@ index 0000000000000000000000000000000000000000..bb7baa91fd4ba763fd8ce216bc9043c5
 +     *
 +     * @return player's old locale
 +     */
++    @Nullable
 +    public String getOldLocale() {
-+        return oldLocale;
++        return this.oldLocale;
 +    }
 +
 +    /**
@@ -48,16 +54,19 @@ index 0000000000000000000000000000000000000000..bb7baa91fd4ba763fd8ce216bc9043c5
 +     *
 +     * @return player's new locale
 +     */
++    @NotNull
 +    public String getNewLocale() {
-+        return newLocale;
++        return this.newLocale;
 +    }
 +
 +    @Override
++    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
++    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0019-Add-BeaconEffectEvent.patch
+++ b/patches/api/0019-Add-BeaconEffectEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add BeaconEffectEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/block/BeaconEffectEvent.java b/src/main/java/com/destroystokyo/paper/event/block/BeaconEffectEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..978813b94a5eae0afccbd3b38b463091a46b56ac
+index 0000000000000000000000000000000000000000..7270c1feece2dc15a4a0503c4bca93a1288f8f13
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/block/BeaconEffectEvent.java
-@@ -0,0 +1,86 @@
+@@ -0,0 +1,91 @@
 +package com.destroystokyo.paper.event.block;
 +
 +import org.bukkit.block.Block;
@@ -18,33 +18,28 @@ index 0000000000000000000000000000000000000000..978813b94a5eae0afccbd3b38b463091
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.block.BlockEvent;
 +import org.bukkit.potion.PotionEffect;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called when a beacon effect is being applied to a player.
 + */
 +public class BeaconEffectEvent extends BlockEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled;
-+    private PotionEffect effect;
-+    private Player player;
-+    private boolean primary;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private final Player player;
++    private final boolean primary;
++    private PotionEffect effect;
++
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public BeaconEffectEvent(@NotNull Block block, @NotNull PotionEffect effect, @NotNull Player player, boolean primary) {
 +        super(block);
 +        this.effect = effect;
 +        this.player = player;
 +        this.primary = primary;
-+    }
-+
-+    @Override
-+    public boolean isCancelled() {
-+        return cancelled;
-+    }
-+
-+    @Override
-+    public void setCancelled(boolean cancelled) {
-+        this.cancelled = cancelled;
 +    }
 +
 +    /**
@@ -54,7 +49,7 @@ index 0000000000000000000000000000000000000000..978813b94a5eae0afccbd3b38b463091
 +     */
 +    @NotNull
 +    public PotionEffect getEffect() {
-+        return effect;
++        return this.effect;
 +    }
 +
 +    /**
@@ -73,26 +68,36 @@ index 0000000000000000000000000000000000000000..978813b94a5eae0afccbd3b38b463091
 +     */
 +    @NotNull
 +    public Player getPlayer() {
-+        return player;
++        return this.player;
 +    }
 +
 +    /**
 +     * Gets whether the effect is a primary beacon effect.
 +     *
-+     * @return true if this event represents a primary effect
++     * @return {@code true} if this event represents a primary effect
 +     */
 +    public boolean isPrimary() {
-+        return primary;
++        return this.primary;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0020-Add-PlayerInitialSpawnEvent.patch
+++ b/patches/api/0020-Add-PlayerInitialSpawnEvent.patch
@@ -7,10 +7,10 @@ For modifying a player's initial spawn location as they join the server
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerInitialSpawnEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerInitialSpawnEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..febd384b43560d7d55c96bda5b0701a27fc9e18e
+index 0000000000000000000000000000000000000000..49e97ae79facceca5fc44c84c3d5f342d64cabc2
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerInitialSpawnEvent.java
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,19 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.Location;
@@ -25,7 +25,8 @@ index 0000000000000000000000000000000000000000..febd384b43560d7d55c96bda5b0701a2
 +@Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +public class PlayerInitialSpawnEvent extends PlayerSpawnLocationEvent {
 +
-+    public PlayerInitialSpawnEvent(@NotNull Player who, @NotNull Location spawnLocation) {
-+        super(who, spawnLocation);
++    @ApiStatus.Internal
++    public PlayerInitialSpawnEvent(@NotNull Player player, @NotNull Location spawnLocation) {
++        super(player, spawnLocation);
 +    }
 +}

--- a/patches/api/0023-Add-exception-reporting-event.patch
+++ b/patches/api/0023-Add-exception-reporting-event.patch
@@ -6,29 +6,32 @@ Subject: [PATCH] Add exception reporting event
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/server/ServerExceptionEvent.java b/src/main/java/com/destroystokyo/paper/event/server/ServerExceptionEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..306dbd975e9380c22dae0dad526725cc47a36f16
+index 0000000000000000000000000000000000000000..9377ee1c2368ce058397037952d17bc010f66957
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/server/ServerExceptionEvent.java
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,45 @@
 +package com.destroystokyo.paper.event.server;
 +
-+import com.google.common.base.Preconditions;
 +import org.bukkit.Bukkit;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +import com.destroystokyo.paper.exception.ServerException;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called whenever an exception is thrown in a recoverable section of the server.
 + */
 +public class ServerExceptionEvent extends Event {
-+    private static final HandlerList handlers = new HandlerList();
-+    @NotNull private ServerException exception;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final ServerException exception;
++
++    @ApiStatus.Internal
 +    public ServerExceptionEvent(@NotNull ServerException exception) {
 +        super(!Bukkit.isPrimaryThread());
-+        this.exception = Preconditions.checkNotNull(exception, "exception");
++        this.exception = exception;
 +    }
 +
 +    /**
@@ -38,18 +41,18 @@ index 0000000000000000000000000000000000000000..306dbd975e9380c22dae0dad526725cc
 +     */
 +    @NotNull
 +    public ServerException getException() {
-+        return exception;
++        return this.exception;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/exception/ServerCommandException.java b/src/main/java/com/destroystokyo/paper/exception/ServerCommandException.java

--- a/patches/api/0033-Entity-AddTo-RemoveFrom-World-Events.patch
+++ b/patches/api/0033-Entity-AddTo-RemoveFrom-World-Events.patch
@@ -6,26 +6,32 @@ Subject: [PATCH] Entity AddTo/RemoveFrom World Events
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityAddToWorldEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityAddToWorldEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..982a0abd9a90fcb99f8d7c60a89021a5b1bb8264
+index 0000000000000000000000000000000000000000..1d8e3c93a139bba11affca74b742269f24300d2c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityAddToWorldEvent.java
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,45 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.World;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.CreatureSpawnEvent;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired any time an entity is being added to the world for any reason (including a chunk loading).
-+ *
-+ * Not to be confused with {@link org.bukkit.event.entity.CreatureSpawnEvent}
++ * <p>
++ * Not to be confused with {@link CreatureSpawnEvent}
 + */
 +public class EntityAddToWorldEvent extends EntityEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final World world;
 +
++    @ApiStatus.Internal
 +    public EntityAddToWorldEvent(@NotNull Entity entity, @NotNull World world) {
 +        super(entity);
 +        this.world = world;
@@ -36,33 +42,32 @@ index 0000000000000000000000000000000000000000..982a0abd9a90fcb99f8d7c60a89021a5
 +     */
 +    @NotNull
 +    public World getWorld() {
-+        return world;
++        return this.world;
 +    }
-+
-+    private static final HandlerList handlers = new HandlerList();
 +
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityRemoveFromWorldEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityRemoveFromWorldEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b58e2e7b8707c6221773b8f023f58a4eb9c7d4b9
+index 0000000000000000000000000000000000000000..d75e6a8334c7408ea8c3f155414fc14dc427f190
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityRemoveFromWorldEvent.java
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,43 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.World;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -70,8 +75,12 @@ index 0000000000000000000000000000000000000000..b58e2e7b8707c6221773b8f023f58a4e
 + * Note: The entity is updated prior to this event being called, as such, the entity's world may not be equal to {@link #getWorld()}.
 + */
 +public class EntityRemoveFromWorldEvent extends EntityEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final World world;
 +
++    @ApiStatus.Internal
 +    public EntityRemoveFromWorldEvent(@NotNull Entity entity, @NotNull World world) {
 +        super(entity);
 +        this.world = world;
@@ -82,18 +91,16 @@ index 0000000000000000000000000000000000000000..b58e2e7b8707c6221773b8f023f58a4e
 +     */
 +    @NotNull
 +    public World getWorld() {
-+        return world;
++        return this.world;
 +    }
-+
-+    private static final HandlerList handlers = new HandlerList();
 +
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0034-EntityPathfindEvent.patch
+++ b/patches/api/0034-EntityPathfindEvent.patch
@@ -7,10 +7,10 @@ Fires when an Entity decides to start moving to a location.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityPathfindEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityPathfindEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..63e46b2fb1b12b36fcb1e98b178cf29dd2e3d1b5
+index 0000000000000000000000000000000000000000..5804497f34bac9a9b6b16c6e5decb0119467df7b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityPathfindEvent.java
-@@ -0,0 +1,82 @@
+@@ -0,0 +1,87 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.Location;
@@ -18,78 +18,83 @@ index 0000000000000000000000000000000000000000..63e46b2fb1b12b36fcb1e98b178cf29d
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +/**
 + * Fired when an Entity decides to start moving towards a location.
-+ *
++ * <p>
 + * This event does not fire for the entities actual movement. Only when it
 + * is choosing to start moving to a location.
 + */
 +public class EntityPathfindEvent extends EntityEvent implements Cancellable {
-+    @Nullable private final Entity targetEntity;
-+    @NotNull private final Location loc;
 +
-+    public EntityPathfindEvent(@NotNull Entity entity, @NotNull Location loc, @Nullable Entity targetEntity) {
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @Nullable private final Entity targetEntity;
++    @NotNull private final Location location;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
++    public EntityPathfindEvent(@NotNull Entity entity, @NotNull Location location, @Nullable Entity targetEntity) {
 +        super(entity);
 +        this.targetEntity = targetEntity;
-+        this.loc = loc;
++        this.location = location;
 +    }
 +
 +    /**
 +     * The Entity that is pathfinding.
++     *
 +     * @return The Entity that is pathfinding.
 +     */
 +    @NotNull
 +    public Entity getEntity() {
-+        return entity;
++        return this.entity;
 +    }
 +
 +    /**
 +     * If the Entity is trying to pathfind to an entity, this is the entity in relation.
++     * <br>
++     * Otherwise this will return {@code null}.
 +     *
-+     * Otherwise this will return null.
-+     *
-+     * @return The entity target or null
++     * @return The entity target or {@code null}
 +     */
 +    @Nullable
 +    public Entity getTargetEntity() {
-+        return targetEntity;
++        return this.targetEntity;
 +    }
 +
 +    /**
 +     * The Location of where the entity is about to move to.
-+     *
++     * <br>
 +     * Note that if the target happened to of been an entity
++     *
 +     * @return Location of where the entity is trying to pathfind to.
 +     */
 +    @NotNull
 +    public Location getLoc() {
-+        return loc;
++        return this.location;
 +    }
-+
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0037-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/api/0037-Add-PlayerUseUnknownEntityEvent.patch
@@ -10,17 +10,19 @@ Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerUseUnknownEntityEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerUseUnknownEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a7228e248e3d8eb2e9f011dfe2c7dd9f3f48000f
+index 0000000000000000000000000000000000000000..f64b253f1794c7987a32a4313df19d7512bea1bc
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerUseUnknownEntityEvent.java
-@@ -0,0 +1,82 @@
+@@ -0,0 +1,86 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 +import org.bukkit.inventory.EquipmentSlot;
 +import org.bukkit.util.Vector;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -33,14 +35,16 @@ index 0000000000000000000000000000000000000000..a7228e248e3d8eb2e9f011dfe2c7dd9f
 + */
 +public class PlayerUseUnknownEntityEvent extends PlayerEvent {
 +
-+    private static final HandlerList HANDLERS = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final int entityId;
 +    private final boolean attack;
 +    private final @NotNull EquipmentSlot hand;
 +    private final @Nullable Vector clickedPosition;
 +
-+    public PlayerUseUnknownEntityEvent(@NotNull Player who, int entityId, boolean attack, @NotNull EquipmentSlot hand, @Nullable Vector clickedPosition) {
-+        super(who);
++    @ApiStatus.Internal
++    public PlayerUseUnknownEntityEvent(@NotNull Player player, int entityId, boolean attack, @NotNull EquipmentSlot hand, @Nullable Vector clickedPosition) {
++        super(player);
 +        this.entityId = entityId;
 +        this.attack = attack;
 +        this.hand = hand;
@@ -59,7 +63,7 @@ index 0000000000000000000000000000000000000000..a7228e248e3d8eb2e9f011dfe2c7dd9f
 +    /**
 +     * Returns whether the interaction was an attack.
 +     *
-+     * @return true if the player is attacking the entity, false if the player is interacting with the entity
++     * @return {@code true} if the player is attacking the entity, {@code false} if the player is interacting with the entity
 +     */
 +    public boolean isAttack() {
 +        return this.attack;
@@ -75,11 +79,11 @@ index 0000000000000000000000000000000000000000..a7228e248e3d8eb2e9f011dfe2c7dd9f
 +    }
 +
 +    /**
-+     * Returns the position relative to the entity that was clicked, or null if not available.
-+     * See {@link org.bukkit.event.player.PlayerInteractAtEntityEvent} for more details.
++     * Returns the position relative to the entity that was clicked, or {@code null} if not available.
++     * See {@link PlayerInteractAtEntityEvent} for more details.
 +     *
-+     * @return the position relative to the entity that was clicked, or null if not available
-+     * @see org.bukkit.event.player.PlayerInteractAtEntityEvent
++     * @return the position relative to the entity that was clicked, or {@code null} if not available
++     * @see PlayerInteractAtEntityEvent
 +     */
 +    public @Nullable Vector getClickedRelativePosition() {
 +        return this.clickedPosition != null ? this.clickedPosition.clone() : null;
@@ -88,11 +92,11 @@ index 0000000000000000000000000000000000000000..a7228e248e3d8eb2e9f011dfe2c7dd9f
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0038-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
+++ b/patches/api/0038-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add handshake event to allow plugins to handle client
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..59ae7bc3a0a2079fe4b3a92d777aca682a58e4e3
+index 0000000000000000000000000000000000000000..7c049bad187b94331f42f96833d1cf4ce03ef477
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.java
-@@ -0,0 +1,277 @@
+@@ -0,0 +1,267 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import com.google.common.base.Preconditions;
@@ -20,6 +20,7 @@ index 0000000000000000000000000000000000000000..59ae7bc3a0a2079fe4b3a92d777aca68
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -27,18 +28,18 @@ index 0000000000000000000000000000000000000000..59ae7bc3a0a2079fe4b3a92d777aca68
 +
 +/**
 + * This event is fired during a player handshake.
-+ *
-+ * <p>If there are no listeners listening to this event, the logic default
-+ * to your server platform will be ran.</p>
++ * <p>
++ * If there are no listeners listening to this event, the logic default
++ * to your server platform will be run.
 + *
 + * <p>WARNING: TAMPERING WITH THIS EVENT CAN BE DANGEROUS</p>
 + */
 +public class PlayerHandshakeEvent extends Event implements Cancellable {
 +
-+    private static final HandlerList HANDLERS = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final String originalHandshake;
 +    @NotNull private final String originalSocketAddressHostname;
-+    private boolean cancelled;
 +    @Nullable private String serverHostname;
 +    @Nullable private String socketAddressHostname;
 +    @Nullable private UUID uniqueId;
@@ -46,26 +47,15 @@ index 0000000000000000000000000000000000000000..59ae7bc3a0a2079fe4b3a92d777aca68
 +    private boolean failed;
 +    private Component failMessage = Component.text("If you wish to use IP forwarding, please enable it in your BungeeCord config as well!", NamedTextColor.YELLOW);
 +
-+    /**
-+     * Creates a new {@link PlayerHandshakeEvent}.
-+     *
-+     * @param originalHandshake the original handshake string
-+     * @param cancelled if this event is enabled
-+     *
-+     * @deprecated in favour of {@link PlayerHandshakeEvent(String, String, boolean)}
-+     */
++    private boolean cancelled;
++
 +    @Deprecated
++    @ApiStatus.Internal
 +    public PlayerHandshakeEvent(@NotNull String originalHandshake, boolean cancelled) {
 +        this(originalHandshake, "127.0.0.1", cancelled);
 +    }
 +
-+    /**
-+     * Creates a new {@link PlayerHandshakeEvent}.
-+     *
-+     * @param originalHandshake the original handshake string
-+     * @param originalSocketAddressHostname the original socket address hostname
-+     * @param cancelled if this event is enabled
-+     */
++    @ApiStatus.Internal
 +    public PlayerHandshakeEvent(@NotNull String originalHandshake, @NotNull String originalSocketAddressHostname, boolean cancelled) {
 +        super(true);
 +        this.originalHandshake = originalHandshake;
@@ -75,9 +65,9 @@ index 0000000000000000000000000000000000000000..59ae7bc3a0a2079fe4b3a92d777aca68
 +
 +    /**
 +     * Determines if this event is cancelled.
-+     *
-+     * <p>When this event is cancelled, custom handshake logic will not
-+     * be processed.</p>
++     * <p>
++     * When this event is cancelled, custom handshake logic will not
++     * be processed.
 +     *
 +     * @return {@code true} if this event is cancelled, {@code false} otherwise
 +     */
@@ -88,15 +78,15 @@ index 0000000000000000000000000000000000000000..59ae7bc3a0a2079fe4b3a92d777aca68
 +
 +    /**
 +     * Sets if this event is cancelled.
++     * <p>
++     * When this event is cancelled, custom handshake logic will not
++     * be processed.
 +     *
-+     * <p>When this event is cancelled, custom handshake logic will not
-+     * be processed.</p>
-+     *
-+     * @param cancelled {@code true} if this event is cancelled, {@code false} otherwise
++     * @param cancel {@code true} if this event is cancelled, {@code false} otherwise
 +     */
 +    @Override
-+    public void setCancelled(boolean cancelled) {
-+        this.cancelled = cancelled;
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
 +    }
 +
 +    /**
@@ -201,9 +191,9 @@ index 0000000000000000000000000000000000000000..59ae7bc3a0a2079fe4b3a92d777aca68
 +
 +    /**
 +     * Determines if authentication failed.
-+     *
-+     * <p>When {@code true}, the client connecting will be disconnected
-+     * with the {@link #getFailMessage() fail message}.</p>
++     * <p>
++     * When {@code true}, the client connecting will be disconnected
++     * with the {@link #getFailMessage() fail message}.
 +     *
 +     * @return {@code true} if authentication failed, {@code false} otherwise
 +     */
@@ -213,9 +203,9 @@ index 0000000000000000000000000000000000000000..59ae7bc3a0a2079fe4b3a92d777aca68
 +
 +    /**
 +     * Sets if authentication failed and the client should be disconnected.
-+     *
-+     * <p>When {@code true}, the client connecting will be disconnected
-+     * with the {@link #getFailMessage() fail message}.</p>
++     * <p>
++     * When {@code true}, the client connecting will be disconnected
++     * with the {@link #getFailMessage() fail message}.
 +     *
 +     * @param failed {@code true} if authentication failed, {@code false} otherwise
 +     */
@@ -280,11 +270,11 @@ index 0000000000000000000000000000000000000000..59ae7bc3a0a2079fe4b3a92d777aca68
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0041-LootTable-API.patch
+++ b/patches/api/0041-LootTable-API.patch
@@ -189,21 +189,27 @@ index 0000000000000000000000000000000000000000..2b01a50b6e18856f4c9e28340a7a111c
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/LootableInventoryReplenishEvent.java b/src/main/java/com/destroystokyo/paper/loottable/LootableInventoryReplenishEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..fd184f13f5e8ee5cf829fff4f44696e1f760430b
+index 0000000000000000000000000000000000000000..5ee1a04aaaa4ef09559f2cf757811e463e2a1be6
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/LootableInventoryReplenishEvent.java
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,47 @@
 +package com.destroystokyo.paper.loottable;
 +
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +public class LootableInventoryReplenishEvent extends PlayerEvent implements Cancellable {
-+    @NotNull private final LootableInventory inventory;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final LootableInventory inventory;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public LootableInventoryReplenishEvent(@NotNull Player player, @NotNull LootableInventory inventory) {
 +        super(player);
 +        this.inventory = inventory;
@@ -211,31 +217,27 @@ index 0000000000000000000000000000000000000000..fd184f13f5e8ee5cf829fff4f44696e1
 +
 +    @NotNull
 +    public LootableInventory getInventory() {
-+        return inventory;
++        return this.inventory;
 +    }
-+
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/block/Barrel.java b/src/main/java/org/bukkit/block/Barrel.java

--- a/patches/api/0042-Add-EntityZapEvent.patch
+++ b/patches/api/0042-Add-EntityZapEvent.patch
@@ -6,13 +6,12 @@ Subject: [PATCH] Add EntityZapEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityZapEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityZapEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1c5fa066c9e5e1b1a06df30842a4c7acc4742df8
+index 0000000000000000000000000000000000000000..dc6d15975a47e68c5bd939e68ddd2773028a6ac8
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityZapEvent.java
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,69 @@
 +package com.destroystokyo.paper.event.entity;
 +
-+import com.google.common.base.Preconditions;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.entity.LightningStrike;
 +import org.bukkit.event.Cancellable;
@@ -20,91 +19,89 @@ index 0000000000000000000000000000000000000000..1c5fa066c9e5e1b1a06df30842a4c7ac
 +import org.bukkit.event.entity.EntityTransformEvent;
 +
 +import java.util.Collections;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ *  Fired when lightning strikes an entity
++ * Fired when lightning strikes an entity
 + */
 +public class EntityZapEvent extends EntityTransformEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled;
-+    @NotNull private final LightningStrike bolt;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final LightningStrike bolt;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public EntityZapEvent(@NotNull final Entity entity, @NotNull final LightningStrike bolt, @NotNull final Entity replacementEntity) {
 +        super(entity, Collections.singletonList(replacementEntity), TransformReason.LIGHTNING);
-+        Preconditions.checkNotNull(bolt);
-+        Preconditions.checkNotNull(replacementEntity);
 +        this.bolt = bolt;
-+    }
-+
-+    public boolean isCancelled() {
-+        return cancelled;
-+    }
-+
-+    public void setCancelled(boolean cancel) {
-+        this.cancelled = cancel;
 +    }
 +
 +    /**
 +     * Gets the lightning bolt that is striking the entity.
++     *
 +     * @return The lightning bolt responsible for this event
 +     */
 +    @NotNull
 +    public LightningStrike getBolt() {
-+        return bolt;
++        return this.bolt;
 +    }
 +
 +    /**
 +     * Gets the entity that will replace the struck entity.
++     *
 +     * @return The entity that will replace the struck entity
 +     */
 +    @NotNull
 +    public Entity getReplacementEntity() {
-+        return getTransformedEntity();
++        return super.getTransformedEntity();
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/event/entity/PigZapEvent.java b/src/main/java/org/bukkit/event/entity/PigZapEvent.java
-index 0e0ed93b568fd2c0d8f6e359c31dc29cb0fa71c2..d3949edfc736b3d67a627ef378748b374769e183 100644
+index 0e0ed93b568fd2c0d8f6e359c31dc29cb0fa71c2..085337f3d3d6adef5fd4ecda133c607e4b77bd93 100644
 --- a/src/main/java/org/bukkit/event/entity/PigZapEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/PigZapEvent.java
-@@ -2,6 +2,7 @@ package org.bukkit.event.entity;
- 
- import java.util.Collections;
- import org.bukkit.entity.Entity;
-+import com.destroystokyo.paper.event.entity.EntityZapEvent;
- import org.bukkit.entity.LightningStrike;
- import org.bukkit.entity.Pig;
- import org.bukkit.entity.PigZombie;
-@@ -12,14 +13,14 @@ import org.jetbrains.annotations.NotNull;
+@@ -12,14 +12,14 @@ import org.jetbrains.annotations.NotNull;
  /**
   * Stores data for pigs being zapped
   */
 -public class PigZapEvent extends EntityTransformEvent implements Cancellable {
 -    private static final HandlerList handlers = new HandlerList();
-+public class PigZapEvent extends EntityZapEvent implements Cancellable {
-+    //private static final HandlerList handlers = new HandlerList();
++public class PigZapEvent extends com.destroystokyo.paper.event.entity.EntityZapEvent implements Cancellable { // Paper
++    // private static final HandlerList handlers = new HandlerList(); // Paper - moved in the super class
      private boolean canceled;
      private final PigZombie pigzombie;
      private final LightningStrike bolt;
  
      public PigZapEvent(@NotNull final Pig pig, @NotNull final LightningStrike bolt, @NotNull final PigZombie pigzombie) {
 -        super(pig, Collections.singletonList((Entity) pigzombie), TransformReason.LIGHTNING);
-+        super(pig, bolt, pigzombie);
++        super(pig, bolt, pigzombie); // Paper
          this.bolt = bolt;
          this.pigzombie = pigzombie;
      }
-@@ -63,6 +64,8 @@ public class PigZapEvent extends EntityTransformEvent implements Cancellable {
+@@ -63,6 +63,8 @@ public class PigZapEvent extends EntityTransformEvent implements Cancellable {
          return pigzombie;
      }
  
@@ -113,7 +110,7 @@ index 0e0ed93b568fd2c0d8f6e359c31dc29cb0fa71c2..d3949edfc736b3d67a627ef378748b37
      @NotNull
      @Override
      public HandlerList getHandlers() {
-@@ -73,4 +76,6 @@ public class PigZapEvent extends EntityTransformEvent implements Cancellable {
+@@ -73,4 +75,6 @@ public class PigZapEvent extends EntityTransformEvent implements Cancellable {
      public static HandlerList getHandlerList() {
          return handlers;
      }

--- a/patches/api/0046-Add-ProjectileCollideEvent.patch
+++ b/patches/api/0046-Add-ProjectileCollideEvent.patch
@@ -7,41 +7,40 @@ Now deprecated and replaced with ProjectileHitEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/ProjectileCollideEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/ProjectileCollideEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6ae2bc3d952d34f298220738856024e0b6594199
+index 0000000000000000000000000000000000000000..3caff9cbb990e03d4331bd601272aec5090affcf
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/ProjectileCollideEvent.java
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,74 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Entity;
 +import org.bukkit.entity.Projectile;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityDamageByEntityEvent;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called when a projectile collides with an entity
 + * <p>
-+ * This event is called <b>before</b> {@link org.bukkit.event.entity.EntityDamageByEntityEvent}, and cancelling it will allow the projectile to continue flying
++ * This event is called <b>before</b> {@link EntityDamageByEntityEvent}, and cancelling it will allow the projectile to continue flying
++ *
 + * @deprecated Deprecated, use {@link org.bukkit.event.entity.ProjectileHitEvent} and check if there is a hit entity
 + */
 +@Deprecated
 +public class ProjectileCollideEvent extends EntityEvent implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final Entity collidedWith;
 +
-+    /**
-+     * Get the entity the projectile collided with
-+     *
-+     * @return the entity collided with
-+     */
-+    @NotNull
-+    public Entity getCollidedWith() {
-+        return collidedWith;
-+    }
++    private boolean cancelled;
 +
-+    public ProjectileCollideEvent(@NotNull Projectile what, @NotNull Entity collidedWith) {
-+        super(what);
++    @ApiStatus.Internal
++    public ProjectileCollideEvent(@NotNull Projectile projectile, @NotNull Entity collidedWith) {
++        super(projectile);
 +        this.collidedWith = collidedWith;
 +    }
 +
@@ -55,28 +54,34 @@ index 0000000000000000000000000000000000000000..6ae2bc3d952d34f298220738856024e0
 +        return (Projectile) super.getEntity();
 +    }
 +
-+    private static final HandlerList handlerList = new HandlerList();
-+
++    /**
++     * Get the entity the projectile collided with
++     *
++     * @return the entity collided with
++     */
 +    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlerList;
++    public Entity getCollidedWith() {
++        return this.collidedWith;
 +    }
-+
-+    @NotNull
-+    @Override
-+    public HandlerList getHandlers() {
-+        return handlerList;
-+    }
-+
-+    private boolean cancelled = false;
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
 +        this.cancelled = cancel;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0049-IllegalPacketEvent.patch
+++ b/patches/api/0049-IllegalPacketEvent.patch
@@ -9,16 +9,16 @@ Lets plugins change the kick message and if it should kick or not.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/IllegalPacketEvent.java b/src/main/java/com/destroystokyo/paper/event/player/IllegalPacketEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8d8e9b16f2a6707d2af7567c7682dfc5db51a737
+index 0000000000000000000000000000000000000000..8dc5971ba441395f7bc13568c5ee88ca34837e95
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/IllegalPacketEvent.java
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,67 @@
 +package com.destroystokyo.paper.event.player;
 +
-+import org.bukkit.Bukkit;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -27,20 +27,24 @@ index 0000000000000000000000000000000000000000..8d8e9b16f2a6707d2af7567c7682dfc5
 + */
 +@Deprecated
 +public class IllegalPacketEvent extends PlayerEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @Nullable private final String type;
-+    @Nullable private final String ex;
++    @Nullable private final String exceptionMessage;
 +    @Nullable private String kickMessage;
 +    private boolean shouldKick = true;
 +
++    @ApiStatus.Internal
 +    public IllegalPacketEvent(@NotNull Player player, @Nullable String type, @Nullable String kickMessage, @NotNull Exception e) {
 +        super(player);
 +        this.type = type;
 +        this.kickMessage = kickMessage;
-+        this.ex = e.getMessage();
++        this.exceptionMessage = e.getMessage();
 +    }
 +
 +    public boolean isShouldKick() {
-+        return shouldKick;
++        return this.shouldKick;
 +    }
 +
 +    public void setShouldKick(boolean shouldKick) {
@@ -49,7 +53,7 @@ index 0000000000000000000000000000000000000000..8d8e9b16f2a6707d2af7567c7682dfc5
 +
 +    @Nullable
 +    public String getKickMessage() {
-+        return kickMessage;
++        return this.kickMessage;
 +    }
 +
 +    public void setKickMessage(@Nullable String kickMessage) {
@@ -58,32 +62,21 @@ index 0000000000000000000000000000000000000000..8d8e9b16f2a6707d2af7567c7682dfc5
 +
 +    @Nullable
 +    public String getType() {
-+        return type;
++        return this.type;
 +    }
 +
 +    @Nullable
 +    public String getExceptionMessage() {
-+        return ex;
++        return this.exceptionMessage;
 +    }
-+
-+    private static final HandlerList handlers = new HandlerList();
 +
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    public static void process(@NotNull Player player, @Nullable String type, @Nullable String kickMessage, @NotNull Exception exception) {
-+        IllegalPacketEvent event = new IllegalPacketEvent(player, type, kickMessage, exception);
-+        event.callEvent();
-+        if (event.shouldKick) {
-+            player.kickPlayer(kickMessage);
-+        }
-+        Bukkit.getLogger().severe(player.getName() + "/" + type + ": " + exception.getMessage());
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0051-PlayerTeleportEndGatewayEvent.patch
+++ b/patches/api/0051-PlayerTeleportEndGatewayEvent.patch
@@ -7,24 +7,27 @@ Allows you to access the Gateway being used in a teleport event
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerTeleportEndGatewayEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerTeleportEndGatewayEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b64ab6eecd8bc4ca9c109b9d83c82861d6260793
+index 0000000000000000000000000000000000000000..40bd79fbe30f19bc93e34da52d2b2bf0768be974
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerTeleportEndGatewayEvent.java
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,32 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.Location;
 +import org.bukkit.block.EndGateway;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.player.PlayerTeleportEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when a teleport is triggered for an End Gateway
 + */
 +public class PlayerTeleportEndGatewayEvent extends PlayerTeleportEvent {
++
 +    @NotNull private final EndGateway gateway;
 +
++    @ApiStatus.Internal
 +    public PlayerTeleportEndGatewayEvent(@NotNull Player player, @NotNull Location from, @NotNull Location to, @NotNull EndGateway gateway) {
 +        super(player, from, to, PlayerTeleportEvent.TeleportCause.END_GATEWAY);
 +        this.gateway = gateway;
@@ -37,6 +40,6 @@ index 0000000000000000000000000000000000000000..b64ab6eecd8bc4ca9c109b9d83c82861
 +     */
 +    @NotNull
 +    public EndGateway getGateway() {
-+        return gateway;
++        return this.gateway;
 +    }
 +}

--- a/patches/api/0058-PlayerAttemptPickupItemEvent.patch
+++ b/patches/api/0058-PlayerAttemptPickupItemEvent.patch
@@ -6,33 +6,39 @@ Subject: [PATCH] PlayerAttemptPickupItemEvent
 
 diff --git a/src/main/java/org/bukkit/event/player/PlayerAttemptPickupItemEvent.java b/src/main/java/org/bukkit/event/player/PlayerAttemptPickupItemEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0788153a9641e75da565d2e6eee37eeee1cbc61e
+index 0000000000000000000000000000000000000000..13e4b1309ea9965a07fc8b276d5a7e606e205824
 --- /dev/null
 +++ b/src/main/java/org/bukkit/event/player/PlayerAttemptPickupItemEvent.java
-@@ -0,0 +1,90 @@
+@@ -0,0 +1,96 @@
 +package org.bukkit.event.player;
 +
 +import org.bukkit.entity.Item;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Thrown when a player attempts to pick an item up from the ground
 + */
 +public class PlayerAttemptPickupItemEvent extends PlayerEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final Item item;
 +    private final int remaining;
 +    private boolean flyAtPlayer = true;
-+    private boolean isCancelled = false;
++
++    private boolean cancelled;
 +
 +    @Deprecated // Remove in 1.13 // Remove in 1.14?
++    @ApiStatus.Internal
 +    public PlayerAttemptPickupItemEvent(@NotNull final Player player, @NotNull final Item item) {
 +        this(player, item, 0);
 +    }
 +
++    @ApiStatus.Internal
 +    public PlayerAttemptPickupItemEvent(@NotNull final Player player, @NotNull final Item item, final int remaining) {
 +        super(player);
 +        this.item = item;
@@ -46,7 +52,7 @@ index 0000000000000000000000000000000000000000..0788153a9641e75da565d2e6eee37eee
 +     */
 +    @NotNull
 +    public Item getItem() {
-+        return item;
++        return this.item;
 +    }
 +
 +    /**
@@ -55,14 +61,14 @@ index 0000000000000000000000000000000000000000..0788153a9641e75da565d2e6eee37eee
 +     * @return amount that will remain on the ground
 +     */
 +    public int getRemaining() {
-+        return remaining;
++        return this.remaining;
 +    }
 +
 +    /**
 +     * Set if the item will fly at the player
 +     * <p>Cancelling the event will set this value to false.</p>
 +     *
-+     * @param flyAtPlayer True for item to fly at player
++     * @param flyAtPlayer {@code true} for item to fly at player
 +     */
 +    public void setFlyAtPlayer(boolean flyAtPlayer) {
 +        this.flyAtPlayer = flyAtPlayer;
@@ -71,7 +77,7 @@ index 0000000000000000000000000000000000000000..0788153a9641e75da565d2e6eee37eee
 +    /**
 +     * Gets if the item will fly at the player
 +     *
-+     * @return True if the item will fly at the player
++     * @return {@code true} if the item will fly at the player
 +     */
 +    public boolean getFlyAtPlayer() {
 +        return this.flyAtPlayer;
@@ -80,23 +86,23 @@ index 0000000000000000000000000000000000000000..0788153a9641e75da565d2e6eee37eee
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return this.isCancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        this.isCancelled = cancel;
++        this.cancelled = cancel;
 +        this.flyAtPlayer = !cancel;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0059-Add-UnknownCommandEvent.patch
+++ b/patches/api/0059-Add-UnknownCommandEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 diff --git a/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java b/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e4f8a0d14ae66468bbb0a5d6bf9c1ee417dc866c
+index 0000000000000000000000000000000000000000..9bdeeecdb6021d61fd9141270011e56b06a58a76
 --- /dev/null
 +++ b/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java
 @@ -0,0 +1,110 @@
@@ -17,6 +17,7 @@ index 0000000000000000000000000000000000000000..e4f8a0d14ae66468bbb0a5d6bf9c1ee4
 +import org.bukkit.command.CommandSender;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.Contract;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
@@ -25,11 +26,14 @@ index 0000000000000000000000000000000000000000..e4f8a0d14ae66468bbb0a5d6bf9c1ee4
 + * Thrown when a player executes a command that is not defined
 + */
 +public class UnknownCommandEvent extends Event {
-+    private static final HandlerList handlers = new HandlerList();
-+    @NotNull private CommandSender sender;
-+    @NotNull private String commandLine;
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final CommandSender sender;
++    @NotNull private final String commandLine;
 +    @Nullable private Component message;
 +
++    @ApiStatus.Internal
 +    public UnknownCommandEvent(@NotNull final CommandSender sender, @NotNull final String commandLine, @Nullable final Component message) {
 +        super(false);
 +        this.sender = sender;
@@ -39,29 +43,26 @@ index 0000000000000000000000000000000000000000..e4f8a0d14ae66468bbb0a5d6bf9c1ee4
 +
 +    /**
 +     * Gets the CommandSender or ConsoleCommandSender
-+     * <p>
 +     *
 +     * @return Sender of the command
 +     */
 +    @NotNull
 +    public CommandSender getSender() {
-+        return sender;
++        return this.sender;
 +    }
 +
 +    /**
-+     * Gets the command that was send
-+     * <p>
++     * Gets the command that was sent
 +     *
 +     * @return Command sent
 +     */
 +    @NotNull
 +    public String getCommandLine() {
-+        return commandLine;
++        return this.commandLine;
 +    }
 +
 +    /**
 +     * Gets message that will be returned
-+     * <p>
 +     *
 +     * @return Unknown command message
 +     * @deprecated use {@link #message()}
@@ -75,9 +76,9 @@ index 0000000000000000000000000000000000000000..e4f8a0d14ae66468bbb0a5d6bf9c1ee4
 +    /**
 +     * Sets message that will be returned
 +     * <p>
-+     * Set to null to avoid any message being sent
++     * Set to {@code null} to avoid any message being sent
 +     *
-+     * @param message the message to be returned, or null
++     * @param message the message to be returned, or {@code null}
 +     * @deprecated use {@link #message(Component)}
 +     */
 +    @Deprecated
@@ -87,7 +88,6 @@ index 0000000000000000000000000000000000000000..e4f8a0d14ae66468bbb0a5d6bf9c1ee4
 +
 +    /**
 +     * Gets message that will be returned
-+     * <p>
 +     *
 +     * @return Unknown command message
 +     */
@@ -100,9 +100,9 @@ index 0000000000000000000000000000000000000000..e4f8a0d14ae66468bbb0a5d6bf9c1ee4
 +    /**
 +     * Sets message that will be returned
 +     * <p>
-+     * Set to null to avoid any message being sent
++     * Set to {@code null} to avoid any message being sent
 +     *
-+     * @param message the message to be returned, or null
++     * @param message the message to be returned, or {@code null}
 +     */
 +    public void message(@Nullable Component message) {
 +        this.message = message;
@@ -111,12 +111,12 @@ index 0000000000000000000000000000000000000000..e4f8a0d14ae66468bbb0a5d6bf9c1ee4
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 +

--- a/patches/api/0061-PlayerPickupItemEvent-setFlyAtPlayer.patch
+++ b/patches/api/0061-PlayerPickupItemEvent-setFlyAtPlayer.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] PlayerPickupItemEvent#setFlyAtPlayer
 
 
 diff --git a/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java b/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
-index 951ea2cc763973655beedcba3c75332d3f297313..26383597cb0bdcf81035b571998332090b785730 100644
+index 951ea2cc763973655beedcba3c75332d3f297313..e528d811f651696069dbd2fd21c5ffad294b26af 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
 @@ -17,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
@@ -16,16 +16,17 @@ index 951ea2cc763973655beedcba3c75332d3f297313..26383597cb0bdcf81035b57199833209
      private boolean cancel = false;
      private final int remaining;
  
-@@ -45,6 +46,27 @@ public class PlayerPickupItemEvent extends PlayerEvent implements Cancellable {
+@@ -45,6 +46,28 @@ public class PlayerPickupItemEvent extends PlayerEvent implements Cancellable {
          return remaining;
      }
  
 +    // Paper start
 +    /**
 +     * Set if the item will fly at the player
-+     * <p>Cancelling the event will set this value to false.</p>
++     * <p>
++     * Cancelling the event will set this value to false.
 +     *
-+     * @param flyAtPlayer True for item to fly at player
++     * @param flyAtPlayer true for item to fly at player
 +     */
 +    public void setFlyAtPlayer(boolean flyAtPlayer) {
 +        this.flyAtPlayer = flyAtPlayer;
@@ -34,7 +35,7 @@ index 951ea2cc763973655beedcba3c75332d3f297313..26383597cb0bdcf81035b57199833209
 +    /**
 +     * Gets if the item will fly at the player
 +     *
-+     * @return True if the item will fly at the player
++     * @return true if the item will fly at the player
 +     */
 +    public boolean getFlyAtPlayer() {
 +        return flyAtPlayer;
@@ -44,7 +45,7 @@ index 951ea2cc763973655beedcba3c75332d3f297313..26383597cb0bdcf81035b57199833209
      @Override
      public boolean isCancelled() {
          return cancel;
-@@ -53,6 +75,7 @@ public class PlayerPickupItemEvent extends PlayerEvent implements Cancellable {
+@@ -53,6 +76,7 @@ public class PlayerPickupItemEvent extends PlayerEvent implements Cancellable {
      @Override
      public void setCancelled(boolean cancel) {
          this.cancel = cancel;

--- a/patches/api/0064-Profile-Lookup-Events.patch
+++ b/patches/api/0064-Profile-Lookup-Events.patch
@@ -8,10 +8,10 @@ profiles that had to be looked up.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/profile/LookupProfileEvent.java b/src/main/java/com/destroystokyo/paper/event/profile/LookupProfileEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8df37c07cd55ddf110d1dd68183d7b697f7a6756
+index 0000000000000000000000000000000000000000..2ad2782aafe76f8b10565c0f0419d6b9c665b267
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/profile/LookupProfileEvent.java
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,48 @@
 +package com.destroystokyo.paper.event.profile;
 +
 +import com.destroystokyo.paper.profile.PlayerProfile;
@@ -19,21 +19,23 @@ index 0000000000000000000000000000000000000000..8df37c07cd55ddf110d1dd68183d7b69
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Allows a plugin to be notified anytime AFTER a Profile has been looked up from the Mojang API
 + * This is an opportunity to view the response and potentially cache things.
-+ *
++ * <p>
 + * No guarantees are made about thread execution context for this event. If you need to know, check
-+ * event.isAsync()
++ * {@link Event#isAsynchronous()}
 + */
 +public class LookupProfileEvent extends Event {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    @NotNull private final PlayerProfile profile;
 +
++    @ApiStatus.Internal
 +    public LookupProfileEvent(@NotNull PlayerProfile profile) {
 +        super(!Bukkit.isPrimaryThread());
 +        this.profile = profile;
@@ -44,31 +46,29 @@ index 0000000000000000000000000000000000000000..8df37c07cd55ddf110d1dd68183d7b69
 +     */
 +    @NotNull
 +    public PlayerProfile getPlayerProfile() {
-+        return profile;
++        return this.profile;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/profile/PreLookupProfileEvent.java b/src/main/java/com/destroystokyo/paper/event/profile/PreLookupProfileEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4dcf6242c9acc62d030a94f67b78729ed29f8c85
+index 0000000000000000000000000000000000000000..3f73ec52f9b581001bef3a19a5f1533dfa474356
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/profile/PreLookupProfileEvent.java
-@@ -0,0 +1,108 @@
+@@ -0,0 +1,112 @@
 +package com.destroystokyo.paper.event.profile;
 +
-+import com.destroystokyo.paper.profile.PlayerProfile;
 +import com.destroystokyo.paper.profile.ProfileProperty;
-+import com.google.common.collect.ArrayListMultimap;
 +import org.bukkit.Bukkit;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
@@ -76,26 +76,30 @@ index 0000000000000000000000000000000000000000..4dcf6242c9acc62d030a94f67b78729e
 +import java.util.HashSet;
 +import java.util.Set;
 +import java.util.UUID;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +/**
 + * Allows a plugin to intercept a Profile Lookup for a Profile by name
-+ *
++ * <p>
 + * At the point of event fire, the UUID and properties are unset.
-+ *
++ * <p>
 + * If a plugin sets the UUID, and optionally the properties, the API call to look up the profile may be skipped.
-+ *
++ * <p>
 + * No guarantees are made about thread execution context for this event. If you need to know, check
-+ * event.isAsync()
++ * {@link Event#isAsynchronous()}
 + */
 +public class PreLookupProfileEvent extends Event {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final String name;
++
 +    private UUID uuid;
 +    @NotNull private Set<ProfileProperty> properties = new HashSet<>();
 +
++    @ApiStatus.Internal
 +    public PreLookupProfileEvent(@NotNull String name) {
 +        super(!Bukkit.isPrimaryThread());
 +        this.name = name;
@@ -106,11 +110,11 @@ index 0000000000000000000000000000000000000000..4dcf6242c9acc62d030a94f67b78729e
 +     */
 +    @NotNull
 +    public String getName() {
-+        return name;
++        return this.name;
 +    }
 +
 +    /**
-+     * If this value is left null by the completion of the event call, then the server will
++     * If this value is left {@code null} by the completion of the event call, then the server will
 +     * trigger a call to the Mojang API to look up the UUID (Network Request), and subsequently, fire a
 +     * {@link LookupProfileEvent}
 +     *
@@ -118,22 +122,22 @@ index 0000000000000000000000000000000000000000..4dcf6242c9acc62d030a94f67b78729e
 +     */
 +    @Nullable
 +    public UUID getUUID() {
-+        return uuid;
++        return this.uuid;
 +    }
 +
 +    /**
 +     * Sets the UUID for this player name. This will skip the initial API call to find the players UUID.
-+     *
++     * <p>
 +     * However, if Profile Properties are needed by the server, you must also set them or else an API call might still be made.
 +     *
-+     * @param uuid the UUID to set for the profile or null to reset
++     * @param uuid the UUID to set for the profile or {@code null} to reset
 +     */
 +    public void setUUID(@Nullable UUID uuid) {
 +        this.uuid = uuid;
 +    }
 +
 +    /**
-+     * @return The currently pending prepopulated properties.
++     * @return The currently pending pre-populated properties.
 +     * Any property in this Set will be automatically prefilled on this Profile
 +     */
 +    @NotNull
@@ -142,8 +146,9 @@ index 0000000000000000000000000000000000000000..4dcf6242c9acc62d030a94f67b78729e
 +    }
 +
 +    /**
-+     * Clears any existing prepopulated properties and uses the supplied properties
++     * Clears any existing pre-populated properties and uses the supplied properties
 +     * Any property in this Set will be automatically prefilled on this Profile
++     *
 +     * @param properties The properties to add
 +     */
 +    public void setProfileProperties(@NotNull Set<ProfileProperty> properties) {
@@ -152,8 +157,9 @@ index 0000000000000000000000000000000000000000..4dcf6242c9acc62d030a94f67b78729e
 +    }
 +
 +    /**
-+     * Adds any properties currently missing to the prepopulated properties set, replacing any that already were set.
++     * Adds any properties currently missing to the pre-populated properties set, replacing any that already were set.
 +     * Any property in this Set will be automatically prefilled on this Profile
++     *
 +     * @param properties The properties to add
 +     */
 +    public void addProfileProperties(@NotNull Set<ProfileProperty> properties) {
@@ -163,12 +169,12 @@ index 0000000000000000000000000000000000000000..4dcf6242c9acc62d030a94f67b78729e
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +}

--- a/patches/api/0069-ProfileWhitelistVerifyEvent.patch
+++ b/patches/api/0069-ProfileWhitelistVerifyEvent.patch
@@ -9,10 +9,10 @@ Allows you to do dynamic whitelisting and change of kick message
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/profile/ProfileWhitelistVerifyEvent.java b/src/main/java/com/destroystokyo/paper/event/profile/ProfileWhitelistVerifyEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c6f5e2b5459368ad1e4db9929ca14568a25793fa
+index 0000000000000000000000000000000000000000..52959c2d19c5b73ccd85afce6b2ab8133478f7c6
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/profile/ProfileWhitelistVerifyEvent.java
-@@ -0,0 +1,142 @@
+@@ -0,0 +1,147 @@
 +/*
 + * Copyright (c) 2017 - Daniel Ennis (Aikar) - MIT License
 + *
@@ -43,28 +43,33 @@ index 0000000000000000000000000000000000000000..c6f5e2b5459368ad1e4db9929ca14568
 +import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +/**
 + * Fires when the server needs to verify if a player is whitelisted.
-+ *
++ * <p>
 + * Plugins may override/control the servers whitelist with this event,
 + * and dynamically change the kick message.
 + */
 +public class ProfileWhitelistVerifyEvent extends Event {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final PlayerProfile profile;
 +    private final boolean whitelistEnabled;
-+    private boolean whitelisted;
 +    private final boolean isOp;
++    private boolean whitelisted;
 +    @Nullable private Component kickMessage;
 +
 +    @Deprecated
++    @ApiStatus.Internal
 +    public ProfileWhitelistVerifyEvent(@NotNull final PlayerProfile profile, boolean whitelistEnabled, boolean whitelisted, boolean isOp, @Nullable String kickMessage) {
 +        this(profile, whitelistEnabled, whitelisted, isOp, kickMessage == null ? null : LegacyComponentSerializer.legacySection().deserialize(kickMessage));
 +    }
 +
++    @ApiStatus.Internal
 +    public ProfileWhitelistVerifyEvent(@NotNull final PlayerProfile profile, boolean whitelistEnabled, boolean whitelisted, boolean isOp, @Nullable Component kickMessage) {
 +        this.profile = profile;
 +        this.whitelistEnabled = whitelistEnabled;
@@ -80,11 +85,11 @@ index 0000000000000000000000000000000000000000..c6f5e2b5459368ad1e4db9929ca14568
 +    @Deprecated
 +    @Nullable
 +    public String getKickMessage() {
-+        return this.kickMessage == null ? null : LegacyComponentSerializer.legacySection().serialize(kickMessage);
++        return this.kickMessage == null ? null : LegacyComponentSerializer.legacySection().serialize(this.kickMessage);
 +    }
 +
 +    /**
-+     * @param kickMessage The message to send to the player on kick if not whitelisted. May set to null to use the server configured default
++     * @param kickMessage The message to send to the player on kick if not whitelisted. May set to {@code null} to use the server configured default
 +     * @deprecated Use {@link #kickMessage(Component)}
 +     */
 +    @Deprecated
@@ -101,7 +106,7 @@ index 0000000000000000000000000000000000000000..c6f5e2b5459368ad1e4db9929ca14568
 +    }
 +
 +    /**
-+     * @param kickMessage The message to send to the player on kick if not whitelisted. May set to null to use the server configured default
++     * @param kickMessage The message to send to the player on kick if not whitelisted. May set to {@code null} to use the server configured default
 +     */
 +    public void kickMessage(@Nullable Component kickMessage) {
 +        this.kickMessage = kickMessage;
@@ -112,18 +117,18 @@ index 0000000000000000000000000000000000000000..c6f5e2b5459368ad1e4db9929ca14568
 +     */
 +    @NotNull
 +    public PlayerProfile getPlayerProfile() {
-+        return profile;
++        return this.profile;
 +    }
 +
 +    /**
 +     * @return Whether the player is whitelisted to play on this server (whitelist may be off is why its true)
 +     */
 +    public boolean isWhitelisted() {
-+        return whitelisted;
++        return this.whitelisted;
 +    }
 +
 +    /**
-+     * Changes the players whitelisted state. false will deny the login
++     * Changes the players whitelisted state. {@code false} will deny the login
 +     * @param whitelisted The new whitelisted state
 +     */
 +    public void setWhitelisted(boolean whitelisted) {
@@ -134,24 +139,24 @@ index 0000000000000000000000000000000000000000..c6f5e2b5459368ad1e4db9929ca14568
 +     * @return if the player obtained whitelist status by having op
 +     */
 +    public boolean isOp() {
-+        return isOp;
++        return this.isOp;
 +    }
 +
 +    /**
 +     * @return if the server even has whitelist on
 +     */
 +    public boolean isWhitelistEnabled() {
-+        return whitelistEnabled;
++        return this.whitelistEnabled;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0072-Add-PlayerJumpEvent.patch
+++ b/patches/api/0072-Add-PlayerJumpEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add PlayerJumpEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerJumpEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerJumpEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..289a0d784a3c74caf8a7231b4dd166096b1849a1
+index 0000000000000000000000000000000000000000..d3c319298d360967b853cf0168c0a1833f094779
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerJumpEvent.java
 @@ -0,0 +1,106 @@
@@ -18,21 +18,27 @@ index 0000000000000000000000000000000000000000..289a0d784a3c74caf8a7231b4dd16609
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.event.player.PlayerMoveEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called when the server detects the player is jumping.
 + * <p>
 + * Added to avoid the overhead and special case logic that many plugins use
-+ * when checking for jumps via PlayerMoveEvent, this event is fired whenever
++ * when checking for jumps via {@link PlayerMoveEvent}, this event is fired whenever
 + * the server detects that the player is jumping.
 + */
 +public class PlayerJumpEvent extends PlayerEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancel = false;
-+    @NotNull private Location from;
-+    @NotNull private Location to;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final Location to;
++    @NotNull private Location from;
++
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PlayerJumpEvent(@NotNull final Player player, @NotNull final Location from, @NotNull final Location to) {
 +        super(player);
 +        this.from = from;
@@ -40,31 +46,29 @@ index 0000000000000000000000000000000000000000..289a0d784a3c74caf8a7231b4dd16609
 +    }
 +
 +    /**
-+     * Gets the cancellation state of this event. A cancelled event will not
-+     * be executed in the server, but will still pass to other plugins
++     * {@inheritDoc}
 +     * <p>
 +     * If a jump event is cancelled, the player will be moved or
-+     * teleported back to the Location as defined by getFrom(). This will not
++     * teleported back to the Location as defined by {@link #getFrom()}. This will not
 +     * fire an event
 +     *
-+     * @return true if this event is cancelled
++     * @return {@code true} if this event is cancelled
 +     */
 +    public boolean isCancelled() {
-+        return cancel;
++        return this.cancelled;
 +    }
 +
 +    /**
-+     * Sets the cancellation state of this event. A cancelled event will not
-+     * be executed in the server, but will still pass to other plugins
++     * {@inheritDoc}
 +     * <p>
 +     * If a jump event is cancelled, the player will be moved or
-+     * teleported back to the Location as defined by getFrom(). This will not
++     * teleported back to the Location as defined by {@link #getFrom()}. This will not
 +     * fire an event
 +     *
-+     * @param cancel true if you wish to cancel this event
++     * @param cancel {@code true} if you wish to cancel this event
 +     */
 +    public void setCancelled(boolean cancel) {
-+        this.cancel = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    /**
@@ -74,7 +78,7 @@ index 0000000000000000000000000000000000000000..289a0d784a3c74caf8a7231b4dd16609
 +     */
 +    @NotNull
 +    public Location getFrom() {
-+        return from;
++        return this.from;
 +    }
 +
 +    /**
@@ -83,13 +87,14 @@ index 0000000000000000000000000000000000000000..289a0d784a3c74caf8a7231b4dd16609
 +     * @param from New location to mark as the players previous location
 +     */
 +    public void setFrom(@NotNull Location from) {
-+        validateLocation(from);
++        Preconditions.checkArgument(from != null, "Cannot use null from location!");
++        Preconditions.checkArgument(from.getWorld() != null, "Cannot use from location with null world!");
 +        this.from = from;
 +    }
 +
 +    /**
 +     * Gets the location this player jumped to
-+     *
++     * <p>
 +     * This information is based on what the client sends, it typically
 +     * has little relation to the arc of the jump at any given point.
 +     *
@@ -97,22 +102,17 @@ index 0000000000000000000000000000000000000000..289a0d784a3c74caf8a7231b4dd16609
 +     */
 +    @NotNull
 +    public Location getTo() {
-+        return to;
-+    }
-+
-+    private void validateLocation(Location loc) {
-+        Preconditions.checkArgument(loc != null, "Cannot use null location!");
-+        Preconditions.checkArgument(loc.getWorld() != null, "Cannot use location with null world!");
++        return this.to;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0074-Add-PlayerArmorChangeEvent.patch
+++ b/patches/api/0074-Add-PlayerArmorChangeEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..57521010ff0574f1bbc96727948a6185fd37e9ee
+index 0000000000000000000000000000000000000000..ab08219497f7e362f113321c4bcfd180b335bf20
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java
-@@ -0,0 +1,139 @@
+@@ -0,0 +1,127 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.Material;
@@ -18,9 +18,6 @@ index 0000000000000000000000000000000000000000..57521010ff0574f1bbc96727948a6185
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.ItemStack;
 +
-+import java.util.Arrays;
-+import java.util.Collections;
-+import java.util.HashSet;
 +import java.util.Set;
 +import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
@@ -34,7 +31,8 @@ index 0000000000000000000000000000000000000000..57521010ff0574f1bbc96727948a6185
 + * Not currently called for environmental factors though it <strong>MAY BE IN THE FUTURE</strong>
 + */
 +public class PlayerArmorChangeEvent extends PlayerEvent {
-+    private static final HandlerList HANDLERS = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    @NotNull private final SlotType slotType;
 +    @NotNull private final ItemStack oldItem;
@@ -78,20 +76,15 @@ index 0000000000000000000000000000000000000000..57521010ff0574f1bbc96727948a6185
 +        return this.newItem;
 +    }
 +
-+    @Override
-+    public String toString() {
-+        return "ArmorChangeEvent{" + "player=" + player + ", slotType=" + slotType + ", oldItem=" + oldItem + ", newItem=" + newItem + '}';
-+    }
-+
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +
 +    public enum SlotType {
@@ -100,11 +93,10 @@ index 0000000000000000000000000000000000000000..57521010ff0574f1bbc96727948a6185
 +        LEGS(NETHERITE_LEGGINGS, DIAMOND_LEGGINGS, GOLDEN_LEGGINGS, IRON_LEGGINGS, CHAINMAIL_LEGGINGS, LEATHER_LEGGINGS),
 +        FEET(NETHERITE_BOOTS, DIAMOND_BOOTS, GOLDEN_BOOTS, IRON_BOOTS, CHAINMAIL_BOOTS, LEATHER_BOOTS);
 +
-+        private final Set<Material> mutableTypes = new HashSet<>();
-+        private Set<Material> immutableTypes;
++        private final Set<Material> types;
 +
 +        SlotType(Material... types) {
-+            this.mutableTypes.addAll(Arrays.asList(types));
++            this.types = Set.of(types);
 +        }
 +
 +        /**
@@ -115,18 +107,14 @@ index 0000000000000000000000000000000000000000..57521010ff0574f1bbc96727948a6185
 +         */
 +        @NotNull
 +        public Set<Material> getTypes() {
-+            if (immutableTypes == null) {
-+                immutableTypes = Collections.unmodifiableSet(mutableTypes);
-+            }
-+
-+            return immutableTypes;
++            return this.types;
 +        }
 +
 +        /**
 +         * Gets the type of slot via the specified material
 +         *
 +         * @param material material to get slot by
-+         * @return slot type the material will go in, or null if it won't
++         * @return slot type the material will go in, or {@code null} if it won't
 +         */
 +        @Nullable
 +        public static SlotType getByMaterial(@NotNull Material material) {

--- a/patches/api/0076-AsyncTabCompleteEvent.patch
+++ b/patches/api/0076-AsyncTabCompleteEvent.patch
@@ -15,10 +15,10 @@ Co-authored-by: Aikar <aikar@aikar.co>
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java b/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9be64a95c2345433b6142d611077dedadcef9f5d
+index 0000000000000000000000000000000000000000..e0847b6f0202bd8267c537f72a5e8c8cb7c6b1db
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java
-@@ -0,0 +1,328 @@
+@@ -0,0 +1,339 @@
 +/*
 + * Copyright (c) 2017 Daniel Ennis (Aikar) MIT License
 + *
@@ -59,47 +59,57 @@ index 0000000000000000000000000000000000000000..9be64a95c2345433b6142d611077deda
 +
 +import java.util.ArrayList;
 +import java.util.List;
++import java.util.Objects;
 +import java.util.stream.Stream;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +/**
-+ * Allows plugins to compute tab completion results asynchronously. If this event provides completions, then the standard synchronous process will not be fired to populate the results. However, the synchronous TabCompleteEvent will fire with the Async results.
-+ *
++ * Allows plugins to compute tab completion results asynchronously.
++ * <p>
++ * If this event provides completions, then the standard synchronous process
++ * will not be fired to populate the results.
++ * However, the synchronous TabCompleteEvent will fire with the Async results.
++ * <p>
 + * Only 1 process will be allowed to provide completions, the Async Event, or the standard process.
 + */
 +public class AsyncTabCompleteEvent extends Event implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final CommandSender sender;
 +    @NotNull private final String buffer;
 +    private final boolean isCommand;
 +    @Nullable
-+    private final Location loc;
++    private final Location location;
 +    private final List<Completion> completions = new ArrayList<>();
 +    private final List<String> stringCompletions = new TransformingRandomAccessList<>(
 +        this.completions,
 +        Completion::suggestion,
 +        Completion::completion
 +    );
++    private boolean handled;
 +    private boolean cancelled;
-+    private boolean handled = false;
-+    private boolean fireSyncHandler = true;
 +
++    @ApiStatus.Internal
 +    public AsyncTabCompleteEvent(@NotNull CommandSender sender, @NotNull String buffer, boolean isCommand, @Nullable Location loc) {
 +        super(true);
 +        this.sender = sender;
 +        this.buffer = buffer;
 +        this.isCommand = isCommand;
-+        this.loc = loc;
++        this.location = loc;
 +    }
 +
 +    @Deprecated
++    @ApiStatus.Internal
 +    public AsyncTabCompleteEvent(@NotNull CommandSender sender, @NotNull List<String> completions, @NotNull String buffer, boolean isCommand, @Nullable Location loc) {
 +        super(true);
 +        this.sender = sender;
 +        this.completions.addAll(fromStrings(completions));
 +        this.buffer = buffer;
 +        this.isCommand = isCommand;
-+        this.loc = loc;
++        this.location = loc;
 +    }
 +
 +    /**
@@ -109,13 +119,13 @@ index 0000000000000000000000000000000000000000..9be64a95c2345433b6142d611077deda
 +     */
 +    @NotNull
 +    public CommandSender getSender() {
-+        return sender;
++        return this.sender;
 +    }
 +
 +    /**
 +     * The list of completions which will be offered to the sender, in order.
 +     * This list is mutable and reflects what will be offered.
-+     *
++     * <p>
 +     * If this collection is not empty after the event is fired, then
 +     * the standard process of calling {@link Command#tabComplete(CommandSender, String, String[])}
 +     * or current player names will not be called.
@@ -132,16 +142,16 @@ index 0000000000000000000000000000000000000000..9be64a95c2345433b6142d611077deda
 +     * If this collection is not empty after the event is fired, then
 +     * the standard process of calling {@link Command#tabComplete(CommandSender, String, String[])}
 +     * or current player names will not be called.
-+     *
-+     * The passed collection will be cloned to a new List. You must call {{@link #getCompletions()}} to mutate from here
++     * <p>
++     * The passed collection will be cloned to a new {@code List}. You must call {{@link #getCompletions()}} to mutate from here
 +     *
 +     * @param completions the new completions
 +     */
 +    public void setCompletions(@NotNull List<String> completions) {
++        Preconditions.checkArgument(completions != null, "Completions list cannot be null");
 +        if (completions == this.stringCompletions) {
 +            return;
 +        }
-+        Preconditions.checkNotNull(completions);
 +        this.completions.clear();
 +        this.completions.addAll(fromStrings(completions));
 +    }
@@ -166,12 +176,12 @@ index 0000000000000000000000000000000000000000..9be64a95c2345433b6142d611077deda
 +     * the standard process of calling {@link Command#tabComplete(CommandSender, String, String[])}
 +     * or current player names will not be called.
 +     * <p>
-+     * The passed collection will be cloned to a new List. You must call {{@link #completions()}} to mutate from here
++     * The passed collection will be cloned to a new {@code List}. You must call {@link #completions()} to mutate from here
 +     *
 +     * @param newCompletions the new completions
 +     */
 +    public void completions(final @NotNull List<Completion> newCompletions) {
-+        Preconditions.checkNotNull(newCompletions, "new completions");
++        Preconditions.checkArgument(newCompletions != null, "new completions cannot be null");
 +        this.completions.clear();
 +        this.completions.addAll(newCompletions);
 +    }
@@ -183,37 +193,37 @@ index 0000000000000000000000000000000000000000..9be64a95c2345433b6142d611077deda
 +     */
 +    @NotNull
 +    public String getBuffer() {
-+        return buffer;
++        return this.buffer;
 +    }
 +
 +    /**
-+     * @return True if it is a command being tab completed, false if it is a chat message.
++     * @return {@code true} if it is a command being tab completed, {@code false} if it is a chat message.
 +     */
 +    public boolean isCommand() {
-+        return isCommand;
++        return this.isCommand;
 +    }
 +
 +    /**
-+     * @return The position looked at by the sender, or null if none
++     * @return The position looked at by the sender, or {@code null} if none
 +     */
 +    @Nullable
 +    public Location getLocation() {
-+        return loc;
++        return this.location;
 +    }
 +
 +    /**
-+     * If true, the standard process of calling {@link Command#tabComplete(CommandSender, String, String[])}
++     * If {@code true}, the standard process of calling {@link Command#tabComplete(CommandSender, String, String[])}
 +     * or current player names will not be called.
 +     *
-+     * @return Is completions considered handled. Always true if completions is not empty.
++     * @return Is completions considered handled. Always {@code true} if completions is not empty.
 +     */
 +    public boolean isHandled() {
-+        return !completions.isEmpty() || handled;
++        return !this.completions.isEmpty() || this.handled;
 +    }
 +
 +    /**
-+     * Sets whether or not to consider the completion request handled.
-+     * If true, the standard process of calling {@link Command#tabComplete(CommandSender, String, String[])}
++     * Sets whether to consider the completion request handled.
++     * If {@code true}, the standard process of calling {@link Command#tabComplete(CommandSender, String, String[])}
 +     * or current player names will not be called.
 +     *
 +     * @param handled if this completion should be marked as being handled
@@ -222,37 +232,35 @@ index 0000000000000000000000000000000000000000..9be64a95c2345433b6142d611077deda
 +        this.handled = handled;
 +    }
 +
-+    private static final HandlerList handlers = new HandlerList();
-+
-+
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    /**
++     * {@inheritDoc}
++     * <br>
 +     * Will provide no completions, and will not fire the synchronous process
-+     * @param cancelled true if you wish to cancel this event
 +     */
 +    @Override
-+    public void setCancelled(boolean cancelled) {
-+        this.cancelled = cancelled;
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
-+    private static @NotNull List<Completion> fromStrings(final @NotNull List<String> strings) {
-+        final List<Completion> list = new ArrayList<>();
-+        for (final String it : strings) {
-+            list.add(new CompletionImpl(it, null));
++    private static @NotNull List<Completion> fromStrings(final @NotNull List<String> suggestions) {
++        final List<Completion> list = new ArrayList<>(suggestions.size());
++        for (final String suggestion : suggestions) {
++            list.add(new CompletionImpl(suggestion, null));
 +        }
 +        return list;
 +    }
@@ -261,6 +269,7 @@ index 0000000000000000000000000000000000000000..9be64a95c2345433b6142d611077deda
 +     * A rich tab completion, consisting of a string suggestion, and a nullable {@link Component} tooltip.
 +     */
 +    public interface Completion extends Examinable {
++
 +        /**
 +         * Get the suggestion string for this {@link Completion}.
 +         *
@@ -292,11 +301,11 @@ index 0000000000000000000000000000000000000000..9be64a95c2345433b6142d611077deda
 +
 +        /**
 +         * Create a new {@link Completion} from a suggestion string and a tooltip {@link Component}.
-+         *
-+         * <p>If the provided component is null, the suggestion will not have a tooltip.</p>
++         * <p>
++         * If the provided component is {@code null}, the suggestion will not have a tooltip.
 +         *
 +         * @param suggestion suggestion string
-+         * @param tooltip    tooltip component, or null
++         * @param tooltip    tooltip component, or {@code null}
 +         * @return new completion instance
 +         */
 +        static @NotNull Completion completion(final @NotNull String suggestion, final @Nullable Component tooltip) {
@@ -304,7 +313,9 @@ index 0000000000000000000000000000000000000000..9be64a95c2345433b6142d611077deda
 +        }
 +    }
 +
++    @ApiStatus.Internal
 +    static final class CompletionImpl implements Completion {
++
 +        private final String suggestion;
 +        private final Component tooltip;
 +
@@ -333,12 +344,12 @@ index 0000000000000000000000000000000000000000..9be64a95c2345433b6142d611077deda
 +            }
 +            final CompletionImpl that = (CompletionImpl) o;
 +            return this.suggestion.equals(that.suggestion)
-+                && java.util.Objects.equals(this.tooltip, that.tooltip);
++                && Objects.equals(this.tooltip, that.tooltip);
 +        }
 +
 +        @Override
 +        public int hashCode() {
-+            return java.util.Objects.hash(this.suggestion, this.tooltip);
++            return Objects.hash(this.suggestion, this.tooltip);
 +        }
 +
 +        @Override

--- a/patches/api/0079-PlayerPickupExperienceEvent.patch
+++ b/patches/api/0079-PlayerPickupExperienceEvent.patch
@@ -7,10 +7,10 @@ Allows plugins to cancel a player picking up an experience orb
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerPickupExperienceEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerPickupExperienceEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f7beb22d5105157940b39efe594ace9d4cb153f5
+index 0000000000000000000000000000000000000000..0ef10ac6bac990837e21520c800d89420a18e3d4
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerPickupExperienceEvent.java
-@@ -0,0 +1,80 @@
+@@ -0,0 +1,83 @@
 +/*
 + * Copyright (c) 2017 Daniel Ennis (Aikar) MIT License
 + *
@@ -39,17 +39,22 @@ index 0000000000000000000000000000000000000000..f7beb22d5105157940b39efe594ace9d
 +import org.bukkit.entity.ExperienceOrb;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
-+import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when a player is attempting to pick up an experience orb
 + */
 +public class PlayerPickupExperienceEvent extends PlayerEvent implements Cancellable {
-+    @NotNull private final ExperienceOrb experienceOrb;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final ExperienceOrb experienceOrb;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PlayerPickupExperienceEvent(@NotNull Player player, @NotNull ExperienceOrb experienceOrb) {
 +        super(player);
 +        this.experienceOrb = experienceOrb;
@@ -60,34 +65,32 @@ index 0000000000000000000000000000000000000000..f7beb22d5105157940b39efe594ace9d
 +     */
 +    @NotNull
 +    public ExperienceOrb getExperienceOrb() {
-+        return experienceOrb;
++        return this.experienceOrb;
 +    }
 +
-+    private static final HandlerList handlers = new HandlerList();
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    /**
++     * {@inheritDoc}
++     * <br>
++     * If {@code true}, cancels picking up the experience orb, leaving it in the world
++     */
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
 +
 +    @NotNull
++    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
-+
-+    @Override
-+    public boolean isCancelled() {
-+        return cancelled;
-+    }
-+
-+    /**
-+     * If true, Cancels picking up the experience orb, leaving it in the world
-+     * @param cancel true if you wish to cancel this event
-+     */
-+    @Override
-+    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0080-ExperienceOrbMergeEvent.patch
+++ b/patches/api/0080-ExperienceOrbMergeEvent.patch
@@ -9,10 +9,10 @@ metadata such as spawn reason, or conditionally move data from source to target.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/ExperienceOrbMergeEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/ExperienceOrbMergeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0ce3e397716c28c30ed05e153babd0bfb9dd354a
+index 0000000000000000000000000000000000000000..c520e5517861c4686806df233d1ef5e6bfb76ad3
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/ExperienceOrbMergeEvent.java
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,91 @@
 +/*
 + * Copyright (c) 2017 Daniel Ennis (Aikar) MIT License
 + *
@@ -42,15 +42,22 @@ index 0000000000000000000000000000000000000000..0ce3e397716c28c30ed05e153babd0bf
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired anytime the server is about to merge 2 experience orbs into one
 + */
 +public class ExperienceOrbMergeEvent extends EntityEvent implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final ExperienceOrb mergeTarget;
 +    @NotNull private final ExperienceOrb mergeSource;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public ExperienceOrbMergeEvent(@NotNull ExperienceOrb mergeTarget, @NotNull ExperienceOrb mergeSource) {
 +        super(mergeTarget);
 +        this.mergeTarget = mergeTarget;
@@ -62,7 +69,7 @@ index 0000000000000000000000000000000000000000..0ce3e397716c28c30ed05e153babd0bf
 +     */
 +    @NotNull
 +    public ExperienceOrb getMergeTarget() {
-+        return mergeTarget;
++        return this.mergeTarget;
 +    }
 +
 +    /**
@@ -70,33 +77,30 @@ index 0000000000000000000000000000000000000000..0ce3e397716c28c30ed05e153babd0bf
 +     */
 +    @NotNull
 +    public ExperienceOrb getMergeSource() {
-+        return mergeSource;
++        return this.mergeSource;
 +    }
 +
-+    private static final HandlerList handlers = new HandlerList();
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    /**
++     * @param cancel {@code true} if you wish to cancel this event, and prevent the orbs from merging
++     */
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
 +
 +    @NotNull
++    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
-+
-+    @Override
-+    public boolean isCancelled() {
-+        return cancelled;
-+    }
-+
-+    /**
-+     * @param cancel true if you wish to cancel this event, and prevent the orbs from merging
-+     */
-+    @Override
-+    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0082-PreCreatureSpawnEvent.patch
+++ b/patches/api/0082-PreCreatureSpawnEvent.patch
@@ -16,41 +16,47 @@ See: https://github.com/PaperMC/Paper/issues/917
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/PreCreatureSpawnEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/PreCreatureSpawnEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8b48759bf6f4fcef0847d9a2461993e3f2fdc9aa
+index 0000000000000000000000000000000000000000..1d582118f19a41b499ee73b5e27ddb66ed34f06b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/PreCreatureSpawnEvent.java
-@@ -0,0 +1,105 @@
+@@ -0,0 +1,109 @@
 +package com.destroystokyo.paper.event.entity;
 +
-+import com.google.common.base.Preconditions;
 +import org.bukkit.Location;
 +import org.bukkit.entity.EntityType;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.CreatureSpawnEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * WARNING: This event only fires for a limited number of cases, and not for every case that CreatureSpawnEvent does.
-+ *
-+ * You should still listen to CreatureSpawnEvent as a backup, and only use this event as an "enhancement".
++ * WARNING: This event only fires for a limited number of cases, and not for every case that {@link CreatureSpawnEvent} does.
++ * <p>
++ * You should still listen to {@link CreatureSpawnEvent} as a backup, and only use this event as an "enhancement".
 + * The intent of this event is to improve server performance, so it fires even if the spawning might fail later, for
 + * example when the entity would be unable to spawn due to limited space or lighting.
-+ * 
-+ * Currently: NATURAL and SPAWNER based reasons. Please submit a Pull Request for future additions.
++ * <p>
++ * Currently: NATURAL and SPAWNER based reasons. <!-- Please submit a Pull Request for future additions. -->
 + * Also, Plugins that replace Entity Registrations with their own custom entities might not fire this event.
 + */
 +public class PreCreatureSpawnEvent extends Event implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final Location location;
 +    @NotNull private final EntityType type;
 +    @NotNull private final CreatureSpawnEvent.SpawnReason reason;
 +    private boolean shouldAbortSpawn;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PreCreatureSpawnEvent(@NotNull Location location, @NotNull EntityType type, @NotNull CreatureSpawnEvent.SpawnReason reason) {
-+        this.location = Preconditions.checkNotNull(location, "Location may not be null");
-+        this.type = Preconditions.checkNotNull(type, "Type may not be null");
-+        this.reason = Preconditions.checkNotNull(reason, "Reason may not be null");
++        this.location = location;
++        this.type = type;
++        this.reason = reason;
 +    }
 +
 +    /**
@@ -58,7 +64,7 @@ index 0000000000000000000000000000000000000000..8b48759bf6f4fcef0847d9a2461993e3
 +     */
 +    @NotNull
 +    public Location getSpawnLocation() {
-+        return location;
++        return this.location;
 +    }
 +
 +    /**
@@ -66,7 +72,7 @@ index 0000000000000000000000000000000000000000..8b48759bf6f4fcef0847d9a2461993e3
 +     */
 +    @NotNull
 +    public EntityType getType() {
-+        return type;
++        return this.type;
 +    }
 +
 +    /**
@@ -74,14 +80,14 @@ index 0000000000000000000000000000000000000000..8b48759bf6f4fcef0847d9a2461993e3
 +     */
 +    @NotNull
 +    public CreatureSpawnEvent.SpawnReason getReason() {
-+        return reason;
++        return this.reason;
 +    }
 +
 +    /**
 +     * @return If the spawn process should be aborted vs trying more attempts
 +     */
 +    public boolean shouldAbortSpawn() {
-+        return shouldAbortSpawn;
++        return this.shouldAbortSpawn;
 +    }
 +
 +    /**
@@ -94,34 +100,32 @@ index 0000000000000000000000000000000000000000..8b48759bf6f4fcef0847d9a2461993e3
 +        this.shouldAbortSpawn = shouldAbortSpawn;
 +    }
 +
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
-+
 +    /**
 +     * @return If the spawn of this creature is cancelled or not
 +     */
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    /**
-+     * Cancelling this event is more efficient than cancelling CreatureSpawnEvent
-+     * @param cancel true if you wish to cancel this event, and abort the spawn of this creature
++     * Cancelling this event is more efficient than cancelling {@link CreatureSpawnEvent}
++     *
++     * @param cancel {@code true} if you wish to cancel this event, and abort the spawn of this creature
 +     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0083-PlayerNaturallySpawnCreaturesEvent.patch
+++ b/patches/api/0083-PlayerNaturallySpawnCreaturesEvent.patch
@@ -10,25 +10,30 @@ Also a highly more effecient way to blanket block spawns in a world
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/PlayerNaturallySpawnCreaturesEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/PlayerNaturallySpawnCreaturesEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..112a0dbf522b8e74ce882678434923814e6b187f
+index 0000000000000000000000000000000000000000..7fcee73d61347165cefef7b92f0e63e0bed8ad73
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/PlayerNaturallySpawnCreaturesEvent.java
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,66 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
-+import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when the server is calculating what chunks to try to spawn monsters in every Monster Spawn Tick event
 + */
 +public class PlayerNaturallySpawnCreaturesEvent extends PlayerEvent implements Cancellable {
-+    private byte radius;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private byte radius;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PlayerNaturallySpawnCreaturesEvent(@NotNull Player player, byte radius) {
 +        super(player);
 +        this.radius = radius;
@@ -38,7 +43,7 @@ index 0000000000000000000000000000000000000000..112a0dbf522b8e74ce88267843492381
 +     * @return The radius of chunks around this player to be included in natural spawn selection
 +     */
 +    public byte getSpawnRadius() {
-+        return radius;
++        return this.radius;
 +    }
 +
 +    /**
@@ -48,33 +53,30 @@ index 0000000000000000000000000000000000000000..112a0dbf522b8e74ce88267843492381
 +        this.radius = radius;
 +    }
 +
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
-+
 +    /**
 +     * @return If this players chunks will be excluded from natural spawns
 +     */
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    /**
-+     * @param cancel true if you wish to cancel this event, and not include this players chunks for natural spawning
++     * @param cancel {@code true} if you wish to cancel this event, and not include this players chunks for natural spawning
 +     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0085-Add-PlayerAdvancementCriterionGrantEvent.patch
+++ b/patches/api/0085-Add-PlayerAdvancementCriterionGrantEvent.patch
@@ -7,10 +7,10 @@ Co-authored-by: The456gamer <the456gamer@the456gamer.dev>
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerAdvancementCriterionGrantEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerAdvancementCriterionGrantEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..99dac77befbf7c0c067f50150e62fe6d6ddaec7c
+index 0000000000000000000000000000000000000000..9502f94b3567fc22c4b61fea5aa251d738dde7ae
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerAdvancementCriterionGrantEvent.java
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,84 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.advancement.Advancement;
@@ -19,6 +19,7 @@ index 0000000000000000000000000000000000000000..99dac77befbf7c0c067f50150e62fe6d
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -26,17 +27,21 @@ index 0000000000000000000000000000000000000000..99dac77befbf7c0c067f50150e62fe6d
 + * If cancelled the criteria will be revoked.
 + */
 +public class PlayerAdvancementCriterionGrantEvent extends PlayerEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final Advancement advancement;
 +    @NotNull private final String criterion;
 +    @NotNull private final AdvancementProgress advancementProgress;
-+    private boolean cancel = false;
 +
-+    public PlayerAdvancementCriterionGrantEvent(@NotNull Player who, @NotNull Advancement advancement, @NotNull String criterion) {
-+        super(who);
++    private boolean cancelled;
++
++    @ApiStatus.Internal
++    public PlayerAdvancementCriterionGrantEvent(@NotNull Player player, @NotNull Advancement advancement, @NotNull String criterion) {
++        super(player);
 +        this.advancement = advancement;
 +        this.criterion = criterion;
-+        this.advancementProgress = who.getAdvancementProgress(advancement);
++        this.advancementProgress = player.getAdvancementProgress(advancement);
 +    }
 +
 +    /**
@@ -46,7 +51,7 @@ index 0000000000000000000000000000000000000000..99dac77befbf7c0c067f50150e62fe6d
 +     */
 +    @NotNull
 +    public Advancement getAdvancement() {
-+        return advancement;
++        return this.advancement;
 +    }
 +
 +    /**
@@ -56,36 +61,37 @@ index 0000000000000000000000000000000000000000..99dac77befbf7c0c067f50150e62fe6d
 +     */
 +    @NotNull
 +    public String getCriterion() {
-+        return criterion;
-+    }
-+
-+    public boolean isCancelled() {
-+        return cancel;
++        return this.criterion;
 +    }
 +
 +    /**
 +     * Gets the current AdvancementProgress.
-+     * See {@link PlayerAdvancementCriterionGrantEvent}
 +     *
 +     * @return advancement progress
 +     */
 +    @NotNull
 +    public AdvancementProgress getAdvancementProgress() {
-+        return advancementProgress;
++        return this.advancementProgress;
 +    }
 +
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
 +    public void setCancelled(boolean cancel) {
-+        this.cancel = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0086-Fill-Profile-Property-Events.patch
+++ b/patches/api/0086-Fill-Profile-Property-Events.patch
@@ -12,10 +12,10 @@ This is useful for implementing a ProfileCache for Player Skulls
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/profile/FillProfileEvent.java b/src/main/java/com/destroystokyo/paper/event/profile/FillProfileEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..71f36e9cae209ec6861835a5e76e018de959040a
+index 0000000000000000000000000000000000000000..c97ded9f9ef1c550cca7d0a3a3b09a85e5999cdf
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/profile/FillProfileEvent.java
-@@ -0,0 +1,75 @@
+@@ -0,0 +1,79 @@
 +/*
 + * Copyright (c) 2018 Daniel Ennis (Aikar) MIT License
 + *
@@ -47,14 +47,19 @@ index 0000000000000000000000000000000000000000..71f36e9cae209ec6861835a5e76e018d
 +import org.bukkit.event.HandlerList;
 +
 +import java.util.Set;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired once a profiles additional properties (such as textures) has been filled
 + */
 +public class FillProfileEvent extends Event {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final PlayerProfile profile;
 +
++    @ApiStatus.Internal
 +    public FillProfileEvent(@NotNull PlayerProfile profile) {
 +        super(!org.bukkit.Bukkit.isPrimaryThread());
 +        this.profile = profile;
@@ -65,7 +70,7 @@ index 0000000000000000000000000000000000000000..71f36e9cae209ec6861835a5e76e018d
 +     */
 +    @NotNull
 +    public PlayerProfile getPlayerProfile() {
-+        return profile;
++        return this.profile;
 +    }
 +
 +    /**
@@ -76,27 +81,26 @@ index 0000000000000000000000000000000000000000..71f36e9cae209ec6861835a5e76e018d
 +     */
 +    @NotNull
 +    public Set<ProfileProperty> getProperties() {
-+        return profile.getProperties();
++        return this.profile.getProperties();
 +    }
 +
-+    private static final HandlerList handlers = new HandlerList();
-+
 +    @NotNull
++    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/profile/PreFillProfileEvent.java b/src/main/java/com/destroystokyo/paper/event/profile/PreFillProfileEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..021bc86310a06f84b39459e0eb8927802726399c
+index 0000000000000000000000000000000000000000..e2a47c4af2c368a361e4a370a01111abe8e48062
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/profile/PreFillProfileEvent.java
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,81 @@
 +/*
 + * Copyright (c) 2018 Daniel Ennis (Aikar) MIT License
 + *
@@ -128,16 +132,21 @@ index 0000000000000000000000000000000000000000..021bc86310a06f84b39459e0eb892780
 +import org.bukkit.event.HandlerList;
 +
 +import java.util.Collection;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when the server is requesting to fill in properties of an incomplete profile, such as textures.
-+ *
-+ * Allows plugins to pre populate cached properties and avoid a call to the Mojang API
++ * <p>
++ * Allows plugins to pre-populate cached properties and avoid a call to the Mojang API
 + */
 +public class PreFillProfileEvent extends Event {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final PlayerProfile profile;
 +
++    @ApiStatus.Internal
 +    public PreFillProfileEvent(@NotNull PlayerProfile profile) {
 +        super(!org.bukkit.Bukkit.isPrimaryThread());
 +        this.profile = profile;
@@ -148,7 +157,7 @@ index 0000000000000000000000000000000000000000..021bc86310a06f84b39459e0eb892780
 +     */
 +    @NotNull
 +    public PlayerProfile getPlayerProfile() {
-+        return profile;
++        return this.profile;
 +    }
 +
 +    /**
@@ -159,18 +168,17 @@ index 0000000000000000000000000000000000000000..021bc86310a06f84b39459e0eb892780
 +     * @param properties The properties to set/append
 +     */
 +    public void setProperties(@NotNull Collection<ProfileProperty> properties) {
-+        profile.setProperties(properties);
++        this.profile.setProperties(properties);
 +    }
 +
-+    private static final HandlerList handlers = new HandlerList();
-+
 +    @NotNull
++    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0090-Add-more-fields-to-AsyncPreLoginEvent.patch
+++ b/patches/api/0090-Add-more-fields-to-AsyncPreLoginEvent.patch
@@ -7,20 +7,19 @@ Co-authored-by: Connor Linfoot <connorlinfoot@me.com>
 Co-authored-by: MCMDEV <john-m.1@gmx.de>
 
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index 3432872303aa0df97b5d9090fe98b269ef3cb9f4..f8b69b52ec8efa103e4e78e1b5c6a015e73d2a75 100644
+index 3432872303aa0df97b5d9090fe98b269ef3cb9f4..bdb7d2345e7d3a48a2f0561832ce126a16781e89 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-@@ -2,6 +2,9 @@ package org.bukkit.event.player;
+@@ -2,6 +2,8 @@ package org.bukkit.event.player;
  
  import java.net.InetAddress;
  import java.util.UUID;
-+
 +import com.destroystokyo.paper.profile.PlayerProfile;
 +import org.bukkit.Bukkit;
  import org.bukkit.event.Event;
  import org.bukkit.event.HandlerList;
  import org.jetbrains.annotations.NotNull;
-@@ -22,9 +25,10 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -22,9 +24,10 @@ public class AsyncPlayerPreLoginEvent extends Event {
      private static final HandlerList handlers = new HandlerList();
      private Result result;
      private net.kyori.adventure.text.Component message; // Paper
@@ -33,7 +32,7 @@ index 3432872303aa0df97b5d9090fe98b269ef3cb9f4..f8b69b52ec8efa103e4e78e1b5c6a015
  
      @Deprecated
      public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress) {
-@@ -32,12 +36,29 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -32,12 +35,29 @@ public class AsyncPlayerPreLoginEvent extends Event {
      }
  
      public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final UUID uniqueId) {
@@ -65,7 +64,7 @@ index 3432872303aa0df97b5d9090fe98b269ef3cb9f4..f8b69b52ec8efa103e4e78e1b5c6a015
      }
  
      /**
-@@ -200,7 +221,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -200,7 +220,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
       */
      @NotNull
      public String getName() {
@@ -74,14 +73,14 @@ index 3432872303aa0df97b5d9090fe98b269ef3cb9f4..f8b69b52ec8efa103e4e78e1b5c6a015
      }
  
      /**
-@@ -220,9 +241,48 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -220,9 +240,48 @@ public class AsyncPlayerPreLoginEvent extends Event {
       */
      @NotNull
      public UUID getUniqueId() {
 -        return uniqueId;
 +        return profile.getId(); // Paper
-     }
- 
++    }
++
 +    // Paper start
 +    /**
 +     * Gets the PlayerProfile of the player logging in
@@ -107,8 +106,8 @@ index 3432872303aa0df97b5d9090fe98b269ef3cb9f4..f8b69b52ec8efa103e4e78e1b5c6a015
 +    @NotNull
 +    public InetAddress getRawAddress() {
 +        return rawAddress;
-+    }
-+
+     }
+ 
 +    /**
 +     * Gets the hostname that the player used to connect to the server, or
 +     * blank if unknown

--- a/patches/api/0091-Add-extended-PaperServerListPingEvent.patch
+++ b/patches/api/0091-Add-extended-PaperServerListPingEvent.patch
@@ -8,10 +8,10 @@ and allows full control of the response sent to the client.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/server/PaperServerListPingEvent.java b/src/main/java/com/destroystokyo/paper/event/server/PaperServerListPingEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96ec5b3b9dc
+index 0000000000000000000000000000000000000000..0bb6fdbdd05ae6a8fb413e0f6b8d84302d697267
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/server/PaperServerListPingEvent.java
-@@ -0,0 +1,334 @@
+@@ -0,0 +1,338 @@
 +package com.destroystokyo.paper.event.server;
 +
 +import static java.util.Objects.requireNonNull;
@@ -30,6 +30,7 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +import java.util.NoSuchElementException;
 +import java.util.UUID;
 +
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -56,6 +57,7 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +    private Object[] players;
 +
 +    @Deprecated
++    @ApiStatus.Internal
 +    public PaperServerListPingEvent(@NotNull StatusClient client, @NotNull String motd, int numPlayers, int maxPlayers,
 +            @NotNull String version, int protocolVersion, @Nullable CachedServerIcon favicon) {
 +        super("", client.getAddress().getAddress(), motd, numPlayers, maxPlayers);
@@ -66,6 +68,7 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +        setServerIcon(favicon);
 +    }
 +
++    @ApiStatus.Internal
 +    public PaperServerListPingEvent(@NotNull StatusClient client, @NotNull net.kyori.adventure.text.Component motd, int numPlayers, int maxPlayers,
 +                                    @NotNull String version, int protocolVersion, @Nullable CachedServerIcon favicon) {
 +        super("", client.getAddress().getAddress(), motd, numPlayers, maxPlayers);
@@ -103,9 +106,9 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +
 +    /**
 +     * Sets the number of players displayed in the server list.
-+     *
-+     * <p>Note that this won't have any effect if {@link #shouldHidePlayers()}
-+     * is enabled.</p>
++     * <p>
++     * Note that this won't have any effect if {@link #shouldHidePlayers()}
++     * is enabled.
 +     *
 +     * @param numPlayers The number of online players
 +     */
@@ -118,9 +121,9 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +
 +    /**
 +     * {@inheritDoc}
-+     *
-+     * <p>Returns {@code -1} if players are hidden using
-+     * {@link #shouldHidePlayers()}.</p>
++     * <p>
++     * Returns {@code -1} if players are hidden using
++     * {@link #shouldHidePlayers()}.
 +     */
 +    @Override
 +    public int getMaxPlayers() {
@@ -135,23 +138,23 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +     * Returns whether all player related information is hidden in the server
 +     * list. This will cause {@link #getNumPlayers()}, {@link #getMaxPlayers()}
 +     * and {@link #getPlayerSample()} to be skipped in the response.
-+     *
-+     * <p>The Vanilla Minecraft client will display the player count as {@code ???}
-+     * when this option is enabled.</p>
++     * <p>
++     * The Vanilla Minecraft client will display the player count as {@code ???}
++     * when this option is enabled.
 +     *
 +     * @return {@code true} if the player count is hidden
 +     */
 +    public boolean shouldHidePlayers() {
-+        return hidePlayers;
++        return this.hidePlayers;
 +    }
 +
 +    /**
 +     * Sets whether all player related information is hidden in the server
 +     * list. This will cause {@link #getNumPlayers()}, {@link #getMaxPlayers()}
 +     * and {@link #getPlayerSample()} to be skipped in the response.
-+     *
-+     * <p>The Vanilla Minecraft client will display the player count as {@code ???}
-+     * when this option is enabled.</p>
++     * <p>
++     * The Vanilla Minecraft client will display the player count as {@code ???}
++     * when this option is enabled.
 +     *
 +     * @param hidePlayers {@code true} if the player count should be hidden
 +     */
@@ -162,9 +165,9 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +    /**
 +     * Returns a mutable list of {@link PlayerProfile} that will be displayed
 +     * as online players on the client.
-+     *
-+     * <p>The Vanilla Minecraft client will display them when hovering the
-+     * player count with the mouse.</p>
++     * <p>
++     * The Vanilla Minecraft client will display them when hovering the
++     * player count with the mouse.
 +     *
 +     * @return The mutable player sample list
 +     */
@@ -180,7 +183,7 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +     */
 +    @NotNull
 +    public String getVersion() {
-+        return version;
++        return this.version;
 +    }
 +
 +    /**
@@ -200,7 +203,7 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +     * has not finished initialization yet
 +     */
 +    public int getProtocolVersion() {
-+        return protocolVersion;
++        return this.protocolVersion;
 +    }
 +
 +    /**
@@ -240,9 +243,9 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +
 +    /**
 +     * {@inheritDoc}
-+     *
-+     * <p>Cancelling this event will cause the connection to be closed immediately,
-+     * without sending a response to the client.</p>
++     * <p>
++     * Cancelling this event will cause the connection to be closed immediately,
++     * without sending a response to the client.
 +     */
 +    @Override
 +    public boolean isCancelled() {
@@ -251,9 +254,9 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +
 +    /**
 +     * {@inheritDoc}
-+     *
-+     * <p>Cancelling this event will cause the connection to be closed immediately,
-+     * without sending a response to the client.</p>
++     * <p>
++     * Cancelling this event will cause the connection to be closed immediately,
++     * without sending a response to the client.
 +     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
@@ -262,10 +265,10 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +
 +    /**
 +     * {@inheritDoc}
-+     *
-+     * <p><b>Note:</b> For compatibility reasons, this method will return all
++     * <p>
++     * <b>Note:</b> For compatibility reasons, this method will return all
 +     * online players, not just the ones referenced in {@link #getPlayerSample()}.
-+     * Removing a player will:</p>
++     * Removing a player will:
 +     *
 +     * <ul>
 +     *     <li>Decrement the online player count (if and only if) the player
@@ -294,6 +297,7 @@ index 0000000000000000000000000000000000000000..e886ac04c0c14ae5dfb87212e262b96e
 +        return (Player) player;
 +    }
 +
++    @ApiStatus.Internal
 +    private final class PlayerIterator implements Iterator<Player> {
 +
 +        private int next;

--- a/patches/api/0097-EndermanEscapeEvent.patch
+++ b/patches/api/0097-EndermanEscapeEvent.patch
@@ -9,23 +9,27 @@ You may cancel this, enabling ranged attacks to damage the enderman for example.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EndermanEscapeEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EndermanEscapeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..806112a8b5a7ce31166675f5b074ceaf42e364b6
+index 0000000000000000000000000000000000000000..f6be848c44d5efaca3fbc03c3be7451411943c24
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EndermanEscapeEvent.java
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,86 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Enderman;
-+import org.bukkit.entity.Entity;
 +import org.bukkit.event.Cancellable;
-+import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +public class EndermanEscapeEvent extends EntityEvent implements Cancellable {
-+    @NotNull private final Reason reason;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final Reason reason;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public EndermanEscapeEvent(@NotNull Enderman entity, @NotNull Reason reason) {
 +        super(entity);
 +        this.reason = reason;
@@ -42,39 +46,34 @@ index 0000000000000000000000000000000000000000..806112a8b5a7ce31166675f5b074ceaf
 +     */
 +    @NotNull
 +    public Reason getReason() {
-+        return reason;
++        return this.reason;
 +    }
-+
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    /**
 +     * Cancels the escape.
-+     *
++     * <p>
 +     * If this escape normally would of resulted in damage avoidance such as indirect,
 +     * the enderman will now take damage.
-+     *
-+     * @param cancel true if you wish to cancel this event
 +     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +
 +    public enum Reason {
@@ -95,7 +94,7 @@ index 0000000000000000000000000000000000000000..806112a8b5a7ce31166675f5b074ceaf
 +         */
 +        STARE,
 +        /**
-+         * Specific case for CRITICAL_HIT where the enderman is taking rain damage
++         * Specific case for {@link #CRITICAL_HIT} where the enderman is taking rain damage
 +         */
 +        DROWN
 +    }

--- a/patches/api/0102-EndermanAttackPlayerEvent.patch
+++ b/patches/api/0102-EndermanAttackPlayerEvent.patch
@@ -9,7 +9,7 @@ This allows you to override/extend the pumpkin/stare logic.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EndermanAttackPlayerEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EndermanAttackPlayerEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f530a3d9314e17d1da896cac633f6a422258d9a9
+index 0000000000000000000000000000000000000000..ae34e679723a2ef436da04c116038272743a8f35
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EndermanAttackPlayerEvent.java
 @@ -0,0 +1,101 @@
@@ -39,23 +39,27 @@ index 0000000000000000000000000000000000000000..f530a3d9314e17d1da896cac633f6a42
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Enderman;
-+import org.bukkit.entity.Entity;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
-+import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when an Enderman determines if it should attack a player or not.
++ * <p>
 + * Starts off cancelled if the player is wearing a pumpkin head or is not looking
 + * at the Enderman, according to Vanilla rules.
-+ *
 + */
 +public class EndermanAttackPlayerEvent extends EntityEvent implements Cancellable {
-+    @NotNull private final Player player;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final Player player;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public EndermanAttackPlayerEvent(@NotNull Enderman entity, @NotNull Player player) {
 +        super(entity);
 +        this.player = player;
@@ -79,38 +83,34 @@ index 0000000000000000000000000000000000000000..f530a3d9314e17d1da896cac633f6a42
 +     */
 +    @NotNull
 +    public Player getPlayer() {
-+        return player;
++        return this.player;
 +    }
-+
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
 +
 +    /**
-+     *
 +     * @return If cancelled, the enderman will not attack
 +     */
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    /**
++     * {@inheritDoc}
++     * <br>
 +     * Cancels if the Enderman will attack this player
-+     * @param cancel true if you wish to cancel this event
 +     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0103-WitchConsumePotionEvent.patch
+++ b/patches/api/0103-WitchConsumePotionEvent.patch
@@ -7,10 +7,10 @@ Fires when a witch consumes the potion in their hand
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/WitchConsumePotionEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/WitchConsumePotionEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..fbbace36d69373046a7f3618ed5c1c1318b489b9
+index 0000000000000000000000000000000000000000..773079aa92280bb97e9b4c0e62d9ead08135610a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/WitchConsumePotionEvent.java
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,73 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Witch;
@@ -18,6 +18,7 @@ index 0000000000000000000000000000000000000000..fbbace36d69373046a7f3618ed5c1c13
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -25,8 +26,13 @@ index 0000000000000000000000000000000000000000..fbbace36d69373046a7f3618ed5c1c13
 + * Fired when a witch consumes the potion in their hand to buff themselves.
 + */
 +public class WitchConsumePotionEvent extends EntityEvent implements Cancellable {
-+    @Nullable private ItemStack potion;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @Nullable private ItemStack potion;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public WitchConsumePotionEvent(@NotNull Witch witch, @Nullable ItemStack potion) {
 +        super(witch);
 +        this.potion = potion;
@@ -43,80 +49,38 @@ index 0000000000000000000000000000000000000000..fbbace36d69373046a7f3618ed5c1c13
 +     */
 +    @Nullable
 +    public ItemStack getPotion() {
-+        return potion;
++        return this.potion;
 +    }
 +
 +    /**
 +     * Sets the potion to be consumed and applied to the witch.
++     *
 +     * @param potion The potion
 +     */
 +    public void setPotion(@Nullable ItemStack potion) {
 +        this.potion = potion != null ? potion.clone() : null;
 +    }
 +
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
-+
 +    /**
-+     * @return Event was cancelled or potion was null
++     * @return Event was cancelled or potion was {@code null}
 +     */
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled || potion == null;
++        return this.cancelled || this.potion == null;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
-+    }
-+}
-diff --git a/src/main/java/com/destroystokyo/paper/event/entity/WitchThrowPotionEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/WitchThrowPotionEvent.java
-new file mode 100644
-index 0000000000000000000000000000000000000000..6ef6367b67261c2b653a97322b9703a9409b3499
---- /dev/null
-+++ b/src/main/java/com/destroystokyo/paper/event/entity/WitchThrowPotionEvent.java
-@@ -0,0 +1,33 @@
-+package com.destroystokyo.paper.event.entity;
-+
-+import org.bukkit.event.Cancellable;
-+import org.bukkit.event.Event;
-+import org.bukkit.event.HandlerList;
-+
-+public class WitchThrowPotionEvent extends Event implements Cancellable {
-+    public WitchThrowPotionEvent() {
++        this.cancelled = cancel;
 +    }
 +
-+
-+    private static final HandlerList handlers = new HandlerList();
-+
++    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
++    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
-+
-+    @Override
-+    public boolean isCancelled() {
-+        return cancelled;
-+    }
-+
-+    @Override
-+    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0104-WitchThrowPotionEvent.patch
+++ b/patches/api/0104-WitchThrowPotionEvent.patch
@@ -6,37 +6,41 @@ Subject: [PATCH] WitchThrowPotionEvent
 Fired when a witch throws a potion at a player
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/WitchThrowPotionEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/WitchThrowPotionEvent.java
-index 6ef6367b67261c2b653a97322b9703a9409b3499..688a596aa2b925651a92bf092e1ef4d77a47258c 100644
---- a/src/main/java/com/destroystokyo/paper/event/entity/WitchThrowPotionEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..f1d546a3576a170ecb3608e07befa0f621ea043a
+--- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/WitchThrowPotionEvent.java
-@@ -1,29 +1,77 @@
- package com.destroystokyo.paper.event.entity;
- 
+@@ -0,0 +1,85 @@
++package com.destroystokyo.paper.event.entity;
++
 +import org.bukkit.entity.LivingEntity;
 +import org.bukkit.entity.Witch;
- import org.bukkit.event.Cancellable;
--import org.bukkit.event.Event;
- import org.bukkit.event.HandlerList;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
- 
--public class WitchThrowPotionEvent extends Event implements Cancellable {
--    public WitchThrowPotionEvent() {
++
 +/**
 + * Fired when a witch throws a potion at a player
 + */
 +public class WitchThrowPotionEvent extends EntityEvent implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final LivingEntity target;
 +    @Nullable private ItemStack potion;
++    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public WitchThrowPotionEvent(@NotNull Witch witch, @NotNull LivingEntity target, @Nullable ItemStack potion) {
 +        super(witch);
 +        this.target = target;
 +        this.potion = potion;
-     }
- 
++    }
++
 +    @NotNull
 +    @Override
 +    public Witch getEntity() {
@@ -48,7 +52,7 @@ index 6ef6367b67261c2b653a97322b9703a9409b3499..688a596aa2b925651a92bf092e1ef4d7
 +     */
 +    @NotNull
 +    public LivingEntity getTarget() {
-+        return target;
++        return this.target;
 +    }
 +
 +    /**
@@ -56,38 +60,39 @@ index 6ef6367b67261c2b653a97322b9703a9409b3499..688a596aa2b925651a92bf092e1ef4d7
 +     */
 +    @Nullable
 +    public ItemStack getPotion() {
-+        return potion;
++        return this.potion;
 +    }
 +
 +    /**
 +     * Sets the potion to be thrown at a player
++     *
 +     * @param potion The potion
 +     */
 +    public void setPotion(@Nullable ItemStack potion) {
 +        this.potion = potion != null ? potion.clone() : null;
 +    }
- 
-     private static final HandlerList handlers = new HandlerList();
- 
-+    @NotNull
-     public HandlerList getHandlers() {
-         return handlers;
-     }
- 
-+    @NotNull
-     public static HandlerList getHandlerList() {
-         return handlers;
-     }
- 
-     private boolean cancelled = false;
- 
++
 +    /**
-+     * @return Event was cancelled or potion was null
++     * @return Event was cancelled or potion was {@code null}
 +     */
-     @Override
-     public boolean isCancelled() {
--        return cancelled;
-+        return cancelled || potion == null;
-     }
- 
-     @Override
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled || this.potion == null;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}

--- a/patches/api/0107-WitchReadyPotionEvent.patch
+++ b/patches/api/0107-WitchReadyPotionEvent.patch
@@ -7,42 +7,32 @@ Control what potion the witch readies to use
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/WitchReadyPotionEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/WitchReadyPotionEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..57f93af14acc6346c5a343e05fe8f5d44d6adbc6
+index 0000000000000000000000000000000000000000..7feca06e72bd585bbfa219df38a2161b77e8d4c4
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/WitchReadyPotionEvent.java
-@@ -0,0 +1,80 @@
+@@ -0,0 +1,68 @@
 +package com.destroystokyo.paper.event.entity;
 +
-+import org.bukkit.Material;
 +import org.bukkit.entity.Witch;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +public class WitchReadyPotionEvent extends EntityEvent implements Cancellable {
-+    private ItemStack potion;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private ItemStack potion;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public WitchReadyPotionEvent(@NotNull Witch witch, @Nullable ItemStack potion) {
 +        super(witch);
 +        this.potion = potion;
-+    }
-+
-+    /**
-+     * Fires the event, returning the desired potion, or air of cancelled
-+     * @param witch the witch whom is readying to use a potion
-+     * @param potion the potion to be used
-+     * @return The ItemStack to be used
-+     */
-+    @Nullable
-+    public static ItemStack process(@NotNull Witch witch, @Nullable ItemStack potion) {
-+        WitchReadyPotionEvent event = new WitchReadyPotionEvent(witch, potion);
-+        if (!event.callEvent() || event.getPotion() == null) {
-+            return new ItemStack(Material.AIR);
-+        }
-+        return event.getPotion();
 +    }
 +
 +    @NotNull
@@ -56,38 +46,36 @@ index 0000000000000000000000000000000000000000..57f93af14acc6346c5a343e05fe8f5d4
 +     */
 +    @Nullable
 +    public ItemStack getPotion() {
-+        return potion;
++        return this.potion;
 +    }
 +
 +    /**
 +     * Sets the potion the which is going to hold and use
++     *
 +     * @param potion The potion
 +     */
 +    public void setPotion(@Nullable ItemStack potion) {
 +        this.potion = potion != null ? potion.clone() : null;
 +    }
 +
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
-+
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0109-Add-EntityTeleportEndGatewayEvent.patch
+++ b/patches/api/0109-Add-EntityTeleportEndGatewayEvent.patch
@@ -6,16 +6,17 @@ Subject: [PATCH] Add EntityTeleportEndGatewayEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityTeleportEndGatewayEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityTeleportEndGatewayEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..bfc69a43c291fbed91b9d0387e4ef18b0ed1b9de
+index 0000000000000000000000000000000000000000..88b9c059f9d66877260c66496443ad0aefaf8f47
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityTeleportEndGatewayEvent.java
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,33 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.Location;
 +import org.bukkit.block.EndGateway;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.event.entity.EntityTeleportEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -25,8 +26,9 @@ index 0000000000000000000000000000000000000000..bfc69a43c291fbed91b9d0387e4ef18b
 +
 +    @NotNull private final EndGateway gateway;
 +
-+    public EntityTeleportEndGatewayEvent(@NotNull Entity what, @NotNull Location from, @NotNull Location to, @NotNull EndGateway gateway) {
-+        super(what, from, to);
++    @ApiStatus.Internal
++    public EntityTeleportEndGatewayEvent(@NotNull Entity entity, @NotNull Location from, @NotNull Location to, @NotNull EndGateway gateway) {
++        super(entity, from, to);
 +        this.gateway = gateway;
 +    }
 +
@@ -37,7 +39,7 @@ index 0000000000000000000000000000000000000000..bfc69a43c291fbed91b9d0387e4ef18b
 +     */
 +    @NotNull
 +    public EndGateway getGateway() {
-+        return gateway;
++        return this.gateway;
 +    }
 +
 +}

--- a/patches/api/0113-PlayerReadyArrowEvent.patch
+++ b/patches/api/0113-PlayerReadyArrowEvent.patch
@@ -8,10 +8,10 @@ Plugins can skip selection of certain arrows and control which is used.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerReadyArrowEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerReadyArrowEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5d04a22fd6964d8d44a2aa069c9629722893b1f4
+index 0000000000000000000000000000000000000000..f30c4c372c92a79fb6c3fe80c4b51b5c8c0d4d3b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerReadyArrowEvent.java
-@@ -0,0 +1,93 @@
+@@ -0,0 +1,94 @@
 +/*
 + * Copyright (c) 2018 Daniel Ennis (Aikar) MIT License
 + *
@@ -39,7 +39,6 @@ index 0000000000000000000000000000000000000000..5d04a22fd6964d8d44a2aa069c962972
 +
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
-+import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.ItemStack;
@@ -49,8 +48,13 @@ index 0000000000000000000000000000000000000000..5d04a22fd6964d8d44a2aa069c962972
 + * Called when a player is firing a bow and the server is choosing an arrow to use.
 + */
 +public class PlayerReadyArrowEvent extends PlayerEvent implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final ItemStack bow;
 +    @NotNull private final ItemStack arrow;
++
++    private boolean cancelled;
 +
 +    public PlayerReadyArrowEvent(@NotNull Player player, @NotNull ItemStack bow, @NotNull ItemStack arrow) {
 +        super(player);
@@ -63,7 +67,7 @@ index 0000000000000000000000000000000000000000..5d04a22fd6964d8d44a2aa069c962972
 +     */
 +    @NotNull
 +    public ItemStack getBow() {
-+        return bow;
++        return this.bow;
 +    }
 +
 +    /**
@@ -71,37 +75,34 @@ index 0000000000000000000000000000000000000000..5d04a22fd6964d8d44a2aa069c962972
 +     */
 +    @NotNull
 +    public ItemStack getArrow() {
-+        return arrow;
++        return this.arrow;
 +    }
-+
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
 +
 +    /**
-+     * Whether or not use of this arrow is cancelled. On cancel, the server will try the next arrow available and fire another event.
++     * {@inheritDoc}
++     * <br>
++     * Whether use of this arrow is cancelled. On cancel, the server will try the next arrow available and fire another event.
 +     */
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    /**
 +     * Cancel use of this arrow. On cancel, the server will try the next arrow available and fire another event.
-+     * @param cancel true if you wish to cancel this event
 +     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++       this.cancelled = cancel;
++    }
++
++    @NotNull
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0114-Add-EntityKnockbackByEntityEvent-and-EntityPushedByE.patch
+++ b/patches/api/0114-Add-EntityKnockbackByEntityEvent-and-EntityPushedByE.patch
@@ -8,26 +8,28 @@ Co-authored-by: aerulion <aerulion@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityKnockbackByEntityEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityKnockbackByEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..42fdf7a5bfab99a61ff2fbf562f2872ac360bef2
+index 0000000000000000000000000000000000000000..e0ba692c9b107f2b042a9c06549185e1c4777e27
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityKnockbackByEntityEvent.java
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,48 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import io.papermc.paper.event.entity.EntityPushedByEntityAttackEvent;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.entity.LivingEntity;
 +import org.bukkit.util.Vector;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when an Entity is knocked back by the hit of another Entity. The acceleration
 + * vector can be modified. If this event is cancelled, the entity is not knocked back.
-+ *
 + */
 +public class EntityKnockbackByEntityEvent extends EntityPushedByEntityAttackEvent {
++
 +    private final float knockbackStrength;
 +
++    @ApiStatus.Internal
 +    public EntityKnockbackByEntityEvent(@NotNull LivingEntity entity, @NotNull Entity hitBy, float knockbackStrength, @NotNull Vector acceleration) {
 +        super(entity, hitBy, acceleration);
 +        this.knockbackStrength = knockbackStrength;
@@ -46,7 +48,7 @@ index 0000000000000000000000000000000000000000..42fdf7a5bfab99a61ff2fbf562f2872a
 +     * @return the original knockback strength.
 +     */
 +    public float getKnockbackStrength() {
-+        return knockbackStrength;
++        return this.knockbackStrength;
 +    }
 +
 +    /**
@@ -60,10 +62,10 @@ index 0000000000000000000000000000000000000000..42fdf7a5bfab99a61ff2fbf562f2872a
 +}
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityPushedByEntityAttackEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityPushedByEntityAttackEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c15401cd206eb9e1a7a8b7154aba0247e2da1e19
+index 0000000000000000000000000000000000000000..70d6e72d4dc0c040c8bccf7acc383e84db472514
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityPushedByEntityAttackEvent.java
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,74 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.entity.Entity;
@@ -71,6 +73,7 @@ index 0000000000000000000000000000000000000000..c15401cd206eb9e1a7a8b7154aba0247
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
 +import org.bukkit.util.Vector;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -82,36 +85,18 @@ index 0000000000000000000000000000000000000000..c15401cd206eb9e1a7a8b7154aba0247
 + */
 +public class EntityPushedByEntityAttackEvent extends EntityEvent implements Cancellable {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    private final @NotNull Entity pushedBy;
 +    private final @NotNull Vector acceleration;
-+    private boolean cancelled = false;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public EntityPushedByEntityAttackEvent(@NotNull Entity entity, @NotNull Entity pushedBy, @NotNull Vector acceleration) {
 +        super(entity);
 +        this.pushedBy = pushedBy;
 +        this.acceleration = acceleration;
-+    }
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    @Override
-+    public boolean isCancelled() {
-+        return cancelled;
-+    }
-+
-+    @Override
-+    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
 +    }
 +
 +    /**
@@ -121,7 +106,7 @@ index 0000000000000000000000000000000000000000..c15401cd206eb9e1a7a8b7154aba0247
 +     */
 +    @NotNull
 +    public Entity getPushedBy() {
-+        return pushedBy;
++        return this.pushedBy;
 +    }
 +
 +    /**
@@ -131,6 +116,27 @@ index 0000000000000000000000000000000000000000..c15401cd206eb9e1a7a8b7154aba0247
 +     */
 +    @NotNull
 +    public Vector getAcceleration() {
-+        return acceleration;
++        return this.acceleration;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0123-EnderDragon-Events.patch
+++ b/patches/api/0123-EnderDragon-Events.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] EnderDragon Events
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFireballHitEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFireballHitEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..615bc4c973ff371d87f996e981207fc15b70275b
+index 0000000000000000000000000000000000000000..bf5f82c8ba36bd245e1536fd4f654487aa8f6e21
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFireballHitEvent.java
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,79 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.AreaEffectCloud;
@@ -27,11 +27,12 @@ index 0000000000000000000000000000000000000000..615bc4c973ff371d87f996e981207fc1
 + * Fired when a DragonFireball collides with a block/entity and spawns an AreaEffectCloud
 + */
 +public class EnderDragonFireballHitEvent extends EntityEvent implements Cancellable {
++
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    @NotNull private final Collection<LivingEntity> targets;
 +    @NotNull private final AreaEffectCloud areaEffectCloud;
-+    private boolean cancelled = false;
++    private boolean cancelled;
 +
 +    @ApiStatus.Internal
 +    public EnderDragonFireballHitEvent(@NotNull DragonFireball fireball, @NotNull Collection<LivingEntity> targets, @NotNull AreaEffectCloud areaEffectCloud) {
@@ -56,7 +57,7 @@ index 0000000000000000000000000000000000000000..615bc4c973ff371d87f996e981207fc1
 +     */
 +    @NotNull
 +    public Collection<LivingEntity> getTargets() {
-+        return targets;
++        return this.targets;
 +    }
 +
 +    /**
@@ -64,20 +65,21 @@ index 0000000000000000000000000000000000000000..615bc4c973ff371d87f996e981207fc1
 +     */
 +    @NotNull
 +    public AreaEffectCloud getAreaEffectCloud() {
-+        return areaEffectCloud;
++        return this.areaEffectCloud;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
++    @Override
 +    public HandlerList getHandlers() {
 +        return HANDLER_LIST;
 +    }
@@ -89,10 +91,10 @@ index 0000000000000000000000000000000000000000..615bc4c973ff371d87f996e981207fc1
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFlameEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFlameEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1915177f4b8f8013656fbdb41240f6c5c88f95d7
+index 0000000000000000000000000000000000000000..4a61878152c95a07160f4216e78b042ca45d24b3
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFlameEvent.java
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,63 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.AreaEffectCloud;
@@ -100,14 +102,20 @@ index 0000000000000000000000000000000000000000..1915177f4b8f8013656fbdb41240f6c5
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when an EnderDragon spawns an AreaEffectCloud by shooting flames
 + */
 +public class EnderDragonFlameEvent extends EntityEvent implements Cancellable {
-+    @NotNull private final AreaEffectCloud areaEffectCloud;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final AreaEffectCloud areaEffectCloud;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public EnderDragonFlameEvent(@NotNull EnderDragon enderDragon, @NotNull AreaEffectCloud areaEffectCloud) {
 +        super(enderDragon);
 +        this.areaEffectCloud = areaEffectCloud;
@@ -127,39 +135,35 @@ index 0000000000000000000000000000000000000000..1915177f4b8f8013656fbdb41240f6c5
 +     */
 +    @NotNull
 +    public AreaEffectCloud getAreaEffectCloud() {
-+        return areaEffectCloud;
++        return this.areaEffectCloud;
 +    }
-+
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonShootFireballEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonShootFireballEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8414bd805ec68d7b305fbf645c59f8d5b762c9ce
+index 0000000000000000000000000000000000000000..3c6c3db37d91aad3638aef107a3bf8ca1d4f7085
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonShootFireballEvent.java
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,64 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.DragonFireball;
@@ -167,14 +171,20 @@ index 0000000000000000000000000000000000000000..8414bd805ec68d7b305fbf645c59f8d5
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when an EnderDragon shoots a fireball
 + */
 +public class EnderDragonShootFireballEvent extends EntityEvent implements Cancellable {
-+    @NotNull private final DragonFireball fireball;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final DragonFireball fireball;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public EnderDragonShootFireballEvent(@NotNull EnderDragon entity, @NotNull DragonFireball fireball) {
 +        super(entity);
 +        this.fireball = fireball;
@@ -194,30 +204,27 @@ index 0000000000000000000000000000000000000000..8414bd805ec68d7b305fbf645c59f8d5
 +     */
 +    @NotNull
 +    public DragonFireball getFireball() {
-+        return fireball;
++        return this.fireball;
 +    }
-+
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0124-PlayerElytraBoostEvent.patch
+++ b/patches/api/0124-PlayerElytraBoostEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] PlayerElytraBoostEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerElytraBoostEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerElytraBoostEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e9a76a25fa5445905a09dbc2fd5b35bff56d80b3
+index 0000000000000000000000000000000000000000..42375d44ed0db457b96165414e9b45a557bac1ab
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerElytraBoostEvent.java
-@@ -0,0 +1,85 @@
+@@ -0,0 +1,90 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Firework;
@@ -18,18 +18,23 @@ index 0000000000000000000000000000000000000000..e9a76a25fa5445905a09dbc2fd5b35bf
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when a player boosts elytra flight with a firework
 + */
 +public class PlayerElytraBoostEvent extends PlayerEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled = false;
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final ItemStack itemStack;
-+    @NotNull private Firework firework;
++    @NotNull private final Firework firework;
 +    private boolean consume = true;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PlayerElytraBoostEvent(@NotNull Player player, @NotNull ItemStack itemStack, @NotNull Firework firework) {
 +        super(player);
 +        this.itemStack = itemStack;
@@ -43,7 +48,7 @@ index 0000000000000000000000000000000000000000..e9a76a25fa5445905a09dbc2fd5b35bf
 +     */
 +    @NotNull
 +    public ItemStack getItemStack() {
-+        return itemStack;
++        return this.itemStack;
 +    }
 +
 +    /**
@@ -53,45 +58,45 @@ index 0000000000000000000000000000000000000000..e9a76a25fa5445905a09dbc2fd5b35bf
 +     */
 +    @NotNull
 +    public Firework getFirework() {
-+        return firework;
++        return this.firework;
 +    }
 +
 +    /**
 +     * Get whether to consume the firework or not
 +     *
-+     * @return True to consume
++     * @return {@code true} to consume
 +     */
 +    public boolean shouldConsume() {
-+        return consume;
++        return this.consume;
 +    }
 +
 +    /**
 +     * Set whether to consume the firework or not
 +     *
-+     * @param consume True to consume
++     * @param consume {@code true} to consume
 +     */
 +    public void setShouldConsume(boolean consume) {
 +        this.consume = consume;
 +    }
 +
-+    @NotNull
-+    @Override
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0125-PlayerLaunchProjectileEvent.patch
+++ b/patches/api/0125-PlayerLaunchProjectileEvent.patch
@@ -6,34 +6,40 @@ Subject: [PATCH] PlayerLaunchProjectileEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5450575459f2d95be93db5a8c6d4d88c69deb2ec
+index 0000000000000000000000000000000000000000..efd947eb0aa0633891d9c6a8bde66d33e29020d7
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,95 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Player;
 +import org.bukkit.entity.Projectile;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityShootBowEvent;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called when a player shoots a projectile.
 + * <p>
 + * Notably this event is not called for arrows as the player does not launch them, rather shoots them with the help
-+ * of a bow or crossbow. A plugin may listen to {@link org.bukkit.event.entity.EntityShootBowEvent} for these actions
-+ * instead.
++ * of a bow or crossbow. A plugin may listen to {@link EntityShootBowEvent}
++ * for these actions instead.
 + */
 +public class PlayerLaunchProjectileEvent extends PlayerEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final Projectile projectile;
 +    @NotNull private final ItemStack itemStack;
 +    private boolean consumeItem = true;
++
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public PlayerLaunchProjectileEvent(@NotNull Player shooter, @NotNull ItemStack itemStack, @NotNull Projectile projectile) {
 +        super(shooter);
 +        this.itemStack = itemStack;
@@ -47,7 +53,7 @@ index 0000000000000000000000000000000000000000..5450575459f2d95be93db5a8c6d4d88c
 +     */
 +    @NotNull
 +    public Projectile getProjectile() {
-+        return projectile;
++        return this.projectile;
 +    }
 +
 +    /**
@@ -57,43 +63,45 @@ index 0000000000000000000000000000000000000000..5450575459f2d95be93db5a8c6d4d88c
 +     */
 +    @NotNull
 +    public ItemStack getItemStack() {
-+        return itemStack;
++        return this.itemStack;
 +    }
 +
 +    /**
 +     * Get whether to consume the ItemStack or not
 +     *
-+     * @return True to consume
++     * @return {@code true} to consume
 +     */
 +    public boolean shouldConsume() {
-+        return consumeItem;
++        return this.consumeItem;
 +    }
 +
 +    /**
 +     * Set whether to consume the ItemStack or not
 +     *
-+     * @param consumeItem True to consume
++     * @param consumeItem {@code true} to consume
 +     */
 +    public void setShouldConsume(boolean consumeItem) {
 +        this.consumeItem = consumeItem;
 +    }
 +
++    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
++    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0126-EntityTransformedEvent.patch
+++ b/patches/api/0126-EntityTransformedEvent.patch
@@ -6,34 +6,38 @@ Subject: [PATCH] EntityTransformedEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityTransformedEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityTransformedEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c6802ca6acad1b841c01284eef0a601774486f55
+index 0000000000000000000000000000000000000000..9ce2638aeec5745f1a2b88e1cc125f57f8c8debe
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityTransformedEvent.java
-@@ -0,0 +1,93 @@
+@@ -0,0 +1,95 @@
 +package com.destroystokyo.paper.event.entity;
-+
 +
 +import org.bukkit.entity.Entity;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
-+import org.bukkit.event.entity.EntityTransformEvent;
 +import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when an entity transforms into another entity
 + * <p>
 + * If the event is cancelled, the entity will not transform
-+ * @deprecated Bukkit has added {@link EntityTransformEvent}, you should start using that
++ *
++ * @deprecated Bukkit has added {@link org.bukkit.event.entity.EntityTransformEvent}, you should start using that
 + */
 +@Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +public class EntityTransformedEvent extends EntityEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled;
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final Entity transformed;
 +    private final TransformedReason reason;
 +
-+    public EntityTransformedEvent(Entity entity, Entity transformed, TransformedReason reason) {
++    private boolean cancelled;
++
++    @ApiStatus.Internal
++    public EntityTransformedEvent(@NotNull Entity entity, @NotNull Entity transformed, @NotNull TransformedReason reason) {
 +        super(entity);
 +        this.transformed = transformed;
 +        this.reason = reason;
@@ -43,40 +47,39 @@ index 0000000000000000000000000000000000000000..c6802ca6acad1b841c01284eef0a6017
 +     * The entity after it has transformed
 +     *
 +     * @return Transformed entity
-+     * @deprecated see {@link EntityTransformEvent#getTransformedEntity()}
 +     */
-+    @Deprecated
++    @NotNull
 +    public Entity getTransformed() {
-+        return transformed;
++        return this.transformed;
 +    }
 +
 +    /**
 +     * @return The reason for the transformation
-+     * @deprecated see {@link EntityTransformEvent#getTransformReason()}
 +     */
-+    @Deprecated
++    @NotNull
 +    public TransformedReason getReason() {
-+        return reason;
-+    }
-+
-+
-+    @Override
-+    public HandlerList getHandlers(){
-+        return handlers;
-+    }
-+
-+    public static HandlerList getHandlerList(){
-+        return handlers;
++        return this.reason;
 +    }
 +
 +    @Override
 +    public boolean isCancelled(){
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel){
-+        cancelled = cancel;
++        this.cancelled = cancel;
++    }
++
++    @Override
++    @NotNull
++    public HandlerList getHandlers(){
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList(){
++        return HANDLER_LIST;
 +    }
 +
 +    public enum TransformedReason {
@@ -97,9 +100,8 @@ index 0000000000000000000000000000000000000000..c6802ca6acad1b841c01284eef0a6017
 +         */
 +        SHEARED,
 +        /**
-+         * When a pig turns to a zombiepigman
++         * When a pig turns to a zombified piglin
 +         */
 +        LIGHTNING
-+
 +    }
 +}

--- a/patches/api/0128-SkeletonHorse-Additions.patch
+++ b/patches/api/0128-SkeletonHorse-Additions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] SkeletonHorse Additions
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SkeletonHorseTrapEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SkeletonHorseTrapEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9ce2948dfaa56d0adf53fe9b6117a90d7773b771
+index 0000000000000000000000000000000000000000..f6724e6e5754996ac10888aaa92baf2dcc6134d3
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/SkeletonHorseTrapEvent.java
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,68 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import com.google.common.collect.ImmutableList;
@@ -18,6 +18,7 @@ index 0000000000000000000000000000000000000000..9ce2948dfaa56d0adf53fe9b6117a90d
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +import java.util.List;
@@ -26,14 +27,19 @@ index 0000000000000000000000000000000000000000..9ce2948dfaa56d0adf53fe9b6117a90d
 + * Event called when a player gets close to a skeleton horse and triggers the lightning trap
 + */
 +public class SkeletonHorseTrapEvent extends EntityEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled;
-+    private final List<HumanEntity> eligibleHumans;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private final List<HumanEntity> eligibleHumans;
++    private boolean cancelled;
++
++    @Deprecated
++    @ApiStatus.Internal
 +    public SkeletonHorseTrapEvent(@NotNull SkeletonHorse horse) {
 +        this(horse, ImmutableList.of());
 +    }
 +
++    @ApiStatus.Internal
 +    public SkeletonHorseTrapEvent(@NotNull SkeletonHorse horse, @NotNull List<HumanEntity> eligibleHumans) {
 +        super(horse);
 +        this.eligibleHumans = eligibleHumans;
@@ -45,9 +51,14 @@ index 0000000000000000000000000000000000000000..9ce2948dfaa56d0adf53fe9b6117a90d
 +        return (SkeletonHorse) super.getEntity();
 +    }
 +
++    @NotNull
++    public List<HumanEntity> getEligibleHumans() {
++        return this.eligibleHumans;
++    }
++
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
@@ -56,19 +67,14 @@ index 0000000000000000000000000000000000000000..9ce2948dfaa56d0adf53fe9b6117a90d
 +    }
 +
 +    @NotNull
-+    public List<HumanEntity> getEligibleHumans() {
-+        return eligibleHumans;
-+    }
-+
-+    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 +

--- a/patches/api/0131-AnvilDamageEvent.patch
+++ b/patches/api/0131-AnvilDamageEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] AnvilDamageEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/block/AnvilDamagedEvent.java b/src/main/java/com/destroystokyo/paper/event/block/AnvilDamagedEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..aa5c3690fb898a7560a9551df91588a0cdc69fe2
+index 0000000000000000000000000000000000000000..4f88c101d81e5c3a8a065260304d5816337666d7
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/block/AnvilDamagedEvent.java
-@@ -0,0 +1,151 @@
+@@ -0,0 +1,154 @@
 +package com.destroystokyo.paper.event.block;
 +
 +import org.bukkit.Material;
@@ -27,10 +27,11 @@ index 0000000000000000000000000000000000000000..aa5c3690fb898a7560a9551df91588a0
 + * Called when an anvil is damaged from being used
 + */
 +public class AnvilDamagedEvent extends InventoryEvent implements Cancellable {
++
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    private boolean cancel;
 +    private DamageState damageState;
++    private boolean cancelled;
 +
 +    @ApiStatus.Internal
 +    public AnvilDamagedEvent(@NotNull InventoryView inventory, @Nullable BlockData blockData) {
@@ -51,7 +52,7 @@ index 0000000000000000000000000000000000000000..aa5c3690fb898a7560a9551df91588a0
 +     */
 +    @NotNull
 +    public DamageState getDamageState() {
-+        return damageState;
++        return this.damageState;
 +    }
 +
 +    /**
@@ -66,31 +67,33 @@ index 0000000000000000000000000000000000000000..aa5c3690fb898a7560a9551df91588a0
 +    /**
 +     * Gets if anvil is breaking on this use
 +     *
-+     * @return True if breaking
++     * @return {@code true} if breaking
 +     */
 +    public boolean isBreaking() {
-+        return damageState == DamageState.BROKEN;
++        return this.damageState == DamageState.BROKEN;
 +    }
 +
 +    /**
 +     * Sets if anvil is breaking on this use
 +     *
-+     * @param breaking True if breaking
++     * @param breaking {@code true} if breaking
 +     */
 +    public void setBreaking(boolean breaking) {
 +        if (breaking) {
-+            damageState = DamageState.BROKEN;
-+        } else if (damageState == DamageState.BROKEN) {
-+            damageState = DamageState.DAMAGED;
++            this.damageState = DamageState.BROKEN;
++        } else if (this.damageState == DamageState.BROKEN) {
++            this.damageState = DamageState.DAMAGED;
 +        }
 +    }
 +
++    @Override
 +    public boolean isCancelled() {
-+        return cancel;
++        return this.cancelled;
 +    }
 +
++    @Override
 +    public void setCancelled(boolean cancel) {
-+        this.cancel = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
@@ -125,7 +128,7 @@ index 0000000000000000000000000000000000000000..aa5c3690fb898a7560a9551df91588a0
 +         */
 +        @NotNull
 +        public Material getMaterial() {
-+            return material;
++            return this.material;
 +        }
 +
 +        /**
@@ -153,7 +156,7 @@ index 0000000000000000000000000000000000000000..aa5c3690fb898a7560a9551df91588a0
 +                return BROKEN;
 +            }
 +            for (DamageState state : values()) {
-+                if (state.material == material) {
++                if (state.getMaterial() == material) {
 +                    return state;
 +                }
 +            }

--- a/patches/api/0132-Add-TNTPrimeEvent.patch
+++ b/patches/api/0132-Add-TNTPrimeEvent.patch
@@ -6,24 +6,29 @@ Subject: [PATCH] Add TNTPrimeEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/block/TNTPrimeEvent.java b/src/main/java/com/destroystokyo/paper/event/block/TNTPrimeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9d7221583454dc922b20af6c233897c0b2ec47da
+index 0000000000000000000000000000000000000000..d8de7332b63feb16c855bf7ea1986fd229489c7c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/block/TNTPrimeEvent.java
-@@ -0,0 +1,116 @@
+@@ -0,0 +1,125 @@
 +package com.destroystokyo.paper.event.block;
 +
++import org.bukkit.Material;
 +import org.bukkit.block.Block;
++import org.bukkit.enchantments.Enchantment;
 +import org.bukkit.entity.Entity;
++import org.bukkit.entity.Player;
++import org.bukkit.entity.TNTPrimed;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.block.BlockEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +/**
-+ * Called when TNT block is about to turn into {@link org.bukkit.entity.TNTPrimed}
++ * Called when TNT block is about to turn into {@link TNTPrimed}
 + * <p>
-+ * Cancelling it won't turn TNT into {@link org.bukkit.entity.TNTPrimed} and leaves
++ * Cancelling it won't turn TNT into {@link TNTPrimed} and leaves
 + * the TNT block as-is
 + *
 + * @author Mark Vainomaa
@@ -31,11 +36,15 @@ index 0000000000000000000000000000000000000000..9d7221583454dc922b20af6c233897c0
 + */
 +@Deprecated(forRemoval = true)
 +public class TNTPrimeEvent extends BlockEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled;
-+    @NotNull private PrimeReason reason;
-+    @Nullable private Entity primerEntity;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final PrimeReason reason;
++    @Nullable private final Entity primerEntity;
++
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public TNTPrimeEvent(@NotNull Block theBlock, @NotNull PrimeReason reason, @Nullable Entity primerEntity) {
 +        super(theBlock);
 +        this.reason = reason;
@@ -54,10 +63,10 @@ index 0000000000000000000000000000000000000000..9d7221583454dc922b20af6c233897c0
 +
 +    /**
 +     * Gets the TNT primer {@link Entity}.
-+     *
-+     * It's null if {@link #getReason()} is {@link PrimeReason#REDSTONE} or {@link PrimeReason#FIRE}.
-+     * It's not null if {@link #getReason()} is {@link PrimeReason#ITEM} or {@link PrimeReason#PROJECTILE}
-+     * It might be null if {@link #getReason()} is {@link PrimeReason#EXPLOSION}
++     * <p>
++     * It's {@code null} if {@link #getReason()} is {@link PrimeReason#REDSTONE} or {@link PrimeReason#FIRE}.
++     * It's not {@code null} if {@link #getReason()} is {@link PrimeReason#ITEM} or {@link PrimeReason#PROJECTILE}
++     * It might be {@code null} if {@link #getReason()} is {@link PrimeReason#EXPLOSION}
 +     *
 +     * @return The {@link Entity} who primed the TNT
 +     */
@@ -67,9 +76,9 @@ index 0000000000000000000000000000000000000000..9d7221583454dc922b20af6c233897c0
 +    }
 +
 +    /**
-+     * Gets whether spawning {@link org.bukkit.entity.TNTPrimed} should be cancelled or not
++     * Gets whether spawning {@link TNTPrimed} should be cancelled or not
 +     *
-+     * @return Whether spawning {@link org.bukkit.entity.TNTPrimed} should be cancelled or not
++     * @return Whether spawning {@link TNTPrimed} should be cancelled or not
 +     */
 +    @Override
 +    public boolean isCancelled() {
@@ -77,24 +86,24 @@ index 0000000000000000000000000000000000000000..9d7221583454dc922b20af6c233897c0
 +    }
 +
 +    /**
-+     * Sets whether to cancel spawning {@link org.bukkit.entity.TNTPrimed} or not
++     * Sets whether to cancel spawning {@link TNTPrimed} or not
 +     *
-+     * @param cancel whether spawning {@link org.bukkit.entity.TNTPrimed} should be cancelled or not
++     * @param cancel whether spawning {@link TNTPrimed} should be cancelled or not
 +     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
 +        this.cancelled = cancel;
 +    }
 +
-+    @Nullable
++    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
-+    @Nullable
++    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    public enum PrimeReason {
@@ -109,14 +118,14 @@ index 0000000000000000000000000000000000000000..9d7221583454dc922b20af6c233897c0
 +        FIRE,
 +
 +        /**
-+         * When {@link org.bukkit.entity.Player} used {@link org.bukkit.Material#FLINT_AND_STEEL} or
-+         * {@link org.bukkit.Material#FIRE_CHARGE} on given TNT block
++         * When {@link Player} used {@link Material#FLINT_AND_STEEL} or
++         * {@link Material#FIRE_CHARGE} on given TNT block
 +         */
 +        ITEM,
 +
 +        /**
 +         * When TNT prime was caused by an {@link Entity} shooting TNT
-+         * using a bow with {@link org.bukkit.enchantments.Enchantment#ARROW_FIRE} enchantment
++         * using a bow with {@link Enchantment#ARROW_FIRE} enchantment
 +         */
 +        PROJECTILE,
 +

--- a/patches/api/0137-Slime-Pathfinder-Events.patch
+++ b/patches/api/0137-Slime-Pathfinder-Events.patch
@@ -6,14 +6,14 @@ Subject: [PATCH] Slime Pathfinder Events
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SlimeChangeDirectionEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SlimeChangeDirectionEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..473fbded8ab534308f2c0bd0b87512fcce5c9e58
+index 0000000000000000000000000000000000000000..30864539574e23bbe9e4c5dc73ad6614de782ac2
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/SlimeChangeDirectionEvent.java
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,40 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Slime;
-+import org.bukkit.event.Cancellable;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -22,9 +22,11 @@ index 0000000000000000000000000000000000000000..473fbded8ab534308f2c0bd0b87512fc
 + * This event does not fire for the entity's actual movement. Only when it
 + * is choosing to change direction.
 + */
-+public class SlimeChangeDirectionEvent extends SlimePathfindEvent implements Cancellable {
++public class SlimeChangeDirectionEvent extends SlimePathfindEvent {
++
 +    private float yaw;
 +
++    @ApiStatus.Internal
 +    public SlimeChangeDirectionEvent(@NotNull Slime slime, float yaw) {
 +        super(slime);
 +        this.yaw = yaw;
@@ -36,7 +38,7 @@ index 0000000000000000000000000000000000000000..473fbded8ab534308f2c0bd0b87512fc
 +     * @return Chosen yaw
 +     */
 +    public float getNewYaw() {
-+        return yaw;
++        return this.yaw;
 +    }
 +
 +    /**
@@ -50,16 +52,17 @@ index 0000000000000000000000000000000000000000..473fbded8ab534308f2c0bd0b87512fc
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SlimePathfindEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SlimePathfindEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..14b67da109321ae6521eab2ac6f6945f05d02db5
+index 0000000000000000000000000000000000000000..706ed85a5415d688aaa5f138cbf583b9e2bab27d
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/SlimePathfindEvent.java
-@@ -0,0 +1,53 @@
+@@ -0,0 +1,56 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Slime;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -69,6 +72,12 @@ index 0000000000000000000000000000000000000000..14b67da109321ae6521eab2ac6f6945f
 + * is choosing to start moving.
 + */
 +public class SlimePathfindEvent extends EntityEvent implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public SlimePathfindEvent(@NotNull Slime slime) {
 +        super(slime);
 +    }
@@ -80,43 +89,39 @@ index 0000000000000000000000000000000000000000..14b67da109321ae6521eab2ac6f6945f
 +     */
 +    @NotNull
 +    public Slime getEntity() {
-+        return (Slime) entity;
++        return (Slime) super.getEntity();
 +    }
-+
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SlimeSwimEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SlimeSwimEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c8dd49d11da5a90a1bac965a75f2b65fd825f3f7
+index 0000000000000000000000000000000000000000..65e8a29751e338b0f0acda7bef9e014852a73e6e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/SlimeSwimEvent.java
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,19 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Slime;
-+import org.bukkit.event.Cancellable;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -125,22 +130,24 @@ index 0000000000000000000000000000000000000000..c8dd49d11da5a90a1bac965a75f2b65f
 + * This event does not fire for the entity's actual movement. Only when it
 + * is choosing to start jumping.
 + */
-+public class SlimeSwimEvent extends SlimeWanderEvent implements Cancellable {
++public class SlimeSwimEvent extends SlimeWanderEvent {
++
++    @ApiStatus.Internal
 +    public SlimeSwimEvent(@NotNull Slime slime) {
 +        super(slime);
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SlimeTargetLivingEntityEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SlimeTargetLivingEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e9ba32799ed838779e49cd4c5011b7515b3363cb
+index 0000000000000000000000000000000000000000..87c64b04dfec232e98361c3ec29da7664498c65b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/SlimeTargetLivingEntityEvent.java
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,33 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.LivingEntity;
 +import org.bukkit.entity.Slime;
-+import org.bukkit.event.Cancellable;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -149,9 +156,11 @@ index 0000000000000000000000000000000000000000..e9ba32799ed838779e49cd4c5011b751
 + * This event does not fire for the entity's actual movement. Only when it
 + * is choosing to start moving.
 + */
-+public class SlimeTargetLivingEntityEvent extends SlimePathfindEvent implements Cancellable {
++public class SlimeTargetLivingEntityEvent extends SlimePathfindEvent {
++
 +    @NotNull private final LivingEntity target;
 +
++    @ApiStatus.Internal
 +    public SlimeTargetLivingEntityEvent(@NotNull Slime slime, @NotNull LivingEntity target) {
 +        super(slime);
 +        this.target = target;
@@ -164,19 +173,19 @@ index 0000000000000000000000000000000000000000..e9ba32799ed838779e49cd4c5011b751
 +     */
 +    @NotNull
 +    public LivingEntity getTarget() {
-+        return target;
++        return this.target;
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SlimeWanderEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SlimeWanderEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4683a7237d2ed527fc85b9b4e5b2eaaf5ae3d797
+index 0000000000000000000000000000000000000000..2ad9cc1673ffbb8b48349e461d1154d1d4ec2874
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/SlimeWanderEvent.java
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,19 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Slime;
-+import org.bukkit.event.Cancellable;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -185,7 +194,9 @@ index 0000000000000000000000000000000000000000..4683a7237d2ed527fc85b9b4e5b2eaaf
 + * This event does not fire for the entity's actual movement. Only when it
 + * is choosing to start moving.
 + */
-+public class SlimeWanderEvent extends SlimePathfindEvent implements Cancellable {
++public class SlimeWanderEvent extends SlimePathfindEvent {
++
++    @ApiStatus.Internal
 +    public SlimeWanderEvent(@NotNull Slime slime) {
 +        super(slime);
 +    }

--- a/patches/api/0138-Add-PhantomPreSpawnEvent.patch
+++ b/patches/api/0138-Add-PhantomPreSpawnEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PhantomPreSpawnEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/PhantomPreSpawnEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/PhantomPreSpawnEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d8f3f1c354331bc5e6fc1d9aa013476baf2daf05
+index 0000000000000000000000000000000000000000..ff7d9ff618ab821eeece6923a694a9a4eea8585d
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/PhantomPreSpawnEvent.java
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,32 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.Location;
@@ -18,13 +18,12 @@ index 0000000000000000000000000000000000000000..d8f3f1c354331bc5e6fc1d9aa013476b
 +import org.bukkit.event.entity.CreatureSpawnEvent;
 +import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
-+import org.jetbrains.annotations.Nullable;
-+
 +
 +/**
 + * Called when a phantom is spawned for an exhausted player
 + */
 +public class PhantomPreSpawnEvent extends PreCreatureSpawnEvent {
++
 +    @NotNull private final Entity entity;
 +
 +    @ApiStatus.Internal
@@ -36,11 +35,11 @@ index 0000000000000000000000000000000000000000..d8f3f1c354331bc5e6fc1d9aa013476b
 +    /**
 +     * Get the entity this phantom is spawning for
 +     *
-+     * @return Entity
++     * @return the Entity
 +     */
 +    @NotNull
 +    public Entity getSpawningEntity() {
-+        return entity;
++        return this.entity;
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Phantom.java b/src/main/java/org/bukkit/entity/Phantom.java

--- a/patches/api/0139-Add-More-Creeper-API.patch
+++ b/patches/api/0139-Add-More-Creeper-API.patch
@@ -6,16 +6,17 @@ Subject: [PATCH] Add More Creeper API
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/CreeperIgniteEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/CreeperIgniteEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e9768c919a1860881802ab68eff559874590ac1c
+index 0000000000000000000000000000000000000000..e86500337f26fcb6bb04545c68c67df32021ce25
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/CreeperIgniteEvent.java
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,60 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Creeper;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -24,10 +25,13 @@ index 0000000000000000000000000000000000000000..e9768c919a1860881802ab68eff55987
 + * {@link Creeper#setIgnited(boolean)}.
 + */
 +public class CreeperIgniteEvent extends EntityEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean canceled;
-+    private boolean ignited;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private boolean ignited;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public CreeperIgniteEvent(@NotNull Creeper creeper, boolean ignited) {
 +        super(creeper);
 +        this.ignited = ignited;
@@ -36,11 +40,11 @@ index 0000000000000000000000000000000000000000..e9768c919a1860881802ab68eff55987
 +    @NotNull
 +    @Override
 +    public Creeper getEntity() {
-+        return (Creeper) entity;
++        return (Creeper) super.getEntity();
 +    }
 +
 +    public boolean isIgnited() {
-+        return ignited;
++        return this.ignited;
 +    }
 +
 +    public void setIgnited(boolean ignited) {
@@ -48,22 +52,22 @@ index 0000000000000000000000000000000000000000..e9768c919a1860881802ab68eff55987
 +    }
 +
 +    public boolean isCancelled() {
-+        return canceled;
++        return this.cancelled;
 +    }
 +
 +    public void setCancelled(boolean cancel) {
-+        canceled = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Creeper.java b/src/main/java/org/bukkit/entity/Creeper.java

--- a/patches/api/0155-PreSpawnerSpawnEvent.patch
+++ b/patches/api/0155-PreSpawnerSpawnEvent.patch
@@ -12,36 +12,36 @@ Dropped as it does not apply due to the earlier PreCreatureSpawnEvent patch not 
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/PreSpawnerSpawnEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/PreSpawnerSpawnEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..48cff063594840a07aeaf35513780e28ea019a76
+index 0000000000000000000000000000000000000000..9a450a0095ed0aa9c92655c2f4e5732bccdd59c9
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/PreSpawnerSpawnEvent.java
 @@ -0,0 +1,29 @@
 +package com.destroystokyo.paper.event.entity;
 +
-+
-+import com.google.common.base.Preconditions;
 +import org.bukkit.Location;
 +import org.bukkit.entity.EntityType;
 +import org.bukkit.event.entity.CreatureSpawnEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called before an entity is spawned into a world by a spawner.
-+ *
++ * <p>
 + * This only includes the spawner's location and not the full BlockState snapshot for performance reasons.
 + * If you really need it you have to get the spawner yourself.
 + */
-+
 +public class PreSpawnerSpawnEvent extends PreCreatureSpawnEvent {
++
 +    @NotNull private final Location spawnerLocation;
 +
++    @ApiStatus.Internal
 +    public PreSpawnerSpawnEvent(@NotNull Location location, @NotNull EntityType type, @NotNull Location spawnerLocation) {
 +        super(location, type, CreatureSpawnEvent.SpawnReason.SPAWNER);
-+        this.spawnerLocation = Preconditions.checkNotNull(spawnerLocation, "Spawner location may not be null");
++        this.spawnerLocation = spawnerLocation;
 +    }
 +
 +    @NotNull
 +    public Location getSpawnerLocation() {
-+        return spawnerLocation;
++        return this.spawnerLocation;
 +    }
 +}

--- a/patches/api/0158-Turtle-API.patch
+++ b/patches/api/0158-Turtle-API.patch
@@ -6,25 +6,29 @@ Subject: [PATCH] Turtle API
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/TurtleGoHomeEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/TurtleGoHomeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..021356d151ed638068e3e89b8cc77b3795883233
+index 0000000000000000000000000000000000000000..cfbc8aaf862ac90e794ee38bf8a6cb9ea414b13e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/TurtleGoHomeEvent.java
-@@ -0,0 +1,49 @@
+@@ -0,0 +1,53 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Turtle;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when a Turtle decides to go home
 + */
 +public class TurtleGoHomeEvent extends EntityEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled = false;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public TurtleGoHomeEvent(@NotNull Turtle turtle) {
 +        super(turtle);
 +    }
@@ -36,35 +40,35 @@ index 0000000000000000000000000000000000000000..021356d151ed638068e3e89b8cc77b37
 +     */
 +    @NotNull
 +    public Turtle getEntity() {
-+        return (Turtle) entity;
++        return (Turtle) super.getEntity();
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/TurtleLayEggEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/TurtleLayEggEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..bcc8dba50e3a3df0206c4827bb468bf884837b8b
+index 0000000000000000000000000000000000000000..e917e64e8ea266a3fc7387c42aad95927f0f0501
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/TurtleLayEggEvent.java
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,92 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.Location;
@@ -72,18 +76,23 @@ index 0000000000000000000000000000000000000000..bcc8dba50e3a3df0206c4827bb468bf8
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when a Turtle lays eggs
 + */
 +public class TurtleLayEggEvent extends EntityEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled = false;
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull
 +    private final Location location;
 +    private int eggCount;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public TurtleLayEggEvent(@NotNull Turtle turtle, @NotNull Location location, int eggCount) {
 +        super(turtle);
 +        this.location = location;
@@ -97,7 +106,7 @@ index 0000000000000000000000000000000000000000..bcc8dba50e3a3df0206c4827bb468bf8
 +     */
 +    @NotNull
 +    public Turtle getEntity() {
-+        return (Turtle) entity;
++        return (Turtle) super.getEntity();
 +    }
 +
 +    /**
@@ -107,7 +116,7 @@ index 0000000000000000000000000000000000000000..bcc8dba50e3a3df0206c4827bb468bf8
 +     */
 +    @NotNull
 +    public Location getLocation() {
-+        return location;
++        return this.location;
 +    }
 +
 +    /**
@@ -116,7 +125,7 @@ index 0000000000000000000000000000000000000000..bcc8dba50e3a3df0206c4827bb468bf8
 +     * @return Number of eggs
 +     */
 +    public int getEggCount() {
-+        return eggCount;
++        return this.eggCount;
 +    }
 +
 +    /**
@@ -126,7 +135,7 @@ index 0000000000000000000000000000000000000000..bcc8dba50e3a3df0206c4827bb468bf8
 +     */
 +    public void setEggCount(int eggCount) {
 +        if (eggCount < 1) {
-+            cancelled = true;
++            this.cancelled = true;
 +            return;
 +        }
 +        this.eggCount = Math.min(eggCount, 4);
@@ -134,30 +143,30 @@ index 0000000000000000000000000000000000000000..bcc8dba50e3a3df0206c4827bb468bf8
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/TurtleStartDiggingEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/TurtleStartDiggingEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..abeb24fccda2acfdb0dfdadacb8fe688bd97cf78
+index 0000000000000000000000000000000000000000..5cdc6b0c3db43279e2bb8043922b31f750ddb3f5
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/TurtleStartDiggingEvent.java
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,66 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.Location;
@@ -165,16 +174,20 @@ index 0000000000000000000000000000000000000000..abeb24fccda2acfdb0dfdadacb8fe688
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when a Turtle starts digging to lay eggs
 + */
 +public class TurtleStartDiggingEvent extends EntityEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled = false;
-+    @NotNull private final Location location;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final Location location;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public TurtleStartDiggingEvent(@NotNull Turtle turtle, @NotNull Location location) {
 +        super(turtle);
 +        this.location = location;
@@ -187,7 +200,7 @@ index 0000000000000000000000000000000000000000..abeb24fccda2acfdb0dfdadacb8fe688
 +     */
 +    @NotNull
 +    public Turtle getEntity() {
-+        return (Turtle) entity;
++        return (Turtle) super.getEntity();
 +    }
 +
 +    /**
@@ -197,27 +210,27 @@ index 0000000000000000000000000000000000000000..abeb24fccda2acfdb0dfdadacb8fe688
 +     */
 +    @NotNull
 +    public Location getLocation() {
-+        return location;
++        return this.location;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Turtle.java b/src/main/java/org/bukkit/entity/Turtle.java

--- a/patches/api/0159-Add-spectator-target-events.patch
+++ b/patches/api/0159-Add-spectator-target-events.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] Add spectator target events
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerStartSpectatingEntityEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerStartSpectatingEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b8ec7ef2d4ef0683cc0d6ca86885dd9a01f47e16
+index 0000000000000000000000000000000000000000..a70a64d2273414d95d77e601a41a208cce78e345
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerStartSpectatingEntityEvent.java
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,71 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Entity;
@@ -19,6 +19,7 @@ index 0000000000000000000000000000000000000000..b8ec7ef2d4ef0683cc0d6ca86885dd9a
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -26,11 +27,14 @@ index 0000000000000000000000000000000000000000..b8ec7ef2d4ef0683cc0d6ca86885dd9a
 + */
 +public class PlayerStartSpectatingEntityEvent extends PlayerEvent implements Cancellable {
 +
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled;
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final Entity currentSpectatorTarget;
 +    @NotNull private final Entity newSpectatorTarget;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PlayerStartSpectatingEntityEvent(@NotNull Player player, @NotNull Entity currentSpectatorTarget, @NotNull Entity newSpectatorTarget) {
 +        super(player);
 +        this.currentSpectatorTarget = currentSpectatorTarget;
@@ -44,7 +48,7 @@ index 0000000000000000000000000000000000000000..b8ec7ef2d4ef0683cc0d6ca86885dd9a
 +     */
 +    @NotNull
 +    public Entity getCurrentSpectatorTarget() {
-+        return currentSpectatorTarget;
++        return this.currentSpectatorTarget;
 +    }
 +
 +    /**
@@ -54,12 +58,12 @@ index 0000000000000000000000000000000000000000..b8ec7ef2d4ef0683cc0d6ca86885dd9a
 +     */
 +    @NotNull
 +    public Entity getNewSpectatorTarget() {
-+        return newSpectatorTarget;
++        return this.newSpectatorTarget;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
@@ -70,21 +74,21 @@ index 0000000000000000000000000000000000000000..b8ec7ef2d4ef0683cc0d6ca86885dd9a
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 +
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerStopSpectatingEntityEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerStopSpectatingEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..693d119ab920a1bd0d1b5a0feb092631715ec0ad
+index 0000000000000000000000000000000000000000..a6a5ebc534cc380740ba42790149c8b85f52aabb
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerStopSpectatingEntityEvent.java
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,57 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Entity;
@@ -92,6 +96,7 @@ index 0000000000000000000000000000000000000000..693d119ab920a1bd0d1b5a0feb092631
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -99,10 +104,12 @@ index 0000000000000000000000000000000000000000..693d119ab920a1bd0d1b5a0feb092631
 + */
 +public class PlayerStopSpectatingEntityEvent extends PlayerEvent implements Cancellable {
 +
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled;
-+    @NotNull private final Entity spectatorTarget;
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
++    @NotNull private final Entity spectatorTarget;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PlayerStopSpectatingEntityEvent(@NotNull Player player, @NotNull Entity spectatorTarget) {
 +        super(player);
 +        this.spectatorTarget = spectatorTarget;
@@ -115,12 +122,12 @@ index 0000000000000000000000000000000000000000..693d119ab920a1bd0d1b5a0feb092631
 +     */
 +    @NotNull
 +    public Entity getSpectatorTarget() {
-+        return spectatorTarget;
++        return this.spectatorTarget;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
@@ -131,11 +138,11 @@ index 0000000000000000000000000000000000000000..693d119ab920a1bd0d1b5a0feb092631
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0165-Add-PlayerConnectionCloseEvent.patch
+++ b/patches/api/0165-Add-PlayerConnectionCloseEvent.patch
@@ -35,10 +35,10 @@ is undefined.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerConnectionCloseEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerConnectionCloseEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..12c1c6fe9dc8dc5f5faf6dcf99f6857219ef22b8
+index 0000000000000000000000000000000000000000..d0fb13adc140f1ca74d0c3448f92baa60684f3e2
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerConnectionCloseEvent.java
-@@ -0,0 +1,95 @@
+@@ -0,0 +1,88 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.event.Event;
@@ -46,6 +46,9 @@ index 0000000000000000000000000000000000000000..12c1c6fe9dc8dc5f5faf6dcf99f68572
 +
 +import java.net.InetAddress;
 +import java.util.UUID;
++import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
++import org.bukkit.event.player.PlayerQuitEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -53,45 +56,35 @@ index 0000000000000000000000000000000000000000..12c1c6fe9dc8dc5f5faf6dcf99f68572
 + * This event is invoked when a player has disconnected. It is guaranteed that,
 + * if the server is in online-mode, that the provided uuid and username have been
 + * validated.
-+ * </p>
-+ *
 + * <p>
 + * The event is invoked for players who have not yet logged into the world, whereas
-+ * {@link org.bukkit.event.player.PlayerQuitEvent} is only invoked on players who have logged into the world.
-+ * </p>
-+ *
++ * {@link PlayerQuitEvent} is only invoked on players who have logged into the world.
 + * <p>
 + * The event is invoked for players who have already logged into the world,
 + * although whether or not the player exists in the world at the time of
 + * firing is undefined. (That is, whether the plugin can retrieve a Player object
 + * using the event parameters is undefined). However, it is guaranteed that this
-+ * event is invoked AFTER {@link org.bukkit.event.player.PlayerQuitEvent}, if the player has already logged into the world.
-+ * </p>
-+ *
++ * event is invoked AFTER {@link PlayerQuitEvent}, if the player has already logged into the world.
 + * <p>
-+ * This event is guaranteed to never fire unless {@link org.bukkit.event.player.AsyncPlayerPreLoginEvent} has
++ * This event is guaranteed to never fire unless {@link AsyncPlayerPreLoginEvent} has
 + * been fired beforehand, and this event may not be called in parallel with
-+ * {@link org.bukkit.event.player.AsyncPlayerPreLoginEvent} for the same connection.
-+ * </p>
-+ *
++ * {@link AsyncPlayerPreLoginEvent} for the same connection.
 + * <p>
-+ * Cancelling the {@link org.bukkit.event.player.AsyncPlayerPreLoginEvent} guarantees the corresponding
++ * Cancelling the {@link AsyncPlayerPreLoginEvent} guarantees the corresponding
 + * {@code PlayerConnectionCloseEvent} is never called.
-+ * </p>
-+ *
 + * <p>
 + * The event may be invoked asynchronously or synchronously. Plugins should check
 + * {@link Event#isAsynchronous()} and handle accordingly.
-+ * </p>
 + */
 +public class PlayerConnectionCloseEvent extends Event {
 +
-+    private static final HandlerList HANDLERS = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    @NotNull private final UUID playerUniqueId;
 +    @NotNull private final String playerName;
 +    @NotNull private final InetAddress ipAddress;
 +
++    @ApiStatus.Internal
 +    public PlayerConnectionCloseEvent(@NotNull final UUID playerUniqueId, @NotNull final String playerName, @NotNull final InetAddress ipAddress, final boolean async) {
 +        super(async);
 +        this.playerUniqueId = playerUniqueId;
@@ -126,11 +119,11 @@ index 0000000000000000000000000000000000000000..12c1c6fe9dc8dc5f5faf6dcf99f68572
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0168-BlockDestroyEvent.patch
+++ b/patches/api/0168-BlockDestroyEvent.patch
@@ -12,7 +12,7 @@ This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java b/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..278f26bed374fe79ff3cd135a76f019bd21906e4
+index 0000000000000000000000000000000000000000..d0421a4cbcb672cc06b40ad41fc06a67f6d2dbbb
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java
 @@ -0,0 +1,123 @@
@@ -30,23 +30,22 @@ index 0000000000000000000000000000000000000000..278f26bed374fe79ff3cd135a76f019b
 + * Fired anytime the server intends to 'destroy' a block through some triggering reason.
 + * This does not fire anytime a block is set to air, but only with more direct triggers such
 + * as physics updates, pistons, Entities changing blocks, commands set to "Destroy".
-+ *
++ * <p>
 + * This event is associated with the game playing a sound effect at the block in question, when
 + * something can be described as "intend to destroy what is there",
-+ *
++ * <p>
 + * Events such as leaves decaying, pistons retracting (where the block is moving), does NOT fire this event.
-+ *
 + */
 +public class BlockDestroyEvent extends BlockExpEvent implements Cancellable {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    @NotNull private final BlockData newState;
 +    private boolean willDrop;
 +    private boolean playEffect = true;
 +    private BlockData effectBlock;
 +
-+    private boolean cancelled = false;
++    private boolean cancelled;
 +
 +    @ApiStatus.Internal
 +    public BlockDestroyEvent(@NotNull Block block, @NotNull BlockData newState, @NotNull BlockData effectBlock, int xp, boolean willDrop) {
@@ -58,6 +57,7 @@ index 0000000000000000000000000000000000000000..278f26bed374fe79ff3cd135a76f019b
 +
 +    /**
 +     * Get the effect that will be played when the block is broken.
++     *
 +     * @return block break effect
 +     */
 +    @NotNull
@@ -67,7 +67,7 @@ index 0000000000000000000000000000000000000000..278f26bed374fe79ff3cd135a76f019b
 +
 +    /**
 +     * Sets the effect that will be played when the block is broken.
-+     * Note: {@link BlockDestroyEvent#playEffect()} must be true in order for this effect to be
++     * Note: {@link BlockDestroyEvent#playEffect()} must be {@code true} in order for this effect to be
 +     * played.
 +     *
 +     * @param effectBlock block effect
@@ -81,7 +81,7 @@ index 0000000000000000000000000000000000000000..278f26bed374fe79ff3cd135a76f019b
 +     */
 +    @NotNull
 +    public BlockData getNewState() {
-+        return newState;
++        return this.newState;
 +    }
 +
 +    /**
@@ -117,25 +117,25 @@ index 0000000000000000000000000000000000000000..278f26bed374fe79ff3cd135a76f019b
 +     */
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    /**
 +     * If the event is cancelled, the block will remain in its previous state.
-+     * @param cancel true if you wish to cancel this event
 +     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
++    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0169-Add-WhitelistToggleEvent.patch
+++ b/patches/api/0169-Add-WhitelistToggleEvent.patch
@@ -6,14 +6,15 @@ Subject: [PATCH] Add WhitelistToggleEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/server/WhitelistToggleEvent.java b/src/main/java/com/destroystokyo/paper/event/server/WhitelistToggleEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..fdd5eedb2b7401439912a3a4343a920f32edc860
+index 0000000000000000000000000000000000000000..22fa169c278639f31aec2695259963038de0af8a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/server/WhitelistToggleEvent.java
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,43 @@
 +package com.destroystokyo.paper.event.server;
 +
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -22,10 +23,12 @@ index 0000000000000000000000000000000000000000..fdd5eedb2b7401439912a3a4343a920f
 + * @author Mark Vainomaa
 + */
 +public class WhitelistToggleEvent extends Event {
-+    private static final HandlerList handlers = new HandlerList();
 +
-+    private boolean enabled;
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
++    private final boolean enabled;
++
++    @ApiStatus.Internal
 +    public WhitelistToggleEvent(boolean enabled) {
 +        this.enabled = enabled;
 +    }
@@ -36,17 +39,17 @@ index 0000000000000000000000000000000000000000..fdd5eedb2b7401439912a3a4343a920f
 +     * @return Whether whitelist is going to be enabled or not
 +     */
 +    public boolean isEnabled() {
-+        return enabled;
++        return this.enabled;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0170-Add-GS4-Query-event.patch
+++ b/patches/api/0170-Add-GS4-Query-event.patch
@@ -6,16 +6,18 @@ Subject: [PATCH] Add GS4 Query event
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/server/GS4QueryEvent.java b/src/main/java/com/destroystokyo/paper/event/server/GS4QueryEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..77a19995f6792a182c5a43d6714e7bda0f42df5b
+index 0000000000000000000000000000000000000000..8edc33bde29e967cec488d0f5e2f1097291978a6
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/server/GS4QueryEvent.java
-@@ -0,0 +1,412 @@
+@@ -0,0 +1,424 @@
 +package com.destroystokyo.paper.event.server;
 +
 +import com.google.common.base.Preconditions;
 +import com.google.common.collect.ImmutableList;
++import org.bukkit.Server;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +import java.net.InetAddress;
@@ -25,79 +27,76 @@ index 0000000000000000000000000000000000000000..77a19995f6792a182c5a43d6714e7bda
 +import java.util.List;
 +
 +/**
-+ * This event is fired if server is getting queried over GS4 Query protocol
-+ *
++ * This event is fired if server is getting queried over GS4 Query protocol.
++ * <br>
 + * Adapted from Velocity's ProxyQueryEvent
 + *
 + * @author Mark Vainomaa
 + */
 +public final class GS4QueryEvent extends Event {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    private final QueryType queryType;
 +    private final InetAddress querierAddress;
 +    private QueryResponse response;
 +
++    @ApiStatus.Internal
 +    public GS4QueryEvent(@NotNull QueryType queryType, @NotNull InetAddress querierAddress, @NotNull QueryResponse response) {
 +        super(true); // should always be called async
-+        this.queryType = Preconditions.checkNotNull(queryType, "queryType");
-+        this.querierAddress = Preconditions.checkNotNull(querierAddress, "querierAddress");
-+        this.response = Preconditions.checkNotNull(response, "response");
++        this.queryType = queryType;
++        this.querierAddress = querierAddress;
++        this.response = response;
 +    }
 +
 +    /**
 +     * Get query type
++     *
 +     * @return query type
 +     */
 +    @NotNull
 +    public QueryType getQueryType() {
-+        return queryType;
++        return this.queryType;
 +    }
 +
 +    /**
 +     * Get querier address
++     *
 +     * @return querier address
 +     */
 +    @NotNull
 +    public InetAddress getQuerierAddress() {
-+        return querierAddress;
++        return this.querierAddress;
 +    }
 +
 +    /**
 +     * Get query response
++     *
 +     * @return query response
 +     */
 +    @NotNull
 +    public QueryResponse getResponse() {
-+        return response;
++        return this.response;
 +    }
 +
 +    /**
 +     * Set query response
++     *
 +     * @param response query response
 +     */
 +    public void setResponse(@NotNull QueryResponse response) {
 +        this.response = Preconditions.checkNotNull(response, "response");
 +    }
 +
-+    @Override
-+    public String toString() {
-+        return "GS4QueryEvent{" +
-+            "queryType=" + queryType +
-+            ", querierAddress=" + querierAddress +
-+            ", response=" + response +
-+            '}';
-+    }
-+
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    /**
@@ -114,10 +113,10 @@ index 0000000000000000000000000000000000000000..77a19995f6792a182c5a43d6714e7bda
 +         * Full query asks pretty much everything present on this event (only hardcoded values cannot be modified here).
 +         */
 +        FULL
-+        ;
 +    }
 +
 +    public final static class QueryResponse {
++
 +        private final String motd;
 +        private final String gameVersion;
 +        private final String map;
@@ -143,95 +142,105 @@ index 0000000000000000000000000000000000000000..77a19995f6792a182c5a43d6714e7bda
 +        }
 +
 +        /**
-+         * Get motd which will be used to reply to the query. By default it is {@link org.bukkit.Server#getMotd()}.
++         * Get motd which will be used to reply to the query. By default it is {@link Server#getMotd()}.
++         *
 +         * @return motd
 +         */
 +        @NotNull
 +        public String getMotd() {
-+            return motd;
++            return this.motd;
 +        }
 +
 +        /**
 +         * Get game version which will be used to reply to the query. By default supported Minecraft versions range is sent.
++         *
 +         * @return game version
 +         */
 +        @NotNull
 +        public String getGameVersion() {
-+            return gameVersion;
++            return this.gameVersion;
 +        }
 +
 +        /**
 +         * Get map name which will be used to reply to the query. By default {@code world} is sent.
++         *
 +         * @return map name
 +         */
 +        @NotNull
 +        public String getMap() {
-+            return map;
++            return this.map;
 +        }
 +
 +        /**
 +         * Get current online player count which will be used to reply to the query.
++         *
 +         * @return online player count
 +         */
 +        public int getCurrentPlayers() {
-+            return currentPlayers;
++            return this.currentPlayers;
 +        }
 +
 +        /**
 +         * Get max player count which will be used to reply to the query.
++         *
 +         * @return max player count
 +         */
 +        public int getMaxPlayers() {
-+            return maxPlayers;
++            return this.maxPlayers;
 +        }
 +
 +        /**
-+         * Get server (public facing) hostname
++         * Get server (public facing) hostname.
++         *
 +         * @return server hostname
 +         */
 +        @NotNull
 +        public String getHostname() {
-+            return hostname;
++            return this.hostname;
 +        }
 +
 +        /**
-+         * Get server (public facing) port
++         * Get server (public facing) port.
++         *
 +         * @return server port
 +         */
 +        public int getPort() {
-+            return port;
++            return this.port;
 +        }
 +
 +        /**
 +         * Get collection of players which will be used to reply to the query.
++         *
 +         * @return collection of players
 +         */
 +        @NotNull
 +        public Collection<String> getPlayers() {
-+            return players;
++            return this.players;
 +        }
 +
 +        /**
 +         * Get server software (name and version) which will be used to reply to the query.
++         *
 +         * @return server software
 +         */
 +        @NotNull
 +        public String getServerVersion() {
-+            return serverVersion;
++            return this.serverVersion;
 +        }
 +
 +        /**
 +         * Get list of plugins which will be used to reply to the query.
++         *
 +         * @return collection of plugins
 +         */
 +        @NotNull
 +        public Collection<PluginInformation> getPlugins() {
-+            return plugins;
++            return this.plugins;
 +        }
 +
-+
 +        /**
-+         * Creates a new {@link Builder} instance from data represented by this response
++         * Creates a new {@link Builder} instance from data represented by this response.
++         *
 +         * @return {@link QueryResponse} builder
 +         */
 +        @NotNull
@@ -250,7 +259,8 @@ index 0000000000000000000000000000000000000000..77a19995f6792a182c5a43d6714e7bda
 +        }
 +
 +        /**
-+         * Creates a new {@link Builder} instance
++         * Creates a new {@link Builder} instance.
++         *
 +         * @return {@link QueryResponse} builder
 +         */
 +        @NotNull
@@ -272,8 +282,8 @@ index 0000000000000000000000000000000000000000..77a19995f6792a182c5a43d6714e7bda
 +            private int maxPlayers;
 +            private int port;
 +
-+            private List<String> players = new ArrayList<>();
-+            private List<PluginInformation> plugins = new ArrayList<>();
++            private final List<String> players = new ArrayList<>();
++            private final List<PluginInformation> plugins = new ArrayList<>();
 +
 +            private Builder() {}
 +
@@ -365,7 +375,8 @@ index 0000000000000000000000000000000000000000..77a19995f6792a182c5a43d6714e7bda
 +            }
 +
 +            /**
-+             * Builds new {@link QueryResponse} with supplied data
++             * Builds new {@link QueryResponse} with supplied data.
++             *
 +             * @return response
 +             */
 +            @NotNull
@@ -389,6 +400,7 @@ index 0000000000000000000000000000000000000000..77a19995f6792a182c5a43d6714e7bda
 +         * Plugin information
 +         */
 +        public static class PluginInformation {
++
 +            private String name;
 +            private String version;
 +
@@ -399,7 +411,7 @@ index 0000000000000000000000000000000000000000..77a19995f6792a182c5a43d6714e7bda
 +
 +            @NotNull
 +            public String getName() {
-+                return name;
++                return this.name;
 +            }
 +
 +            public void setName(@NotNull String name) {
@@ -412,7 +424,7 @@ index 0000000000000000000000000000000000000000..77a19995f6792a182c5a43d6714e7bda
 +
 +            @NotNull
 +            public String getVersion() {
-+                return version;
++                return this.version;
 +            }
 +
 +            @NotNull

--- a/patches/api/0171-Add-PlayerPostRespawnEvent.patch
+++ b/patches/api/0171-Add-PlayerPostRespawnEvent.patch
@@ -6,26 +6,30 @@ Subject: [PATCH] Add PlayerPostRespawnEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerPostRespawnEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerPostRespawnEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..31f34b54801f6699ce43355fa2a0a51f1ad0c997
+index 0000000000000000000000000000000000000000..16961aac061e78fb84029f8435ab5f7c493b1362
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerPostRespawnEvent.java
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,56 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.Location;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired after a player has respawned
 + */
 +public class PlayerPostRespawnEvent extends PlayerEvent {
-+    private final static HandlerList handlers = new HandlerList();
++
++    private final static HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final Location respawnedLocation;
 +    private final boolean isBedSpawn;
 +
++    @ApiStatus.Internal
 +    public PlayerPostRespawnEvent(@NotNull final Player respawnPlayer, @NotNull final Location respawnedLocation, final boolean isBedSpawn) {
 +        super(respawnPlayer);
 +        this.respawnedLocation = respawnedLocation;
@@ -39,7 +43,7 @@ index 0000000000000000000000000000000000000000..31f34b54801f6699ce43355fa2a0a51f
 +     */
 +    @NotNull
 +    public Location getRespawnedLocation() {
-+        return respawnedLocation.clone();
++        return this.respawnedLocation.clone();
 +    }
 +
 +    /**
@@ -48,18 +52,18 @@ index 0000000000000000000000000000000000000000..31f34b54801f6699ce43355fa2a0a51f
 +     * @return whether the player respawned to their bed
 +     */
 +    public boolean isBedSpawn() {
-+        return isBedSpawn;
++        return this.isBedSpawn;
 +    }
 +
 +    @Override
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java b/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java

--- a/patches/api/0174-Server-Tick-Events.patch
+++ b/patches/api/0174-Server-Tick-Events.patch
@@ -7,14 +7,15 @@ Fires event at start and end of a server tick
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/server/ServerTickEndEvent.java b/src/main/java/com/destroystokyo/paper/event/server/ServerTickEndEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..dd7327c70fb72089dec6552317ba28961236db56
+index 0000000000000000000000000000000000000000..17e9f39ce1cc7489e936c96f95b8b0579528b222
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/server/ServerTickEndEvent.java
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,62 @@
 +package com.destroystokyo.paper.event.server;
 +
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -22,11 +23,13 @@ index 0000000000000000000000000000000000000000..dd7327c70fb72089dec6552317ba2896
 + */
 +public class ServerTickEndEvent extends Event {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final int tickNumber;
 +    private final double tickDuration;
 +    private final long timeEnd;
 +
++    @ApiStatus.Internal
 +    public ServerTickEndEvent(int tickNumber, double tickDuration, long timeRemaining) {
 +        this.tickNumber = tickNumber;
 +        this.tickDuration = tickDuration;
@@ -37,21 +40,21 @@ index 0000000000000000000000000000000000000000..dd7327c70fb72089dec6552317ba2896
 +     * @return What tick this was since start (first tick = 1)
 +     */
 +    public int getTickNumber() {
-+        return tickNumber;
++        return this.tickNumber;
 +    }
 +
 +    /**
 +     * @return Time in milliseconds of how long this tick took
 +     */
 +    public double getTickDuration() {
-+        return tickDuration;
++        return this.tickDuration;
 +    }
 +
 +    /**
 +     * Amount of nanoseconds remaining before the next tick should start.
-+     *
++     * <p>
 +     * If this value is negative, then that means the server has exceeded the tick time limit and TPS has been lost.
-+     *
++     * <p>
 +     * Method will continuously return the updated time remaining value. (return value is not static)
 +     *
 +     * @return Amount of nanoseconds remaining before the next tick should start
@@ -62,31 +65,34 @@ index 0000000000000000000000000000000000000000..dd7327c70fb72089dec6552317ba2896
 +
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/server/ServerTickStartEvent.java b/src/main/java/com/destroystokyo/paper/event/server/ServerTickStartEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..eac85f1f49088bb71afb01eff4d5f53887306461
+index 0000000000000000000000000000000000000000..fb5bbfffea8b883e4c8769484a2b64dd895cb617
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/server/ServerTickStartEvent.java
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,35 @@
 +package com.destroystokyo.paper.event.server;
 +
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +public class ServerTickStartEvent extends Event {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final int tickNumber;
 +
++    @ApiStatus.Internal
 +    public ServerTickStartEvent(int tickNumber) {
 +        this.tickNumber = tickNumber;
 +    }
@@ -95,16 +101,16 @@ index 0000000000000000000000000000000000000000..eac85f1f49088bb71afb01eff4d5f538
 +     * @return What tick this is going be since start (first tick = 1)
 +     */
 +    public int getTickNumber() {
-+        return tickNumber;
++        return this.tickNumber;
 +    }
 +
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0184-Add-ThrownEggHatchEvent.patch
+++ b/patches/api/0184-Add-ThrownEggHatchEvent.patch
@@ -8,16 +8,18 @@ Adds a new event similar to PlayerEggThrowEvent, but without the Player requirem
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/ThrownEggHatchEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/ThrownEggHatchEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..085d77dde83d6ed13eb83f23cf3e51d380187c9c
+index 0000000000000000000000000000000000000000..092bab9be36acc0f04c7ea5b3510879169a0a125
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/ThrownEggHatchEvent.java
-@@ -0,0 +1,115 @@
+@@ -0,0 +1,120 @@
 +package com.destroystokyo.paper.event.entity;
 +
++import com.google.common.base.Preconditions;
 +import org.bukkit.entity.Egg;
 +import org.bukkit.entity.EntityType;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -26,12 +28,15 @@ index 0000000000000000000000000000000000000000..085d77dde83d6ed13eb83f23cf3e51d3
 + * This event fires for all thrown eggs that may hatch, players, dispensers, etc.
 + */
 +public class ThrownEggHatchEvent extends Event {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final Egg egg;
 +    private boolean hatching;
-+    private EntityType hatchType;
 +    private byte numHatches;
++    private EntityType hatchType;
 +
++    @ApiStatus.Internal
 +    public ThrownEggHatchEvent(@NotNull final Egg egg, final boolean hatching, final byte numHatches, @NotNull final EntityType hatchingType) {
 +        this.egg = egg;
 +        this.hatching = hatching;
@@ -46,7 +51,7 @@ index 0000000000000000000000000000000000000000..085d77dde83d6ed13eb83f23cf3e51d3
 +     */
 +    @NotNull
 +    public Egg getEgg() {
-+        return egg;
++        return this.egg;
 +    }
 +
 +    /**
@@ -56,13 +61,13 @@ index 0000000000000000000000000000000000000000..085d77dde83d6ed13eb83f23cf3e51d3
 +     * @return boolean Whether the egg is going to hatch or not
 +     */
 +    public boolean isHatching() {
-+        return hatching;
++        return this.hatching;
 +    }
 +
 +    /**
 +     * Sets whether the egg will hatch or not.
 +     *
-+     * @param hatching true if you want the egg to hatch, false if you want it
++     * @param hatching {@code true} if you want the egg to hatch, {@code false} if you want it
 +     *     not to
 +     */
 +    public void setHatching(boolean hatching) {
@@ -70,13 +75,13 @@ index 0000000000000000000000000000000000000000..085d77dde83d6ed13eb83f23cf3e51d3
 +    }
 +
 +    /**
-+     * Get the type of the mob being hatched (EntityType.CHICKEN by default)
++     * Get the type of the mob being hatched ({@link EntityType#CHICKEN} by default)
 +     *
 +     * @return The type of the mob being hatched by the egg
 +     */
 +    @NotNull
 +    public EntityType getHatchingType() {
-+        return hatchType;
++        return this.hatchType;
 +    }
 +
 +    /**
@@ -85,7 +90,7 @@ index 0000000000000000000000000000000000000000..085d77dde83d6ed13eb83f23cf3e51d3
 +     * @param hatchType The type of the mob being hatched by the egg
 +     */
 +    public void setHatchingType(@NotNull EntityType hatchType) {
-+        if (!hatchType.isSpawnable()) throw new IllegalArgumentException("Can't spawn that entity type from an egg!");
++        Preconditions.checkArgument(hatchType.isSpawnable(), "Can't spawn that entity type from an egg!");
 +        this.hatchType = hatchType;
 +    }
 +
@@ -93,22 +98,22 @@ index 0000000000000000000000000000000000000000..085d77dde83d6ed13eb83f23cf3e51d3
 +     * Get the number of mob hatches from the egg. By default the number will
 +     * be the number the server would've done
 +     * <ul>
-+     * <li>7/8 chance of being 0
-+     * <li>31/256 ~= 1/8 chance to be 1
-+     * <li>1/256 chance to be 4
++     *  <li>7/8 chance of being 0
++     *  <li>31/256 ~= 1/8 chance to be 1
++     *  <li>1/256 chance to be 4
 +     * </ul>
 +     *
 +     * @return The number of mobs going to be hatched by the egg
 +     */
 +    public byte getNumHatches() {
-+        return numHatches;
++        return this.numHatches;
 +    }
 +
 +    /**
 +     * Change the number of mobs coming out of the hatched egg
 +     * <p>
-+     * The boolean hatching will override this number. Ie. If hatching =
-+     * false, this number will not matter
++     * The boolean hatching will override this number. I.e. If hatching is
++     * {@code false}, this number will not matter
 +     *
 +     * @param numHatches The number of mobs coming out of the egg
 +     */
@@ -119,11 +124,11 @@ index 0000000000000000000000000000000000000000..085d77dde83d6ed13eb83f23cf3e51d3
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0185-Entity-Jump-API.patch
+++ b/patches/api/0185-Entity-Jump-API.patch
@@ -6,16 +6,17 @@ Subject: [PATCH] Entity Jump API
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityJumpEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityJumpEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f0067c2e953d18e1a33536980071ba3f0152ecb4
+index 0000000000000000000000000000000000000000..a6306c957fcacdcbcc8037b4ee33a167d21ff29e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityJumpEvent.java
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,50 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.LivingEntity;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -24,9 +25,12 @@ index 0000000000000000000000000000000000000000..f0067c2e953d18e1a33536980071ba3f
 + * Cancelling the event will stop the entity from jumping
 + */
 +public class EntityJumpEvent extends EntityEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean canceled;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public EntityJumpEvent(@NotNull LivingEntity entity) {
 +        super(entity);
 +    }
@@ -34,26 +38,26 @@ index 0000000000000000000000000000000000000000..f0067c2e953d18e1a33536980071ba3f
 +    @NotNull
 +    @Override
 +    public LivingEntity getEntity() {
-+        return (LivingEntity) entity;
++        return (LivingEntity) super.getEntity();
 +    }
 +
 +    public boolean isCancelled() {
-+        return canceled;
++        return this.cancelled;
 +    }
 +
 +    public void setCancelled(boolean cancel) {
-+        canceled = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java

--- a/patches/api/0190-Add-Player-Client-Options-API.patch
+++ b/patches/api/0190-Add-Player-Client-Options-API.patch
@@ -90,10 +90,10 @@ index 0000000000000000000000000000000000000000..4a0c39405d4fbed457787e3c6ded4cc6
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerClientOptionsChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerClientOptionsChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..cf67dc7d465223710adbf2b798109f525d3b057d
+index 0000000000000000000000000000000000000000..1757055d821d9ec7c728aa6c1b52fa6aea591ae5
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerClientOptionsChangeEvent.java
-@@ -0,0 +1,134 @@
+@@ -0,0 +1,136 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import com.destroystokyo.paper.ClientOption;
@@ -103,6 +103,7 @@ index 0000000000000000000000000000000000000000..cf67dc7d465223710adbf2b798109f52
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.MainHand;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +import java.util.Map;
@@ -112,7 +113,7 @@ index 0000000000000000000000000000000000000000..cf67dc7d465223710adbf2b798109f52
 + */
 +public class PlayerClientOptionsChangeEvent extends PlayerEvent {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    private final String locale;
 +    private final int viewDistance;
@@ -136,6 +137,7 @@ index 0000000000000000000000000000000000000000..cf67dc7d465223710adbf2b798109f52
 +        this.textFilteringEnabled = false;
 +    }
 +
++    @ApiStatus.Internal
 +    public PlayerClientOptionsChangeEvent(@NotNull Player player, @NotNull Map<ClientOption<?>, ?> options) {
 +        super(player);
 +
@@ -151,81 +153,81 @@ index 0000000000000000000000000000000000000000..cf67dc7d465223710adbf2b798109f52
 +
 +    @NotNull
 +    public String getLocale() {
-+        return locale;
++        return this.locale;
 +    }
 +
 +    public boolean hasLocaleChanged() {
-+        return !locale.equals(player.getClientOption(ClientOption.LOCALE));
++        return !this.locale.equals(this.player.getClientOption(ClientOption.LOCALE));
 +    }
 +
 +    public int getViewDistance() {
-+        return viewDistance;
++        return this.viewDistance;
 +    }
 +
 +    public boolean hasViewDistanceChanged() {
-+        return viewDistance != player.getClientOption(ClientOption.VIEW_DISTANCE);
++        return this.viewDistance != this.player.getClientOption(ClientOption.VIEW_DISTANCE);
 +    }
 +
 +    @NotNull
 +    public ChatVisibility getChatVisibility() {
-+        return chatVisibility;
++        return this.chatVisibility;
 +    }
 +
 +    public boolean hasChatVisibilityChanged() {
-+        return chatVisibility != player.getClientOption(ClientOption.CHAT_VISIBILITY);
++        return this.chatVisibility != this.player.getClientOption(ClientOption.CHAT_VISIBILITY);
 +    }
 +
 +    public boolean hasChatColorsEnabled() {
-+        return chatColors;
++        return this.chatColors;
 +    }
 +
 +    public boolean hasChatColorsEnabledChanged() {
-+        return chatColors != player.getClientOption(ClientOption.CHAT_COLORS_ENABLED);
++        return this.chatColors != this.player.getClientOption(ClientOption.CHAT_COLORS_ENABLED);
 +    }
 +
 +    @NotNull
 +    public SkinParts getSkinParts() {
-+        return skinparts;
++        return this.skinparts;
 +    }
 +
 +    public boolean hasSkinPartsChanged() {
-+        return skinparts.getRaw() != player.getClientOption(ClientOption.SKIN_PARTS).getRaw();
++        return this.skinparts.getRaw() != this.player.getClientOption(ClientOption.SKIN_PARTS).getRaw();
 +    }
 +
 +    @NotNull
 +    public MainHand getMainHand() {
-+        return mainHand;
++        return this.mainHand;
 +    }
 +
 +    public boolean hasMainHandChanged() {
-+        return mainHand != player.getClientOption(ClientOption.MAIN_HAND);
++        return this.mainHand != this.player.getClientOption(ClientOption.MAIN_HAND);
 +    }
 +
 +    public boolean allowsServerListings() {
-+        return allowsServerListings;
++        return this.allowsServerListings;
 +    }
 +
 +    public boolean hasAllowServerListingsChanged() {
-+        return allowsServerListings != player.getClientOption(ClientOption.ALLOW_SERVER_LISTINGS);
++        return this.allowsServerListings != this.player.getClientOption(ClientOption.ALLOW_SERVER_LISTINGS);
 +    }
 +
 +    public boolean hasTextFilteringEnabled() {
-+        return textFilteringEnabled;
++        return this.textFilteringEnabled;
 +    }
 +
 +    public boolean hasTextFilteringChanged() {
-+        return textFilteringEnabled != player.getClientOption(ClientOption.TEXT_FILTERING_ENABLED);
++        return this.textFilteringEnabled != this.player.getClientOption(ClientOption.TEXT_FILTERING_ENABLED);
 +    }
 +
 +    @Override
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java

--- a/patches/api/0191-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/patches/api/0191-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerAttackEntityCooldownResetEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerAttackEntityCooldownResetEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ebdebe7b6ec6ed5aadc7ee925ba0147e61e6bc84
+index 0000000000000000000000000000000000000000..5ceaff1a499d08575ddcdcbead8e2cef6cfbea47
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerAttackEntityCooldownResetEvent.java
-@@ -0,0 +1,76 @@
+@@ -0,0 +1,77 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Entity;
@@ -17,6 +17,7 @@ index 0000000000000000000000000000000000000000..ebdebe7b6ec6ed5aadc7ee925ba0147e
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -24,47 +25,18 @@ index 0000000000000000000000000000000000000000..ebdebe7b6ec6ed5aadc7ee925ba0147e
 + */
 +public class PlayerAttackEntityCooldownResetEvent extends PlayerEvent implements Cancellable {
 +
-+    private final float cooledAttackStrength;
-+    private boolean cancel = false;
-+    private static final HandlerList handlers = new HandlerList();
-+    @NotNull private final Entity attackedEntity;
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    public PlayerAttackEntityCooldownResetEvent(@NotNull Player who, @NotNull Entity attackedEntity, float cooledAttackStrength) {
-+        super(who);
++    @NotNull private final Entity attackedEntity;
++    private final float cooledAttackStrength;
++
++    private boolean cancelled;
++
++    @ApiStatus.Internal
++    public PlayerAttackEntityCooldownResetEvent(@NotNull Player player, @NotNull Entity attackedEntity, float cooledAttackStrength) {
++        super(player);
 +        this.attackedEntity = attackedEntity;
 +        this.cooledAttackStrength = cooledAttackStrength;
-+    }
-+
-+    @Override
-+    public @NotNull HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    public static @NotNull HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    /**
-+     * Gets the cancellation state of this event. A cancelled event will not
-+     * be executed in the server, but will still pass to other plugins
-+     * <p>
-+     * If an attack cooldown event is cancelled, the players attack strength will remain at the same value instead of being reset.
-+     *
-+     * @return true if this event is cancelled
-+     */
-+    @Override
-+    public boolean isCancelled() {
-+        return cancel;
-+    }
-+
-+    /**
-+     * Cancelling this event will prevent the target player from having their cooldown reset from attacking this entity
-+     *
-+     * @param cancel true if you wish to cancel this event
-+     */
-+    @Override
-+    public void setCancelled(boolean cancel) {
-+        this.cancel = cancel;
 +    }
 +
 +    /**
@@ -73,7 +45,7 @@ index 0000000000000000000000000000000000000000..ebdebe7b6ec6ed5aadc7ee925ba0147e
 +     * @return returns the original player cooldown value
 +     */
 +    public float getCooledAttackStrength() {
-+        return cooledAttackStrength;
++        return this.cooledAttackStrength;
 +    }
 +
 +    /**
@@ -83,6 +55,35 @@ index 0000000000000000000000000000000000000000..ebdebe7b6ec6ed5aadc7ee925ba0147e
 +     */
 +    @NotNull
 +    public Entity getAttackedEntity() {
-+        return attackedEntity;
++        return this.attackedEntity;
++    }
++
++    /**
++     * {@inheritDoc}
++     * <p>
++     * If an attack cooldown event is cancelled, the players attack strength will remain at the same value instead of being reset.
++     */
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    /**
++     * {@inheritDoc}
++     * <p>
++     * Cancelling this event will prevent the target player from having their cooldown reset from attacking this entity
++     */
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public static @NotNull HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0202-Add-and-implement-PlayerRecipeBookClickEvent.patch
+++ b/patches/api/0202-Add-and-implement-PlayerRecipeBookClickEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add and implement PlayerRecipeBookClickEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerRecipeBookClickEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerRecipeBookClickEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7fa937d339ee98ad308deebb523fead6522eb262
+index 0000000000000000000000000000000000000000..c38ac6d0e0ac4ecbdc73d2bedd7731ff34c9d192
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerRecipeBookClickEvent.java
-@@ -0,0 +1,84 @@
+@@ -0,0 +1,89 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.NamespacedKey;
@@ -17,17 +17,22 @@ index 0000000000000000000000000000000000000000..7fa937d339ee98ad308deebb523fead6
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called when a player clicks a recipe in the recipe book
 + */
 +public class PlayerRecipeBookClickEvent extends PlayerEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancel = false;
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private NamespacedKey recipe;
 +    private boolean makeAll;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PlayerRecipeBookClickEvent(@NotNull Player player, @NotNull NamespacedKey recipe, boolean makeAll) {
 +        super(player);
 +        this.recipe = recipe;
@@ -41,7 +46,7 @@ index 0000000000000000000000000000000000000000..7fa937d339ee98ad308deebb523fead6
 +     */
 +    @NotNull
 +    public NamespacedKey getRecipe() {
-+        return recipe;
++        return this.recipe;
 +    }
 +
 +    /**
@@ -54,17 +59,17 @@ index 0000000000000000000000000000000000000000..7fa937d339ee98ad308deebb523fead6
 +    }
 +
 +    /**
-+     * Gets a boolean which indicates whether or not the player requested to make the maximum amount of results. This is
-+     * true if shift is pressed while the recipe is clicked in the recipe book
++     * Gets a boolean which indicates whether the player requested to make the maximum amount of results. This is
++     * {@code true} if shift is pressed while the recipe is clicked in the recipe book
 +     *
 +     * @return {@code true} if shift is pressed while the recipe is clicked
 +     */
 +    public boolean isMakeAll() {
-+        return makeAll;
++        return this.makeAll;
 +    }
 +
 +    /**
-+     * Sets whether or not the maximum amount of results should be made. If this is true, the request is handled as if
++     * Sets whether the maximum amount of results should be made. If this is {@code true}, the request is handled as if
 +     * the player had pressed shift while clicking on the recipe
 +     *
 +     * @param makeAll {@code true} if the request should attempt to make the maximum amount of results
@@ -75,23 +80,23 @@ index 0000000000000000000000000000000000000000..7fa937d339ee98ad308deebb523fead6
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancel;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        this.cancel = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/event/player/PlayerRecipeBookClickEvent.java b/src/main/java/org/bukkit/event/player/PlayerRecipeBookClickEvent.java

--- a/patches/api/0206-Add-PrepareResultEvent-PrepareGrindstoneEvent.patch
+++ b/patches/api/0206-Add-PrepareResultEvent-PrepareGrindstoneEvent.patch
@@ -11,27 +11,30 @@ Grindstone is a backwards compat from a previous PrepareGrindstoneEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/inventory/PrepareGrindstoneEvent.java b/src/main/java/com/destroystokyo/paper/event/inventory/PrepareGrindstoneEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..83bfb7276b458bae1e21cb7ba9f4f7c4c2acf76f
+index 0000000000000000000000000000000000000000..b31e6777f5d163c61309da9ff204ad5773ba7f54
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/inventory/PrepareGrindstoneEvent.java
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,31 @@
 +package com.destroystokyo.paper.event.inventory;
 +
 +import org.bukkit.Warning;
 +import org.bukkit.inventory.GrindstoneInventory;
 +import org.bukkit.inventory.InventoryView;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +/**
 + * Called when an item is put in a slot for grinding in a Grindstone
++ *
 + * @deprecated use {@link org.bukkit.event.inventory.PrepareGrindstoneEvent}
 + */
 +@Deprecated
-+@Warning(false)
++@Warning
 +public class PrepareGrindstoneEvent extends PrepareResultEvent {
 +
++    @ApiStatus.Internal
 +    public PrepareGrindstoneEvent(@NotNull InventoryView inventory, @Nullable ItemStack result) {
 +        super(inventory, result);
 +    }
@@ -45,15 +48,16 @@ index 0000000000000000000000000000000000000000..83bfb7276b458bae1e21cb7ba9f4f7c4
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/inventory/PrepareResultEvent.java b/src/main/java/com/destroystokyo/paper/event/inventory/PrepareResultEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..25e5f0354b3b65c656d6c173ec108825f1e8b1be
+index 0000000000000000000000000000000000000000..c305c606bef93866993095cec5f50e191c5a382a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/inventory/PrepareResultEvent.java
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,40 @@
 +package com.destroystokyo.paper.event.inventory;
 +
 +import org.bukkit.event.inventory.PrepareInventoryResultEvent;
 +import org.bukkit.inventory.InventoryView;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -63,12 +67,14 @@ index 0000000000000000000000000000000000000000..25e5f0354b3b65c656d6c173ec108825
 +public class PrepareResultEvent extends PrepareInventoryResultEvent {
 +
 +    // HandlerList on PrepareInventoryResultEvent to ensure api compat
++
++    @ApiStatus.Internal
 +    public PrepareResultEvent(@NotNull InventoryView inventory, @Nullable ItemStack result) {
 +        super(inventory, result);
 +    }
 +
 +    /**
-+     * Get result item, may be null.
++     * Get result item, may be {@code null}.
 +     *
 +     * @return result item
 +     */
@@ -78,7 +84,7 @@ index 0000000000000000000000000000000000000000..25e5f0354b3b65c656d6c173ec108825
 +    }
 +
 +    /**
-+     * Set result item, may be null.
++     * Set result item, may be {@code null}.
 +     *
 +     * @param result result item
 +     */

--- a/patches/api/0207-Add-BellRingEvent.patch
+++ b/patches/api/0207-Add-BellRingEvent.patch
@@ -8,26 +8,28 @@ village bell. Passes along the bell block and the player who rang it.
 
 diff --git a/src/main/java/io/papermc/paper/event/block/BellRingEvent.java b/src/main/java/io/papermc/paper/event/block/BellRingEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..548aeeab7d45173f36616a4a2f215f5838696089
+index 0000000000000000000000000000000000000000..7d3f04d5ab620f37d2253b575ae370d95ecf21ef
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/BellRingEvent.java
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,22 @@
 +package io.papermc.paper.event.block;
 +
 +import org.bukkit.block.Block;
 +import org.bukkit.block.BlockFace;
 +import org.bukkit.entity.Entity;
-+import org.bukkit.event.Cancellable;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +/**
 + * Called when a bell is rung.
++ *
 + * @deprecated use {@link org.bukkit.event.block.BellRingEvent}
 + */
 +@Deprecated
-+public class BellRingEvent extends org.bukkit.event.block.BellRingEvent implements Cancellable {
++public class BellRingEvent extends org.bukkit.event.block.BellRingEvent {
 +
++    @ApiStatus.Internal
 +    public BellRingEvent(@NotNull Block block, @NotNull BlockFace direction, @Nullable Entity entity) {
 +        super(block, direction, entity);
 +    }

--- a/patches/api/0226-Add-PlayerItemCooldownEvent.patch
+++ b/patches/api/0226-Add-PlayerItemCooldownEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerItemCooldownEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerItemCooldownEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerItemCooldownEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..58d18f05af13d836ddc62fcd30befcb06f07c57c
+index 0000000000000000000000000000000000000000..c2764ffd51831351b934568e1301b2e4073dc0c4
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerItemCooldownEvent.java
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,82 @@
 +package io.papermc.paper.event.player;
 +
 +import com.google.common.base.Preconditions;
@@ -18,18 +18,23 @@ index 0000000000000000000000000000000000000000..58d18f05af13d836ddc62fcd30befcb0
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Fired when a player receives an item cooldown.
 + */
 +public class PlayerItemCooldownEvent extends PlayerEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull
 +    private final Material type;
-+    private boolean cancelled;
 +    private int cooldown;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PlayerItemCooldownEvent(@NotNull Player player, @NotNull Material type, int cooldown) {
 +        super(player);
 +        this.type = type;
@@ -43,7 +48,7 @@ index 0000000000000000000000000000000000000000..58d18f05af13d836ddc62fcd30befcb0
 +     */
 +    @NotNull
 +    public Material getType() {
-+        return type;
++        return this.type;
 +    }
 +
 +    /**
@@ -52,7 +57,7 @@ index 0000000000000000000000000000000000000000..58d18f05af13d836ddc62fcd30befcb0
 +     * @return cooldown in ticks
 +     */
 +    public int getCooldown() {
-+        return cooldown;
++        return this.cooldown;
 +    }
 +
 +    /**
@@ -68,7 +73,7 @@ index 0000000000000000000000000000000000000000..58d18f05af13d836ddc62fcd30befcb0
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
@@ -79,11 +84,11 @@ index 0000000000000000000000000000000000000000..58d18f05af13d836ddc62fcd30befcb0
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0228-Add-PlayerShearBlockEvent.patch
+++ b/patches/api/0228-Add-PlayerShearBlockEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerShearBlockEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/block/PlayerShearBlockEvent.java b/src/main/java/io/papermc/paper/event/block/PlayerShearBlockEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..aa7d440b797eac9e62678d03cc87f42838758bfd
+index 0000000000000000000000000000000000000000..9bb4a79320eac7d662d9d04765664b6a7e955a4f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/PlayerShearBlockEvent.java
-@@ -0,0 +1,108 @@
+@@ -0,0 +1,113 @@
 +package io.papermc.paper.event.block;
 +
 +import org.bukkit.block.Block;
@@ -19,6 +19,7 @@ index 0000000000000000000000000000000000000000..aa7d440b797eac9e62678d03cc87f428
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.EquipmentSlot;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +import java.util.List;
@@ -32,15 +33,19 @@ index 0000000000000000000000000000000000000000..aa7d440b797eac9e62678d03cc87f428
 + * Examples include shearing a pumpkin to turn it into a carved pumpkin or shearing a beehive to get honeycomb.
 + */
 +public class PlayerShearBlockEvent extends PlayerEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled = false;
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final Block block;
 +    private final ItemStack item;
 +    private final EquipmentSlot hand;
 +    private final List<ItemStack> drops;
 +
-+    public PlayerShearBlockEvent(@NotNull Player who, @NotNull Block block, @NotNull ItemStack item, @NotNull EquipmentSlot hand, @NotNull List<ItemStack> drops) {
-+        super(who);
++    private boolean cancelled;
++
++    @ApiStatus.Internal
++    public PlayerShearBlockEvent(@NotNull Player player, @NotNull Block block, @NotNull ItemStack item, @NotNull EquipmentSlot hand, @NotNull List<ItemStack> drops) {
++        super(player);
 +        this.block = block;
 +        this.item = item;
 +        this.hand = hand;
@@ -54,7 +59,7 @@ index 0000000000000000000000000000000000000000..aa7d440b797eac9e62678d03cc87f428
 +     */
 +    @NotNull
 +    public Block getBlock() {
-+        return block;
++        return this.block;
 +    }
 +
 +    /**
@@ -64,7 +69,7 @@ index 0000000000000000000000000000000000000000..aa7d440b797eac9e62678d03cc87f428
 +     */
 +    @NotNull
 +    public ItemStack getItem() {
-+        return item;
++        return this.item;
 +    }
 +
 +    /**
@@ -74,7 +79,7 @@ index 0000000000000000000000000000000000000000..aa7d440b797eac9e62678d03cc87f428
 +     */
 +    @NotNull
 +    public EquipmentSlot getHand() {
-+        return hand;
++        return this.hand;
 +    }
 +
 +    /**
@@ -84,7 +89,7 @@ index 0000000000000000000000000000000000000000..aa7d440b797eac9e62678d03cc87f428
 +     */
 +    @NotNull
 +    public List<ItemStack> getDrops() {
-+        return drops;
++        return this.drops;
 +    }
 +
 +    /**
@@ -94,7 +99,7 @@ index 0000000000000000000000000000000000000000..aa7d440b797eac9e62678d03cc87f428
 +     */
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    /**
@@ -110,11 +115,11 @@ index 0000000000000000000000000000000000000000..aa7d440b797eac9e62678d03cc87f428
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0229-Player-Chunk-Load-Unload-Events.patch
+++ b/patches/api/0229-Player-Chunk-Load-Unload-Events.patch
@@ -6,95 +6,101 @@ Subject: [PATCH] Player Chunk Load/Unload Events
 
 diff --git a/src/main/java/io/papermc/paper/event/packet/PlayerChunkLoadEvent.java b/src/main/java/io/papermc/paper/event/packet/PlayerChunkLoadEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2c1cda1126e577a88f19071e958eddb5a38785af
+index 0000000000000000000000000000000000000000..3ddbc099a13df939b3912f30b54e7635840ba5a4
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/packet/PlayerChunkLoadEvent.java
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,45 @@
 +package io.papermc.paper.event.packet;
 +
 +import org.bukkit.Chunk;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.world.ChunkEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Is called when a {@link org.bukkit.entity.Player} receives a {@link org.bukkit.Chunk}
++ * Is called when a {@link Player} receives a {@link Chunk}
 + * <p>
 + * Can for example be used for spawning a fake entity when the player receives a chunk.
-+ *
++ * <p>
 + * Should only be used for packet/clientside related stuff.
 + * Not intended for modifying server side state.
 + */
 +public class PlayerChunkLoadEvent extends ChunkEvent {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final Player player;
 +
++    @ApiStatus.Internal
 +    public PlayerChunkLoadEvent(@NotNull Chunk chunk, @NotNull Player player) {
 +        super(chunk);
 +        this.player = player;
 +    }
 +
 +    @NotNull
-+    @Override
-+    public HandlerList getHandlers() {
-+        return handlers;
++    public Player getPlayer() {
++        return this.player;
 +    }
 +
 +    @NotNull
-+    public Player getPlayer() {
-+        return player;
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/event/packet/PlayerChunkUnloadEvent.java b/src/main/java/io/papermc/paper/event/packet/PlayerChunkUnloadEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..12163a7b0591a7d022dc7eb9ee6608a1b6c39d9b
+index 0000000000000000000000000000000000000000..2cac7e27991c04a9ced261f2dd8ad8657ccddf6b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/packet/PlayerChunkUnloadEvent.java
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,43 @@
 +package io.papermc.paper.event.packet;
 +
 +import org.bukkit.Chunk;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.world.ChunkEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Is called when a {@link Player} receives a chunk unload packet.
-+ *
++ * <p>
 + * Should only be used for packet/clientside related stuff.
 + * Not intended for modifying server side.
 + */
 +public class PlayerChunkUnloadEvent extends ChunkEvent {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final Player player;
 +
++    @ApiStatus.Internal
 +    public PlayerChunkUnloadEvent(@NotNull Chunk chunk, @NotNull Player player) {
 +        super(chunk);
 +        this.player = player;
 +    }
 +
 +    @NotNull
-+    @Override
-+    public HandlerList getHandlers() {
-+        return handlers;
++    public Player getPlayer() {
++        return this.player;
 +    }
 +
 +    @NotNull
-+    public Player getPlayer() {
-+        return player;
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0232-Added-PlayerTradeEvent.patch
+++ b/patches/api/0232-Added-PlayerTradeEvent.patch
@@ -13,36 +13,40 @@ event being about villager trades.
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerPurchaseEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerPurchaseEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c5648055c5e815474bf1e564a5c192ff5c0624fb
+index 0000000000000000000000000000000000000000..61c62877c38e27eacc20aa43ef02dc43e9b50bfc
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerPurchaseEvent.java
-@@ -0,0 +1,112 @@
+@@ -0,0 +1,109 @@
 +package io.papermc.paper.event.player;
 +
-+import java.util.Objects;
++import com.google.common.base.Preconditions;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.MerchantRecipe;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called when a player trades with a standalone merchant GUI.
 + */
 +public class PlayerPurchaseEvent extends PlayerEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled;
 +
-+    private boolean increaseTradeUses;
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private boolean rewardExp;
++    private boolean increaseTradeUses;
 +    private MerchantRecipe trade;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PlayerPurchaseEvent(@NotNull Player player,
 +                               @NotNull MerchantRecipe trade,
 +                               boolean rewardExp,
 +                               boolean increaseTradeUses) {
-+        super(Objects.requireNonNull(player, "Player cannot be null!"));
++        super(player);
 +        setTrade(trade);
 +        this.rewardExp = rewardExp;
 +        this.increaseTradeUses = increaseTradeUses;
@@ -50,6 +54,7 @@ index 0000000000000000000000000000000000000000..c5648055c5e815474bf1e564a5c192ff
 +
 +    /**
 +     * Gets the associated trade with this event
++     *
 +     * @return the trade
 +     */
 +    @NotNull
@@ -59,10 +64,12 @@ index 0000000000000000000000000000000000000000..c5648055c5e815474bf1e564a5c192ff
 +
 +    /**
 +     * Sets the trade. This is then used to determine the next prices
++     *
 +     * @param trade the trade to use
 +     */
 +    public void setTrade(@NotNull MerchantRecipe trade) {
-+        this.trade = Objects.requireNonNull(trade, "Trade cannot be null!");
++        Preconditions.checkArgument(trade != null, "Trade cannot be null!");
++        this.trade = trade;
 +    }
 +
 +    /**
@@ -74,6 +81,7 @@ index 0000000000000000000000000000000000000000..c5648055c5e815474bf1e564a5c192ff
 +
 +    /**
 +     * Sets whether the trade will try to reward exp
++     *
 +     * @param rewardExp try to reward exp
 +     */
 +    public void setRewardExp(boolean rewardExp) {
@@ -81,37 +89,26 @@ index 0000000000000000000000000000000000000000..c5648055c5e815474bf1e564a5c192ff
 +    }
 +
 +    /**
-+     * @return whether or not the trade will count as a use of the trade
++     * @return whether the trade will count as a use of the trade
 +     */
 +    public boolean willIncreaseTradeUses() {
 +        return this.increaseTradeUses;
 +    }
 +
 +    /**
-+     * Sets whether or not the trade will count as a use
-+     * @param increaseTradeUses true to count/false to not count
++     * Sets whether the trade will count as a use
++     *
++     * @param increaseTradeUses {@code true} to count, {@code false} otherwise
 +     */
 +    public void setIncreaseTradeUses(boolean increaseTradeUses) {
 +        this.increaseTradeUses = increaseTradeUses;
 +    }
 +
-+    /**
-+     * Gets the cancellation state of this event. A cancelled event will not
-+     * be executed in the server, but will still pass to other plugins
-+     *
-+     * @return true if this event is cancelled
-+     */
 +    @Override
 +    public boolean isCancelled() {
 +        return this.cancelled;
 +    }
 +
-+    /**
-+     * Sets the cancellation state of this event. A cancelled event will not
-+     * be executed in the server, but will still pass to other plugins.
-+     *
-+     * @param cancel true if you wish to cancel this event
-+     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
 +        this.cancelled = cancel;
@@ -120,26 +117,27 @@ index 0000000000000000000000000000000000000000..c5648055c5e815474bf1e564a5c192ff
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerTradeEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerTradeEvent.java
 new file mode 100755
-index 0000000000000000000000000000000000000000..a41fc186746b87f76347dfcc1f80d0969398322b
+index 0000000000000000000000000000000000000000..559d1a3c783e6c726f48d1c88b2ff8c0888890ac
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerTradeEvent.java
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,32 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.AbstractVillager;
 +import org.bukkit.entity.Player;
 +import org.bukkit.inventory.MerchantRecipe;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -149,6 +147,7 @@ index 0000000000000000000000000000000000000000..a41fc186746b87f76347dfcc1f80d096
 +
 +    private final AbstractVillager villager;
 +
++    @ApiStatus.Internal
 +    public PlayerTradeEvent(@NotNull Player player, @NotNull AbstractVillager villager, @NotNull MerchantRecipe trade, boolean rewardExp, boolean increaseTradeUses) {
 +        super(player, trade, rewardExp, increaseTradeUses);
 +        this.villager = villager;
@@ -156,6 +155,7 @@ index 0000000000000000000000000000000000000000..a41fc186746b87f76347dfcc1f80d096
 +
 +    /**
 +     * Gets the Villager or Wandering trader associated with this event
++     *
 +     * @return the villager or wandering trader
 +     */
 +    @NotNull

--- a/patches/api/0233-Add-TargetHitEvent-API.patch
+++ b/patches/api/0233-Add-TargetHitEvent-API.patch
@@ -6,19 +6,21 @@ Subject: [PATCH] Add TargetHitEvent API
 
 diff --git a/src/main/java/io/papermc/paper/event/block/TargetHitEvent.java b/src/main/java/io/papermc/paper/event/block/TargetHitEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..cc067ae118af9957b1b9f5c8d45f63f9154f4942
+index 0000000000000000000000000000000000000000..5247e7f78e0076089c1e1bdea2afbb455c43732a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/TargetHitEvent.java
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,61 @@
 +package io.papermc.paper.event.block;
 +
++import com.google.common.base.Preconditions;
 +import org.bukkit.block.Block;
 +import org.bukkit.block.BlockFace;
 +import org.bukkit.entity.Projectile;
-+import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.ProjectileHitEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Range;
 +
 +/**
 + * Called when a Target Block is hit by a projectile.
@@ -27,35 +29,16 @@ index 0000000000000000000000000000000000000000..cc067ae118af9957b1b9f5c8d45f63f9
 + * and in the case that the shooter is a player, will stop them from receiving
 + * advancement criteria.
 + */
-+public class TargetHitEvent extends ProjectileHitEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled;
++public class TargetHitEvent extends ProjectileHitEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private int signalStrength;
 +
++    @ApiStatus.Internal
 +    public TargetHitEvent(@NotNull Projectile projectile, @NotNull Block block, @NotNull BlockFace blockFace, int signalStrength) {
 +        super(projectile, null, block, blockFace);
 +        this.signalStrength = signalStrength;
-+    }
-+
-+    @Override
-+    public boolean isCancelled() {
-+        return cancelled;
-+    }
-+
-+    @Override
-+    public void setCancelled(boolean cancelled) {
-+        this.cancelled = cancelled;
-+    }
-+
-+    @NotNull
-+    @Override
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
 +    }
 +
 +    /**
@@ -63,8 +46,8 @@ index 0000000000000000000000000000000000000000..cc067ae118af9957b1b9f5c8d45f63f9
 +     *
 +     * @return the strength of the redstone signal to be emitted
 +     */
-+    public int getSignalStrength() {
-+        return signalStrength;
++    public @Range(from = 0, to = 15) int getSignalStrength() {
++        return this.signalStrength;
 +    }
 +
 +    /**
@@ -72,10 +55,19 @@ index 0000000000000000000000000000000000000000..cc067ae118af9957b1b9f5c8d45f63f9
 +     *
 +     * @param signalStrength the strength of the redstone signal to be emitted
 +     */
-+    public void setSignalStrength(int signalStrength) {
-+        if (signalStrength < 0 || signalStrength > 15) {
-+            throw new IllegalArgumentException("Signal strength out of range (" + signalStrength + "), must be in range [0,15]");
-+        }
++    public void setSignalStrength(@Range(from = 0, to = 15) int signalStrength) {
++        Preconditions.checkArgument(signalStrength >= 0 && signalStrength <= 15, "Signal strength out of range (%s), must be in range [0,15]", signalStrength);
 +        this.signalStrength = signalStrength;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0236-Add-PlayerFlowerPotManipulateEvent.patch
+++ b/patches/api/0236-Add-PlayerFlowerPotManipulateEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerFlowerPotManipulateEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerFlowerPotManipulateEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerFlowerPotManipulateEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4c141f3d8f668cdf9c75865a8e3ecbd012d9e521
+index 0000000000000000000000000000000000000000..373a6ec68fb575b82b06bf250768c1a6909efe38
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerFlowerPotManipulateEvent.java
-@@ -0,0 +1,82 @@
+@@ -0,0 +1,85 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.block.Block;
@@ -18,13 +18,15 @@ index 0000000000000000000000000000000000000000..4c141f3d8f668cdf9c75865a8e3ecbd0
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called when a player places an item in or takes an item out of a flowerpot.
 + */
 +public class PlayerFlowerPotManipulateEvent extends PlayerEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    @NotNull
 +    private final Block flowerpot;
@@ -32,23 +34,14 @@ index 0000000000000000000000000000000000000000..4c141f3d8f668cdf9c75865a8e3ecbd0
 +    private final ItemStack item;
 +    private final boolean placing;
 +
-+    private boolean cancel = false;
++    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public PlayerFlowerPotManipulateEvent(@NotNull final Player player, @NotNull final Block flowerpot, @NotNull final ItemStack item, final boolean placing) {
 +        super(player);
 +        this.flowerpot = flowerpot;
 +        this.item = item;
 +        this.placing = placing;
-+    }
-+
-+    @Override
-+    public boolean isCancelled() {
-+        return cancel;
-+    }
-+
-+    @Override
-+    public void setCancelled(boolean cancel) {
-+        this.cancel = cancel;
 +    }
 +
 +    /**
@@ -58,7 +51,7 @@ index 0000000000000000000000000000000000000000..4c141f3d8f668cdf9c75865a8e3ecbd0
 +     */
 +    @NotNull
 +    public Block getFlowerpot() {
-+        return flowerpot;
++        return this.flowerpot;
 +    }
 +
 +    /**
@@ -69,7 +62,7 @@ index 0000000000000000000000000000000000000000..4c141f3d8f668cdf9c75865a8e3ecbd0
 +     */
 +    @NotNull
 +    public ItemStack getItem() {
-+        return item;
++        return this.item;
 +    }
 +
 +    /**
@@ -78,17 +71,27 @@ index 0000000000000000000000000000000000000000..4c141f3d8f668cdf9c75865a8e3ecbd0
 +     * @return if the item is being placed into the flowerpot
 +     */
 +    public boolean isPlacing() {
-+        return placing;
++        return this.placing;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0238-Add-EntityLoadCrossbowEvent.patch
+++ b/patches/api/0238-Add-EntityLoadCrossbowEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add EntityLoadCrossbowEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityLoadCrossbowEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityLoadCrossbowEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..66e41bfe89f35d3947ea47aedcd36ac8f01ac5b6
+index 0000000000000000000000000000000000000000..8434ea803e3135380f9351c82a414ccb65c478a9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityLoadCrossbowEvent.java
-@@ -0,0 +1,98 @@
+@@ -0,0 +1,96 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.entity.LivingEntity;
@@ -25,12 +25,14 @@ index 0000000000000000000000000000000000000000..66e41bfe89f35d3947ea47aedcd36ac8
 + * Called when a LivingEntity loads a crossbow with a projectile.
 + */
 +public class EntityLoadCrossbowEvent extends EntityEvent implements Cancellable {
++
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    private final ItemStack crossbow;
 +    private final EquipmentSlot hand;
-+    private boolean cancelled;
++
 +    private boolean consumeItem = true;
++    private boolean cancelled;
 +
 +    @ApiStatus.Internal
 +    public EntityLoadCrossbowEvent(@NotNull LivingEntity entity, @NotNull ItemStack crossbow, @NotNull EquipmentSlot hand) {
@@ -42,7 +44,7 @@ index 0000000000000000000000000000000000000000..66e41bfe89f35d3947ea47aedcd36ac8
 +    @NotNull
 +    @Override
 +    public LivingEntity getEntity() {
-+        return (LivingEntity) entity;
++        return (LivingEntity) super.getEntity();
 +    }
 +
 +    /**
@@ -52,7 +54,7 @@ index 0000000000000000000000000000000000000000..66e41bfe89f35d3947ea47aedcd36ac8
 +     */
 +    @NotNull
 +    public ItemStack getCrossbow() {
-+        return crossbow;
++        return this.crossbow;
 +    }
 +
 +    /**
@@ -62,19 +64,17 @@ index 0000000000000000000000000000000000000000..66e41bfe89f35d3947ea47aedcd36ac8
 +     */
 +    @NotNull
 +    public EquipmentSlot getHand() {
-+        return hand;
++        return this.hand;
 +    }
 +
 +    /**
-+     *
 +     * @return should the itemstack be consumed
 +     */
 +    public boolean shouldConsumeItem() {
-+        return consumeItem;
++        return this.consumeItem;
 +    }
 +
 +    /**
-+     *
 +     * @param consume should the item be consumed
 +     */
 +    public void setConsumeItem(boolean consume) {
@@ -83,14 +83,12 @@ index 0000000000000000000000000000000000000000..66e41bfe89f35d3947ea47aedcd36ac8
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    /**
-+     * Set whether or not to cancel the crossbow being loaded. If canceled, the
++     * Set whether to cancel the crossbow being loaded. If canceled, the
 +     * projectile that would be loaded into the crossbow will not be consumed.
-+     *
-+     * @param cancel true if you wish to cancel this event
 +     */
 +    @Override
 +    public void setCancelled(boolean cancel) {

--- a/patches/api/0239-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/api/0239-Added-WorldGameRuleChangeEvent.patch
@@ -6,19 +6,19 @@ Subject: [PATCH] Added WorldGameRuleChangeEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/world/WorldGameRuleChangeEvent.java b/src/main/java/io/papermc/paper/event/world/WorldGameRuleChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..20c25a0f9d65188402e8bb3981348bc6462904bf
+index 0000000000000000000000000000000000000000..2831fb8ad22e457f85523f65be9cba2432109f01
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/world/WorldGameRuleChangeEvent.java
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,92 @@
 +package io.papermc.paper.event.world;
 +
 +import org.bukkit.GameRule;
 +import org.bukkit.World;
 +import org.bukkit.command.CommandSender;
-+import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.world.WorldEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -34,6 +34,7 @@ index 0000000000000000000000000000000000000000..20c25a0f9d65188402e8bb3981348bc6
 +    private String value;
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public WorldGameRuleChangeEvent(@NotNull World world, @Nullable CommandSender commandSender, @NotNull GameRule<?> gameRule, @NotNull String value) {
 +        super(world);
 +        this.commandSender = commandSender;
@@ -48,7 +49,7 @@ index 0000000000000000000000000000000000000000..20c25a0f9d65188402e8bb3981348bc6
 +     */
 +    @Nullable
 +    public CommandSender getCommandSender() {
-+        return commandSender;
++        return this.commandSender;
 +    }
 +
 +    /**
@@ -58,7 +59,7 @@ index 0000000000000000000000000000000000000000..20c25a0f9d65188402e8bb3981348bc6
 +     */
 +    @NotNull
 +    public GameRule<?> getGameRule() {
-+        return gameRule;
++        return this.gameRule;
 +    }
 +
 +    /**
@@ -68,7 +69,7 @@ index 0000000000000000000000000000000000000000..20c25a0f9d65188402e8bb3981348bc6
 +     */
 +    @NotNull
 +    public String getValue() {
-+        return value;
++        return this.value;
 +    }
 +
 +    /**
@@ -82,7 +83,7 @@ index 0000000000000000000000000000000000000000..20c25a0f9d65188402e8bb3981348bc6
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override

--- a/patches/api/0240-Added-ServerResourcesReloadedEvent.patch
+++ b/patches/api/0240-Added-ServerResourcesReloadedEvent.patch
@@ -6,21 +6,21 @@ Subject: [PATCH] Added ServerResourcesReloadedEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/server/ServerResourcesReloadedEvent.java b/src/main/java/io/papermc/paper/event/server/ServerResourcesReloadedEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7a8d6815c17a107039399298f7ac9f0612faee02
+index 0000000000000000000000000000000000000000..a7ed7d6b6469e175d3949ffa9c502cbfde609215
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/server/ServerResourcesReloadedEvent.java
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,49 @@
 +package io.papermc.paper.event.server;
 +
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.server.ServerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called when resources such as datapacks are reloaded (e.g. /minecraft:reload)
 + * <p>
-+ *     Intended for use to re-register custom recipes, advancements that may be lost during a reload like this.
-+ * </p>
++ * Intended for use to re-register custom recipes, advancements that may be lost during a reload like this.
 + */
 +public class ServerResourcesReloadedEvent extends ServerEvent {
 +
@@ -28,6 +28,7 @@ index 0000000000000000000000000000000000000000..7a8d6815c17a107039399298f7ac9f06
 +
 +    private final Cause cause;
 +
++    @ApiStatus.Internal
 +    public ServerResourcesReloadedEvent(@NotNull Cause cause) {
 +        this.cause = cause;
 +    }
@@ -39,7 +40,7 @@ index 0000000000000000000000000000000000000000..7a8d6815c17a107039399298f7ac9f06
 +     */
 +    @NotNull
 +    public Cause getCause() {
-+        return cause;
++        return this.cause;
 +    }
 +
 +    @NotNull

--- a/patches/api/0241-Add-BlockFailedDispenseEvent.patch
+++ b/patches/api/0241-Add-BlockFailedDispenseEvent.patch
@@ -6,25 +6,28 @@ Subject: [PATCH] Add BlockFailedDispenseEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/block/BlockFailedDispenseEvent.java b/src/main/java/io/papermc/paper/event/block/BlockFailedDispenseEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..dab794341170ed10d5a05c1b4c180d164e0f70e2
+index 0000000000000000000000000000000000000000..d531b034b49b163e5095e840a5c9c4fe5eb73319
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/BlockFailedDispenseEvent.java
-@@ -0,0 +1,57 @@
+@@ -0,0 +1,56 @@
 +package io.papermc.paper.event.block;
 +
 +import org.bukkit.block.Block;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.block.BlockEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called when a block tries to dispense an item, but its inventory is empty.
 + */
 +public class BlockFailedDispenseEvent extends BlockEvent {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    private boolean shouldPlayEffect = true;
 +
++    @ApiStatus.Internal
 +    public BlockFailedDispenseEvent(@NotNull Block theBlock) {
 +        super(theBlock);
 +    }
@@ -46,8 +49,6 @@ index 0000000000000000000000000000000000000000..dab794341170ed10d5a05c1b4c180d16
 +    }
 +
 +    /**
-+     * {@inheritDoc}
-+     *
 +     * @return {@link #shouldPlayEffect()}
 +     */
 +    @Override
@@ -57,13 +58,11 @@ index 0000000000000000000000000000000000000000..dab794341170ed10d5a05c1b4c180d16
 +    }
 +
 +    @Override
-+    public @NotNull
-+    HandlerList getHandlers() {
-+        return handlers;
++    public @NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
 +    }
 +
-+    public static @NotNull
-+    HandlerList getHandlerList() {
-+        return handlers;
++    public static @NotNull HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0242-Added-PlayerLecternPageChangeEvent.patch
+++ b/patches/api/0242-Added-PlayerLecternPageChangeEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Added PlayerLecternPageChangeEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerLecternPageChangeEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerLecternPageChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..26370e46e4a12e3470e9bb747fac5786a7305810
+index 0000000000000000000000000000000000000000..6ed2a6c8c033937d933b6d4834953b8112a98bb3
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerLecternPageChangeEvent.java
-@@ -0,0 +1,115 @@
+@@ -0,0 +1,117 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.block.Lectern;
@@ -18,20 +18,22 @@ index 0000000000000000000000000000000000000000..26370e46e4a12e3470e9bb747fac5786
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
-+import org.jetbrains.annotations.Nullable;
 +
 +public class PlayerLecternPageChangeEvent extends PlayerEvent implements Cancellable {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    private boolean cancelled;
 +    private final Lectern lectern;
 +    private final ItemStack book;
 +    private final PageChangeDirection pageChangeDirection;
 +    private final int oldPage;
 +    private int newPage;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PlayerLecternPageChangeEvent(@NotNull Player player, @NotNull Lectern lectern, @NotNull ItemStack book, @NotNull PageChangeDirection pageChangeDirection, int oldPage, int newPage) {
 +        super(player);
 +        this.lectern = lectern;
@@ -48,7 +50,7 @@ index 0000000000000000000000000000000000000000..26370e46e4a12e3470e9bb747fac5786
 +     */
 +    @NotNull
 +    public Lectern getLectern() {
-+        return lectern;
++        return this.lectern;
 +    }
 +
 +    /**
@@ -68,7 +70,7 @@ index 0000000000000000000000000000000000000000..26370e46e4a12e3470e9bb747fac5786
 +     */
 +    @NotNull
 +    public PageChangeDirection getPageChangeDirection() {
-+        return pageChangeDirection;
++        return this.pageChangeDirection;
 +    }
 +
 +    /**
@@ -77,7 +79,7 @@ index 0000000000000000000000000000000000000000..26370e46e4a12e3470e9bb747fac5786
 +     * @return the page changed from
 +     */
 +    public int getOldPage() {
-+        return oldPage;
++        return this.oldPage;
 +    }
 +
 +    /**
@@ -86,7 +88,7 @@ index 0000000000000000000000000000000000000000..26370e46e4a12e3470e9bb747fac5786
 +     * @return the page changed to
 +     */
 +    public int getNewPage() {
-+        return newPage;
++        return this.newPage;
 +    }
 +
 +    /**
@@ -101,7 +103,7 @@ index 0000000000000000000000000000000000000000..26370e46e4a12e3470e9bb747fac5786
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override

--- a/patches/api/0243-Added-PlayerLoomPatternSelectEvent.patch
+++ b/patches/api/0243-Added-PlayerLoomPatternSelectEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Added PlayerLoomPatternSelectEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerLoomPatternSelectEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerLoomPatternSelectEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8cb05709f7cb5dee993ff6fea1626c41b90a7d8b
+index 0000000000000000000000000000000000000000..c614bd1a725adee0c434a9331099d0c35d7411f6
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerLoomPatternSelectEvent.java
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,80 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.block.banner.PatternType;
@@ -18,6 +18,7 @@ index 0000000000000000000000000000000000000000..8cb05709f7cb5dee993ff6fea1626c41
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.LoomInventory;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -27,10 +28,12 @@ index 0000000000000000000000000000000000000000..8cb05709f7cb5dee993ff6fea1626c41
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    private boolean cancelled;
 +    private final LoomInventory loomInventory;
 +    private PatternType patternType;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PlayerLoomPatternSelectEvent(@NotNull Player player, @NotNull LoomInventory loomInventory, @NotNull PatternType patternType) {
 +        super(player);
 +        this.loomInventory = loomInventory;
@@ -44,7 +47,7 @@ index 0000000000000000000000000000000000000000..8cb05709f7cb5dee993ff6fea1626c41
 +     */
 +    @NotNull
 +    public LoomInventory getLoomInventory() {
-+        return loomInventory;
++        return this.loomInventory;
 +    }
 +
 +    /**
@@ -54,7 +57,7 @@ index 0000000000000000000000000000000000000000..8cb05709f7cb5dee993ff6fea1626c41
 +     */
 +    @NotNull
 +    public PatternType getPatternType() {
-+        return patternType;
++        return this.patternType;
 +    }
 +
 +    /**
@@ -68,7 +71,7 @@ index 0000000000000000000000000000000000000000..8cb05709f7cb5dee993ff6fea1626c41
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override

--- a/patches/api/0247-Add-StructuresLocateEvent.patch
+++ b/patches/api/0247-Add-StructuresLocateEvent.patch
@@ -7,10 +7,10 @@ Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/event/world/StructureLocateEvent.java b/src/main/java/io/papermc/paper/event/world/StructureLocateEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..679677cf6a889ee23822b728b882e741c500df81
+index 0000000000000000000000000000000000000000..1ac3369455972aeb1ade5dc023d1f818cd3535fa
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/world/StructureLocateEvent.java
-@@ -0,0 +1,158 @@
+@@ -0,0 +1,163 @@
 +package io.papermc.paper.event.world;
 +
 +import org.bukkit.Location;
@@ -32,18 +32,23 @@ index 0000000000000000000000000000000000000000..679677cf6a889ee23822b728b882e741
 + *     <li>An Explorer/Treasure Map is activated.</li>
 + *     <li>{@link World#locateNearestStructure(Location, StructureType, int, boolean)} is invoked.</li>
 + * </ul>
++ *
 + * @deprecated no longer used, see {@link StructuresLocateEvent}
 + */
 +@Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +public class StructureLocateEvent extends WorldEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final Location origin;
 +    private Location result = null;
 +    private StructureType type;
 +    private int radius;
 +    private boolean findUnexplored;
-+    private boolean cancelled = false;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public StructureLocateEvent(@NotNull World world, @NotNull Location origin, @NotNull StructureType structureType, int radius, boolean findUnexplored) {
 +        super(world);
 +        this.origin = origin;
@@ -52,29 +57,18 @@ index 0000000000000000000000000000000000000000..679677cf6a889ee23822b728b882e741
 +        this.findUnexplored = findUnexplored;
 +    }
 +
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    @Override
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
 +    /**
 +     * Gets the location set as the structure location, if it was defined.
 +     * <p>
 +     * Returns {@code null} if it has not been set by {@link StructureLocateEvent#setResult(Location)}.
 +     * Since this event fires <i>before</i> the search is done, the actual location is unknown at this point.
 +     *
-+     * @return The result location, if it has been set. null if it has not.
++     * @return The result location, if it has been set. {@code null} if it has not.
 +     * @see World#locateNearestStructure(Location, StructureType, int, boolean)
 +     */
 +    @Nullable
 +    public Location getResult() {
-+        return result;
++        return this.result;
 +    }
 +
 +    /**
@@ -93,7 +87,7 @@ index 0000000000000000000000000000000000000000..679677cf6a889ee23822b728b882e741
 +     */
 +    @NotNull
 +    public StructureType getType() {
-+        return type;
++        return this.type;
 +    }
 +
 +    /**
@@ -112,7 +106,7 @@ index 0000000000000000000000000000000000000000..679677cf6a889ee23822b728b882e741
 +     */
 +    @NotNull
 +    public Location getOrigin() {
-+        return origin;
++        return this.origin;
 +    }
 +
 +    /**
@@ -123,7 +117,7 @@ index 0000000000000000000000000000000000000000..679677cf6a889ee23822b728b882e741
 +     * @return the search radius.
 +     */
 +    public int getRadius() {
-+        return radius;
++        return this.radius;
 +    }
 +
 +    /**
@@ -145,7 +139,7 @@ index 0000000000000000000000000000000000000000..679677cf6a889ee23822b728b882e741
 +     * @return Whether to search for only unexplored structures.
 +     */
 +    public boolean shouldFindUnexplored() {
-+        return findUnexplored;
++        return this.findUnexplored;
 +    }
 +
 +    /**
@@ -161,20 +155,31 @@ index 0000000000000000000000000000000000000000..679677cf6a889ee23822b728b882e741
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
 +        this.cancelled = cancel;
 +    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
 +}
 diff --git a/src/main/java/io/papermc/paper/event/world/StructuresLocateEvent.java b/src/main/java/io/papermc/paper/event/world/StructuresLocateEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4342b162f69b6509503e9772ddd2c5ac6659545a
+index 0000000000000000000000000000000000000000..be86894561ff808d911e123b09bda72c9ed09185
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/world/StructuresLocateEvent.java
-@@ -0,0 +1,210 @@
+@@ -0,0 +1,213 @@
 +package io.papermc.paper.event.world;
 +
 +import io.papermc.paper.math.Position;
@@ -190,6 +195,7 @@ index 0000000000000000000000000000000000000000..4342b162f69b6509503e9772ddd2c5ac
 +import org.bukkit.event.world.WorldEvent;
 +import org.bukkit.generator.structure.Structure;
 +import org.bukkit.generator.structure.StructureType;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +import org.jetbrains.annotations.UnmodifiableView;
@@ -217,8 +223,10 @@ index 0000000000000000000000000000000000000000..4342b162f69b6509503e9772ddd2c5ac
 +    private List<ConfiguredStructure> legacy$structures;
 +    private int radius;
 +    private boolean findUnexplored;
++
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public StructuresLocateEvent(@NotNull World world, @NotNull Location origin, @NotNull List<Structure> structures, int radius, boolean findUnexplored) {
 +        super(world);
 +        this.origin = origin;
@@ -242,8 +250,8 @@ index 0000000000000000000000000000000000000000..4342b162f69b6509503e9772ddd2c5ac
 +     * Returns {@code null} if it has not been set by {@link StructuresLocateEvent#setResult(Result)}.
 +     * Since this event fires <i>before</i> the search is done, the actual result is unknown at this point.
 +     *
-+     * @return The result location and structure, if it has been set. null if it has not.
-+     * @see World#locateNearestStructure(Location, org.bukkit.generator.structure.StructureType, int, boolean)
++     * @return The result location and structure, if it has been set. {@code null} if it has not.
++     * @see World#locateNearestStructure(Location, StructureType, int, boolean)
 +     */
 +    public @Nullable Result getResult() {
 +        return this.result;

--- a/patches/api/0248-Add-BlockPreDispenseEvent.patch
+++ b/patches/api/0248-Add-BlockPreDispenseEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add BlockPreDispenseEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/block/BlockPreDispenseEvent.java b/src/main/java/io/papermc/paper/event/block/BlockPreDispenseEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..07aad3f4ff60a6a6de69634b0d31926e9c00e77b
+index 0000000000000000000000000000000000000000..62547d5853e7355a805fa1e7f1e5f56d06fca4ba
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/BlockPreDispenseEvent.java
-@@ -0,0 +1,60 @@
+@@ -0,0 +1,65 @@
 +package io.papermc.paper.event.block;
 +
 +import org.bukkit.block.Block;
@@ -17,14 +17,19 @@ index 0000000000000000000000000000000000000000..07aad3f4ff60a6a6de69634b0d31926e
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.block.BlockEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +public class BlockPreDispenseEvent extends BlockEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled = false;
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final ItemStack itemStack;
 +    private final int slot;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public BlockPreDispenseEvent(@NotNull Block block, @NotNull ItemStack itemStack, int slot) {
 +        super(block);
 +        this.itemStack = itemStack;
@@ -38,7 +43,7 @@ index 0000000000000000000000000000000000000000..07aad3f4ff60a6a6de69634b0d31926e
 +     */
 +    @NotNull
 +    public ItemStack getItemStack() {
-+        return itemStack;
++        return this.itemStack;
 +    }
 +
 +    /**
@@ -47,17 +52,7 @@ index 0000000000000000000000000000000000000000..07aad3f4ff60a6a6de69634b0d31926e
 +     * @return The inventory slot
 +     */
 +    public int getSlot() {
-+        return slot;
-+    }
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
++        return this.slot;
 +    }
 +
 +    @Override
@@ -68,5 +63,15 @@ index 0000000000000000000000000000000000000000..07aad3f4ff60a6a6de69634b0d31926e
 +    @Override
 +    public void setCancelled(boolean cancel) {
 +        this.cancelled = cancel;
++    }
++
++    @NotNull
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0250-Added-PlayerChangeBeaconEffectEvent.patch
+++ b/patches/api/0250-Added-PlayerChangeBeaconEffectEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Added PlayerChangeBeaconEffectEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerChangeBeaconEffectEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerChangeBeaconEffectEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..812712b3b233c454dfab039fb9f16d6becca2d93
+index 0000000000000000000000000000000000000000..1cc5dfb6d31f312f07acb1d5fb4719d6f4c2c4ff
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerChangeBeaconEffectEvent.java
-@@ -0,0 +1,143 @@
+@@ -0,0 +1,137 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.block.Block;
@@ -26,21 +26,21 @@ index 0000000000000000000000000000000000000000..812712b3b233c454dfab039fb9f16d6b
 + * Called when a player sets the effect for a beacon
 + */
 +public class PlayerChangeBeaconEffectEvent extends PlayerEvent implements Cancellable {
++
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
++    private final Block beacon;
 +    private PotionEffectType primary;
 +    private PotionEffectType secondary;
-+    private final Block beacon;
 +    private boolean consumeItem = true;
 +
-+    private boolean isCancelled;
++    private boolean cancelled;
 +
 +    @ApiStatus.Internal
 +    public PlayerChangeBeaconEffectEvent(@NotNull Player player, @Nullable PotionEffectType primary, @Nullable PotionEffectType secondary, @NotNull Block beacon) {
 +        super(player);
 +        this.primary = primary;
 +        this.secondary = secondary;
-+        this.isCancelled = false;
 +        this.beacon = beacon;
 +    }
 +
@@ -48,7 +48,7 @@ index 0000000000000000000000000000000000000000..812712b3b233c454dfab039fb9f16d6b
 +     * @return the primary effect
 +     */
 +    @Nullable public PotionEffectType getPrimary() {
-+        return primary;
++        return this.primary;
 +    }
 +
 +    /**
@@ -66,7 +66,7 @@ index 0000000000000000000000000000000000000000..812712b3b233c454dfab039fb9f16d6b
 +     * @return the secondary effect
 +     */
 +    @Nullable public PotionEffectType getSecondary() {
-+        return secondary;
++        return this.secondary;
 +    }
 +
 +    /**
@@ -86,7 +86,7 @@ index 0000000000000000000000000000000000000000..812712b3b233c454dfab039fb9f16d6b
 +     */
 +    @NotNull
 +    public Block getBeacon() {
-+        return beacon;
++        return this.beacon;
 +    }
 +
 +    /**
@@ -95,10 +95,10 @@ index 0000000000000000000000000000000000000000..812712b3b233c454dfab039fb9f16d6b
 +     * Independent of {@link #isCancelled()}. If the event is cancelled
 +     * the item will <b>NOT</b> be consumed.
 +     *
-+     * @return true if item will be consumed
++     * @return {@code true} if item will be consumed
 +     */
 +    public boolean willConsumeItem() {
-+        return consumeItem;
++        return this.consumeItem;
 +    }
 +
 +    /**
@@ -107,40 +107,34 @@ index 0000000000000000000000000000000000000000..812712b3b233c454dfab039fb9f16d6b
 +     * Independent of {@link #isCancelled()}. If the event is cancelled
 +     * the item will <b>NOT</b> be consumed.
 +     *
-+     * @param consumeItem true if item should be consumed
++     * @param consumeItem {@code true} if item should be consumed
 +     */
 +    public void setConsumeItem(boolean consumeItem) {
 +        this.consumeItem = consumeItem;
 +    }
 +
 +    /**
-+     * Gets the cancellation state of this event. A cancelled event will not
-+     * be executed in the server, but will still pass to other plugins
++     * {@inheritDoc}
 +     * <p>
 +     * If a {@link PlayerChangeBeaconEffectEvent} is cancelled, the changes will
 +     * not take effect
-+     *
-+     * @return true if this event is cancelled
 +     */
 +    @Override
 +    public boolean isCancelled() {
-+        return this.isCancelled;
++        return this.cancelled;
 +    }
 +
 +    /**
-+     * Sets the cancellation state of this event. A cancelled event will not
-+     * be executed in the server, but will still pass to other plugins
++     * {@inheritDoc}
 +     * <p>
 +     * If cancelled, the item will <b>NOT</b> be consumed regardless of what {@link #willConsumeItem()} says
 +     * <p>
 +     * If a {@link PlayerChangeBeaconEffectEvent} is cancelled, the changes will not be applied
 +     * or saved.
-+     *
-+     * @param cancel true if you wish to cancel this event
 +     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        this.isCancelled = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @Override

--- a/patches/api/0251-Added-PlayerStonecutterRecipeSelectEvent.patch
+++ b/patches/api/0251-Added-PlayerStonecutterRecipeSelectEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Added PlayerStonecutterRecipeSelectEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerStonecutterRecipeSelectEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerStonecutterRecipeSelectEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..fb1bca3a9d12096c9a2b2663f466a8ff5f2b4319
+index 0000000000000000000000000000000000000000..8a7e1cb49ace104af3f9571fbc36b80687141736
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerStonecutterRecipeSelectEvent.java
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,60 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Player;
@@ -24,9 +24,10 @@ index 0000000000000000000000000000000000000000..fb1bca3a9d12096c9a2b2663f466a8ff
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    private boolean cancelled;
 +    private final StonecutterInventory stonecutterInventory;
 +    private StonecuttingRecipe stonecuttingRecipe;
++
++    private boolean cancelled;
 +
 +    public PlayerStonecutterRecipeSelectEvent(@NotNull Player player, @NotNull StonecutterInventory stonecutterInventory, @NotNull StonecuttingRecipe stonecuttingRecipe) {
 +        super(player);
@@ -36,12 +37,12 @@ index 0000000000000000000000000000000000000000..fb1bca3a9d12096c9a2b2663f466a8ff
 +
 +    @NotNull
 +    public StonecutterInventory getStonecutterInventory() {
-+        return stonecutterInventory;
++        return this.stonecutterInventory;
 +    }
 +
 +    @NotNull
 +    public StonecuttingRecipe getStonecuttingRecipe() {
-+        return stonecuttingRecipe;
++        return this.stonecuttingRecipe;
 +    }
 +
 +    public void setStonecuttingRecipe(@NotNull StonecuttingRecipe stonecuttingRecipe) {
@@ -50,7 +51,7 @@ index 0000000000000000000000000000000000000000..fb1bca3a9d12096c9a2b2663f466a8ff
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override

--- a/patches/api/0253-add-DragonEggFormEvent.patch
+++ b/patches/api/0253-add-DragonEggFormEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add DragonEggFormEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/block/DragonEggFormEvent.java b/src/main/java/io/papermc/paper/event/block/DragonEggFormEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5495b87330518363498e1ac5d8f0a832be35fefb
+index 0000000000000000000000000000000000000000..695c21a296c6d12e1204eba33b92c44e7c2d98b8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/DragonEggFormEvent.java
-@@ -0,0 +1,63 @@
+@@ -0,0 +1,55 @@
 +package io.papermc.paper.event.block;
 +
 +import org.bukkit.Material;
@@ -17,59 +17,51 @@ index 0000000000000000000000000000000000000000..5495b87330518363498e1ac5d8f0a832
 +import org.bukkit.block.BlockState;
 +import org.bukkit.boss.DragonBattle;
 +import org.bukkit.entity.EnderDragon;
-+import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.block.BlockFormEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called when the {@link EnderDragon} is defeated (killed) in a {@link DragonBattle},
 + * causing a {@link Material#DRAGON_EGG} (more formally: {@link #getNewState()})
 + * to possibly appear depending on {@link #isCancelled()}.
++ * <p>
 + * <b>This event might be cancelled by default depending on
-+ * eg. {@link DragonBattle#hasBeenPreviouslyKilled()} and server configuration.</b>
++ * e.g. {@link DragonBattle#hasBeenPreviouslyKilled()} and server configuration.</b>
 + */
-+public class DragonEggFormEvent extends BlockFormEvent implements Cancellable {
-+	private static final HandlerList handlers = new HandlerList();
-+	private final DragonBattle dragonBattle;
-+	private boolean cancelled;
-+	
-+	public DragonEggFormEvent(@NotNull Block block, @NotNull BlockState newState,
-+			@NotNull DragonBattle dragonBattle) {
-+		super(block, newState);
-+		this.dragonBattle = dragonBattle;
-+	}
-+	
-+	@Override
-+	public boolean isCancelled() {
-+		return cancelled;
-+	}
-+	
-+	@Override
-+	public void setCancelled(boolean cancelled) {
-+		this.cancelled = cancelled;
-+	}
-+	
-+	/**
-+	 * Gets the {@link DragonBattle} associated with this event.
-+	 * Keep in mind that the {@link EnderDragon} is already dead
-+	 * when this event is called.
-+	 *
-+	 * @return the dragon battle
-+	 */
-+	@NotNull
-+	public DragonBattle getDragonBattle() {
-+		return dragonBattle;
-+	}
-+	
-+	@NotNull
-+	@Override
-+	public HandlerList getHandlers() {
-+		return handlers;
-+	}
-+	
-+	@NotNull
-+	public static HandlerList getHandlerList() {
-+		return handlers;
-+	}
++public class DragonEggFormEvent extends BlockFormEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private final DragonBattle dragonBattle;
++
++    @ApiStatus.Internal
++    public DragonEggFormEvent(@NotNull Block block, @NotNull BlockState newState, @NotNull DragonBattle dragonBattle) {
++        super(block, newState);
++        this.dragonBattle = dragonBattle;
++    }
++
++    /**
++     * Gets the {@link DragonBattle} associated with this event.
++     * Keep in mind that the {@link EnderDragon} is already dead
++     * when this event is called.
++     *
++     * @return the dragon battle
++     */
++    @NotNull
++    public DragonBattle getDragonBattle() {
++        return this.dragonBattle;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
 +}

--- a/patches/api/0254-EntityMoveEvent.patch
+++ b/patches/api/0254-EntityMoveEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] EntityMoveEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityMoveEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityMoveEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..245d56ba7e8e37e3555b606f5e85fc663897f62b
+index 0000000000000000000000000000000000000000..46990a220f70b04218b14aec1e9efbd46c2ad77c
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityMoveEvent.java
-@@ -0,0 +1,143 @@
+@@ -0,0 +1,150 @@
 +package io.papermc.paper.event.entity;
 +
 +import com.google.common.base.Preconditions;
@@ -19,6 +19,7 @@ index 0000000000000000000000000000000000000000..245d56ba7e8e37e3555b606f5e85fc66
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
 +import org.bukkit.event.player.PlayerMoveEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -27,11 +28,15 @@ index 0000000000000000000000000000000000000000..245d56ba7e8e37e3555b606f5e85fc66
 + * Does not fire for players; use {@link PlayerMoveEvent} for player movement.
 + */
 +public class EntityMoveEvent extends EntityEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean canceled;
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private Location from;
 +    private Location to;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public EntityMoveEvent(@NotNull LivingEntity entity, @NotNull Location from, @NotNull Location to) {
 +        super(entity);
 +        this.from = from;
@@ -41,15 +46,7 @@ index 0000000000000000000000000000000000000000..245d56ba7e8e37e3555b606f5e85fc66
 +    @Override
 +    @NotNull
 +    public LivingEntity getEntity() {
-+        return (LivingEntity) entity;
-+    }
-+
-+    public boolean isCancelled() {
-+        return canceled;
-+    }
-+
-+    public void setCancelled(boolean cancel) {
-+        canceled = cancel;
++        return (LivingEntity) super.getEntity();
 +    }
 +
 +    /**
@@ -59,7 +56,7 @@ index 0000000000000000000000000000000000000000..245d56ba7e8e37e3555b606f5e85fc66
 +     */
 +    @NotNull
 +    public Location getFrom() {
-+        return from;
++        return this.from;
 +    }
 +
 +    /**
@@ -79,7 +76,7 @@ index 0000000000000000000000000000000000000000..245d56ba7e8e37e3555b606f5e85fc66
 +     */
 +    @NotNull
 +    public Location getTo() {
-+        return to;
++        return this.to;
 +    }
 +
 +    /**
@@ -98,7 +95,7 @@ index 0000000000000000000000000000000000000000..245d56ba7e8e37e3555b606f5e85fc66
 +     * @return whether the entity has changed position or not
 +     */
 +    public boolean hasChangedPosition() {
-+        return hasExplicitlyChangedPosition() || !from.getWorld().equals(to.getWorld());
++        return hasExplicitlyChangedPosition() || !this.from.getWorld().equals(this.to.getWorld());
 +    }
 +
 +    /**
@@ -107,7 +104,7 @@ index 0000000000000000000000000000000000000000..245d56ba7e8e37e3555b606f5e85fc66
 +     * @return whether the entity has changed position or not
 +     */
 +    public boolean hasExplicitlyChangedPosition() {
-+        return from.getX() != to.getX() || from.getY() != to.getY() || from.getZ() != to.getZ();
++        return this.from.getX() != this.to.getX() || this.from.getY() != this.to.getY() || this.from.getZ() != this.to.getZ();
 +    }
 +
 +    /**
@@ -125,7 +122,7 @@ index 0000000000000000000000000000000000000000..245d56ba7e8e37e3555b606f5e85fc66
 +     * @return whether the entity has moved to a new block or not
 +     */
 +    public boolean hasExplicitlyChangedBlock() {
-+        return from.getBlockX() != to.getBlockX() || from.getBlockY() != to.getBlockY() || from.getBlockZ() != to.getBlockZ();
++        return this.from.getBlockX() != this.to.getBlockX() || this.from.getBlockY() != this.to.getBlockY() || this.from.getBlockZ() != this.to.getBlockZ();
 +    }
 +
 +    /**
@@ -134,7 +131,7 @@ index 0000000000000000000000000000000000000000..245d56ba7e8e37e3555b606f5e85fc66
 +     * @return whether the entity has changed orientation or not
 +     */
 +    public boolean hasChangedOrientation() {
-+        return from.getPitch() != to.getPitch() || from.getYaw() != to.getYaw();
++        return this.from.getPitch() != this.to.getPitch() || this.from.getYaw() != this.to.getYaw();
 +    }
 +
 +    private void validateLocation(@NotNull Location loc) {
@@ -143,13 +140,23 @@ index 0000000000000000000000000000000000000000..245d56ba7e8e37e3555b606f5e85fc66
 +    }
 +
 +    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @Override
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0261-Add-worldborder-events.patch
+++ b/patches/api/0261-Add-worldborder-events.patch
@@ -6,16 +6,17 @@ Subject: [PATCH] Add worldborder events
 
 diff --git a/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java b/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..126fe50b519a8d7cd158f799058cb235f9c4cbdb
+index 0000000000000000000000000000000000000000..02ac479840c137ca5afcec149ef884e5a5d62928
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
-@@ -0,0 +1,114 @@
+@@ -0,0 +1,117 @@
 +package io.papermc.paper.event.world.border;
 +
 +import org.bukkit.World;
 +import org.bukkit.WorldBorder;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -31,6 +32,7 @@ index 0000000000000000000000000000000000000000..126fe50b519a8d7cd158f799058cb235
 +    private long duration;
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public WorldBorderBoundsChangeEvent(@NotNull World world, @NotNull WorldBorder worldBorder, @NotNull Type type, double oldSize, double newSize, long duration) {
 +        super(world, worldBorder);
 +        this.type = type;
@@ -46,7 +48,7 @@ index 0000000000000000000000000000000000000000..126fe50b519a8d7cd158f799058cb235
 +     */
 +    @NotNull
 +    public Type getType() {
-+        return type;
++        return this.type;
 +    }
 +
 +    /**
@@ -55,7 +57,7 @@ index 0000000000000000000000000000000000000000..126fe50b519a8d7cd158f799058cb235
 +     * @return the old size
 +     */
 +    public double getOldSize() {
-+        return oldSize;
++        return this.oldSize;
 +    }
 +
 +    /**
@@ -64,7 +66,7 @@ index 0000000000000000000000000000000000000000..126fe50b519a8d7cd158f799058cb235
 +     * @return the new size
 +     */
 +    public double getNewSize() {
-+        return newSize;
++        return this.newSize;
 +    }
 +
 +    /**
@@ -73,8 +75,7 @@ index 0000000000000000000000000000000000000000..126fe50b519a8d7cd158f799058cb235
 +     * @param newSize the new size
 +     */
 +    public void setNewSize(double newSize) {
-+        // PAIL: TODO: Magic Values
-+        this.newSize = Math.min(6.0E7D, Math.max(1.0D, newSize));
++        this.newSize = Math.min(this.worldBorder.getMaxSize(), Math.max(1.0D, newSize));
 +    }
 +
 +    /**
@@ -83,7 +84,7 @@ index 0000000000000000000000000000000000000000..126fe50b519a8d7cd158f799058cb235
 +     * @return the time in milliseconds for the change
 +     */
 +    public long getDuration() {
-+        return duration;
++        return this.duration;
 +    }
 +
 +    /**
@@ -95,12 +96,14 @@ index 0000000000000000000000000000000000000000..126fe50b519a8d7cd158f799058cb235
 +    public void setDuration(long duration) {
 +        // PAIL: TODO: Magic Values
 +        this.duration = Math.min(9223372036854775L, Math.max(0L, duration));
-+        if (duration >= 0 && type == Type.INSTANT_MOVE) type = Type.STARTED_MOVE;
++        if (duration >= 0 && this.type == Type.INSTANT_MOVE) {
++            this.type = Type.STARTED_MOVE;
++        }
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
@@ -126,15 +129,16 @@ index 0000000000000000000000000000000000000000..126fe50b519a8d7cd158f799058cb235
 +}
 diff --git a/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeFinishEvent.java b/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeFinishEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..60eabed056ee9b9cdd6f5d13307b9be38705330f
+index 0000000000000000000000000000000000000000..a44964593b7f78c5086dc4928e75ad892e624671
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeFinishEvent.java
-@@ -0,0 +1,65 @@
+@@ -0,0 +1,67 @@
 +package io.papermc.paper.event.world.border;
 +
 +import org.bukkit.World;
 +import org.bukkit.WorldBorder;
 +import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -148,6 +152,7 @@ index 0000000000000000000000000000000000000000..60eabed056ee9b9cdd6f5d13307b9be3
 +    private final double newSize;
 +    private final double duration;
 +
++    @ApiStatus.Internal
 +    public WorldBorderBoundsChangeFinishEvent(@NotNull World world, @NotNull WorldBorder worldBorder, double oldSize, double newSize, double duration) {
 +        super(world, worldBorder);
 +        this.oldSize = oldSize;
@@ -161,7 +166,7 @@ index 0000000000000000000000000000000000000000..60eabed056ee9b9cdd6f5d13307b9be3
 +     * @return the old size
 +     */
 +    public double getOldSize() {
-+        return oldSize;
++        return this.oldSize;
 +    }
 +
 +    /**
@@ -170,18 +175,18 @@ index 0000000000000000000000000000000000000000..60eabed056ee9b9cdd6f5d13307b9be3
 +     * @return the new size
 +     */
 +    public double getNewSize() {
-+        return newSize;
++        return this.newSize;
 +    }
 +
 +    /**
 +     * Gets the duration this worldborder took to make the change.
 +     * <p>
-+     * Can be 0 if handlers for {@link io.papermc.paper.event.world.border.WorldBorderCenterChangeEvent} set the duration to 0.
++     * Can be 0 if handlers for {@link WorldBorderCenterChangeEvent} set the duration to 0.
 +     *
 +     * @return the duration of the transition
 +     */
 +    public double getDuration() {
-+        return duration;
++        return this.duration;
 +    }
 +
 +    @NotNull
@@ -197,10 +202,10 @@ index 0000000000000000000000000000000000000000..60eabed056ee9b9cdd6f5d13307b9be3
 +}
 diff --git a/src/main/java/io/papermc/paper/event/world/border/WorldBorderCenterChangeEvent.java b/src/main/java/io/papermc/paper/event/world/border/WorldBorderCenterChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4a10c773a8d05a596066e63306dead74c1363fd7
+index 0000000000000000000000000000000000000000..a90f67e902c6ae35b2399e6f72a3ff8a5c15d05a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/world/border/WorldBorderCenterChangeEvent.java
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,79 @@
 +package io.papermc.paper.event.world.border;
 +
 +import org.bukkit.Location;
@@ -208,7 +213,7 @@ index 0000000000000000000000000000000000000000..4a10c773a8d05a596066e63306dead74
 +import org.bukkit.WorldBorder;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
-+import org.bukkit.event.world.WorldEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -220,8 +225,10 @@ index 0000000000000000000000000000000000000000..4a10c773a8d05a596066e63306dead74
 +
 +    private final Location oldCenter;
 +    private Location newCenter;
++
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public WorldBorderCenterChangeEvent(@NotNull World world, @NotNull WorldBorder worldBorder, @NotNull Location oldCenter, @NotNull Location newCenter) {
 +        super(world, worldBorder);
 +        this.oldCenter = oldCenter;
@@ -235,7 +242,7 @@ index 0000000000000000000000000000000000000000..4a10c773a8d05a596066e63306dead74
 +     */
 +    @NotNull
 +    public Location getOldCenter() {
-+        return oldCenter;
++        return this.oldCenter;
 +    }
 +
 +    /**
@@ -245,7 +252,7 @@ index 0000000000000000000000000000000000000000..4a10c773a8d05a596066e63306dead74
 +     */
 +    @NotNull
 +    public Location getNewCenter() {
-+        return newCenter;
++        return this.newCenter;
 +    }
 +
 +    /**
@@ -259,7 +266,7 @@ index 0000000000000000000000000000000000000000..4a10c773a8d05a596066e63306dead74
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
@@ -280,29 +287,30 @@ index 0000000000000000000000000000000000000000..4a10c773a8d05a596066e63306dead74
 +}
 diff --git a/src/main/java/io/papermc/paper/event/world/border/WorldBorderEvent.java b/src/main/java/io/papermc/paper/event/world/border/WorldBorderEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..67bd469d3680c9554ce6c1d5493826a252682835
+index 0000000000000000000000000000000000000000..adb244f9be35c43ff99dbc3a771e1fdfb21da68c
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/world/border/WorldBorderEvent.java
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,23 @@
 +package io.papermc.paper.event.world.border;
 +
 +import org.bukkit.World;
 +import org.bukkit.WorldBorder;
-+import org.bukkit.event.Cancellable;
 +import org.bukkit.event.world.WorldEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +public abstract class WorldBorderEvent extends WorldEvent {
 +
-+    private final WorldBorder worldBorder;
++    protected final WorldBorder worldBorder;
 +
-+    public WorldBorderEvent(@NotNull World world, @NotNull WorldBorder worldBorder) {
++    @ApiStatus.Internal
++    protected WorldBorderEvent(@NotNull World world, @NotNull WorldBorder worldBorder) {
 +        super(world);
 +        this.worldBorder = worldBorder;
 +    }
 +
 +    @NotNull
 +    public WorldBorder getWorldBorder() {
-+        return worldBorder;
++        return this.worldBorder;
 +    }
 +}

--- a/patches/api/0262-added-PlayerNameEntityEvent.patch
+++ b/patches/api/0262-added-PlayerNameEntityEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] added PlayerNameEntityEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerNameEntityEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerNameEntityEvent.java
 new file mode 100755
-index 0000000000000000000000000000000000000000..ef9e53a73eff469bbaa8fb20c634297acb9d1986
+index 0000000000000000000000000000000000000000..84736d4a438e9023fbdeac1aea4d8b741cc39b61
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerNameEntityEvent.java
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,110 @@
 +package io.papermc.paper.event.player;
 +
 +import net.kyori.adventure.text.Component;
@@ -18,6 +18,7 @@ index 0000000000000000000000000000000000000000..ef9e53a73eff469bbaa8fb20c634297a
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -26,11 +27,15 @@ index 0000000000000000000000000000000000000000..ef9e53a73eff469bbaa8fb20c634297a
 + */
 +public class PlayerNameEntityEvent extends PlayerEvent implements Cancellable {
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private LivingEntity entity;
 +    private Component name;
 +    private boolean persistent;
++
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public PlayerNameEntityEvent(@NotNull Player player, @NotNull LivingEntity entity, @NotNull Component name, boolean persistent) {
 +        super(player);
 +        this.entity = entity;
@@ -40,11 +45,12 @@ index 0000000000000000000000000000000000000000..ef9e53a73eff469bbaa8fb20c634297a
 +
 +    /**
 +     * Gets the name to be given to the entity.
++     *
 +     * @return the name
 +     */
 +    @Nullable
 +    public Component getName() {
-+        return name;
++        return this.name;
 +    }
 +
 +    /**
@@ -63,7 +69,7 @@ index 0000000000000000000000000000000000000000..ef9e53a73eff469bbaa8fb20c634297a
 +     */
 +    @NotNull
 +    public LivingEntity getEntity() {
-+        return entity;
++        return this.entity;
 +    }
 +
 +    /**
@@ -81,7 +87,7 @@ index 0000000000000000000000000000000000000000..ef9e53a73eff469bbaa8fb20c634297a
 +     * @return persistent
 +     */
 +    public boolean isPersistent() {
-+        return persistent;
++        return this.persistent;
 +    }
 +
 +    /**
@@ -93,29 +99,15 @@ index 0000000000000000000000000000000000000000..ef9e53a73eff469bbaa8fb20c634297a
 +        this.persistent = persistent;
 +    }
 +
-+    /**
-+     * Gets the cancellation state of this event. A cancelled event will not
-+     * be executed in the server, but will still pass to other plugins
-+     *
-+     * @return true if this event is cancelled
-+     */
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
-+    /**
-+     * Sets the cancellation state of this event. A cancelled event will not
-+     * be executed in the server, but will still pass to other plugins.
-+     *
-+     * @param cancel true if you wish to cancel this event
-+     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
 +        this.cancelled = cancel;
 +    }
-+
-+    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    @NotNull
 +    @Override

--- a/patches/api/0271-Added-PlayerDeepSleepEvent.patch
+++ b/patches/api/0271-Added-PlayerDeepSleepEvent.patch
@@ -6,16 +6,17 @@ Subject: [PATCH] Added PlayerDeepSleepEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerDeepSleepEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerDeepSleepEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e3ee540bb0a5bc578b148fbcf8b5e39ab9c8575c
+index 0000000000000000000000000000000000000000..54cf2ec5e025fac9a0c8f151ff4f8c83a62b8405
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerDeepSleepEvent.java
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,48 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -31,13 +32,14 @@ index 0000000000000000000000000000000000000000..e3ee540bb0a5bc578b148fbcf8b5e39a
 +
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public PlayerDeepSleepEvent(@NotNull Player player) {
 +        super(player);
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override

--- a/patches/api/0273-Added-PlayerBedFailEnterEvent.patch
+++ b/patches/api/0273-Added-PlayerBedFailEnterEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Added PlayerBedFailEnterEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerBedFailEnterEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerBedFailEnterEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e0028733615ddc9e34359f673ca1c3cadb133948
+index 0000000000000000000000000000000000000000..6cd803e108dc2e6c0b8afda123123450403ef729
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerBedFailEnterEvent.java
 @@ -0,0 +1,119 @@
@@ -18,6 +18,7 @@ index 0000000000000000000000000000000000000000..e0028733615ddc9e34359f673ca1c3ca
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -29,8 +30,10 @@ index 0000000000000000000000000000000000000000..e0028733615ddc9e34359f673ca1c3ca
 +    private final Block bed;
 +    private boolean willExplode;
 +    private Component message;
++
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public PlayerBedFailEnterEvent(@NotNull Player player, @NotNull FailReason failReason, @NotNull Block bed, boolean willExplode, @Nullable Component message) {
 +        super(player);
 +        this.failReason = failReason;
@@ -41,16 +44,16 @@ index 0000000000000000000000000000000000000000..e0028733615ddc9e34359f673ca1c3ca
 +
 +    @NotNull
 +    public FailReason getFailReason() {
-+        return failReason;
++        return this.failReason;
 +    }
 +
 +    @NotNull
 +    public Block getBed() {
-+        return bed;
++        return this.bed;
 +    }
 +
 +    public boolean getWillExplode() {
-+        return willExplode;
++        return this.willExplode;
 +    }
 +
 +    public void setWillExplode(boolean willExplode) {
@@ -59,7 +62,7 @@ index 0000000000000000000000000000000000000000..e0028733615ddc9e34359f673ca1c3ca
 +
 +    @Nullable
 +    public Component getMessage() {
-+        return message;
++        return this.message;
 +    }
 +
 +    public void setMessage(@Nullable Component message) {
@@ -68,19 +71,18 @@ index 0000000000000000000000000000000000000000..e0028733615ddc9e34359f673ca1c3ca
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    /**
-+     * Cancel this event.
++     * {@inheritDoc}
 +     * <p>
-+     * <b>NOTE: This does not cancel the player getting in the bed, but any messages/explosions
-+     * that may occur because of the interaction.</b>
-+     * @param cancel true if you wish to cancel this event
++     * <b>NOTE</b>: This does not cancel the player getting in the bed, but any messages/explosions
++     * that may occur because of the interaction.
 +     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
@@ -94,7 +96,7 @@ index 0000000000000000000000000000000000000000..e0028733615ddc9e34359f673ca1c3ca
 +        return HANDLER_LIST;
 +    }
 +
-+    public static enum FailReason {
++    public enum FailReason {
 +        /**
 +         * The world doesn't allow sleeping (ex. Nether or The End). Entering
 +         * the bed is prevented and the bed explodes.
@@ -124,8 +126,6 @@ index 0000000000000000000000000000000000000000..e0028733615ddc9e34359f673ca1c3ca
 +        /**
 +         * Entering the bed is prevented due to there being monsters nearby.
 +         */
-+        NOT_SAFE;
-+
-+        public static final FailReason[] VALUES = values();
++        NOT_SAFE
 +    }
 +}

--- a/patches/api/0274-Introduce-beacon-activation-deactivation-events.patch
+++ b/patches/api/0274-Introduce-beacon-activation-deactivation-events.patch
@@ -6,16 +6,17 @@ Subject: [PATCH] Introduce beacon activation/deactivation events
 
 diff --git a/src/main/java/io/papermc/paper/event/block/BeaconActivatedEvent.java b/src/main/java/io/papermc/paper/event/block/BeaconActivatedEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7575ca7dd84dee89528ec2e5e5f99f97d8a10f58
+index 0000000000000000000000000000000000000000..05609ec9df637c9aa53528218cbc8cda30f0aea1
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/BeaconActivatedEvent.java
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,43 @@
 +package io.papermc.paper.event.block;
 +
 +import org.bukkit.block.Beacon;
 +import org.bukkit.block.Block;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.block.BlockEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -23,8 +24,10 @@ index 0000000000000000000000000000000000000000..7575ca7dd84dee89528ec2e5e5f99f97
 + * Activation occurs when the beacon beam becomes visible.
 + */
 +public class BeaconActivatedEvent extends BlockEvent {
-+    private static final HandlerList handlers = new HandlerList();
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @ApiStatus.Internal
 +    public BeaconActivatedEvent(@NotNull Block block) {
 +        super(block);
 +    }
@@ -36,26 +39,26 @@ index 0000000000000000000000000000000000000000..7575ca7dd84dee89528ec2e5e5f99f97
 +     */
 +    @NotNull
 +    public Beacon getBeacon() {
-+        return (Beacon) block.getState();
++        return (Beacon) this.block.getState();
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/event/block/BeaconDeactivatedEvent.java b/src/main/java/io/papermc/paper/event/block/BeaconDeactivatedEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..34f18468b4cfc08717cc3442778c9e85124e5a22
+index 0000000000000000000000000000000000000000..dc106d6bfbd9d0ab84b17597d71381a5c0b07d64
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/BeaconDeactivatedEvent.java
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,46 @@
 +package io.papermc.paper.event.block;
 +
 +import org.bukkit.Material;
@@ -63,6 +66,7 @@ index 0000000000000000000000000000000000000000..34f18468b4cfc08717cc3442778c9e85
 +import org.bukkit.block.Block;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.block.BlockEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -70,32 +74,34 @@ index 0000000000000000000000000000000000000000..34f18468b4cfc08717cc3442778c9e85
 + * Called when a beacon is deactivated, either because its base block(s) or itself were destroyed.
 + */
 +public class BeaconDeactivatedEvent extends BlockEvent {
-+    private static final HandlerList handlers = new HandlerList();
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @ApiStatus.Internal
 +    public BeaconDeactivatedEvent(@NotNull Block block) {
 +        super(block);
 +    }
 +
 +    /**
 +     * Returns the beacon that was deactivated.
-+     * This will return null if the beacon does not exist.
++     * This will return {@code null} if the beacon does not exist.
 +     * (which can occur after the deactivation of a now broken beacon)
 +     *
-+     * @return The beacon that got deactivated, or null if it does not exist.
++     * @return The beacon that got deactivated, or {@code null} if it does not exist.
 +     */
 +    @Nullable
 +    public Beacon getBeacon() {
-+        return block.getType() == Material.BEACON ? (Beacon) block.getState() : null;
++        return this.block.getType() == Material.BEACON ? (Beacon) this.block.getState() : null;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0288-Add-EntityInsideBlockEvent.patch
+++ b/patches/api/0288-Add-EntityInsideBlockEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add EntityInsideBlockEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityInsideBlockEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityInsideBlockEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..109dd7e6d0e7bb0a83fc4c5230f7d5dc122f2bb5
+index 0000000000000000000000000000000000000000..3e98db83060e614c606de41dcd4b4ac4f242edc9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityInsideBlockEvent.java
-@@ -0,0 +1,84 @@
+@@ -0,0 +1,86 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.block.Block;
@@ -17,6 +17,7 @@ index 0000000000000000000000000000000000000000..109dd7e6d0e7bb0a83fc4c5230f7d5dc
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -58,6 +59,7 @@ index 0000000000000000000000000000000000000000..109dd7e6d0e7bb0a83fc4c5230f7d5dc
 +    private final Block block;
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public EntityInsideBlockEvent(@NotNull Entity entity, @NotNull Block block) {
 +        super(entity);
 +        this.block = block;
@@ -70,12 +72,12 @@ index 0000000000000000000000000000000000000000..109dd7e6d0e7bb0a83fc4c5230f7d5dc
 +     */
 +    @NotNull
 +    public Block getBlock() {
-+        return block;
++        return this.block;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override

--- a/patches/api/0293-Add-PufferFishStateChangeEvent.patch
+++ b/patches/api/0293-Add-PufferFishStateChangeEvent.patch
@@ -6,26 +6,30 @@ Subject: [PATCH] Add PufferFishStateChangeEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/PufferFishStateChangeEvent.java b/src/main/java/io/papermc/paper/event/entity/PufferFishStateChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3585457b21aca2a2f1779868a0fa91f8011ad3c9
+index 0000000000000000000000000000000000000000..4e04b49c1e2bc2a965c9be2388539d9ed5a58f89
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/PufferFishStateChangeEvent.java
-@@ -0,0 +1,80 @@
+@@ -0,0 +1,87 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.entity.PufferFish;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called just before a {@link PufferFish} inflates or deflates.
 + */
 +public class PufferFishStateChangeEvent extends EntityEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled;
-+    private int newPuffState;
 +
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private final int newPuffState;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PufferFishStateChangeEvent(@NotNull PufferFish entity, int newPuffState) {
 +        super(entity);
 +        this.newPuffState = newPuffState;
@@ -34,7 +38,7 @@ index 0000000000000000000000000000000000000000..3585457b21aca2a2f1779868a0fa91f8
 +    @NotNull
 +    @Override
 +    public PufferFish getEntity() {
-+        return (PufferFish) entity;
++        return (PufferFish) super.getEntity();
 +    }
 +
 +    /**
@@ -42,6 +46,7 @@ index 0000000000000000000000000000000000000000..3585457b21aca2a2f1779868a0fa91f8
 +     * <p>
 +     * This is what the {@link PufferFish}'s new puff state will be after this event if it isn't cancelled.<br>
 +     * Refer to {@link PufferFish#getPuffState()} to get the current puff state.
++     *
 +     * @return The <strong>new</strong> puff state, 0 being not inflated, 1 being slightly inflated and 2 being fully inflated
 +     */
 +    public int getNewPuffState() {
@@ -50,24 +55,26 @@ index 0000000000000000000000000000000000000000..3585457b21aca2a2f1779868a0fa91f8
 +
 +    /**
 +     * Get if the {@link PufferFish} is going to inflate.
-+     * @return If its going to inflate
++     *
++     * @return If it's going to inflate
 +     */
 +    public boolean isInflating() {
-+        return getNewPuffState() > getEntity().getPuffState();
++        return this.newPuffState > this.getEntity().getPuffState();
 +    }
 +
 +    /**
 +     * Get if the {@link PufferFish} is going to deflate.
-+     * @return If its going to deflate
++     *
++     * @return If it's going to deflate
 +     */
 +    public boolean isDeflating() {
-+        return getNewPuffState() < getEntity().getPuffState();
++        return this.newPuffState < this.getEntity().getPuffState();
 +    }
 +
 +    /**
-+     * Set whether or not to cancel the {@link PufferFish} (in/de)flating.
++     * Set whether to cancel the {@link PufferFish} (in/de)flating.
 +     *
-+     * @param cancel true if you wish to cancel the (in/de)flation
++     * @param cancel {@code true} if you wish to cancel the (in/de)flation
 +     */
 +    @Override
 +    public void setCancelled(boolean cancel) {
@@ -76,17 +83,17 @@ index 0000000000000000000000000000000000000000..3585457b21aca2a2f1779868a0fa91f8
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0294-Add-BellRevealRaiderEvent.patch
+++ b/patches/api/0294-Add-BellRevealRaiderEvent.patch
@@ -6,34 +6,37 @@ Subject: [PATCH] Add BellRevealRaiderEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/block/BellRevealRaiderEvent.java b/src/main/java/io/papermc/paper/event/block/BellRevealRaiderEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ac14cb18fe29391899f6adeb00beacb755a556c7
+index 0000000000000000000000000000000000000000..e41599405514cd7eea93d842243f6c5c938b93f1
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/BellRevealRaiderEvent.java
-@@ -0,0 +1,60 @@
+@@ -0,0 +1,63 @@
 +package io.papermc.paper.event.block;
 +
 +import org.bukkit.block.Block;
-+import org.bukkit.entity.Entity;
 +import org.bukkit.entity.Raider;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.block.BlockEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Called when a {@link org.bukkit.entity.Raider} is revealed by a bell.
++ * Called when a {@link Raider} is revealed by a bell.
++ *
 + * @deprecated use {@link org.bukkit.event.block.BellResonateEvent}
 + */
 +@Deprecated
 +public class BellRevealRaiderEvent extends BlockEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
 +
-+    private boolean cancelled = false;
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final Raider raider;
++    private boolean cancelled;
 +
-+    public BellRevealRaiderEvent(@NotNull Block theBlock, @NotNull Entity raider) {
++    @ApiStatus.Internal
++    public BellRevealRaiderEvent(@NotNull Block theBlock, @NotNull Raider raider) {
 +        super(theBlock);
-+        this.raider = (Raider) raider;
++        this.raider = raider;
 +    }
 +
 +    /**
@@ -43,12 +46,12 @@ index 0000000000000000000000000000000000000000..ac14cb18fe29391899f6adeb00beacb7
 +     */
 +    @NotNull
 +    public Raider getEntity() {
-+        return raider;
++        return this.raider;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    /**
@@ -63,10 +66,10 @@ index 0000000000000000000000000000000000000000..ac14cb18fe29391899f6adeb00beacb7
 +
 +    @Override
 +    public @NotNull HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    public static @NotNull HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0295-Add-ElderGuardianAppearanceEvent.patch
+++ b/patches/api/0295-Add-ElderGuardianAppearanceEvent.patch
@@ -6,35 +6,33 @@ Subject: [PATCH] Add ElderGuardianAppearanceEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/ElderGuardianAppearanceEvent.java b/src/main/java/io/papermc/paper/event/entity/ElderGuardianAppearanceEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4cd551c8311ff8f7321ed2dc6a4efc87162dadfe
+index 0000000000000000000000000000000000000000..47eabdc8b1a3a3207f197eeca00f3ca5c9940b89
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/ElderGuardianAppearanceEvent.java
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,67 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.entity.ElderGuardian;
-+import org.bukkit.entity.Entity;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
-+import java.util.Collections;
-+import java.util.List;
-+
 +/**
-+ * Is called when an {@link org.bukkit.entity.ElderGuardian} appears in front of a {@link org.bukkit.entity.Player}.
++ * Is called when an {@link ElderGuardian} appears in front of a {@link Player}.
 + */
 +public class ElderGuardianAppearanceEvent extends EntityEvent implements Cancellable {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    private boolean cancelled;
 +    private final Player affectedPlayer;
++    private boolean cancelled;
 +
-+    public ElderGuardianAppearanceEvent(@NotNull Entity what, @NotNull Player affectedPlayer) {
-+        super(what);
++    @ApiStatus.Internal
++    public ElderGuardianAppearanceEvent(@NotNull ElderGuardian guardian, @NotNull Player affectedPlayer) {
++        super(guardian);
 +        this.affectedPlayer = affectedPlayer;
 +    }
 +
@@ -45,7 +43,7 @@ index 0000000000000000000000000000000000000000..4cd551c8311ff8f7321ed2dc6a4efc87
 +     */
 +    @NotNull
 +    public Player getAffectedPlayer() {
-+        return affectedPlayer;
++        return this.affectedPlayer;
 +    }
 +
 +    /**
@@ -55,12 +53,12 @@ index 0000000000000000000000000000000000000000..4cd551c8311ff8f7321ed2dc6a4efc87
 +     */
 +    @NotNull
 +    public ElderGuardian getEntity() {
-+        return (ElderGuardian) entity;
++        return (ElderGuardian) super.getEntity();
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
@@ -71,11 +69,11 @@ index 0000000000000000000000000000000000000000..4cd551c8311ff8f7321ed2dc6a4efc87
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0297-Add-WaterBottleSplashEvent.patch
+++ b/patches/api/0297-Add-WaterBottleSplashEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add WaterBottleSplashEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/WaterBottleSplashEvent.java b/src/main/java/io/papermc/paper/event/entity/WaterBottleSplashEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4c4c645a1597b5afb62f78dc1cfae62c5fe60fcf
+index 0000000000000000000000000000000000000000..749d37256b9298fe866852e2d00cee99d8079f07
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/WaterBottleSplashEvent.java
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,130 @@
 +package io.papermc.paper.event.entity;
 +
 +import java.util.Collection;
@@ -19,6 +19,7 @@ index 0000000000000000000000000000000000000000..4c4c645a1597b5afb62f78dc1cfae62c
 +import org.bukkit.entity.LivingEntity;
 +import org.bukkit.entity.ThrownPotion;
 +import org.bukkit.event.entity.PotionSplashEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Unmodifiable;
 +
@@ -27,9 +28,11 @@ index 0000000000000000000000000000000000000000..4c4c645a1597b5afb62f78dc1cfae62c
 + * different entities in different ways.
 + */
 +public class WaterBottleSplashEvent extends PotionSplashEvent {
++
 +    private final @NotNull Set<LivingEntity> rehydrate;
 +    private final @NotNull Set<LivingEntity> extinguish;
 +
++    @ApiStatus.Internal
 +    public WaterBottleSplashEvent(
 +        final @NotNull ThrownPotion potion,
 +        final @NotNull Map<LivingEntity, Double> affectedEntities,
@@ -114,6 +117,7 @@ index 0000000000000000000000000000000000000000..4c4c645a1597b5afb62f78dc1cfae62c
 +
 +    /**
 +     * Doesn't make sense for this event as intensity doesn't vary.
++     *
 +     * @return a confusing value
 +     * @deprecated check if {@link #getToDamage()} contains an entity
 +     */
@@ -125,6 +129,7 @@ index 0000000000000000000000000000000000000000..4c4c645a1597b5afb62f78dc1cfae62c
 +
 +    /**
 +     * Doesn't make sense for this event as intensity doesn't vary.
++     *
 +     * @deprecated use {@link #damageAsWaterSensitive(LivingEntity)}
 +     * or {@link #doNotDamageAsWaterSensitive(LivingEntity)} to change which entities are
 +     * damaged

--- a/patches/api/0300-Adds-PlayerArmSwingEvent.patch
+++ b/patches/api/0300-Adds-PlayerArmSwingEvent.patch
@@ -6,22 +6,24 @@ Subject: [PATCH] Adds PlayerArmSwingEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerArmSwingEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerArmSwingEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ce76b07cfaa9173c78e2844add2bc5bb437b1106
+index 0000000000000000000000000000000000000000..3e8cbd13eb16e0926130bb8b07e2101602b19565
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerArmSwingEvent.java
-@@ -0,0 +1,27 @@
+@@ -0,0 +1,29 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.player.PlayerAnimationEvent;
 +import org.bukkit.event.player.PlayerAnimationType;
 +import org.bukkit.inventory.EquipmentSlot;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +public class PlayerArmSwingEvent extends PlayerAnimationEvent {
 +
 +    private final EquipmentSlot equipmentSlot;
 +
++    @ApiStatus.Internal
 +    public PlayerArmSwingEvent(@NotNull Player player, @NotNull EquipmentSlot equipmentSlot) {
 +        super(player, equipmentSlot == EquipmentSlot.HAND ? PlayerAnimationType.ARM_SWING : PlayerAnimationType.OFF_ARM_SWING);
 +        this.equipmentSlot = equipmentSlot;

--- a/patches/api/0305-Add-PlayerSetSpawnEvent.patch
+++ b/patches/api/0305-Add-PlayerSetSpawnEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerSetSpawnEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerSetSpawnEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerSetSpawnEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c615dbe6ca1289bb090b8e28e98b9ad7b0af8b2a
+index 0000000000000000000000000000000000000000..6a823008deaf26f751e598bc967f19c15525acce
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerSetSpawnEvent.java
-@@ -0,0 +1,175 @@
+@@ -0,0 +1,178 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import net.kyori.adventure.text.Component;
@@ -18,11 +18,13 @@ index 0000000000000000000000000000000000000000..c615dbe6ca1289bb090b8e28e98b9ad7
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +/**
-+ * Called when a player's spawn is set, either by themselves or otherwise.<br>
++ * Called when a player's spawn is set, either by themselves or otherwise.
++ * <br>
 + * Cancelling this event will prevent the spawn from being set.
 + */
 +public class PlayerSetSpawnEvent extends PlayerEvent implements Cancellable {
@@ -37,8 +39,9 @@ index 0000000000000000000000000000000000000000..c615dbe6ca1289bb090b8e28e98b9ad7
 +
 +    private boolean cancelled;
 +
-+    public PlayerSetSpawnEvent(@NotNull Player who, @NotNull Cause cause, @Nullable Location location, boolean forced, boolean notifyPlayer, @Nullable Component notification) {
-+        super(who);
++    @ApiStatus.Internal
++    public PlayerSetSpawnEvent(@NotNull Player player, @NotNull Cause cause, @Nullable Location location, boolean forced, boolean notifyPlayer, @Nullable Component notification) {
++        super(player);
 +        this.cause = cause;
 +        this.location = location;
 +        this.forced = forced;
@@ -53,7 +56,7 @@ index 0000000000000000000000000000000000000000..c615dbe6ca1289bb090b8e28e98b9ad7
 +     */
 +    @NotNull
 +    public Cause getCause() {
-+        return cause;
++        return this.cause;
 +    }
 +
 +    /**
@@ -62,18 +65,18 @@ index 0000000000000000000000000000000000000000..c615dbe6ca1289bb090b8e28e98b9ad7
 +     * will change the resulting spawn point of the player. Use
 +     * {@link Location#clone()} to get a copy of this location.
 +     *
-+     * @return the spawn location, or null if removing the location
++     * @return the spawn location, or {@code null} if removing the location
 +     */
 +    @Nullable
 +    public Location getLocation() {
-+        return location;
++        return this.location;
 +    }
 +
 +    /**
 +     * Sets the location to be set as the spawn location. The yaw
 +     * of this location is the spawn angle.
 +     *
-+     * @param location the spawn location, or null to remove the spawn location
++     * @param location the spawn location, or {@code null} to remove the spawn location
 +     */
 +    public void setLocation(@Nullable Location location) {
 +        this.location = location;
@@ -82,16 +85,16 @@ index 0000000000000000000000000000000000000000..c615dbe6ca1289bb090b8e28e98b9ad7
 +    /**
 +     * Gets if this is a force spawn location
 +     *
-+     * @return true if forced
++     * @return {@code true} if forced
 +     */
 +    public boolean isForced() {
-+        return forced;
++        return this.forced;
 +    }
 +
 +    /**
 +     * Sets if this is a forced spawn location
 +     *
-+     * @param forced true to force
++     * @param forced {@code true} to force
 +     */
 +    public void setForced(boolean forced) {
 +        this.forced = forced;
@@ -101,17 +104,17 @@ index 0000000000000000000000000000000000000000..c615dbe6ca1289bb090b8e28e98b9ad7
 +     * Gets if this action will notify the player their spawn
 +     * has been set.
 +     *
-+     * @return true to notify
++     * @return {@code true} to notify
 +     */
 +    public boolean willNotifyPlayer() {
-+        return notifyPlayer;
++        return this.notifyPlayer;
 +    }
 +
 +    /**
 +     * Sets if this action will notify the player that their spawn
 +     * has been set.
 +     *
-+     * @param notifyPlayer true to notify
++     * @param notifyPlayer {@code true} to notify
 +     */
 +    public void setNotifyPlayer(boolean notifyPlayer) {
 +        this.notifyPlayer = notifyPlayer;
@@ -121,17 +124,17 @@ index 0000000000000000000000000000000000000000..c615dbe6ca1289bb090b8e28e98b9ad7
 +     * Gets the notification message that will be sent to the player
 +     * if {@link #willNotifyPlayer()} returns true.
 +     *
-+     * @return null if no notification
++     * @return {@code null} if no notification
 +     */
 +    @Nullable
 +    public Component getNotification() {
-+        return notification;
++        return this.notification;
 +    }
 +
 +    /**
 +     * Sets the notification message that will be sent to the player.
 +     *
-+     * @param notification null to send no message
++     * @param notification {@code null} to send no message
 +     */
 +    public void setNotification(@Nullable Component notification) {
 +        this.notification = notification;
@@ -175,8 +178,8 @@ index 0000000000000000000000000000000000000000..c615dbe6ca1289bb090b8e28e98b9ad7
 +         */
 +        COMMAND,
 +        /**
-+         * When a plugin uses {@link Player#setBedSpawnLocation(Location)} or
-+         * {@link Player#setBedSpawnLocation(Location, boolean)}.
++         * When a plugin uses {@link Player#setRespawnLocation(Location)} or
++         * {@link Player#setRespawnLocation(Location, boolean)}.
 +         */
 +        PLUGIN,
 +        /**

--- a/patches/api/0306-Added-EntityDamageItemEvent.patch
+++ b/patches/api/0306-Added-EntityDamageItemEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Added EntityDamageItemEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityDamageItemEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityDamageItemEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..13862939d7b633f08d5c70bfd2097c47278efcce
+index 0000000000000000000000000000000000000000..72ac972dea684a3ffac3bd48726746be0620af2e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityDamageItemEvent.java
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,81 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.entity.Entity;
@@ -17,6 +17,7 @@ index 0000000000000000000000000000000000000000..13862939d7b633f08d5c70bfd2097c47
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -28,10 +29,13 @@ index 0000000000000000000000000000000000000000..13862939d7b633f08d5c70bfd2097c47
 +public class EntityDamageItemEvent extends EntityEvent implements Cancellable {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final ItemStack item;
 +    private int damage;
++
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public EntityDamageItemEvent(@NotNull Entity entity, @NotNull ItemStack item, int damage) {
 +        super(entity);
 +        this.item = item;
@@ -45,7 +49,7 @@ index 0000000000000000000000000000000000000000..13862939d7b633f08d5c70bfd2097c47
 +     */
 +    @NotNull
 +    public ItemStack getItem() {
-+        return item;
++        return this.item;
 +    }
 +
 +    /**
@@ -54,7 +58,7 @@ index 0000000000000000000000000000000000000000..13862939d7b633f08d5c70bfd2097c47
 +     * @return durability change
 +     */
 +    public int getDamage() {
-+        return damage;
++        return this.damage;
 +    }
 +
 +    /**
@@ -68,12 +72,12 @@ index 0000000000000000000000000000000000000000..13862939d7b633f08d5c70bfd2097c47
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        cancelled = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull

--- a/patches/api/0309-Add-BlockBreakBlockEvent.patch
+++ b/patches/api/0309-Add-BlockBreakBlockEvent.patch
@@ -6,17 +6,17 @@ Subject: [PATCH] Add BlockBreakBlockEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/block/BlockBreakBlockEvent.java b/src/main/java/io/papermc/paper/event/block/BlockBreakBlockEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..51129c5c90dafdba08b7f533a71448ace56381d5
+index 0000000000000000000000000000000000000000..4f7535daf0d9967fadb0c6f8afbd3993eace410d
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/BlockBreakBlockEvent.java
-@@ -0,0 +1,60 @@
+@@ -0,0 +1,61 @@
 +package io.papermc.paper.event.block;
 +
 +import org.bukkit.block.Block;
 +import org.bukkit.event.HandlerList;
-+import org.bukkit.event.block.BlockEvent;
 +import org.bukkit.event.block.BlockExpEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +import java.util.List;
@@ -30,9 +30,10 @@ index 0000000000000000000000000000000000000000..51129c5c90dafdba08b7f533a71448ac
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    private final List<ItemStack> drops;
 +    private final Block source;
++    private final List<ItemStack> drops;
 +
++    @ApiStatus.Internal
 +    public BlockBreakBlockEvent(@NotNull Block block, @NotNull Block source, @NotNull List<ItemStack> drops) {
 +        super(block, 0);
 +        this.source = source;
@@ -40,13 +41,13 @@ index 0000000000000000000000000000000000000000..51129c5c90dafdba08b7f533a71448ac
 +    }
 +
 +    /**
-+     * Get the drops of this event
++     * Gets the drops of this event
 +     *
 +     * @return the drops
 +     */
 +    @NotNull
 +    public List<ItemStack> getDrops() {
-+        return drops;
++        return this.drops;
 +    }
 +
 +    /**
@@ -56,7 +57,7 @@ index 0000000000000000000000000000000000000000..51129c5c90dafdba08b7f533a71448ac
 +     */
 +    @NotNull
 +    public Block getSource() {
-+        return source;
++        return this.source;
 +    }
 +
 +    @NotNull

--- a/patches/api/0325-Add-PlayerItemFrameChangeEvent.patch
+++ b/patches/api/0325-Add-PlayerItemFrameChangeEvent.patch
@@ -6,19 +6,19 @@ Subject: [PATCH] Add PlayerItemFrameChangeEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerItemFrameChangeEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerItemFrameChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..451fb94a5802755c255e04aebb40f178bbfbf996
+index 0000000000000000000000000000000000000000..7bd61b66db42ecc8c9a3a16f563552414488079e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerItemFrameChangeEvent.java
-@@ -0,0 +1,97 @@
+@@ -0,0 +1,104 @@
 +package io.papermc.paper.event.player;
 +
-+import org.bukkit.Material;
 +import org.bukkit.entity.ItemFrame;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -27,12 +27,15 @@ index 0000000000000000000000000000000000000000..451fb94a5802755c255e04aebb40f178
 + */
 +public class PlayerItemFrameChangeEvent extends PlayerEvent implements Cancellable {
 +
-+    private static final HandlerList HANDLERS = new HandlerList();
-+    private boolean cancelled;
-+    private final ItemFrame itemFrame;
-+    private ItemStack itemStack;
-+    private final ItemFrameChangeAction action;
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
++    private final ItemFrame itemFrame;
++    private final ItemFrameChangeAction action;
++    private ItemStack itemStack;
++
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public PlayerItemFrameChangeEvent(@NotNull Player player, @NotNull ItemFrame itemFrame,
 +                                      @NotNull ItemStack itemStack, @NotNull ItemFrameChangeAction action) {
 +        super(player);
@@ -43,46 +46,50 @@ index 0000000000000000000000000000000000000000..451fb94a5802755c255e04aebb40f178
 +
 +    /**
 +     * Gets the {@link ItemFrame} involved in this event.
++     *
 +     * @return the {@link ItemFrame}
 +     */
 +    @NotNull
 +    public ItemFrame getItemFrame() {
-+        return itemFrame;
++        return this.itemFrame;
 +    }
 +
 +    /**
 +     * Gets the {@link ItemStack} involved in this event.
 +     * This is the item being added, rotated, or removed from the {@link ItemFrame}.
-+     * <p>If this method returns air, then the resulting item in the ItemFrame will be empty.</p>
++     * <p>
++     * If this method returns air, then the resulting item in the ItemFrame will be empty.
++     *
 +     * @return the {@link ItemStack} being added, rotated, or removed
 +     */
 +    @NotNull
 +    public ItemStack getItemStack() {
-+        return itemStack;
++        return this.itemStack;
 +    }
 +
 +    /**
 +     * Sets the {@link ItemStack} that this {@link ItemFrame} holds.
-+     * If null is provided, the ItemStack will become air and the result in the ItemFrame will be empty.
++     * If {@code null} is provided, the ItemStack will become air and the result in the ItemFrame will be empty.
++     *
 +     * @param itemStack {@link ItemFrame} item
 +     */
 +    public void setItemStack(@Nullable ItemStack itemStack) {
-+        this.itemStack = itemStack == null ? new ItemStack(Material.AIR) : itemStack;
++        this.itemStack = itemStack == null ? ItemStack.empty() : itemStack;
 +    }
 +
 +    /**
 +     * Gets the action that was performed on this {@link ItemFrame}.
-+     * @see ItemFrameChangeAction
++     *
 +     * @return action performed on the item frame in this event
 +     */
 +    @NotNull
 +    public ItemFrameChangeAction getAction() {
-+        return action;
++        return this.action;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
@@ -93,12 +100,12 @@ index 0000000000000000000000000000000000000000..451fb94a5802755c255e04aebb40f178
 +    @Override
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return HANDLERS;
++        return HANDLER_LIST;
 +    }
 +
 +    public enum ItemFrameChangeAction {

--- a/patches/api/0354-Add-TameableDeathMessageEvent.patch
+++ b/patches/api/0354-Add-TameableDeathMessageEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add TameableDeathMessageEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/TameableDeathMessageEvent.java b/src/main/java/io/papermc/paper/event/entity/TameableDeathMessageEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..70cd37aefbd5d64c798ab2fc3b6d502134690348
+index 0000000000000000000000000000000000000000..5d449b90829bca7a6ff3060b637561d8f99dc156
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/TameableDeathMessageEvent.java
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,72 @@
 +package io.papermc.paper.event.entity;
 +
 +import net.kyori.adventure.text.Component;
@@ -17,6 +17,7 @@ index 0000000000000000000000000000000000000000..70cd37aefbd5d64c798ab2fc3b6d5021
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -24,12 +25,14 @@ index 0000000000000000000000000000000000000000..70cd37aefbd5d64c798ab2fc3b6d5021
 + */
 +public class TameableDeathMessageEvent extends EntityEvent implements Cancellable {
 +
-+    private static final HandlerList handlers = new HandlerList();
-+    private boolean cancelled;
-+    private Component deathMessage;
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    public TameableDeathMessageEvent(@NotNull Tameable what, @NotNull Component deathMessage) {
-+        super(what);
++    private Component deathMessage;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
++    public TameableDeathMessageEvent(@NotNull Tameable tameable, @NotNull Component deathMessage) {
++        super(tameable);
 +        this.deathMessage = deathMessage;
 +    }
 +
@@ -49,12 +52,18 @@ index 0000000000000000000000000000000000000000..70cd37aefbd5d64c798ab2fc3b6d5021
 +     */
 +    @NotNull
 +    public Component deathMessage() {
-+        return deathMessage;
++        return this.deathMessage;
++    }
++
++    @NotNull
++    @Override
++    public Tameable getEntity() {
++        return (Tameable) super.getEntity();
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
@@ -64,18 +73,12 @@ index 0000000000000000000000000000000000000000..70cd37aefbd5d64c798ab2fc3b6d5021
 +
 +    @NotNull
 +    @Override
-+    public Tameable getEntity() {
-+        return (Tameable) super.getEntity();
-+    }
-+
-+    @NotNull
-+    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0359-Add-EntityDyeEvent-and-CollarColorable-interface.patch
+++ b/patches/api/0359-Add-EntityDyeEvent-and-CollarColorable-interface.patch
@@ -37,33 +37,39 @@ index 0000000000000000000000000000000000000000..bb68e6a2528eee81eb3f26f22b9c3550
 +}
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityDyeEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityDyeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..aefbaccd32f1ab25a4da63bdc878922e0c220478
+index 0000000000000000000000000000000000000000..c43a3ad32902dbb13287e801375213745ce07b3c
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityDyeEvent.java
-@@ -0,0 +1,75 @@
+@@ -0,0 +1,81 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.DyeColor;
++import org.bukkit.entity.Cat;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.entity.Player;
++import org.bukkit.entity.Sheep;
++import org.bukkit.entity.Wolf;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +/**
-+ * Called when an entity is dyed. Currently, this is called for {@link org.bukkit.entity.Sheep}
-+ * being dyed, and {@link org.bukkit.entity.Wolf}/{@link org.bukkit.entity.Cat} collars being dyed.
++ * Called when an entity is dyed. Currently, this is called for {@link Sheep}
++ * being dyed, and {@link Wolf}/{@link Cat} collars being dyed.
 + */
 +public class EntityDyeEvent extends EntityEvent implements Cancellable {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    private DyeColor dyeColor;
 +    private final Player player;
-+    private boolean cancel;
++    private DyeColor dyeColor;
 +
++    private boolean cancelled;
++
++    @ApiStatus.Internal
 +    public EntityDyeEvent(@NotNull Entity entity, @NotNull DyeColor dyeColor, @Nullable Player player) {
 +        super(entity);
 +        this.dyeColor = dyeColor;
@@ -91,20 +97,20 @@ index 0000000000000000000000000000000000000000..aefbaccd32f1ab25a4da63bdc878922e
 +    /**
 +     * Returns the player dyeing the entity, if available.
 +     *
-+     * @return player or null
++     * @return player or {@code null}
 +     */
 +    public @Nullable Player getPlayer() {
-+        return player;
++        return this.player;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return this.cancel;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        this.cancel = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @Override
@@ -117,7 +123,7 @@ index 0000000000000000000000000000000000000000..aefbaccd32f1ab25a4da63bdc878922e
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Cat.java b/src/main/java/org/bukkit/entity/Cat.java
-index 9bc385682472418c787481bbc809f238194d5918..4ea1027c8540cdba82acf829d0720846b3a13e3e 100644
+index 0534fbc228f64cf3b361ab097d9b88212bdb0f36..d03adfaa4176617ef2ace2754fe02b63860e3aee 100644
 --- a/src/main/java/org/bukkit/entity/Cat.java
 +++ b/src/main/java/org/bukkit/entity/Cat.java
 @@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;

--- a/patches/api/0360-Add-PlayerStopUsingItemEvent.patch
+++ b/patches/api/0360-Add-PlayerStopUsingItemEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerStopUsingItemEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerStopUsingItemEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerStopUsingItemEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3689551baf2c9880f3e2a70435f8b4ad05cba49a
+index 0000000000000000000000000000000000000000..bbe5f0543a567f1484ab700b1b2ceeb4a22b411b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerStopUsingItemEvent.java
-@@ -0,0 +1,53 @@
+@@ -0,0 +1,55 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Player;
@@ -23,7 +23,9 @@ index 0000000000000000000000000000000000000000..3689551baf2c9880f3e2a70435f8b4ad
 + * Examples of this are letting go of the interact button when holding a bow, an edible item, or a spyglass.
 + */
 +public class PlayerStopUsingItemEvent extends PlayerEvent {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    @NotNull private final ItemStack item;
 +    private final int ticksHeldFor;
 +
@@ -40,7 +42,7 @@ index 0000000000000000000000000000000000000000..3689551baf2c9880f3e2a70435f8b4ad
 +     */
 +    @NotNull
 +    public ItemStack getItem() {
-+        return item;
++        return this.item;
 +    }
 +
 +    /**
@@ -49,17 +51,17 @@ index 0000000000000000000000000000000000000000..3689551baf2c9880f3e2a70435f8b4ad
 +     * @return int the number of ticks the item was held for
 +     */
 +    public int getTicksHeldFor() {
-+        return ticksHeldFor;
++        return this.ticksHeldFor;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0363-Add-WardenAngerChangeEvent.patch
+++ b/patches/api/0363-Add-WardenAngerChangeEvent.patch
@@ -8,12 +8,13 @@ another entity.
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/WardenAngerChangeEvent.java b/src/main/java/io/papermc/paper/event/entity/WardenAngerChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6da98b535c9ba57942faa62e1172a62b84ab0b6a
+index 0000000000000000000000000000000000000000..7f738c1116feae8e8571488d516fab2ab6c0244e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/WardenAngerChangeEvent.java
-@@ -0,0 +1,105 @@
+@@ -0,0 +1,108 @@
 +package io.papermc.paper.event.entity;
 +
++import com.google.common.base.Preconditions;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.entity.Warden;
 +import org.bukkit.event.Cancellable;
@@ -21,6 +22,7 @@ index 0000000000000000000000000000000000000000..6da98b535c9ba57942faa62e1172a62b
 +import org.bukkit.event.entity.EntityEvent;
 +import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Range;
 +
 +/**
 + * Called when a Warden's anger level has changed due to another entity.
@@ -31,10 +33,11 @@ index 0000000000000000000000000000000000000000..6da98b535c9ba57942faa62e1172a62b
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    private boolean cancelled;
 +    private final Entity target;
 +    private final int oldAnger;
 +    private int newAnger;
++
++    private boolean cancelled;
 +
 +    @ApiStatus.Internal
 +    public WardenAngerChangeEvent(@NotNull final Warden warden, @NotNull final Entity target, final int oldAnger, final int newAnger) {
@@ -51,7 +54,7 @@ index 0000000000000000000000000000000000000000..6da98b535c9ba57942faa62e1172a62b
 +     */
 +    @NotNull
 +    public Entity getTarget() {
-+        return target;
++        return this.target;
 +    }
 +
 +    /**
@@ -60,8 +63,9 @@ index 0000000000000000000000000000000000000000..6da98b535c9ba57942faa62e1172a62b
 +     * @return old anger level
 +     * @see Warden#getAnger(Entity)
 +     */
++    @Range(from = 0, to = 150)
 +    public int getOldAnger() {
-+        return oldAnger;
++        return this.oldAnger;
 +    }
 +
 +    /**
@@ -70,8 +74,9 @@ index 0000000000000000000000000000000000000000..6da98b535c9ba57942faa62e1172a62b
 +     * @return new anger level
 +     * @see Warden#getAnger(Entity)
 +     */
++    @Range(from = 0, to = 150)
 +    public int getNewAnger() {
-+        return newAnger;
++        return this.newAnger;
 +    }
 +
 +    /**
@@ -83,27 +88,25 @@ index 0000000000000000000000000000000000000000..6da98b535c9ba57942faa62e1172a62b
 +     * @see Warden#setAnger(Entity, int)
 +     * @throws IllegalArgumentException if newAnger is greater than 150
 +     */
-+    public void setNewAnger(int newAnger) {
-+        if (newAnger > 150)
-+            throw new IllegalArgumentException("newAnger must not be greater than 150");
-+
++    public void setNewAnger(@Range(from = 0, to = 150) int newAnger) {
++        Preconditions.checkArgument(newAnger <= 150, "newAnger must not be greater than 150");
 +        this.newAnger = newAnger;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public Warden getEntity() {
-+        return (Warden) entity;
++        return (Warden) super.getEntity();
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
-+    public void setCancelled(boolean cancelled) {
-+        this.cancelled = cancelled;
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull

--- a/patches/api/0367-Add-EntityPortalReadyEvent.patch
+++ b/patches/api/0367-Add-EntityPortalReadyEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add EntityPortalReadyEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityPortalReadyEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityPortalReadyEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3c6c1d7e97a0c9813bbc585fd209cc63f498e0d4
+index 0000000000000000000000000000000000000000..3450735c86a8af45491c010a796262ae892f14dc
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityPortalReadyEvent.java
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,94 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.PortalType;
@@ -18,6 +18,9 @@ index 0000000000000000000000000000000000000000..3c6c1d7e97a0c9813bbc585fd209cc63
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.bukkit.event.entity.EntityPortalEvent;
++import org.bukkit.event.player.PlayerPortalEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -33,10 +36,12 @@ index 0000000000000000000000000000000000000000..3c6c1d7e97a0c9813bbc585fd209cc63
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    private World targetWorld;
 +    private final PortalType portalType;
++    private World targetWorld;
++
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public EntityPortalReadyEvent(final @NotNull Entity entity, final @Nullable World targetWorld, final @NotNull PortalType portalType) {
 +        super(entity);
 +        this.targetWorld = targetWorld;
@@ -45,25 +50,25 @@ index 0000000000000000000000000000000000000000..3c6c1d7e97a0c9813bbc585fd209cc63
 +
 +    /**
 +     * Gets the world this portal will teleport to.
-+     * Can be null if "allow-nether" is false in server.properties
++     * Can be {@code null} if "allow-nether" is false in server.properties
 +     * or if there is another situation where there is no world to teleport to.
 +     * <p>
-+     * This world may be modified by later events such as {@link org.bukkit.event.player.PlayerPortalEvent}
-+     * or {@link org.bukkit.event.entity.EntityPortalEvent}.
++     * This world may be modified by later events such as {@link PlayerPortalEvent}
++     * or {@link EntityPortalEvent}.
 +     *
 +     * @return the world the portal will teleport the entity to.
 +     */
 +    public @Nullable World getTargetWorld() {
-+        return targetWorld;
++        return this.targetWorld;
 +    }
 +
 +    /**
-+     * Sets the world this portal will teleport to. A null value
++     * Sets the world this portal will teleport to. A {@code null} value
 +     * will essentially cancel the teleport and prevent further events
-+     * such as {@link org.bukkit.event.player.PlayerPortalEvent} from firing.
++     * such as {@link PlayerPortalEvent} from firing.
 +     * <p>
-+     * This world may be modified by later events such as {@link org.bukkit.event.player.PlayerPortalEvent}
-+     * or {@link org.bukkit.event.entity.EntityPortalEvent}.
++     * This world may be modified by later events such as {@link PlayerPortalEvent}
++     * or {@link EntityPortalEvent}.
 +     *
 +     * @param targetWorld the world
 +     */
@@ -77,12 +82,12 @@ index 0000000000000000000000000000000000000000..3c6c1d7e97a0c9813bbc585fd209cc63
 +     * @return the portal type
 +     */
 +    public @NotNull PortalType getPortalType() {
-+        return portalType;
++        return this.portalType;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override

--- a/patches/api/0377-Add-PlayerInventorySlotChangeEvent.patch
+++ b/patches/api/0377-Add-PlayerInventorySlotChangeEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerInventorySlotChangeEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerInventorySlotChangeEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerInventorySlotChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0a3e3b56b754d8838674c88105bd1312b96eb69d
+index 0000000000000000000000000000000000000000..0be9708dbf84fa51a754474834406f9fa7457dbe
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerInventorySlotChangeEvent.java
-@@ -0,0 +1,99 @@
+@@ -0,0 +1,101 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Player;
@@ -23,7 +23,9 @@ index 0000000000000000000000000000000000000000..0a3e3b56b754d8838674c88105bd1312
 + * Called when a slot contents change in a player's inventory.
 + */
 +public class PlayerInventorySlotChangeEvent extends PlayerEvent {
-+    private static final HandlerList handlers = new HandlerList();
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final int rawSlot;
 +    private final int slot;
 +    private final ItemStack oldItemStack;
@@ -44,7 +46,7 @@ index 0000000000000000000000000000000000000000..0a3e3b56b754d8838674c88105bd1312
 +     * @return The raw slot number.
 +     */
 +    public int getRawSlot() {
-+        return rawSlot;
++        return this.rawSlot;
 +    }
 +
 +    /**
@@ -57,7 +59,7 @@ index 0000000000000000000000000000000000000000..0a3e3b56b754d8838674c88105bd1312
 +     * @return The slot number.
 +     */
 +    public int getSlot() {
-+        return slot;
++        return this.slot;
 +    }
 +
 +    /**
@@ -67,7 +69,7 @@ index 0000000000000000000000000000000000000000..0a3e3b56b754d8838674c88105bd1312
 +     */
 +    @NotNull
 +    public ItemStack getOldItemStack() {
-+        return oldItemStack;
++        return this.oldItemStack;
 +    }
 +
 +    /**
@@ -77,7 +79,7 @@ index 0000000000000000000000000000000000000000..0a3e3b56b754d8838674c88105bd1312
 +     */
 +    @NotNull
 +    public ItemStack getNewItemStack() {
-+        return newItemStack;
++        return this.newItemStack;
 +    }
 +
 +    /**
@@ -86,7 +88,7 @@ index 0000000000000000000000000000000000000000..0a3e3b56b754d8838674c88105bd1312
 +     * @return Whether the slot change advancements will be triggered.
 +     */
 +    public boolean shouldTriggerAdvancements() {
-+        return triggerAdvancements;
++        return this.triggerAdvancements;
 +    }
 +
 +    /**
@@ -101,11 +103,11 @@ index 0000000000000000000000000000000000000000..0a3e3b56b754d8838674c88105bd1312
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0383-Added-EntityToggleSitEvent.patch
+++ b/patches/api/0383-Added-EntityToggleSitEvent.patch
@@ -6,16 +6,17 @@ Subject: [PATCH] Added EntityToggleSitEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityToggleSitEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityToggleSitEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b53e9eb7df916721ad79925d711624b3da5619bb
+index 0000000000000000000000000000000000000000..06222a8c7a19909582a00fd2e1553cc0be9d88e3
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityToggleSitEvent.java
-@@ -0,0 +1,53 @@
+@@ -0,0 +1,55 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.entity.Entity;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -25,9 +26,10 @@ index 0000000000000000000000000000000000000000..b53e9eb7df916721ad79925d711624b3
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    private boolean cancelled;
 +    private final boolean isSitting;
++    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public EntityToggleSitEvent(@NotNull Entity entity, boolean isSitting) {
 +        super(entity);
 +        this.isSitting = isSitting;

--- a/patches/api/0385-Add-PrePlayerAttackEntityEvent.patch
+++ b/patches/api/0385-Add-PrePlayerAttackEntityEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PrePlayerAttackEntityEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PrePlayerAttackEntityEvent.java b/src/main/java/io/papermc/paper/event/player/PrePlayerAttackEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d49999ea597ef247bbf2298e6bf5600bfe003c3e
+index 0000000000000000000000000000000000000000..148f46f4572a778f090b461808b53cf9cad10e11
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PrePlayerAttackEntityEvent.java
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,93 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Entity;
@@ -17,18 +17,19 @@ index 0000000000000000000000000000000000000000..d49999ea597ef247bbf2298e6bf5600b
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Called when the player tries to attack an entity.
-+ *
++ * <p>
 + * This occurs before any of the damage logic, so cancelling this event
 + * will prevent any sort of sounds from being played when attacking.
-+ *
++ * <p>
 + * This event will fire as cancelled for certain entities, with {@link PrePlayerAttackEntityEvent#willAttack()} being false
 + * to indicate that this entity will not actually be attacked.
 + * <p>
-+ * Note: there may be other factors (invulnerability, etc) that will prevent this entity from being attacked that this event will not cover
++ * Note: there may be other factors (invulnerability, etc.) that will prevent this entity from being attacked that this event will not cover
 + */
 +public class PrePlayerAttackEntityEvent extends PlayerEvent implements Cancellable {
 +
@@ -36,11 +37,13 @@ index 0000000000000000000000000000000000000000..d49999ea597ef247bbf2298e6bf5600b
 +
 +    @NotNull
 +    private final Entity attacked;
-+    private boolean cancelled;
 +    private final boolean willAttack;
 +
-+    public PrePlayerAttackEntityEvent(@NotNull Player who, @NotNull Entity attacked, boolean willAttack) {
-+        super(who);
++    private boolean cancelled;
++
++    @ApiStatus.Internal
++    public PrePlayerAttackEntityEvent(@NotNull Player player, @NotNull Entity attacked, boolean willAttack) {
++        super(player);
 +        this.attacked = attacked;
 +        this.willAttack = willAttack;
 +        this.cancelled = !willAttack;
@@ -48,6 +51,7 @@ index 0000000000000000000000000000000000000000..d49999ea597ef247bbf2298e6bf5600b
 +
 +    /**
 +     * Gets the entity that was attacked in this event.
++     *
 +     * @return entity that was attacked
 +     */
 +    @NotNull
@@ -57,14 +61,35 @@ index 0000000000000000000000000000000000000000..d49999ea597ef247bbf2298e6bf5600b
 +
 +    /**
 +     * Gets if this entity will be attacked normally.
-+     * Entities like falling sand will return false because
++     * Entities like falling sand will return {@code false} because
 +     * their entity type does not allow them to be attacked.
 +     * <p>
-+     * Note: there may be other factors (invulnerability, etc) that will prevent this entity from being attacked that this event will not cover
++     * Note: there may be other factors (invulnerability, etc.) that will prevent this entity from being attacked that this event will not cover
++     *
 +     * @return if the entity will actually be attacked
 +     */
 +    public boolean willAttack() {
 +        return this.willAttack;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    /**
++     * Sets if this attack should be cancelled, note if {@link PrePlayerAttackEntityEvent#willAttack()} returns false
++     * this event will always be cancelled.
++     *
++     * @param cancel {@code true} if you wish to cancel this event
++     */
++    @Override
++    public void setCancelled(boolean cancel) {
++        if (!this.willAttack) {
++            return;
++        }
++
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
@@ -76,24 +101,5 @@ index 0000000000000000000000000000000000000000..d49999ea597ef247bbf2298e6bf5600b
 +    @NotNull
 +    public static HandlerList getHandlerList() {
 +        return HANDLER_LIST;
-+    }
-+
-+    @Override
-+    public boolean isCancelled() {
-+        return this.cancelled;
-+    }
-+
-+    /**
-+     * Sets if this attack should be cancelled, note if {@link PrePlayerAttackEntityEvent#willAttack()} returns false
-+     * this event will always be cancelled.
-+     * @param cancel true if you wish to cancel this event
-+     */
-+    @Override
-+    public void setCancelled(boolean cancel) {
-+        if (!this.willAttack) {
-+            return;
-+        }
-+
-+        this.cancelled = cancel;
 +    }
 +}

--- a/patches/api/0388-Add-paper-dumplisteners-command.patch
+++ b/patches/api/0388-Add-paper-dumplisteners-command.patch
@@ -56,10 +56,10 @@ index 5b28e9b1daba7834af67dbc193dd656bedd9a994..fbebf649e893cf872be9b27091146a7c
 +    }
  }
 diff --git a/src/main/java/com/destroystokyo/paper/event/executor/StaticMethodHandleEventExecutor.java b/src/main/java/com/destroystokyo/paper/event/executor/StaticMethodHandleEventExecutor.java
-index c83672427324bd068ed52916f700b68446a226f6..87ea5354808dbbdefbdfc78f352a543f72a0d033 100644
+index 827f2b27f70a7ec0bc11d039305c3e58c02a4ef4..52da2d040e3b335f9e47bc5dc26e17d9c06d9569 100644
 --- a/src/main/java/com/destroystokyo/paper/event/executor/StaticMethodHandleEventExecutor.java
 +++ b/src/main/java/com/destroystokyo/paper/event/executor/StaticMethodHandleEventExecutor.java
-@@ -18,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
+@@ -17,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
  public class StaticMethodHandleEventExecutor implements EventExecutor {
      private final Class<? extends Event> eventClass;
      private final MethodHandle handle;
@@ -67,7 +67,7 @@ index c83672427324bd068ed52916f700b68446a226f6..87ea5354808dbbdefbdfc78f352a543f
  
      public StaticMethodHandleEventExecutor(@NotNull Class<? extends Event> eventClass, @NotNull Method m) {
          Preconditions.checkArgument(Modifier.isStatic(m.getModifiers()), "Not a static method: %s", m);
-@@ -29,6 +30,7 @@ public class StaticMethodHandleEventExecutor implements EventExecutor {
+@@ -28,6 +29,7 @@ public class StaticMethodHandleEventExecutor implements EventExecutor {
          } catch (IllegalAccessException e) {
              throw new AssertionError("Unable to set accessible", e);
          }
@@ -75,7 +75,7 @@ index c83672427324bd068ed52916f700b68446a226f6..87ea5354808dbbdefbdfc78f352a543f
      }
  
      @Override
-@@ -40,4 +42,10 @@ public class StaticMethodHandleEventExecutor implements EventExecutor {
+@@ -39,4 +41,10 @@ public class StaticMethodHandleEventExecutor implements EventExecutor {
              SneakyThrow.sneaky(throwable);
          }
      }

--- a/patches/api/0392-Player-Entity-Tracking-Events.patch
+++ b/patches/api/0392-Player-Entity-Tracking-Events.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Player Entity Tracking Events
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerTrackEntityEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerTrackEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..40024c8d5fe81e23eae9b37a08fca34a91e40011
+index 0000000000000000000000000000000000000000..356f8933a7715b4fc123e3a4879bb2cd085835c5
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerTrackEntityEvent.java
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,62 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Entity;
@@ -17,6 +17,7 @@ index 0000000000000000000000000000000000000000..40024c8d5fe81e23eae9b37a08fca34a
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -29,24 +30,15 @@ index 0000000000000000000000000000000000000000..40024c8d5fe81e23eae9b37a08fca34a
 + */
 +public class PlayerTrackEntityEvent extends PlayerEvent implements Cancellable {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final Entity entity;
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public PlayerTrackEntityEvent(@NotNull Player player, @NotNull Entity entity) {
 +        super(player);
 +        this.entity = entity;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    @Override
-+    public HandlerList getHandlers() {
-+        return handlers;
 +    }
 +
 +    /**
@@ -56,31 +48,43 @@ index 0000000000000000000000000000000000000000..40024c8d5fe81e23eae9b37a08fca34a
 +     */
 +    @NotNull
 +    public Entity getEntity() {
-+        return entity;
++        return this.entity;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
 +        this.cancelled = cancel;
 +    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerUntrackEntityEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerUntrackEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..82bb2d2b4bf05d7b4e8dd22280deb04433c2ad9e
+index 0000000000000000000000000000000000000000..c573eeaeb599ca717b09f9fd3f106a4800e9c386
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerUntrackEntityEvent.java
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,48 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Entity;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -91,31 +95,34 @@ index 0000000000000000000000000000000000000000..82bb2d2b4bf05d7b4e8dd22280deb044
 + */
 +public class PlayerUntrackEntityEvent extends PlayerEvent {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final Entity entity;
 +
++    @ApiStatus.Internal
 +    public PlayerUntrackEntityEvent(@NotNull Player player, @NotNull Entity entity) {
 +        super(player);
 +        this.entity = entity;
 +    }
 +
++    /**
++     * Gets the entity that will be untracked
++     *
++     * @return the entity untracked
++     */
++    @NotNull
++    public Entity getEntity() {
++        return this.entity;
++    }
++
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    /**
-+     * Gets the entity that will be untracked
-+     * @return the entity untracked
-+     */
-+    @NotNull
-+    public Entity getEntity() {
-+        return entity;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0395-Add-BlockLockCheckEvent.patch
+++ b/patches/api/0395-Add-BlockLockCheckEvent.patch
@@ -23,33 +23,31 @@ index 0000000000000000000000000000000000000000..f309961e0e96b6baacc4fe6d80dabd6c
 +}
 diff --git a/src/main/java/io/papermc/paper/event/block/BlockLockCheckEvent.java b/src/main/java/io/papermc/paper/event/block/BlockLockCheckEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d298ebecaa6e0a4cdc273e326d1976d27efe0e32
+index 0000000000000000000000000000000000000000..4c335212f6a5ad4a304c3c0f66ffd7e0974c0572
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/BlockLockCheckEvent.java
-@@ -0,0 +1,187 @@
+@@ -0,0 +1,186 @@
 +package io.papermc.paper.event.block;
 +
 +import com.google.common.base.Preconditions;
 +import io.papermc.paper.block.LockableTileState;
 +import net.kyori.adventure.sound.Sound;
 +import net.kyori.adventure.text.Component;
-+import org.bukkit.Nameable;
 +import org.bukkit.block.Block;
-+import org.bukkit.block.BlockState;
-+import org.bukkit.block.Lockable;
-+import org.bukkit.block.TileState;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.block.BlockEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +import java.util.Objects;
 +
 +/**
-+ * Called when the server tries to check the lock on a lockable tile entity.
-+ * @see #setResult(Result) to change behavior
++ * Called when the server tries to check the lock on a lockable block entity.
++ * <br>
++ * See {@link #setResult(Result)} to change behavior
 + */
 +public class BlockLockCheckEvent extends BlockEvent {
 +
@@ -57,11 +55,12 @@ index 0000000000000000000000000000000000000000..d298ebecaa6e0a4cdc273e326d1976d2
 +
 +    private final LockableTileState state;
 +    private final Player player;
-+    private ItemStack itemStack;
-+    private Result result = Result.DEFAULT;
 +    private Component lockedMessage;
 +    private Sound lockedSound;
++    private ItemStack itemStack;
++    private Result result = Result.DEFAULT;
 +
++    @ApiStatus.Internal
 +    public BlockLockCheckEvent(final @NotNull Block block, final @NotNull LockableTileState state, final @NotNull Player player, final @NotNull Component lockedMessage, final @NotNull Sound lockedSound) {
 +        super(block);
 +        this.state = state;
@@ -71,7 +70,7 @@ index 0000000000000000000000000000000000000000..d298ebecaa6e0a4cdc273e326d1976d2
 +    }
 +
 +    /**
-+     * Gets the snapshot {@link LockableTileState} of the tile entity
++     * Gets the snapshot {@link LockableTileState} of the block entity
 +     * whose lock is being checked.
 +     *
 +     * @return the snapshot block state.
@@ -105,11 +104,11 @@ index 0000000000000000000000000000000000000000..d298ebecaa6e0a4cdc273e326d1976d2
 +    /**
 +     * Sets the itemstack that will be used as the key item.
 +     *
-+     * @param stack the stack to use as a key (or null to fall back to the player's main hand item)
++     * @param stack the stack to use as a key
 +     * @see #resetKeyItem() to clear a custom key item
 +     */
 +    public void setKeyItem(@NotNull ItemStack stack) {
-+        Preconditions.checkNotNull(stack, "stack is null");
++        Preconditions.checkArgument(stack != null, "stack cannot be null");
 +        this.itemStack = stack;
 +    }
 +
@@ -123,7 +122,7 @@ index 0000000000000000000000000000000000000000..d298ebecaa6e0a4cdc273e326d1976d2
 +    /**
 +     * Checks if a custom key stack has been set.
 +     *
-+     * @return true if a custom key itemstack has been set
++     * @return {@code true} if a custom key itemstack has been set
 +     */
 +    public boolean isUsingCustomKeyItemStack() {
 +        return this.itemStack != null;
@@ -140,11 +139,11 @@ index 0000000000000000000000000000000000000000..d298ebecaa6e0a4cdc273e326d1976d2
 +    }
 +
 +    /**
-+     * Gets the result of this event. {@link org.bukkit.event.Event.Result#DEFAULT} is the default
-+     * allowing the vanilla logic to check the lock of this block. Set to {@link org.bukkit.event.Event.Result#ALLOW}
-+     * or {@link org.bukkit.event.Event.Result#DENY} to override that behavior.
++     * Gets the result of this event. {@link Result#DEFAULT} is the default
++     * allowing the vanilla logic to check the lock of this block. Set to {@link Result#ALLOW}
++     * or {@link Result#DENY} to override that behavior.
 +     * <p>
-+     * Setting this to {@link org.bukkit.event.Event.Result#ALLOW} bypasses the spectator check.
++     * Setting this to {@link Result#ALLOW} bypasses the spectator check.
 +     *
 +     * @param result the result of this event
 +     */
@@ -153,11 +152,11 @@ index 0000000000000000000000000000000000000000..d298ebecaa6e0a4cdc273e326d1976d2
 +    }
 +
 +    /**
-+     * Shorthand method to set the {@link #getResult()} to {@link org.bukkit.event.Event.Result#DENY},
++     * Shorthand method to set the {@link #getResult()} to {@link Result#DENY},
 +     * the locked message and locked sound.
 +     *
-+     * @param lockedMessage the message to show if locked (or null for none)
-+     * @param lockedSound the sound to play if locked (or null for none)
++     * @param lockedMessage the message to show if locked (or {@code null} for none)
++     * @param lockedSound the sound to play if locked (or {@code null} for none)
 +     */
 +    public void denyWithMessageAndSound(@Nullable Component lockedMessage, @Nullable Sound lockedSound) {
 +        this.result = Result.DENY;
@@ -169,7 +168,7 @@ index 0000000000000000000000000000000000000000..d298ebecaa6e0a4cdc273e326d1976d2
 +     * Gets the locked message that will be sent if the
 +     * player cannot open the block.
 +     *
-+     * @return the locked message (or null if none)
++     * @return the locked message (or {@code null} if none)
 +     */
 +    public @Nullable Component getLockedMessage() {
 +        return this.lockedMessage;
@@ -179,7 +178,7 @@ index 0000000000000000000000000000000000000000..d298ebecaa6e0a4cdc273e326d1976d2
 +     * Sets the locked message that will be sent if the
 +     * player cannot open the block.
 +     *
-+     * @param lockedMessage the locked message (or null for none)
++     * @param lockedMessage the locked message (or {@code null} for none)
 +     */
 +    public void setLockedMessage(@Nullable Component lockedMessage) {
 +        this.lockedMessage = lockedMessage;
@@ -189,7 +188,7 @@ index 0000000000000000000000000000000000000000..d298ebecaa6e0a4cdc273e326d1976d2
 +     * Gets the locked sound that will play if the
 +     * player cannot open the block.
 +     *
-+     * @return the locked sound (or null if none)
++     * @return the locked sound (or {@code null} if none)
 +     */
 +    public @Nullable Sound getLockedSound() {
 +        return this.lockedSound;
@@ -199,7 +198,7 @@ index 0000000000000000000000000000000000000000..d298ebecaa6e0a4cdc273e326d1976d2
 +     * Sets the locked sound that will play if the
 +     * player cannot open the block.
 +     *
-+     * @param lockedSound the locked sound (or null for none)
++     * @param lockedSound the locked sound (or {@code null} for none)
 +     */
 +    public void setLockedSound(@Nullable Sound lockedSound) {
 +        this.lockedSound = lockedSound;

--- a/patches/api/0404-Add-EntityFertilizeEggEvent.patch
+++ b/patches/api/0404-Add-EntityFertilizeEggEvent.patch
@@ -6,32 +6,34 @@ Subject: [PATCH] Add EntityFertilizeEggEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityFertilizeEggEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityFertilizeEggEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..adc596cae5e4a6e52c51eba16b5aa37410d30e5c
+index 0000000000000000000000000000000000000000..35d54650c53bc64dd7c440240ad2f2b9b87d7ae8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityFertilizeEggEvent.java
-@@ -0,0 +1,140 @@
+@@ -0,0 +1,139 @@
 +package io.papermc.paper.event.entity;
 +
-+import com.google.common.base.Preconditions;
++import org.bukkit.Material;
 +import org.bukkit.entity.LivingEntity;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityBreedEvent;
 +import org.bukkit.event.entity.EntityEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +/**
 + * Called when two entities mate and the mating process results in a fertilization.
-+ * Fertilization differs from normal breeding, as represented by the {@link org.bukkit.event.entity.EntityBreedEvent}, as
++ * Fertilization differs from normal breeding, as represented by the {@link EntityBreedEvent}, as
 + * it does not result in the immediate creation of the child entity in the world.
 + * <p>
 + * An example of this would be:
 + * <ul>
-+ * <li>A frog being marked as "is_pregnant" and laying {@link org.bukkit.Material#FROGSPAWN} later.</li>
-+ * <li>Sniffers producing the {@link org.bukkit.Material#SNIFFER_EGG} item, which needs to be placed before it can begin to hatch.</li>
-+ * <li>A turtle being marked with "HasEgg" and laying a {@link org.bukkit.Material#TURTLE_EGG} later.</li>
++ * <li>A frog being marked as "is_pregnant" and laying {@link Material#FROGSPAWN} later.</li>
++ * <li>Sniffers producing the {@link Material#SNIFFER_EGG} item, which needs to be placed before it can begin to hatch.</li>
++ * <li>A turtle being marked with "HasEgg" and laying a {@link Material#TURTLE_EGG} later.</li>
 + * </ul>
 + *
 + * The event hence only exposes the two parent entities in the fertilization process and cannot provide the child entity, as it will only exist at a later point in time.
@@ -46,14 +48,11 @@ index 0000000000000000000000000000000000000000..adc596cae5e4a6e52c51eba16b5aa374
 +    private final ItemStack bredWith;
 +    private int experience;
 +
-+    private boolean cancel;
++    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public EntityFertilizeEggEvent(@NotNull LivingEntity mother, @NotNull LivingEntity father, @Nullable Player breeder, @Nullable ItemStack bredWith, int experience) {
 +        super(mother);
-+        Preconditions.checkArgument(mother != null, "Cannot have null mother");
-+        Preconditions.checkArgument(father != null, "Cannot have null father");
-+
-+        // Breeder can be null in the case of spontaneous conception
 +        this.mother = mother;
 +        this.father = father;
 +        this.breeder = breeder;
@@ -64,7 +63,7 @@ index 0000000000000000000000000000000000000000..adc596cae5e4a6e52c51eba16b5aa374
 +    @NotNull
 +    @Override
 +    public LivingEntity getEntity() {
-+        return (LivingEntity) entity;
++        return (LivingEntity) super.getEntity();
 +    }
 +
 +    /**
@@ -75,7 +74,7 @@ index 0000000000000000000000000000000000000000..adc596cae5e4a6e52c51eba16b5aa374
 +     */
 +    @NotNull
 +    public LivingEntity getMother() {
-+        return mother;
++        return this.mother;
 +    }
 +
 +    /**
@@ -86,28 +85,28 @@ index 0000000000000000000000000000000000000000..adc596cae5e4a6e52c51eba16b5aa374
 +     */
 +    @NotNull
 +    public LivingEntity getFather() {
-+        return father;
++        return this.father;
 +    }
 +
 +    /**
-+     * Gets the Entity responsible for fertilization. Breeder is null for spontaneous
++     * Gets the Entity responsible for fertilization. Breeder is {@code null} for spontaneous
 +     * conception.
 +     *
-+     * @return The Entity who initiated breeding.
++     * @return The Entity who initiated fertilization.
 +     */
 +    @Nullable
 +    public Player getBreeder() {
-+        return breeder;
++        return this.breeder;
 +    }
 +
 +    /**
 +     * The ItemStack that was used to initiate fertilization, if present.
 +     *
-+     * @return ItemStack used to initiate breeding.
++     * @return ItemStack used to initiate fertilization.
 +     */
 +    @Nullable
 +    public ItemStack getBredWith() {
-+        return bredWith;
++        return this.bredWith;
 +    }
 +
 +    /**
@@ -116,7 +115,7 @@ index 0000000000000000000000000000000000000000..adc596cae5e4a6e52c51eba16b5aa374
 +     * @return experience amount
 +     */
 +    public int getExperience() {
-+        return experience;
++        return this.experience;
 +    }
 +
 +    /**
@@ -131,12 +130,12 @@ index 0000000000000000000000000000000000000000..adc596cae5e4a6e52c51eba16b5aa374
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancel;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        this.cancel = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull

--- a/patches/api/0405-Add-CompostItemEvent-and-EntityCompostItemEvent.patch
+++ b/patches/api/0405-Add-CompostItemEvent-and-EntityCompostItemEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add CompostItemEvent and EntityCompostItemEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/block/CompostItemEvent.java b/src/main/java/io/papermc/paper/event/block/CompostItemEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..150c6c1468a36bf51f53b6227c50ab517b10f5ce
+index 0000000000000000000000000000000000000000..29f21c03cc063a279ca4ae0be00e9ef43f45be9a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/CompostItemEvent.java
-@@ -0,0 +1,65 @@
+@@ -0,0 +1,67 @@
 +package io.papermc.paper.event.block;
 +
 +import org.bukkit.block.Block;
@@ -17,6 +17,7 @@ index 0000000000000000000000000000000000000000..150c6c1468a36bf51f53b6227c50ab51
 +import org.bukkit.event.block.BlockEvent;
 +import org.bukkit.event.inventory.InventoryMoveItemEvent;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -30,6 +31,7 @@ index 0000000000000000000000000000000000000000..150c6c1468a36bf51f53b6227c50ab51
 +    private final ItemStack item;
 +    private boolean willRaiseLevel;
 +
++    @ApiStatus.Internal
 +    public CompostItemEvent(@NotNull Block composter, @NotNull ItemStack item, boolean willRaiseLevel) {
 +        super(composter);
 +        this.item = item;
@@ -49,7 +51,7 @@ index 0000000000000000000000000000000000000000..150c6c1468a36bf51f53b6227c50ab51
 +    /**
 +     * Gets whether the composter will rise a level.
 +     *
-+     * @return true if successful
++     * @return {@code true} if successful
 +     */
 +    public boolean willRaiseLevel() {
 +        return this.willRaiseLevel;
@@ -58,7 +60,7 @@ index 0000000000000000000000000000000000000000..150c6c1468a36bf51f53b6227c50ab51
 +    /**
 +     * Sets whether the composter will rise a level.
 +     *
-+     * @param willRaiseLevel true if the composter should rise a level
++     * @param willRaiseLevel {@code true} if the composter should rise a level
 +     */
 +    public void setWillRaiseLevel(boolean willRaiseLevel) {
 +        this.willRaiseLevel = willRaiseLevel;
@@ -77,10 +79,10 @@ index 0000000000000000000000000000000000000000..150c6c1468a36bf51f53b6227c50ab51
 +}
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityCompostItemEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityCompostItemEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..fd94caaece9629df859cab85b98218ab3c8f22af
+index 0000000000000000000000000000000000000000..ba8473ec936b1cea8b13b269283c377cb1b6da0b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityCompostItemEvent.java
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,45 @@
 +package io.papermc.paper.event.entity;
 +
 +import io.papermc.paper.event.block.CompostItemEvent;
@@ -88,6 +90,7 @@ index 0000000000000000000000000000000000000000..fd94caaece9629df859cab85b98218ab
 +import org.bukkit.entity.Entity;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -95,12 +98,13 @@ index 0000000000000000000000000000000000000000..fd94caaece9629df859cab85b98218ab
 + */
 +public class EntityCompostItemEvent extends CompostItemEvent implements Cancellable {
 +
-+    private final Entity who;
++    private final Entity entity;
 +    private boolean cancelled;
 +
-+    public EntityCompostItemEvent(@NotNull Entity who, @NotNull Block composter, @NotNull ItemStack item, boolean willRaiseLevel) {
++    @ApiStatus.Internal
++    public EntityCompostItemEvent(@NotNull Entity entity, @NotNull Block composter, @NotNull ItemStack item, boolean willRaiseLevel) {
 +        super(composter, item, willRaiseLevel);
-+        this.who = who;
++        this.entity = entity;
 +    }
 +
 +    /**
@@ -110,7 +114,7 @@ index 0000000000000000000000000000000000000000..fd94caaece9629df859cab85b98218ab
 +     */
 +    @NotNull
 +    public Entity getEntity() {
-+        return this.who;
++        return this.entity;
 +    }
 +
 +    @Override

--- a/patches/api/0414-Add-event-for-player-editing-sign.patch
+++ b/patches/api/0414-Add-event-for-player-editing-sign.patch
@@ -6,14 +6,15 @@ Subject: [PATCH] Add event for player editing sign
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerOpenSignEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerOpenSignEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a82c0db092684bcb5e3c99f8158eb407268b0b5a
+index 0000000000000000000000000000000000000000..c38c32ae349e094ffef84386607f4b9d5fe361f5
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerOpenSignEvent.java
-@@ -0,0 +1,104 @@
+@@ -0,0 +1,108 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.block.Sign;
 +import org.bukkit.block.sign.Side;
++import org.bukkit.entity.HumanEntity;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
@@ -27,11 +28,14 @@ index 0000000000000000000000000000000000000000..a82c0db092684bcb5e3c99f8158eb407
 + * Cancelling this event stops the sign editing menu from opening.
 + */
 +public class PlayerOpenSignEvent extends PlayerEvent implements Cancellable {
++
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
-+    private boolean cancel = false;
++
 +    private final Sign sign;
 +    private final Side side;
 +    private final Cause cause;
++
++    private boolean cancelled;
 +
 +    @ApiStatus.Internal
 +    public PlayerOpenSignEvent(final @NotNull Player editor, final @NotNull Sign sign, final @NotNull Side side, final @NotNull Cause cause) {
@@ -48,7 +52,7 @@ index 0000000000000000000000000000000000000000..a82c0db092684bcb5e3c99f8158eb407
 +     */
 +    @NotNull
 +    public Sign getSign() {
-+        return sign;
++        return this.sign;
 +    }
 +
 +    /**
@@ -59,7 +63,7 @@ index 0000000000000000000000000000000000000000..a82c0db092684bcb5e3c99f8158eb407
 +     */
 +    @NotNull
 +    public Side getSide() {
-+        return side;
++        return this.side;
 +    }
 +
 +    /**
@@ -68,17 +72,17 @@ index 0000000000000000000000000000000000000000..a82c0db092684bcb5e3c99f8158eb407
 +     * @return the cause
 +     */
 +    public @NotNull Cause getCause() {
-+        return cause;
++        return this.cause;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancel;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        this.cancel = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull
@@ -105,7 +109,7 @@ index 0000000000000000000000000000000000000000..a82c0db092684bcb5e3c99f8158eb407
 +         */
 +        INTERACT,
 +        /**
-+         * The event was triggered via a plugin with {@link org.bukkit.entity.HumanEntity#openSign(Sign, Side)}
++         * The event was triggered via a plugin with {@link HumanEntity#openSign(Sign, Side)}
 +         */
 +        PLUGIN,
 +        /**

--- a/patches/api/0417-Add-whitelist-events.patch
+++ b/patches/api/0417-Add-whitelist-events.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add whitelist events
 
 diff --git a/src/main/java/io/papermc/paper/event/server/WhitelistStateUpdateEvent.java b/src/main/java/io/papermc/paper/event/server/WhitelistStateUpdateEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..34bcdc9a3c3426e17c1905dc3dbad762c0fe3f41
+index 0000000000000000000000000000000000000000..2f4273d694278517e2613f0da5e89c73ccc8779f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/server/WhitelistStateUpdateEvent.java
-@@ -0,0 +1,83 @@
+@@ -0,0 +1,87 @@
 +package io.papermc.paper.event.server;
 +
 +import com.destroystokyo.paper.profile.PlayerProfile;
@@ -18,6 +18,7 @@ index 0000000000000000000000000000000000000000..34bcdc9a3c3426e17c1905dc3dbad762
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -26,12 +27,15 @@ index 0000000000000000000000000000000000000000..34bcdc9a3c3426e17c1905dc3dbad762
 +public class WhitelistStateUpdateEvent extends Event implements Cancellable {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
-+    private boolean cancel = false;
++
 +    @NotNull private final PlayerProfile playerProfile;
 +    @NotNull private final WhitelistStatus status;
 +
-+    public WhitelistStateUpdateEvent(@NotNull PlayerProfile who, @NotNull WhitelistStatus status) {
-+        this.playerProfile = who;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
++    public WhitelistStateUpdateEvent(@NotNull PlayerProfile playerProfile, @NotNull WhitelistStatus status) {
++        this.playerProfile = playerProfile;
 +        this.status = status;
 +    }
 +
@@ -42,7 +46,7 @@ index 0000000000000000000000000000000000000000..34bcdc9a3c3426e17c1905dc3dbad762
 +     */
 +    @NotNull
 +    public OfflinePlayer getPlayer() {
-+        return Bukkit.getOfflinePlayer(playerProfile.getId());
++        return Bukkit.getOfflinePlayer(this.playerProfile.getId());
 +    }
 +
 +    /**
@@ -52,7 +56,7 @@ index 0000000000000000000000000000000000000000..34bcdc9a3c3426e17c1905dc3dbad762
 +     */
 +    @NotNull
 +    public PlayerProfile getPlayerProfile() {
-+        return playerProfile;
++        return this.playerProfile;
 +    }
 +
 +    /**
@@ -62,17 +66,17 @@ index 0000000000000000000000000000000000000000..34bcdc9a3c3426e17c1905dc3dbad762
 +     */
 +    @NotNull
 +    public WhitelistStatus getStatus() {
-+        return status;
++        return this.status;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancel;
++        return this.cancelled;
 +    }
 +
 +    @Override
 +    public void setCancelled(boolean cancel) {
-+        this.cancel = cancel;
++        this.cancelled = cancel;
 +    }
 +
 +    @NotNull

--- a/patches/api/0419-Add-PlayerFailMoveEvent.patch
+++ b/patches/api/0419-Add-PlayerFailMoveEvent.patch
@@ -6,16 +6,17 @@ Subject: [PATCH] Add PlayerFailMoveEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerFailMoveEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerFailMoveEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..48610aa5eaacfe55e6931aac6f1a6644fb1718ef
+index 0000000000000000000000000000000000000000..c848fa029bac07f80eef870c98eebc2596b90aed
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerFailMoveEvent.java
-@@ -0,0 +1,109 @@
+@@ -0,0 +1,118 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.Location;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
@@ -26,14 +27,15 @@ index 0000000000000000000000000000000000000000..48610aa5eaacfe55e6931aac6f1a6644
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    private final FailReason failReason;
-+    private boolean allowed;
-+    private boolean logWarning;
 +    private final Location from;
 +    private final Location to;
++    private boolean allowed;
++    private boolean logWarning;
 +
-+    public PlayerFailMoveEvent(@NotNull Player who, @NotNull FailReason failReason, boolean allowed,
++    @ApiStatus.Internal
++    public PlayerFailMoveEvent(@NotNull Player player, @NotNull FailReason failReason, boolean allowed,
 +                               boolean logWarning, @NotNull Location from, @NotNull Location to) {
-+        super(who);
++        super(player);
 +        this.failReason = failReason;
 +        this.allowed = allowed;
 +        this.logWarning = logWarning;
@@ -43,41 +45,46 @@ index 0000000000000000000000000000000000000000..48610aa5eaacfe55e6931aac6f1a6644
 +
 +    /**
 +     * Gets the reason this movement was prevented by the server
++     *
 +     * @return The reason the movement was prevented
 +     */
 +    @NotNull
 +    public FailReason getFailReason() {
-+        return failReason;
++        return this.failReason;
 +    }
 +
 +    /**
 +     * Gets the location this player moved from
++     *
 +     * @return Location the player moved from
 +     */
 +    @NotNull
 +    public Location getFrom() {
-+        return from.clone();
++        return this.from.clone();
 +    }
 +
 +    /**
 +     * Gets the location this player tried to move to
++     *
 +     * @return Location the player tried to move to
 +     */
 +    @NotNull
 +    public Location getTo() {
-+        return to.clone();
++        return this.to.clone();
 +    }
 +
 +    /**
 +     * Gets if the check should be bypassed, allowing the movement
++     *
 +     * @return whether to bypass the check
 +     */
 +    public boolean isAllowed() {
-+        return allowed;
++        return this.allowed;
 +    }
 +
 +    /**
 +     * Set if the check should be bypassed and the movement should be allowed
++     *
 +     * @param allowed whether to bypass the check
 +     */
 +    public void setAllowed(boolean allowed) {
@@ -85,15 +92,17 @@ index 0000000000000000000000000000000000000000..48610aa5eaacfe55e6931aac6f1a6644
 +    }
 +
 +    /**
-+     * Gets if warnings will be printed to console. eg. "Player123 moved too quickly!"
++     * Gets if warnings will be printed to console. e.g. "Player123 moved too quickly!"
++     *
 +     * @return whether to log warnings
 +     */
 +    public boolean getLogWarning() {
-+        return logWarning;
++        return this.logWarning;
 +    }
 +
 +    /**
-+     * Set if a warning is printed to console. eg. "Player123 moved too quickly!"
++     * Set if a warning is printed to console. e.g. "Player123 moved too quickly!"
++     *
 +     * @param logWarning whether to log warnings
 +     */
 +    public void setLogWarning(boolean logWarning) {

--- a/patches/api/0430-Add-PlayerPickItemEvent.patch
+++ b/patches/api/0430-Add-PlayerPickItemEvent.patch
@@ -6,17 +6,18 @@ Subject: [PATCH] Add PlayerPickItemEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerPickItemEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerPickItemEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f3011d00c9d62ebf4c0d10a04c05c0497fd8e5a3
+index 0000000000000000000000000000000000000000..c5987ebea49e4b99c9ff7fa967aad1533b7b0ca6
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerPickItemEvent.java
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,96 @@
 +package io.papermc.paper.event.player;
 +
-+import org.apache.commons.lang3.Validate;
++import com.google.common.base.Preconditions;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Range;
 +
@@ -29,11 +30,15 @@ index 0000000000000000000000000000000000000000..f3011d00c9d62ebf4c0d10a04c05c049
 + * Note: This event will not be fired for players in creative mode.
 + */
 +public class PlayerPickItemEvent extends PlayerEvent implements Cancellable {
++
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private int targetSlot;
 +    private int sourceSlot;
++
 +    private boolean cancelled;
 +
++    @ApiStatus.Internal
 +    public PlayerPickItemEvent(@NotNull Player player, int targetSlot, int sourceSlot) {
 +        super(player);
 +        this.targetSlot = targetSlot;
@@ -56,7 +61,7 @@ index 0000000000000000000000000000000000000000..f3011d00c9d62ebf4c0d10a04c05c049
 +     * @param targetSlot hotbar slot (0-8 inclusive)
 +     */
 +    public void setTargetSlot(@Range(from = 0, to = 8) int targetSlot) {
-+        Validate.isTrue(targetSlot >= 0 && targetSlot <= 8, "Target slot must be in range 0 - 8 (inclusive)");
++        Preconditions.checkArgument(targetSlot >= 0 && targetSlot <= 8, "Target slot must be in range 0 - 8 (inclusive)");
 +        this.targetSlot = targetSlot;
 +    }
 +
@@ -76,7 +81,7 @@ index 0000000000000000000000000000000000000000..f3011d00c9d62ebf4c0d10a04c05c049
 +     * @param sourceSlot player inventory slot (0-35 inclusive)
 +     */
 +    public void setSourceSlot(@Range(from = 0, to = 35) int sourceSlot) {
-+        Validate.isTrue(sourceSlot >= 0 && sourceSlot <= 35, "Source slot must be in range of the players inventorys slot ids");
++        Preconditions.checkArgument(sourceSlot >= 0 && sourceSlot <= 35, "Source slot must be in range of the player's inventory slot");
 +        this.sourceSlot = sourceSlot;
 +    }
 +

--- a/patches/api/0453-Add-PlayerShieldDisableEvent.patch
+++ b/patches/api/0453-Add-PlayerShieldDisableEvent.patch
@@ -17,10 +17,10 @@ the cooldown event.
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerShieldDisableEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerShieldDisableEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e74f30ca8f41d7ddc15c52dd34bf201805d91d9d
+index 0000000000000000000000000000000000000000..25c13b01c5630a6de30058532458d779763e4e42
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerShieldDisableEvent.java
-@@ -0,0 +1,102 @@
+@@ -0,0 +1,92 @@
 +package io.papermc.paper.event.player;
 +
 +import com.google.common.base.Preconditions;
@@ -42,10 +42,12 @@ index 0000000000000000000000000000000000000000..e74f30ca8f41d7ddc15c52dd34bf2018
 + * disabled in the first place.
 + */
 +public class PlayerShieldDisableEvent extends PlayerEvent implements Cancellable {
++
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    private final Entity damager;
 +    private int cooldown;
++
 +    private boolean cancelled;
 +
 +    @ApiStatus.Internal
@@ -62,7 +64,7 @@ index 0000000000000000000000000000000000000000..e74f30ca8f41d7ddc15c52dd34bf2018
 +     */
 +    @NotNull
 +    public Entity getDamager() {
-+        return damager;
++        return this.damager;
 +    }
 +
 +    /**
@@ -74,7 +76,7 @@ index 0000000000000000000000000000000000000000..e74f30ca8f41d7ddc15c52dd34bf2018
 +     * @return cooldown in ticks
 +     */
 +    public int getCooldown() {
-+        return cooldown;
++        return this.cooldown;
 +    }
 +
 +    /**
@@ -90,23 +92,11 @@ index 0000000000000000000000000000000000000000..e74f30ca8f41d7ddc15c52dd34bf2018
 +        this.cooldown = cooldown;
 +    }
 +
-+    /**
-+     * Gets the cancellation state of this event. A cancelled event will not
-+     * be executed in the server, but will still pass to other plugins
-+     *
-+     * @return true if this event is cancelled
-+     */
 +    @Override
 +    public boolean isCancelled() {
 +        return this.cancelled;
 +    }
 +
-+    /**
-+     * Sets the cancellation state of this event. A cancelled event will not
-+     * be executed in the server, but will still pass to other plugins.
-+     *
-+     * @param cancel true if you wish to cancel this event
-+     */
 +    @Override
 +    public void setCancelled(final boolean cancel) {
 +        this.cancelled = cancel;

--- a/patches/api/0457-Add-ShulkerDuplicateEvent.patch
+++ b/patches/api/0457-Add-ShulkerDuplicateEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add ShulkerDuplicateEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/ShulkerDuplicateEvent.java b/src/main/java/io/papermc/paper/event/entity/ShulkerDuplicateEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1fd54ca6bff3a61b8dfde3350216045376d00ca9
+index 0000000000000000000000000000000000000000..88d8278e49f1bb32e97ee551d8ad31d4a59534e2
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/ShulkerDuplicateEvent.java
 @@ -0,0 +1,71 @@
@@ -46,7 +46,7 @@ index 0000000000000000000000000000000000000000..1fd54ca6bff3a61b8dfde33502160453
 +    @Override
 +    @NotNull
 +    public Shulker getEntity() {
-+        return (Shulker) entity;
++        return (Shulker) super.getEntity();
 +    }
 +
 +    /**
@@ -57,12 +57,12 @@ index 0000000000000000000000000000000000000000..1fd54ca6bff3a61b8dfde33502160453
 +     */
 +    @NotNull
 +    public Shulker getParent() {
-+        return parent;
++        return this.parent;
 +    }
 +
 +    @Override
 +    public boolean isCancelled() {
-+        return cancelled;
++        return this.cancelled;
 +    }
 +
 +    @Override

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -3482,10 +3482,10 @@ index 0000000000000000000000000000000000000000..cea9c098ade00ee87b8efc8164ab72f5
 +}
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7ae65f05eb2219a63a108728e4137b245775d08b
+index 0000000000000000000000000000000000000000..8ebef203d1e2584aed61bd61a93e231416eda749
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
-@@ -0,0 +1,532 @@
+@@ -0,0 +1,528 @@
 +package io.papermc.paper.util;
 +
 +import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -3946,10 +3946,6 @@ index 0000000000000000000000000000000000000000..7ae65f05eb2219a63a108728e4137b24
 +     */
 +    public static Location toLocation(Entity entity) {
 +        return new Location(entity.getCommandSenderWorld().getWorld(), entity.getX(), entity.getY(), entity.getZ());
-+    }
-+
-+    public static org.bukkit.block.Block toBukkitBlock(Level world, BlockPos pos) {
-+        return world.getWorld().getBlockAt(pos.getX(), pos.getY(), pos.getZ());
 +    }
 +
 +    public static BlockPos toBlockPosition(Location loc) {
@@ -7737,7 +7733,7 @@ index 98836000cbca2a21649cb8f2a466986373405ea1..bbbf6dd8e566ecdca8794e3b03765fe7
              return false;
          } else {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d6a1b9bbf9737ed884ecf4af31e1521f46807405..5ee460d5d6e017a52bf26cfd56ca2cfeb82d3343 100644
+index aa3032f9dac2700f2621a860deeec49ada801939..e51bed4771dcef6201f943e9289c4a53f029f1ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2531,4 +2531,9 @@ public final class CraftServer implements Server {

--- a/patches/server/0046-Add-BeaconEffectEvent.patch
+++ b/patches/server/0046-Add-BeaconEffectEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add BeaconEffectEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
-index 9fb27f93a7ccbf64f9babf19f626d1f45b1c7103..f4e1dc338dd240371694dd7a3455c79d5cea251a 100644
+index 9fb27f93a7ccbf64f9babf19f626d1f45b1c7103..25ec3ab534872500a2eb51cd44062e2754c404bb 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
 @@ -43,6 +43,10 @@ import net.minecraft.world.phys.AABB;
@@ -31,7 +31,7 @@ index 9fb27f93a7ccbf64f9babf19f626d1f45b1c7103..f4e1dc338dd240371694dd7a3455c79d
  
              Player entityhuman;
 +            // Paper start - BeaconEffectEvent
-+            org.bukkit.block.Block block = ((Player) list.get(0)).level().getWorld().getBlockAt(worldPosition.getX(), worldPosition.getY(), worldPosition.getZ());
++            org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(((Player) list.get(0)).level(), worldPosition);
 +            PotionEffect effect = CraftPotionUtil.toBukkit(new MobEffectInstance(effects, i, b0, true, true));
 +            // Paper end - BeaconEffectEvent
  

--- a/patches/server/0060-Add-exception-reporting-event.patch
+++ b/patches/server/0060-Add-exception-reporting-event.patch
@@ -49,29 +49,22 @@ index 0000000000000000000000000000000000000000..f699ce18ca044f813e194ef2786b7ea8
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/players/OldUsersConverter.java b/src/main/java/net/minecraft/server/players/OldUsersConverter.java
-index 8d06e8d286da2573e40794adab695ff77e5afd86..b3c6e76105ee26a79a84a203935530f859460652 100644
+index 8d06e8d286da2573e40794adab695ff77e5afd86..9143ce01650b51e7f6a677c5941ade91a506449f 100644
 --- a/src/main/java/net/minecraft/server/players/OldUsersConverter.java
 +++ b/src/main/java/net/minecraft/server/players/OldUsersConverter.java
-@@ -1,5 +1,6 @@
- package net.minecraft.server.players;
- 
-+import com.destroystokyo.paper.exception.ServerInternalException;
- import com.google.common.collect.Lists;
- import com.google.common.collect.Maps;
- import com.google.common.io.Files;
-@@ -357,6 +358,7 @@ public class OldUsersConverter {
+@@ -357,6 +357,7 @@ public class OldUsersConverter {
                              root = NbtIo.readCompressed(new java.io.FileInputStream(file5), NbtAccounter.unlimitedHeap());
                          } catch (Exception exception) {
                              exception.printStackTrace();
-+                            ServerInternalException.reportInternalException(exception); // Paper - ServerExceptionEvent
++                            com.destroystokyo.paper.exception.ServerInternalException.reportInternalException(exception); // Paper - ServerExceptionEvent
                          }
  
                          if (root != null) {
-@@ -370,6 +372,7 @@ public class OldUsersConverter {
+@@ -370,6 +371,7 @@ public class OldUsersConverter {
                                  NbtIo.writeCompressed(root, new java.io.FileOutputStream(file2));
                              } catch (Exception exception) {
                                  exception.printStackTrace();
-+                                ServerInternalException.reportInternalException(exception); // Paper - ServerExceptionEvent
++                                com.destroystokyo.paper.exception.ServerInternalException.reportInternalException(exception); // Paper - ServerExceptionEvent
                              }
                         }
                          // CraftBukkit end
@@ -88,25 +81,14 @@ index c6fb4c33d7ea52b88d8fc0d90748cbab7387c565..2b5b2869589991be37a4f128faabbff5
              }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 6fbadd278138743f87fcf6b3c3d3c57af41d437c..aee40ef7ae18ad00d8af88dd1e2397fe8df78309 100644
+index 6fbadd278138743f87fcf6b3c3d3c57af41d437c..eb2b4ba79488c3d43421c39852c36c4387372f38 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1,5 +1,10 @@
- package net.minecraft.world.level;
- 
-+import co.aikar.timings.Timing;
-+import co.aikar.timings.Timings;
-+import com.destroystokyo.paper.event.server.ServerExceptionEvent;
-+import com.destroystokyo.paper.exception.ServerInternalException;
-+import com.google.common.base.MoreObjects;
- import com.google.common.collect.Lists;
- import com.mojang.serialization.Codec;
- import java.io.IOException;
-@@ -736,6 +741,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -736,6 +736,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // Paper start - Prevent block entity and entity crashes
              final String msg = String.format("Entity threw exception at %s:%s,%s,%s", entity.level().getWorld().getName(), entity.getX(), entity.getY(), entity.getZ());
              MinecraftServer.LOGGER.error(msg, throwable);
-+            getCraftServer().getPluginManager().callEvent(new ServerExceptionEvent(new ServerInternalException(msg, throwable))); // Paper - ServerExceptionEvent
++            getCraftServer().getPluginManager().callEvent(new com.destroystokyo.paper.event.server.ServerExceptionEvent(new com.destroystokyo.paper.exception.ServerInternalException(msg, throwable))); // Paper - ServerExceptionEvent
              entity.discard();
              // Paper end - Prevent block entity and entity crashes
          }

--- a/patches/server/0070-Add-World-Util-Methods.patch
+++ b/patches/server/0070-Add-World-Util-Methods.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add World Util Methods
 Methods that can be used for other patches to help improve logic.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index aee40ef7ae18ad00d8af88dd1e2397fe8df78309..c48e62063609634a0660c75b9305e9d73e10b4aa 100644
+index eb2b4ba79488c3d43421c39852c36c4387372f38..c3138a2ff6446fb72d9eb1bd31f851d7df6b94f2 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -352,6 +352,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -347,6 +347,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return chunk == null ? null : chunk.getFluidState(blockposition);
      }
  

--- a/patches/server/0075-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
+++ b/patches/server/0075-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
@@ -6,14 +6,14 @@ Subject: [PATCH] Only process BlockPhysicsEvent if a plugin has a listener
 Saves on some object allocation and processing when no plugin listens to this
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 455f72f2a653154d4528c53d39866d3cd85b6862..36de11970c3cb605357ec5c49d0654a43263bc00 100644
+index cc2775d94f3b6ebd7f97e14e324bf292d5874de4..a4df17bf15ac8e427039428f947df4f08c746de6 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1457,6 +1457,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
-+            worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
++            worldserver.hasPhysicsEvent = org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
  
              this.profiler.push(() -> {
                  return worldserver + " " + worldserver.dimension().location();
@@ -30,10 +30,10 @@ index a127acc6c44bfd078e06c74b408d62df6e85d1fe..5975cc2fa72609ea5f3e6f99155d6e5b
      public LevelChunk getChunkIfLoaded(int x, int z) {
          return this.chunkSource.getChunk(x, z, false);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index c48e62063609634a0660c75b9305e9d73e10b4aa..a617c69054523dda56b78f175fc8b9c134b60ae2 100644
+index c3138a2ff6446fb72d9eb1bd31f851d7df6b94f2..61056b2873a58bf8d0f70e39022ded4b1fcbc5a5 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -501,7 +501,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -496,7 +496,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  // CraftBukkit start
                  iblockdata1.updateIndirectNeighbourShapes(this, blockposition, k, j - 1); // Don't call an event for the old block to limit event spam
                  CraftWorld world = ((ServerLevel) this).getWorld();

--- a/patches/server/0081-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/server/0081-Add-PlayerUseUnknownEntityEvent.patch
@@ -28,10 +28,10 @@ index 644a0fdea6576647539b96528717dbaeab498d93..221e64a66ff12a8de5c75992fc26a54a
 +    // Paper end - PlayerUseUnknownEntityEvent
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 04e68886a5385234701962f2502948052074515e..a91ba515265c869529776521345887574e1d4076 100644
+index 04e68886a5385234701962f2502948052074515e..369a34e76ca7aff97cb4258fb5e5503450f0e357 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2400,8 +2400,38 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2400,7 +2400,26 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  });
              }
          }
@@ -40,33 +40,40 @@ index 04e68886a5385234701962f2502948052074515e..a91ba515265c86952977652134588757
 +            packet.dispatch(new net.minecraft.network.protocol.game.ServerboundInteractPacket.Handler() {
 +                @Override
 +                public void onInteraction(net.minecraft.world.InteractionHand hand) {
-+                    ServerGamePacketListenerImpl.this.callPlayerUseUnknownEntityEvent(packet, hand, null);
++                    CraftEventFactory.callPlayerUseUnknownEntityEvent(ServerGamePacketListenerImpl.this.player, packet, hand, null);
 +                }
 +
 +                @Override
 +                public void onInteraction(net.minecraft.world.InteractionHand hand, net.minecraft.world.phys.Vec3 pos) {
-+                    ServerGamePacketListenerImpl.this.callPlayerUseUnknownEntityEvent(packet, hand, pos);
++                    CraftEventFactory.callPlayerUseUnknownEntityEvent(ServerGamePacketListenerImpl.this.player, packet, hand, pos);
 +                }
-+
+ 
 +                @Override
 +                public void onAttack() {
-+                    ServerGamePacketListenerImpl.this.callPlayerUseUnknownEntityEvent(packet, net.minecraft.world.InteractionHand.MAIN_HAND, null);
++                    CraftEventFactory.callPlayerUseUnknownEntityEvent(ServerGamePacketListenerImpl.this.player, packet, net.minecraft.world.InteractionHand.MAIN_HAND, null);
 +                }
 +            });
 +        }
-+
-+    }
- 
-+    private void callPlayerUseUnknownEntityEvent(ServerboundInteractPacket packet, InteractionHand hand, @Nullable net.minecraft.world.phys.Vec3 vector) {
-+        this.cserver.getPluginManager().callEvent(new com.destroystokyo.paper.event.player.PlayerUseUnknownEntityEvent(
-+            this.getCraftPlayer(),
-+            packet.getEntityId(),
-+            packet.isAttack(),
-+            hand == InteractionHand.MAIN_HAND ? EquipmentSlot.HAND : EquipmentSlot.OFF_HAND,
-+            vector != null ? new org.bukkit.util.Vector(vector.x, vector.y, vector.z) : null)
-+        );
++        // Paper end - PlayerUseUnknownEntityEvent
      }
-+    // Paper end - PlayerUseUnknownEntityEvent
  
      @Override
-     public void handleClientCommand(ServerboundClientCommandPacket packet) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index a0dc52c805a82e267b66502a480cf76bc82a20d4..5d78797792977da434717d510004a548f461e6aa 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1888,4 +1888,14 @@ public class CraftEventFactory {
+         Bukkit.getPluginManager().callEvent(event);
+         return event;
+     }
++
++    // Paper start - PlayerUseUnknownEntityEvent
++    public static void callPlayerUseUnknownEntityEvent(net.minecraft.world.entity.player.Player player, net.minecraft.network.protocol.game.ServerboundInteractPacket packet, InteractionHand hand, @Nullable net.minecraft.world.phys.Vec3 vector) {
++        new com.destroystokyo.paper.event.player.PlayerUseUnknownEntityEvent(
++            (Player) player.getBukkitEntity(), packet.getEntityId(), packet.isAttack(),
++            CraftEquipmentSlot.getHand(hand),
++            vector != null ? CraftVector.toBukkit(vector) : null
++        ).callEvent();
++    }
++    // Paper end - PlayerUseUnknownEntityEvent
+ }

--- a/patches/server/0097-Faster-redstone-torch-rapid-clock-removal.patch
+++ b/patches/server/0097-Faster-redstone-torch-rapid-clock-removal.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Faster redstone torch rapid clock removal
 Only resize the the redstone torch list once, since resizing arrays / lists is costly
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index a617c69054523dda56b78f175fc8b9c134b60ae2..7c977fad2084a849266caf8e424d0e8e24e8626f 100644
+index 61056b2873a58bf8d0f70e39022ded4b1fcbc5a5..f11e00b3a7164e8af6e33a9a09328539df5405fc 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -176,6 +176,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -171,6 +171,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      private org.spigotmc.TickLimiter tileLimiter;
      private int tileTickPosition;
      public final Map<Explosion.CacheKey, Float> explosionDensityCache = new HashMap<>(); // Paper - Optimize explosions

--- a/patches/server/0099-Fix-global-sound-handling.patch
+++ b/patches/server/0099-Fix-global-sound-handling.patch
@@ -11,7 +11,7 @@ Co-authored-by: lexikiq <noellekiq@gmail.com>
 Co-authored-by: Aikar <aikar@aikar.co>
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index dcf2b9820eb9ad92dc7dc559e509a694d3949f02..54b3103d558adacba5f7a7b9fd230649623c7702 100644
+index ddab865f4237b91020f3c5f9726d93f8dbf0eda6..5f0885c13116ad070dc076cca5a527b2a616c541 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1318,7 +1318,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -81,10 +81,10 @@ index 5bc68514a1e8a212e2681f06b918548c0ec565b6..1977e702f6af39ebf100c1f2f2edc2d1
                              double deltaLength = Math.sqrt(distanceSquared);
                              double relativeX = player.getX() + (deltaX / deltaLength) * viewDistance;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 7c977fad2084a849266caf8e424d0e8e24e8626f..bffd24f48e509c9049d4c35687bfd35b505db255 100644
+index f11e00b3a7164e8af6e33a9a09328539df5405fc..610ce2574a61fcee00f5224b554b285079a75698 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1273,4 +1273,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1268,4 +1268,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
          private ExplosionInteraction() {}
      }

--- a/patches/server/0102-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0102-Add-setting-for-proxy-online-mode-status.patch
@@ -46,10 +46,10 @@ index 3c9c6a697143c7e980add58576ad288b8f51ae35..92c22dc10e385f1942f2ec375bbce9fa
  
      public void add(GameProfile profile) {
 diff --git a/src/main/java/net/minecraft/server/players/OldUsersConverter.java b/src/main/java/net/minecraft/server/players/OldUsersConverter.java
-index b3c6e76105ee26a79a84a203935530f859460652..e697b8f7b165d2394d8155cbee7453e23ac2bee4 100644
+index 9143ce01650b51e7f6a677c5941ade91a506449f..86c88e81e275d52576122a5083b419e64cb011fc 100644
 --- a/src/main/java/net/minecraft/server/players/OldUsersConverter.java
 +++ b/src/main/java/net/minecraft/server/players/OldUsersConverter.java
-@@ -66,7 +66,8 @@ public class OldUsersConverter {
+@@ -65,7 +65,8 @@ public class OldUsersConverter {
              return new String[i];
          });
  
@@ -60,7 +60,7 @@ index b3c6e76105ee26a79a84a203935530f859460652..e697b8f7b165d2394d8155cbee7453e2
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fb6c21a43e771317526972c183d95402d941924b..040d5fa985f746d90e144b668ebb2adb79c33daa 100644
+index ec7f1845e7d547761efb070bbd91d921f71a0509..edf6fb3db243e4c9b28641504e383f0b03e672d2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1821,7 +1821,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0106-Add-EntityZapEvent.patch
+++ b/patches/server/0106-Add-EntityZapEvent.patch
@@ -28,7 +28,7 @@ index 22f7318711041bfc2847d519933c46b9fd523d01..4034b8e7503f611dc9be121d8da2020a
                  entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
                  entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a0dc52c805a82e267b66502a480cf76bc82a20d4..18cd6963863d030e3c360f5e00e8786f28ee04b9 100644
+index 5d78797792977da434717d510004a548f461e6aa..60c0c8ac706386e089d1a4cbacb5442f63ea05dc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1265,6 +1265,14 @@ public class CraftEventFactory {
@@ -36,7 +36,7 @@ index a0dc52c805a82e267b66502a480cf76bc82a20d4..18cd6963863d030e3c360f5e00e8786f
      }
  
 +    // Paper start
-+    public static com.destroystokyo.paper.event.entity.EntityZapEvent callEntityZapEvent (Entity entity, Entity lightning, Entity changedEntity) {
++    public static com.destroystokyo.paper.event.entity.EntityZapEvent callEntityZapEvent(Entity entity, Entity lightning, Entity changedEntity) {
 +        com.destroystokyo.paper.event.entity.EntityZapEvent event = new com.destroystokyo.paper.event.entity.EntityZapEvent(entity.getBukkitEntity(), (LightningStrike) lightning.getBukkitEntity(), changedEntity.getBukkitEntity());
 +        entity.getBukkitEntity().getServer().getPluginManager().callEvent(event);
 +        return event;

--- a/patches/server/0113-Optimize-Level.hasChunkAt-BlockPosition-Z.patch
+++ b/patches/server/0113-Optimize-Level.hasChunkAt-BlockPosition-Z.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Optimize Level.hasChunkAt(BlockPosition)Z
 Reduce method invocations for World.isLoaded(BlockPosition)Z
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index bffd24f48e509c9049d4c35687bfd35b505db255..0a9b7693a19179a2e8903da76266adf589ae7abb 100644
+index 610ce2574a61fcee00f5224b554b285079a75698..e4a2afc20efcfd7a6107dc56217ae8451dd5a7d6 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -353,6 +353,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -348,6 +348,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return chunk == null ? null : chunk.getFluidState(blockposition);
      }
  

--- a/patches/server/0120-PlayerTeleportEndGatewayEvent.patch
+++ b/patches/server/0120-PlayerTeleportEndGatewayEvent.patch
@@ -7,7 +7,7 @@ Allows you to access the Gateway being used in a teleport event
 Fix the offset used for player teleportation
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-index 8e63135d42d1a06cc7741e33eb3e057321ea53bc..8ae723c6500bb92f937a27730c2a5ec912247c0a 100644
+index 8e63135d42d1a06cc7741e33eb3e057321ea53bc..08d34dff616b6c117a969809cdeb3853e28dc473 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 @@ -207,11 +207,11 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
@@ -24,12 +24,3 @@ index 8e63135d42d1a06cc7741e33eb3e057321ea53bc..8ae723c6500bb92f937a27730c2a5ec9
                      Bukkit.getPluginManager().callEvent(teleEvent);
                      if (teleEvent.isCancelled()) {
                          return;
-@@ -224,7 +224,7 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
- 
-                 }
- 
--                org.bukkit.event.entity.EntityTeleportEvent teleEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTeleportEvent(entity1, blockposition1.getX() + 0.5, blockposition1.getY() + 0.5, blockposition1.getZ() + 0.5);
-+                org.bukkit.event.entity.EntityTeleportEvent teleEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTeleportEvent(entity1, blockposition1.getX() + 0.5, blockposition1.getY() + 0.5, blockposition1.getZ() + 0.5); // Paper - diff on change
-                 if (teleEvent.isCancelled()) {
-                     return;
-                 }

--- a/patches/server/0121-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/server/0121-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -7,10 +7,10 @@ Provides counts without the ineffeciency of using .getEntities().size()
 which creates copy of the collections.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 0a9b7693a19179a2e8903da76266adf589ae7abb..1a23790dea064d0e19b58858f9693cb5ec5e5552 100644
+index e4a2afc20efcfd7a6107dc56217ae8451dd5a7d6..0045016cd22c34168c4ae5f2fe951d536394be9a 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -119,7 +119,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -114,7 +114,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public static final int TICKS_PER_DAY = 24000;
      public static final int MAX_ENTITY_SPAWN_Y = 20000000;
      public static final int MIN_ENTITY_SPAWN_Y = -20000000;
@@ -20,7 +20,7 @@ index 0a9b7693a19179a2e8903da76266adf589ae7abb..1a23790dea064d0e19b58858f9693cb5
      private final List<TickingBlockEntity> pendingBlockEntityTickers = Lists.newArrayList();
      private boolean tickingBlockEntities;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 68a7db9c840f101950435b386058f4cf409bfc05..27f7b2cacd3113289b852c767e379d9769a9fa01 100644
+index b2632cbc7903e23eb68e9901df039f5d8293bd77..e6b104e57381343f08a0a2a7b2e3a81b6ddadda4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -157,6 +157,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0136-Add-UnknownCommandEvent.patch
+++ b/patches/server/0136-Add-UnknownCommandEvent.patch
@@ -100,7 +100,7 @@ index 495a7b713a7ab9c19aad34512b76523bad43b89d..15a5059994371da4850adcf726034a71
  
              return null;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7678b7eb8561bca272bdb26de5a9f96bd18d005d..59776663cee396f29f05988d8e22dd5c23b118b5 100644
+index 11111b1015d362b35cbb6d35bee91c3c130e7cc7..46acd80641b2ecafd9f364d7ad9b477b6b2f0289 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -527,6 +527,7 @@ public final class CraftServer implements Server {
@@ -118,7 +118,7 @@ index 7678b7eb8561bca272bdb26de5a9f96bd18d005d..59776663cee396f29f05988d8e22dd5c
 -            sender.sendMessage(org.spigotmc.SpigotConfig.unknownCommandMessage);
 +            // Paper start
 +            org.bukkit.event.command.UnknownCommandEvent event = new org.bukkit.event.command.UnknownCommandEvent(sender, commandLine, net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(org.spigotmc.SpigotConfig.unknownCommandMessage));
-+            Bukkit.getServer().getPluginManager().callEvent(event);
++            this.getPluginManager().callEvent(event);
 +            if (event.message() != null) {
 +                sender.sendMessage(event.message());
 +            }

--- a/patches/server/0138-Profile-Lookup-Events.patch
+++ b/patches/server/0138-Profile-Lookup-Events.patch
@@ -7,7 +7,7 @@ Adds a Pre Lookup Event and a Post Lookup Event so that plugins may prefill in p
 profiles that had to be looked up.
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java b/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java
-index 7b9e797b42c88b17d6a7c590a423f4e85d99a59d..fd841c62c659a427dd08da5dbdf0e2e625391bc0 100644
+index 7b9e797b42c88b17d6a7c590a423f4e85d99a59d..b2ad0c4d92ed960190e3801fbc6a21dcc53bcb46 100644
 --- a/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java
 @@ -1,9 +1,14 @@
@@ -35,7 +35,7 @@ index 7b9e797b42c88b17d6a7c590a423f4e85d99a59d..fd841c62c659a427dd08da5dbdf0e2e6
 +            PreLookupProfileEvent event = new PreLookupProfileEvent(name);
 +            event.callEvent();
 +            if (event.getUUID() != null) {
-+                // Plugin provided UUI, we can skip network call.
++                // Plugin provided UUID, we can skip network call.
 +                GameProfile gameprofile = new GameProfile(event.getUUID(), name);
 +                // We might even have properties!
 +                Set<ProfileProperty> profileProperties = event.getProfileProperties();

--- a/patches/server/0157-Add-PlayerArmorChangeEvent.patch
+++ b/patches/server/0157-Add-PlayerArmorChangeEvent.patch
@@ -5,17 +5,10 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a799b64e9d655e7eba509e9930e623a88bbb0389..acf892ce7cf566fc6b9b88c6502c97a06cdedfd4 100644
+index a799b64e9d655e7eba509e9930e623a88bbb0389..882bb83a552be415711c8df8118e91981fc63e46 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1,5 +1,6 @@
- package net.minecraft.world.entity;
- 
-+import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent; // Paper
- import com.google.common.base.Objects;
- import com.google.common.collect.ImmutableList;
- import com.google.common.collect.ImmutableMap;
-@@ -3047,6 +3048,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3047,6 +3047,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
              ItemStack itemstack1 = this.getItemBySlot(enumitemslot);
  
              if (this.equipmentHasChanged(itemstack, itemstack1)) {
@@ -23,7 +16,7 @@ index a799b64e9d655e7eba509e9930e623a88bbb0389..acf892ce7cf566fc6b9b88c6502c97a0
 +                if (this instanceof ServerPlayer && enumitemslot.getType() == EquipmentSlot.Type.ARMOR) {
 +                    final org.bukkit.inventory.ItemStack oldItem = CraftItemStack.asBukkitCopy(itemstack);
 +                    final org.bukkit.inventory.ItemStack newItem = CraftItemStack.asBukkitCopy(itemstack1);
-+                    new PlayerArmorChangeEvent((Player) this.getBukkitEntity(), PlayerArmorChangeEvent.SlotType.valueOf(enumitemslot.name()), oldItem, newItem).callEvent();
++                    new com.destroystokyo.paper.event.player.PlayerArmorChangeEvent((Player) this.getBukkitEntity(), com.destroystokyo.paper.event.player.PlayerArmorChangeEvent.SlotType.valueOf(enumitemslot.name()), oldItem, newItem).callEvent();
 +                }
 +                // Paper end - PlayerArmorChangeEvent
                  if (map == null) {

--- a/patches/server/0159-Fix-MC-117075-Block-entity-unload-lag-spike.patch
+++ b/patches/server/0159-Fix-MC-117075-Block-entity-unload-lag-spike.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix MC-117075: Block entity unload lag spike
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 1a23790dea064d0e19b58858f9693cb5ec5e5552..2c135093e8eee614e23676a2f07ee4a22ca8203c 100644
+index 0045016cd22c34168c4ae5f2fe951d536394be9a..c8914696785d0d6c451d598616a83c316f611aad 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -734,6 +734,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -729,6 +729,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          boolean flag = this.tickRateManager().runsNormally();
  
          int tilesThisCycle = 0;
@@ -17,7 +17,7 @@ index 1a23790dea064d0e19b58858f9693cb5ec5e5552..2c135093e8eee614e23676a2f07ee4a2
          for (tileTickPosition = 0; tileTickPosition < this.blockEntityTickers.size(); tileTickPosition++) { // Paper - Disable tick limiters
              this.tileTickPosition = (this.tileTickPosition < this.blockEntityTickers.size()) ? this.tileTickPosition : 0;
              TickingBlockEntity tickingblockentity = (TickingBlockEntity) this.blockEntityTickers.get(this.tileTickPosition);
-@@ -742,12 +744,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -737,12 +739,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              if (tickingblockentity.isRemoved()) {
                  // Spigot start
                  tilesThisCycle--;

--- a/patches/server/0160-use-CB-BlockState-implementations-for-captured-block.patch
+++ b/patches/server/0160-use-CB-BlockState-implementations-for-captured-block.patch
@@ -18,10 +18,10 @@ the blockstate that will be valid for restoration, as opposed to dropping
 information on restoration when the event is cancelled.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 2c135093e8eee614e23676a2f07ee4a22ca8203c..19d6a829edb977d064c5d5a42ae3cab4fc806bb6 100644
+index c8914696785d0d6c451d598616a83c316f611aad..8a7276f83744252ac5a418f9acb219e02c508b2f 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -157,7 +157,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -152,7 +152,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean preventPoiUpdated = false; // CraftBukkit - SPIGOT-5710
      public boolean captureBlockStates = false;
      public boolean captureTreeGeneration = false;
@@ -30,7 +30,7 @@ index 2c135093e8eee614e23676a2f07ee4a22ca8203c..19d6a829edb977d064c5d5a42ae3cab4
      public Map<BlockPos, BlockEntity> capturedTileEntities = new HashMap<>();
      public List<ItemEntity> captureDrops;
      public final it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<SpawnCategory> ticksPerSpawnCategory = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
-@@ -395,7 +395,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -390,7 +390,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean setBlock(BlockPos pos, BlockState state, int flags, int maxUpdateDepth) {
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {
@@ -39,7 +39,7 @@ index 2c135093e8eee614e23676a2f07ee4a22ca8203c..19d6a829edb977d064c5d5a42ae3cab4
              if (blockstate == null) {
                  blockstate = CapturedBlockState.getTreeBlockState(this, pos, flags);
                  this.capturedBlockStates.put(pos.immutable(), blockstate);
-@@ -415,7 +415,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -410,7 +410,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // CraftBukkit start - capture blockstates
              boolean captured = false;
              if (this.captureBlockStates && !this.capturedBlockStates.containsKey(pos)) {
@@ -49,7 +49,7 @@ index 2c135093e8eee614e23676a2f07ee4a22ca8203c..19d6a829edb977d064c5d5a42ae3cab4
                  this.capturedBlockStates.put(pos.immutable(), blockstate);
                  captured = true;
              }
-@@ -616,7 +617,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -611,7 +612,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public BlockState getBlockState(BlockPos pos) {
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {

--- a/patches/server/0167-PreCreatureSpawnEvent.patch
+++ b/patches/server/0167-PreCreatureSpawnEvent.patch
@@ -15,7 +15,7 @@ instead and save a lot of server resources.
 See: https://github.com/PaperMC/Paper/issues/917
 
 diff --git a/src/main/java/net/minecraft/util/SpawnUtil.java b/src/main/java/net/minecraft/util/SpawnUtil.java
-index b77ebe04f1018962b85110258c8a0a2db8612485..1a0cd6ae172c911d3b4cc0f82e253536a4898ca9 100644
+index b77ebe04f1018962b85110258c8a0a2db8612485..1954fdc7b72700d5948e93ebcb0e6a26fe244a1b 100644
 --- a/src/main/java/net/minecraft/util/SpawnUtil.java
 +++ b/src/main/java/net/minecraft/util/SpawnUtil.java
 @@ -22,10 +22,10 @@ public class SpawnUtil {
@@ -31,18 +31,14 @@ index b77ebe04f1018962b85110258c8a0a2db8612485..1a0cd6ae172c911d3b4cc0f82e253536
          // CraftBukkit end
          BlockPos.MutableBlockPos blockposition_mutableblockposition = blockposition.mutable();
  
-@@ -35,6 +35,26 @@ public class SpawnUtil {
+@@ -35,6 +35,22 @@ public class SpawnUtil {
  
              blockposition_mutableblockposition.setWithOffset(blockposition, i1, k, j1);
              if (worldserver.getWorldBorder().isWithinBounds((BlockPos) blockposition_mutableblockposition) && SpawnUtil.moveToPossibleSpawnPosition(worldserver, k, blockposition_mutableblockposition, spawnutil_a)) {
 +                // Paper start - PreCreatureSpawnEvent
-+                String key = EntityType.getKey(entitytypes).getPath();
-+                org.bukkit.entity.EntityType type = org.bukkit.entity.EntityType.fromName(key);
-+
-+                com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event;
-+                event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
++                com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
 +                    io.papermc.paper.util.MCUtil.toLocation(worldserver, blockposition),
-+                    type,
++                    org.bukkit.craftbukkit.entity.CraftEntityType.minecraftToBukkit(entitytypes),
 +                    reason
 +                );
 +                if (!event.callEvent()) {
@@ -59,25 +55,21 @@ index b77ebe04f1018962b85110258c8a0a2db8612485..1a0cd6ae172c911d3b4cc0f82e253536
  
                  if (t0 != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/EntityType.java b/src/main/java/net/minecraft/world/entity/EntityType.java
-index 382b55167dede435b034866bd394455f0f6f2a00..bd4ae65070eb4b98dae0529b5985f80093bf8185 100644
+index 382b55167dede435b034866bd394455f0f6f2a00..035af9ccf679a562203a4a2c4f2b38098c57b492 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityType.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityType.java
-@@ -418,6 +418,20 @@ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeT
+@@ -418,6 +418,16 @@ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeT
      @Nullable
      public T spawn(ServerLevel worldserver, @Nullable CompoundTag nbttagcompound, @Nullable Consumer<T> consumer, BlockPos blockposition, MobSpawnType enummobspawn, boolean flag, boolean flag1, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason) {
          // CraftBukkit end
 +        // Paper start - PreCreatureSpawnEvent
-+        org.bukkit.entity.EntityType type = org.bukkit.entity.EntityType.fromName(EntityType.getKey(this).getPath());
-+        if (type != null) {
-+            com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event;
-+            event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
-+                io.papermc.paper.util.MCUtil.toLocation(worldserver, blockposition),
-+                type,
-+                spawnReason
-+            );
-+            if (!event.callEvent()) {
-+                return null;
-+            }
++        com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
++            io.papermc.paper.util.MCUtil.toLocation(worldserver, blockposition),
++            org.bukkit.craftbukkit.entity.CraftEntityType.minecraftToBukkit(this),
++            spawnReason
++        );
++        if (!event.callEvent()) {
++            return null;
 +        }
 +        // Paper end - PreCreatureSpawnEvent
          T t0 = this.create(worldserver, nbttagcompound, consumer, blockposition, enummobspawn, flag, flag1);
@@ -97,39 +89,32 @@ index f0d5e45d0d6ac51106379d20690d34a032a24c39..bfd156acbae31619234fffb180472609
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index fdd1fd084c46b0220c9e7e0389e9b52e782d2878..28f63a211f4ae207b2400d16b1725808ad87f334 100644
+index fdd1fd084c46b0220c9e7e0389e9b52e782d2878..0166c5ff685490cbf67a9d26f48cb1a0be754488 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-@@ -130,6 +130,27 @@ public abstract class BaseSpawner {
+@@ -130,6 +130,20 @@ public abstract class BaseSpawner {
                          } else if (!SpawnPlacements.checkSpawnRules((EntityType) optional.get(), world, MobSpawnType.SPAWNER, blockposition1, world.getRandom())) {
                              continue;
                          }
 +                        // Paper start - PreCreatureSpawnEvent
-+                        EntityType<?> entityType = optional.get();
-+                        String key = EntityType.getKey(entityType).getPath();
-+
-+                        org.bukkit.entity.EntityType type = org.bukkit.entity.EntityType.fromName(key);
-+                        if (type != null) {
-+                            com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event;
-+                            event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
-+                                io.papermc.paper.util.MCUtil.toLocation(world, d0, d1, d2),
-+                                type,
-+                                org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.SPAWNER
-+                            );
-+                            if (!event.callEvent()) {
-+                                flag = true;
-+                                if (event.shouldAbortSpawn()) {
-+                                    break;
-+                                }
-+                                continue;
++                        com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
++                            io.papermc.paper.util.MCUtil.toLocation(world, d0, d1, d2),
++                            org.bukkit.craftbukkit.entity.CraftEntityType.minecraftToBukkit(optional.get()),
++                            org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.SPAWNER
++                        );
++                        if (!event.callEvent()) {
++                            flag = true;
++                            if (event.shouldAbortSpawn()) {
++                                break;
 +                            }
++                            continue;
 +                        }
 +                        // Paper end - PreCreatureSpawnEvent
  
                          Entity entity = EntityType.loadEntityRecursive(nbttagcompound, world, (entity1) -> {
                              entity1.moveTo(d0, d1, d2, entity1.getYRot(), entity1.getXRot());
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 604766a286d00bb4b40c20482376fe80651beabe..286592be7aeb183d1a9ee439c250f2acf932f0bf 100644
+index 604766a286d00bb4b40c20482376fe80651beabe..352d230b365c512a4b9831265d3a57825f80fbfd 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -213,7 +213,13 @@ public final class NaturalSpawner {
@@ -147,7 +132,7 @@ index 604766a286d00bb4b40c20482376fe80651beabe..286592be7aeb183d1a9ee439c250f2ac
                                          Mob entityinsentient = NaturalSpawner.getMobForSpawn(world, biomesettingsmobs_c.type);
  
                                          if (entityinsentient == null) {
-@@ -261,19 +267,44 @@ public final class NaturalSpawner {
+@@ -261,19 +267,40 @@ public final class NaturalSpawner {
          return squaredDistance <= 576.0D ? false : (world.getSharedSpawnPos().closerToCenterThan(new Vec3((double) pos.getX() + 0.5D, (double) pos.getY(), (double) pos.getZ() + 0.5D), 24.0D) ? false : Objects.equals(new ChunkPos(pos), chunk.getPos()) || world.isNaturalSpawningAllowed((BlockPos) pos));
      }
  
@@ -164,19 +149,15 @@ index 604766a286d00bb4b40c20482376fe80651beabe..286592be7aeb183d1a9ee439c250f2ac
          EntityType<?> entitytypes = spawnEntry.type;
  
 +        // Paper start - PreCreatureSpawnEvent
-+        com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event;
-+        org.bukkit.entity.EntityType type = org.bukkit.entity.EntityType.fromName(EntityType.getKey(entitytypes).getPath());
-+        if (type != null) {
-+            event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
-+                io.papermc.paper.util.MCUtil.toLocation(world, pos),
-+                type, SpawnReason.NATURAL
-+            );
-+            if (!event.callEvent()) {
-+                if (event.shouldAbortSpawn()) {
-+                    return PreSpawnStatus.ABORT; // Paper
-+                }
-+                return PreSpawnStatus.CANCELLED; // Paper
++        com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
++            io.papermc.paper.util.MCUtil.toLocation(world, pos),
++            org.bukkit.craftbukkit.entity.CraftEntityType.minecraftToBukkit(entitytypes), SpawnReason.NATURAL
++        );
++        if (!event.callEvent()) {
++            if (event.shouldAbortSpawn()) {
++                return PreSpawnStatus.ABORT;
 +            }
++            return PreSpawnStatus.CANCELLED;
 +        }
 +        // Paper end - PreCreatureSpawnEvent
          if (entitytypes.getCategory() == MobCategory.MISC) {

--- a/patches/server/0171-Extend-Player-Interact-cancellation.patch
+++ b/patches/server/0171-Extend-Player-Interact-cancellation.patch
@@ -9,21 +9,16 @@ However, it is possible to close these GUIs from the server.
 Flower pots are also not updated on the client when interaction is cancelled, this patch
 also resolves this.
 
-Update adjacent blocks of doors, double plants, pistons and beds
-when cancelling interaction.
-
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 45236a077d798d6a257a2e982b58901167ecd06e..f56ba2973aaf0fd41a974d6b38c2b2797631959e 100644
+index 45236a077d798d6a257a2e982b58901167ecd06e..a8d33286832786031ac57e6ce27d5181e1a3d9b1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -519,7 +519,13 @@ public class ServerPlayerGameMode {
+@@ -519,7 +519,11 @@ public class ServerPlayerGameMode {
  
                  // send a correcting update to the client for the block above as well, this because of replaceable blocks (such as grass, sea grass etc)
                  player.connection.send(new ClientboundBlockUpdatePacket(world, blockposition.above()));
 +            // Paper start - extend Player Interact cancellation // TODO: consider merging this into the extracted method
-+            } else if (iblockdata.getBlock() instanceof net.minecraft.world.level.block.StructureBlock) {
-+                player.connection.send(new net.minecraft.network.protocol.game.ClientboundContainerClosePacket(this.player.containerMenu.containerId));
-+            } else if (iblockdata.getBlock() instanceof net.minecraft.world.level.block.CommandBlock) {
++            } else if (iblockdata.is(Blocks.STRUCTURE_BLOCK) || iblockdata.getBlock() instanceof net.minecraft.world.level.block.CommandBlock) {
 +                player.connection.send(new net.minecraft.network.protocol.game.ClientboundContainerClosePacket(this.player.containerMenu.containerId));
              }
 +            // Paper end - extend Player Interact cancellation

--- a/patches/server/0175-Implement-extended-PaperServerListPingEvent.patch
+++ b/patches/server/0175-Implement-extended-PaperServerListPingEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement extended PaperServerListPingEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/network/PaperServerListPingEventImpl.java b/src/main/java/com/destroystokyo/paper/network/PaperServerListPingEventImpl.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5d7110a33957a597592cacb864c947eb053e8563
+index 0000000000000000000000000000000000000000..6ed2114f577ce12d2d493985e798609c7d83f15e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/network/PaperServerListPingEventImpl.java
 @@ -0,0 +1,31 @@
@@ -25,7 +25,7 @@ index 0000000000000000000000000000000000000000..5d7110a33957a597592cacb864c947eb
 +    private final MinecraftServer server;
 +
 +    PaperServerListPingEventImpl(MinecraftServer server, StatusClient client, int protocolVersion, @Nullable CachedServerIcon icon) {
-+        super(client, server.server.motd(), server.getPlayerCount(), server.getMaxPlayers(),
++        super(client, server.motd(), server.getPlayerCount(), server.getMaxPlayers(),
 +                server.getServerModName() + ' ' + server.getServerVersion(), protocolVersion, icon);
 +        this.server = server;
 +    }
@@ -181,7 +181,7 @@ index 0000000000000000000000000000000000000000..6b0bdc266109cdfb874f08bf74323603
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index dad61777658cafaaae56928f3492075067149fd8..eb305e3e4e6574637cd20f99ca979be8acd09e9b 100644
+index 6587cd9ea257d0f6f1308ea8ca4d0245178b2870..0f3589ae1c5577c612b93289fc42cdb977486b6b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -3,6 +3,9 @@ package net.minecraft.server;

--- a/patches/server/0176-Add-more-fields-to-AsyncPreLoginEvent.patch
+++ b/patches/server/0176-Add-more-fields-to-AsyncPreLoginEvent.patch
@@ -7,7 +7,7 @@ Co-authored-by: Connor Linfoot <connorlinfoot@me.com>
 Co-authored-by: MCMDEV <john-m.1@gmx.de>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index abfeaa9485b71d0b802c41bfd8e113d0bc9e9773..c05c4258c48d967be7bde8570ac7bd91a9f3bdda 100644
+index abfeaa9485b71d0b802c41bfd8e113d0bc9e9773..b41aa61f80cd4ab8ddd19da397244392f9efde78 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -157,7 +157,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener,
@@ -41,7 +41,7 @@ index abfeaa9485b71d0b802c41bfd8e113d0bc9e9773..c05c4258c48d967be7bde8570ac7bd91
  
 -        AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, uniqueId);
 +        // Paper start - Add more fields to AsyncPlayerPreLoginEvent
-+        final java.net.InetAddress rawAddress = ((java.net.InetSocketAddress) this.connection.channel.remoteAddress()).getAddress();
++        final InetAddress rawAddress = ((InetSocketAddress) this.connection.channel.remoteAddress()).getAddress();
 +        com.destroystokyo.paper.profile.PlayerProfile profile = org.bukkit.Bukkit.createProfile(uniqueId, playerName);
 +        AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, rawAddress, uniqueId, profile, this.connection.hostname);
          server.getPluginManager().callEvent(asyncEvent);

--- a/patches/server/0177-Player.setPlayerProfile-API.patch
+++ b/patches/server/0177-Player.setPlayerProfile-API.patch
@@ -9,7 +9,7 @@ This can be useful for changing name or skins after a player has logged in.
 public-f net.minecraft.world.entity.player.Player gameProfile
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2d633b9921e04dac21d705ffdf0f5a92b41c2e30..32724550974616c1a17ee3c58fb34fed45898c36 100644
+index 35c8c18fac425a60300718e80fd5304d2e41b53a..e37dc60167b8a6c3c321b5931ed90d13d4520236 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1461,7 +1461,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -22,13 +22,13 @@ index 2d633b9921e04dac21d705ffdf0f5a92b41c2e30..32724550974616c1a17ee3c58fb34fed
          if (Float.isNaN(f)) {
              f = 0;
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index c05c4258c48d967be7bde8570ac7bd91a9f3bdda..b23b7560854a9904e28bbd06afccf5bb0dae16e2 100644
+index b41aa61f80cd4ab8ddd19da397244392f9efde78..e745061f3e6a4541f44ba119106915cdb7023fc6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -295,11 +295,11 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener,
  
          // Paper start - Add more fields to AsyncPlayerPreLoginEvent
-         final java.net.InetAddress rawAddress = ((java.net.InetSocketAddress) this.connection.channel.remoteAddress()).getAddress();
+         final InetAddress rawAddress = ((InetSocketAddress) this.connection.channel.remoteAddress()).getAddress();
 -        com.destroystokyo.paper.profile.PlayerProfile profile = org.bukkit.Bukkit.createProfile(uniqueId, playerName);
 +        com.destroystokyo.paper.profile.PlayerProfile profile = com.destroystokyo.paper.profile.CraftPlayerProfile.asBukkitMirror(gameprofile); // Paper - setPlayerProfileAPI
          AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, rawAddress, uniqueId, profile, this.connection.hostname);

--- a/patches/server/0193-WitchReadyPotionEvent.patch
+++ b/patches/server/0193-WitchReadyPotionEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] WitchReadyPotionEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Witch.java b/src/main/java/net/minecraft/world/entity/monster/Witch.java
-index 96a87db9f8976d3f1ff09beb9598db31fff72d5b..f45b46e30e1ad0516c5b380e476bc7dacb91391a 100644
+index 96a87db9f8976d3f1ff09beb9598db31fff72d5b..25a1edf64602a13c07779e58b167a8471019588e 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Witch.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Witch.java
 @@ -160,7 +160,11 @@ public class Witch extends Raider implements RangedAttackMob {
@@ -15,9 +15,28 @@ index 96a87db9f8976d3f1ff09beb9598db31fff72d5b..f45b46e30e1ad0516c5b380e476bc7da
 -                    this.setItemSlot(EquipmentSlot.MAINHAND, PotionUtils.setPotion(new ItemStack(Items.POTION), potionregistry));
 +                    // Paper start
 +                    ItemStack potion = PotionUtils.setPotion(new ItemStack(Items.POTION), potionregistry);
-+                    org.bukkit.inventory.ItemStack bukkitStack = com.destroystokyo.paper.event.entity.WitchReadyPotionEvent.process((org.bukkit.entity.Witch) this.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(potion));
-+                    this.setItemSlot(EquipmentSlot.MAINHAND, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(bukkitStack));
++                    potion = org.bukkit.craftbukkit.event.CraftEventFactory.handleWitchReadyPotionEvent(this, potion);
++                    this.setItemSlot(EquipmentSlot.MAINHAND, potion);
 +                    // Paper end
                      this.usingTime = this.getMainHandItem().getUseDuration();
                      this.setUsingItem(true);
                      if (!this.isSilent()) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 5bc9b40dd3bbb2e743205adec77cad402564dabf..6e37cb0200f56182030962d981694ab5b126be0d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1935,4 +1935,14 @@ public class CraftEventFactory {
+         ).callEvent();
+     }
+     // Paper end - PlayerUseUnknownEntityEvent
++
++    // Paper start - WitchReadyPotionEvent
++    public static ItemStack handleWitchReadyPotionEvent(net.minecraft.world.entity.monster.Witch witch, @Nullable ItemStack potion) {
++        com.destroystokyo.paper.event.entity.WitchReadyPotionEvent event = new com.destroystokyo.paper.event.entity.WitchReadyPotionEvent((org.bukkit.entity.Witch) witch.getBukkitEntity(), CraftItemStack.asCraftMirror(potion));
++        if (!event.callEvent() || event.getPotion() == null) {
++            return ItemStack.EMPTY;
++        }
++        return org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getPotion());
++    }
++    // Paper end - WitchReadyPotionEvent
+ }

--- a/patches/server/0195-Add-EntityTeleportEndGatewayEvent.patch
+++ b/patches/server/0195-Add-EntityTeleportEndGatewayEvent.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Add EntityTeleportEndGatewayEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-index 8ae723c6500bb92f937a27730c2a5ec912247c0a..223550eccdf0a5596b8595a30f02ad891ffd91ea 100644
+index 08d34dff616b6c117a969809cdeb3853e28dc473..223550eccdf0a5596b8595a30f02ad891ffd91ea 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 @@ -224,8 +224,14 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
  
                  }
  
--                org.bukkit.event.entity.EntityTeleportEvent teleEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTeleportEvent(entity1, blockposition1.getX() + 0.5, blockposition1.getY() + 0.5, blockposition1.getZ() + 0.5); // Paper - diff on change
+-                org.bukkit.event.entity.EntityTeleportEvent teleEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTeleportEvent(entity1, blockposition1.getX() + 0.5, blockposition1.getY() + 0.5, blockposition1.getZ() + 0.5);
 -                if (teleEvent.isCancelled()) {
 +                // Paper start - EntityTeleportEndGatewayEvent
 +                org.bukkit.Location location = new org.bukkit.Location(world.getWorld(), blockposition1.getX() + 0.5D, blockposition1.getY(), blockposition1.getZ() + 0.5D);

--- a/patches/server/0200-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0200-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index acf892ce7cf566fc6b9b88c6502c97a06cdedfd4..fa1c7d1781a2e2269359fa1860de79e918de7635 100644
+index 882bb83a552be415711c8df8118e91981fc63e46..f01a0d7a19329aabbfa69be68c48a409d11aa352 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3808,12 +3808,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3807,12 +3807,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (this.isUsingItem() && !this.useItem.isEmpty()) {
              Item item = this.useItem.getItem();
  

--- a/patches/server/0203-Add-EntityKnockbackByEntityEvent-and-EntityPushedByE.patch
+++ b/patches/server/0203-Add-EntityKnockbackByEntityEvent-and-EntityPushedByE.patch
@@ -33,10 +33,10 @@ index d96fc02a8b84dbcfc17496ca476a5dee8821b785..94c6914a7af6329e4bed8a8d470563b7
  
      protected void markHurt() {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index fa1c7d1781a2e2269359fa1860de79e918de7635..854177cb491d602c1f33e3496e01ba8a63d708e6 100644
+index f01a0d7a19329aabbfa69be68c48a409d11aa352..b58a13e33a0b98bbbdd3283fc3b90cde11ecd37f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1513,7 +1513,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1512,7 +1512,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                          d0 = (Math.random() - Math.random()) * 0.01D;
                      }
  
@@ -45,7 +45,7 @@ index fa1c7d1781a2e2269359fa1860de79e918de7635..854177cb491d602c1f33e3496e01ba8a
                      if (!flag) {
                          this.indicateDamage(d0, d1);
                      }
-@@ -1561,7 +1561,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1560,7 +1560,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      protected void blockedByShield(LivingEntity target) {
@@ -54,7 +54,7 @@ index fa1c7d1781a2e2269359fa1860de79e918de7635..854177cb491d602c1f33e3496e01ba8a
      }
  
      private boolean checkTotemDeathProtection(DamageSource source) {
-@@ -1820,6 +1820,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1819,6 +1819,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public void knockback(double strength, double x, double z) {
@@ -66,11 +66,11 @@ index fa1c7d1781a2e2269359fa1860de79e918de7635..854177cb491d602c1f33e3496e01ba8a
          strength *= 1.0D - this.getAttributeValue(Attributes.KNOCKBACK_RESISTANCE);
          if (strength > 0.0D) {
              this.hasImpulse = true;
-@@ -1827,6 +1832,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1826,6 +1831,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
              Vec3 vec3d1 = (new Vec3(x, 0.0D, z)).normalize().scale(strength);
  
              this.setDeltaMovement(vec3d.x / 2.0D - vec3d1.x, this.onGround() ? Math.min(0.4D, vec3d.y / 2.0D + strength) : vec3d.y, vec3d.z / 2.0D - vec3d1.z);
-+            // Paper start - Add EntityKnockbackByEntityEvent and EntityPushedByEntityAttackEventt
++            // Paper start - Add EntityKnockbackByEntityEvent and EntityPushedByEntityAttackEvent
 +            Vec3 currentMovement = this.getDeltaMovement();
 +            org.bukkit.util.Vector delta = new org.bukkit.util.Vector(currentMovement.x - vec3d.x, currentMovement.y - vec3d.y, currentMovement.z - vec3d.z);
 +            // Restore old velocity to be able to access it in the event

--- a/patches/server/0209-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0209-InventoryCloseEvent-Reason-API.patch
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index aa9d514f26fbe70edf3a8b7443fbaf577cf3a030..35ed4ba377eadb72d59a7984bc40f3834136174c 100644
+index 180a9ade7bbc84d8c64b6c92583ba870464c23a5..a6749080a192a591dd4e52f56b691df8d9cfcd98 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1235,7 +1235,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -75,25 +75,17 @@ index d51244c634d0209efb98be965ce7318480220b96..33108a55c1cc305d44238d0862755af8
          this.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 32724550974616c1a17ee3c58fb34fed45898c36..1e40b7933e9e984ae4b3683c7cf82a564a723048 100644
+index e37dc60167b8a6c3c321b5931ed90d13d4520236..ddc9361f80bf28252852f9169b0f5d2f7a8320ba 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -219,6 +219,7 @@ import org.bukkit.event.inventory.ClickType;
- import org.bukkit.event.inventory.CraftItemEvent;
- import org.bukkit.event.inventory.InventoryAction;
- import org.bukkit.event.inventory.InventoryClickEvent;
-+import org.bukkit.event.inventory.InventoryCloseEvent; // Paper
- import org.bukkit.event.inventory.InventoryCreativeEvent;
- import org.bukkit.event.inventory.InventoryType.SlotType;
- import org.bukkit.event.inventory.SmithItemEvent;
-@@ -2531,10 +2532,15 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2520,10 +2520,15 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void handleContainerClose(ServerboundContainerClosePacket packet) {
 +        // Paper start - Inventory close reason
-+        this.handleContainerClose(packet, InventoryCloseEvent.Reason.PLAYER);
++        this.handleContainerClose(packet, org.bukkit.event.inventory.InventoryCloseEvent.Reason.PLAYER);
 +    }
-+    public void handleContainerClose(ServerboundContainerClosePacket packet, InventoryCloseEvent.Reason reason) {
++    public void handleContainerClose(ServerboundContainerClosePacket packet, org.bukkit.event.inventory.InventoryCloseEvent.Reason reason) {
 +        // Paper end - Inventory close reason
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
  
@@ -173,7 +165,7 @@ index 092d2bfab7e8fd9840e853f09adc85311ab29046..af6f8d11f0384c353332f5c5bb0967e5
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e0ce56ab1a1980800402e55ee49df3b896afee60..28b51b1ecf54f9a43678d21cd1b40da32a63d645 100644
+index 4d0d2b1bc24a0d56724d7062bdbc3c7cf78e2b8a..047be06ad290e6e066689fe3b95902a3459304b3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1152,7 +1152,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -186,7 +178,7 @@ index e0ce56ab1a1980800402e55ee49df3b896afee60..28b51b1ecf54f9a43678d21cd1b40da3
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 848bcabb5922c99ee78cb541c87b464cea032749..3ec8302c569ef923ddca3f9bfb3c506832fe7659 100644
+index 83efc53d933e6de7ee414e89226d3a0cb54e3cf3..de7971320df8cb1c00c6a836a5c3c953a10f9a69 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1331,7 +1331,7 @@ public class CraftEventFactory {

--- a/patches/server/0211-Refresh-player-inventory-when-cancelling-PlayerInter.patch
+++ b/patches/server/0211-Refresh-player-inventory-when-cancelling-PlayerInter.patch
@@ -16,10 +16,10 @@ Refresh the player inventory when PlayerInteractEntityEvent is
 cancelled to avoid this problem.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 1e40b7933e9e984ae4b3683c7cf82a564a723048..7080f19eab36df503ee285ed81a00624c12e056f 100644
+index ddc9361f80bf28252852f9169b0f5d2f7a8320ba..2e2bf7ba0a2511128cac1ff47b9a38a67b61522c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2412,6 +2412,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2411,6 +2411,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              }
  
                              if (event.isCancelled()) {

--- a/patches/server/0218-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/patches/server/0218-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -17,10 +17,10 @@ index d04d0b9cbf91beb57da7e37e72f8e7c98cf6cf4c..e6e3a7ae08f7346ccbce02b9d3623948
          Iterator iterator = list.iterator();
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 19d6a829edb977d064c5d5a42ae3cab4fc806bb6..0ead21982ff57ba748eb6b4169e9e1a8c32bf34e 100644
+index 8a7276f83744252ac5a418f9acb219e02c508b2f..37c50c9da4249a92811aaa5cef5743ccefdcb4a8 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -772,6 +772,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -767,6 +767,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // Paper end - Prevent block entity and entity crashes
          }
      }

--- a/patches/server/0219-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0219-Vanished-players-don-t-have-rights.patch
@@ -39,10 +39,10 @@ index a6638e626600e4304a973497a39e3fac52203b16..c19069f65a9ecbc9000ea4333417a2df
  
          BlockCanBuildEvent event = new BlockCanBuildEvent(CraftBlock.at(context.getLevel(), context.getClickedPos()), player, CraftBlockData.fromData(state), defaultReturn);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 0ead21982ff57ba748eb6b4169e9e1a8c32bf34e..e85e47b5fd8f59a298afd8962986dfc4fa956a10 100644
+index 37c50c9da4249a92811aaa5cef5743ccefdcb4a8..181201ecd6c617cc37ba097a667bd96ae3b1823e 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -276,6 +276,45 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -271,6 +271,45 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.tileLimiter = new org.spigotmc.TickLimiter(this.spigotConfig.tileMaxTickTime);
      }
  
@@ -89,7 +89,7 @@ index 0ead21982ff57ba748eb6b4169e9e1a8c32bf34e..e85e47b5fd8f59a298afd8962986dfc4
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 3ec8302c569ef923ddca3f9bfb3c506832fe7659..b297f6eb25192079e8e388d034d4e3ede8d5ab37 100644
+index de7971320df8cb1c00c6a836a5c3c953a10f9a69..3ee2b011689b9d2df03947c1e04e3042b8e8c853 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1368,6 +1368,14 @@ public class CraftEventFactory {

--- a/patches/server/0225-Add-TNTPrimeEvent.patch
+++ b/patches/server/0225-Add-TNTPrimeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add TNTPrimeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 666c62d796cae9a70516680e26196f7e02c53918..290d97437e9c593816b4f4c4e738c268be616dc0 100644
+index 666c62d796cae9a70516680e26196f7e02c53918..623a4cc921442dbba4f80df3be06762b4b1289ae 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 @@ -558,6 +558,11 @@ public class EnderDragon extends Mob implements Enemy {
@@ -13,7 +13,7 @@ index 666c62d796cae9a70516680e26196f7e02c53918..290d97437e9c593816b4f4c4e738c268
                      craftBlock.getNMS().spawnAfterBreak((ServerLevel) this.level(), blockposition, ItemStack.EMPTY, false);
                  }
 +                // Paper start - TNTPrimeEvent
-+                org.bukkit.block.Block tntBlock = this.level().getWorld().getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ());
++                org.bukkit.block.Block tntBlock = CraftBlock.at(this.level(), blockposition);
 +                if (!new com.destroystokyo.paper.event.block.TNTPrimeEvent(tntBlock, com.destroystokyo.paper.event.block.TNTPrimeEvent.PrimeReason.EXPLOSION, explosionSource.getIndirectSourceEntity().getBukkitEntity()).callEvent())
 +                    continue;
 +                // Paper end - TNTPrimeEvent
@@ -21,7 +21,7 @@ index 666c62d796cae9a70516680e26196f7e02c53918..290d97437e9c593816b4f4c4e738c268
  
                  this.level().removeBlock(blockposition, false);
 diff --git a/src/main/java/net/minecraft/world/level/block/FireBlock.java b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-index 016c8b7762c2b4eacb95a455940db4684b34e03c..c214a8a72c3fa27eaadc458b10a610e0de7937ec 100644
+index 016c8b7762c2b4eacb95a455940db4684b34e03c..da9cd2da60186b94f3b8a259c13b20f20e50fccb 100644
 --- a/src/main/java/net/minecraft/world/level/block/FireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FireBlock.java
 @@ -302,12 +302,19 @@ public class FireBlock extends BaseFireBlock {
@@ -36,7 +36,7 @@ index 016c8b7762c2b4eacb95a455940db4684b34e03c..c214a8a72c3fa27eaadc458b10a610e0
  
              if (block instanceof TntBlock) {
 +                // Paper start - TNTPrimeEvent
-+                org.bukkit.block.Block tntBlock = io.papermc.paper.util.MCUtil.toBukkitBlock(world, blockposition);
++                org.bukkit.block.Block tntBlock = org.bukkit.craftbukkit.block.CraftBlock.at(world, blockposition);
 +                if (!new com.destroystokyo.paper.event.block.TNTPrimeEvent(tntBlock, com.destroystokyo.paper.event.block.TNTPrimeEvent.PrimeReason.FIRE, null).callEvent()) {
 +                    return;
 +                }
@@ -46,7 +46,7 @@ index 016c8b7762c2b4eacb95a455940db4684b34e03c..c214a8a72c3fa27eaadc458b10a610e0
              }
          }
 diff --git a/src/main/java/net/minecraft/world/level/block/TntBlock.java b/src/main/java/net/minecraft/world/level/block/TntBlock.java
-index cc20c320cbb3420e5e302a94571bab374c8553c8..ab53b42eec6eb57b373487e50066967042d6eb40 100644
+index cc20c320cbb3420e5e302a94571bab374c8553c8..4edd2e7bb62df65d6da8c8a623cf03e7e947bf75 100644
 --- a/src/main/java/net/minecraft/world/level/block/TntBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/TntBlock.java
 @@ -49,6 +49,12 @@ public class TntBlock extends Block {
@@ -54,7 +54,7 @@ index cc20c320cbb3420e5e302a94571bab374c8553c8..ab53b42eec6eb57b373487e500669670
          if (!oldState.is(state.getBlock())) {
              if (world.hasNeighborSignal(pos) && CraftEventFactory.callTNTPrimeEvent(world, pos, PrimeCause.REDSTONE, null, null)) { // CraftBukkit - TNTPrimeEvent
 +                // Paper start - TNTPrimeEvent
-+                org.bukkit.block.Block tntBlock = io.papermc.paper.util.MCUtil.toBukkitBlock(world, pos);
++                org.bukkit.block.Block tntBlock = org.bukkit.craftbukkit.block.CraftBlock.at(world, pos);
 +                if (!new com.destroystokyo.paper.event.block.TNTPrimeEvent(tntBlock, com.destroystokyo.paper.event.block.TNTPrimeEvent.PrimeReason.REDSTONE, null).callEvent()) {
 +                    return;
 +                }
@@ -67,7 +67,7 @@ index cc20c320cbb3420e5e302a94571bab374c8553c8..ab53b42eec6eb57b373487e500669670
      public void neighborChanged(BlockState state, Level world, BlockPos pos, Block sourceBlock, BlockPos sourcePos, boolean notify) {
          if (world.hasNeighborSignal(pos) && CraftEventFactory.callTNTPrimeEvent(world, pos, PrimeCause.REDSTONE, null, sourcePos)) { // CraftBukkit - TNTPrimeEvent
 +            // Paper start - TNTPrimeEvent
-+            org.bukkit.block.Block tntBlock = io.papermc.paper.util.MCUtil.toBukkitBlock(world, pos);
++            org.bukkit.block.Block tntBlock = org.bukkit.craftbukkit.block.CraftBlock.at(world, pos);
 +            if (!new com.destroystokyo.paper.event.block.TNTPrimeEvent(tntBlock, com.destroystokyo.paper.event.block.TNTPrimeEvent.PrimeReason.REDSTONE, null).callEvent()) {
 +                return;
 +            }
@@ -80,7 +80,7 @@ index cc20c320cbb3420e5e302a94571bab374c8553c8..ab53b42eec6eb57b373487e500669670
      public void wasExploded(Level world, BlockPos pos, Explosion explosion) {
          if (!world.isClientSide) {
 +            // Paper start - TNTPrimeEvent
-+            org.bukkit.block.Block tntBlock = io.papermc.paper.util.MCUtil.toBukkitBlock(world, pos);
++            org.bukkit.block.Block tntBlock = org.bukkit.craftbukkit.block.CraftBlock.at(world, pos);
 +            org.bukkit.entity.Entity source = explosion.source != null ? explosion.source.getBukkitEntity() : null;
 +            if (!new com.destroystokyo.paper.event.block.TNTPrimeEvent(tntBlock, com.destroystokyo.paper.event.block.TNTPrimeEvent.PrimeReason.EXPLOSION, source).callEvent()) {
 +                return;
@@ -94,7 +94,7 @@ index cc20c320cbb3420e5e302a94571bab374c8553c8..ab53b42eec6eb57b373487e500669670
              }
              // CraftBukkit end
 +            // Paper start - TNTPrimeEvent
-+            org.bukkit.block.Block tntBlock = io.papermc.paper.util.MCUtil.toBukkitBlock(world, pos);
++            org.bukkit.block.Block tntBlock = org.bukkit.craftbukkit.block.CraftBlock.at(world, pos);
 +            if (!new com.destroystokyo.paper.event.block.TNTPrimeEvent(tntBlock, com.destroystokyo.paper.event.block.TNTPrimeEvent.PrimeReason.ITEM, player.getBukkitEntity()).callEvent()) {
 +                return InteractionResult.FAIL;
 +            }
@@ -107,7 +107,7 @@ index cc20c320cbb3420e5e302a94571bab374c8553c8..ab53b42eec6eb57b373487e500669670
                  }
                  // CraftBukkit end
 +                // Paper start - TNTPrimeEvent
-+                org.bukkit.block.Block tntBlock = io.papermc.paper.util.MCUtil.toBukkitBlock(world, blockposition);
++                org.bukkit.block.Block tntBlock = org.bukkit.craftbukkit.block.CraftBlock.at(world, blockposition);
 +                if (!new com.destroystokyo.paper.event.block.TNTPrimeEvent(tntBlock, com.destroystokyo.paper.event.block.TNTPrimeEvent.PrimeReason.PROJECTILE, projectile.getBukkitEntity()).callEvent()) {
 +                    return;
 +                }

--- a/patches/server/0226-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/patches/server/0226-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -22,10 +22,10 @@ to take the burden of this into their own hand without having to rely on
 plugins doing unsafe things.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 7080f19eab36df503ee285ed81a00624c12e056f..a93d34bee92a2d1b48ddfa7a764d4038fb7af787 100644
+index 2e2bf7ba0a2511128cac1ff47b9a38a67b61522c..14dc58263afbdafb576bd10f7b98403466093834 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -257,6 +257,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -256,6 +256,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      private int ackBlockChangesUpTo = -1;
      // CraftBukkit start - multithreaded fields
      private final AtomicInteger chatSpamTickCount = new AtomicInteger();
@@ -33,7 +33,7 @@ index 7080f19eab36df503ee285ed81a00624c12e056f..a93d34bee92a2d1b48ddfa7a764d4038
      // CraftBukkit end
      private int dropSpamTickCount;
      private double firstGoodX;
-@@ -374,6 +375,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -373,6 +374,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          this.keepConnectionAlive();
          // CraftBukkit start
          for (int spam; (spam = this.chatSpamTickCount.get()) > 0 && !this.chatSpamTickCount.compareAndSet(spam, spam - 1); ) ;
@@ -41,7 +41,7 @@ index 7080f19eab36df503ee285ed81a00624c12e056f..a93d34bee92a2d1b48ddfa7a764d4038
          /* Use thread-safe field access instead
          if (this.chatSpamTickCount > 0) {
              --this.chatSpamTickCount;
-@@ -697,7 +699,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -696,7 +698,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      public void handleCustomCommandSuggestions(ServerboundCommandSuggestionPacket packet) {
          // PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel()); // Paper - AsyncTabCompleteEvent; run this async
          // CraftBukkit start

--- a/patches/server/0244-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/patches/server/0244-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ray tracing methods to LivingEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 854177cb491d602c1f33e3496e01ba8a63d708e6..9780f8f42caa8bc5b67af85eeb8ab146b2b3a9e9 100644
+index b58a13e33a0b98bbbdd3283fc3b90cde11ecd37f..9e0555b1e98bba6a9305c3996c69347e47d73204 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3829,6 +3829,19 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3828,6 +3828,19 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      // Paper start - Make shield blocking delay configurable

--- a/patches/server/0246-Improve-death-events.patch
+++ b/patches/server/0246-Improve-death-events.patch
@@ -80,10 +80,10 @@ index 33108a55c1cc305d44238d0862755af874f19395..1042b19c906e40d4a4e9ef76d6922814
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9780f8f42caa8bc5b67af85eeb8ab146b2b3a9e9..d22ce89c97107c0c6db3f911329e53328c2387c4 100644
+index 9e0555b1e98bba6a9305c3996c69347e47d73204..bd70046b4fef307b6b8b626a65f0b4a366ab7158 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -259,6 +259,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -258,6 +258,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      public Set<UUID> collidableExemptions = new HashSet<>();
      public boolean bukkitPickUpLoot;
      public org.bukkit.craftbukkit.entity.CraftLivingEntity getBukkitLivingEntity() { return (org.bukkit.craftbukkit.entity.CraftLivingEntity) super.getBukkitEntity(); } // Paper
@@ -91,7 +91,7 @@ index 9780f8f42caa8bc5b67af85eeb8ab146b2b3a9e9..d22ce89c97107c0c6db3f911329e5332
  
      @Override
      public float getBukkitYaw() {
-@@ -1522,13 +1523,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1521,13 +1522,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
              if (this.isDeadOrDying()) {
                  if (!this.checkTotemDeathProtection(source)) {
@@ -109,16 +109,15 @@ index 9780f8f42caa8bc5b67af85eeb8ab146b2b3a9e9..d22ce89c97107c0c6db3f911329e5332
                  }
              } else if (flag1) {
                  this.playHurtSound(source);
-@@ -1679,7 +1679,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
-         if (!this.isRemoved() && !this.dead) {
+@@ -1679,6 +1679,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              Entity entity = damageSource.getEntity();
              LivingEntity entityliving = this.getKillCredit();
--
+ 
 +            /* // Paper - move down to make death event cancellable - this is the awardKillScore below
              if (this.deathScore >= 0 && entityliving != null) {
                  entityliving.awardKillScore(this, this.deathScore, damageSource);
              }
-@@ -1691,24 +1691,59 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1690,24 +1691,59 @@ public abstract class LivingEntity extends Entity implements Attackable {
              if (!this.level().isClientSide && this.hasCustomName()) {
                  if (org.spigotmc.SpigotConfig.logNamedDeaths) LivingEntity.LOGGER.info("Named entity {} died: {}", this, this.getCombatTracker().getDeathMessage().getString()); // Spigot
              }
@@ -132,7 +131,8 @@ index 9780f8f42caa8bc5b67af85eeb8ab146b2b3a9e9..d22ce89c97107c0c6db3f911329e5332
              if (world instanceof ServerLevel) {
                  ServerLevel worldserver = (ServerLevel) world;
 +                // Paper - move below into if for onKill
-+
+ 
+-                if (entity == null || entity.killedEntity(worldserver, this)) {
 +                // Paper start
 +                org.bukkit.event.entity.EntityDeathEvent deathEvent = this.dropAllDeathLoot(damageSource);
 +                if (deathEvent == null || !deathEvent.isCancelled()) {
@@ -147,8 +147,7 @@ index 9780f8f42caa8bc5b67af85eeb8ab146b2b3a9e9..d22ce89c97107c0c6db3f911329e5332
 +                        this.clearedEquipmentSlots.clear();
 +                    }
 +                    // Paper end
- 
--                if (entity == null || entity.killedEntity(worldserver, this)) {
++
 +                    if (this.isSleeping()) {
 +                        this.stopSleeping();
 +                    }
@@ -183,7 +182,7 @@ index 9780f8f42caa8bc5b67af85eeb8ab146b2b3a9e9..d22ce89c97107c0c6db3f911329e5332
          }
      }
  
-@@ -1716,7 +1751,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1715,7 +1751,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (!this.level().isClientSide) {
              boolean flag = false;
  
@@ -192,7 +191,7 @@ index 9780f8f42caa8bc5b67af85eeb8ab146b2b3a9e9..d22ce89c97107c0c6db3f911329e5332
                  if (this.level().getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
                      BlockPos blockposition = this.blockPosition();
                      BlockState iblockdata = Blocks.WITHER_ROSE.defaultBlockState();
-@@ -1745,7 +1780,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1744,7 +1780,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
          }
      }
  
@@ -205,7 +204,7 @@ index 9780f8f42caa8bc5b67af85eeb8ab146b2b3a9e9..d22ce89c97107c0c6db3f911329e5332
          Entity entity = source.getEntity();
          int i;
  
-@@ -1760,18 +1799,27 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1759,18 +1799,27 @@ public abstract class LivingEntity extends Entity implements Attackable {
          this.dropEquipment(); // CraftBukkit - from below
          if (this.shouldDropLoot() && this.level().getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
              this.dropFromLootTable(source, flag);
@@ -422,7 +421,7 @@ index b98f26b6958cb3f874a4c0d85e2c10ec517cbbff..adcba9111415a20a4a55bb182be84c9f
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b297f6eb25192079e8e388d034d4e3ede8d5ab37..3bd92edf2f4e7a63a07bd2bbae002f99484a9069 100644
+index 3ee2b011689b9d2df03947c1e04e3042b8e8c853..131fa4d389c3ddad31651f298ccd807847462f38 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -890,9 +890,16 @@ public class CraftEventFactory {

--- a/patches/server/0257-PreSpawnerSpawnEvent.patch
+++ b/patches/server/0257-PreSpawnerSpawnEvent.patch
@@ -9,21 +9,19 @@ SpawnerSpawnEvent gets called instead of the CreatureSpawnEvent for
 spawners.
 
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index 28f63a211f4ae207b2400d16b1725808ad87f334..1b0093a23011f7d1c0da88c0a934d94ad4d6b3e2 100644
+index 0166c5ff685490cbf67a9d26f48cb1a0be754488..cae8c508972d771ad96228ace8a7e6cbc34d5489 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-@@ -136,11 +136,11 @@ public abstract class BaseSpawner {
- 
-                         org.bukkit.entity.EntityType type = org.bukkit.entity.EntityType.fromName(key);
-                         if (type != null) {
--                            com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event;
--                            event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
-+                            com.destroystokyo.paper.event.entity.PreSpawnerSpawnEvent event;
-+                            event = new com.destroystokyo.paper.event.entity.PreSpawnerSpawnEvent(
-                                 io.papermc.paper.util.MCUtil.toLocation(world, d0, d1, d2),
-                                 type,
--                                org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.SPAWNER
-+                                io.papermc.paper.util.MCUtil.toLocation(world, pos)
-                             );
-                             if (!event.callEvent()) {
-                                 flag = true;
+@@ -131,10 +131,10 @@ public abstract class BaseSpawner {
+                             continue;
+                         }
+                         // Paper start - PreCreatureSpawnEvent
+-                        com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
++                        com.destroystokyo.paper.event.entity.PreSpawnerSpawnEvent event = new com.destroystokyo.paper.event.entity.PreSpawnerSpawnEvent(
+                             io.papermc.paper.util.MCUtil.toLocation(world, d0, d1, d2),
+                             org.bukkit.craftbukkit.entity.CraftEntityType.minecraftToBukkit(optional.get()),
+-                            org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.SPAWNER
++                            io.papermc.paper.util.MCUtil.toLocation(world, pos)
+                         );
+                         if (!event.callEvent()) {
+                             flag = true;

--- a/patches/server/0258-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0258-Add-LivingEntity-getTargetEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index d22ce89c97107c0c6db3f911329e53328c2387c4..966db97da239e3712d382d18c2a0c6c111b60ab2 100644
+index bd70046b4fef307b6b8b626a65f0b4a366ab7158..1f89fe5ee232089df6b63277d6e2938da840f5c0 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -116,6 +116,7 @@ import net.minecraft.world.level.storage.loot.LootTable;
+@@ -115,6 +115,7 @@ import net.minecraft.world.level.storage.loot.LootTable;
  import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
  import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
  import net.minecraft.world.phys.AABB;

--- a/patches/server/0260-Catch-JsonParseException-in-entity-and-block-entity-.patch
+++ b/patches/server/0260-Catch-JsonParseException-in-entity-and-block-entity-.patch
@@ -13,10 +13,10 @@ Shulkers) may need to be changed in order for it to re-save properly
 No more crashing though.
 
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
-index b08190d604f7f95f771a4da115cc50c38c5f1691..8235d23dc9778b9444288d58ffdb5d515df56bf9 100644
+index 36c0215a1ebc9372e5f355ecbe34fc1aaefd6903..0d3ccf3ae219a3b24d17be03de8fd4906cb7235d 100644
 --- a/src/main/java/io/papermc/paper/util/MCUtil.java
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
-@@ -536,4 +536,19 @@ public final class MCUtil {
+@@ -532,4 +532,19 @@ public final class MCUtil {
      public static int getTicketLevelFor(net.minecraft.world.level.chunk.ChunkStatus status) {
          return net.minecraft.server.level.ChunkMap.MAX_VIEW_DISTANCE + net.minecraft.world.level.chunk.ChunkStatus.getDistance(status);
      }
@@ -76,7 +76,7 @@ index 25764076fec05b1362aa9b9b608e03bd39817d90..fce3a45d09a93ca68a3d49f2e666afa4
  
      }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
-index f4e1dc338dd240371694dd7a3455c79d5cea251a..f3b9a692417dbfc67b939a753c29ad1c159e274b 100644
+index 25ec3ab534872500a2eb51cd44062e2754c404bb..a1097950766ad31393340b423ea3f98a1f555368 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
 @@ -389,7 +389,7 @@ public class BeaconBlockEntity extends BlockEntity implements MenuProvider, Name

--- a/patches/server/0263-Add-more-Witch-API.patch
+++ b/patches/server/0263-Add-more-Witch-API.patch
@@ -7,20 +7,18 @@ Subject: [PATCH] Add more Witch API
 public net.minecraft.world.entity.monster.Witch usingTime
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Witch.java b/src/main/java/net/minecraft/world/entity/monster/Witch.java
-index f45b46e30e1ad0516c5b380e476bc7dacb91391a..02386e7eabc6669296ce35158fa35a3c88c6b563 100644
+index 25a1edf64602a13c07779e58b167a8471019588e..f9ffc5f4cbfdcf5c7351a883d2e5c26492175283 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Witch.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Witch.java
-@@ -160,21 +160,10 @@ public class Witch extends Raider implements RangedAttackMob {
+@@ -160,21 +160,7 @@ public class Witch extends Raider implements RangedAttackMob {
                  }
  
                  if (potionregistry != null) {
 -                    // Paper start
-                     ItemStack potion = PotionUtils.setPotion(new ItemStack(Items.POTION), potionregistry);
--                    org.bukkit.inventory.ItemStack bukkitStack = com.destroystokyo.paper.event.entity.WitchReadyPotionEvent.process((org.bukkit.entity.Witch) this.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(potion));
--                    this.setItemSlot(EquipmentSlot.MAINHAND, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(bukkitStack));
-+                    // Paper start - logic moved into setDrinkingPotion, copy exact impl into the method and then comment out
-+                    this.setDrinkingPotion(potion);
-                     // Paper end
+-                    ItemStack potion = PotionUtils.setPotion(new ItemStack(Items.POTION), potionregistry);
+-                    potion = org.bukkit.craftbukkit.event.CraftEventFactory.handleWitchReadyPotionEvent(this, potion);
+-                    this.setItemSlot(EquipmentSlot.MAINHAND, potion);
+-                    // Paper end
 -                    this.usingTime = this.getMainHandItem().getUseDuration();
 -                    this.setUsingItem(true);
 -                    if (!this.isSilent()) {
@@ -31,18 +29,18 @@ index f45b46e30e1ad0516c5b380e476bc7dacb91391a..02386e7eabc6669296ce35158fa35a3c
 -
 -                    attributemodifiable.removeModifier(Witch.SPEED_MODIFIER_DRINKING.getId());
 -                    attributemodifiable.addTransientModifier(Witch.SPEED_MODIFIER_DRINKING);
++                    this.setDrinkingPotion(PotionUtils.setPotion(new ItemStack(Items.POTION), potionregistry)); // Paper - logic moved into setDrinkingPotion, copy exact impl into the method and then comment out
                  }
              }
  
-@@ -186,6 +175,24 @@ public class Witch extends Raider implements RangedAttackMob {
+@@ -186,6 +172,23 @@ public class Witch extends Raider implements RangedAttackMob {
          super.aiStep();
      }
  
 +    // Paper start - moved to its own method
 +    public void setDrinkingPotion(ItemStack potion) {
-+        org.bukkit.inventory.ItemStack bukkitStack = com.destroystokyo.paper.event.entity.WitchReadyPotionEvent.process((org.bukkit.entity.Witch) this.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(potion));
-+        this.setItemSlot(EquipmentSlot.MAINHAND, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(bukkitStack));
-+        // Paper end
++        potion = org.bukkit.craftbukkit.event.CraftEventFactory.handleWitchReadyPotionEvent(this, potion);
++        this.setItemSlot(EquipmentSlot.MAINHAND, potion);
 +        this.usingTime = this.getMainHandItem().getUseDuration();
 +        this.setUsingItem(true);
 +        if (!this.isSilent()) {

--- a/patches/server/0265-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/patches/server/0265-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add option to prevent players from moving into unloaded
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a93d34bee92a2d1b48ddfa7a764d4038fb7af787..4e7b46ef3585b30bd8057e6fc2aa9611e829539b 100644
+index 14dc58263afbdafb576bd10f7b98403466093834..5f68a0cd7e2484933dfa09cb54a0f2f18fa2241c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -475,9 +475,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -474,9 +474,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  double d0 = entity.getX();
                  double d1 = entity.getY();
                  double d2 = entity.getZ();
@@ -22,7 +22,7 @@ index a93d34bee92a2d1b48ddfa7a764d4038fb7af787..4e7b46ef3585b30bd8057e6fc2aa9611
                  float f = Mth.wrapDegrees(packet.getYRot());
                  float f1 = Mth.wrapDegrees(packet.getXRot());
                  double d6 = d3 - this.vehicleFirstGoodX;
-@@ -511,6 +511,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -510,6 +510,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  }
                  speed *= 2f; // TODO: Get the speed of the vehicle instead of the player
  
@@ -39,7 +39,7 @@ index a93d34bee92a2d1b48ddfa7a764d4038fb7af787..4e7b46ef3585b30bd8057e6fc2aa9611
                  if (d10 - d9 > Math.max(100.0D, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isSingleplayerOwner()) {
                  // CraftBukkit end
                      ServerGamePacketListenerImpl.LOGGER.warn("{} (vehicle of {}) moved too quickly! {},{},{}", new Object[]{entity.getName().getString(), this.player.getName().getString(), d6, d7, d8});
-@@ -1173,9 +1183,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1172,9 +1182,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                  } else {
                      this.awaitingTeleportTime = this.tickCount;
@@ -52,7 +52,7 @@ index a93d34bee92a2d1b48ddfa7a764d4038fb7af787..4e7b46ef3585b30bd8057e6fc2aa9611
                      float f = Mth.wrapDegrees(packet.getYRot(this.player.getYRot()));
                      float f1 = Mth.wrapDegrees(packet.getXRot(this.player.getXRot()));
  
-@@ -1231,6 +1241,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1230,6 +1240,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  } else {
                                      speed = this.player.getAbilities().walkingSpeed * 10f;
                                  }

--- a/patches/server/0272-Don-t-allow-digging-into-unloaded-chunks.patch
+++ b/patches/server/0272-Don-t-allow-digging-into-unloaded-chunks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Don't allow digging into unloaded chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index f56ba2973aaf0fd41a974d6b38c2b2797631959e..deef24ad28ecf7895aa03bf8dae085814d307ece 100644
+index a8d33286832786031ac57e6ce27d5181e1a3d9b1..e8b12b27e5ec74afb940f575e5ce78e5905d55f4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -119,8 +119,8 @@ public class ServerPlayerGameMode {
@@ -59,10 +59,10 @@ index f56ba2973aaf0fd41a974d6b38c2b2797631959e..deef24ad28ecf7895aa03bf8dae08581
  
                  this.level.destroyBlockProgress(this.player.getId(), pos, -1);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index cce8a2a7d7b510f4741b28de89f505647d5673e8..1b633a87dbec1152de74a4cd9eb60426d05a9e36 100644
+index 5f68a0cd7e2484933dfa09cb54a0f2f18fa2241c..7c9e4673ef06c08f04691137cbef5ed3fc5d0b4b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1585,6 +1585,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1584,6 +1584,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              case START_DESTROY_BLOCK:
              case ABORT_DESTROY_BLOCK:
              case STOP_DESTROY_BLOCK:

--- a/patches/server/0277-Book-Size-Limits.patch
+++ b/patches/server/0277-Book-Size-Limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Book Size Limits
 Puts some limits on the size of books.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 1b633a87dbec1152de74a4cd9eb60426d05a9e36..831281ab33e8d2ec4e31a03fe7dc18ce7928d3d6 100644
+index 7c9e4673ef06c08f04691137cbef5ed3fc5d0b4b..06120b7da7f830f4bb36e5c1ec71201e344a1182 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1019,6 +1019,45 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1018,6 +1018,45 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void handleEditBook(ServerboundEditBookPacket packet) {

--- a/patches/server/0278-Add-PlayerConnectionCloseEvent.patch
+++ b/patches/server/0278-Add-PlayerConnectionCloseEvent.patch
@@ -38,7 +38,7 @@ public net.minecraft.server.network.ServerLoginPacketListenerImpl$State
 public net.minecraft.server.network.ServerLoginPacketListenerImpl state
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 157f055df00faf3a7870df8109e84fdb12f55964..cd9ed68079abf103759865a3e2a038ac629a18ea 100644
+index 157f055df00faf3a7870df8109e84fdb12f55964..7648b889bc488197f32545e8c3671a54102c01ec 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -644,6 +644,26 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -51,7 +51,7 @@ index 157f055df00faf3a7870df8109e84fdb12f55964..cd9ed68079abf103759865a3e2a038ac
 +                    /* Player was logged in, either game listener or configuration listener */
 +                    final com.mojang.authlib.GameProfile profile = commonPacketListener.getOwner();
 +                    new com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent(profile.getId(),
-+                        profile.getName(), ((java.net.InetSocketAddress)address).getAddress(), false).callEvent();
++                        profile.getName(), ((InetSocketAddress) this.address).getAddress(), false).callEvent();
 +                } else if (packetListener instanceof net.minecraft.server.network.ServerLoginPacketListenerImpl loginListener) {
 +                    /* Player is login stage */
 +                    switch (loginListener.state) {
@@ -61,7 +61,7 @@ index 157f055df00faf3a7870df8109e84fdb12f55964..cd9ed68079abf103759865a3e2a038ac
 +                        case ACCEPTED:
 +                            final com.mojang.authlib.GameProfile profile = loginListener.authenticatedProfile; /* Should be non-null at this stage */
 +                            new com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent(profile.getId(), profile.getName(),
-+                                ((java.net.InetSocketAddress)address).getAddress(), false).callEvent();
++                                ((InetSocketAddress) this.address).getAddress(), false).callEvent();
 +                    }
 +                }
 +                // Paper end - Add PlayerConnectionCloseEvent
@@ -69,7 +69,7 @@ index 157f055df00faf3a7870df8109e84fdb12f55964..cd9ed68079abf103759865a3e2a038ac
              }
          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index b23b7560854a9904e28bbd06afccf5bb0dae16e2..ba0bdd685c49c02bcb1b6d840ddceb9049565d34 100644
+index e745061f3e6a4541f44ba119106915cdb7023fc6..f4ed58b03876c35f8964a8a1b8ce89961b9ee6d3 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -60,7 +60,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener,

--- a/patches/server/0282-BlockDestroyEvent.patch
+++ b/patches/server/0282-BlockDestroyEvent.patch
@@ -11,10 +11,10 @@ floating in the air.
 This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index e85e47b5fd8f59a298afd8962986dfc4fa956a10..cea3b4744a45b100f0c5c5cef6ecd4b932a89b71 100644
+index 181201ecd6c617cc37ba097a667bd96ae3b1823e..28ed20fc6e53490392c59b927889d78eb268b777 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -31,6 +31,7 @@ import net.minecraft.nbt.CompoundTag;
+@@ -26,6 +26,7 @@ import net.minecraft.nbt.CompoundTag;
  import net.minecraft.network.protocol.Packet;
  import net.minecraft.resources.ResourceKey;
  import net.minecraft.resources.ResourceLocation;
@@ -22,7 +22,7 @@ index e85e47b5fd8f59a298afd8962986dfc4fa956a10..cea3b4744a45b100f0c5c5cef6ecd4b9
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.FullChunkStatus;
  import net.minecraft.server.level.ServerLevel;
-@@ -586,9 +587,26 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -581,9 +582,26 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              return false;
          } else {
              FluidState fluid = this.getFluidState(pos);
@@ -33,7 +33,7 @@ index e85e47b5fd8f59a298afd8962986dfc4fa956a10..cea3b4744a45b100f0c5c5cef6ecd4b9
 +            BlockState effectType = iblockdata;
 +            int xp = iblockdata.getBlock().getExpDrop(iblockdata, (ServerLevel) this, pos, ItemStack.EMPTY, true);
 +            if (com.destroystokyo.paper.event.block.BlockDestroyEvent.getHandlerList().getRegisteredListeners().length > 0) {
-+                com.destroystokyo.paper.event.block.BlockDestroyEvent event = new com.destroystokyo.paper.event.block.BlockDestroyEvent(MCUtil.toBukkitBlock(this, pos), fluid.createLegacyBlock().createCraftBlockData(), effectType.createCraftBlockData(), xp, drop);
++                com.destroystokyo.paper.event.block.BlockDestroyEvent event = new com.destroystokyo.paper.event.block.BlockDestroyEvent(org.bukkit.craftbukkit.block.CraftBlock.at(this, pos), fluid.createLegacyBlock().createCraftBlockData(), effectType.createCraftBlockData(), xp, drop);
 +                if (!event.callEvent()) {
 +                    return false;
 +                }

--- a/patches/server/0284-Brigadier-Mojang-API.patch
+++ b/patches/server/0284-Brigadier-Mojang-API.patch
@@ -131,10 +131,10 @@ index af7cb518a32a4d550eae833fdd5bb17fd4058717..40ff3090fb17fb0f01a9b52639fb783e
  
              if (commandnode2.canUse(source)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 831281ab33e8d2ec4e31a03fe7dc18ce7928d3d6..addd76950902ee219bf73186d3ebac1a6f931e47 100644
+index 06120b7da7f830f4bb36e5c1ec71201e344a1182..f68822bf363a1805678d8b19a0d6ffc0386337c8 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -733,8 +733,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -732,8 +732,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                          ParseResults<CommandSourceStack> parseresults = this.server.getCommands().getDispatcher().parse(stringreader, this.player.createCommandSourceStack());
  
                          this.server.getCommands().getDispatcher().getCompletionSuggestions(parseresults).thenAccept((suggestions) -> {
@@ -149,7 +149,7 @@ index 831281ab33e8d2ec4e31a03fe7dc18ce7928d3d6..addd76950902ee219bf73186d3ebac1a
                          });
                      });
                  }
-@@ -749,7 +753,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -748,7 +752,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                          builder.suggest(completion.suggestion(), PaperAdventure.asVanilla(completion.tooltip()));
                      }
                  });

--- a/patches/server/0286-Limit-Client-Sign-length-more.patch
+++ b/patches/server/0286-Limit-Client-Sign-length-more.patch
@@ -22,10 +22,10 @@ it only impacts data sent from the client.
 Set -DPaper.maxSignLength=XX to change limit or -1 to disable
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index addd76950902ee219bf73186d3ebac1a6f931e47..d9d983a15aa0e08f1a5e4ac8de485d40d42fac15 100644
+index f68822bf363a1805678d8b19a0d6ffc0386337c8..3fd78a485bff00304e9eea69df376ae8c44be448 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -291,6 +291,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -290,6 +290,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      private final MessageSignatureCache messageSignatureCache = MessageSignatureCache.createDefault();
      private final FutureChain chatMessageChain;
      private boolean waitingForSwitchToConfig;
@@ -33,7 +33,7 @@ index addd76950902ee219bf73186d3ebac1a6f931e47..d9d983a15aa0e08f1a5e4ac8de485d40
  
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player, CommonListenerCookie clientData) {
          super(server, connection, clientData, player); // CraftBukkit
-@@ -3059,7 +3060,19 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3047,7 +3048,19 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void handleSignUpdate(ServerboundSignUpdatePacket packet) {

--- a/patches/server/0288-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0288-Entity-getEntitySpawnReason.patch
@@ -22,7 +22,7 @@ index 2eddeb8d5239bbfeefbf4d3bd363f1ad083299b6..e2b44b8ddb8afc6e1f7dddadb434c226
              });
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 46b71a140ab8a1b997415184db09cb8a3ea39c52..c67ef9387f1d7ddfda89a096e764133118167175 100644
+index e1518465e4ffc473a75a57e4d9b3ad399a022589..4e7e3935a0040f48a1dc8f32e3da6d5a3ba154cb 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1203,6 +1203,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -98,10 +98,10 @@ index 5baf85f179c096a9e2be170d7def110d02952dae..c601bd02a75e10af7ad7040b3a4d974c
  
          } catch (Throwable throwable) {
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index 1b0093a23011f7d1c0da88c0a934d94ad4d6b3e2..ef7da9043f2a6e2041d2a2850aaf19b7c95f706a 100644
+index cae8c508972d771ad96228ace8a7e6cbc34d5489..3184f73ce799cc5202d2129be736e2fed9a3b8e3 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-@@ -189,6 +189,7 @@ public abstract class BaseSpawner {
+@@ -182,6 +182,7 @@ public abstract class BaseSpawner {
                          }
  
                          entity.spawnedViaMobSpawner = true; // Paper

--- a/patches/server/0289-Fire-event-on-GS4-query.patch
+++ b/patches/server/0289-Fire-event-on-GS4-query.patch
@@ -4,27 +4,6 @@ Date: Sun, 17 Mar 2019 21:46:56 +0200
 Subject: [PATCH] Fire event on GS4 query
 
 
-diff --git a/src/main/java/net/minecraft/server/rcon/NetworkDataOutputStream.java b/src/main/java/net/minecraft/server/rcon/NetworkDataOutputStream.java
-index 51cb2644aa516a59e19fecb308d519dbc7e5fb11..e6340e0c98f6b208133ebaa44cdd1133be192eca 100644
---- a/src/main/java/net/minecraft/server/rcon/NetworkDataOutputStream.java
-+++ b/src/main/java/net/minecraft/server/rcon/NetworkDataOutputStream.java
-@@ -22,6 +22,16 @@ public class NetworkDataOutputStream {
-         this.dataOutputStream.write(0);
-     }
- 
-+    // Paper start - Fire event on GS4 query
-+    public void writeStringUnchecked(String string) {
-+        try {
-+            writeString(string);
-+        } catch (IOException e) {
-+            com.destroystokyo.paper.util.SneakyThrow.sneaky(e);
-+        }
-+    }
-+    // Paper end - Fire event on GS4 query
-+
-     public void write(int value) throws IOException {
-         this.dataOutputStream.write(value);
-     }
 diff --git a/src/main/java/net/minecraft/server/rcon/thread/QueryThreadGs4.java b/src/main/java/net/minecraft/server/rcon/thread/QueryThreadGs4.java
 index 88917d7a179739fc13c59831b15e7ddc711bed1b..1ef089dbf83de35d875c00efdf468c397be56978 100644
 --- a/src/main/java/net/minecraft/server/rcon/thread/QueryThreadGs4.java

--- a/patches/server/0294-Optimize-Captured-BlockEntity-Lookup.patch
+++ b/patches/server/0294-Optimize-Captured-BlockEntity-Lookup.patch
@@ -10,10 +10,10 @@ Optimize to check if the captured list even has values in it, and also to
 just do a get call since the value can never be null.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index cea3b4744a45b100f0c5c5cef6ecd4b932a89b71..3f1c0f3b879bf562db2b999dd39a3ce37759775d 100644
+index 28ed20fc6e53490392c59b927889d78eb268b777..caf2c9799aa5ddbd5caf160e2c8f2e8f0cdaa1f8 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -915,9 +915,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -910,9 +910,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      @Nullable
      public BlockEntity getBlockEntity(BlockPos blockposition, boolean validate) {

--- a/patches/server/0296-Mob-Spawner-API-Enhancements.patch
+++ b/patches/server/0296-Mob-Spawner-API-Enhancements.patch
@@ -9,10 +9,10 @@ public net.minecraft.world.level.BaseSpawner delay(Lnet/minecraft/world/level/Le
 public net.minecraft.world.level.BaseSpawner setNextSpawnData(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/SpawnData;)V
 
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index ef7da9043f2a6e2041d2a2850aaf19b7c95f706a..8e6d782f3a5a000217b7dcd27fc88aa340a58f47 100644
+index 3184f73ce799cc5202d2129be736e2fed9a3b8e3..b771f954f3fccd92e15196bf542e0d3703cfb71a 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-@@ -235,7 +235,13 @@ public abstract class BaseSpawner {
+@@ -228,7 +228,13 @@ public abstract class BaseSpawner {
      }
  
      public void load(@Nullable Level world, BlockPos pos, CompoundTag nbt) {
@@ -26,7 +26,7 @@ index ef7da9043f2a6e2041d2a2850aaf19b7c95f706a..8e6d782f3a5a000217b7dcd27fc88aa3
          boolean flag = nbt.contains("SpawnData", 10);
  
          if (flag) {
-@@ -258,9 +264,15 @@ public abstract class BaseSpawner {
+@@ -251,9 +257,15 @@ public abstract class BaseSpawner {
              this.spawnPotentials = SimpleWeightedRandomList.single(this.nextSpawnData != null ? this.nextSpawnData : new SpawnData());
          }
  
@@ -44,7 +44,7 @@ index ef7da9043f2a6e2041d2a2850aaf19b7c95f706a..8e6d782f3a5a000217b7dcd27fc88aa3
              this.spawnCount = nbt.getShort("SpawnCount");
          }
  
-@@ -277,9 +289,20 @@ public abstract class BaseSpawner {
+@@ -270,9 +282,20 @@ public abstract class BaseSpawner {
      }
  
      public CompoundTag save(CompoundTag nbt) {

--- a/patches/server/0362-Validate-PickItem-Packet-and-kick-for-invalid.patch
+++ b/patches/server/0362-Validate-PickItem-Packet-and-kick-for-invalid.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Validate PickItem Packet and kick for invalid
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d9d983a15aa0e08f1a5e4ac8de485d40d42fac15..ec897c87642bf3cc8d9c0cea4cb76d4594acc95d 100644
+index 3fd78a485bff00304e9eea69df376ae8c44be448..a522c27a61384490aa938912316dfd76ab439cfd 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -860,7 +860,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -859,7 +859,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      @Override
      public void handlePickItem(ServerboundPickItemPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());

--- a/patches/server/0366-Prevent-teleporting-dead-entities.patch
+++ b/patches/server/0366-Prevent-teleporting-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent teleporting dead entities
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ec897c87642bf3cc8d9c0cea4cb76d4594acc95d..6ec2d3876d2064ed76a475ea93178b77f9cf6696 100644
+index a522c27a61384490aa938912316dfd76ab439cfd..8700bfc853aa60cca55524bbba8f9343d4994faa 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1538,6 +1538,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1537,6 +1537,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      }
  
      public void internalTeleport(double d0, double d1, double d2, float f, float f1, Set<RelativeMovement> set) { // Paper

--- a/patches/server/0367-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0367-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -495,7 +495,7 @@ index 52eb3176437113f9a0ff85d10ce5c2415e1b5570..b54ddd0ba0b001fbcb1838a838ca4890
          }
      }
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index cd9ed68079abf103759865a3e2a038ac629a18ea..dc9f8625e15c49ea64d2b7d9515d36d5ef834820 100644
+index 7648b889bc488197f32545e8c3671a54102c01ec..44e62675a2d612a8d727d9ce6db5fb85d1a0bcc8 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -75,13 +75,13 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -587,25 +587,25 @@ index 187b2cf175ba5cea94158d29b53993dc5a7c5b94..3b6bafb242d2623c15f26acdacd03647
      final MinecraftServer server;
      public volatile boolean running;
 diff --git a/src/main/java/net/minecraft/server/players/OldUsersConverter.java b/src/main/java/net/minecraft/server/players/OldUsersConverter.java
-index e697b8f7b165d2394d8155cbee7453e23ac2bee4..6706ac701963fed4798247e6e835b06fc92b0cf4 100644
+index 86c88e81e275d52576122a5083b419e64cb011fc..45d4638d568ea2aee805aa1b0542533019e5870d 100644
 --- a/src/main/java/net/minecraft/server/players/OldUsersConverter.java
 +++ b/src/main/java/net/minecraft/server/players/OldUsersConverter.java
-@@ -358,7 +358,7 @@ public class OldUsersConverter {
+@@ -357,7 +357,7 @@ public class OldUsersConverter {
                          try {
                              root = NbtIo.readCompressed(new java.io.FileInputStream(file5), NbtAccounter.unlimitedHeap());
                          } catch (Exception exception) {
 -                            exception.printStackTrace();
 +                            io.papermc.paper.util.TraceUtil.printStackTrace(exception); // Paper
-                             ServerInternalException.reportInternalException(exception); // Paper - ServerExceptionEvent
+                             com.destroystokyo.paper.exception.ServerInternalException.reportInternalException(exception); // Paper - ServerExceptionEvent
                          }
  
-@@ -372,7 +372,7 @@ public class OldUsersConverter {
+@@ -371,7 +371,7 @@ public class OldUsersConverter {
                              try {
                                  NbtIo.writeCompressed(root, new java.io.FileOutputStream(file2));
                              } catch (Exception exception) {
 -                                exception.printStackTrace();
 +                                io.papermc.paper.util.TraceUtil.printStackTrace(exception); // Paper
-                                 ServerInternalException.reportInternalException(exception); // Paper - ServerExceptionEvent
+                                 com.destroystokyo.paper.exception.ServerInternalException.reportInternalException(exception); // Paper - ServerExceptionEvent
                              }
                         }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java

--- a/patches/server/0385-Prevent-position-desync-causing-tp-exploit.patch
+++ b/patches/server/0385-Prevent-position-desync-causing-tp-exploit.patch
@@ -13,10 +13,10 @@ behaviour, we need to move all of this dangerous logic outside
 of the move call and into an appropriate place in the tick method.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 6ec2d3876d2064ed76a475ea93178b77f9cf6696..b3549abb6ff622974574b35445bd6f562f5c4aca 100644
+index 8700bfc853aa60cca55524bbba8f9343d4994faa..927fa8ee5e1b2d5822f80c586f474e6e115c3b15 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1359,6 +1359,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1358,6 +1358,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              this.player.move(MoverType.PLAYER, new Vec3(d6, d7, d8));
                              this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move

--- a/patches/server/0388-Add-PlayerRecipeBookClickEvent.patch
+++ b/patches/server/0388-Add-PlayerRecipeBookClickEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerRecipeBookClickEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b3549abb6ff622974574b35445bd6f562f5c4aca..7d63a20a87b79608637846fda4a5a2441a05ab03 100644
+index 927fa8ee5e1b2d5822f80c586f474e6e115c3b15..cbb2b7665dbc2114a21000f274a0ce600420a31d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2966,16 +2966,40 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2954,16 +2954,40 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              if (!this.player.containerMenu.stillValid(this.player)) {
                  ServerGamePacketListenerImpl.LOGGER.debug("Player {} interacted with invalid menu {}", this.player, this.player.containerMenu);
              } else {

--- a/patches/server/0390-Add-permission-for-command-blocks.patch
+++ b/patches/server/0390-Add-permission-for-command-blocks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add permission for command blocks
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index deef24ad28ecf7895aa03bf8dae085814d307ece..6721b086ec4e8efe29b75a0e08dc15015e180c09 100644
+index e8b12b27e5ec74afb940f575e5ce78e5905d55f4..c3eb4b6372eed0b7eb636f495ce494b676767b6e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -397,7 +397,7 @@ public class ServerPlayerGameMode {
@@ -18,10 +18,10 @@ index deef24ad28ecf7895aa03bf8dae085814d307ece..6721b086ec4e8efe29b75a0e08dc1501
                  return false;
              } else if (this.player.blockActionRestricted(this.level, pos, this.gameModeForPlayer)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 7d63a20a87b79608637846fda4a5a2441a05ab03..6dbf7734b640dc9cd553dfd6afb4c9cd4e3d66da 100644
+index cbb2b7665dbc2114a21000f274a0ce600420a31d..faf1add04576013b0d8743fe64688522d0c34ae9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -771,7 +771,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -770,7 +770,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (!this.server.isCommandBlockEnabled()) {
              this.player.sendSystemMessage(Component.translatable("advMode.notEnabled"));
@@ -30,7 +30,7 @@ index 7d63a20a87b79608637846fda4a5a2441a05ab03..6dbf7734b640dc9cd553dfd6afb4c9cd
              this.player.sendSystemMessage(Component.translatable("advMode.notAllowed"));
          } else {
              BaseCommandBlock commandblocklistenerabstract = null;
-@@ -838,7 +838,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -837,7 +837,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (!this.server.isCommandBlockEnabled()) {
              this.player.sendSystemMessage(Component.translatable("advMode.notEnabled"));

--- a/patches/server/0392-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0392-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -8,7 +8,7 @@ makes it so that the server keeps the last difficulty used instead
 of restoring the server.properties every single load.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 1913eb3eb6a1ddc2d96240cbc50d4cf7325ebd3b..9d41c8e93aa97a78da26bef5cfbed8412d4e1451 100644
+index f786bf10a42fa4e9f610416959c60c52729c277b..21176d6e57ae9e975b1e7de14b3364365cc1012d 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -825,7 +825,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -89,10 +89,10 @@ index e3413273076b697d560c927ea0e12f34722a79c1..ab92c2c0ff5ebb395670c23fe0e3a812
  
                  playerlist.sendPlayerPermissionLevel(this);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 6dbf7734b640dc9cd553dfd6afb4c9cd4e3d66da..48fca15cdc6b0bafc3d8ff13cc96b3258104c1fb 100644
+index faf1add04576013b0d8743fe64688522d0c34ae9..f4230861d3d927726e7317ff1ebab4eac2dcff72 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3169,7 +3169,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3157,7 +3157,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      public void handleChangeDifficulty(ServerboundChangeDifficultyPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (this.player.hasPermissions(2) || this.isSingleplayerOwner()) {
@@ -102,7 +102,7 @@ index 6dbf7734b640dc9cd553dfd6afb4c9cd4e3d66da..48fca15cdc6b0bafc3d8ff13cc96b325
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 045066f5ba6dd69259664c5bf9eafae41b708892..dead1bc2a354a1433f10caf81bc0633fda947042 100644
+index e7d73f2b56680bcbdd8b4e06547a518ec8145549..04a3b84f3dab7d8eff16a19b1c3cd0a70ba450c5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -955,8 +955,8 @@ public final class CraftServer implements Server {

--- a/patches/server/0399-Do-not-accept-invalid-client-settings.patch
+++ b/patches/server/0399-Do-not-accept-invalid-client-settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Do not accept invalid client settings
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 48fca15cdc6b0bafc3d8ff13cc96b3258104c1fb..cbc472cc725c925395f60b7bea0de6663b5346ab 100644
+index f4230861d3d927726e7317ff1ebab4eac2dcff72..6482886597e67a7e77b9087e283129da33a8bd8e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3161,6 +3161,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3149,6 +3149,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      @Override
      public void handleClientInformation(ServerboundClientInformationPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());

--- a/patches/server/0403-Add-PrepareResultEvent.patch
+++ b/patches/server/0403-Add-PrepareResultEvent.patch
@@ -94,55 +94,54 @@ index 9c2fe69ced7a46bbd8b0fbe10fa67d0a39b0f375..e40d9dbdbe5359c38af6d764d01c9be4
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 64236f5f126998157bb7bbae40ed0cd1550281e5..8ac093866aec59b4e031b953d4c3c3af66733812 100644
+index 4dddda15446857caa628d01c496aa1398b436894..58a1c1f48655b7403379bcd46945f4b16f73d790 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1714,26 +1714,53 @@ public class CraftEventFactory {
+@@ -1715,6 +1715,12 @@ public class CraftEventFactory {
+     }
+ 
+     public static PrepareAnvilEvent callPrepareAnvilEvent(InventoryView view, ItemStack item) {
++        // Paper start - Add PrepareResultEvent
++        if (true) {
++            view.getTopInventory().setItem(net.minecraft.world.inventory.AnvilMenu.RESULT_SLOT, CraftItemStack.asCraftMirror(item));
++            return null; // verify nothing uses return - disable event: handled below in PrepareResult
++        }
++        // Paper end - Add PrepareResultEvent
+         PrepareAnvilEvent event = new PrepareAnvilEvent(view, CraftItemStack.asCraftMirror(item).clone());
+         event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
+         event.getInventory().setItem(2, event.getResult());
+@@ -1722,6 +1728,12 @@ public class CraftEventFactory {
+     }
+ 
+     public static PrepareGrindstoneEvent callPrepareGrindstoneEvent(InventoryView view, ItemStack item) {
++        // Paper start - Add PrepareResultEvent
++        if (true) {
++            view.getTopInventory().setItem(net.minecraft.world.inventory.GrindstoneMenu.RESULT_SLOT, CraftItemStack.asCraftMirror(item));
++            return null; // verify nothing uses return - disable event: handled below in PrepareResult
++        }
++        // Paper end - Add PrepareResultEvent
+         PrepareGrindstoneEvent event = new PrepareGrindstoneEvent(view, CraftItemStack.asCraftMirror(item).clone());
+         event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
+         event.getInventory().setItem(2, event.getResult());
+@@ -1729,12 +1741,39 @@ public class CraftEventFactory {
+     }
+ 
+     public static PrepareSmithingEvent callPrepareSmithingEvent(InventoryView view, ItemStack item) {
++        // Paper start - Add PrepareResultEvent
++        if (true) {
++            view.getTopInventory().setItem(net.minecraft.world.inventory.SmithingMenu.RESULT_SLOT, CraftItemStack.asCraftMirror(item));
++            return null; // verify nothing uses return - disable event: handled below in PrepareResult
++        }
++        // Paper end - Add PrepareResultEvent
+         PrepareSmithingEvent event = new PrepareSmithingEvent(view, CraftItemStack.asCraftMirror(item).clone());
+         event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
+         event.getInventory().setResult(event.getResult());
          return event;
      }
  
--    public static PrepareAnvilEvent callPrepareAnvilEvent(InventoryView view, ItemStack item) {
--        PrepareAnvilEvent event = new PrepareAnvilEvent(view, CraftItemStack.asCraftMirror(item).clone());
--        event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
-+    // Paper start - Add PrepareResultEvent; disable this method, handled below
-+    public static void callPrepareAnvilEvent(InventoryView view, ItemStack item) { // Paper - verify nothing uses return - handled below in PrepareResult
-+        PrepareAnvilEvent event = new PrepareAnvilEvent(view, CraftItemStack.asCraftMirror(item)); // Paper - remove clone
-+        //event.getView().getPlayer().getServer().getPluginManager().callEvent(event); // Paper - disable event
-         event.getInventory().setItem(2, event.getResult());
--        return event;
-+        //return event;
-     }
-+    // Paper end - Add PrepareResultEvent
- 
--    public static PrepareGrindstoneEvent callPrepareGrindstoneEvent(InventoryView view, ItemStack item) {
--        PrepareGrindstoneEvent event = new PrepareGrindstoneEvent(view, CraftItemStack.asCraftMirror(item).clone());
--        event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
-+    // Paper start - Add PrepareResultEvent; disable this method, handled below
-+    public static void callPrepareGrindstoneEvent(InventoryView view, ItemStack item) {
-+        PrepareGrindstoneEvent event = new PrepareGrindstoneEvent(view, CraftItemStack.asCraftMirror(item)); // Paper - remove clone
-+        // event.getView().getPlayer().getServer().getPluginManager().callEvent(event); // Paper - disable event
-         event.getInventory().setItem(2, event.getResult());
--        return event;
-+        // return event;
-     }
-+    // Paper end - Add PrepareResultEvent
- 
--    public static PrepareSmithingEvent callPrepareSmithingEvent(InventoryView view, ItemStack item) {
--        PrepareSmithingEvent event = new PrepareSmithingEvent(view, CraftItemStack.asCraftMirror(item).clone());
--        event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
-+    // Paper start - Add PrepareResultEvent; disable this method, handled in callPrepareResultEvent
-+    public static void callPrepareSmithingEvent(InventoryView view, ItemStack item) { // Paper - verify nothing uses return - handled below in PrepareResult
-+        PrepareSmithingEvent event = new PrepareSmithingEvent(view, CraftItemStack.asCraftMirror(item)); // Paper - remove clone
-+        //event.getView().getPlayer().getServer().getPluginManager().callEvent(event); // Paper - disable event
-         event.getInventory().setResult(event.getResult());
--        return event;
-+        //return event; // Paper
-+    }
-+    // Paper end - Add PrepareResultEvent
-+
 +    // Paper start - Add PrepareResultEvent
 +    public static void callPrepareResultEvent(AbstractContainerMenu container, int resultSlot) {
-+        com.destroystokyo.paper.event.inventory.PrepareResultEvent event;
++        final com.destroystokyo.paper.event.inventory.PrepareResultEvent event;
 +        InventoryView view = container.getBukkitView();
 +        org.bukkit.inventory.ItemStack origItem = view.getTopInventory().getItem(resultSlot);
 +        CraftItemStack result = origItem != null ? CraftItemStack.asCraftCopy(origItem) : null;
@@ -158,8 +157,9 @@ index 64236f5f126998157bb7bbae40ed0cd1550281e5..8ac093866aec59b4e031b953d4c3c3af
 +        event.callEvent();
 +        event.getInventory().setItem(resultSlot, event.getResult());
 +        container.broadcastChanges();;
-     }
++    }
 +    // Paper end - Add PrepareResultEvent
- 
++
      /**
       * Mob spawner event.
+      */

--- a/patches/server/0425-PortalCreateEvent-needs-to-know-its-entity.patch
+++ b/patches/server/0425-PortalCreateEvent-needs-to-know-its-entity.patch
@@ -18,121 +18,90 @@ index 556d8d395df3660ec7923c6814bc281c5fce442f..b4f2b75960674e81c8189dc908523c56
  
                          world.notifyAndUpdatePhysics(newblockposition, null, oldBlock, block, world.getBlockState(newblockposition), updateFlag, 512); // send null chunk as chunk.k() returns false by this point
 diff --git a/src/main/java/net/minecraft/world/level/block/BaseFireBlock.java b/src/main/java/net/minecraft/world/level/block/BaseFireBlock.java
-index e707553bbddf84bc48ec7186da00c3eb0632946d..91400c16b8bd8953265bf37ec1cd34ac95133e32 100644
+index e707553bbddf84bc48ec7186da00c3eb0632946d..839469c1249829b42e752e5a1b613550c3f65bba 100644
 --- a/src/main/java/net/minecraft/world/level/block/BaseFireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/BaseFireBlock.java
-@@ -142,20 +142,23 @@ public abstract class BaseFireBlock extends Block {
-         super.entityInside(state, world, pos, entity);
-     }
+@@ -144,12 +144,19 @@ public abstract class BaseFireBlock extends Block {
  
-+    // Paper start - ItemActionContext param
-+    @Override public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify) { this.onPlace(state, world, pos, oldState, notify, null); }
      @Override
--    public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify) {
--        if (!oldState.is(state.getBlock())) {
-+    public void onPlace(BlockState iblockdata, Level world, BlockPos blockposition, BlockState iblockdata1, boolean flag, net.minecraft.world.item.context.UseOnContext itemActionContext) {
-+        // Paper end - ItemActionContext param
-+        if (!iblockdata1.is(iblockdata.getBlock())) {
+     public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify) {
++        // Paper start - UseOnContext param
++        this.onPlace(state, world, pos, oldState, notify, null);
++    }
++
++    @Override
++    public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify, net.minecraft.world.item.context.UseOnContext context) {
++        // Paper end - UseOnContext param
+         if (!oldState.is(state.getBlock())) {
              if (BaseFireBlock.inPortalDimension(world)) {
--                Optional<PortalShape> optional = PortalShape.findEmptyPortalShape(world, pos, Direction.Axis.X);
-+                Optional<PortalShape> optional = PortalShape.findEmptyPortalShape(world, blockposition, Direction.Axis.X);
+                 Optional<PortalShape> optional = PortalShape.findEmptyPortalShape(world, pos, Direction.Axis.X);
  
                  if (optional.isPresent()) {
 -                    ((PortalShape) optional.get()).createPortalBlocks();
-+                    ((PortalShape) optional.get()).createPortalBlocks(itemActionContext); // Paper - pass ItemActionContext param
++                    ((PortalShape) optional.get()).createPortalBlocks(context); // Paper - pass context param
                      return;
                  }
              }
- 
--            if (!state.canSurvive(world, pos)) {
--                this.fireExtinguished(world, pos); // CraftBukkit - fuel block broke
-+            if (!iblockdata.canSurvive(world, blockposition)) {
-+                fireExtinguished(world, blockposition); // CraftBukkit - fuel block broke
-             }
- 
-         }
 diff --git a/src/main/java/net/minecraft/world/level/block/FireBlock.java b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-index 5e5d0e5b41b5ed90a5f0109b231d468bbc566ae7..b1e9ea9ece5ef8ecbe2ed919fda8e1153724dc93 100644
+index 65b2873ca8032a64a4968b7587637644df1aeca5..c5116d12f3c073f0a8695a8cd00545e6d947644d 100644
 --- a/src/main/java/net/minecraft/world/level/block/FireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-@@ -14,6 +14,7 @@ import net.minecraft.server.level.ServerLevel;
- import net.minecraft.tags.BiomeTags;
- import net.minecraft.util.RandomSource;
- import net.minecraft.world.item.context.BlockPlaceContext;
-+import net.minecraft.world.item.context.UseOnContext;
- import net.minecraft.world.level.BlockGetter;
- import net.minecraft.world.level.GameRules;
- import net.minecraft.world.level.Level;
-@@ -368,9 +369,11 @@ public class FireBlock extends BaseFireBlock {
+@@ -368,8 +368,10 @@ public class FireBlock extends BaseFireBlock {
      }
  
      @Override
 -    public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify) {
 -        super.onPlace(state, world, pos, oldState, notify);
--        world.scheduleTick(pos, (Block) this, FireBlock.getFireTickDelay(world.random));
-+    // Paper start - ItemActionContext param
-+    public void onPlace(BlockState iblockdata, Level world, BlockPos blockposition, BlockState iblockdata1, boolean flag, UseOnContext itemActionContext) {
-+        super.onPlace(iblockdata, world, blockposition, iblockdata1, flag, itemActionContext);
-+        // Paper end - ItemActionContext param
-+        world.scheduleTick(blockposition, this, getFireTickDelay(world.random));
++    // Paper start - UseOnContext param
++    public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify, net.minecraft.world.item.context.UseOnContext context) {
++        super.onPlace(state, world, pos, oldState, notify, context);
++        // Paper end - UseOnContext param
+         world.scheduleTick(pos, (Block) this, FireBlock.getFireTickDelay(world.random));
      }
  
-     private static int getFireTickDelay(RandomSource random) {
 diff --git a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
-index 7e4264f87a0f81db71d49dbede32a1bad87f7ca8..aa15d65f69f89da97cecd47c3458cd3b4937055f 100644
+index 6f60622f2dad5f82fb24505612e7e3a32722ab93..c7b6377aafd32f67eb8ba4dedd7cce5841b2d58d 100644
 --- a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 +++ b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
-@@ -43,6 +43,7 @@ import net.minecraft.world.item.DyeColor;
- import net.minecraft.world.item.Item;
- import net.minecraft.world.item.ItemStack;
- import net.minecraft.world.item.context.BlockPlaceContext;
-+import net.minecraft.world.item.context.UseOnContext;
- import net.minecraft.world.level.BlockGetter;
- import net.minecraft.world.level.EmptyBlockGetter;
- import net.minecraft.world.level.Explosion;
-@@ -163,6 +164,12 @@ public abstract class BlockBehaviour implements FeatureElement {
+@@ -163,6 +163,13 @@ public abstract class BlockBehaviour implements FeatureElement {
          DebugPackets.sendNeighborsUpdatePacket(world, pos);
      }
  
-+    // Paper start - add ItemActionContext param
++    // Paper start - UseOnContext param
 +    @Deprecated
-+    public void onPlace(BlockState iblockdata, Level world, BlockPos blockposition, BlockState iblockdata1, boolean flag, UseOnContext itemActionContext) {
-+        this.onPlace(iblockdata, world, blockposition, iblockdata1, flag);
++    public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify, net.minecraft.world.item.context.UseOnContext context) {
++        this.onPlace(state, world, pos, oldState, notify);
 +    }
-+    // Paper end - ItemActionContext param
++    // Paper end - UseOnContext param
++
      /** @deprecated */
      @Deprecated
      public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify) {
 diff --git a/src/main/java/net/minecraft/world/level/portal/PortalShape.java b/src/main/java/net/minecraft/world/level/portal/PortalShape.java
-index 9fc4997277dd199cf6cffccceb3a9735398c5356..39321dd4e60be218cb839a89f6cdf32702b72939 100644
+index 9fc4997277dd199cf6cffccceb3a9735398c5356..912cee9ec45876f831ca230b59a1be3b48ce6aa5 100644
 --- a/src/main/java/net/minecraft/world/level/portal/PortalShape.java
 +++ b/src/main/java/net/minecraft/world/level/portal/PortalShape.java
-@@ -11,6 +11,7 @@ import net.minecraft.tags.BlockTags;
- import net.minecraft.util.Mth;
- import net.minecraft.world.entity.Entity;
- import net.minecraft.world.entity.EntityDimensions;
-+import net.minecraft.world.item.context.UseOnContext;
- import net.minecraft.world.level.LevelAccessor;
- import net.minecraft.world.level.block.Blocks;
- import net.minecraft.world.level.block.NetherPortalBlock;
-@@ -190,7 +191,10 @@ public class PortalShape {
+@@ -190,7 +190,14 @@ public class PortalShape {
      }
  
      // CraftBukkit start - return boolean
--    public boolean createPortalBlocks() {
-+    // Paper start - ItemActionContext param
-+    @Deprecated public boolean createPortalBlocks() { return this.createPortalBlocks(null); }
-+    public boolean createPortalBlocks(UseOnContext itemActionContext) {
-+        // Paper end - ItemActionContext param
++    @io.papermc.paper.annotation.DoNotUse @Deprecated // Paper
+     public boolean createPortalBlocks() {
++        // Paper start - UseOnContext param
++        return this.createPortalBlocks(null);
++    }
++
++    public boolean createPortalBlocks(net.minecraft.world.item.context.UseOnContext useOnContext) {
++        // Paper end - UseOnContext param
          org.bukkit.World bworld = this.level.getMinecraftWorld().getWorld();
  
          // Copy below for loop
-@@ -200,7 +204,7 @@ public class PortalShape {
+@@ -200,7 +207,7 @@ public class PortalShape {
              this.blocks.setBlock(blockposition, iblockdata, 18);
          });
  
 -        PortalCreateEvent event = new PortalCreateEvent((java.util.List<org.bukkit.block.BlockState>) (java.util.List) this.blocks.getList(), bworld, null, PortalCreateEvent.CreateReason.FIRE);
-+        PortalCreateEvent event = new PortalCreateEvent((java.util.List<org.bukkit.block.BlockState>) (java.util.List) blocks.getList(), bworld, itemActionContext == null || itemActionContext.getPlayer() == null ? null : itemActionContext.getPlayer().getBukkitEntity(), PortalCreateEvent.CreateReason.FIRE); // Paper - pass entity param
++        PortalCreateEvent event = new PortalCreateEvent((java.util.List<org.bukkit.block.BlockState>) (java.util.List) blocks.getList(), bworld, useOnContext == null || useOnContext.getPlayer() == null ? null : useOnContext.getPlayer().getBukkitEntity(), PortalCreateEvent.CreateReason.FIRE); // Paper - pass entity param
          this.level.getMinecraftWorld().getServer().server.getPluginManager().callEvent(event);
  
          if (event.isCancelled()) {

--- a/patches/server/0430-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0430-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -9,10 +9,10 @@ as this is how Vanilla teleports entities.
 Cancel any pending motion when teleported.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index cbc472cc725c925395f60b7bea0de6663b5346ab..9a6f2281efb3b62ddcb194061bf3dbc4b80a440b 100644
+index 6482886597e67a7e77b9087e283129da33a8bd8e..231e8c5d719c73ecc1c2463e74661af07bf46df5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -657,7 +657,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -656,7 +656,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  return;
              }
  
@@ -21,7 +21,7 @@ index cbc472cc725c925395f60b7bea0de6663b5346ab..9a6f2281efb3b62ddcb194061bf3dbc4
              this.lastGoodX = this.awaitingPositionFromClient.x;
              this.lastGoodY = this.awaitingPositionFromClient.y;
              this.lastGoodZ = this.awaitingPositionFromClient.z;
-@@ -1580,7 +1580,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1579,7 +1579,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // CraftBukkit end
  
          this.awaitingTeleportTime = this.tickCount;
@@ -57,10 +57,10 @@ index 70380d5807cac6dec19ebe581d685b1e32d8830b..9946f04c7e5877f094293c4c0976aeec
          this.setYRot(yaw);
          this.setXRot(pitch);
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index 8e6d782f3a5a000217b7dcd27fc88aa340a58f47..7fdf026bdeb85d149e24aa013181a848ece4c55e 100644
+index b771f954f3fccd92e15196bf542e0d3703cfb71a..41d2793e69bd664456b5e3c5891b03bdcb31d103 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-@@ -169,6 +169,7 @@ public abstract class BaseSpawner {
+@@ -162,6 +162,7 @@ public abstract class BaseSpawner {
                              return;
                          }
  

--- a/patches/server/0440-Fix-for-large-move-vectors-crashing-server.patch
+++ b/patches/server/0440-Fix-for-large-move-vectors-crashing-server.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix for large move vectors crashing server
 Check movement distance also based on current position.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9a6f2281efb3b62ddcb194061bf3dbc4b80a440b..93c708ad4f16cc6fc8334c36b1131235bc6e2925 100644
+index 231e8c5d719c73ecc1c2463e74661af07bf46df5..d9811d50ee24a41991ad67a10805c3701b002824 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -473,9 +473,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -472,9 +472,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  float prevYaw = this.player.getYRot();
                  float prevPitch = this.player.getXRot();
                  // CraftBukkit end
@@ -22,7 +22,7 @@ index 9a6f2281efb3b62ddcb194061bf3dbc4b80a440b..93c708ad4f16cc6fc8334c36b1131235
                  double d3 = ServerGamePacketListenerImpl.clampHorizontal(packet.getX()); final double toX = d3; // Paper - OBFHELPER
                  double d4 = ServerGamePacketListenerImpl.clampVertical(packet.getY()); final double toY = d4; // Paper - OBFHELPER
                  double d5 = ServerGamePacketListenerImpl.clampHorizontal(packet.getZ()); final double toZ = d5; // Paper - OBFHELPER
-@@ -485,7 +485,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -484,7 +484,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  double d7 = d4 - this.vehicleFirstGoodY;
                  double d8 = d5 - this.vehicleFirstGoodZ;
                  double d9 = entity.getDeltaMovement().lengthSqr();
@@ -40,7 +40,7 @@ index 9a6f2281efb3b62ddcb194061bf3dbc4b80a440b..93c708ad4f16cc6fc8334c36b1131235
  
                  // CraftBukkit start - handle custom speeds and skipped ticks
                  this.allowedPlayerTicks += (System.currentTimeMillis() / 50) - this.lastTick;
-@@ -531,9 +540,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -530,9 +539,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                  boolean flag = worldserver.noCollision(entity, entity.getBoundingBox().deflate(0.0625D));
  
@@ -53,7 +53,7 @@ index 9a6f2281efb3b62ddcb194061bf3dbc4b80a440b..93c708ad4f16cc6fc8334c36b1131235
                  boolean flag1 = entity.verticalCollisionBelow;
  
                  if (entity instanceof LivingEntity) {
-@@ -1265,7 +1274,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1264,7 +1273,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                          double d7 = d1 - this.firstGoodY;
                          double d8 = d2 - this.firstGoodZ;
                          double d9 = this.player.getDeltaMovement().lengthSqr();
@@ -71,7 +71,7 @@ index 9a6f2281efb3b62ddcb194061bf3dbc4b80a440b..93c708ad4f16cc6fc8334c36b1131235
  
                          if (this.player.isSleeping()) {
                              if (d10 > 1.0D) {
-@@ -1319,9 +1337,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1318,9 +1336,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              AABB axisalignedbb = this.player.getBoundingBox();
  

--- a/patches/server/0443-Retain-block-place-order-when-capturing-blockstates.patch
+++ b/patches/server/0443-Retain-block-place-order-when-capturing-blockstates.patch
@@ -10,10 +10,10 @@ In general, look at making this logic more robust (i.e properly handling
 cases where a captured entry is overriden) - but for now this will do.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 3f1c0f3b879bf562db2b999dd39a3ce37759775d..3e98a86dd56855485c7d8c26eb30f2bbace2d66c 100644
+index caf2c9799aa5ddbd5caf160e2c8f2e8f0cdaa1f8..9879f9fd804f93faae4419add2c4c64fc6902ba1 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -159,7 +159,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -154,7 +154,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean captureBlockStates = false;
      public boolean captureTreeGeneration = false;
      public Map<BlockPos, org.bukkit.craftbukkit.block.CraftBlockState> capturedBlockStates = new java.util.LinkedHashMap<>(); // Paper

--- a/patches/server/0447-Avoid-error-bubbling-up-when-item-stack-is-empty-in-.patch
+++ b/patches/server/0447-Avoid-error-bubbling-up-when-item-stack-is-empty-in-.patch
@@ -8,7 +8,7 @@ This can realistically only happen if there's custom loot active on fishing
 which can return 0 items. This would disconnect the player who's fishing.
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
-index 94bdd467108bc5fd0211f67a792787ef7c356619..f3694d432e280cace281eda95d8c2d4dd5d6930a 100644
+index 94bdd467108bc5fd0211f67a792787ef7c356619..b6ebae97dc863ba1748e9b32555f940077846be8 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 @@ -503,9 +503,15 @@ public class FishingHook extends Projectile {
@@ -16,7 +16,7 @@ index 94bdd467108bc5fd0211f67a792787ef7c356619..f3694d432e280cace281eda95d8c2d4d
                  while (iterator.hasNext()) {
                      ItemStack itemstack1 = (ItemStack) iterator.next();
 -                    ItemEntity entityitem = new ItemEntity(this.level(), this.getX(), this.getY(), this.getZ(), itemstack1);
-+                    // Paper start, new EntityItem would throw if for whatever reason (mostly shitty datapacks) the itemstack1 turns out to be empty
++                    // Paper start - new ItemEntity would throw if for whatever reason (mostly shitty datapacks) the itemstack1 turns out to be empty
 +                    // if the item stack is empty we instead just have our entityitem as null
 +                    ItemEntity entityitem = null;
 +                    if (!itemstack1.isEmpty()) {
@@ -35,7 +35,7 @@ index 94bdd467108bc5fd0211f67a792787ef7c356619..f3694d432e280cace281eda95d8c2d4d
  
 -                    entityitem.setDeltaMovement(d0 * 0.1D, d1 * 0.1D + Math.sqrt(Math.sqrt(d0 * d0 + d1 * d1 + d2 * d2)) * 0.08D, d2 * 0.1D);
 -                    this.level().addFreshEntity(entityitem);
-+                    // Paper start, entity item can be null, so we need to check against this
++                    // Paper start - entity item can be null, so we need to check against this
 +                    if (entityitem != null) {
 +                        entityitem.setDeltaMovement(d0 * 0.1D, d1 * 0.1D + Math.sqrt(Math.sqrt(d0 * d0 + d1 * d1 + d2 * d2)) * 0.08D, d2 * 0.1D);
 +                        this.level().addFreshEntity(entityitem);

--- a/patches/server/0460-Add-PlayerItemCooldownEvent.patch
+++ b/patches/server/0460-Add-PlayerItemCooldownEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerItemCooldownEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ServerItemCooldowns.java b/src/main/java/net/minecraft/world/item/ServerItemCooldowns.java
-index 47283d2a49209839002212e663a503a82ea86587..2cc8be27ac71d281ac62a2612723caca111f522e 100644
+index 47283d2a49209839002212e663a503a82ea86587..e0c4c0a9bab0bbc32358030a482aa04c2e1d3894 100644
 --- a/src/main/java/net/minecraft/world/item/ServerItemCooldowns.java
 +++ b/src/main/java/net/minecraft/world/item/ServerItemCooldowns.java
 @@ -10,6 +10,16 @@ public class ServerItemCooldowns extends ItemCooldowns {
@@ -15,7 +15,7 @@ index 47283d2a49209839002212e663a503a82ea86587..2cc8be27ac71d281ac62a2612723caca
 +    // Paper start - Add PlayerItemCooldownEvent
 +    @Override
 +    public void addCooldown(Item item, int duration) {
-+        io.papermc.paper.event.player.PlayerItemCooldownEvent event = new io.papermc.paper.event.player.PlayerItemCooldownEvent(this.player.getBukkitEntity(), org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(item), duration);
++        io.papermc.paper.event.player.PlayerItemCooldownEvent event = new io.papermc.paper.event.player.PlayerItemCooldownEvent(this.player.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemType.minecraftToBukkit(item), duration);
 +        if (event.callEvent()) {
 +            super.addCooldown(item, event.getCooldown());
 +        }

--- a/patches/server/0465-Add-PlayerShearBlockEvent.patch
+++ b/patches/server/0465-Add-PlayerShearBlockEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerShearBlockEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/BeehiveBlock.java b/src/main/java/net/minecraft/world/level/block/BeehiveBlock.java
-index 44e72176a0da08a77fa192ee31c0fcd53f0dc22d..65d3311cfa251b0d3246413d0714acff7d31e844 100644
+index 44e72176a0da08a77fa192ee31c0fcd53f0dc22d..27f1c1ac12251f1438ee8bf14f4afb5fe601138f 100644
 --- a/src/main/java/net/minecraft/world/level/block/BeehiveBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/BeehiveBlock.java
 @@ -127,7 +127,7 @@ public class BeehiveBlock extends BaseEntityBlock {
@@ -22,7 +22,7 @@ index 44e72176a0da08a77fa192ee31c0fcd53f0dc22d..65d3311cfa251b0d3246413d0714acff
  
              if (itemstack.is(Items.SHEARS)) {
 +                // Paper start - Add PlayerShearBlockEvent
-+                io.papermc.paper.event.block.PlayerShearBlockEvent event = new io.papermc.paper.event.block.PlayerShearBlockEvent((org.bukkit.entity.Player) player.getBukkitEntity(), io.papermc.paper.util.MCUtil.toBukkitBlock(world, pos), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemstack), (hand == InteractionHand.OFF_HAND ? org.bukkit.inventory.EquipmentSlot.OFF_HAND : org.bukkit.inventory.EquipmentSlot.HAND), new java.util.ArrayList<>());
++                io.papermc.paper.event.block.PlayerShearBlockEvent event = new io.papermc.paper.event.block.PlayerShearBlockEvent((org.bukkit.entity.Player) player.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(world, pos), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemstack), org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(hand), new java.util.ArrayList<>());
 +                event.getDrops().add(org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(new ItemStack(Items.HONEYCOMB, 3)));
 +                if (!event.callEvent()) {
 +                    return InteractionResult.PASS;
@@ -39,7 +39,7 @@ index 44e72176a0da08a77fa192ee31c0fcd53f0dc22d..65d3311cfa251b0d3246413d0714acff
                      entityhuman1.broadcastBreakEvent(hand);
                  });
 diff --git a/src/main/java/net/minecraft/world/level/block/PumpkinBlock.java b/src/main/java/net/minecraft/world/level/block/PumpkinBlock.java
-index df11efd22682c2ed799dabf15d2cfa5973e8dca9..0f07ba8e01d437eb5fe32566616f27dd2e2f0bbd 100644
+index df11efd22682c2ed799dabf15d2cfa5973e8dca9..cc13b74fa37b5df6fe6f1423496b9fb03d71d083 100644
 --- a/src/main/java/net/minecraft/world/level/block/PumpkinBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/PumpkinBlock.java
 @@ -35,13 +35,24 @@ public class PumpkinBlock extends Block {
@@ -47,7 +47,7 @@ index df11efd22682c2ed799dabf15d2cfa5973e8dca9..0f07ba8e01d437eb5fe32566616f27dd
          if (itemStack.is(Items.SHEARS)) {
              if (!world.isClientSide) {
 +                // Paper start - Add PlayerShearBlockEvent
-+                io.papermc.paper.event.block.PlayerShearBlockEvent event = new io.papermc.paper.event.block.PlayerShearBlockEvent((org.bukkit.entity.Player) player.getBukkitEntity(), io.papermc.paper.util.MCUtil.toBukkitBlock(world, pos), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack), (hand == InteractionHand.OFF_HAND ? org.bukkit.inventory.EquipmentSlot.OFF_HAND : org.bukkit.inventory.EquipmentSlot.HAND), new java.util.ArrayList<>());
++                io.papermc.paper.event.block.PlayerShearBlockEvent event = new io.papermc.paper.event.block.PlayerShearBlockEvent((org.bukkit.entity.Player) player.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(world, pos), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack), org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(hand), new java.util.ArrayList<>());
 +                event.getDrops().add(org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(new ItemStack(Items.PUMPKIN_SEEDS, 4)));
 +                if (!event.callEvent()) {
 +                    return InteractionResult.PASS;

--- a/patches/server/0466-Limit-recipe-packets.patch
+++ b/patches/server/0466-Limit-recipe-packets.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit recipe packets
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 93c708ad4f16cc6fc8334c36b1131235bc6e2925..52ad9ec75333ba6aac38ae3874b26435a1f896d4 100644
+index d9811d50ee24a41991ad67a10805c3701b002824..97525a4ee491f8954825ee3039da861ba6101d66 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -258,6 +258,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -257,6 +257,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      // CraftBukkit start - multithreaded fields
      private final AtomicInteger chatSpamTickCount = new AtomicInteger();
      private final java.util.concurrent.atomic.AtomicInteger tabSpamLimiter = new java.util.concurrent.atomic.AtomicInteger(); // Paper - configurable tab spam limits
@@ -16,7 +16,7 @@ index 93c708ad4f16cc6fc8334c36b1131235bc6e2925..52ad9ec75333ba6aac38ae3874b26435
      // CraftBukkit end
      private int dropSpamTickCount;
      private double firstGoodX;
-@@ -377,6 +378,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -376,6 +377,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // CraftBukkit start
          for (int spam; (spam = this.chatSpamTickCount.get()) > 0 && !this.chatSpamTickCount.compareAndSet(spam, spam - 1); ) ;
          if (tabSpamLimiter.get() > 0) tabSpamLimiter.getAndDecrement(); // Paper - configurable tab spam limits
@@ -24,14 +24,14 @@ index 93c708ad4f16cc6fc8334c36b1131235bc6e2925..52ad9ec75333ba6aac38ae3874b26435
          /* Use thread-safe field access instead
          if (this.chatSpamTickCount > 0) {
              --this.chatSpamTickCount;
-@@ -2978,6 +2980,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2966,6 +2968,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void handlePlaceRecipe(ServerboundPlaceRecipePacket packet) {
 +        // Paper start - auto recipe limit
 +        if (!org.bukkit.Bukkit.isPrimaryThread()) {
 +            if (this.recipeSpamPackets.addAndGet(io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.recipeSpamIncrement) > io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.recipeSpamLimit) {
-+                this.server.scheduleOnMain(() -> this.disconnect(net.minecraft.network.chat.Component.translatable("disconnect.spam", new Object[0])));
++                this.server.scheduleOnMain(() -> this.disconnect(net.minecraft.network.chat.Component.translatable("disconnect.spam")));
 +                return;
 +            }
 +        }

--- a/patches/server/0481-Add-PlayerFlowerPotManipulateEvent.patch
+++ b/patches/server/0481-Add-PlayerFlowerPotManipulateEvent.patch
@@ -5,28 +5,24 @@ Subject: [PATCH] Add PlayerFlowerPotManipulateEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/FlowerPotBlock.java b/src/main/java/net/minecraft/world/level/block/FlowerPotBlock.java
-index c450faf8c043665eab020141f3c27e3d9890cb86..8684b28a0aa4ec9b2a7f15d07410264cf030a19c 100644
+index c450faf8c043665eab020141f3c27e3d9890cb86..fbe399fa2c27ba283e4a51f9a2559baf86fdff11 100644
 --- a/src/main/java/net/minecraft/world/level/block/FlowerPotBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FlowerPotBlock.java
-@@ -66,6 +66,25 @@ public class FlowerPotBlock extends Block {
+@@ -66,6 +66,21 @@ public class FlowerPotBlock extends Block {
          boolean bl = blockState.is(Blocks.AIR);
          boolean bl2 = this.isEmpty();
          if (bl != bl2) {
 +            // Paper start - Add PlayerFlowerPotManipulateEvent
-+            org.bukkit.entity.Player player1 = (org.bukkit.entity.Player) player.getBukkitEntity();
-+            boolean placing = bl2;
-+            org.bukkit.block.Block bukkitblock = org.bukkit.craftbukkit.block.CraftBlock.at(world, pos);
-+            org.bukkit.inventory.ItemStack bukkititemstack = org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(itemStack);
-+            org.bukkit.Material mat = org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(this.potted);
-+            org.bukkit.inventory.ItemStack bukkititemstack1 = new org.bukkit.inventory.ItemStack(mat, 1);
-+            org.bukkit.inventory.ItemStack whichitem = placing ? bukkititemstack : bukkititemstack1;
++            boolean placing = bl2; // OBFHELPER
++            org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(world, pos);
++            org.bukkit.inventory.ItemStack placedStack = org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(itemStack);
++            org.bukkit.inventory.ItemStack pottedStack = new org.bukkit.inventory.ItemStack(org.bukkit.craftbukkit.block.CraftBlockType.minecraftToBukkit(this.potted));
++            org.bukkit.inventory.ItemStack stack = placing ? placedStack : pottedStack;
 +
-+            io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent event = new io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent(player1, bukkitblock, whichitem, placing);
-+            player1.getServer().getPluginManager().callEvent(event);
-+
-+            if (event.isCancelled()) {
++            io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent event = new io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent((org.bukkit.entity.Player) player.getBukkitEntity(), block, stack, placing);
++            if (!event.callEvent()) {
 +                // Update client
-+                player1.updateInventory();
++                player.containerMenu.sendAllDataToRemote();
 +
 +                return InteractionResult.PASS;
 +            }

--- a/patches/server/0482-Fix-interact-event-not-being-called-sometimes.patch
+++ b/patches/server/0482-Fix-interact-event-not-being-called-sometimes.patch
@@ -11,10 +11,10 @@ Subject: [PATCH] Fix interact event not being called sometimes
 Co-authored-by: Moulberry <james.jenour@protonmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 52ad9ec75333ba6aac38ae3874b26435a1f896d4..1f39a44b27cf427885a14115946f0f1a54508c5b 100644
+index 97525a4ee491f8954825ee3039da861ba6101d66..6f8f1e3c5bb823fb992493b7e37cd352a84298fd 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1753,7 +1753,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1752,7 +1752,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  MutableComponent ichatmutablecomponent = Component.translatable("build.tooHigh", i - 1).withStyle(ChatFormatting.RED);
  
                                  this.player.sendSystemMessage(ichatmutablecomponent, true);
@@ -23,7 +23,7 @@ index 52ad9ec75333ba6aac38ae3874b26435a1f896d4..1f39a44b27cf427885a14115946f0f1a
                                  this.player.swing(enumhand, true);
                              }
                          }
-@@ -2299,13 +2299,20 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2298,13 +2298,20 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          double d3 = this.player.gameMode.getGameModeForPlayer() == GameType.CREATIVE ? 5.0D : 4.5D;
          // SPIGOT-5607: Only call interact event if no block or entity is being clicked. Use bukkit ray trace method, because it handles blocks and entities at the same time
          // SPIGOT-7429: Make sure to call PlayerInteractEvent for spectators and non-pickable entities

--- a/patches/server/0485-Add-EntityLoadCrossbowEvent.patch
+++ b/patches/server/0485-Add-EntityLoadCrossbowEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add EntityLoadCrossbowEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/CrossbowItem.java b/src/main/java/net/minecraft/world/item/CrossbowItem.java
-index ba570f1c9654e1004e068a1efe2118f36c954505..06689ee8799079510a1a4e7b68029b9629e318fb 100644
+index ba570f1c9654e1004e068a1efe2118f36c954505..f3a428f80c265639250114498b10067b4bf1ada1 100644
 --- a/src/main/java/net/minecraft/world/item/CrossbowItem.java
 +++ b/src/main/java/net/minecraft/world/item/CrossbowItem.java
 @@ -89,7 +89,14 @@ public class CrossbowItem extends ProjectileWeaponItem implements Vanishable {
@@ -15,7 +15,7 @@ index ba570f1c9654e1004e068a1efe2118f36c954505..06689ee8799079510a1a4e7b68029b96
 -        if (f >= 1.0F && !CrossbowItem.isCharged(stack) && CrossbowItem.tryLoadProjectiles(user, stack)) {
 +        // Paper start - Add EntityLoadCrossbowEvent
 +        if (f >= 1.0F && !CrossbowItem.isCharged(stack) /*&& CrossbowItem.tryLoadProjectiles(entityliving, itemstack)*/) {
-+            final io.papermc.paper.event.entity.EntityLoadCrossbowEvent event = new io.papermc.paper.event.entity.EntityLoadCrossbowEvent(user.getBukkitLivingEntity(), stack.asBukkitMirror(), user.getUsedItemHand() == InteractionHand.MAIN_HAND ? org.bukkit.inventory.EquipmentSlot.HAND : org.bukkit.inventory.EquipmentSlot.OFF_HAND);
++            final io.papermc.paper.event.entity.EntityLoadCrossbowEvent event = new io.papermc.paper.event.entity.EntityLoadCrossbowEvent(user.getBukkitLivingEntity(), stack.asBukkitMirror(), org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(user.getUsedItemHand()));
 +            if (!event.callEvent() || !tryLoadProjectiles(user, stack, event.shouldConsumeItem())) {
 +                if (user instanceof ServerPlayer player) player.containerMenu.sendAllDataToRemote();
 +                return;

--- a/patches/server/0489-Add-BlockFailedDispenseEvent.patch
+++ b/patches/server/0489-Add-BlockFailedDispenseEvent.patch
@@ -32,17 +32,17 @@ index 913ed110d8402d377152753325901eb7f3ac82d6..1d13f8a1009d6eda351c697052d499d5
              } else {
                  ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 23fb49657e07c99e10d238420ecb177ca515a2af..0887f8102b703ede1e528345851e48f786dc7c58 100644
+index cddd081d451f38e90d8b49a16abb0c95d498defe..6a95328293e3600b7a560074a0e6083db9cd3e1f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2040,4 +2040,12 @@ public class CraftEventFactory {
-         Bukkit.getPluginManager().callEvent(event);
-         return event;
+@@ -2072,4 +2072,12 @@ public class CraftEventFactory {
+         return org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getPotion());
      }
+     // Paper end - WitchReadyPotionEvent
 +
 +    // Paper start
-+    public static boolean handleBlockFailedDispenseEvent(ServerLevel serverLevel, BlockPos blockposition) {
-+        org.bukkit.block.Block block = serverLevel.getWorld().getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ());
++    public static boolean handleBlockFailedDispenseEvent(ServerLevel serverLevel, BlockPos pos) {
++        org.bukkit.block.Block block = CraftBlock.at(serverLevel, pos);
 +        io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
 +        return event.callEvent();
 +    }

--- a/patches/server/0491-Add-PlayerLoomPatternSelectEvent.patch
+++ b/patches/server/0491-Add-PlayerLoomPatternSelectEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerLoomPatternSelectEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/LoomMenu.java b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
-index a98157f600837898dd8ef12671c4bb713e30f30c..b8440f2cd7ca46c243407ae1ba8f8c7adab4ecd4 100644
+index a98157f600837898dd8ef12671c4bb713e30f30c..e8c755dc71d9818f025eb25224122b19c5f9e15b 100644
 --- a/src/main/java/net/minecraft/world/inventory/LoomMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
-@@ -173,8 +173,35 @@ public class LoomMenu extends AbstractContainerMenu {
+@@ -173,8 +173,36 @@ public class LoomMenu extends AbstractContainerMenu {
      @Override
      public boolean clickMenuButton(net.minecraft.world.entity.player.Player player, int id) {
          if (id >= 0 && id < this.selectablePatterns.size()) {
@@ -18,7 +18,7 @@ index a98157f600837898dd8ef12671c4bb713e30f30c..b8440f2cd7ca46c243407ae1ba8f8c7a
 +            int selectablePatternIndex = id;
 +            io.papermc.paper.event.player.PlayerLoomPatternSelectEvent event = new io.papermc.paper.event.player.PlayerLoomPatternSelectEvent((Player) player.getBukkitEntity(), ((CraftInventoryLoom) getBukkitView().getTopInventory()), org.bukkit.block.banner.PatternType.getByIdentifier(this.selectablePatterns.get(selectablePatternIndex).value().getHashname()));
 +            if (!event.callEvent()) {
-+                ((Player) player.getBukkitEntity()).updateInventory();
++                player.containerMenu.sendAllDataToRemote();
 +                return false;
 +            }
 +            Holder<BannerPattern> selectedPattern = null;
@@ -33,13 +33,14 @@ index a98157f600837898dd8ef12671c4bb713e30f30c..b8440f2cd7ca46c243407ae1ba8f8c7a
 +            if (selectedPattern == null) {
 +                for (BannerPattern pattern : BuiltInRegistries.BANNER_PATTERN) {
 +                    if (event.getPatternType().getIdentifier().equals(pattern.getHashname())) {
-+                        selectedPattern = BuiltInRegistries.BANNER_PATTERN.getHolder(BuiltInRegistries.BANNER_PATTERN.getId(pattern)).orElseThrow();
++                        selectedPattern = BuiltInRegistries.BANNER_PATTERN.wrapAsHolder(pattern);
 +                        break;
 +                    }
 +                }
 +                selectablePatternIndex = -1;
 +            }
-+            ((Player) player.getBukkitEntity()).updateInventory();
++
++            player.containerMenu.sendAllDataToRemote();
 +            this.selectedBannerPatternIndex.set(selectablePatternIndex);
 +            this.setupResultSlot(java.util.Objects.requireNonNull(selectedPattern, "selectedPattern was null, this is unexpected"));
 +            // Paper end - Add PlayerLoomPatternSelectEvent

--- a/patches/server/0504-Add-BlockPreDispenseEvent.patch
+++ b/patches/server/0504-Add-BlockPreDispenseEvent.patch
@@ -17,16 +17,16 @@ index 5593a0aa9e618071b6521b213dde0f628348c3dc..644e64850479cea20a98b8a65503ccf3
                      tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0887f8102b703ede1e528345851e48f786dc7c58..1e45ca6c042fe86785ac36645e1ce2f5a85a8d23 100644
+index 6a95328293e3600b7a560074a0e6083db9cd3e1f..456c1df6b5956b521e8f379b9020ed53f66a365b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2047,5 +2047,11 @@ public class CraftEventFactory {
+@@ -2079,5 +2079,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }
 +
 +    public static boolean handleBlockPreDispenseEvent(ServerLevel serverLevel, BlockPos pos, ItemStack itemStack, int slot) {
-+        org.bukkit.block.Block block = serverLevel.getWorld().getBlockAt(pos.getX(), pos.getY(), pos.getZ());
++        org.bukkit.block.Block block = CraftBlock.at(serverLevel, pos);
 +        io.papermc.paper.event.block.BlockPreDispenseEvent event = new io.papermc.paper.event.block.BlockPreDispenseEvent(block, org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack), slot);
 +        return event.callEvent();
 +    }

--- a/patches/server/0505-Add-PlayerChangeBeaconEffectEvent.patch
+++ b/patches/server/0505-Add-PlayerChangeBeaconEffectEvent.patch
@@ -5,21 +5,19 @@ Subject: [PATCH] Add PlayerChangeBeaconEffectEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/BeaconMenu.java b/src/main/java/net/minecraft/world/inventory/BeaconMenu.java
-index e6a4e8dcdbc49b427c2802f1a358f8f9ad04d0f0..611cbe0e47474f94cd203ac86ca9e80cab621134 100644
+index e6a4e8dcdbc49b427c2802f1a358f8f9ad04d0f0..b670c0cb3886c99d38a91b5c13aa2cefaae702cf 100644
 --- a/src/main/java/net/minecraft/world/inventory/BeaconMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/BeaconMenu.java
-@@ -169,13 +169,26 @@ public class BeaconMenu extends AbstractContainerMenu {
-     public MobEffect getSecondaryEffect() {
+@@ -170,12 +170,24 @@ public class BeaconMenu extends AbstractContainerMenu {
          return BeaconMenu.decodeEffect(this.beaconData.get(2));
      }
+ 
 +    // Paper start - Add PlayerChangeBeaconEffectEvent
-+    private static @Nullable org.bukkit.potion.PotionEffectType convert(Optional<MobEffect> effect) {
-+        return effect.flatMap(net.minecraft.core.registries.BuiltInRegistries.MOB_EFFECT::getResourceKey).map(key -> {
-+            return org.bukkit.potion.PotionEffectType.getByKey(org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(key.location()));
-+        }).orElse(null);
++    private static @Nullable org.bukkit.potion.PotionEffectType convert(Optional<MobEffect> optionalEffect) {
++        return optionalEffect.map(org.bukkit.craftbukkit.potion.CraftPotionEffectType::minecraftToBukkit).orElse(null);
 +    }
 +    // Paper end - Add PlayerChangeBeaconEffectEvent
- 
++
      public void updateEffects(Optional<MobEffect> primary, Optional<MobEffect> secondary) {
          if (this.paymentSlot.hasItem()) {
 -            this.beaconData.set(1, BeaconMenu.encodeEffect((MobEffect) primary.orElse(null))); // CraftBukkit - decompile error

--- a/patches/server/0507-Add-PlayerStonecutterRecipeSelectEvent.patch
+++ b/patches/server/0507-Add-PlayerStonecutterRecipeSelectEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add PlayerStonecutterRecipeSelectEvent
 Co-Authored-By: MiniDigger <admin@benndorf.dev>
 
 diff --git a/src/main/java/net/minecraft/world/inventory/StonecutterMenu.java b/src/main/java/net/minecraft/world/inventory/StonecutterMenu.java
-index e40d9dbdbe5359c38af6d764d01c9be422654aaa..4924993fab57bcf72a5d75cc2f7e6bed4f9f511c 100644
+index e40d9dbdbe5359c38af6d764d01c9be422654aaa..1a5d8debc053b24e5856de916f1d248b36f645ba 100644
 --- a/src/main/java/net/minecraft/world/inventory/StonecutterMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/StonecutterMenu.java
 @@ -63,7 +63,7 @@ public class StonecutterMenu extends AbstractContainerMenu {
@@ -18,7 +18,7 @@ index e40d9dbdbe5359c38af6d764d01c9be422654aaa..4924993fab57bcf72a5d75cc2f7e6bed
          this.recipes = Lists.newArrayList();
          this.input = ItemStack.EMPTY;
          this.slotUpdateListener = () -> {
-@@ -161,7 +161,29 @@ public class StonecutterMenu extends AbstractContainerMenu {
+@@ -161,7 +161,30 @@ public class StonecutterMenu extends AbstractContainerMenu {
      @Override
      public boolean clickMenuButton(net.minecraft.world.entity.player.Player player, int id) {
          if (this.isValidRecipeIndex(id)) {
@@ -30,20 +30,21 @@ index e40d9dbdbe5359c38af6d764d01c9be422654aaa..4924993fab57bcf72a5d75cc2f7e6bed
 +            if (this.isValidRecipeIndex(id)) {
 +                io.papermc.paper.event.player.PlayerStonecutterRecipeSelectEvent event = new io.papermc.paper.event.player.PlayerStonecutterRecipeSelectEvent((Player) player.getBukkitEntity(), (org.bukkit.inventory.StonecutterInventory) getBukkitView().getTopInventory(), (org.bukkit.inventory.StonecuttingRecipe) this.getRecipes().get(id).toBukkitRecipe());
 +                if (!event.callEvent()) {
-+                    ((Player) player.getBukkitEntity()).updateInventory();
++                    player.containerMenu.sendAllDataToRemote();
 +                    return false;
 +                }
-+                int newRecipeIndex;
-+                if (!this.getRecipes().get(recipeIndex).id().equals(org.bukkit.craftbukkit.util.CraftNamespacedKey.toMinecraft(event.getStonecuttingRecipe().getKey()))) { // If the recipe did NOT stay the same
-+                    for (newRecipeIndex = 0; newRecipeIndex < this.getRecipes().size(); newRecipeIndex++) {
-+                        if (this.getRecipes().get(newRecipeIndex).id().equals(org.bukkit.craftbukkit.util.CraftNamespacedKey.toMinecraft(event.getStonecuttingRecipe().getKey()))) {
++
++                net.minecraft.resources.ResourceLocation key = org.bukkit.craftbukkit.util.CraftNamespacedKey.toMinecraft(event.getStonecuttingRecipe().getKey());
++                if (!this.getRecipes().get(recipeIndex).id().equals(key)) { // If the recipe did NOT stay the same
++                    for (int newRecipeIndex = 0; newRecipeIndex < this.getRecipes().size(); newRecipeIndex++) {
++                        if (this.getRecipes().get(newRecipeIndex).id().equals(key)) {
 +                            recipeIndex = newRecipeIndex;
 +                            break;
 +                        }
 +                    }
 +                }
 +            }
-+            ((Player) player.getBukkitEntity()).updateInventory();
++            player.containerMenu.sendAllDataToRemote();
 +            this.selectedRecipeIndex.set(recipeIndex); // set new index, so that listeners can read it
 +            // Paper end - Add PlayerStonecutterRecipeSelectEvent
              this.setupResultSlot();

--- a/patches/server/0511-Add-EntityMoveEvent.patch
+++ b/patches/server/0511-Add-EntityMoveEvent.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Add EntityMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 4fd56dc6f1a9dc15b639d6aeba29e678354ee7f8..37c4245a30ee6a5f786364aa46dee832396ba4fd 100644
+index 06b7816bafa3ac1093b796ca6e7bb3462df8bfec..3f061e1135bac08e6ea1530407ff2667904339a5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1526,6 +1526,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
-             worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
+             worldserver.hasPhysicsEvent = org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
 +            worldserver.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - Add EntityMoveEvent
  
              this.profiler.push(() -> {
@@ -29,7 +29,7 @@ index b93976abbc98c1beffe4b464735c9b5a71cb45a4..f75722633789155af38184982ce6459a
      public LevelChunk getChunkIfLoaded(int x, int z) {
          return this.chunkSource.getChunk(x, z, false);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 95ee76c0e96318866a7b21355c9617c2ca79776e..bcd1a608796065eb705363bdc246151b68553c0e 100644
+index 6150f5c17ba80cb7acd5b114d9dec79e6008e89a..fced5d9a6d60bd673f44c0754725831b8510b95a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3361,6 +3361,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -40,7 +40,7 @@ index 95ee76c0e96318866a7b21355c9617c2ca79776e..bcd1a608796065eb705363bdc246151b
 +        if (((ServerLevel) this.level()).hasEntityMoveEvent && !(this instanceof net.minecraft.world.entity.player.Player)) {
 +            if (this.xo != this.getX() || this.yo != this.getY() || this.zo != this.getZ() || this.yRotO != this.getYRot() || this.xRotO != this.getXRot()) {
 +                Location from = new Location(this.level().getWorld(), this.xo, this.yo, this.zo, this.yRotO, this.xRotO);
-+                Location to = new Location (this.level().getWorld(), this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());
++                Location to = new Location(this.level().getWorld(), this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());
 +                io.papermc.paper.event.entity.EntityMoveEvent event = new io.papermc.paper.event.entity.EntityMoveEvent(this.getBukkitLivingEntity(), from, to.clone());
 +                if (!event.callEvent()) {
 +                    this.absMoveTo(from.getX(), from.getY(), from.getZ(), from.getYaw(), from.getPitch());

--- a/patches/server/0523-Add-PlayerNameEntityEvent.patch
+++ b/patches/server/0523-Add-PlayerNameEntityEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerNameEntityEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/NameTagItem.java b/src/main/java/net/minecraft/world/item/NameTagItem.java
-index af072de68435d1678651bdf2fa13b314ca9c9d58..d12b3fb8b5e28ba4524d163878be978b1b42d019 100644
+index af072de68435d1678651bdf2fa13b314ca9c9d58..a0b3c2d3b3f86ecd6cb80ff767839d29ca4f4f68 100644
 --- a/src/main/java/net/minecraft/world/item/NameTagItem.java
 +++ b/src/main/java/net/minecraft/world/item/NameTagItem.java
 @@ -15,9 +15,14 @@ public class NameTagItem extends Item {
@@ -18,10 +18,10 @@ index af072de68435d1678651bdf2fa13b314ca9c9d58..d12b3fb8b5e28ba4524d163878be978b
 +                // Paper start - Add PlayerNameEntityEvent
 +                io.papermc.paper.event.player.PlayerNameEntityEvent event = new io.papermc.paper.event.player.PlayerNameEntityEvent(((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity(), entity.getBukkitLivingEntity(), io.papermc.paper.adventure.PaperAdventure.asAdventure(stack.getHoverName()), true);
 +                if (!event.callEvent()) return InteractionResult.PASS;
-+                LivingEntity newEntityLiving = ((org.bukkit.craftbukkit.entity.CraftLivingEntity) event.getEntity()).getHandle();
-+                newEntityLiving.setCustomName(event.getName() != null ? io.papermc.paper.adventure.PaperAdventure.asVanilla(event.getName()) : null);
-+                if (event.isPersistent() && newEntityLiving instanceof Mob) {
-+                    ((Mob) newEntityLiving).setPersistenceRequired();
++                LivingEntity newEntity = ((org.bukkit.craftbukkit.entity.CraftLivingEntity) event.getEntity()).getHandle();
++                newEntity.setCustomName(event.getName() != null ? io.papermc.paper.adventure.PaperAdventure.asVanilla(event.getName()) : null);
++                if (event.isPersistent() && newEntity instanceof Mob) {
++                    ((Mob) newEntity).setPersistenceRequired();
 +                    // Paper end - Add PlayerNameEntityEvent
                  }
  

--- a/patches/server/0527-Allow-using-signs-inside-spawn-protection.patch
+++ b/patches/server/0527-Allow-using-signs-inside-spawn-protection.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow using signs inside spawn protection
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 1f39a44b27cf427885a14115946f0f1a54508c5b..8520433df409d30c746640602e36a54587020b08 100644
+index 6f8f1e3c5bb823fb992493b7e37cd352a84298fd..03a343734b00e08611e670496e9c27bbea239153 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1745,7 +1745,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1744,7 +1744,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      int i = this.player.level().getMaxBuildHeight();
  
                      if (blockposition.getY() < i) {

--- a/patches/server/0533-Don-t-ignore-result-of-PlayerEditBookEvent.patch
+++ b/patches/server/0533-Don-t-ignore-result-of-PlayerEditBookEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't ignore result of PlayerEditBookEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8520433df409d30c746640602e36a54587020b08..dd31da062fd7dbc420e4b3066a526b5892abdfea 100644
+index 03a343734b00e08611e670496e9c27bbea239153..10e45e3424a732049f91d4d71c98e210e2bef391 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1180,7 +1180,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1179,7 +1179,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
  
          itemstack.addTagElement("pages", nbttaglist);

--- a/patches/server/0543-fix-PlayerItemHeldEvent-firing-twice.patch
+++ b/patches/server/0543-fix-PlayerItemHeldEvent-firing-twice.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] fix PlayerItemHeldEvent firing twice
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index dd31da062fd7dbc420e4b3066a526b5892abdfea..923026fbc223d845ed8ea4028522b4c6d21673f2 100644
+index 10e45e3424a732049f91d4d71c98e210e2bef391..194004b29f068991b70e6bde0c4da9f2c4738c1f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1914,6 +1914,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1913,6 +1913,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (this.player.isImmobile()) return; // CraftBukkit
          if (packet.getSlot() >= 0 && packet.getSlot() < Inventory.getSelectionSize()) {

--- a/patches/server/0544-Add-PlayerDeepSleepEvent.patch
+++ b/patches/server/0544-Add-PlayerDeepSleepEvent.patch
@@ -5,16 +5,18 @@ Subject: [PATCH] Add PlayerDeepSleepEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 10caa677309c5a8191830c98597468079e784459..caa71993f3ee344151a3e053ba527b868c13251b 100644
+index 10caa677309c5a8191830c98597468079e784459..f47874dc9270d177aa7c39266e36713d0c934640 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -246,6 +246,11 @@ public abstract class Player extends LivingEntity {
+@@ -246,6 +246,13 @@ public abstract class Player extends LivingEntity {
  
          if (this.isSleeping()) {
              ++this.sleepCounter;
 +            // Paper start - Add PlayerDeepSleepEvent
-+            if (this.sleepCounter == 100) {
-+                if (!new io.papermc.paper.event.player.PlayerDeepSleepEvent((org.bukkit.entity.Player) getBukkitEntity()).callEvent()) { this.sleepCounter = Integer.MIN_VALUE; }
++            if (this.sleepCounter == SLEEP_DURATION) {
++                if (!new io.papermc.paper.event.player.PlayerDeepSleepEvent((org.bukkit.entity.Player) getBukkitEntity()).callEvent()) {
++                    this.sleepCounter = Integer.MIN_VALUE;
++                }
 +            }
 +            // Paper end - Add PlayerDeepSleepEvent
              if (this.sleepCounter > 100) {

--- a/patches/server/0546-Add-PlayerBedFailEnterEvent.patch
+++ b/patches/server/0546-Add-PlayerBedFailEnterEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerBedFailEnterEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/BedBlock.java b/src/main/java/net/minecraft/world/level/block/BedBlock.java
-index 77438ea56b83f6aecd5f9acb9c55d4cd6e86ff95..40559727591278f44dbf50e2d3406054ffeb8ae9 100644
+index 77438ea56b83f6aecd5f9acb9c55d4cd6e86ff95..c5d892950b4027cf9879eafc1c0f4e4c62fb4f51 100644
 --- a/src/main/java/net/minecraft/world/level/block/BedBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/BedBlock.java
 @@ -119,14 +119,23 @@ public class BedBlock extends HorizontalDirectionalBlock implements EntityBlock
@@ -14,7 +14,7 @@ index 77438ea56b83f6aecd5f9acb9c55d4cd6e86ff95..40559727591278f44dbf50e2d3406054
                  player.startSleepInBed(pos).ifLeft((entityhuman_enumbedresult) -> {
 +                    // Paper start - PlayerBedFailEnterEvent
 +                    if (entityhuman_enumbedresult != null) {
-+                        io.papermc.paper.event.player.PlayerBedFailEnterEvent event = new io.papermc.paper.event.player.PlayerBedFailEnterEvent((org.bukkit.entity.Player) player.getBukkitEntity(), io.papermc.paper.event.player.PlayerBedFailEnterEvent.FailReason.VALUES[entityhuman_enumbedresult.ordinal()], org.bukkit.craftbukkit.block.CraftBlock.at(world, finalblockposition), !world.dimensionType().bedWorks(), io.papermc.paper.adventure.PaperAdventure.asAdventure(entityhuman_enumbedresult.getMessage()));
++                        io.papermc.paper.event.player.PlayerBedFailEnterEvent event = new io.papermc.paper.event.player.PlayerBedFailEnterEvent((org.bukkit.entity.Player) player.getBukkitEntity(), io.papermc.paper.event.player.PlayerBedFailEnterEvent.FailReason.values()[entityhuman_enumbedresult.ordinal()], org.bukkit.craftbukkit.block.CraftBlock.at(world, finalblockposition), !world.dimensionType().bedWorks(), io.papermc.paper.adventure.PaperAdventure.asAdventure(entityhuman_enumbedresult.getMessage()));
 +                        if (!event.callEvent()) {
 +                            return;
 +                        }

--- a/patches/server/0548-Expand-PlayerRespawnEvent-fix-passed-parameter-issue.patch
+++ b/patches/server/0548-Expand-PlayerRespawnEvent-fix-passed-parameter-issue.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand PlayerRespawnEvent, fix passed parameter issues
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 923026fbc223d845ed8ea4028522b4c6d21673f2..6acec839ee6d7a8893016e79af76892d63a7b601 100644
+index 194004b29f068991b70e6bde0c4da9f2c4738c1f..87af53e0ce39a72f8bd861a9ff66b7e8ad8ef026 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2632,7 +2632,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2620,7 +2620,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              case PERFORM_RESPAWN:
                  if (this.player.wonGame) {
                      this.player.wonGame = false;

--- a/patches/server/0560-Expand-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0560-Expand-PlayerGameModeChangeEvent.patch
@@ -94,7 +94,7 @@ index 5a26a7d6e052c0533f73b1930da6c801f23cb521..895c2cd385622fcc426e9e920ff35109
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index f66ce9ae705b0fbe17a1bb437bad6808ff47ed92..37513cf5714afda6c552219c2eca8134c054d2bb 100644
+index a03d1a85019afdc42de2b8449fc38384c4dac51e..4fe571915b247ec612b2376dce57991e441f63c2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -73,21 +73,28 @@ public class ServerPlayerGameMode {
@@ -131,10 +131,10 @@ index f66ce9ae705b0fbe17a1bb437bad6808ff47ed92..37513cf5714afda6c552219c2eca8134
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3d727afa81b4134d6bc7ab13e0fef3a741a39f36..476cd64e29b7171952fe4f02b661f871897a10f1 100644
+index 87af53e0ce39a72f8bd861a9ff66b7e8ad8ef026..ce890d584cdb77bfb082ded375297fa7413da8ed 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2641,7 +2641,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2629,7 +2629,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                      this.player = this.server.getPlayerList().respawn(this.player, false, RespawnReason.DEATH);
                      if (this.server.isHardcore()) {

--- a/patches/server/0563-Move-range-check-for-block-placing-up.patch
+++ b/patches/server/0563-Move-range-check-for-block-placing-up.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Move range check for block placing up
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4ee35e2f717a5a55c9f90a6528f5c93529a92a84..b27e232689b8af2f3c9f643b9bee805f9a7a0434 100644
+index ce890d584cdb77bfb082ded375297fa7413da8ed..41b232bea2b3b007deedf101e33f3575a04fa81a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1731,6 +1731,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1730,6 +1730,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          if (itemstack.isItemEnabled(worldserver.enabledFeatures())) {
              BlockHitResult movingobjectpositionblock = packet.getHitResult();
              Vec3 vec3d = movingobjectpositionblock.getLocation();

--- a/patches/server/0566-Add-Unix-domain-socket-support.patch
+++ b/patches/server/0566-Add-Unix-domain-socket-support.patch
@@ -87,10 +87,10 @@ index 25ddfe8e5da65e4ac70be2820ba139e7f3852c0c..87abd6274f9da9367094bad0c28acfa4
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b27e232689b8af2f3c9f643b9bee805f9a7a0434..9c8188a5937206448479e9e29efcee7b938fb2cc 100644
+index 41b232bea2b3b007deedf101e33f3575a04fa81a..f3fcb18af47c04654aa004b5f1b94b9f48c6f78a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2464,6 +2464,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2463,6 +2463,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      // Spigot Start
      public SocketAddress getRawAddress()
      {

--- a/patches/server/0572-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0572-Add-PlayerKickEvent-causes.patch
@@ -48,7 +48,7 @@ index 96814e626a95e4e3c2f4df1a0339d37bb02f2e61..ba12919c3f9aec34a9e64993b143ae92
  
          public boolean shouldDisconnect() {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b3b78ad64c5cd9bde4756c5e619d0188ec8f2608..2535f33e1ee5f1bac3247231138966fe070615cd 100644
+index 773e4850956a7ffcd78cc241a598fd13bcfe1d20..7ee46b9f98794d1fec0a8feea71fd495f9199dd0 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2167,7 +2167,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -209,10 +209,10 @@ index 6bb846d3ee2fb54ab3ffa116607f2a83e538460e..a65a1466dab52fca75cda16a4b22fef0
          if (this.cserver.getServer().isRunning()) {
              this.cserver.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a936972556723c244 100644
+index f3fcb18af47c04654aa004b5f1b94b9f48c6f78a..12c80c955333184254a23659b792b2fda5957dfc 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -342,7 +342,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -341,7 +341,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          if (this.clientIsFloating && !this.player.isSleeping() && !this.player.isPassenger() && !this.player.isDeadOrDying()) {
              if (++this.aboveGroundTickCount > 80) {
                  ServerGamePacketListenerImpl.LOGGER.warn("{} was kicked for floating too long!", this.player.getName().getString());
@@ -221,7 +221,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
                  return;
              }
          } else {
-@@ -361,7 +361,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -360,7 +360,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              if (this.clientVehicleIsFloating && this.player.getRootVehicle().getControllingPassenger() == this.player) {
                  if (++this.aboveGroundVehicleTickCount > 80) {
                      ServerGamePacketListenerImpl.LOGGER.warn("{} was kicked for floating a vehicle too long!", this.player.getName().getString());
@@ -230,7 +230,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
                      return;
                  }
              } else {
-@@ -392,7 +392,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -391,7 +391,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
          if (this.player.getLastActionTime() > 0L && this.server.getPlayerIdleTimeout() > 0 && Util.getMillis() - this.player.getLastActionTime() > (long) this.server.getPlayerIdleTimeout() * 1000L * 60L) {
              this.player.resetLastActionTime(); // CraftBukkit - SPIGOT-854
@@ -239,7 +239,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
          }
  
      }
-@@ -462,7 +462,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -461,7 +461,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      public void handleMoveVehicle(ServerboundMoveVehiclePacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (ServerGamePacketListenerImpl.containsInvalidValues(packet.getX(), packet.getY(), packet.getZ(), packet.getYRot(), packet.getXRot())) {
@@ -248,7 +248,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
          } else {
              Entity entity = this.player.getRootVehicle();
  
-@@ -664,7 +664,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -663,7 +663,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (packet.getId() == this.awaitingTeleport) {
              if (this.awaitingPositionFromClient == null) {
@@ -257,7 +257,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
                  return;
              }
  
-@@ -722,7 +722,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -721,7 +721,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel()); // Paper - AsyncTabCompleteEvent; run this async
          // CraftBukkit start
          if (this.chatSpamTickCount.addAndGet(io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.tabSpamIncrement) > io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.tabSpamLimit && !this.server.getPlayerList().isOp(this.player.getGameProfile())) { // Paper - configurable tab spam limits
@@ -266,7 +266,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
              return;
          }
          // CraftBukkit end
-@@ -874,7 +874,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -873,7 +873,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // Paper start - validate pick item position
          if (!(packet.getSlot() >= 0 && packet.getSlot() < this.player.getInventory().items.size())) {
              ServerGamePacketListenerImpl.LOGGER.warn("{} tried to set an invalid carried item", this.player.getName().getString());
@@ -275,7 +275,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
              return;
          }
          this.player.getInventory().pickSlot(packet.getSlot()); // Paper - Diff above if changed
-@@ -1059,7 +1059,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1058,7 +1058,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  int byteLength = testString.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
                  if (byteLength > 256 * 4) {
                      ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send a book with with a page too large!");
@@ -284,7 +284,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
                      return;
                  }
                  byteTotal += byteLength;
-@@ -1082,14 +1082,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1081,14 +1081,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
              if (byteTotal > byteAllowed) {
                  ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send too large of a book. Book Size: " + byteTotal + " - Allowed:  "+ byteAllowed + " - Pages: " + pageList.size());
@@ -301,7 +301,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
              return;
          }
          this.lastBookTick = MinecraftServer.currentTick;
-@@ -1233,7 +1233,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1232,7 +1232,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      public void handleMovePlayer(ServerboundMovePlayerPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (ServerGamePacketListenerImpl.containsInvalidValues(packet.getX(0.0D), packet.getY(0.0D), packet.getZ(0.0D), packet.getYRot(0.0F), packet.getXRot(0.0F))) {
@@ -310,7 +310,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
          } else {
              ServerLevel worldserver = this.player.serverLevel();
  
-@@ -1653,7 +1653,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1652,7 +1652,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                          this.dropCount++;
                          if (this.dropCount >= 20) {
                              ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " dropped their items too quickly!");
@@ -319,7 +319,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
                              return;
                          }
                      }
-@@ -1936,7 +1936,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1935,7 +1935,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              this.player.resetLastActionTime();
          } else {
              ServerGamePacketListenerImpl.LOGGER.warn("{} tried to set an invalid carried item", this.player.getName().getString());
@@ -328,7 +328,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
          }
      }
  
-@@ -1949,7 +1949,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1948,7 +1948,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
          // CraftBukkit end
          if (ServerGamePacketListenerImpl.isChatMessageIllegal(packet.message())) {
@@ -337,7 +337,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
          } else {
              Optional<LastSeenMessages> optional = this.tryHandleChat(packet.lastSeenMessages());
  
-@@ -1981,7 +1981,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1980,7 +1980,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      @Override
      public void handleChatCommand(ServerboundChatCommandPacket packet) {
          if (ServerGamePacketListenerImpl.isChatMessageIllegal(packet.command())) {
@@ -346,7 +346,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
          } else {
              Optional<LastSeenMessages> optional = this.tryHandleChat(packet.lastSeenMessages());
  
-@@ -2037,7 +2037,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2036,7 +2036,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      private void handleMessageDecodeFailure(SignedMessageChain.DecodeException exception) {
          ServerGamePacketListenerImpl.LOGGER.warn("Failed to update secure chat state for {}: '{}'", this.player.getGameProfile().getName(), exception.getComponent().getString());
          if (exception.shouldDisconnect()) {
@@ -355,7 +355,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
          } else {
              this.player.sendSystemMessage(exception.getComponent().copy().withStyle(ChatFormatting.RED));
          }
-@@ -2085,7 +2085,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2084,7 +2084,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
              if (optional.isEmpty()) {
                  ServerGamePacketListenerImpl.LOGGER.warn("Failed to validate message acknowledgements from {}", this.player.getName().getString());
@@ -364,7 +364,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
              }
  
              return optional;
-@@ -2271,7 +2271,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2270,7 +2270,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // this.chatSpamTickCount += 20;
          if (this.chatSpamTickCount.addAndGet(20) > 200 && !this.server.getPlayerList().isOp(this.player.getGameProfile())) {
              // CraftBukkit end
@@ -373,7 +373,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
          }
  
      }
-@@ -2283,7 +2283,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2282,7 +2282,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          synchronized (this.lastSeenMessages) {
              if (!this.lastSeenMessages.applyOffset(packet.offset())) {
                  ServerGamePacketListenerImpl.LOGGER.warn("Failed to validate message acknowledgements from {}", this.player.getName().getString());
@@ -382,7 +382,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
              }
  
          }
-@@ -2436,7 +2436,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2435,7 +2435,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              }
  
              if (i > 4096) {
@@ -391,7 +391,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
              }
  
          }
-@@ -2493,7 +2493,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2492,7 +2492,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // Spigot Start
          if ( entity == this.player && !this.player.isSpectator() )
          {
@@ -400,25 +400,25 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
              return;
          }
          // Spigot End
-@@ -2592,7 +2592,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2591,7 +2591,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  // CraftBukkit end
                              }
                          } else {
 -                            ServerGamePacketListenerImpl.this.disconnect(Component.translatable("multiplayer.disconnect.invalid_entity_attacked"));
-+                            ServerGamePacketListenerImpl.this.disconnect(Component.translatable("multiplayer.disconnect.invalid_entity_attacked"),  org.bukkit.event.player.PlayerKickEvent.Cause.INVALID_ENTITY_ATTACKED); // Paper - add cause
++                            ServerGamePacketListenerImpl.this.disconnect(Component.translatable("multiplayer.disconnect.invalid_entity_attacked"), org.bukkit.event.player.PlayerKickEvent.Cause.INVALID_ENTITY_ATTACKED); // Paper - add cause
                              ServerGamePacketListenerImpl.LOGGER.warn("Player {} tried to attack an invalid entity", ServerGamePacketListenerImpl.this.player.getName().getString());
                          }
                      }
-@@ -3001,7 +3001,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2989,7 +2989,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // Paper start - auto recipe limit
          if (!org.bukkit.Bukkit.isPrimaryThread()) {
              if (this.recipeSpamPackets.addAndGet(io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.recipeSpamIncrement) > io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.recipeSpamLimit) {
--                this.server.scheduleOnMain(() -> this.disconnect(net.minecraft.network.chat.Component.translatable("disconnect.spam", new Object[0])));
-+                this.server.scheduleOnMain(() -> this.disconnect(net.minecraft.network.chat.Component.translatable("disconnect.spam", new Object[0]), org.bukkit.event.player.PlayerKickEvent.Cause.SPAM)); // Paper - kick event cause
+-                this.server.scheduleOnMain(() -> this.disconnect(net.minecraft.network.chat.Component.translatable("disconnect.spam")));
++                this.server.scheduleOnMain(() -> this.disconnect(net.minecraft.network.chat.Component.translatable("disconnect.spam"), org.bukkit.event.player.PlayerKickEvent.Cause.SPAM)); // Paper - kick event cause
                  return;
              }
          }
-@@ -3243,7 +3243,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3231,7 +3231,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
          if (!Objects.equals(profilepublickey_a, profilepublickey_a1)) {
              if (profilepublickey_a != null && profilepublickey_a1.expiresAt().isBefore(profilepublickey_a.expiresAt())) {
@@ -427,7 +427,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
              } else {
                  try {
                      SignatureValidator signaturevalidator = this.server.getProfileKeySignatureValidator();
-@@ -3256,7 +3256,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3244,7 +3244,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      this.resetPlayerChatState(remotechatsession_a.validate(this.player.getGameProfile(), signaturevalidator));
                  } catch (ProfilePublicKey.ValidationException profilepublickey_b) {
                      ServerGamePacketListenerImpl.LOGGER.error("Failed to validate profile key: {}", profilepublickey_b.getMessage());
@@ -437,7 +437,7 @@ index 9c8188a5937206448479e9e29efcee7b938fb2cc..692c9235d4a6026e3598074a93697255
  
              }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 27ae2ac95d4f53c1c16b35f737fa6c138ddcc644..14b0f78d78b9f5bdaf96b80baface0df04f8f8fc 100644
+index 27ae2ac95d4f53c1c16b35f737fa6c138ddcc644..1f3f316cd1946c4a0e1ba767a93beec7eb9f3f2b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -682,7 +682,7 @@ public abstract class PlayerList {
@@ -445,7 +445,7 @@ index 27ae2ac95d4f53c1c16b35f737fa6c138ddcc644..14b0f78d78b9f5bdaf96b80baface0df
              entityplayer = (ServerPlayer) iterator.next();
              this.save(entityplayer); // CraftBukkit - Force the player's inventory to be saved
 -            entityplayer.connection.disconnect(Component.translatable("multiplayer.disconnect.duplicate_login"));
-+            entityplayer.connection.disconnect(Component.translatable("multiplayer.disconnect.duplicate_login", new Object[0]), org.bukkit.event.player.PlayerKickEvent.Cause.DUPLICATE_LOGIN); // Paper - kick event cause
++            entityplayer.connection.disconnect(Component.translatable("multiplayer.disconnect.duplicate_login"), org.bukkit.event.player.PlayerKickEvent.Cause.DUPLICATE_LOGIN); // Paper - kick event cause
          }
  
          // Instead of kicking then returning, we need to store the kick reason
@@ -491,7 +491,7 @@ index 6724d0a1af13e97bc1d3bd94fd43fef742a0deab..20ba0a0c9eae28658888a77dd2170f62
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d626d5c836724bcfe61c0580a266d7b1e6f4af65..37295ee7451d62ee59e6449bf7635007eb43ac10 100644
+index 9356752eae2499654f26fb60490490adbc1010c9..8b54fe6ee1c07a70f9823f1a2a13887620a6dfda 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -549,7 +549,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0577-Add-BellRevealRaiderEvent.patch
+++ b/patches/server/0577-Add-BellRevealRaiderEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add BellRevealRaiderEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BellBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BellBlockEntity.java
-index d21f7e9712ac2d9088ce19d415e4ba7863d8cebf..aee8401e72228d0bbf89b940715f405353093585 100644
+index d21f7e9712ac2d9088ce19d415e4ba7863d8cebf..cc511deaca0e2c1a5a255f3125f691c851101401 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BellBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BellBlockEntity.java
 @@ -156,7 +156,7 @@ public class BellBlockEntity extends BlockEntity {
@@ -17,15 +17,16 @@ index d21f7e9712ac2d9088ce19d415e4ba7863d8cebf..aee8401e72228d0bbf89b940715f4053
          // CraftBukkit end
      }
  
-@@ -191,7 +191,11 @@ public class BellBlockEntity extends BlockEntity {
-         return entity.isAlive() && !entity.isRemoved() && pos.closerToCenterThan(entity.position(), 48.0D) && entity.getType().is(EntityTypeTags.RAIDERS);
+@@ -192,6 +192,13 @@ public class BellBlockEntity extends BlockEntity {
      }
  
--    private static void glow(LivingEntity entity) {
-+    // Paper start - Add BellRevealRaiderEvent
-+    private static void glow(LivingEntity entity) { glow(entity, null); }
+     private static void glow(LivingEntity entity) {
++        // Paper start - Add BellRevealRaiderEvent
++        glow(entity, null);
++    }
++
 +    private static void glow(LivingEntity entity, @javax.annotation.Nullable BlockPos pos) {
-+        if (pos != null && !new io.papermc.paper.event.block.BellRevealRaiderEvent(entity.level().getWorld().getBlockAt(io.papermc.paper.util.MCUtil.toLocation(entity.level(), pos)), entity.getBukkitEntity()).callEvent()) return;
++        if (pos != null && !new io.papermc.paper.event.block.BellRevealRaiderEvent(org.bukkit.craftbukkit.block.CraftBlock.at(entity.level(), pos), (org.bukkit.entity.Raider) entity.getBukkitEntity()).callEvent()) return;
 +        // Paper end - Add BellRevealRaiderEvent
          entity.addEffect(new MobEffectInstance(MobEffects.GLOWING, 60));
      }

--- a/patches/server/0579-Add-ElderGuardianAppearanceEvent.patch
+++ b/patches/server/0579-Add-ElderGuardianAppearanceEvent.patch
@@ -34,7 +34,7 @@ index fd803cbdad0e75f43279c5d5049b0152c2d013c3..fcc60a419c6dade50848d4c1e6e8daf0
  
          list.forEach((entityplayer) -> {
 diff --git a/src/main/java/net/minecraft/world/entity/monster/ElderGuardian.java b/src/main/java/net/minecraft/world/entity/monster/ElderGuardian.java
-index 1dfdb378a2491b0ae64a4152e4cd8b539dfdf65b..6d4810626980ce46e02042a5660f615c58d0d5fd 100644
+index 1dfdb378a2491b0ae64a4152e4cd8b539dfdf65b..91ff663b2260d1cdd1388c93068e4cd9d0331aea 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/ElderGuardian.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/ElderGuardian.java
 @@ -70,7 +70,7 @@ public class ElderGuardian extends Guardian {
@@ -42,7 +42,7 @@ index 1dfdb378a2491b0ae64a4152e4cd8b539dfdf65b..6d4810626980ce46e02042a5660f615c
          if ((this.tickCount + this.getId()) % 1200 == 0) {
              MobEffectInstance mobeffect = new MobEffectInstance(MobEffects.DIG_SLOWDOWN, 6000, 2);
 -            List<ServerPlayer> list = MobEffectUtil.addEffectToPlayersAround((ServerLevel) this.level(), this, this.position(), 50.0D, mobeffect, 1200, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.ATTACK); // CraftBukkit
-+            List<ServerPlayer> list = MobEffectUtil.addEffectToPlayersAround((ServerLevel) this.level(), this, this.position(), 50.0D, mobeffect, 1200, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.ATTACK, (player) -> new io.papermc.paper.event.entity.ElderGuardianAppearanceEvent(getBukkitEntity(), player.getBukkitEntity()).callEvent()); // CraftBukkit // Paper - Add ElderGuardianAppearanceEvent
++            List<ServerPlayer> list = MobEffectUtil.addEffectToPlayersAround((ServerLevel) this.level(), this, this.position(), 50.0D, mobeffect, 1200, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.ATTACK, (player) -> new io.papermc.paper.event.entity.ElderGuardianAppearanceEvent((org.bukkit.entity.ElderGuardian) this.getBukkitEntity(), player.getBukkitEntity()).callEvent()); // CraftBukkit // Paper - Add ElderGuardianAppearanceEvent
  
              list.forEach((entityplayer) -> {
                  entityplayer.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, this.isSilent() ? 0.0F : 1.0F));

--- a/patches/server/0587-Fix-PlayerDropItemEvent-using-wrong-item.patch
+++ b/patches/server/0587-Fix-PlayerDropItemEvent-using-wrong-item.patch
@@ -18,10 +18,10 @@ index 895c2cd385622fcc426e9e920ff35109f444b569..12d3809792384643e550b34e59c58d49
  
                  this.awardStat(Stats.DROP);
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index caa71993f3ee344151a3e053ba527b868c13251b..b113c886b81d9ac77f16aa5acf7e1d9e61854b9f 100644
+index f47874dc9270d177aa7c39266e36713d0c934640..00477c81dc3f5d8289b08881b119b699552e5722 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -723,6 +723,11 @@ public abstract class Player extends LivingEntity {
+@@ -725,6 +725,11 @@ public abstract class Player extends LivingEntity {
              }
  
              double d0 = this.getEyeY() - 0.30000001192092896D;

--- a/patches/server/0589-Ensure-disconnect-for-book-edit-is-called-on-main.patch
+++ b/patches/server/0589-Ensure-disconnect-for-book-edit-is-called-on-main.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ensure disconnect for book edit is called on main
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 692c9235d4a6026e3598074a936972556723c244..728a02bc2037f3afcdfb2755d11105b2d6687751 100644
+index 12c80c955333184254a23659b792b2fda5957dfc..95a3be18ccd2ba638d617d3e4d165f9c7a4062ed 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1089,7 +1089,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1088,7 +1088,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // Paper end - Book size limits
          // CraftBukkit start
          if (this.lastBookTick + 20 > MinecraftServer.currentTick) {

--- a/patches/server/0591-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/patches/server/0591-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -8,7 +8,7 @@ ticket level 33 (yes getChunkIfLoaded will actually perform a chunk
 load in that case).
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index da2a8f57b733b84106ed0818f4402d9c9d854481..0a7f98900cf45fdb11e64c2ed7139fcad940f0d5 100644
+index 3f0745a9bfba35c0b133aa4bf2312e1b5eb640aa..af51a014156ade4d9c1b874a4c57a6de8849aea1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -225,7 +225,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -21,10 +21,10 @@ index da2a8f57b733b84106ed0818f4402d9c9d854481..0a7f98900cf45fdb11e64c2ed7139fca
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 3e98a86dd56855485c7d8c26eb30f2bbace2d66c..596bcc62e5754b5a2c29de263ba2f7fd9b6e0bed 100644
+index 9879f9fd804f93faae4419add2c4c64fc6902ba1..9130ba6b008bab38212b162b4795cff63df5b957 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -187,6 +187,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -182,6 +182,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return (CraftServer) Bukkit.getServer();
      }
  

--- a/patches/server/0592-Fix-commands-from-signs-not-firing-command-events.patch
+++ b/patches/server/0592-Fix-commands-from-signs-not-firing-command-events.patch
@@ -58,7 +58,7 @@ index 0000000000000000000000000000000000000000..01a2bc1feec808790bb93618ce46adb9
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
-index 9939cad5af2d7873f188f18978029663a8d785de..c79a80428961b0941d4f6ed31d641cbf0e6a7203 100644
+index 9939cad5af2d7873f188f18978029663a8d785de..f3cea7a8de334419b4a2f6dc64ef0e20fd715e75 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
 @@ -273,7 +273,17 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
@@ -71,7 +71,7 @@ index 9939cad5af2d7873f188f18978029663a8d785de..c79a80428961b0941d4f6ed31d641cbf
 +                if (org.spigotmc.SpigotConfig.logCommands)  {
 +                    LOGGER.info("{} issued server command: {}", player.getScoreboardName(), command);
 +                }
-+                io.papermc.paper.event.player.PlayerSignCommandPreprocessEvent event = new io.papermc.paper.event.player.PlayerSignCommandPreprocessEvent((org.bukkit.entity.Player) player.getBukkitEntity(), command, new org.bukkit.craftbukkit.util.LazyPlayerSet(player.getServer()), (org.bukkit.block.Sign) io.papermc.paper.util.MCUtil.toBukkitBlock(this.level, this.worldPosition).getState(), front ? Side.FRONT : Side.BACK);
++                io.papermc.paper.event.player.PlayerSignCommandPreprocessEvent event = new io.papermc.paper.event.player.PlayerSignCommandPreprocessEvent((org.bukkit.entity.Player) player.getBukkitEntity(), command, new org.bukkit.craftbukkit.util.LazyPlayerSet(player.getServer()), (org.bukkit.block.Sign) CraftBlock.at(this.level, this.worldPosition).getState(), front ? Side.FRONT : Side.BACK);
 +                if (!event.callEvent()) {
 +                    return false;
 +                }

--- a/patches/server/0593-Add-PlayerArmSwingEvent.patch
+++ b/patches/server/0593-Add-PlayerArmSwingEvent.patch
@@ -5,15 +5,15 @@ Subject: [PATCH] Add PlayerArmSwingEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 728a02bc2037f3afcdfb2755d11105b2d6687751..297f9731f005c93c5d8d2d1913bd3bf74afdda47 100644
+index 95a3be18ccd2ba638d617d3e4d165f9c7a4062ed..3285e26962f16cfc959a2cbedf961fb592100c33 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2321,7 +2321,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2320,7 +2320,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          } // Paper end - Call interact event
  
          // Arm swing animation
 -        PlayerAnimationEvent event = new PlayerAnimationEvent(this.getCraftPlayer(), (packet.getHand() == InteractionHand.MAIN_HAND) ? PlayerAnimationType.ARM_SWING : PlayerAnimationType.OFF_ARM_SWING);
-+        io.papermc.paper.event.player.PlayerArmSwingEvent event = new io.papermc.paper.event.player.PlayerArmSwingEvent(this.getCraftPlayer(), packet.getHand() == InteractionHand.MAIN_HAND ? org.bukkit.inventory.EquipmentSlot.HAND : org.bukkit.inventory.EquipmentSlot.OFF_HAND); // Paper - Add PlayerArmSwingEvent
++        io.papermc.paper.event.player.PlayerArmSwingEvent event = new io.papermc.paper.event.player.PlayerArmSwingEvent(this.getCraftPlayer(), org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(packet.getHand())); // Paper - Add PlayerArmSwingEvent
          this.cserver.getPluginManager().callEvent(event);
  
          if (event.isCancelled()) return;

--- a/patches/server/0594-Fix-kick-event-leave-message-not-being-sent.patch
+++ b/patches/server/0594-Fix-kick-event-leave-message-not-being-sent.patch
@@ -50,10 +50,10 @@ index a65a1466dab52fca75cda16a4b22fef03b6207a0..0306771b8f90dcdd77f151c19c6c2d75
          MinecraftServer minecraftserver = this.server;
          Connection networkmanager = this.connection;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 297f9731f005c93c5d8d2d1913bd3bf74afdda47..ffe90271365138d6046b52cad2cf661d25d6e6d4 100644
+index 3285e26962f16cfc959a2cbedf961fb592100c33..a28141f7a4b59d98e1eb9fbd8c431fa3eedaf53e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1875,6 +1875,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1874,6 +1874,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void onDisconnect(Component reason) {
@@ -66,7 +66,7 @@ index 297f9731f005c93c5d8d2d1913bd3bf74afdda47..ffe90271365138d6046b52cad2cf661d
          // CraftBukkit start - Rarely it would send a disconnect line twice
          if (this.processedDisconnect) {
              return;
-@@ -1883,11 +1889,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1882,11 +1888,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
          // CraftBukkit end
          ServerGamePacketListenerImpl.LOGGER.info("{} lost connection: {}", this.player.getName().getString(), reason.getString());
@@ -86,7 +86,7 @@ index 297f9731f005c93c5d8d2d1913bd3bf74afdda47..ffe90271365138d6046b52cad2cf661d
          this.chatMessageChain.close();
          // CraftBukkit start - Replace vanilla quit message handling with our own.
          /*
-@@ -1897,7 +1909,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1896,7 +1908,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
          this.player.disconnect();
          // Paper start - Adventure
@@ -96,7 +96,7 @@ index 297f9731f005c93c5d8d2d1913bd3bf74afdda47..ffe90271365138d6046b52cad2cf661d
              this.server.getPlayerList().broadcastSystemMessage(PaperAdventure.asVanilla(quitMessage), false);
              // Paper end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 14b0f78d78b9f5bdaf96b80baface0df04f8f8fc..9e9d4b5cc32beef41aa6d3b0ad8dbbd158b1f148 100644
+index 1f3f316cd1946c4a0e1ba767a93beec7eb9f3f2b..569d1f1682b9c785701fbb04683fea880504c94c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -568,6 +568,11 @@ public abstract class PlayerList {

--- a/patches/server/0595-Add-config-for-mobs-immune-to-default-effects.patch
+++ b/patches/server/0595-Add-config-for-mobs-immune-to-default-effects.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config for mobs immune to default effects
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cedd1f8063504cc58b2735a8d53a3c39a605bf5f..378e5bfd58caf21e9ebecc900f02163c64a48073 100644
+index aab173a8c36f8f03cfad84a69b9a34bd19369649..8dcebc2b6e8baf4ed5f269a1b9cec9e5cd754047 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1164,7 +1164,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1163,7 +1163,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (this.getMobType() == MobType.UNDEAD) {
              MobEffect mobeffectlist = effect.getEffect();
  

--- a/patches/server/0603-Prevent-AFK-kick-while-watching-end-credits.patch
+++ b/patches/server/0603-Prevent-AFK-kick-while-watching-end-credits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent AFK kick while watching end credits
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ffe90271365138d6046b52cad2cf661d25d6e6d4..b04460f710ed24ab94011e9d6b79953338d5b7e0 100644
+index a28141f7a4b59d98e1eb9fbd8c431fa3eedaf53e..5689d048b74e7608119f2e5db0022ba9b6180e5b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -390,7 +390,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -389,7 +389,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              --this.dropSpamTickCount;
          }
  

--- a/patches/server/0614-Add-BlockBreakBlockEvent.patch
+++ b/patches/server/0614-Add-BlockBreakBlockEvent.patch
@@ -5,33 +5,34 @@ Subject: [PATCH] Add BlockBreakBlockEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
-index 89a62fbeeb78c864938a1cea84178478c6dc1b34..9120b4a70dbf84f19480b952658414e16d2c23c1 100644
+index 89a62fbeeb78c864938a1cea84178478c6dc1b34..57d92c1785586dfab2b3934733d8ba253e042e2e 100644
 --- a/src/main/java/net/minecraft/world/level/block/Block.java
 +++ b/src/main/java/net/minecraft/world/level/block/Block.java
-@@ -313,6 +313,23 @@ public class Block extends BlockBehaviour implements ItemLike {
-         }
+@@ -314,6 +314,24 @@ public class Block extends BlockBehaviour implements ItemLike {
  
      }
+ 
 +    // Paper start - Add BlockBreakBlockEvent
-+    public static boolean dropResources(BlockState state, LevelAccessor world, BlockPos pos, @Nullable BlockEntity blockEntity, BlockPos source) {
-+        if (world instanceof ServerLevel) {
-+            List<org.bukkit.inventory.ItemStack> items = com.google.common.collect.Lists.newArrayList();
-+            for (net.minecraft.world.item.ItemStack drop : net.minecraft.world.level.block.Block.getDrops(state, world.getMinecraftWorld(), pos, blockEntity)) {
++    public static boolean dropResources(BlockState state, LevelAccessor levelAccessor, BlockPos pos, @Nullable BlockEntity blockEntity, BlockPos source) {
++        if (levelAccessor instanceof ServerLevel serverLevel) {
++            List<org.bukkit.inventory.ItemStack> items = new java.util.ArrayList<>();
++            for (ItemStack drop : Block.getDrops(state, serverLevel, pos, blockEntity)) {
 +                items.add(org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(drop));
 +            }
-+            io.papermc.paper.event.block.BlockBreakBlockEvent event = new io.papermc.paper.event.block.BlockBreakBlockEvent(org.bukkit.craftbukkit.block.CraftBlock.at(world, pos), org.bukkit.craftbukkit.block.CraftBlock.at(world, source), items);
++            io.papermc.paper.event.block.BlockBreakBlockEvent event = new io.papermc.paper.event.block.BlockBreakBlockEvent(org.bukkit.craftbukkit.block.CraftBlock.at(levelAccessor, pos), org.bukkit.craftbukkit.block.CraftBlock.at(levelAccessor, source), items);
 +            event.callEvent();
-+            for (var drop : event.getDrops()) {
-+                popResource(world.getMinecraftWorld(), pos, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(drop));
++            for (org.bukkit.inventory.ItemStack drop : event.getDrops()) {
++                popResource(serverLevel, pos, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(drop));
 +            }
-+            state.spawnAfterBreak(world.getMinecraftWorld(), pos, ItemStack.EMPTY, true);
++            state.spawnAfterBreak(serverLevel, pos, ItemStack.EMPTY, true);
 +        }
 +        return true;
 +    }
 +    // Paper end - Add BlockBreakBlockEvent
- 
++
      public static void dropResources(BlockState state, Level world, BlockPos pos, @Nullable BlockEntity blockEntity, @Nullable Entity entity, ItemStack tool) {
          if (world instanceof ServerLevel) {
+             Block.getDrops(state, (ServerLevel) world, pos, blockEntity, entity, tool).forEach((itemstack1) -> {
 diff --git a/src/main/java/net/minecraft/world/level/block/piston/PistonBaseBlock.java b/src/main/java/net/minecraft/world/level/block/piston/PistonBaseBlock.java
 index 3ae61e7b50bfc440c597f88843f92903f8a66801..0dbdcd443fe8a299119ea5ba3acb1a0412856184 100644
 --- a/src/main/java/net/minecraft/world/level/block/piston/PistonBaseBlock.java

--- a/patches/server/0618-Add-back-EntityPortalExitEvent.patch
+++ b/patches/server/0618-Add-back-EntityPortalExitEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add back EntityPortalExitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fb085b7c72896bc6e5223eb2d87d1e6b435114dc..8825afb72b3d85840a15b02dbd3d914de06a62a8 100644
+index fb085b7c72896bc6e5223eb2d87d1e6b435114dc..207c97bf5ad773ca80151284796432a055095631 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3272,6 +3272,28 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
@@ -13,11 +13,11 @@ index fb085b7c72896bc6e5223eb2d87d1e6b435114dc..8825afb72b3d85840a15b02dbd3d914d
                  // CraftBukkit start
                  worldserver = shapedetectorshape.world;
 +                // Paper start - Call EntityPortalExitEvent
-+                CraftEntity bukkitEntity = this.getBukkitEntity();
 +                Vec3 position = shapedetectorshape.pos;
 +                float yaw = shapedetectorshape.yRot;
-+                float pitch = bukkitEntity.getLocation().getPitch(); // Keep entity pitch as per moveTo line below
++                float pitch = this.getXRot(); // Keep entity pitch as per moveTo line below
 +                Vec3 velocity = shapedetectorshape.speed;
++                CraftEntity bukkitEntity = this.getBukkitEntity();
 +                org.bukkit.event.entity.EntityPortalExitEvent event = new org.bukkit.event.entity.EntityPortalExitEvent(bukkitEntity,
 +                    bukkitEntity.getLocation(), new Location(worldserver.getWorld(), position.x, position.y, position.z, yaw, pitch),
 +                    bukkitEntity.getVelocity(), org.bukkit.craftbukkit.util.CraftVector.toBukkit(shapedetectorshape.speed));
@@ -28,7 +28,7 @@ index fb085b7c72896bc6e5223eb2d87d1e6b435114dc..8825afb72b3d85840a15b02dbd3d914d
 +
 +                if (!event.isCancelled() && event.getTo() != null) {
 +                    worldserver = ((CraftWorld) event.getTo().getWorld()).getHandle();
-+                    position = new Vec3(event.getTo().getX(), event.getTo().getY(), event.getTo().getZ());
++                    position = CraftLocation.toVec3D(event.getTo());
 +                    yaw = event.getTo().getYaw();
 +                    pitch = event.getTo().getPitch();
 +                    velocity = org.bukkit.craftbukkit.util.CraftVector.toNMS(event.getAfter());

--- a/patches/server/0624-Add-critical-damage-API.patch
+++ b/patches/server/0624-Add-critical-damage-API.patch
@@ -28,10 +28,10 @@ index df8c88bfa749e02f633350446101dcce05db7ac1..ed1277fad60992344b94f8a939febaca
 +    // Paper end - add critical damage API
  }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index b113c886b81d9ac77f16aa5acf7e1d9e61854b9f..2c15a39d19d392e8aa2f5d70bf1bab9816fc186a 100644
+index 00477c81dc3f5d8289b08881b119b699552e5722..89c1928b1bf6f3a291794c5582b5e1efb4b74327 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1253,7 +1253,7 @@ public abstract class Player extends LivingEntity {
+@@ -1255,7 +1255,7 @@ public abstract class Player extends LivingEntity {
                          flag1 = true;
                      }
  
@@ -40,7 +40,7 @@ index b113c886b81d9ac77f16aa5acf7e1d9e61854b9f..2c15a39d19d392e8aa2f5d70bf1bab98
  
                      flag2 = flag2 && !this.level().paperConfig().entities.behavior.disablePlayerCrits; // Paper - Toggleable player crits
                      flag2 = flag2 && !this.isSprinting();
-@@ -1293,7 +1293,7 @@ public abstract class Player extends LivingEntity {
+@@ -1295,7 +1295,7 @@ public abstract class Player extends LivingEntity {
                      }
  
                      Vec3 vec3d = target.getDeltaMovement();
@@ -49,7 +49,7 @@ index b113c886b81d9ac77f16aa5acf7e1d9e61854b9f..2c15a39d19d392e8aa2f5d70bf1bab98
  
                      if (flag5) {
                          if (i > 0) {
-@@ -1321,7 +1321,7 @@ public abstract class Player extends LivingEntity {
+@@ -1323,7 +1323,7 @@ public abstract class Player extends LivingEntity {
  
                                  if (entityliving != this && entityliving != target && !this.isAlliedTo((Entity) entityliving) && (!(entityliving instanceof ArmorStand) || !((ArmorStand) entityliving).isMarker()) && this.distanceToSqr((Entity) entityliving) < 9.0D) {
                                      // CraftBukkit start - Only apply knockback if the damage hits
@@ -71,7 +71,7 @@ index 0e1d4bd6f70e439b33eca57bf06e9e090825f58a..5f75e54cde19614461dd8375ded1d6b3
          int k = entity.getRemainingFireTicks();
          boolean flag1 = entity.getType().is(EntityTypeTags.DEFLECTS_ARROWS);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 166035d8f708b94a9563c3802418ab6200071bc6..25133298b26523bd36300ab03e216200c915386b 100644
+index 64d27612d21d44950ba12be69aa6bfa339fef39c..32d3588431ece0e11e52dd332904609a045fa3ef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1043,7 +1043,7 @@ public class CraftEventFactory {
@@ -120,7 +120,7 @@ index 166035d8f708b94a9563c3802418ab6200071bc6..25133298b26523bd36300ab03e216200
 +    // Paper start - Add critical damage API
 +    @Deprecated
      private static EntityDamageEvent callEntityDamageEvent(Entity damager, Entity damagee, DamageCause cause, Map<DamageModifier, Double> modifiers, Map<DamageModifier, Function<? super Double, Double>> modifierFunctions, boolean cancelled) {
-+        return CraftEventFactory.callEntityDamageEvent(damager, damagee, cause, modifiers, modifierFunctions, false, false);
++        return CraftEventFactory.callEntityDamageEvent(damager, damagee, cause, modifiers, modifierFunctions, cancelled, false);
 +    }
 +
 +    private static EntityDamageEvent callEntityDamageEvent(Entity damager, Entity damagee, DamageCause cause, Map<DamageModifier, Double> modifiers, Map<DamageModifier, Function<? super Double, Double>> modifierFunctions, boolean cancelled, boolean critical) {

--- a/patches/server/0631-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
+++ b/patches/server/0631-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
@@ -51,10 +51,10 @@ index 5fff2d791b924e402a1b861c3cff8989c19d5e3b..b04b31e599c4954d4d4176f9d99f29bf
      @Override
      public void doCloseContainer() {
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 2c15a39d19d392e8aa2f5d70bf1bab9816fc186a..c6a4252979da274ec5c3c6d95548c18e12977c3b 100644
+index 89c1928b1bf6f3a291794c5582b5e1efb4b74327..865b5a43d108e87dc93d1d678371efaacb65507a 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -506,6 +506,11 @@ public abstract class Player extends LivingEntity {
+@@ -508,6 +508,11 @@ public abstract class Player extends LivingEntity {
          this.containerMenu = this.inventoryMenu;
      }
      // Paper end - Inventory close reason

--- a/patches/server/0633-Improve-and-expand-AsyncCatcher.patch
+++ b/patches/server/0633-Improve-and-expand-AsyncCatcher.patch
@@ -17,10 +17,10 @@ Async catch modifications to critical entity state
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b04460f710ed24ab94011e9d6b79953338d5b7e0..8c82679ced26d540f708c566796ab7ed96faee65 100644
+index 5689d048b74e7608119f2e5db0022ba9b6180e5b..3a68fda44bbbfc706a53ea19312a040e38bfd8c3 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1563,6 +1563,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1562,6 +1562,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      }
  
      public void internalTeleport(double d0, double d1, double d2, float f, float f1, Set<RelativeMovement> set) { // Paper
@@ -29,10 +29,10 @@ index b04460f710ed24ab94011e9d6b79953338d5b7e0..8c82679ced26d540f708c566796ab7ed
          if (player.isRemoved()) {
              LOGGER.info("Attempt to teleport removed player {} restricted", player.getScoreboardName());
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 378e5bfd58caf21e9ebecc900f02163c64a48073..61c8d108122e27f063d677e1d3130a4d3eeecb94 100644
+index 8dcebc2b6e8baf4ed5f269a1b9cec9e5cd754047..f1ac4256878bd5737ded1f7d3e8b51416887f545 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1118,7 +1118,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1117,7 +1117,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public boolean addEffect(MobEffectInstance mobeffect, @Nullable Entity entity, EntityPotionEffectEvent.Cause cause) {
@@ -166,7 +166,7 @@ index bbbf6dd8e566ecdca8794e3b03765fe7e426a2bd..66ab901956ca394c251c420338643d39
                  PersistentEntitySectionManager.LOGGER.warn("Entity {} wasn't found in section {} (destroying due to {})", new Object[]{this.entity, SectionPos.of(this.currentSectionKey), reason});
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 938b3147040a43601f425b056dc4a83ccf2564be..605c04d10b47b71787b7f3369d4fdfbb98327c1d 100644
+index 8a37dd71f1551ce27c1a729eab2a11c465b684e3..b58788161b758eee5fbaee3280c8551116e82566 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1724,6 +1724,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0638-Make-sure-inlined-getChunkAt-has-inlined-logic-for-l.patch
+++ b/patches/server/0638-Make-sure-inlined-getChunkAt-has-inlined-logic-for-l.patch
@@ -10,10 +10,10 @@ chunks did get inlined, but the standard CPS.getChunkAt
 method was not inlined.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 596bcc62e5754b5a2c29de263ba2f7fd9b6e0bed..e8b9050f9abe6f269aab775bb12993bcf18aff2a 100644
+index 9130ba6b008bab38212b162b4795cff63df5b957..c49ff35c92874273233ec53ed63aaff9c79edcd0 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -363,6 +363,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -358,6 +358,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      @Override
      public final LevelChunk getChunk(int chunkX, int chunkZ) { // Paper - final to help inline

--- a/patches/server/0648-Don-t-respond-to-ServerboundCommandSuggestionPacket-.patch
+++ b/patches/server/0648-Don-t-respond-to-ServerboundCommandSuggestionPacket-.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Don't respond to ServerboundCommandSuggestionPacket when
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8c82679ced26d540f708c566796ab7ed96faee65..277da3de55663e46fec47a3a41345bcd2a111d28 100644
+index 3a68fda44bbbfc706a53ea19312a040e38bfd8c3..ed3efe348d345ceac3c5c6842c5b02ec95ab6b10 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -726,6 +726,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -725,6 +725,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              return;
          }
          // CraftBukkit end

--- a/patches/server/0669-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0669-Hide-unnecessary-itemmeta-from-clients.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Hide unnecessary itemmeta from clients
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
-index 0a86e72e50d4aab7d19f588c3f11d7465c6fe817..c881d6ea6acbcbd1414a0b7d6b5a26076244e34e 100644
+index 86f6e5bad325dd3d817b643388b196121624b8c7..062225ac8b5fbc44290352d78b215640691f3c23 100644
 --- a/src/main/java/net/minecraft/server/level/ServerEntity.java
 +++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
 @@ -337,7 +337,7 @@ public class ServerEntity {
@@ -18,10 +18,10 @@ index 0a86e72e50d4aab7d19f588c3f11d7465c6fe817..c881d6ea6acbcbd1414a0b7d6b5a2607
                  }
              }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 277da3de55663e46fec47a3a41345bcd2a111d28..7fa4b7e5980d07ede8a3a7640f361dfa57d8927a 100644
+index ed3efe348d345ceac3c5c6842c5b02ec95ab6b10..737bf4600b1565684a78d973e785b881d7ddd4ea 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2554,8 +2554,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2553,8 +2553,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  // Refresh the current entity metadata
                                  entity.getEntityData().refresh(ServerGamePacketListenerImpl.this.player);
                                  // SPIGOT-7136 - Allays
@@ -33,7 +33,7 @@ index 277da3de55663e46fec47a3a41345bcd2a111d28..7fa4b7e5980d07ede8a3a7640f361dfa
                                  }
                              }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index d43ac664cae11d2f7d0c6965a57234430086f8ca..45ad7703da01bc2bac56bb9447925a9b2bb9ea81 100644
+index 8623d6a59445ab1cc0a04ca87ee7b3e3567e1ddc..37f35a576c4bdf22daf6f47b412d9147980762b0 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3189,7 +3189,7 @@ public abstract class LivingEntity extends Entity implements Attackable {

--- a/patches/server/0688-Validate-usernames.patch
+++ b/patches/server/0688-Validate-usernames.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Validate usernames
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index d4658328eeecb1c9e3e25eec14dea07e9e2a8b74..ebda34825bbd10145a81d54c345e31c2a4fb5de4 100644
+index a7da99ac31bbcb8b6f1814a2d5509c7067aafb08..fb582acfe9e5cb68314ee39e1d54a550d6700e76 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -63,6 +63,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener,
@@ -26,7 +26,7 @@ index d4658328eeecb1c9e3e25eec14dea07e9e2a8b74..ebda34825bbd10145a81d54c345e31c2
          GameProfile gameprofile = this.server.getSingleplayerProfile();
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 3df033f99ccc5b803eca2fe6d4f1e60399c4bee1..18014d03078be9081c1cbec9e8b9805f719a521d 100644
+index 75e3d7f81e21caaffd79d095022c4196507a9059..584b1627cf18e6aee9338ade0f94d983e2dda412 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -677,7 +677,7 @@ public abstract class PlayerList {
@@ -39,10 +39,10 @@ index 3df033f99ccc5b803eca2fe6d4f1e60399c4bee1..18014d03078be9081c1cbec9e8b9805f
              }
          }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index c6a4252979da274ec5c3c6d95548c18e12977c3b..2b68edde9fa03aa04793d3a44dd6edbdbeaf6722 100644
+index 865b5a43d108e87dc93d1d678371efaacb65507a..addbfbf1cae0a9c38ee1daabdb74e9af324f3a94 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -2330,9 +2330,23 @@ public abstract class Player extends LivingEntity {
+@@ -2332,9 +2332,23 @@ public abstract class Player extends LivingEntity {
      }
  
      public static boolean isValidUsername(String name) {

--- a/patches/server/0722-Don-t-allow-vehicle-movement-from-players-while-tele.patch
+++ b/patches/server/0722-Don-t-allow-vehicle-movement-from-players-while-tele.patch
@@ -7,10 +7,10 @@ Bring the vehicle move packet behavior in line with the
 regular player move packet.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 7fa4b7e5980d07ede8a3a7640f361dfa57d8927a..180635f6893cf027fdaeec251009e3f18fb5b9a7 100644
+index 737bf4600b1565684a78d973e785b881d7ddd4ea..469b98f56124583fc9be37cfdac13edb89894814 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -465,6 +465,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -464,6 +464,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              this.disconnect(Component.translatable("multiplayer.disconnect.invalid_vehicle_movement"), org.bukkit.event.player.PlayerKickEvent.Cause.INVALID_VEHICLE_MOVEMENT); // Paper - kick event cause
          } else {
              Entity entity = this.player.getRootVehicle();

--- a/patches/server/0736-Prevent-tile-entity-copies-loading-chunks.patch
+++ b/patches/server/0736-Prevent-tile-entity-copies-loading-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent tile entity copies loading chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 180635f6893cf027fdaeec251009e3f18fb5b9a7..ff3fc822898a6a9d1eb15be3881faab8a1d9016e 100644
+index 469b98f56124583fc9be37cfdac13edb89894814..7f4d844a2a20f4d33856078d2b0568fc432841ea 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3111,7 +3111,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3099,7 +3099,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  BlockPos blockposition = BlockEntity.getPosFromTag(nbttagcompound);
  
                  if (this.player.level().isLoaded(blockposition)) {

--- a/patches/server/0738-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0738-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -18,10 +18,10 @@ index c39b19bee3aca093a2087e19875a50ff21cf1ab3..8d7d5cadbd65833d46dce71609e93829
  
              if (dedicatedserverproperties.enableQuery) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ff3fc822898a6a9d1eb15be3881faab8a1d9016e..b84d748953e03f1852c4edf3d8d9466f2bce67c6 100644
+index 7f4d844a2a20f4d33856078d2b0568fc432841ea..fb38b0971ac45b3ae06a5b84abc960f1cac88c5e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2675,7 +2675,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2663,7 +2663,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      this.player = this.server.getPlayerList().respawn(this.player, false, RespawnReason.DEATH);
                      if (this.server.isHardcore()) {
                          this.player.setGameMode(GameType.SPECTATOR, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.HARDCORE_DEATH, null); // Paper - Expand PlayerGameModeChangeEvent

--- a/patches/server/0745-fix-powder-snow-cauldrons-not-turning-to-water.patch
+++ b/patches/server/0745-fix-powder-snow-cauldrons-not-turning-to-water.patch
@@ -7,7 +7,7 @@ Powder snow cauldrons should turn to water when
 extinguishing an entity
 
 diff --git a/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java b/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
-index 542bc6be48d5c53eee988156e7aa6ecfccb51069..333cc37e4f3ca3ea95191dcaafda6be59ef79b96 100644
+index 542bc6be48d5c53eee988156e7aa6ecfccb51069..42c1e3dfec23d6a7d832bf73d47ecae1212ec2c9 100644
 --- a/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
 @@ -69,7 +69,7 @@ public class LayeredCauldronBlock extends AbstractCauldronBlock {
@@ -23,7 +23,7 @@ index 542bc6be48d5c53eee988156e7aa6ecfccb51069..333cc37e4f3ca3ea95191dcaafda6be5
  
      }
  
-+    @Deprecated // Paper - fix powdered snow cauldron extinguishing entities; use #handleEntityOnFireInsideWithEvent
++    @io.papermc.paper.annotation.DoNotUse @Deprecated // Paper - fix powdered snow cauldron extinguishing entities; use #handleEntityOnFireInsideWithEvent
      private void handleEntityOnFireInside(BlockState state, Level world, BlockPos pos) {
          if (this.precipitationType == Biome.Precipitation.SNOW) {
              LayeredCauldronBlock.lowerFillLevel((BlockState) Blocks.WATER_CAULDRON.defaultBlockState().setValue(LayeredCauldronBlock.LEVEL, (Integer) state.getValue(LayeredCauldronBlock.LEVEL)), world, pos);

--- a/patches/server/0756-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0756-Throw-exception-on-world-create-while-being-ticked.patch
@@ -7,7 +7,7 @@ There are no plans to support creating worlds while worlds are
 being ticked themselvess.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c0353463f59ae4d3fe94ee15feb95a4ec1a064f4..6e7e8aa26a60d774d51148bc8dca5e5c901f81e7 100644
+index 8080eee9babe02660724eee756700a4d5e69014f..ab1f4e62b2ffed99b47ae23cae172f20ed586b27 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -307,6 +307,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -35,7 +35,7 @@ index c0353463f59ae4d3fe94ee15feb95a4ec1a064f4..6e7e8aa26a60d774d51148bc8dca5e5c
 +        Iterator iterator = this.getAllLevels().iterator(); // Paper - Throw exception on world create while being ticked; move down
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
-             worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
+             worldserver.hasPhysicsEvent = org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
 @@ -1571,6 +1574,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.profiler.pop();
              worldserver.explosionDensityCache.clear(); // Paper - Optimize explosions
@@ -45,7 +45,7 @@ index c0353463f59ae4d3fe94ee15feb95a4ec1a064f4..6e7e8aa26a60d774d51148bc8dca5e5c
          this.profiler.popPush("connection");
          MinecraftTimings.connectionTimer.startTiming(); // Spigot // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 006aa818b2985a129954390b878298deb6109981..3e002b7d9acdb05817b84641dfba75584fc6ed11 100644
+index 3b39b48d5fbf1515ae91d745501e0c8e28a4f9d6..d01b3bb932fbaf8f3568acf878110aa8b5b69d62 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -874,6 +874,11 @@ public final class CraftServer implements Server {

--- a/patches/server/0769-Fix-Spigot-Config-not-using-commands.spam-exclusions.patch
+++ b/patches/server/0769-Fix-Spigot-Config-not-using-commands.spam-exclusions.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Spigot Config not using commands.spam-exclusions
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b84d748953e03f1852c4edf3d8d9466f2bce67c6..f1c712dce7d5d0b0aea81c9ec57812f2d256b92f 100644
+index fb38b0971ac45b3ae06a5b84abc960f1cac88c5e..a801fff4d8339bf26689c28c8bd19f2d24b11836 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2292,7 +2292,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2291,7 +2291,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
          // Spigot end
          // this.chatSpamTickCount += 20;

--- a/patches/server/0770-More-Teleport-API.patch
+++ b/patches/server/0770-More-Teleport-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More Teleport API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f1c712dce7d5d0b0aea81c9ec57812f2d256b92f..4d1fcd2d1ec8080144ded7ceffd8fa0e4bea95bb 100644
+index a801fff4d8339bf26689c28c8bd19f2d24b11836..1b8c985b8014d11dbef9fde0ba900a14ad84d603 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1551,11 +1551,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1550,11 +1550,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              return false; // CraftBukkit - Return event status
          }
  
@@ -72,7 +72,7 @@ index b7df71633527dce2e4f954caee249e3b31b82226..ee1dc74b2f48bf8d684562de895ab631
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1fe839581edc496826885937ab0e10ec0a056212..451ef858cfc4504efe52f30d449d632b92569bd9 100644
+index 1551924d052087b8a5dc9e5342fd0fbc8022b405..71337c5163b53fc4728380c24e926bccd736538c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1165,13 +1165,101 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0773-Send-block-entities-after-destroy-prediction.patch
+++ b/patches/server/0773-Send-block-entities-after-destroy-prediction.patch
@@ -7,7 +7,7 @@ Minecraft's prediction system does not handle block entities, so if we are manua
 block breaking we need to set it after the prediction is finished. This fixes block entities not showing when cancelling the BlockBreakEvent.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index be25ea71cb3a3bd324935754604c9f7473a88d0a..75967b3526f3f946ffc6784b87b787396ab15368 100644
+index 8f4c9b99b638cfce8cc7c55f6369f62e757f4e48..f3389dc345d8b6e5389ae37848d9b268d4bbad83 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -62,6 +62,8 @@ public class ServerPlayerGameMode {
@@ -57,10 +57,10 @@ index be25ea71cb3a3bd324935754604c9f7473a88d0a..75967b3526f3f946ffc6784b87b78739
              }
          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4d1fcd2d1ec8080144ded7ceffd8fa0e4bea95bb..c9b0a0489386fde907adb35f0291416e39c350a5 100644
+index 1b8c985b8014d11dbef9fde0ba900a14ad84d603..418ece49cab9f4f2a7f65e8226a497658d0abd34 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1697,8 +1697,28 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1696,8 +1696,28 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      return;
                  }
                  // Paper end - Don't allow digging into unloaded chunks

--- a/patches/server/0774-Warn-on-plugins-accessing-faraway-chunks.patch
+++ b/patches/server/0774-Warn-on-plugins-accessing-faraway-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Warn on plugins accessing faraway chunks
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index e8b9050f9abe6f269aab775bb12993bcf18aff2a..2d4a471af69f3036fb2996aae3fd26960b73838f 100644
+index c49ff35c92874273233ec53ed63aaff9c79edcd0..76deb93a1a1d3f93498176f32ef291e1299c588d 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -350,7 +350,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -345,7 +345,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      }
  
      private static boolean isInWorldBoundsHorizontal(BlockPos pos) {

--- a/patches/server/0789-Call-BlockPhysicsEvent-more-often.patch
+++ b/patches/server/0789-Call-BlockPhysicsEvent-more-often.patch
@@ -5,33 +5,26 @@ Subject: [PATCH] Call BlockPhysicsEvent more often
 
 
 diff --git a/src/main/java/net/minecraft/world/level/redstone/CollectingNeighborUpdater.java b/src/main/java/net/minecraft/world/level/redstone/CollectingNeighborUpdater.java
-index 7d54abc2553f4b319df4d533a0b689c1807b6102..395bb163fb1d62dd2e6949e1146c337c0bbc626f 100644
+index 7d54abc2553f4b319df4d533a0b689c1807b6102..87db9febbbf53702be0e1e89a95db99e823713e5 100644
 --- a/src/main/java/net/minecraft/world/level/redstone/CollectingNeighborUpdater.java
 +++ b/src/main/java/net/minecraft/world/level/redstone/CollectingNeighborUpdater.java
-@@ -119,7 +119,27 @@ public class CollectingNeighborUpdater implements NeighborUpdater {
+@@ -119,7 +119,20 @@ public class CollectingNeighborUpdater implements NeighborUpdater {
          public boolean runNext(Level world) {
              BlockPos blockPos = this.sourcePos.relative(NeighborUpdater.UPDATE_ORDER[this.idx++]);
              BlockState blockState = world.getBlockState(blockPos);
 -            NeighborUpdater.executeUpdate(world, blockState, blockPos, this.sourceBlock, this.sourcePos, false);
 +            // Paper start - Call BlockPhysicsEvent
 +            try {
-+                boolean cancelled = false;
-+                org.bukkit.craftbukkit.CraftWorld cworld = world.getWorld();
-+                if (cworld != null) {
-+                    org.bukkit.event.block.BlockPhysicsEvent event = new org.bukkit.event.block.BlockPhysicsEvent(
-+                        org.bukkit.craftbukkit.block.CraftBlock.at(world, blockPos),
-+                        org.bukkit.craftbukkit.block.data.CraftBlockData.fromData(blockState),
-+                        org.bukkit.craftbukkit.block.CraftBlock.at(world, sourcePos));
++                org.bukkit.event.block.BlockPhysicsEvent event = new org.bukkit.event.block.BlockPhysicsEvent(
++                    org.bukkit.craftbukkit.block.CraftBlock.at(world, blockPos),
++                    org.bukkit.craftbukkit.block.data.CraftBlockData.fromData(blockState),
++                    org.bukkit.craftbukkit.block.CraftBlock.at(world, this.sourcePos));
 +
-+                    if (!event.callEvent()) {
-+                        cancelled = true;
-+                    }
-+                }
-+                if (!cancelled) { // continue to check for adjacent block (increase idx)
++                if (event.callEvent()) { // continue to check for adjacent block (increase idx)
 +                    NeighborUpdater.executeUpdate(world, blockState, blockPos, this.sourceBlock, this.sourcePos, false);
 +                }
 +            } catch (StackOverflowError ex) {
-+                world.lastPhysicsProblem = new BlockPos(blockPos);
++                world.lastPhysicsProblem = blockPos;
 +            }
 +            // Paper end - Call BlockPhysicsEvent
              if (this.idx < NeighborUpdater.UPDATE_ORDER.length && NeighborUpdater.UPDATE_ORDER[this.idx] == this.skipDirection) {

--- a/patches/server/0795-Fix-a-bunch-of-vanilla-bugs.patch
+++ b/patches/server/0795-Fix-a-bunch-of-vanilla-bugs.patch
@@ -113,7 +113,7 @@ index 6cd6d69a20e95e344fc18ab67dc300824537a59b..2e2a7c2cf3081187da817479a9da3eb1
              }
          }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 7c13ef020ac183253465d691adebb0e40f24ee8a..d1ce32936f3b581a4e60582b4f5a433db49d380a 100644
+index 63e7f41eaed3f22c1bc0191790ff0ad313dc4ffd..7c5c9efe4d6037c4c5444d108d76af241144d6b5 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1233,7 +1233,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -160,7 +160,7 @@ index efd95132301f50cd159339444e48cd4988accb1b..2fd04f7d39c4d06aa85133a3f53caa6d
              while (!world.noCollision((Entity) this) && this.getY() < (double) (world.getMaxBuildHeight() - 1)) {
                  this.setPos(this.getX(), this.getY() + 1.0D, this.getZ());
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 75967b3526f3f946ffc6784b87b787396ab15368..da8a60fbbba3866780615e65d6e242774a965bc6 100644
+index f3389dc345d8b6e5389ae37848d9b268d4bbad83..5d1b8bae981dc538ee1fe4fb993e44f227168233 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -92,7 +92,7 @@ public class ServerPlayerGameMode {
@@ -173,7 +173,7 @@ index 75967b3526f3f946ffc6784b87b787396ab15368..da8a60fbbba3866780615e65d6e24277
              this.player.server.getPlayerList().broadcastAll(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE, this.player), this.player); // CraftBukkit
              this.level.updateSleepingPlayerList();
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index b40ad88b42dd8fcbf6138cd4f1933360cce0ad28..6bdb0a9f82b7cb1d7045d2582533b22af9ee8f72 100644
+index a8a57819993f3657d6525a98527ec47631174bed..598dce073d7887d44a6630820c7e5746ce1c6dcc 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -709,8 +709,10 @@ public abstract class PlayerList {
@@ -372,10 +372,10 @@ index 4a0f4c83228187a2082ad029680056b1801f77bd..31831811ce16265e9828fa34d9e67d8a
                          player.awardStat(Stats.RAID_TRIGGER);
                          CriteriaTriggers.BAD_OMEN.trigger(player);
 diff --git a/src/main/java/net/minecraft/world/inventory/BeaconMenu.java b/src/main/java/net/minecraft/world/inventory/BeaconMenu.java
-index 611cbe0e47474f94cd203ac86ca9e80cab621134..de919d72e6e3ef160c7d22ca6a4e9f79a1fe493e 100644
+index b670c0cb3886c99d38a91b5c13aa2cefaae702cf..9599a5f96601030bf7f7cbd3392861d626959f9d 100644
 --- a/src/main/java/net/minecraft/world/inventory/BeaconMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/BeaconMenu.java
-@@ -178,6 +178,11 @@ public class BeaconMenu extends AbstractContainerMenu {
+@@ -177,6 +177,11 @@ public class BeaconMenu extends AbstractContainerMenu {
      // Paper end - Add PlayerChangeBeaconEffectEvent
  
      public void updateEffects(Optional<MobEffect> primary, Optional<MobEffect> secondary) {
@@ -439,7 +439,7 @@ index 6e45582f8ea7dd2a46f58369c5581764538bff0d..3ecc92439fc85d224ff52f41c5e34079
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java b/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
-index 333cc37e4f3ca3ea95191dcaafda6be59ef79b96..91071fa934222c9246547c788e3e6cb18fcaa990 100644
+index 42c1e3dfec23d6a7d832bf73d47ecae1212ec2c9..a4857675772d4fe849ba85fc21a369decca42fc0 100644
 --- a/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
 @@ -68,7 +68,7 @@ public class LayeredCauldronBlock extends AbstractCauldronBlock {
@@ -474,7 +474,7 @@ index c7ba7ac1a3869e4db1ef6b0350b3cab7f31a94c4..d7beeac4a8e4a16221809663a5aa0338
      }
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
-index 2ceadc753eb99a08881f1292de789528f4a3de85..ae9c69176168e53f6270a0bc02240d190630d015 100644
+index 61a618f09af475407a78343eecb4352052b1df1e..247f24c7fadc203ee0f6a6f85122c91ab4c82f80 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
 @@ -291,7 +291,11 @@ public class BeaconBlockEntity extends BlockEntity implements MenuProvider, Name

--- a/patches/server/0799-Correctly-handle-interactions-with-items-on-cooldown.patch
+++ b/patches/server/0799-Correctly-handle-interactions-with-items-on-cooldown.patch
@@ -30,18 +30,17 @@ index da8a60fbbba3866780615e65d6e242774a965bc6..88b71210d0845e8a4a2cd424ba238c4b
          this.interactResult = event.useItemInHand() == Event.Result.DENY;
          this.interactPosition = blockposition.immutable();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 52a4a2b90f5b4684ffb94bf1db6020490e14942d..944bb12b14d50cdd7064ae7300c71465e15cb217 100644
+index 531eeb68bc0623b3c71e67789603ab7946e05818..a1860e21fd53b801ffd651cd27f5a8f9fcd02ee0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -543,7 +543,13 @@ public class CraftEventFactory {
-         return CraftEventFactory.callPlayerInteractEvent(who, action, position, direction, itemstack, false, hand, null);
+@@ -544,6 +544,12 @@ public class CraftEventFactory {
      }
  
-+
-+    // Paper start - cancelledItem param
      public static PlayerInteractEvent callPlayerInteractEvent(net.minecraft.world.entity.player.Player who, Action action, BlockPos position, Direction direction, ItemStack itemstack, boolean cancelledBlock, InteractionHand hand, Vec3 targetPos) {
++        // Paper start - cancelledItem param
 +        return CraftEventFactory.callPlayerInteractEvent(who, action, position, direction, itemstack, cancelledBlock, false, hand, targetPos);
 +    }
++
 +    public static PlayerInteractEvent callPlayerInteractEvent(net.minecraft.world.entity.player.Player who, Action action, BlockPos position, Direction direction, ItemStack itemstack, boolean cancelledBlock, boolean cancelledItem, InteractionHand hand, Vec3 targetPos) {
 +        // Paper end - cancelledItem param
          Player player = (who == null) ? null : (Player) who.getBukkitEntity();

--- a/patches/server/0807-Add-fire-tick-delay-option.patch
+++ b/patches/server/0807-Add-fire-tick-delay-option.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add fire-tick-delay option
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/FireBlock.java b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-index b1e9ea9ece5ef8ecbe2ed919fda8e1153724dc93..14817a0d760afc9edd6a97d51ace2348a8fcfbfa 100644
+index c5116d12f3c073f0a8695a8cd00545e6d947644d..7f05e58358024d303eab9ab4fbc1bb299760ad1e 100644
 --- a/src/main/java/net/minecraft/world/level/block/FireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-@@ -172,7 +172,7 @@ public class FireBlock extends BaseFireBlock {
+@@ -171,7 +171,7 @@ public class FireBlock extends BaseFireBlock {
  
      @Override
      public void tick(BlockState state, ServerLevel world, BlockPos pos, RandomSource random) {
@@ -17,20 +17,18 @@ index b1e9ea9ece5ef8ecbe2ed919fda8e1153724dc93..14817a0d760afc9edd6a97d51ace2348
          if (world.getGameRules().getBoolean(GameRules.RULE_DOFIRETICK)) {
              if (!state.canSurvive(world, pos)) {
                  this.fireExtinguished(world, pos); // CraftBukkit - invalid place location
-@@ -373,11 +373,13 @@ public class FireBlock extends BaseFireBlock {
-     public void onPlace(BlockState iblockdata, Level world, BlockPos blockposition, BlockState iblockdata1, boolean flag, UseOnContext itemActionContext) {
-         super.onPlace(iblockdata, world, blockposition, iblockdata1, flag, itemActionContext);
-         // Paper end - ItemActionContext param
--        world.scheduleTick(blockposition, this, getFireTickDelay(world.random));
-+        world.scheduleTick(blockposition, this, getFireTickDelay(world)); // Paper - Add fire-tick-delay option
+@@ -372,11 +372,11 @@ public class FireBlock extends BaseFireBlock {
+     public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify, net.minecraft.world.item.context.UseOnContext context) {
+         super.onPlace(state, world, pos, oldState, notify, context);
+         // Paper end - UseOnContext param
+-        world.scheduleTick(pos, (Block) this, FireBlock.getFireTickDelay(world.random));
++        world.scheduleTick(pos, (Block) this, FireBlock.getFireTickDelay(world)); // Paper - Add fire-tick-delay option
      }
  
 -    private static int getFireTickDelay(RandomSource random) {
 -        return 30 + random.nextInt(10);
-+    // Paper start - Add fire-tick-delay option
-+    private static int getFireTickDelay(Level world) {
-+        return world.paperConfig().environment.fireTickDelay + world.random.nextInt(10);
-+    // Paper end - Add fire-tick-delay option
++    private static int getFireTickDelay(Level world) { // Paper - Add fire-tick-delay option
++        return world.paperConfig().environment.fireTickDelay + world.random.nextInt(10); // Paper - Add fire-tick-delay option
      }
  
      @Override

--- a/patches/server/0813-Add-PrePlayerAttackEntityEvent.patch
+++ b/patches/server/0813-Add-PrePlayerAttackEntityEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PrePlayerAttackEntityEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 2b68edde9fa03aa04793d3a44dd6edbdbeaf6722..e0fd3c3a129216ad1272a6e038eb16cb44e45475 100644
+index addbfbf1cae0a9c38ee1daabdb74e9af324f3a94..a7690e89bb6ed07512fc8a110f541183b7df0a63 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1230,8 +1230,17 @@ public abstract class Player extends LivingEntity {
+@@ -1232,8 +1232,17 @@ public abstract class Player extends LivingEntity {
      }
  
      public void attack(Entity target) {

--- a/patches/server/0822-Friction-API.patch
+++ b/patches/server/0822-Friction-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Friction API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 5cc93ed8e082324c12ba55e7d388a8cdc7f67f1a..2d8404f4b78ab9a25a3e6be8cf8bf5bb0b1ea090 100644
+index 2e989789139ede20c808d7b024ce95d6c585b5d8..d6f12c3e995ff1b1d77538fd77402225c29b1c51 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -261,6 +261,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -260,6 +260,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      public boolean bukkitPickUpLoot;
      public org.bukkit.craftbukkit.entity.CraftLivingEntity getBukkitLivingEntity() { return (org.bukkit.craftbukkit.entity.CraftLivingEntity) super.getBukkitEntity(); } // Paper
      public boolean silentDeath = false; // Paper - mark entity as dying silently for cancellable death event
@@ -16,7 +16,7 @@ index 5cc93ed8e082324c12ba55e7d388a8cdc7f67f1a..2d8404f4b78ab9a25a3e6be8cf8bf5bb
  
      @Override
      public float getBukkitYaw() {
-@@ -716,7 +717,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -715,7 +716,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public boolean shouldDiscardFriction() {
@@ -25,7 +25,7 @@ index 5cc93ed8e082324c12ba55e7d388a8cdc7f67f1a..2d8404f4b78ab9a25a3e6be8cf8bf5bb
      }
  
      public void setDiscardFriction(boolean noDrag) {
-@@ -760,6 +761,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -759,6 +760,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      @Override
      public void addAdditionalSaveData(CompoundTag nbt) {
@@ -37,7 +37,7 @@ index 5cc93ed8e082324c12ba55e7d388a8cdc7f67f1a..2d8404f4b78ab9a25a3e6be8cf8bf5bb
          nbt.putFloat("Health", this.getHealth());
          nbt.putShort("HurtTime", (short) this.hurtTime);
          nbt.putInt("HurtByTimestamp", this.lastHurtByMobTimestamp);
-@@ -803,6 +809,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -802,6 +808,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
          }
          this.internalSetAbsorptionAmount(absorptionAmount);
          // Paper end - Check for NaN

--- a/patches/server/0830-Improve-inlining-for-some-hot-BlockBehavior-and-Flui.patch
+++ b/patches/server/0830-Improve-inlining-for-some-hot-BlockBehavior-and-Flui.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Improve inlining for some hot BlockBehavior and FluidState
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
-index c8ccf424dccef47aaa9c9b6e03f49fe783035c0a..ab174986ad558916427a70f59c6907f17b0d01df 100644
+index c7b6377aafd32f67eb8ba4dedd7cce5841b2d58d..e57e3a26b0fb856e1ab693df5783fe8b9bee9719 100644
 --- a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 +++ b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 @@ -975,15 +975,15 @@ public abstract class BlockBehaviour implements FeatureElement {

--- a/patches/server/0834-Improve-logging-and-errors.patch
+++ b/patches/server/0834-Improve-logging-and-errors.patch
@@ -40,10 +40,10 @@ index 536f0c496ce36ca3248fc6eeac9bbd77214a36f9..31718823250a1490b783f426fff65bf5
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c9b0a0489386fde907adb35f0291416e39c350a5..9edc0f95bf4487f1928cc151ed39bf4e0d05e653 100644
+index 418ece49cab9f4f2a7f65e8226a497658d0abd34..14ed8f39490ab1010974ba04b2202f73c2f83fb0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3309,7 +3309,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3297,7 +3297,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                      this.resetPlayerChatState(remotechatsession_a.validate(this.player.getGameProfile(), signaturevalidator));
                  } catch (ProfilePublicKey.ValidationException profilepublickey_b) {

--- a/patches/server/0837-Add-missing-SpigotConfig-logCommands-check.patch
+++ b/patches/server/0837-Add-missing-SpigotConfig-logCommands-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add missing SpigotConfig logCommands check
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9edc0f95bf4487f1928cc151ed39bf4e0d05e653..40db361e677865cbcf339e6159392cccc7dd97c5 100644
+index 14ed8f39490ab1010974ba04b2202f73c2f83fb0..8a2680112ccb04dff5cb49e87778b2a6c2d03518 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2053,7 +2053,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2052,7 +2052,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      private void performChatCommand(ServerboundChatCommandPacket packet, LastSeenMessages lastSeenMessages) {
          // CraftBukkit start
          String command = "/" + packet.command();

--- a/patches/server/0839-Flying-Fall-Damage.patch
+++ b/patches/server/0839-Flying-Fall-Damage.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Flying Fall Damage
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index e0fd3c3a129216ad1272a6e038eb16cb44e45475..182180275be3bf90b9f8e66dcf19ad6ce02136bf 100644
+index a7690e89bb6ed07512fc8a110f541183b7df0a63..eb6a4518d3919cacc3b7a83870c0f0e87eba3f6e 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -180,6 +180,7 @@ public abstract class Player extends LivingEntity {
@@ -16,7 +16,7 @@ index e0fd3c3a129216ad1272a6e038eb16cb44e45475..182180275be3bf90b9f8e66dcf19ad6c
  
      // CraftBukkit start
      public boolean fauxSleeping;
-@@ -1669,7 +1670,7 @@ public abstract class Player extends LivingEntity {
+@@ -1671,7 +1672,7 @@ public abstract class Player extends LivingEntity {
  
      @Override
      public boolean causeFallDamage(float fallDistance, float damageMultiplier, DamageSource damageSource) {

--- a/patches/server/0840-Add-exploded-block-state-to-BlockExplodeEvent-and-En.patch
+++ b/patches/server/0840-Add-exploded-block-state-to-BlockExplodeEvent-and-En.patch
@@ -54,7 +54,7 @@ index c7075aaf417b1dc9eab4a19b72fac50d2a44286b..34159798e6617ce13b3ac8aae07d24d9
                  this.wasCanceled = event.isCancelled();
                  bukkitBlocks = event.blockList();
 diff --git a/src/main/java/net/minecraft/world/level/block/BedBlock.java b/src/main/java/net/minecraft/world/level/block/BedBlock.java
-index 40559727591278f44dbf50e2d3406054ffeb8ae9..c6322da14262b8cc2a37ffef5149d008b74bd5e5 100644
+index c5d892950b4027cf9879eafc1c0f4e4c62fb4f51..c14cddd42c61512c312231b1e93ccc6efbde620c 100644
 --- a/src/main/java/net/minecraft/world/level/block/BedBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/BedBlock.java
 @@ -96,6 +96,7 @@ public class BedBlock extends HorizontalDirectionalBlock implements EntityBlock
@@ -130,7 +130,7 @@ index f81c0d07a5efc92942d8ab5c50a8260db033307d..8afc396c162d928902a9d9beb9f039b0
      // See BlockStateFactory#createBlockState(World, BlockPosition, IBlockData, TileEntity)
      private static CraftBlockState getBlockState(World world, BlockPos blockPosition, net.minecraft.world.level.block.state.BlockState blockData, BlockEntity tileEntity) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 944bb12b14d50cdd7064ae7300c71465e15cb217..d55c52e6a89ddd469fdd648fbe5d0f44a60b0892 100644
+index a1860e21fd53b801ffd651cd27f5a8f9fcd02ee0..52444c7c83e60e5fe40c485c13a59cca9ce5ee20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1045,7 +1045,7 @@ public class CraftEventFactory {

--- a/patches/server/0842-config-for-disabling-entity-tag-tags.patch
+++ b/patches/server/0842-config-for-disabling-entity-tag-tags.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] config for disabling entity tag tags
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityType.java b/src/main/java/net/minecraft/world/entity/EntityType.java
-index dcdc982b22b7fc836e6ad423a75c75c1d33eb7d8..fe8efe89c7d390ff9565f388685b57daeebfd08b 100644
+index 557df259ae54defb43e475e10fc4732854e64f77..656c68b37bc25d6b77f295f9efe0a81dd20b69c1 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityType.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityType.java
-@@ -497,6 +497,13 @@ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeT
+@@ -493,6 +493,13 @@ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeT
                  if (world.isClientSide || !entity.onlyOpCanSetNbt() || player != null && minecraftserver.getPlayerList().isOp(player.getGameProfile())) {
                      CompoundTag nbttagcompound1 = entity.saveWithoutId(new CompoundTag());
                      UUID uuid = entity.getUUID();

--- a/patches/server/0843-Use-single-player-info-update-packet-on-join.patch
+++ b/patches/server/0843-Use-single-player-info-update-packet-on-join.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use single player info update packet on join
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 40db361e677865cbcf339e6159392cccc7dd97c5..2153bcc91db2907a4a99771a01e2c7884e41460a 100644
+index 8a2680112ccb04dff5cb49e87778b2a6c2d03518..37a918777ee7128fc85c4ab33c1a630daf9f91fe 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3339,7 +3339,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3327,7 +3327,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          this.signedMessageDecoder = session.createMessageDecoder(this.player.getUUID());
          this.chatMessageChain.append(() -> {
              this.player.setChatSession(session);
@@ -18,7 +18,7 @@ index 40db361e677865cbcf339e6159392cccc7dd97c5..2153bcc91db2907a4a99771a01e2c788
      }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 82802c797bc60e92770595d166acc144f3f57006..cb19120aef8ff37a625c82635caeead02f228bcf 100644
+index 598dce073d7887d44a6630820c7e5746ce1c6dcc..2eeb216002c1c91879780225335225552744524b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -358,6 +358,7 @@ public abstract class PlayerList {

--- a/patches/server/0844-Correctly-shrink-items-during-EntityResurrectEvent.patch
+++ b/patches/server/0844-Correctly-shrink-items-during-EntityResurrectEvent.patch
@@ -22,10 +22,10 @@ This patch corrects this behaviour by only shrinking the item if a totem
 of undying was found and the event was called uncancelled.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2d8404f4b78ab9a25a3e6be8cf8bf5bb0b1ea090..b6a8530074c898392879405e8ae774ce15c05776 100644
+index d6f12c3e995ff1b1d77538fd77402225c29b1c51..0bb241158cde5c3af1b28065a39c2455ef82eefe 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1610,7 +1610,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1609,7 +1609,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.level().getCraftServer().getPluginManager().callEvent(event);
  
              if (!event.isCancelled()) {

--- a/patches/server/0850-Update-the-flag-when-a-captured-block-state-is-outda.patch
+++ b/patches/server/0850-Update-the-flag-when-a-captured-block-state-is-outda.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Update the flag when a captured block state is outdated
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index ff8e8a4f1002ca095df232336c4551b115383ef4..0bf91f88a9385797c508d165501ab18658707d71 100644
+index 76deb93a1a1d3f93498176f32ef291e1299c588d..cb4be07de48cbb18d6b7cd79f57aae40cfcc8a56 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -456,6 +456,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -451,6 +451,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  blockstate = CapturedBlockState.getTreeBlockState(this, pos, flags);
                  this.capturedBlockStates.put(pos.immutable(), blockstate);
              }

--- a/patches/server/0851-Add-EntityFertilizeEggEvent.patch
+++ b/patches/server/0851-Add-EntityFertilizeEggEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add EntityFertilizeEggEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Turtle.java b/src/main/java/net/minecraft/world/entity/animal/Turtle.java
-index 6bbcdd34fb89ea5774e825de8f9a588552716fc2..1a2a4dcb3cfa2690f2aa936a6c176319d807bd74 100644
+index 6bbcdd34fb89ea5774e825de8f9a588552716fc2..379990c0ea9d10fd3c627ffff2198cb554780eb0 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Turtle.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Turtle.java
 @@ -445,6 +445,10 @@ public class Turtle extends Animal {
@@ -24,7 +24,7 @@ index 6bbcdd34fb89ea5774e825de8f9a588552716fc2..1a2a4dcb3cfa2690f2aa936a6c176319
  
              if (this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
 -                this.level.addFreshEntity(new ExperienceOrb(this.level, this.animal.getX(), this.animal.getY(), this.animal.getZ(), randomsource.nextInt(7) + 1, org.bukkit.entity.ExperienceOrb.SpawnReason.BREED, entityplayer)); // Paper;
-+                if(event.getExperience() > 0) this.level.addFreshEntity(new ExperienceOrb(this.level, this.animal.getX(), this.animal.getY(), this.animal.getZ(), event.getExperience(), org.bukkit.entity.ExperienceOrb.SpawnReason.BREED, entityplayer)); // Paper - Add EntityFertilizeEggEvent event
++                if (event.getExperience() > 0) this.level.addFreshEntity(new ExperienceOrb(this.level, this.animal.getX(), this.animal.getY(), this.animal.getZ(), event.getExperience(), org.bukkit.entity.ExperienceOrb.SpawnReason.BREED, entityplayer)); // Paper - Add EntityFertilizeEggEvent event
              }
  
          }
@@ -69,30 +69,29 @@ index 0e85e3ab58d848b119212fa7d2eb4f92d3efe29b..0a5b953bd8c0c7f181da4090b950e9e6
          this.playSound(SoundEvents.SNIFFER_EGG_PLOP, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 0.5F);
          } // Paper - Call EntityDropItemEvent
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d55c52e6a89ddd469fdd648fbe5d0f44a60b0892..8925e85ebbdbca9b9c8527c5494e190b989d1291 100644
+index 25003a2e2fcf729effe79fbc0fcda0476cc5fb61..e28f6ea159bdae063d8a54856e6a374174e275cf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2092,4 +2092,29 @@ public class CraftEventFactory {
+@@ -2124,4 +2124,28 @@ public class CraftEventFactory {
          return event.callEvent();
      }
      // Paper end
 +
 +    // Paper start - add EntityFertilizeEggEvent
 +    /**
-+     * Calls the io.papermc.paper.event.entity.EntityFertilizeEggEvent.
++     * Calls the {@link io.papermc.paper.event.entity.EntityFertilizeEggEvent}.
 +     * If the event is cancelled, this method also resets the love on both the {@code breeding} and {@code other} entity.
 +     *
 +     * @param breeding the entity on which #spawnChildFromBreeding was called.
 +     * @param other    the partner of the entity.
 +     * @return the event after it was called. The instance may be used to retrieve the experience of the event.
 +     */
-+    public static io.papermc.paper.event.entity.EntityFertilizeEggEvent callEntityFertilizeEggEvent(net.minecraft.world.entity.animal.Animal breeding,
-+                                                                                                    net.minecraft.world.entity.animal.Animal other) {
-+        net.minecraft.server.level.ServerPlayer serverPlayer = breeding.getLoveCause();
++    public static io.papermc.paper.event.entity.EntityFertilizeEggEvent callEntityFertilizeEggEvent(Animal breeding, Animal other) {
++        ServerPlayer serverPlayer = breeding.getLoveCause();
 +        if (serverPlayer == null) serverPlayer = other.getLoveCause();
 +        final int experience = breeding.getRandom().nextInt(7) + 1; // From Animal#spawnChildFromBreeding(ServerLevel, Animal)
 +
-+        final io.papermc.paper.event.entity.EntityFertilizeEggEvent event = new io.papermc.paper.event.entity.EntityFertilizeEggEvent((org.bukkit.entity.LivingEntity) breeding.getBukkitEntity(), (org.bukkit.entity.LivingEntity) other.getBukkitEntity(), serverPlayer == null ? null : serverPlayer.getBukkitEntity(), breeding.breedItem == null ? null : org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(breeding.breedItem).clone(), experience);
++        final io.papermc.paper.event.entity.EntityFertilizeEggEvent event = new io.papermc.paper.event.entity.EntityFertilizeEggEvent((LivingEntity) breeding.getBukkitEntity(), (LivingEntity) other.getBukkitEntity(), serverPlayer == null ? null : serverPlayer.getBukkitEntity(), breeding.breedItem == null ? null : CraftItemStack.asCraftMirror(breeding.breedItem).clone(), experience);
 +        if (!event.callEvent()) {
 +            breeding.resetLove();
 +            other.resetLove(); // stop the pathfinding to avoid infinite loop

--- a/patches/server/0853-Add-CompostItemEvent-and-EntityCompostItemEvent.patch
+++ b/patches/server/0853-Add-CompostItemEvent-and-EntityCompostItemEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add CompostItemEvent and EntityCompostItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/ComposterBlock.java b/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
-index 413b307acaad5823b9e06f49fa2faf561f5f7b9a..d78fe4081bc2938326066e0afddb4a6c833a4bf7 100644
+index 413b307acaad5823b9e06f49fa2faf561f5f7b9a..f9084e2605d7403721fe6b714bfad051f932aaef 100644
 --- a/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
 @@ -328,7 +328,21 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
@@ -31,15 +31,15 @@ index 413b307acaad5823b9e06f49fa2faf561f5f7b9a..d78fe4081bc2938326066e0afddb4a6c
              return iblockdata;
          } else {
              int j = i + 1;
-@@ -478,6 +492,11 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+@@ -477,6 +491,11 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+             if (!itemstack.isEmpty()) {
                  this.changed = true;
                  BlockState iblockdata = ComposterBlock.addItem((Entity) null, this.state, this.level, this.pos, itemstack);
- 
 +                // Paper start - Add CompostItemEvent and EntityCompostItemEvent
 +                if (iblockdata == null) {
 +                    return;
 +                }
 +                // Paper end - Add CompostItemEvent and EntityCompostItemEvent
+ 
                  this.level.levelEvent(1500, this.pos, iblockdata != this.state ? 1 : 0);
                  this.removeItemNoUpdate(0);
-             }

--- a/patches/server/0862-Treat-sequence-violations-like-they-should-be.patch
+++ b/patches/server/0862-Treat-sequence-violations-like-they-should-be.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Treat sequence violations like they should be
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2153bcc91db2907a4a99771a01e2c7884e41460a..204cf94df7b9520a0aed6e08f6d8843a3b706d3b 100644
+index 37a918777ee7128fc85c4ab33c1a630daf9f91fe..0dd9cbd0d0277334bf6feaa50ab6aeb573f02bad 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1957,6 +1957,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1956,6 +1956,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      public void ackBlockChangesUpTo(int sequence) {
          if (sequence < 0) {

--- a/patches/server/0864-Prevent-causing-expired-keys-from-impacting-new-join.patch
+++ b/patches/server/0864-Prevent-causing-expired-keys-from-impacting-new-join.patch
@@ -24,10 +24,10 @@ index 0e54e8faa48751a651b953bec72543a94edf74bc..d43106eb89b14667e85cd6e8fa047d64
          UPDATE_GAME_MODE((serialized, buf) -> {
              serialized.gameMode = GameType.byId(buf.readVarInt());
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 204cf94df7b9520a0aed6e08f6d8843a3b706d3b..1e1c3fb7a5e078b870ea733b35b004737f3c1ced 100644
+index 0dd9cbd0d0277334bf6feaa50ab6aeb573f02bad..9440310f6a46fb62c4526f3cfb0464750fe72f84 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -287,6 +287,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -286,6 +286,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      private int knownMovePacketCount;
      @Nullable
      private RemoteChatSession chatSession;
@@ -35,7 +35,7 @@ index 204cf94df7b9520a0aed6e08f6d8843a3b706d3b..1e1c3fb7a5e078b870ea733b35b00473
      private SignedMessageChain.Decoder signedMessageDecoder;
      private final LastSeenMessagesValidator lastSeenMessages = new LastSeenMessagesValidator(20);
      private final MessageSignatureCache messageSignatureCache = MessageSignatureCache.createDefault();
-@@ -395,6 +396,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -394,6 +395,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              this.disconnect(Component.translatable("multiplayer.disconnect.idling"), org.bukkit.event.player.PlayerKickEvent.Cause.IDLING); // Paper - kick event cause
          }
  
@@ -49,7 +49,7 @@ index 204cf94df7b9520a0aed6e08f6d8843a3b706d3b..1e1c3fb7a5e078b870ea733b35b00473
      }
  
      public void resetPosition() {
-@@ -3337,6 +3345,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3325,6 +3333,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      private void resetPlayerChatState(RemoteChatSession session) {
          this.chatSession = session;

--- a/patches/server/0871-Fix-DamageCause-for-Falling-Blocks.patch
+++ b/patches/server/0871-Fix-DamageCause-for-Falling-Blocks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix DamageCause for Falling Blocks
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8925e85ebbdbca9b9c8527c5494e190b989d1291..16ac933192a8d1c805e1b7d38fc1966d7de691a3 100644
+index 0e640dc081228484a4568f2c5fed71610ac1c6c6..734f68cee62a31513bdfefa5c7074ac38b3c1622 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1085,6 +1085,11 @@ public class CraftEventFactory {

--- a/patches/server/0875-Expand-PlayerItemMendEvent.patch
+++ b/patches/server/0875-Expand-PlayerItemMendEvent.patch
@@ -51,7 +51,7 @@ index 561703f56637046bc274c378a63c03f684b5b787..5190613932bc1084d617f49e1517a994
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 16ac933192a8d1c805e1b7d38fc1966d7de691a3..8081fe1a1855b6c00bfa3914380ba045ed872292 100644
+index 734f68cee62a31513bdfefa5c7074ac38b3c1622..1325f680ce03b6ffae04f5c519b789fdd10ed8a3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1321,10 +1321,10 @@ public class CraftEventFactory {

--- a/patches/server/0878-Fix-block-place-logic.patch
+++ b/patches/server/0878-Fix-block-place-logic.patch
@@ -41,10 +41,10 @@ index 0e9d515381a673e683b63a12c1a9e79a5eedd80b..096eb30dcfdd62b1d946891f7480e9d9
                          }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 58dd1f7738c2e36ef8e0b802b6a7c5685c34476d..e4810342370e05647d569f83f064d299de1de756 100644
+index cb4be07de48cbb18d6b7cd79f57aae40cfcc8a56..b942e9f163fa342c58b74d1cd6ffe6bdbe4f691a 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -565,17 +565,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -560,17 +560,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  // CraftBukkit start
                  iblockdata1.updateIndirectNeighbourShapes(this, blockposition, k, j - 1); // Don't call an event for the old block to limit event spam
                  CraftWorld world = ((ServerLevel) this).getWorld();

--- a/patches/server/0890-Call-missing-BlockDispenseEvent.patch
+++ b/patches/server/0890-Call-missing-BlockDispenseEvent.patch
@@ -50,20 +50,20 @@ index b83af374a33a66a6ceeca119b961eea883bba41c..175b965c92b8b8be9c671e1ee478afa9
                              for (int k = 0; k < 5; ++k) {
                                  worldserver.sendParticles(ParticleTypes.SPLASH, (double) blockposition.getX() + worldserver.random.nextDouble(), (double) (blockposition.getY() + 1), (double) blockposition.getZ() + worldserver.random.nextDouble(), 1, 0.0D, 0.0D, 0.0D, 1.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8081fe1a1855b6c00bfa3914380ba045ed872292..84e527cf6db14b1fe23a1b169c3bf5609c535e06 100644
+index 598ff7a93fa9cf3c2971c082d1019dbc23bafa2d..34c4acecab9eb9e1d23e390747b348645eedfca8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2098,6 +2098,32 @@ public class CraftEventFactory {
+@@ -2130,6 +2130,32 @@ public class CraftEventFactory {
      }
      // Paper end
  
 +    // Paper start - Call missing BlockDispenseEvent
 +    @Nullable
 +    public static ItemStack handleBlockDispenseEvent(net.minecraft.core.dispenser.BlockSource pointer, BlockPos to, ItemStack itemStack, net.minecraft.core.dispenser.DispenseItemBehavior instance) {
-+        org.bukkit.block.Block bukkitBlock = pointer.level().getWorld().getBlockAt(pointer.pos().getX(), pointer.pos().getY(), pointer.pos().getZ());
++        org.bukkit.block.Block bukkitBlock = CraftBlock.at(pointer.level(), pointer.pos());
 +        CraftItemStack craftItem = CraftItemStack.asCraftMirror(itemStack.copyWithCount(1));
 +
-+        org.bukkit.event.block.BlockDispenseEvent event = new org.bukkit.event.block.BlockDispenseEvent(bukkitBlock, craftItem.clone(), new org.bukkit.util.Vector(to.getX(), to.getY(), to.getZ()));
++        org.bukkit.event.block.BlockDispenseEvent event = new org.bukkit.event.block.BlockDispenseEvent(bukkitBlock, craftItem.clone(), CraftVector.toBukkit(to));
 +        if (!net.minecraft.world.level.block.DispenserBlock.eventFired) {
 +            if (!event.callEvent()) {
 +                return itemStack;
@@ -73,9 +73,9 @@ index 8081fe1a1855b6c00bfa3914380ba045ed872292..84e527cf6db14b1fe23a1b169c3bf560
 +        if (!event.getItem().equals(craftItem)) {
 +            // Chain to handler for new item
 +            ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
-+            net.minecraft.core.dispenser.DispenseItemBehavior idispensebehavior = net.minecraft.world.level.block.DispenserBlock.DISPENSER_REGISTRY.get(eventStack.getItem());
-+            if (idispensebehavior != net.minecraft.core.dispenser.DispenseItemBehavior.NOOP && idispensebehavior != instance) {
-+                idispensebehavior.dispense(pointer, eventStack);
++            net.minecraft.core.dispenser.DispenseItemBehavior itemBehavior = net.minecraft.world.level.block.DispenserBlock.DISPENSER_REGISTRY.get(eventStack.getItem());
++            if (itemBehavior != net.minecraft.core.dispenser.DispenseItemBehavior.NOOP && itemBehavior != instance) {
++                itemBehavior.dispense(pointer, eventStack);
 +                return itemStack;
 +            }
 +        }
@@ -85,4 +85,4 @@ index 8081fe1a1855b6c00bfa3914380ba045ed872292..84e527cf6db14b1fe23a1b169c3bf560
 +
      // Paper start - add EntityFertilizeEggEvent
      /**
-      * Calls the io.papermc.paper.event.entity.EntityFertilizeEggEvent.
+      * Calls the {@link io.papermc.paper.event.entity.EntityFertilizeEggEvent}.

--- a/patches/server/0900-ExperienceOrb-should-call-EntitySpawnEvent.patch
+++ b/patches/server/0900-ExperienceOrb-should-call-EntitySpawnEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ExperienceOrb should call EntitySpawnEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 84e527cf6db14b1fe23a1b169c3bf5609c535e06..f64a0628f5d487cb113d86319d7b51237b4a9f6e 100644
+index 11f38ba85aa7410642ac541ce84f8efd65590bc1..470558446908581188b007410082cfcee3f16f4d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -734,7 +734,8 @@ public class CraftEventFactory {

--- a/patches/server/0903-Implement-PlayerFailMoveEvent.patch
+++ b/patches/server/0903-Implement-PlayerFailMoveEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement PlayerFailMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e6fc3db8d2d2fca291f9161e6e9d8e22e43284f6..42dda7d490cf11f35011c0998565c43b38d242e0 100644
+index 9440310f6a46fb62c4526f3cfb0464750fe72f84..c4c9b3061aa79b8ab8e5b1f68780f4910a657b1d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1272,8 +1272,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1271,8 +1271,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      double d0 = ServerGamePacketListenerImpl.clampHorizontal(packet.getX(this.player.getX())); final double toX = d0; // Paper - OBFHELPER
                      double d1 = ServerGamePacketListenerImpl.clampVertical(packet.getY(this.player.getY())); final double toY = d1; // Paper - OBFHELPER
                      double d2 = ServerGamePacketListenerImpl.clampHorizontal(packet.getZ(this.player.getZ())); final double toZ = d2; // Paper - OBFHELPER
@@ -19,7 +19,7 @@ index e6fc3db8d2d2fca291f9161e6e9d8e22e43284f6..42dda7d490cf11f35011c0998565c43b
  
                      if (this.player.isPassenger()) {
                          this.player.absMoveTo(this.player.getX(), this.player.getY(), this.player.getZ(), f, f1);
-@@ -1338,8 +1338,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1337,8 +1337,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  }
                                  // Paper start - Prevent moving into unloaded chunks
                                  if (this.player.level().paperConfig().chunks.preventMovingIntoUnloadedChunks && (this.player.getX() != toX || this.player.getZ() != toZ) && !worldserver.areChunksLoadedForMove(this.player.getBoundingBox().expandTowards(new Vec3(toX, toY, toZ).subtract(this.player.position())))) {
@@ -36,7 +36,7 @@ index e6fc3db8d2d2fca291f9161e6e9d8e22e43284f6..42dda7d490cf11f35011c0998565c43b
                                  }
                                  // Paper end - Prevent moving into unloaded chunks
  
-@@ -1348,9 +1354,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1347,9 +1353,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                                      if (d10 - d9 > Math.max(f2, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isSingleplayerOwner()) {
                                      // CraftBukkit end
@@ -56,7 +56,7 @@ index e6fc3db8d2d2fca291f9161e6e9d8e22e43284f6..42dda7d490cf11f35011c0998565c43b
                                      }
                                  }
                              }
-@@ -1412,14 +1425,29 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1411,14 +1424,29 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              d8 = d2 - this.player.getZ();
                              d10 = d6 * d6 + d7 * d7 + d8 * d8;
@@ -89,7 +89,7 @@ index e6fc3db8d2d2fca291f9161e6e9d8e22e43284f6..42dda7d490cf11f35011c0998565c43b
                                  this.internalTeleport(d3, d4, d5, f, f1, Collections.emptySet()); // CraftBukkit - SPIGOT-1807: Don't call teleport event, when the client thinks the player is falling, because the chunks are not loaded on the client yet.
                                  this.player.doCheckFallDamage(this.player.getX() - d3, this.player.getY() - d4, this.player.getZ() - d5, packet.isOnGround());
                              } else {
-@@ -3363,4 +3391,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3351,4 +3379,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
          InteractionResult run(ServerPlayer player, Entity entity, InteractionHand hand);
      }

--- a/patches/server/0908-Only-capture-actual-tree-growth.patch
+++ b/patches/server/0908-Only-capture-actual-tree-growth.patch
@@ -29,10 +29,10 @@ index e14d928e8bf484c61f2687621623942a27f30db1..0fd5decb0790423aba80a7c1e55ce39a
                      }
                      entityhuman.awardStat(Stats.ITEM_USED.get(item)); // SPIGOT-7236 - award stat
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index e4810342370e05647d569f83f064d299de1de756..5d675d4a5380c3a67e5a320cdb7bffe8a823d855 100644
+index b942e9f163fa342c58b74d1cd6ffe6bdbe4f691a..cd19005d3f239a27a4ce764588c8df0b229035bf 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1377,4 +1377,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1372,4 +1372,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return range <= 0 ? 64.0 * 64.0 : range * range; // 64 is taken from default in ServerLevel#levelEvent
      }
      // Paper end - respect global sound events gamerule

--- a/patches/server/0919-Don-t-tab-complete-namespaced-commands-if-send-names.patch
+++ b/patches/server/0919-Don-t-tab-complete-namespaced-commands-if-send-names.patch
@@ -11,10 +11,10 @@ This patch prevents server from sending namespaced commands when player
 requests tab-complete only commands.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 498f2990b2d4f033b8e792bcef5af31bd5b60532..c52d4f2db071b2aea276a96e8cbd550dd6f3880f 100644
+index c4c9b3061aa79b8ab8e5b1f68780f4910a657b1d..5cb6984475eb89ed2a822d7a9e485bed47d6431b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -763,6 +763,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -762,6 +762,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                          ParseResults<CommandSourceStack> parseresults = this.server.getCommands().getDispatcher().parse(stringreader, this.player.createCommandSourceStack());
  
                          this.server.getCommands().getDispatcher().getCompletionSuggestions(parseresults).thenAccept((suggestions) -> {

--- a/patches/server/0920-Properly-handle-BlockBreakEvent-isDropItems.patch
+++ b/patches/server/0920-Properly-handle-BlockBreakEvent-isDropItems.patch
@@ -9,7 +9,7 @@ food consumption, turtle egg count decreases, ice to water
 conversions and beehive releases
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 88b71210d0845e8a4a2cd424ba238c4b5e27933b..e9b41b818c867d26fe9d3fa6e4d55fb432083d62 100644
+index 3621770701c6fb1da75c69a41297684493380e37..4747b05619f37009a5a236678aceec6cfc1c0b79 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -431,8 +431,8 @@ public class ServerPlayerGameMode {
@@ -24,7 +24,7 @@ index 88b71210d0845e8a4a2cd424ba238c4b5e27933b..e9b41b818c867d26fe9d3fa6e4d55fb4
  
                      // return true; // CraftBukkit
 diff --git a/src/main/java/net/minecraft/world/level/block/BeehiveBlock.java b/src/main/java/net/minecraft/world/level/block/BeehiveBlock.java
-index a0ab721a01faccf216259c46e6d6f638426732c2..2d4a770ec7c0737eee6f06b32958716d50d230a1 100644
+index 799e44ae5a7c3d6994653d43d455c39f3e30b012..25e8d6066fb94d0b9a244ab1fec5139b9266d86d 100644
 --- a/src/main/java/net/minecraft/world/level/block/BeehiveBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/BeehiveBlock.java
 @@ -84,8 +84,8 @@ public class BeehiveBlock extends BaseEntityBlock {
@@ -39,14 +39,14 @@ index a0ab721a01faccf216259c46e6d6f638426732c2..2d4a770ec7c0737eee6f06b32958716d
              BeehiveBlockEntity tileentitybeehive = (BeehiveBlockEntity) blockEntity;
  
 diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
-index 9120b4a70dbf84f19480b952658414e16d2c23c1..660ede322b4f4ccad241820d8ffd4540ebb18fbc 100644
+index 57d92c1785586dfab2b3934733d8ba253e042e2e..c4bf01177b2dfcc88f6992dc85de216d448a79f8 100644
 --- a/src/main/java/net/minecraft/world/level/block/Block.java
 +++ b/src/main/java/net/minecraft/world/level/block/Block.java
-@@ -410,10 +410,18 @@ public class Block extends BlockBehaviour implements ItemLike {
+@@ -411,10 +411,18 @@ public class Block extends BlockBehaviour implements ItemLike {
          return this.defaultBlockState();
      }
  
-+    @io.papermc.paper.annotation.DoNotUse // Paper - fix drops not preventing stats/food exhaustion
++    @io.papermc.paper.annotation.DoNotUse @Deprecated // Paper - fix drops not preventing stats/food exhaustion
      public void playerDestroy(Level world, Player player, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity, ItemStack tool) {
 +        // Paper start - fix drops not preventing stats/food exhaustion
 +        this.playerDestroy(world, player, pos, state, blockEntity, tool, true, true);

--- a/patches/server/0921-Fire-entity-death-event-for-ender-dragon.patch
+++ b/patches/server/0921-Fire-entity-death-event-for-ender-dragon.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fire entity death event for ender dragon
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 955d0ddb69c29de723b85c65f42b0274813aadac..dd9800094b132954f0677eb6610fe27db4cec711 100644
+index d0de3ef6c78785a047ecdf2412df082d53fb985b..a86ae40b945b1ecdf42a69d753d0412f39ee3001 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 @@ -642,6 +642,15 @@ public class EnderDragon extends Mob implements Enemy {
@@ -14,7 +14,7 @@ index 955d0ddb69c29de723b85c65f42b0274813aadac..dd9800094b132954f0677eb6610fe27d
      public void kill() {
 +        // Paper start - Fire entity death event
 +        this.silentDeath = true;
-+        org.bukkit.event.entity.EntityDeathEvent deathEvent =  org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this);
++        org.bukkit.event.entity.EntityDeathEvent deathEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this);
 +        if (deathEvent.isCancelled()) {
 +            this.silentDeath = false; // Reset to default if event was cancelled
 +            return;

--- a/patches/server/0925-Add-BlockFace-to-BlockDamageEvent.patch
+++ b/patches/server/0925-Add-BlockFace-to-BlockDamageEvent.patch
@@ -18,7 +18,7 @@ index e9b41b818c867d26fe9d3fa6e4d55fb432083d62..c9594f82c31cd750cdfb26619b1094a8
                  if (blockEvent.isCancelled()) {
                      // Let the client know the block still exists
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f64a0628f5d487cb113d86319d7b51237b4a9f6e..51cf0a068d17c0b6eaee38bb1af5b3c470de5875 100644
+index 470558446908581188b007410082cfcee3f16f4d..e420a558994129b2907d7e75152a558a01dc7b2e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -649,13 +649,13 @@ public class CraftEventFactory {

--- a/patches/server/0930-Add-PlayerPickItemEvent.patch
+++ b/patches/server/0930-Add-PlayerPickItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerPickItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c52d4f2db071b2aea276a96e8cbd550dd6f3880f..a3513ef6952ea1b446540505ab98d1cb865f7324 100644
+index 5cb6984475eb89ed2a822d7a9e485bed47d6431b..74da8d5ba6ee6e7b897a0d28dac5d3d05faf3a88 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -900,8 +900,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -899,8 +899,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              this.disconnect("Invalid hotbar selection (Hacking?)", org.bukkit.event.player.PlayerKickEvent.Cause.ILLEGAL_ACTION); // Paper - kick event cause
              return;
          }

--- a/patches/server/0936-Add-titleOverride-to-InventoryOpenEvent.patch
+++ b/patches/server/0936-Add-titleOverride-to-InventoryOpenEvent.patch
@@ -79,7 +79,7 @@ index 94c2ea713e0614de570458f6b9c418a3d67d14b5..acbb64010cd59668aa1bcb52ff122078
          if (!player.isImmobile()) player.connection.send(new ClientboundOpenScreenPacket(container.containerId, windowType, io.papermc.paper.adventure.PaperAdventure.asVanilla(adventure$title))); // Paper - Prevent opening inventories when frozen
          player.containerMenu = container;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 51cf0a068d17c0b6eaee38bb1af5b3c470de5875..3865e6c7af0203ff9a366571a276b8af43b97c7c 100644
+index e420a558994129b2907d7e75152a558a01dc7b2e..c74e6c6cd92d618cde3733200bcc23279c0df679 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1438,10 +1438,21 @@ public class CraftEventFactory {

--- a/patches/server/0940-Add-slot-sanity-checks-in-container-clicks.patch
+++ b/patches/server/0940-Add-slot-sanity-checks-in-container-clicks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add slot sanity checks in container clicks
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a3513ef6952ea1b446540505ab98d1cb865f7324..401658927b6bf4946709f0f2aeba01f944ec4dfb 100644
+index 74da8d5ba6ee6e7b897a0d28dac5d3d05faf3a88..c02249e271151b49cd581943ee8f890ca440e2c3 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2892,6 +2892,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2880,6 +2880,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              break;
                          case SWAP:
                              if ((packet.getButtonNum() >= 0 && packet.getButtonNum() < 9) || packet.getButtonNum() == 40) {

--- a/patches/server/0973-Don-t-fire-sync-events-during-worldgen.patch
+++ b/patches/server/0973-Don-t-fire-sync-events-during-worldgen.patch
@@ -31,7 +31,7 @@ index 0e7811ae2a8731ae7475aabd2322e56ab364bc32..b5d6a7eaa24d9968e159d77a4295be00
          if (entity.valid) {
              MinecraftServer.LOGGER.error("Attempted Double World add on {}", entity, new Throwable());
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0e299073086cc06324794ca8b6e74674a70cc77a..5fec06e12ede63496f75ccf43f52b16301d11eb0 100644
+index ce6bbf5b56925c501804bff4626da8b7b2c8ff63..9e1d0e46e94cc72705af5e1d01de6bb7bea40107 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -624,7 +624,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
@@ -48,10 +48,10 @@ index 0e299073086cc06324794ca8b6e74674a70cc77a..5fec06e12ede63496f75ccf43f52b163
          this.entityData.set(Entity.DATA_POSE, pose);
      }
 diff --git a/src/main/java/net/minecraft/world/entity/EntityType.java b/src/main/java/net/minecraft/world/entity/EntityType.java
-index fe8efe89c7d390ff9565f388685b57daeebfd08b..0f111b76ccbc260a1dad562c9c1d8a0465849dfe 100644
+index 656c68b37bc25d6b77f295f9efe0a81dd20b69c1..8ba573bb4099ee5b27b61f333e72d794c48d5f29 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityType.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityType.java
-@@ -588,9 +588,15 @@ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeT
+@@ -584,9 +584,15 @@ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeT
      }
  
      public static Optional<Entity> create(CompoundTag nbt, Level world) {
@@ -68,10 +68,10 @@ index fe8efe89c7d390ff9565f388685b57daeebfd08b..0f111b76ccbc260a1dad562c9c1d8a04
          }, () -> {
              EntityType.LOGGER.warn("Skipping Entity with id {}", nbt.getString("id"));
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f6eda18a0bcc398538c76bf4ca7c2a611523aa5d..be0fa9a9e91c87234b0cd7b63c4e7dba8629ebe5 100644
+index 5a47bffc059df227352a497881ebf1364a6c0019..1d1fe8e8c23fc177960fb78d2e38ea9846fc3938 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1134,6 +1134,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1133,6 +1133,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public boolean addEffect(MobEffectInstance mobeffect, @Nullable Entity entity, EntityPotionEffectEvent.Cause cause) {
@@ -83,7 +83,7 @@ index f6eda18a0bcc398538c76bf4ca7c2a611523aa5d..be0fa9a9e91c87234b0cd7b63c4e7dba
          // org.spigotmc.AsyncCatcher.catchOp("effect add"); // Spigot // Paper - move to API
          if (this.isTickingEffects) {
              this.effectsToProcess.add(new ProcessableEffect(mobeffect, cause));
-@@ -1153,10 +1158,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1152,10 +1157,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  override = new MobEffectInstance(mobeffect1).update(mobeffect);
              }
  
@@ -97,7 +97,7 @@ index f6eda18a0bcc398538c76bf4ca7c2a611523aa5d..be0fa9a9e91c87234b0cd7b63c4e7dba
              // CraftBukkit end
  
              if (mobeffect1 == null) {
-@@ -1164,7 +1172,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1163,7 +1171,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  this.onEffectAdded(mobeffect, entity);
                  flag = true;
                  // CraftBukkit start

--- a/patches/server/0976-Restore-vanilla-entity-drops-behavior.patch
+++ b/patches/server/0976-Restore-vanilla-entity-drops-behavior.patch
@@ -50,7 +50,7 @@ index 6147ffdcb83a9d013a05facd75453d6500064fe7..ecf463139bb6567103d81ae26cfff53d
          if (entityitem == null) {
              return null;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5fec06e12ede63496f75ccf43f52b16301d11eb0..4575e3e8a21e47d39fd3639163e804ec9dc452a6 100644
+index 9e1d0e46e94cc72705af5e1d01de6bb7bea40107..86013d6eda6708b38c2013a242ced07eea7a3f01 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2476,6 +2476,25 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
@@ -66,7 +66,7 @@ index 5fec06e12ede63496f75ccf43f52b16301d11eb0..4575e3e8a21e47d39fd3639163e804ec
 +        }
 +
 +        public void runConsumer(final org.bukkit.World fallbackWorld, final Location fallbackLoc) {
-+            if (this.dropConsumer == null || org.bukkit.craftbukkit.util.CraftMagicNumbers.getItem(this.stack.getType()) != this.item) {
++            if (this.dropConsumer == null || org.bukkit.craftbukkit.inventory.CraftItemType.bukkitToMinecraft(this.stack.getType()) != this.item) {
 +                fallbackWorld.dropItem(fallbackLoc, this.stack);
 +            } else {
 +                this.dropConsumer.accept(org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(this.stack));
@@ -104,10 +104,10 @@ index 5fec06e12ede63496f75ccf43f52b16301d11eb0..4575e3e8a21e47d39fd3639163e804ec
              return this.spawnAtLocation(entityitem);
          }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index be0fa9a9e91c87234b0cd7b63c4e7dba8629ebe5..d3d958b58934bcb513ffef474a9de58c61e654a2 100644
+index 1d1fe8e8c23fc177960fb78d2e38ea9846fc3938..1b1bb94138c0f5ce197ec4cab251cdc9991c8fc7 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -254,7 +254,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -253,7 +253,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      // CraftBukkit start
      public int expToDrop;
      public boolean forceDrops;
@@ -165,10 +165,10 @@ index e3412f9dd86dddd241bea8f6dcaeed77a7e67f08..6dfcc296ff7e59ecbebc5446973fabc9
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 3865e6c7af0203ff9a366571a276b8af43b97c7c..93f79e5c7244fc155364a35a75a62d42f2d1ee27 100644
+index 469f7b1b26e8c69c6cb89a5bed01dae65aa9ba2d..c39cb1bd6304b765f439fbd9022e26e9554105e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -937,17 +937,21 @@ public class CraftEventFactory {
+@@ -937,17 +937,23 @@ public class CraftEventFactory {
      }
  
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim) {
@@ -182,10 +182,12 @@ index 3865e6c7af0203ff9a366571a276b8af43b97c7c..93f79e5c7244fc155364a35a75a62d42
          return CraftEventFactory.callEntityDeathEvent(victim, drops, com.google.common.util.concurrent.Runnables.doNothing());
      }
 -    public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops, Runnable lootCheck) {
-+    private static java.util.function.Function<org.bukkit.inventory.ItemStack, Entity.DefaultDrop> FROM_FUNCTION = stack -> {
++
++    private static final java.util.function.Function<org.bukkit.inventory.ItemStack, Entity.DefaultDrop> FROM_FUNCTION = stack -> {
 +        if (stack == null) return null;
 +        return new Entity.DefaultDrop(CraftItemType.bukkitToMinecraft(stack.getType()), stack, null);
 +    };
++
 +    public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<Entity.DefaultDrop> drops, Runnable lootCheck) { // Paper
          // Paper end
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
@@ -194,14 +196,14 @@ index 3865e6c7af0203ff9a366571a276b8af43b97c7c..93f79e5c7244fc155364a35a75a62d42
          populateFields(victim, event); // Paper - make cancellable
          CraftWorld world = (CraftWorld) entity.getWorld();
          Bukkit.getServer().getPluginManager().callEvent(event);
-@@ -961,19 +965,23 @@ public class CraftEventFactory {
+@@ -961,19 +967,23 @@ public class CraftEventFactory {
          victim.expToDrop = event.getDroppedExp();
          lootCheck.run(); // Paper - advancement triggers before destroying items
  
 -        for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
 +        // Paper start - Restore vanilla drops behavior
 +        for (Entity.DefaultDrop drop : drops) {
-+            if (drop == null) continue;;
++            if (drop == null) continue;
 +            final org.bukkit.inventory.ItemStack stack = drop.stack();
 +            // Paper end - Restore vanilla drops behavior
              if (stack == null || stack.getType() == Material.AIR || stack.getAmount() == 0) continue;
@@ -222,7 +224,7 @@ index 3865e6c7af0203ff9a366571a276b8af43b97c7c..93f79e5c7244fc155364a35a75a62d42
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
          populateFields(victim, event); // Paper - make cancellable
-@@ -992,10 +1000,14 @@ public class CraftEventFactory {
+@@ -992,10 +1002,14 @@ public class CraftEventFactory {
          victim.expToDrop = event.getDroppedExp();
          victim.newExp = event.getNewExp();
  

--- a/patches/server/0977-Dont-resend-blocks-on-interactions.patch
+++ b/patches/server/0977-Dont-resend-blocks-on-interactions.patch
@@ -8,7 +8,7 @@ In general, the client now has an acknowledgment system which will prevent block
 It should be noted that this system does not yet support block entities, so those still need to resynced when needed.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index c9594f82c31cd750cdfb26619b1094a865058faf..bc0df2e1401b13737e23faae01ba16edc2a10d21 100644
+index d0ca98c3f9ea5c8cb1053da6b17e9a90c86b3ae7..5063eb6d4a24600262c32d2c9eb5fb5bf8fa354e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -199,7 +199,7 @@ public class ServerPlayerGameMode {
@@ -124,7 +124,7 @@ index c9594f82c31cd750cdfb26619b1094a865058faf..bc0df2e1401b13737e23faae01ba16ed
 -                player.connection.send(new ClientboundBlockUpdatePacket(world, blockposition.above()));
 +                //player.connection.send(new ClientboundBlockUpdatePacket(world, blockposition.above())); // Paper - Don't resync blocks
              // Paper start - extend Player Interact cancellation // TODO: consider merging this into the extracted method
-             } else if (iblockdata.getBlock() instanceof net.minecraft.world.level.block.StructureBlock) {
+             } else if (iblockdata.is(Blocks.STRUCTURE_BLOCK) || iblockdata.getBlock() instanceof net.minecraft.world.level.block.CommandBlock) {
                  player.connection.send(new net.minecraft.network.protocol.game.ClientboundContainerClosePacket(this.player.containerMenu.containerId));
 diff --git a/src/main/java/net/minecraft/world/item/BucketItem.java b/src/main/java/net/minecraft/world/item/BucketItem.java
 index 4b9e726e6ac255e743479d5c2e0cdb98464399a4..6371f326fc86cfc53e39bf8ed13b646f7705fbbc 100644

--- a/patches/server/0981-Add-experience-points-API.patch
+++ b/patches/server/0981-Add-experience-points-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add experience points API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 182180275be3bf90b9f8e66dcf19ad6ce02136bf..2759fa8768cfa7a38af7266a8e58af5feab138fa 100644
+index eb6a4518d3919cacc3b7a83870c0f0e87eba3f6e..d8ef2466e235b8121dd04bde0800ed2dbf8e370c 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1823,7 +1823,7 @@ public abstract class Player extends LivingEntity {
+@@ -1825,7 +1825,7 @@ public abstract class Player extends LivingEntity {
      }
  
      public int getXpNeededForNextLevel() {

--- a/patches/server/0982-Add-drops-to-shear-events.patch
+++ b/patches/server/0982-Add-drops-to-shear-events.patch
@@ -233,10 +233,10 @@ index 8adcfc8f6772a32b5915e4a07100e8eb735f907a..b5d6857eaf2bed14adcb5f5e80d91b44
  
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 93f79e5c7244fc155364a35a75a62d42f2d1ee27..b9e90f589749dfc9324c4aa2062c505fbd4447bc 100644
+index c39cb1bd6304b765f439fbd9022e26e9554105e0..23b4b5d63d45108534bde330079c7a12b3aa4f5f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1716,20 +1716,20 @@ public class CraftEventFactory {
+@@ -1718,20 +1718,20 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -264,25 +264,26 @@ index 93f79e5c7244fc155364a35a75a62d42f2d1ee27..b9e90f589749dfc9324c4aa2062c505f
  
      public static Cancellable handleStatisticsIncrease(net.minecraft.world.entity.player.Player entityHuman, net.minecraft.stats.Stat<?> statistic, int current, int newValue) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index e1f9a603e7adf3468faa9bb6d93dd3339327b47e..fdb2c65ca47df95ef5735216eb9b1c1380e41f32 100644
+index e1f9a603e7adf3468faa9bb6d93dd3339327b47e..870954fc59efdc1e0c6b5047f5a89dfaf7522d0e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -61,6 +61,15 @@ public final class CraftItemStack extends ItemStack {
-         }
+@@ -62,6 +62,16 @@ public final class CraftItemStack extends ItemStack {
          return stack;
      }
+ 
 +    // Paper start
 +    public static java.util.List<net.minecraft.world.item.ItemStack> asNMSCopy(java.util.List<? extends ItemStack> originals) {
-+        final java.util.List<net.minecraft.world.item.ItemStack> nms = new java.util.ArrayList<>();
-+        for (final org.bukkit.inventory.ItemStack original : originals) {
-+            nms.add(asNMSCopy(original));
++        final java.util.List<net.minecraft.world.item.ItemStack> items = new java.util.ArrayList<>(originals.size());
++        for (final ItemStack original : originals) {
++            items.add(asNMSCopy(original));
 +        }
-+        return nms;
++        return items;
 +    }
 +    // Paper end
- 
++
      public static net.minecraft.world.item.ItemStack copyNMSStack(net.minecraft.world.item.ItemStack original, int amount) {
          net.minecraft.world.item.ItemStack stack = original.copy();
+         stack.setCount(amount);
 diff --git a/src/test/java/io/papermc/paper/entity/ShearableDropsTest.java b/src/test/java/io/papermc/paper/entity/ShearableDropsTest.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..e612515f7709dbe5d1fa5751337cdc34fce10a98

--- a/patches/server/0983-Add-PlayerShieldDisableEvent.patch
+++ b/patches/server/0983-Add-PlayerShieldDisableEvent.patch
@@ -33,10 +33,10 @@ index 433d8eccdd225651af8c88babfdb94d19ce546d8..026654c4d3a910f0dbfed5475f231370
              }
          }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 2759fa8768cfa7a38af7266a8e58af5feab138fa..3ccfc9cbf1b9dd91f3cefaec8f2dbcfa6afba8a9 100644
+index d8ef2466e235b8121dd04bde0800ed2dbf8e370c..4f2d4ed485ce0d5f82f562281c40dc6a660e554b 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -969,7 +969,7 @@ public abstract class Player extends LivingEntity {
+@@ -971,7 +971,7 @@ public abstract class Player extends LivingEntity {
      protected void blockUsingShield(LivingEntity attacker) {
          super.blockUsingShield(attacker);
          if (attacker.canDisableShield()) {
@@ -45,11 +45,11 @@ index 2759fa8768cfa7a38af7266a8e58af5feab138fa..3ccfc9cbf1b9dd91f3cefaec8f2dbcfa
          }
  
      }
-@@ -1452,7 +1452,14 @@ public abstract class Player extends LivingEntity {
+@@ -1454,7 +1454,14 @@ public abstract class Player extends LivingEntity {
          this.attack(target);
      }
  
-+    @io.papermc.paper.annotation.DoNotUse // Paper - Add PlayerShieldDisableEvent
++    @io.papermc.paper.annotation.DoNotUse @Deprecated // Paper - Add PlayerShieldDisableEvent
      public void disableShield(boolean sprinting) {
 +        // Paper start - Add PlayerShieldDisableEvent
 +        disableShield(sprinting, null);
@@ -60,7 +60,7 @@ index 2759fa8768cfa7a38af7266a8e58af5feab138fa..3ccfc9cbf1b9dd91f3cefaec8f2dbcfa
          float f = 0.25F + (float) EnchantmentHelper.getBlockEfficiency(this) * 0.05F;
  
          if (sprinting) {
-@@ -1460,7 +1467,16 @@ public abstract class Player extends LivingEntity {
+@@ -1462,7 +1469,16 @@ public abstract class Player extends LivingEntity {
          }
  
          if (this.random.nextFloat() < f) {

--- a/patches/server/0984-Validate-ResourceLocation-in-NBT-reading.patch
+++ b/patches/server/0984-Validate-ResourceLocation-in-NBT-reading.patch
@@ -40,10 +40,10 @@ index 5f9dcab27a07969c93555ad0892683c62cbebc8c..a4d875df936b6de16f0233482b03af05
          this.path = path;
      }
 diff --git a/src/main/java/net/minecraft/world/entity/EntityType.java b/src/main/java/net/minecraft/world/entity/EntityType.java
-index 0f111b76ccbc260a1dad562c9c1d8a0465849dfe..704e0b03d3bdff01eacd7781715f2d3a901155b1 100644
+index 8ba573bb4099ee5b27b61f333e72d794c48d5f29..69bdf3f2ee731e59e8d454816a9ca72cb49c0fe0 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityType.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityType.java
-@@ -618,7 +618,7 @@ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeT
+@@ -614,7 +614,7 @@ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeT
      }
  
      public static Optional<EntityType<?>> by(CompoundTag nbt) {

--- a/patches/server/0985-Properly-handle-experience-dropping-on-block-break.patch
+++ b/patches/server/0985-Properly-handle-experience-dropping-on-block-break.patch
@@ -7,10 +7,10 @@ This causes spawnAfterBreak to spawn xp by default, removing the need to manuall
 For classes that use custom xp amounts, they can drop the resources with disabling
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 5d675d4a5380c3a67e5a320cdb7bffe8a823d855..aa5437860c0471dcc0e6b01cb97e1cbadb752fab 100644
+index cd19005d3f239a27a4ce764588c8df0b229035bf..d5290c97babfa9415bd52deb14610821f0fa2575 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -630,7 +630,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -625,7 +625,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              if (drop) {
                  BlockEntity tileentity = iblockdata.hasBlockEntity() ? this.getBlockEntity(pos) : null;
  
@@ -21,23 +21,23 @@ index 5d675d4a5380c3a67e5a320cdb7bffe8a823d855..aa5437860c0471dcc0e6b01cb97e1cba
  
              boolean flag1 = this.setBlock(pos, fluid.createLegacyBlock(), 3, maxUpdateDepth);
 diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
-index 660ede322b4f4ccad241820d8ffd4540ebb18fbc..63217d3db86b467f3358730eb8b9b3c941558bab 100644
+index c4bf01177b2dfcc88f6992dc85de216d448a79f8..6896d46fce2e466ebee23ac2dc00312ec1beefdb 100644
 --- a/src/main/java/net/minecraft/world/level/block/Block.java
 +++ b/src/main/java/net/minecraft/world/level/block/Block.java
-@@ -320,23 +320,31 @@ public class Block extends BlockBehaviour implements ItemLike {
-             for (net.minecraft.world.item.ItemStack drop : net.minecraft.world.level.block.Block.getDrops(state, world.getMinecraftWorld(), pos, blockEntity)) {
+@@ -321,23 +321,31 @@ public class Block extends BlockBehaviour implements ItemLike {
+             for (ItemStack drop : Block.getDrops(state, serverLevel, pos, blockEntity)) {
                  items.add(org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(drop));
              }
 +            Block block = state.getBlock(); // Paper - Properly handle xp dropping
-             io.papermc.paper.event.block.BlockBreakBlockEvent event = new io.papermc.paper.event.block.BlockBreakBlockEvent(org.bukkit.craftbukkit.block.CraftBlock.at(world, pos), org.bukkit.craftbukkit.block.CraftBlock.at(world, source), items);
-+            event.setExpToDrop(block.getExpDrop(state, (ServerLevel) world, pos, net.minecraft.world.item.ItemStack.EMPTY, true)); // Paper - Properly handle xp dropping
+             io.papermc.paper.event.block.BlockBreakBlockEvent event = new io.papermc.paper.event.block.BlockBreakBlockEvent(org.bukkit.craftbukkit.block.CraftBlock.at(levelAccessor, pos), org.bukkit.craftbukkit.block.CraftBlock.at(levelAccessor, source), items);
++            event.setExpToDrop(block.getExpDrop(state, serverLevel, pos, net.minecraft.world.item.ItemStack.EMPTY, true)); // Paper - Properly handle xp dropping
              event.callEvent();
-             for (var drop : event.getDrops()) {
-                 popResource(world.getMinecraftWorld(), pos, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(drop));
+             for (org.bukkit.inventory.ItemStack drop : event.getDrops()) {
+                 popResource(serverLevel, pos, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(drop));
              }
--            state.spawnAfterBreak(world.getMinecraftWorld(), pos, ItemStack.EMPTY, true);
-+            state.spawnAfterBreak(world.getMinecraftWorld(), pos, ItemStack.EMPTY, false); // Paper - Properly handle xp dropping
-+            block.popExperience((ServerLevel) world, pos, event.getExpToDrop()); // Paper - Properly handle xp dropping
+-            state.spawnAfterBreak(serverLevel, pos, ItemStack.EMPTY, true);
++            state.spawnAfterBreak(serverLevel, pos, ItemStack.EMPTY, false); // Paper - Properly handle xp dropping
++            block.popExperience(serverLevel, pos, event.getExpToDrop()); // Paper - Properly handle xp dropping
          }
          return true;
      }
@@ -58,7 +58,7 @@ index 660ede322b4f4ccad241820d8ffd4540ebb18fbc..63217d3db86b467f3358730eb8b9b3c9
          }
  
      }
-@@ -420,7 +428,7 @@ public class Block extends BlockBehaviour implements ItemLike {
+@@ -421,7 +429,7 @@ public class Block extends BlockBehaviour implements ItemLike {
          player.awardStat(Stats.BLOCK_MINED.get(this));
          player.causeFoodExhaustion(0.005F, org.bukkit.event.entity.EntityExhaustionEvent.ExhaustionReason.BLOCK_MINED); // CraftBukkit - EntityExhaustionEvent
          if (includeDrops) { // Paper - fix drops not preventing stats/food exhaustion
@@ -68,7 +68,7 @@ index 660ede322b4f4ccad241820d8ffd4540ebb18fbc..63217d3db86b467f3358730eb8b9b3c9
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
-index ab174986ad558916427a70f59c6907f17b0d01df..20de3aeb4991dcfd0bbf813075a4c76e277b7598 100644
+index e57e3a26b0fb856e1ab693df5783fe8b9bee9719..64300077fce6eb28b6bddd42b3467eaa4c80c9f5 100644
 --- a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 +++ b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 @@ -1183,6 +1183,7 @@ public abstract class BlockBehaviour implements FeatureElement {

--- a/patches/server/0990-Starlight.patch
+++ b/patches/server/0990-Starlight.patch
@@ -4882,7 +4882,7 @@ index 209596e89307b9e1d0ff4c465876d29fef4fc290..c3e7bd8865cc8990fc59f1ff0dfc1697
          return this.level.getChunkSource().chunkMap.isOldChunkAround(chunkPos, checkRadius);
      }
 diff --git a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
-index 20de3aeb4991dcfd0bbf813075a4c76e277b7598..4c6ab71c3222ce03edd70abef35c71398d885c13 100644
+index 64300077fce6eb28b6bddd42b3467eaa4c80c9f5..e28ac8f7960f648099e5f3607530a406c72e5056 100644
 --- a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 +++ b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 @@ -881,6 +881,7 @@ public abstract class BlockBehaviour implements FeatureElement {

--- a/patches/server/0991-Rewrite-chunk-system.patch
+++ b/patches/server/0991-Rewrite-chunk-system.patch
@@ -14610,7 +14610,7 @@ index cea9c098ade00ee87b8efc8164ab72f5279758f0..197224e31175252d8438a8df585bbb65
 +    }
  }
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
-index 8235d23dc9778b9444288d58ffdb5d515df56bf9..1ccf71be865af4d3c5ab8f4323a228a947e0bf3f 100644
+index 0d3ccf3ae219a3b24d17be03de8fd4906cb7235d..850f75172e9efa72cabb8e5bd124b96a0b1a945f 100644
 --- a/src/main/java/io/papermc/paper/util/MCUtil.java
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
 @@ -6,17 +6,30 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -14656,7 +14656,7 @@ index 8235d23dc9778b9444288d58ffdb5d515df56bf9..1ccf71be865af4d3c5ab8f4323a228a9
  import java.util.concurrent.CompletableFuture;
  import java.util.concurrent.ExecutionException;
  import java.util.concurrent.LinkedBlockingQueue;
-@@ -533,6 +549,100 @@ public final class MCUtil {
+@@ -529,6 +545,100 @@ public final class MCUtil {
          }
      }
  
@@ -15532,7 +15532,7 @@ index deb2d8c22a1c5724d0ac8571f4ea54711988dc4b..72d013d06705b08ed696e3d3b6d631d6
                  DedicatedServer dedicatedserver1 = new DedicatedServer(optionset, worldLoader.get(), thread, convertable_conversionsession, resourcepackrepository, worldstem, dedicatedserversettings, DataFixers.getDataFixer(), services, LoggerChunkProgressListener::new);
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7d637094afecc2a838f9cc5cc837f8bf63cfd5aa..365b11eb92e76cda975a5989a556abcf4c8fdaa4 100644
+index 48da5bdabcf38afbbd1509eca56d5c761622409f..48e3b0f065b370f780f8a6145fba9f3f7976badb 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -311,7 +311,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -19236,10 +19236,10 @@ index 13209267c26f46492a92e820889a9be0bd2287a0..f3b96a921e7d085b51da62fa5493384a
          this.desiredChunksPerTick = Double.isNaN((double)desiredBatchSize) ? 0.01F : Mth.clamp(desiredBatchSize, 0.01F, 64.0F);
          if (this.unacknowledgedBatches == 0) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 50fdc6c1a4aeaa5a6deacc2e7b5aecc8f9016b79..58788d9fb5033a288454ce9b52c7efa71c603a09 100644
+index c02249e271151b49cd581943ee8f890ca440e2c3..fa70d470327e307909cb17467f39f4596909f364 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -744,6 +744,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -743,6 +743,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              return;
          }
          // Paper end - Don't suggest if tab-complete is disabled
@@ -19254,7 +19254,7 @@ index 50fdc6c1a4aeaa5a6deacc2e7b5aecc8f9016b79..58788d9fb5033a288454ce9b52c7efa7
          TAB_COMPLETE_EXECUTOR.execute(() -> {
          StringReader stringreader = new StringReader(packet.getCommand());
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index b07b19876ba9edb25b89503a8c6e5a5897eb326c..39ebcbac5b735582717dd98c84f065614f361805 100644
+index 16ef96f0b2f68556b89c9d732d0e1a407f083fdc..d2e65c105c38c71a6b1739b95547772511a36345 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -293,7 +293,7 @@ public abstract class PlayerList {
@@ -19405,7 +19405,7 @@ index 640db9f71608310a64e09f1e3e677c01e6ccd98a..f2a7cb6ebed7a4b4019a09af2a025f62
                          if (flag1) {
                              ++this.converted;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4575e3e8a21e47d39fd3639163e804ec9dc452a6..b48cca64325c55edf505a08126ccfec5a533d2fa 100644
+index 86013d6eda6708b38c2013a242ced07eea7a3f01..43d6ed4ab09227ca23cbd51df9a42a5a3b909396 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -479,6 +479,58 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
@@ -19815,10 +19815,10 @@ index 57d4d2014f33a2f069d6c5aaa8e87e36b63a7177..cc888bbcd6a50124fa553bc4a8ffd1e8
  
      <T extends Entity> List<T> getEntities(EntityTypeTest<Entity, T> filter, AABB box, Predicate<? super T> predicate);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index aa5437860c0471dcc0e6b01cb97e1cbadb752fab..9a0d648f04063dd7701d1cbe548a6d45fc216928 100644
+index d5290c97babfa9415bd52deb14610821f0fa2575..c9afe29bae7f339184f4f46d8f9828f5762d0a9c 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -550,6 +550,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -545,6 +545,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
              if ((i & 2) != 0 && (!this.isClientSide || (i & 4) == 0) && (this.isClientSide || chunk == null || (chunk.getFullStatus() != null && chunk.getFullStatus().isOrAfter(FullChunkStatus.BLOCK_TICKING)))) { // allow chunk to be null here as chunk.isReady() is false when we send our notification during block placement
                  this.sendBlockUpdated(blockposition, iblockdata1, iblockdata, i);
@@ -19830,7 +19830,7 @@ index aa5437860c0471dcc0e6b01cb97e1cbadb752fab..9a0d648f04063dd7701d1cbe548a6d45
              }
  
              if ((i & 1) != 0) {
-@@ -941,7 +946,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -936,7 +941,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          }
          // Paper end - Perf: Optimize capturedTileEntities lookup
          // CraftBukkit end
@@ -19839,7 +19839,7 @@ index aa5437860c0471dcc0e6b01cb97e1cbadb752fab..9a0d648f04063dd7701d1cbe548a6d45
      }
  
      public void setBlockEntity(BlockEntity blockEntity) {
-@@ -1032,26 +1037,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1027,26 +1032,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public List<Entity> getEntities(@Nullable Entity except, AABB box, Predicate<? super Entity> predicate) {
          this.getProfiler().incrementCounter("getEntities");
          List<Entity> list = Lists.newArrayList();
@@ -19867,7 +19867,7 @@ index aa5437860c0471dcc0e6b01cb97e1cbadb752fab..9a0d648f04063dd7701d1cbe548a6d45
          return list;
      }
  
-@@ -1069,34 +1055,23 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1064,34 +1050,23 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      public <T extends Entity> void getEntities(EntityTypeTest<Entity, T> filter, AABB box, Predicate<? super T> predicate, List<? super T> result, int limit) {
          this.getProfiler().incrementCounter("getEntities");
@@ -19918,7 +19918,7 @@ index aa5437860c0471dcc0e6b01cb97e1cbadb752fab..9a0d648f04063dd7701d1cbe548a6d45
      }
  
      @Nullable
-@@ -1388,4 +1363,45 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1383,4 +1358,45 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          }
      }
      // Paper end - notify observers even if grow failed
@@ -21420,7 +21420,7 @@ index 1eff5e4800ad3b628a42113fb3ba67458e56a40d..d4e0ef75dd12709a0dcf9193821c30b8
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2edf73bae205c6ce9ad1811dffc4028ca54130b1..d6acca68e885b137ab097cabadd9dbf49798341f 100644
+index f401aa456e1b03230cdd5d2e109909f7b43f3774..3ea2cee19e6fe1b94e39ef535102d41ec2c0bdad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1384,7 +1384,6 @@ public final class CraftServer implements Server {

--- a/patches/server/0993-Optimize-isInWorldBounds-and-getBlockState-for-inlin.patch
+++ b/patches/server/0993-Optimize-isInWorldBounds-and-getBlockState-for-inlin.patch
@@ -29,10 +29,10 @@ index 369b54b96c682717ef93d05312714b4d30efaceb..beadef19ee136c27601f0d116a869673
          this.x = x;
          this.y = y;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 9a0d648f04063dd7701d1cbe548a6d45fc216928..9ea53a55946fbfa35ccceb9c94bb63bd40d3c2f6 100644
+index c9afe29bae7f339184f4f46d8f9828f5762d0a9c..5f98f3e1bc76076278cbe63d5fbb8ec75b3bf04b 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -342,7 +342,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -337,7 +337,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      // Paper end
  
      public boolean isInWorldBounds(BlockPos pos) {

--- a/patches/server/0994-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
+++ b/patches/server/0994-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
@@ -25,10 +25,10 @@ index 09a9452705cc8d4133940c081583d6d38d226f71..5f3502b148588a76079c1d9f55e4203f
                                  }
                              }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 3ccfc9cbf1b9dd91f3cefaec8f2dbcfa6afba8a9..44a17a8e763455e834dcf488044a0f4907ce346e 100644
+index 4f2d4ed485ce0d5f82f562281c40dc6a660e554b..df8d6f3eb675354ce0d180fc56886ce12788d6ae 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -786,6 +786,14 @@ public abstract class Player extends LivingEntity {
+@@ -788,6 +788,14 @@ public abstract class Player extends LivingEntity {
                  return null;
              }
              // CraftBukkit end

--- a/patches/server/0995-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
+++ b/patches/server/0995-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 976b9981d6022eab6b124dd279eac82364644585..22771be445acd07d40b0a51c0a6d062e3df3ac95 100644
+index b4568e0dcb33aa516c1bcd7338e7f9220ac71ff6..00bf8fb845f9230e8e01edbf202ffd208ff4cf8f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3724,7 +3724,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -62,10 +62,10 @@ index bb8e962e63c7a2d931f9bd7f7c002aa35cfa5fd3..0fa131a6c98adb498fc8d534e0e39647
      default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition) {
          // Paper start - Add predicate for blocks when raytracing
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 9ea53a55946fbfa35ccceb9c94bb63bd40d3c2f6..6163a682f12d75fa2658ecd0de33ee56dbc5771b 100644
+index 5f98f3e1bc76076278cbe63d5fbb8ec75b3bf04b..29b6494d17bc8b9926244c286e05c821a6297f7b 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -334,10 +334,87 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -329,10 +329,87 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return null;
      }
  

--- a/patches/server/1000-Entity-Activation-Range-2.0.patch
+++ b/patches/server/1000-Entity-Activation-Range-2.0.patch
@@ -111,7 +111,7 @@ index 5f3502b148588a76079c1d9f55e4203f6de56406..4357d45305cdf82659fcc0df9fa42b1a
          } else {
              passenger.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b48cca64325c55edf505a08126ccfec5a533d2fa..95a590f4a379c1905e700036042b9bde1c0f3264 100644
+index 43d6ed4ab09227ca23cbd51df9a42a5a3b909396..9ac9b5f9461e02d3d280125bb9b66c5c53ab35d7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -411,6 +411,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
@@ -339,10 +339,10 @@ index b149e8bcac034bb3fc118a9adcb0de45e18ed5e9..fc35cfc9d045f3e5b6a50af1d0ba83b6
 +
  }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 6163a682f12d75fa2658ecd0de33ee56dbc5771b..9b574d4aa1faf5814942641c48afe503d6f83bc4 100644
+index 29b6494d17bc8b9926244c286e05c821a6297f7b..6f2515d3476f7a5da898efb3c60e8f4aaad09b06 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -162,6 +162,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -157,6 +157,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public Map<BlockPos, BlockEntity> capturedTileEntities = new java.util.LinkedHashMap<>(); // Paper - Retain block place order when capturing blockstates
      public List<ItemEntity> captureDrops;
      public final it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<SpawnCategory> ticksPerSpawnCategory = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();

--- a/patches/server/1001-Optional-per-player-mob-spawns.patch
+++ b/patches/server/1001-Optional-per-player-mob-spawns.patch
@@ -79,7 +79,7 @@ index e03d2d3d35470cb3971606c66da382672eef1f82..4bfc12a50a262f49c0262b06b39faa81
      // CraftBukkit start
      public String displayName;
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 28ec1cc4dec6d12627761a58d635fd51dbc398b3..da9f091e1c2dd8b025e806f53a4708b623ee4cd8 100644
+index c44c10e15564af6ba0f6d60a1b5f38c6e874a43a..14f4ceb6c0be34d23b24c1695f966145c3aaee96 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -70,6 +70,12 @@ public final class NaturalSpawner {
@@ -236,7 +236,7 @@ index 28ec1cc4dec6d12627761a58d635fd51dbc398b3..da9f091e1c2dd8b025e806f53a4708b6
      }
  
      private static boolean isRightDistanceToPlayerAndSpawnPoint(ServerLevel world, ChunkAccess chunk, BlockPos.MutableBlockPos pos, double squaredDistance) {
-@@ -577,7 +628,7 @@ public final class NaturalSpawner {
+@@ -573,7 +624,7 @@ public final class NaturalSpawner {
              MobCategory enumcreaturetype = entitytypes.getCategory();
  
              this.mobCategoryCounts.addTo(enumcreaturetype, 1);
@@ -245,7 +245,7 @@ index 28ec1cc4dec6d12627761a58d635fd51dbc398b3..da9f091e1c2dd8b025e806f53a4708b6
          }
  
          public int getSpawnableChunkCount() {
-@@ -593,6 +644,7 @@ public final class NaturalSpawner {
+@@ -589,6 +640,7 @@ public final class NaturalSpawner {
              int i = limit * this.spawnableChunkCount / NaturalSpawner.MAGIC_NUMBER;
              // CraftBukkit end
  

--- a/patches/server/1002-Anti-Xray.patch
+++ b/patches/server/1002-Anti-Xray.patch
@@ -1117,7 +1117,7 @@ index 4357d45305cdf82659fcc0df9fa42b1ae1029cc1..811c9c7970dfef290acdf0bbd803b27c
          this.convertable = convertable_conversionsession;
          this.uuid = WorldUUID.getUUID(convertable_conversionsession.levelDirectory.path().toFile());
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index bc0df2e1401b13737e23faae01ba16edc2a10d21..97490f58aace9bfb6d034e9a97393142f73043d1 100644
+index 5063eb6d4a24600262c32d2c9eb5fb5bf8fa354e..692a01b52a71e26887ee42cbd5fd64b0a81bfc99 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -49,7 +49,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
@@ -1155,7 +1155,7 @@ index f3b96a921e7d085b51da62fa5493384a7ded1f9d..12f2bf95d3ea3d29f6b4b9ec38a92f71
          if (io.papermc.paper.event.packet.PlayerChunkLoadEvent.getHandlerList().getRegisteredListeners().length > 0) {
              new io.papermc.paper.event.packet.PlayerChunkLoadEvent(new org.bukkit.craftbukkit.CraftChunk(chunk), handler.getPlayer().getBukkitEntity()).callEvent();
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 34bd7e81f9480c97afd69c11eca216b03e6a5a1f..eae6121a2f3fb33146b0a625cc82c8bce8efc91b 100644
+index 23443444ae0c52392bd9cdd758057437d99e376a..10f2222c95362c41cab693410d0e7bb9746f3e4d 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -418,7 +418,7 @@ public abstract class PlayerList {
@@ -1168,10 +1168,10 @@ index 34bd7e81f9480c97afd69c11eca216b03e6a5a1f..eae6121a2f3fb33146b0a625cc82c8bc
          }
          // Paper end - Send empty chunk
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 9b574d4aa1faf5814942641c48afe503d6f83bc4..6dafbbed864feebe73c648cf38cee6d64e9eea85 100644
+index 6f2515d3476f7a5da898efb3c60e8f4aaad09b06..927c7948e567764e8cf75c7ce486e1ea6c9a8d87 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -177,6 +177,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -172,6 +172,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      }
      // Paper end - add paper world config
  
@@ -1179,7 +1179,7 @@ index 9b574d4aa1faf5814942641c48afe503d6f83bc4..6dafbbed864feebe73c648cf38cee6d6
      public final co.aikar.timings.WorldTimingsHandler timings; // Paper
      public static BlockPos lastPhysicsProblem; // Spigot
      private org.spigotmc.TickLimiter entityLimiter;
-@@ -202,7 +203,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -197,7 +198,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      public abstract ResourceKey<LevelStem> getTypeKey();
  
@@ -1188,7 +1188,7 @@ index 9b574d4aa1faf5814942641c48afe503d6f83bc4..6dafbbed864feebe73c648cf38cee6d6
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
          this.paperConfig = paperWorldConfigCreator.apply(this.spigotConfig); // Paper - create paper world config
          this.generator = gen;
-@@ -288,6 +289,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -283,6 +284,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.keepSpawnInMemory = this.paperConfig().spawn.keepSpawnLoaded; // Paper - Option to keep spawn chunks loaded
          this.entityLimiter = new org.spigotmc.TickLimiter(this.spigotConfig.entityMaxTickTime);
          this.tileLimiter = new org.spigotmc.TickLimiter(this.spigotConfig.tileMaxTickTime);
@@ -1196,7 +1196,7 @@ index 9b574d4aa1faf5814942641c48afe503d6f83bc4..6dafbbed864feebe73c648cf38cee6d6
      }
  
      // Paper start - Cancel hit for vanished players
-@@ -563,6 +565,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -558,6 +560,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // CraftBukkit end
  
              BlockState iblockdata1 = chunk.setBlockState(pos, state, (flags & 64) != 0, (flags & 1024) == 0); // CraftBukkit custom NO_PLACE flag
@@ -1571,7 +1571,7 @@ index d4e0ef75dd12709a0dcf9193821c30b8943e6c36..fd702027e62eb38d51fb7c46ef268e9b
      private static final byte[] EMPTY_LIGHT = new byte[2048];
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d6acca68e885b137ab097cabadd9dbf49798341f..8505a2925f368355ed7e8a3d1df651142e5c43b5 100644
+index 3ea2cee19e6fe1b94e39ef535102d41ec2c0bdad..b8f05300a17d415505deb8da4a923357220ae1bd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2610,7 +2610,7 @@ public final class CraftServer implements Server {

--- a/patches/server/1006-Entity-load-save-limit-per-chunk.patch
+++ b/patches/server/1006-Entity-load-save-limit-per-chunk.patch
@@ -9,10 +9,10 @@ defaults are only included for certain entites, this allows setting
 limits for any entity type.
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityType.java b/src/main/java/net/minecraft/world/entity/EntityType.java
-index 704e0b03d3bdff01eacd7781715f2d3a901155b1..edc723ea5ca3a325106e7af38c60dbf9f0f5fb77 100644
+index 69bdf3f2ee731e59e8d454816a9ca72cb49c0fe0..09e8445a3f8c6b3ebc852a75a9a25b41a51ba659 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityType.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityType.java
-@@ -644,9 +644,20 @@ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeT
+@@ -640,9 +640,20 @@ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeT
          final Spliterator<? extends Tag> spliterator = entityNbtList.spliterator();
  
          return StreamSupport.stream(new Spliterator<Entity>() {

--- a/patches/server/1007-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/1007-Fix-and-optimise-world-force-upgrading.patch
@@ -267,7 +267,7 @@ index 72d013d06705b08ed696e3d3b6d631d65800c2c9..61840cfd64caba6595dfc99c91c76a19
          Main.LOGGER.info("Forcing world upgrade! {}", session.getLevelId()); // CraftBukkit
          WorldUpgrader worldupgrader = new WorldUpgrader(session, dataFixer, dimensionOptionsRegistry, eraseCache);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a0972ad233ce1582fd4d054eba282d47ddbc10d3..18a3d611b141b79683af7241e3c0598320f27516 100644
+index 79de3c639795cfc0bd86f842446e2bb3ab71d23a..1dfafbe508b4e4598339f412e5fb9d92717b5d26 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -584,11 +584,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -298,10 +298,10 @@ index a0972ad233ce1582fd4d054eba282d47ddbc10d3..18a3d611b141b79683af7241e3c05983
  
              if (dimensionKey == LevelStem.OVERWORLD) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 6dafbbed864feebe73c648cf38cee6d64e9eea85..3805556aaef0a92fc043e9542876af897b1e3c3c 100644
+index 927c7948e567764e8cf75c7ce486e1ea6c9a8d87..7694b7f299495a084ce71c5d04e5e690a75fe55b 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -186,6 +186,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -181,6 +181,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public final Map<Explosion.CacheKey, Float> explosionDensityCache = new HashMap<>(); // Paper - Optimize explosions
      public java.util.ArrayDeque<net.minecraft.world.level.block.RedstoneTorchBlock.Toggle> redstoneUpdateInfos; // Paper - Faster redstone torch rapid clock removal; Move from Map in BlockRedstoneTorch to here
  
@@ -352,7 +352,7 @@ index 0db8ee3b640e6d1268e9c1cccda85459bd447105..42d37bee3a459adcd46408596ccf93ab
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8505a2925f368355ed7e8a3d1df651142e5c43b5..b83c2f1e0ea117eecda94cb51b0ea5bba4d7ab5e 100644
+index b8f05300a17d415505deb8da4a923357220ae1bd..4df3b94c8126f00188f5e125757411a0359728fa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1345,9 +1345,7 @@ public final class CraftServer implements Server {

--- a/patches/server/1008-Improved-Watchdog-Support.patch
+++ b/patches/server/1008-Improved-Watchdog-Support.patch
@@ -71,7 +71,7 @@ index 6f2452de76e8f5fcc1367066e0e753740764eb98..e047dee632022abfe05865d1e71838be
              cause = cause.getCause();
          }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b7e6533ab3eb0898b053b11ed782aaa503bdde58..e530f4b4a9f097e0a54b56d0f33a7d05a93c67f0 100644
+index 1dfafbe508b4e4598339f412e5fb9d92717b5d26..97826afb097851f5736a64ae154d42147de55648 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -296,7 +296,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -266,7 +266,7 @@ index 9e0c5bb92fb45cab7d78c5ad631c64170d48729f..6de6dad36203479677a29ad61e21bc36
      }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index b71d7714fbaa7d4493ccddf877c9668f25b104bf..0ce7ce1899ac4115051353fc3eb0c622846d6748 100644
+index d5908d63b6dd23279951f0691d55c660b3a788a8..cb81990877f918a5305478b5e8ac7dde6a78f238 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -612,7 +612,7 @@ public abstract class PlayerList {
@@ -291,10 +291,10 @@ index f5829ae484d93b547a5437b85a9621346384a11b..83701fbfaa56a232593ee8f11a3afb89
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 3805556aaef0a92fc043e9542876af897b1e3c3c..a7e9faed6873def24986d1d010b797b9c4999024 100644
+index 7694b7f299495a084ce71c5d04e5e690a75fe55b..9149ddd3d950d1616ec3c85d54c494bcc6501e83 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -940,6 +940,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -935,6 +935,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          try {
              tickConsumer.accept(entity);
          } catch (Throwable throwable) {

--- a/patches/server/1011-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/1011-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -25,10 +25,10 @@ index 34159798e6617ce13b3ac8aae07d24d9bca6ee36..f54219d2b973136ad00a0f03cbd99f6b
  
                              if (!this.level.isInWorldBounds(blockposition)) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index a7e9faed6873def24986d1d010b797b9c4999024..c07cfd8fdf056bb613ab5b64a58975d0ed9446ee 100644
+index 9149ddd3d950d1616ec3c85d54c494bcc6501e83..cb31b2f88e701dc9bb14ea5c568e4666f6cdc0b9 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -545,6 +545,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -540,6 +540,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean setBlock(BlockPos pos, BlockState state, int flags, int maxUpdateDepth) {
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {
@@ -40,7 +40,7 @@ index a7e9faed6873def24986d1d010b797b9c4999024..c07cfd8fdf056bb613ab5b64a58975d0
              if (blockstate == null) {
                  blockstate = CapturedBlockState.getTreeBlockState(this, pos, flags);
 diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
-index 63217d3db86b467f3358730eb8b9b3c941558bab..68b94b4ebd710f3ab18f397d9dfa0ef5b8f182e0 100644
+index 6896d46fce2e466ebee23ac2dc00312ec1beefdb..b60a52788e73de3dcb086c1a4628466b25c9d3ef 100644
 --- a/src/main/java/net/minecraft/world/level/block/Block.java
 +++ b/src/main/java/net/minecraft/world/level/block/Block.java
 @@ -90,6 +90,19 @@ public class Block extends BlockBehaviour implements ItemLike {
@@ -106,7 +106,7 @@ index 3dfe79684f662ac7cae4583bfe03a633438b4df7..be74adc86f0ca467f3b59e7b57fd47a8
  
              world.playSound((Player) null, pos, SoundEvents.PISTON_CONTRACT, SoundSource.BLOCKS, 0.5F, world.random.nextFloat() * 0.15F + 0.6F);
 diff --git a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
-index 4c6ab71c3222ce03edd70abef35c71398d885c13..7ba5d00516dc310355d08dda955c934fe26786ee 100644
+index e28ac8f7960f648099e5f3607530a406c72e5056..e493b34aa8726ed48f8e5db2ae8ea561cc5b1f75 100644
 --- a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 +++ b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 @@ -189,7 +189,7 @@ public abstract class BlockBehaviour implements FeatureElement {

--- a/patches/server/1015-Eigencraft-redstone-implementation.patch
+++ b/patches/server/1015-Eigencraft-redstone-implementation.patch
@@ -24,10 +24,10 @@ Co-authored-by: egg82 <phantom_zero@ymail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java b/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..22a2547810d0c029f29685faddf7ac21cde2df0b
+index 0000000000000000000000000000000000000000..fa062e6543e8a0377e3d4715996955dba005ee80
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java
-@@ -0,0 +1,957 @@
+@@ -0,0 +1,958 @@
 +package com.destroystokyo.paper.util;
 +
 +import java.util.List;
@@ -41,6 +41,7 @@ index 0000000000000000000000000000000000000000..22a2547810d0c029f29685faddf7ac21
 +import net.minecraft.world.level.block.Block;
 +import net.minecraft.world.level.block.RedStoneWireBlock;
 +import net.minecraft.world.level.block.state.BlockState;
++import org.bukkit.craftbukkit.block.CraftBlock;
 +import org.bukkit.event.block.BlockRedstoneEvent;
 +
 +import com.google.common.collect.Lists;
@@ -925,7 +926,7 @@ index 0000000000000000000000000000000000000000..22a2547810d0c029f29685faddf7ac21
 +        // egg82's amendment
 +        // Adding Bukkit's BlockRedstoneEvent - er.. event.
 +        if (i != j) {
-+            BlockRedstoneEvent event = new BlockRedstoneEvent(worldIn.getWorld().getBlockAt(upd.self.getX(), upd.self.getY(), upd.self.getZ()), i, j);
++            BlockRedstoneEvent event = new BlockRedstoneEvent(CraftBlock.at(worldIn, upd.self), i, j);
 +            worldIn.getCraftServer().getPluginManager().callEvent(event);
 +            j = event.getNewCurrent();
 +        }
@@ -986,7 +987,7 @@ index 0000000000000000000000000000000000000000..22a2547810d0c029f29685faddf7ac21
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
-index 7cc1410803c0054566ce2849e0b04b14e5b0ab92..5ffb1453bf332e8035abacc97ab36d78e1248484 100644
+index 7cc1410803c0054566ce2849e0b04b14e5b0ab92..c80af964a2b4026f738aecd2058a7e99d225cce0 100644
 --- a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 @@ -259,6 +259,116 @@ public class RedStoneWireBlock extends Block {
@@ -1085,7 +1086,7 @@ index 7cc1410803c0054566ce2849e0b04b14e5b0ab92..5ffb1453bf332e8035abacc97ab36d78
 +        }
 +
 +        if (i != j) {
-+            org.bukkit.event.block.BlockRedstoneEvent event = new org.bukkit.event.block.BlockRedstoneEvent(worldIn.getWorld().getBlockAt(pos1.getX(), pos1.getY(), pos1.getZ()), i, j);
++            org.bukkit.event.block.BlockRedstoneEvent event = new org.bukkit.event.block.BlockRedstoneEvent(org.bukkit.craftbukkit.block.CraftBlock.at(worldIn, pos1), i, j);
 +            worldIn.getCraftServer().getPluginManager().callEvent(event);
 +
 +            j = event.getNewCurrent();

--- a/patches/server/1018-Improve-boat-collision-performance.patch
+++ b/patches/server/1018-Improve-boat-collision-performance.patch
@@ -17,10 +17,10 @@ index edf937591abf62416bd692e40b7b7a6badbe877d..b40864e41e1506884fdefefbf3cf4833
      };
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 22771be445acd07d40b0a51c0a6d062e3df3ac95..fd35911a6057eed19e6b1a9cbefdfe9cd0cd998c 100644
+index 00bf8fb845f9230e8e01edbf202ffd208ff4cf8f..66e302f7a9d2b4dfe0a5b1c988c67f91f6ce0c98 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1437,7 +1437,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1436,7 +1436,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  if (!source.is(DamageTypeTags.IS_PROJECTILE)) {
                      Entity entity = source.getDirectEntity();
  
@@ -29,7 +29,7 @@ index 22771be445acd07d40b0a51c0a6d062e3df3ac95..fd35911a6057eed19e6b1a9cbefdfe9c
                          LivingEntity entityliving = (LivingEntity) entity;
  
                          this.blockUsingShield(entityliving);
-@@ -1531,11 +1531,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1530,11 +1530,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  }
  
                  if (entity1 != null && !source.is(DamageTypeTags.NO_KNOCKBACK)) {

--- a/patches/server/1021-Execute-chunk-tasks-mid-tick.patch
+++ b/patches/server/1021-Execute-chunk-tasks-mid-tick.patch
@@ -19,7 +19,7 @@ index 6b3cde6d4d1e63bec01f502f2027ee9fddac08aa..46449728f69ee7d4f78470f8da23c055
  
      private MinecraftTimings() {}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e530f4b4a9f097e0a54b56d0f33a7d05a93c67f0..6498e05e45468979bc5140e54920ed9c528c19bd 100644
+index 97826afb097851f5736a64ae154d42147de55648..d2526c39c91dd62ad676f04afc45332d774528d1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1357,8 +1357,79 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -151,10 +151,10 @@ index f24734f2a38eb5f2dc39f418a1f506a600127a79..3535f86b92c4e61fd84defbbf37e0746
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index c07cfd8fdf056bb613ab5b64a58975d0ed9446ee..e221fe55d6ec5e77a82d33570a2ac1a77c221112 100644
+index cb31b2f88e701dc9bb14ea5c568e4666f6cdc0b9..43052e3194812fe8d7aa6569c1c1c49d8ba25446 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -929,6 +929,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -924,6 +924,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  // Spigot end
              } else if (flag && this.shouldTickBlocksAt(tickingblockentity.getPos())) {
                  tickingblockentity.tick();
@@ -166,7 +166,7 @@ index c07cfd8fdf056bb613ab5b64a58975d0ed9446ee..e221fe55d6ec5e77a82d33570a2ac1a7
              }
          }
          this.blockEntityTickers.removeAll(toRemove); // Paper - Fix MC-117075
-@@ -943,6 +948,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -938,6 +943,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public <T extends Entity> void guardEntityTick(Consumer<T> tickConsumer, T entity) {
          try {
              tickConsumer.accept(entity);

--- a/patches/server/1022-Optimise-random-block-ticking.patch
+++ b/patches/server/1022-Optimise-random-block-ticking.patch
@@ -311,7 +311,7 @@ index b7a3f15dc1ed9e9322a86921052984c7cbd3262a..f8de91393564b3691c17339ac9196cc0
      public void getAll(IntConsumer action) {
          for(int i = 0; i < this.size; ++i) {
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Turtle.java b/src/main/java/net/minecraft/world/entity/animal/Turtle.java
-index 1a2a4dcb3cfa2690f2aa936a6c176319d807bd74..f97bdfbd07db000845d3b791de64056c3c23f7ba 100644
+index 379990c0ea9d10fd3c627ffff2198cb554780eb0..d595f1590619b24d460fc2c10a5412844f62cba0 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Turtle.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Turtle.java
 @@ -87,7 +87,7 @@ public class Turtle extends Animal {
@@ -324,10 +324,10 @@ index 1a2a4dcb3cfa2690f2aa936a6c176319d807bd74..f97bdfbd07db000845d3b791de64056c
  
      public BlockPos getHomePos() {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index e221fe55d6ec5e77a82d33570a2ac1a77c221112..fd3828d2074c7e369dbea6a25d9bac436f624750 100644
+index 43052e3194812fe8d7aa6569c1c1c49d8ba25446..1712cf22d987a87c427f042a89a9fff90203b079 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1400,10 +1400,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1395,10 +1395,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public abstract RecipeManager getRecipeManager();
  
      public BlockPos getBlockRandomPos(int x, int y, int z, int l) {

--- a/patches/server/1026-Collision-optimisations.patch
+++ b/patches/server/1026-Collision-optimisations.patch
@@ -2201,7 +2201,7 @@ index 803ed79940af00b49aec4b1414ddfacb57ff4f3f..569dbd5a1479b41b2604aacd351bf6d3
              }
          }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0ce7ce1899ac4115051353fc3eb0c622846d6748..0dd44f3625ca9383f22e4862ad3e92452e26befd 100644
+index cb81990877f918a5305478b5e8ac7dde6a78f238..4816897a82c569717bf7ea139a55ab3fd931a63e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -935,7 +935,7 @@ public abstract class PlayerList {
@@ -2214,7 +2214,7 @@ index 0ce7ce1899ac4115051353fc3eb0c622846d6748..0dd44f3625ca9383f22e4862ad3e9245
              entityplayer1.setPos(entityplayer1.getX(), entityplayer1.getY() + 1.0D, entityplayer1.getZ());
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a6685b3f845aa08bf14fda63d66ce98e51e67678..2c06f3ebf7e1069727387bfc60db30c958c14b5a 100644
+index bea396af243ad6c8649832587d9c443afe84bb92..9ee1e3da1cb16291ff3e37829e25227a6b97a177 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1238,9 +1238,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
@@ -2613,10 +2613,10 @@ index cc888bbcd6a50124fa553bc4a8ffd1e8885d3856..f42dd9602805e9d538506ee4e3eac7e2
  
      // Paper start - Affects Spawning API
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index fd3828d2074c7e369dbea6a25d9bac436f624750..d5ccc0e74397359fbcd2907dbf9249eca0fd5acf 100644
+index 1712cf22d987a87c427f042a89a9fff90203b079..f21f1b3fcab47f18cbf26a9797b1b7b9a5dccfc9 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -299,6 +299,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -294,6 +294,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.entityLimiter = new org.spigotmc.TickLimiter(this.spigotConfig.entityMaxTickTime);
          this.tileLimiter = new org.spigotmc.TickLimiter(this.spigotConfig.tileMaxTickTime);
          this.chunkPacketBlockController = this.paperConfig().anticheat.antiXray.enabled ? new com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray(this, executor) : com.destroystokyo.paper.antixray.ChunkPacketBlockController.NO_OPERATION_INSTANCE; // Paper - Anti-Xray
@@ -2627,7 +2627,7 @@ index fd3828d2074c7e369dbea6a25d9bac436f624750..d5ccc0e74397359fbcd2907dbf9249ec
      }
  
      // Paper start - Cancel hit for vanished players
-@@ -340,6 +344,366 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -335,6 +339,366 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return true;
      }
      // Paper end - Cancel hit for vanished players
@@ -2994,7 +2994,7 @@ index fd3828d2074c7e369dbea6a25d9bac436f624750..d5ccc0e74397359fbcd2907dbf9249ec
      @Override
      public boolean isClientSide() {
          return this.isClientSide;
-@@ -963,7 +1327,17 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -958,7 +1322,17 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      @Override
      public boolean noCollision(@Nullable Entity entity, AABB box) {
          if (entity instanceof net.minecraft.world.entity.decoration.ArmorStand && !entity.level().paperConfig().entities.armorStands.doCollisionEntityLookups) return false;
@@ -3014,7 +3014,7 @@ index fd3828d2074c7e369dbea6a25d9bac436f624750..d5ccc0e74397359fbcd2907dbf9249ec
      // Paper end - Option to prevent armor stands from doing entity lookups
  
 diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
-index 68b94b4ebd710f3ab18f397d9dfa0ef5b8f182e0..73d6f881a7d4d8ff96040d34ac502e5b0937d577 100644
+index b60a52788e73de3dcb086c1a4628466b25c9d3ef..22036ed3ea0629bc12981a8d91a03e55cc2117d6 100644
 --- a/src/main/java/net/minecraft/world/level/block/Block.java
 +++ b/src/main/java/net/minecraft/world/level/block/Block.java
 @@ -284,7 +284,7 @@ public class Block extends BlockBehaviour implements ItemLike {
@@ -3027,7 +3027,7 @@ index 68b94b4ebd710f3ab18f397d9dfa0ef5b8f182e0..73d6f881a7d4d8ff96040d34ac502e5b
  
      public boolean propagatesSkylightDown(BlockState state, BlockGetter world, BlockPos pos) {
 diff --git a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
-index 7ba5d00516dc310355d08dda955c934fe26786ee..97a9fbbe6d8435e88e5fe716770e4034ab0db7a7 100644
+index e493b34aa8726ed48f8e5db2ae8ea561cc5b1f75..2892e586146cbc560f0bcf4b9af6d0575cb0a82e 100644
 --- a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 +++ b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 @@ -882,6 +882,10 @@ public abstract class BlockBehaviour implements FeatureElement {

--- a/patches/server/1027-Optimise-collision-checking-in-player-move-packet-ha.patch
+++ b/patches/server/1027-Optimise-collision-checking-in-player-move-packet-ha.patch
@@ -8,10 +8,10 @@ Move collision logic to just the hasNewCollision call instead of getCubes + hasN
 CHECK ME
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 58788d9fb5033a288454ce9b52c7efa71c603a09..cd5730de05a7fac186875e97721c53dab3b7695f 100644
+index fa70d470327e307909cb17467f39f4596909f364..500cbbfe02cddfdcfb7f8d5ae9cf70c9b55d284f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -553,7 +553,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -552,7 +552,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      return;
                  }
  
@@ -20,7 +20,7 @@ index 58788d9fb5033a288454ce9b52c7efa71c603a09..cd5730de05a7fac186875e97721c53da
  
                  d6 = d3 - this.vehicleLastGoodX; // Paper - diff on change, used for checking large move vectors above
                  d7 = d4 - this.vehicleLastGoodY - 1.0E-6D; // Paper - diff on change, used for checking large move vectors above
-@@ -569,6 +569,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -568,6 +568,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  }
  
                  entity.move(MoverType.PLAYER, new Vec3(d6, d7, d8));
@@ -28,7 +28,7 @@ index 58788d9fb5033a288454ce9b52c7efa71c603a09..cd5730de05a7fac186875e97721c53da
                  double d11 = d7;
  
                  d6 = d3 - entity.getX();
-@@ -582,15 +583,23 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -581,15 +582,23 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  boolean flag2 = false;
  
                  if (d10 > org.spigotmc.SpigotConfig.movedWronglyThreshold) { // Spigot
@@ -55,7 +55,7 @@ index 58788d9fb5033a288454ce9b52c7efa71c603a09..cd5730de05a7fac186875e97721c53da
                      entity.absMoveTo(d0, d1, d2, f, f1);
                      this.player.absMoveTo(d0, d1, d2, this.player.getYRot(), this.player.getXRot()); // CraftBukkit
                      this.send(new ClientboundMoveVehiclePacket(entity));
-@@ -669,7 +678,32 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -668,7 +677,32 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      }
  
      private boolean noBlocksAround(Entity entity) {
@@ -89,7 +89,7 @@ index 58788d9fb5033a288454ce9b52c7efa71c603a09..cd5730de05a7fac186875e97721c53da
      }
  
      @Override
-@@ -1282,7 +1316,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1281,7 +1315,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  }
  
                  if (this.awaitingPositionFromClient != null) {
@@ -98,7 +98,7 @@ index 58788d9fb5033a288454ce9b52c7efa71c603a09..cd5730de05a7fac186875e97721c53da
                          this.awaitingTeleportTime = this.tickCount;
                          this.teleport(this.awaitingPositionFromClient.x, this.awaitingPositionFromClient.y, this.awaitingPositionFromClient.z, this.player.getYRot(), this.player.getXRot());
                      }
-@@ -1389,7 +1423,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1388,7 +1422,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  }
                              }
  
@@ -107,7 +107,7 @@ index 58788d9fb5033a288454ce9b52c7efa71c603a09..cd5730de05a7fac186875e97721c53da
  
                              d6 = d0 - this.lastGoodX; // Paper - diff on change, used for checking large move vectors above
                              d7 = d1 - this.lastGoodY; // Paper - diff on change, used for checking large move vectors above
-@@ -1431,6 +1465,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1430,6 +1464,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              this.player.move(MoverType.PLAYER, new Vec3(d6, d7, d8));
                              this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move
@@ -115,7 +115,7 @@ index 58788d9fb5033a288454ce9b52c7efa71c603a09..cd5730de05a7fac186875e97721c53da
                              // Paper start - prevent position desync
                              if (this.awaitingPositionFromClient != null) {
                                  return; // ... thanks Mojang for letting move calls teleport across dimensions.
-@@ -1459,7 +1494,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1458,7 +1493,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  }
                              }
  
@@ -134,7 +134,7 @@ index 58788d9fb5033a288454ce9b52c7efa71c603a09..cd5730de05a7fac186875e97721c53da
                              if (teleportBack) {
                                  io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.CLIPPED_INTO_BLOCK,
                                      toX, toY, toZ, toYaw, toPitch, false);
-@@ -1559,6 +1604,33 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1558,6 +1603,33 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
      }
  

--- a/patches/server/1030-Add-Alternate-Current-redstone-implementation.patch
+++ b/patches/server/1030-Add-Alternate-Current-redstone-implementation.patch
@@ -22,12 +22,13 @@ Alternate Current's wire handler.
 
 diff --git a/src/main/java/alternate/current/wire/LevelHelper.java b/src/main/java/alternate/current/wire/LevelHelper.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f55c5c67b8461e9ef5614ea1a37f6e2866f39be3
+index 0000000000000000000000000000000000000000..7d60b8b6dd7f3a2878e75c78f329bc4158c80aec
 --- /dev/null
 +++ b/src/main/java/alternate/current/wire/LevelHelper.java
-@@ -0,0 +1,65 @@
+@@ -0,0 +1,66 @@
 +package alternate.current.wire;
 +
++import org.bukkit.craftbukkit.block.CraftBlock;
 +import org.bukkit.event.block.BlockRedstoneEvent;
 +
 +import net.minecraft.core.BlockPos;
@@ -41,7 +42,7 @@ index 0000000000000000000000000000000000000000..f55c5c67b8461e9ef5614ea1a37f6e28
 +public class LevelHelper {
 +
 +    static int doRedstoneEvent(ServerLevel level, BlockPos pos, int prevPower, int newPower) {
-+        BlockRedstoneEvent event = new BlockRedstoneEvent(level.getWorld().getBlockAt(pos.getX(), pos.getY(), pos.getZ()), prevPower, newPower);
++        BlockRedstoneEvent event = new BlockRedstoneEvent(CraftBlock.at(level, pos), prevPower, newPower);
 +        level.getCraftServer().getPluginManager().callEvent(event);
 +
 +        return event.getNewCurrent();
@@ -2034,10 +2035,10 @@ index 5eaf8585df1f885f4a08fdd06ff4bb730961e400..ab2e84f85da7931e133ad5f0d2686cd1
  
          EntityCallbacks() {}
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index d5ccc0e74397359fbcd2907dbf9249eca0fd5acf..8f437225d2a4e08ca47873cd42277d9f0f9f5529 100644
+index f21f1b3fcab47f18cbf26a9797b1b7b9a5dccfc9..19f23a6c8fb5c02843c27fb8a242ec9d0d1b538b 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1892,4 +1892,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1887,4 +1887,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return ret;
      }
      // Paper end
@@ -2053,7 +2054,7 @@ index d5ccc0e74397359fbcd2907dbf9249eca0fd5acf..8f437225d2a4e08ca47873cd42277d9f
 +    // Paper end - optimize redstone (Alternate Current)
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
-index 5ffb1453bf332e8035abacc97ab36d78e1248484..7339795addfeaedc3c8a7db03f73546fb5fba06b 100644
+index c80af964a2b4026f738aecd2058a7e99d225cce0..b5a71fd4e2f55bf036c2c697da5d50cc90fc657c 100644
 --- a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 @@ -259,7 +259,7 @@ public class RedStoneWireBlock extends Block {

--- a/patches/server/1032-Properly-resend-entities.patch
+++ b/patches/server/1032-Properly-resend-entities.patch
@@ -92,10 +92,10 @@ index 07a362f9e485d0d507f16f1dda1ac84ade07ab27..58b602e550258c1062ee940bc46538da
      public static class DataItem<T> {
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 97490f58aace9bfb6d034e9a97393142f73043d1..83e017efd15d0ecaffc327f02d6d5330c8ed6937 100644
+index 692a01b52a71e26887ee42cbd5fd64b0a81bfc99..ef3048a4748113538a0ee0af5b526b2cd51d5c29 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -563,6 +563,7 @@ public class ServerPlayerGameMode {
+@@ -561,6 +561,7 @@ public class ServerPlayerGameMode {
              }
              // Paper end - extend Player Interact cancellation
              player.getBukkitEntity().updateInventory(); // SPIGOT-2867
@@ -103,7 +103,7 @@ index 97490f58aace9bfb6d034e9a97393142f73043d1..83e017efd15d0ecaffc327f02d6d5330
              enuminteractionresult = (event.useItemInHand() != Event.Result.ALLOW) ? InteractionResult.SUCCESS : InteractionResult.PASS;
          } else if (this.gameModeForPlayer == GameType.SPECTATOR) {
              MenuProvider itileinventory = iblockdata.getMenuProvider(world, blockposition);
-@@ -606,6 +607,11 @@ public class ServerPlayerGameMode {
+@@ -604,6 +605,11 @@ public class ServerPlayerGameMode {
  
                  return enuminteractionresult1;
              }
@@ -116,10 +116,10 @@ index 97490f58aace9bfb6d034e9a97393142f73043d1..83e017efd15d0ecaffc327f02d6d5330
          return enuminteractionresult;
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index cd5730de05a7fac186875e97721c53dab3b7695f..8ca5d7c1bfacb1b47aa680eee167af08d0396ae0 100644
+index 500cbbfe02cddfdcfb7f8d5ae9cf70c9b55d284f..2562ea3b63b055319a775c12ff327d127f8039c3 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1990,6 +1990,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1989,6 +1989,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              }
  
              if (cancelled) {
@@ -127,7 +127,7 @@ index cd5730de05a7fac186875e97721c53dab3b7695f..8ca5d7c1bfacb1b47aa680eee167af08
                  this.player.getBukkitEntity().updateInventory(); // SPIGOT-2524
                  return;
              }
-@@ -2704,7 +2705,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2703,7 +2704,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              // Entity in bucket - SPIGOT-4048 and SPIGOT-6859a
                              if ((entity instanceof Bucketable && entity instanceof LivingEntity && origItem != null && origItem.asItem() == Items.WATER_BUCKET) && (event.isCancelled() || ServerGamePacketListenerImpl.this.player.getInventory().getSelected() == null || ServerGamePacketListenerImpl.this.player.getInventory().getSelected().getItem() != origItem)) {
@@ -137,7 +137,7 @@ index cd5730de05a7fac186875e97721c53dab3b7695f..8ca5d7c1bfacb1b47aa680eee167af08
                              }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0dd44f3625ca9383f22e4862ad3e92452e26befd..e0ee45036b9bf14a6e2013fe291cde0402b85b1f 100644
+index 4816897a82c569717bf7ea139a55ab3fd931a63e..91feb12732564c90656da487664dbc12e55397fc 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -390,7 +390,7 @@ public abstract class PlayerList {
@@ -150,7 +150,7 @@ index 0dd44f3625ca9383f22e4862ad3e92452e26befd..e0ee45036b9bf14a6e2013fe291cde04
          this.sendLevelInfo(player, worldserver1);
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index fd35911a6057eed19e6b1a9cbefdfe9cd0cd998c..a4217f984148b12960c74ad2ef7cee761f305030 100644
+index 66e302f7a9d2b4dfe0a5b1c988c67f91f6ce0c98..3c517a82ac15a96f6be449a2422d5c9e894091a5 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3822,6 +3822,11 @@ public abstract class LivingEntity extends Entity implements Attackable {

--- a/patches/server/1033-Optimize-Hoppers.patch
+++ b/patches/server/1033-Optimize-Hoppers.patch
@@ -50,17 +50,17 @@ index 0000000000000000000000000000000000000000..5c42823726e70ce6c9d0121d07431548
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 6498e05e45468979bc5140e54920ed9c528c19bd..a7fb5d121a9fd59d5a3951075e975533721cb87f 100644
+index d2526c39c91dd62ad676f04afc45332d774528d1..f12bf36a247a47b8d831536a4fefd2a2ce424494 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1691,6 +1691,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
-         while (iterator.hasNext()) {
+@@ -1692,6 +1692,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              ServerLevel worldserver = (ServerLevel) iterator.next();
-             worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
-+            net.minecraft.world.level.block.entity.HopperBlockEntity.skipHopperEvents = worldserver.paperConfig().hopper.disableMoveEvent || org.bukkit.event.inventory.InventoryMoveItemEvent.getHandlerList().getRegisteredListeners().length == 0; // Paper - Perf: Optimize Hoppers
+             worldserver.hasPhysicsEvent = org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
              worldserver.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - Add EntityMoveEvent
++            net.minecraft.world.level.block.entity.HopperBlockEntity.skipHopperEvents = worldserver.paperConfig().hopper.disableMoveEvent || org.bukkit.event.inventory.InventoryMoveItemEvent.getHandlerList().getRegisteredListeners().length == 0; // Paper - Perf: Optimize Hoppers
  
              this.profiler.push(() -> {
+                 return worldserver + " " + worldserver.dimension().location();
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
 index 2470acc82292bedd930be404a2e1d1f8fad700e1..ed27a963223bfe18310ad5adabf461b5e307ef9c 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java

--- a/patches/server/1037-Lag-compensation-ticks.patch
+++ b/patches/server/1037-Lag-compensation-ticks.patch
@@ -8,7 +8,7 @@ Areas affected by lag comepnsation:
  - Eating food items
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a7fb5d121a9fd59d5a3951075e975533721cb87f..90ae7e8c81f6a9ede8aeaeec3bf784023522cefc 100644
+index f12bf36a247a47b8d831536a4fefd2a2ce424494..d06185566b447c432d4dc2e3ba04d121bcdbc71b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -311,6 +311,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -19,14 +19,14 @@ index a7fb5d121a9fd59d5a3951075e975533721cb87f..90ae7e8c81f6a9ede8aeaeec3bf78402
  
      public static <S extends MinecraftServer> S spin(Function<Thread, S> serverFactory) {
          AtomicReference<S> atomicreference = new AtomicReference();
-@@ -1690,6 +1691,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
-         Iterator iterator = this.getAllLevels().iterator(); // Paper - Throw exception on world create while being ticked; move down
-         while (iterator.hasNext()) {
-             ServerLevel worldserver = (ServerLevel) iterator.next();
-+            worldserver.updateLagCompensationTick(); // Paper - lag compensation
-             worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
-             net.minecraft.world.level.block.entity.HopperBlockEntity.skipHopperEvents = worldserver.paperConfig().hopper.disableMoveEvent || org.bukkit.event.inventory.InventoryMoveItemEvent.getHandlerList().getRegisteredListeners().length == 0; // Paper - Perf: Optimize Hoppers
+@@ -1693,6 +1694,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+             worldserver.hasPhysicsEvent = org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
              worldserver.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - Add EntityMoveEvent
+             net.minecraft.world.level.block.entity.HopperBlockEntity.skipHopperEvents = worldserver.paperConfig().hopper.disableMoveEvent || org.bukkit.event.inventory.InventoryMoveItemEvent.getHandlerList().getRegisteredListeners().length == 0; // Paper - Perf: Optimize Hoppers
++            worldserver.updateLagCompensationTick(); // Paper - lag compensation
+ 
+             this.profiler.push(() -> {
+                 return worldserver + " " + worldserver.dimension().location();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
 index ab2e84f85da7931e133ad5f0d2686cd1738f6ea1..5bbfb1af24e13a9e6a02ad8c36bb504a17f06398 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
@@ -50,7 +50,7 @@ index ab2e84f85da7931e133ad5f0d2686cd1738f6ea1..5bbfb1af24e13a9e6a02ad8c36bb504a
      // Add env and gen to constructor, IWorldDataServer -> WorldDataServer
      public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, PrimaryLevelData iworlddataserver, ResourceKey<Level> resourcekey, LevelStem worlddimension, ChunkProgressListener worldloadlistener, boolean flag, long i, List<CustomSpawner> list, boolean flag1, @Nullable RandomSequences randomsequences, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 83e017efd15d0ecaffc327f02d6d5330c8ed6937..cfd4ac06a9af6bf3fac293110482e1df690e075e 100644
+index ef3048a4748113538a0ee0af5b526b2cd51d5c29..a7b217ddbcbf92513bd38101fdfca2075505e267 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -124,7 +124,7 @@ public class ServerPlayerGameMode {
@@ -63,7 +63,7 @@ index 83e017efd15d0ecaffc327f02d6d5330c8ed6937..cfd4ac06a9af6bf3fac293110482e1df
  
          if (this.hasDelayedDestroy) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a4217f984148b12960c74ad2ef7cee761f305030..6071451339080bbdd98fb634791a56988984c8bc 100644
+index 3c517a82ac15a96f6be449a2422d5c9e894091a5..b9a7b9049b21eb81175168ec75f2446328a2c039 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3827,6 +3827,10 @@ public abstract class LivingEntity extends Entity implements Attackable {


### PR DESCRIPTION
This is a small cleanup of the events (mostly paper ones) with some redundant stuff that comes often when reviewing event pr (like annotating the constructor as Internal, formatting etc.). The server changes is just an update to use the right methods that probably didn't exists yet at the time the event was made and some other minor things.