### PR TITLE
Fix WaterBottleSplashEvent not forwarding hit result

### DIFF
--- a/patches/api/0297-Add-WaterBottleSplashEvent.patch
+++ b/patches/api/0297-Add-WaterBottleSplashEvent.patch
@@ -6,21 +6,25 @@ Subject: [PATCH] Add WaterBottleSplashEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/WaterBottleSplashEvent.java b/src/main/java/io/papermc/paper/event/entity/WaterBottleSplashEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..749d37256b9298fe866852e2d00cee99d8079f07
+index 0000000000000000000000000000000000000000..362afc28190dd6f0ed0407273f2be1aab73bb8f5
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/WaterBottleSplashEvent.java
-@@ -0,0 +1,130 @@
+@@ -0,0 +1,137 @@
 +package io.papermc.paper.event.entity;
 +
 +import java.util.Collection;
 +import java.util.Map;
 +import java.util.Set;
 +import java.util.stream.Collectors;
++import org.bukkit.block.Block;
++import org.bukkit.block.BlockFace;
++import org.bukkit.entity.Entity;
 +import org.bukkit.entity.LivingEntity;
 +import org.bukkit.entity.ThrownPotion;
 +import org.bukkit.event.entity.PotionSplashEvent;
 +import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
 +import org.jetbrains.annotations.Unmodifiable;
 +
 +/**
@@ -35,11 +39,14 @@ index 0000000000000000000000000000000000000000..749d37256b9298fe866852e2d00cee99
 +    @ApiStatus.Internal
 +    public WaterBottleSplashEvent(
 +        final @NotNull ThrownPotion potion,
++        final @Nullable Entity hitEntity,
++        final @Nullable Block hitBlock,
++        final @Nullable BlockFace hitFace,
 +        final @NotNull Map<LivingEntity, Double> affectedEntities,
 +        final @NotNull Set<LivingEntity> rehydrate,
 +        final @NotNull Set<LivingEntity> extinguish
 +    ) {
-+        super(potion, affectedEntities);
++        super(potion, hitEntity, hitBlock, hitFace, affectedEntities);
 +        this.rehydrate = rehydrate;
 +        this.extinguish = extinguish;
 +    }

--- a/patches/server/0585-Fix-potions-splash-events.patch
+++ b/patches/server/0585-Fix-potions-splash-events.patch
@@ -8,7 +8,7 @@ Fixes SPIGOT-6221: https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-6
 Fix splash events cancellation that still show particles/sound
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
-index b87077c47a0131c5f4ca085b6b32e657043a9e1a..bb116b0c75a311d0dc65c032a7727598890ef942 100644
+index b87077c47a0131c5f4ca085b6b32e657043a9e1a..77235314f4ccc28255b98f2bb52f553fe93313f3 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 @@ -105,56 +105,77 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
@@ -19,7 +19,7 @@ index b87077c47a0131c5f4ca085b6b32e657043a9e1a..bb116b0c75a311d0dc65c032a7727598
  
              if (flag) {
 -                this.applyWater();
-+                showParticles = this.applyWater(); // Paper - Fix potions splash events
++                showParticles = this.applyWater(hitResult); // Paper - Fix potions splash events
              } else if (true || !list.isEmpty()) { // CraftBukkit - Call event even if no effects to apply
                  if (this.isLingering()) {
 -                    this.makeAreaOfEffectCloud(itemstack, potionregistry, hitResult); // CraftBukkit - Pass MovingObjectPosition
@@ -41,7 +41,7 @@ index b87077c47a0131c5f4ca085b6b32e657043a9e1a..bb116b0c75a311d0dc65c032a7727598
  
 -    private void applyWater() {
 +    private static final Predicate<net.minecraft.world.entity.LivingEntity> APPLY_WATER_GET_ENTITIES_PREDICATE = ThrownPotion.WATER_SENSITIVE_OR_ON_FIRE.or(Axolotl.class::isInstance); // Paper - Fix potions splash events
-+    private boolean applyWater() { // Paper - Fix potions splash events
++    private boolean applyWater(@Nullable HitResult hitResult) { // Paper - Fix potions splash events
          AABB axisalignedbb = this.getBoundingBox().inflate(4.0D, 2.0D, 4.0D);
 -        List<net.minecraft.world.entity.LivingEntity> list = this.level().getEntitiesOfClass(net.minecraft.world.entity.LivingEntity.class, axisalignedbb, ThrownPotion.WATER_SENSITIVE_OR_ON_FIRE);
 +        // Paper start - Fix potions splash events
@@ -78,10 +78,10 @@ index b87077c47a0131c5f4ca085b6b32e657043a9e1a..bb116b0c75a311d0dc65c032a7727598
 -            Axolotl axolotl = (Axolotl) iterator1.next();
 -
 -            axolotl.rehydrate();
-+        io.papermc.paper.event.entity.WaterBottleSplashEvent event = new io.papermc.paper.event.entity.WaterBottleSplashEvent(
-+            (org.bukkit.entity.ThrownPotion) this.getBukkitEntity(), affected, rehydrate, extinguish
++        io.papermc.paper.event.entity.WaterBottleSplashEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callWaterBottleSplashEvent(
++            this, hitResult, affected, rehydrate, extinguish
 +        );
-+        if (event.callEvent()) {
++        if (!event.isCancelled()) {
 +            for (LivingEntity affectedEntity : event.getToDamage()) {
 +                ((CraftLivingEntity) affectedEntity).getHandle().hurt(this.damageSources().indirectMagic(this, this.getOwner()), 1.0F);
 +            }
@@ -153,3 +153,40 @@ index b87077c47a0131c5f4ca085b6b32e657043a9e1a..bb116b0c75a311d0dc65c032a7727598
      }
  
      public boolean isLingering() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 64d27612d21d44950ba12be69aa6bfa339fef39c..833011c1f1746e000adc72ab092295fd4fab2ab8 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -874,6 +874,32 @@ public class CraftEventFactory {
+         return event;
+     }
+ 
++    // Paper start - Fix potions splash events
++    public static io.papermc.paper.event.entity.WaterBottleSplashEvent callWaterBottleSplashEvent(net.minecraft.world.entity.projectile.ThrownPotion potion, @Nullable HitResult hitResult, Map<LivingEntity, Double> affectedEntities, java.util.Set<LivingEntity> rehydrate, java.util.Set<LivingEntity> extinguish) {
++        ThrownPotion thrownPotion = (ThrownPotion) potion.getBukkitEntity();
++
++        Block hitBlock = null;
++        BlockFace hitFace = null;
++        org.bukkit.entity.Entity hitEntity = null;
++
++        if (hitResult != null) {
++            if (hitResult.getType() == HitResult.Type.BLOCK) {
++                BlockHitResult blockHitResult = (BlockHitResult) hitResult;
++                hitBlock = CraftBlock.at(potion.level(), blockHitResult.getBlockPos());
++                hitFace = CraftBlock.notchToBlockFace(blockHitResult.getDirection());
++            } else if (hitResult.getType() == HitResult.Type.ENTITY) {
++                hitEntity = ((EntityHitResult) hitResult).getEntity().getBukkitEntity();
++            }
++        }
++
++        io.papermc.paper.event.entity.WaterBottleSplashEvent event = new io.papermc.paper.event.entity.WaterBottleSplashEvent(
++            thrownPotion, hitEntity, hitBlock, hitFace, affectedEntities, rehydrate, extinguish
++        );
++        event.callEvent();
++        return event;
++    }
++    // Paper end - Fix potions splash events
++
+     /**
+      * BlockFadeEvent
+      */

