### PR TITLE
Fire BlockPreDispenseEvent for droppers

### DIFF
--- a/patches/server/0504-Add-BlockPreDispenseEvent.patch
+++ b/patches/server/0504-Add-BlockPreDispenseEvent.patch
@@ -17,17 +17,17 @@ index 5593a0aa9e618071b6521b213dde0f628348c3dc..644e64850479cea20a98b8a65503ccf3
                      tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
                  }
 diff --git a/src/main/java/net/minecraft/world/level/block/DropperBlock.java b/src/main/java/net/minecraft/world/level/block/DropperBlock.java
-index 1d13f8a1009d6eda351c697052d499d594a6aaa8..7cc7ee9d9cb0dd1b785e1b48a1296fd914ba14a4 100644
+index 1d13f8a1009d6eda351c697052d499d594a6aaa8..9a8a0fb958e8ec782111507bae957f854b2aac72 100644
 --- a/src/main/java/net/minecraft/world/level/block/DropperBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/DropperBlock.java
-@@ -65,6 +65,7 @@ public class DropperBlock extends DispenserBlock {
-                 ItemStack itemstack = tileentitydispenser.getItem(i);
- 
-                 if (!itemstack.isEmpty()) {
-+                    if (!org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockPreDispenseEvent(world, pos, itemstack, i)) return; // Paper - Add BlockPreDispenseEvent
-                     Direction enumdirection = (Direction) world.getBlockState(pos).getValue(DropperBlock.FACING);
-                     Container iinventory = HopperBlockEntity.getContainerAt(world, pos.relative(enumdirection));
+@@ -70,6 +70,7 @@ public class DropperBlock extends DispenserBlock {
                      ItemStack itemstack1;
+ 
+                     if (iinventory == null) {
++                        if (!org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockPreDispenseEvent(world, pos, itemstack, i)) return; // Paper - Add BlockPreDispenseEvent
+                         itemstack1 = DropperBlock.DISPENSE_BEHAVIOUR.dispense(sourceblock, itemstack);
+                     } else {
+                         // CraftBukkit start - Fire event when pushing items into other inventories
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 index 6a95328293e3600b7a560074a0e6083db9cd3e1f..456c1df6b5956b521e8f379b9020ed53f66a365b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java

--- a/patches/server/0504-Add-BlockPreDispenseEvent.patch
+++ b/patches/server/0504-Add-BlockPreDispenseEvent.patch
@@ -16,6 +16,18 @@ index 5593a0aa9e618071b6521b213dde0f628348c3dc..644e64850479cea20a98b8a65503ccf3
                      DispenserBlock.eventFired = false; // CraftBukkit - reset event status
                      tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
                  }
+diff --git a/src/main/java/net/minecraft/world/level/block/DropperBlock.java b/src/main/java/net/minecraft/world/level/block/DropperBlock.java
+index 1d13f8a1009d6eda351c697052d499d594a6aaa8..7cc7ee9d9cb0dd1b785e1b48a1296fd914ba14a4 100644
+--- a/src/main/java/net/minecraft/world/level/block/DropperBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/DropperBlock.java
+@@ -65,6 +65,7 @@ public class DropperBlock extends DispenserBlock {
+                 ItemStack itemstack = tileentitydispenser.getItem(i);
+ 
+                 if (!itemstack.isEmpty()) {
++                    if (!org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockPreDispenseEvent(world, pos, itemstack, i)) return; // Paper - Add BlockPreDispenseEvent
+                     Direction enumdirection = (Direction) world.getBlockState(pos).getValue(DropperBlock.FACING);
+                     Container iinventory = HopperBlockEntity.getContainerAt(world, pos.relative(enumdirection));
+                     ItemStack itemstack1;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 index 6a95328293e3600b7a560074a0e6083db9cd3e1f..456c1df6b5956b521e8f379b9020ed53f66a365b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java


### PR DESCRIPTION
The BlockPreDispenseEvent, added in #5075, is only fired for dispensers, and not droppers. I see this as an inconsistency in the API, as BlockDispenseEvent is called for both droppers and dispensers.

What I'm trying to achieve is being able to cancel droppers doing anything while also avoiding the sound and particles. This is possible for dispensers through this event. Cancelling BlockDispenseEvent works fine for droppers, but it still plays the click sound.

I saw prior discussion in the Discord (many months ago) which mentions that there is no reason the event isn't called for droppers, and that it really should.