### PR TITLE
[ci skip] Fix JavaDoc mistake in BlockPistonRetractEvent

### DIFF
--- a/patches/api/0056-Fix-upstream-javadocs.patch
+++ b/patches/api/0056-Fix-upstream-javadocs.patch
@@ -614,6 +614,19 @@ index 44f7f6939a27b9a0a796d91eac4b7c97ec90a643..641c71ab66bd2499b35cf3c1d533fd10
   */
  public class BlockExplodeEvent extends BlockEvent implements Cancellable {
      private static final HandlerList handlers = new HandlerList();
+diff --git a/src/main/java/org/bukkit/event/block/BlockPistonRetractEvent.java b/src/main/java/org/bukkit/event/block/BlockPistonRetractEvent.java
+index 340fa397e68c024df380a28db21545a0c83d9fa6..79ac8a5db689cf9f8e2ff4cb7c06df6989128d10 100644
+--- a/src/main/java/org/bukkit/event/block/BlockPistonRetractEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockPistonRetractEvent.java
+@@ -34,7 +34,7 @@ public class BlockPistonRetractEvent extends BlockPistonEvent {
+ 
+     /**
+      * Get an immutable list of the blocks which will be moved by the
+-     * extending.
++     * retracting.
+      *
+      * @return Immutable list of the moved blocks.
+      */
 diff --git a/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java b/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
 index be0a2d1f234d8265d98e54e518a994957b1f3ab7..4e3c406ba883aae553e8d69b6b719b872cd6096c 100644
 --- a/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java


### PR DESCRIPTION
I think it should be called "Get an immutable list of the blocks which will be moved by the retracting." instead of " ... extracting."