--- a/patches/server/0624-Add-critical-damage-API.patch
+++ b/patches/server/0624-Add-critical-damage-API.patch
@@ -71,10 +71,10 @@ index 0e1d4bd6f70e439b33eca57bf06e9e090825f58a..5f75e54cde19614461dd8375ded1d6b3
          int k = entity.getRemainingFireTicks();
          boolean flag1 = entity.getType().is(EntityTypeTags.DEFLECTS_ARROWS);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 64d27612d21d44950ba12be69aa6bfa339fef39c..32d3588431ece0e11e52dd332904609a045fa3ef 100644
+index 833011c1f1746e000adc72ab092295fd4fab2ab8..bc5966ced62aeeed784077517658d7f28550c449 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1043,7 +1043,7 @@ public class CraftEventFactory {
+@@ -1069,7 +1069,7 @@ public class CraftEventFactory {
                  } else {
                      damageCause = DamageCause.ENTITY_EXPLOSION;
                  }
@@ -83,7 +83,7 @@ index 64d27612d21d44950ba12be69aa6bfa339fef39c..32d3588431ece0e11e52dd332904609a
              }
              event.setCancelled(cancelled);
  
-@@ -1075,7 +1075,7 @@ public class CraftEventFactory {
+@@ -1101,7 +1101,7 @@ public class CraftEventFactory {
                  cause = DamageCause.SONIC_BOOM;
              }
  
@@ -92,7 +92,7 @@ index 64d27612d21d44950ba12be69aa6bfa339fef39c..32d3588431ece0e11e52dd332904609a
          } else if (source.is(DamageTypes.FELL_OUT_OF_WORLD)) {
              EntityDamageEvent event = new EntityDamageByBlockEvent(null, entity.getBukkitEntity(), DamageCause.VOID, modifiers, modifierFunctions);
              event.setCancelled(cancelled);
-@@ -1145,7 +1145,7 @@ public class CraftEventFactory {
+@@ -1171,7 +1171,7 @@ public class CraftEventFactory {
              } else {
                  throw new IllegalStateException(String.format("Unhandled damage of %s by %s from %s", entity, damager.getHandle(), source.getMsgId()));
              }
@@ -101,7 +101,7 @@ index 64d27612d21d44950ba12be69aa6bfa339fef39c..32d3588431ece0e11e52dd332904609a
              event.setCancelled(cancelled);
              CraftEventFactory.callEvent(event);
              if (!event.isCancelled()) {
-@@ -1194,20 +1194,28 @@ public class CraftEventFactory {
+@@ -1220,20 +1220,28 @@ public class CraftEventFactory {
          }
  
          if (cause != null) {

--- a/patches/server/0720-More-Projectile-API.patch
+++ b/patches/server/0720-More-Projectile-API.patch
@@ -20,7 +20,7 @@ public net.minecraft.world.entity.projectile.Projectile canHitEntity(Lnet/minecr
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
-index bb116b0c75a311d0dc65c032a7727598890ef942..bc003f35251c119db095b73c951bf03d8cb7ba8c 100644
+index 77235314f4ccc28255b98f2bb52f553fe93313f3..5f316b09fb914ccb0782efe521ad85727f5dd02f 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 @@ -100,6 +100,11 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
@@ -30,7 +30,7 @@ index bb116b0c75a311d0dc65c032a7727598890ef942..bc003f35251c119db095b73c951bf03d
 +        // Paper start - More projectile API
 +        this.splash(hitResult);
 +    }
-+    public void splash(@org.jetbrains.annotations.Nullable HitResult hitResult) {
++    public void splash(@Nullable HitResult hitResult) {
 +        // Paper end - More projectile API
          if (!this.level().isClientSide) {
              ItemStack itemstack = this.getItem();
@@ -509,7 +509,7 @@ index 20f9735c7cb76024e15dbdca7684f5c560876175..8a6af0db8e0aa0cffbf19584be747076
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 25133298b26523bd36300ab03e216200c915386b..af7e3acde2eb521ac809b4c5980ff6adb30c7135 100644
+index bc5966ced62aeeed784077517658d7f28550c449..1514eb294a2e191abb3afe7374c24b351a202c04 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -831,19 +831,19 @@ public class CraftEventFactory {

--- a/patches/server/0729-Fix-new-block-data-for-EntityChangeBlockEvent.patch
+++ b/patches/server/0729-Fix-new-block-data-for-EntityChangeBlockEvent.patch
@@ -131,7 +131,7 @@ index 6f452605e9dc9ebd9980eae9fdeea34417a37a88..2c60a3765d22909e73b660492410ab84
                                  }
                                  // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
-index bc003f35251c119db095b73c951bf03d8cb7ba8c..aaed936c7b6a6ebcd69c8c51f5c92c3b1c51ec27 100644
+index aa523ba36c975e6ac92544ee14d7904f35789bec..efe2095063fd402ed645d711611d85bc3753a5b8 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 @@ -306,7 +306,7 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
@@ -196,10 +196,10 @@ index 61abbcfe97e3d3e3da5ee658672549d14594ad17..05e14322e519d1399e87beb532e1cc4a
              }
              // CraftBukkit end
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index af7e3acde2eb521ac809b4c5980ff6adb30c7135..52a4a2b90f5b4684ffb94bf1db6020490e14942d 100644
+index fb39bae1a76739cdb1da2b73173c1eb3ce3cd16b..2af7ba566697681f71e5b733591709bc28dfc8ce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1410,11 +1410,11 @@ public class CraftEventFactory {
+@@ -1436,11 +1436,11 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0840-Add-exploded-block-state-to-BlockExplodeEvent-and-En.patch
+++ b/patches/server/0840-Add-exploded-block-state-to-BlockExplodeEvent-and-En.patch
@@ -133,7 +133,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b
 index a1860e21fd53b801ffd651cd27f5a8f9fcd02ee0..52444c7c83e60e5fe40c485c13a59cca9ce5ee20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1045,7 +1045,7 @@ public class CraftEventFactory {
+@@ -1071,7 +1071,7 @@ public class CraftEventFactory {
              CraftEventFactory.entityDamage = null;
              EntityDamageEvent event;
              if (damager == null) {

--- a/patches/server/0851-Add-EntityFertilizeEggEvent.patch
+++ b/patches/server/0851-Add-EntityFertilizeEggEvent.patch
@@ -69,10 +69,10 @@ index 0e85e3ab58d848b119212fa7d2eb4f92d3efe29b..0a5b953bd8c0c7f181da4090b950e9e6
          this.playSound(SoundEvents.SNIFFER_EGG_PLOP, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 0.5F);
          } // Paper - Call EntityDropItemEvent
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 25003a2e2fcf729effe79fbc0fcda0476cc5fb61..e28f6ea159bdae063d8a54856e6a374174e275cf 100644
+index adad1dd09d190d8b7dfcf5a469d2514b043ee357..06263beb88b6f201d8aef12c28a8d91e148f94e5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2124,4 +2124,28 @@ public class CraftEventFactory {
+@@ -2150,4 +2150,28 @@ public class CraftEventFactory {
          return event.callEvent();
      }
      // Paper end

--- a/patches/server/0871-Fix-DamageCause-for-Falling-Blocks.patch
+++ b/patches/server/0871-Fix-DamageCause-for-Falling-Blocks.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b
 index 0e640dc081228484a4568f2c5fed71610ac1c6c6..734f68cee62a31513bdfefa5c7074ac38b3c1622 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1085,6 +1085,11 @@ public class CraftEventFactory {
+@@ -1111,6 +1111,11 @@ public class CraftEventFactory {
              } else if (source.is(DamageTypes.SONIC_BOOM)) {
                  cause = DamageCause.SONIC_BOOM;
              }

--- a/patches/server/0875-Expand-PlayerItemMendEvent.patch
+++ b/patches/server/0875-Expand-PlayerItemMendEvent.patch
@@ -54,7 +54,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b
 index 734f68cee62a31513bdfefa5c7074ac38b3c1622..1325f680ce03b6ffae04f5c519b789fdd10ed8a3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1321,10 +1321,10 @@ public class CraftEventFactory {
+@@ -1347,10 +1347,10 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0890-Call-missing-BlockDispenseEvent.patch
+++ b/patches/server/0890-Call-missing-BlockDispenseEvent.patch
@@ -50,10 +50,10 @@ index b83af374a33a66a6ceeca119b961eea883bba41c..175b965c92b8b8be9c671e1ee478afa9
                              for (int k = 0; k < 5; ++k) {
                                  worldserver.sendParticles(ParticleTypes.SPLASH, (double) blockposition.getX() + worldserver.random.nextDouble(), (double) (blockposition.getY() + 1), (double) blockposition.getZ() + worldserver.random.nextDouble(), 1, 0.0D, 0.0D, 0.0D, 1.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 598ff7a93fa9cf3c2971c082d1019dbc23bafa2d..34c4acecab9eb9e1d23e390747b348645eedfca8 100644
+index bcd734bf14b911682afa367a87a4fd1b042dcd0d..8ba2d84c7daae945e6a2174a740090f4f8a9413c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2130,6 +2130,32 @@ public class CraftEventFactory {
+@@ -2156,6 +2156,32 @@ public class CraftEventFactory {
      }
      // Paper end
  

--- a/patches/server/0936-Add-titleOverride-to-InventoryOpenEvent.patch
+++ b/patches/server/0936-Add-titleOverride-to-InventoryOpenEvent.patch
@@ -82,7 +82,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b
 index e420a558994129b2907d7e75152a558a01dc7b2e..c74e6c6cd92d618cde3733200bcc23279c0df679 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1438,10 +1438,21 @@ public class CraftEventFactory {
+@@ -1464,10 +1464,21 @@ public class CraftEventFactory {
      }
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container) {
@@ -105,7 +105,7 @@ index e420a558994129b2907d7e75152a558a01dc7b2e..c74e6c6cd92d618cde3733200bcc2327
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
              player.connection.handleContainerClose(new ServerboundContainerClosePacket(player.containerMenu.containerId), InventoryCloseEvent.Reason.OPEN_NEW); // Paper - Inventory close reason
          }
-@@ -1456,10 +1467,10 @@ public class CraftEventFactory {
+@@ -1482,10 +1493,10 @@ public class CraftEventFactory {
  
          if (event.isCancelled()) {
              container.transferTo(player.containerMenu, craftPlayer);

--- a/patches/server/0976-Restore-vanilla-entity-drops-behavior.patch
+++ b/patches/server/0976-Restore-vanilla-entity-drops-behavior.patch
@@ -165,10 +165,10 @@ index e3412f9dd86dddd241bea8f6dcaeed77a7e67f08..6dfcc296ff7e59ecbebc5446973fabc9
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 469f7b1b26e8c69c6cb89a5bed01dae65aa9ba2d..c39cb1bd6304b765f439fbd9022e26e9554105e0 100644
+index 7c5b6ab17439c6dc958a910c683114b6397f3379..5519ef3b82b5a04536bb2ffb7ce1ba460a2df8d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -937,17 +937,23 @@ public class CraftEventFactory {
+@@ -963,17 +963,23 @@ public class CraftEventFactory {
      }
  
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim) {
@@ -196,7 +196,7 @@ index 469f7b1b26e8c69c6cb89a5bed01dae65aa9ba2d..c39cb1bd6304b765f439fbd9022e26e9
          populateFields(victim, event); // Paper - make cancellable
          CraftWorld world = (CraftWorld) entity.getWorld();
          Bukkit.getServer().getPluginManager().callEvent(event);
-@@ -961,19 +967,23 @@ public class CraftEventFactory {
+@@ -987,19 +993,23 @@ public class CraftEventFactory {
          victim.expToDrop = event.getDroppedExp();
          lootCheck.run(); // Paper - advancement triggers before destroying items
  
@@ -224,7 +224,7 @@ index 469f7b1b26e8c69c6cb89a5bed01dae65aa9ba2d..c39cb1bd6304b765f439fbd9022e26e9
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
          populateFields(victim, event); // Paper - make cancellable
-@@ -992,10 +1002,14 @@ public class CraftEventFactory {
+@@ -1018,10 +1028,14 @@ public class CraftEventFactory {
          victim.expToDrop = event.getDroppedExp();
          victim.newExp = event.getNewExp();
  

--- a/patches/server/0982-Add-drops-to-shear-events.patch
+++ b/patches/server/0982-Add-drops-to-shear-events.patch
@@ -233,10 +233,10 @@ index 8adcfc8f6772a32b5915e4a07100e8eb735f907a..b5d6857eaf2bed14adcb5f5e80d91b44
  
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c39cb1bd6304b765f439fbd9022e26e9554105e0..23b4b5d63d45108534bde330079c7a12b3aa4f5f 100644
+index 5519ef3b82b5a04536bb2ffb7ce1ba460a2df8d6..9389249662f4c7a8656c60671152cc6969cad96c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1718,20 +1718,20 @@ public class CraftEventFactory {
+@@ -1744,20 +1744,20 @@ public class CraftEventFactory {
          return event;
      }
  


### PR DESCRIPTION
This fix an issue where getHitBlock, getHitEntity and getHitBlockFace are always null for this event unlike its parent.