### PR TITLE
Updated Upstream (Bukkit)

### DIFF
--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -2116,7 +2116,7 @@ index 7ad7bcf9a9333c8d6d1d7cab53a6d457ec20bbf6..c4f86ba1037f3f0e5d697a0962d71d6f
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index cc577b5af6832ea9c98aceb587de378095277ada..0025139f403cfc80ace9f8584ccf42d3a5cbb718 100644
+index 53450c104a25151094961a58ffa0d809e3b9a064..474765f40801a766c853018ea6e1adcd010375d2 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -30,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
@@ -2128,7 +2128,7 @@ index cc577b5af6832ea9c98aceb587de378095277ada..0025139f403cfc80ace9f8584ccf42d3
  
      /**
       * Gets the entity's current position
-@@ -763,4 +763,20 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -765,4 +765,20 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      @Override
      Spigot spigot();
      // Spigot end

--- a/patches/api/0016-Entity-Origin-API.patch
+++ b/patches/api/0016-Entity-Origin-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity Origin API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 0025139f403cfc80ace9f8584ccf42d3a5cbb718..fd3b707893ba59aa6f6e4009113c5a94be5d7536 100644
+index 474765f40801a766c853018ea6e1adcd010375d2..b0967614bfdba06b5e11c910186aa66ac7e2d503 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -778,5 +778,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -780,5 +780,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.customName())));
      }

--- a/patches/api/0063-Entity-fromMobSpawner.patch
+++ b/patches/api/0063-Entity-fromMobSpawner.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index fd3b707893ba59aa6f6e4009113c5a94be5d7536..28e2d003db578e7c0468c0d443fda3a40e2a0efa 100644
+index b0967614bfdba06b5e11c910186aa66ac7e2d503..b422a949b22edf412b518abb3e5ca0847c73d36b 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -788,5 +788,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -790,5 +790,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      @Nullable
      Location getOrigin();

--- a/patches/api/0122-Entity-getChunk-API.patch
+++ b/patches/api/0122-Entity-getChunk-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Entity#getChunk API
 Get the chunk the entity is currently registered to
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 28e2d003db578e7c0468c0d443fda3a40e2a0efa..77a706dde5995a8a6306b1d0a144dd37d580dea3 100644
+index b422a949b22edf412b518abb3e5ca0847c73d36b..57a1d07d0430019fd38c72b9f58c7145927ecd02 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -3,6 +3,7 @@ package org.bukkit.entity;
@@ -17,7 +17,7 @@ index 28e2d003db578e7c0468c0d443fda3a40e2a0efa..77a706dde5995a8a6306b1d0a144dd37
  import org.bukkit.EntityEffect;
  import org.bukkit.Location;
  import org.bukkit.Nameable;
-@@ -795,5 +796,16 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -797,5 +798,16 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @return True if entity spawned from a mob spawner
       */
      boolean fromMobSpawner();

--- a/patches/api/0172-Entity-getEntitySpawnReason.patch
+++ b/patches/api/0172-Entity-getEntitySpawnReason.patch
@@ -12,10 +12,10 @@ or DEFAULT since data was not stored.
 Co-authored-by: Aurora <aurora@relanet.eu>
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 14e42959033919ff6409e48ddf01c0f15c28eb10..469e85c3cb371842a78b32f8da97fe9c71bf409b 100644
+index a0ed358156f9cbeb9e3cbb910ac17785edd30152..8a01590cc0ee7517dc4c2a52e95aad2680610a43 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -834,5 +834,11 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -836,5 +836,11 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
          // TODO remove impl here
          return getLocation().getChunk();
      }

--- a/patches/api/0205-Add-entity-liquid-API.patch
+++ b/patches/api/0205-Add-entity-liquid-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add entity liquid API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 469e85c3cb371842a78b32f8da97fe9c71bf409b..1e766f77e39b86b0561884a478d10cedc3d98fc2 100644
+index 8a01590cc0ee7517dc4c2a52e95aad2680610a43..4d6d75387b9a3ec467982e17a5131cd10f302260 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -840,5 +840,40 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -842,5 +842,40 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      @NotNull
      org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason getEntitySpawnReason();

--- a/patches/api/0216-Entity-isTicking.patch
+++ b/patches/api/0216-Entity-isTicking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 1e766f77e39b86b0561884a478d10cedc3d98fc2..387413af95421159eae04737cc04c8221e88357b 100644
+index 4d6d75387b9a3ec467982e17a5131cd10f302260..56e3a0649089e2546658144a3f09135be3a4e5e8 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -875,5 +875,10 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -877,5 +877,10 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * Check if entity is in lava
       */
      boolean isInLava();

--- a/patches/api/0259-Expose-Tracked-Players.patch
+++ b/patches/api/0259-Expose-Tracked-Players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 387413af95421159eae04737cc04c8221e88357b..9d3694c6e1144e04006425fb96b802c96e5fdc12 100644
+index 56e3a0649089e2546658144a3f09135be3a4e5e8..d68ccecaadcf7a906058e66a750f4cfce5dd7b3f 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -880,5 +880,14 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -882,5 +882,14 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * Check if entity is inside a ticking chunk
       */
      boolean isTicking();

--- a/patches/api/0318-Add-critical-damage-API.patch
+++ b/patches/api/0318-Add-critical-damage-API.patch
@@ -5,28 +5,38 @@ Subject: [PATCH] Add critical damage API
 
 
 diff --git a/src/main/java/org/bukkit/event/entity/EntityDamageByEntityEvent.java b/src/main/java/org/bukkit/event/entity/EntityDamageByEntityEvent.java
-index 0a43b1ffdb03bb8b67e880dfd9a6a1ce5d02eb32..f79eb4a0f634354ac68995144821bc4e966d2dd8 100644
+index 04449ef55caacf2ac910f0916f8afeb428c282e9..6b24d1281cb8f0253430c9c1a1323e2670bb9c93 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityDamageByEntityEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/EntityDamageByEntityEvent.java
-@@ -4,6 +4,7 @@ import com.google.common.base.Function;
- import java.util.Map;
+@@ -5,6 +5,7 @@ import java.util.Map;
  import org.bukkit.damage.DamageSource;
+ import org.bukkit.damage.DamageType;
  import org.bukkit.entity.Entity;
 +import org.jetbrains.annotations.ApiStatus;
  import org.jetbrains.annotations.NotNull;
  
  /**
-@@ -11,17 +12,43 @@ import org.jetbrains.annotations.NotNull;
+@@ -12,15 +13,18 @@ import org.jetbrains.annotations.NotNull;
   */
  public class EntityDamageByEntityEvent extends EntityDamageEvent {
      private final Entity damager;
 +    private final boolean critical; // Paper
+ 
+     @Deprecated(forRemoval = true)
+     public EntityDamageByEntityEvent(@NotNull final Entity damager, @NotNull final Entity damagee, @NotNull final DamageCause cause, final double damage) {
+         this(damager, damagee, cause, DamageSource.builder(DamageType.GENERIC).withCausingEntity(damager).withDirectEntity(damager).build(), damage);
+     }
  
 +    @Deprecated
      public EntityDamageByEntityEvent(@NotNull final Entity damager, @NotNull final Entity damagee, @NotNull final DamageCause cause, @NotNull final DamageSource damageSource, final double damage) {
          super(damagee, cause, damageSource, damage);
          this.damager = damager;
 +        this.critical = false; // Paper - add critical damage API
+     }
+ 
+     @Deprecated(forRemoval = true)
+@@ -28,11 +32,34 @@ public class EntityDamageByEntityEvent extends EntityDamageEvent {
+         this(damager, damagee, cause, DamageSource.builder(DamageType.GENERIC).withCausingEntity(damager).withDirectEntity(damager).build(), modifiers, modifierFunctions);
      }
  
 +    @Deprecated

--- a/patches/api/0324-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/api/0324-Add-Raw-Byte-Entity-Serialization.patch
@@ -24,10 +24,10 @@ index 434fde52986ba07d7209ff47483f74fe31e8ebe7..0c7204e390f44b649fc26cd46152abeb
       * Creates and returns the next EntityId available.
       * <p>
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 9d3694c6e1144e04006425fb96b802c96e5fdc12..f69a6bccb174ce48ce0393c633279f84553d1df8 100644
+index d68ccecaadcf7a906058e66a750f4cfce5dd7b3f..2e2c8d7d2e2c27e2f1264a267d589b2c790f366b 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -889,5 +889,32 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -891,5 +891,32 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      @Deprecated
      @NotNull Set<Player> getTrackedPlayers();

--- a/patches/api/0330-Entity-powdered-snow-API.patch
+++ b/patches/api/0330-Entity-powdered-snow-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity powdered snow API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index f69a6bccb174ce48ce0393c633279f84553d1df8..1b9abd69483941f19ee7d0bb28e2655806dd3ca8 100644
+index 2e2c8d7d2e2c27e2f1264a267d589b2c790f366b..bdc2bbeddc47587334a8e92f5e0728f3c50218f6 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -916,5 +916,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -918,5 +918,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @return Whether the entity was successfully spawned.
       */
      public boolean spawnAt(@NotNull Location location, @NotNull org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason);

--- a/patches/api/0369-Collision-API.patch
+++ b/patches/api/0369-Collision-API.patch
@@ -25,10 +25,10 @@ index 44ee56a5956cc17194c767a0c1071a2abffe818a..43dd6c59cceba12f27e6b265acc3ad97
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 3905c12b23bbfc88c9667b04e60fad7ad2febd60..3fec6816bcc9167314b021a9989409649da6f7a7 100644
+index 948d6a08ff459afd5d4d5b151c41d94d1d5847b6..4ea16c106cfab12ebc753781fb7f406330c3f25c 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -966,4 +966,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -968,4 +968,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      boolean isInPowderedSnow();
      // Paper end

--- a/patches/api/0396-Add-Sneaking-API-for-Entities.patch
+++ b/patches/api/0396-Add-Sneaking-API-for-Entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Sneaking API for Entities
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 3fec6816bcc9167314b021a9989409649da6f7a7..e5627ed4c6bac789ab847e9b423c0b78834b9430 100644
+index 4ea16c106cfab12ebc753781fb7f406330c3f25c..b6f7aae6cd7d4364caf89c46e55c65961f8dae91 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -777,6 +777,25 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -779,6 +779,25 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      @NotNull
      Pose getPose();
  

--- a/patches/api/0398-Add-exploded-block-state-to-BlockExplodeEvent-and-En.patch
+++ b/patches/api/0398-Add-exploded-block-state-to-BlockExplodeEvent-and-En.patch
@@ -65,10 +65,10 @@ index 641c71ab66bd2499b35cf3c1d533fd105d096e10..7dcbb75170296c1dd1d784a032bf3696
       * Returns the list of blocks that would have been removed or were removed
       * from the explosion event.
 diff --git a/src/main/java/org/bukkit/event/entity/EntityDamageByBlockEvent.java b/src/main/java/org/bukkit/event/entity/EntityDamageByBlockEvent.java
-index 5ba9f7edf3bb814844ba9599c622a5106394c897..03889ab9b26c6f8fa4c9f51b7f67ad3ff40ef5db 100644
+index 467a0d6cabc5e860628be3b1e62de773efde5d2e..1fb15e2ade8ff3c4d662eca87b078b4577f786e1 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityDamageByBlockEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/EntityDamageByBlockEvent.java
-@@ -10,18 +10,25 @@ import org.jetbrains.annotations.Nullable;
+@@ -11,28 +11,35 @@ import org.jetbrains.annotations.Nullable;
  
  /**
   * Called when an entity is damaged by a block
@@ -81,11 +81,23 @@ index 5ba9f7edf3bb814844ba9599c622a5106394c897..03889ab9b26c6f8fa4c9f51b7f67ad3f
      private final Block damager;
 +    private final org.bukkit.block.BlockState damagerBlockState; // Paper
  
+     @Deprecated(forRemoval = true)
+     public EntityDamageByBlockEvent(@Nullable final Block damager, @NotNull final Entity damagee, @NotNull final DamageCause cause, final double damage) {
+-        this(damager, damagee, cause, (damager != null) ? DamageSource.builder(DamageType.GENERIC).withDamageLocation(damager.getLocation()).build() : DamageSource.builder(DamageType.GENERIC).build(), damage);
++        this(damager, damagee, cause, (damager != null) ? DamageSource.builder(DamageType.GENERIC).withDamageLocation(damager.getLocation()).build() : DamageSource.builder(DamageType.GENERIC).build(), damage, null); // Paper
+     }
+ 
 -    public EntityDamageByBlockEvent(@Nullable final Block damager, @NotNull final Entity damagee, @NotNull final DamageCause cause, @NotNull final DamageSource damageSource, final double damage) {
 +    public EntityDamageByBlockEvent(@Nullable final Block damager, @NotNull final Entity damagee, @NotNull final DamageCause cause, @NotNull final DamageSource damageSource, final double damage, final @Nullable org.bukkit.block.BlockState damagerBlockState) { // Paper
          super(damagee, cause, damageSource, damage);
          this.damager = damager;
 +        this.damagerBlockState = damagerBlockState; // Paper
+     }
+ 
+     @Deprecated(forRemoval = true)
+     public EntityDamageByBlockEvent(@Nullable final Block damager, @NotNull final Entity damagee, @NotNull final DamageCause cause, @NotNull final Map<DamageModifier, Double> modifiers, @NotNull final Map<DamageModifier, ? extends Function<? super Double, Double>> modifierFunctions) {
+-        this(damager, damagee, cause, (damager != null) ? DamageSource.builder(DamageType.GENERIC).withDamageLocation(damager.getLocation()).build() : DamageSource.builder(DamageType.GENERIC).build(), modifiers, modifierFunctions);
++        this(damager, damagee, cause, (damager != null) ? DamageSource.builder(DamageType.GENERIC).withDamageLocation(damager.getLocation()).build() : DamageSource.builder(DamageType.GENERIC).build(), modifiers, modifierFunctions, null); // Paper
      }
  
 -    public EntityDamageByBlockEvent(@Nullable final Block damager, @NotNull final Entity damagee, @NotNull final DamageCause cause, @NotNull final DamageSource damageSource, @NotNull final Map<DamageModifier, Double> modifiers, @NotNull final Map<DamageModifier, ? extends Function<? super Double, Double>> modifierFunctions) {
@@ -96,7 +108,7 @@ index 5ba9f7edf3bb814844ba9599c622a5106394c897..03889ab9b26c6f8fa4c9f51b7f67ad3f
      }
  
      /**
-@@ -33,4 +40,20 @@ public class EntityDamageByBlockEvent extends EntityDamageEvent {
+@@ -44,4 +51,20 @@ public class EntityDamageByBlockEvent extends EntityDamageEvent {
      public Block getDamager() {
          return damager;
      }

--- a/patches/api/0402-Add-Entity-Body-Yaw-API.patch
+++ b/patches/api/0402-Add-Entity-Body-Yaw-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Entity Body Yaw API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index e5627ed4c6bac789ab847e9b423c0b78834b9430..79bd8e5fe58c99133a620e46237bd667bf70e508 100644
+index b6f7aae6cd7d4364caf89c46e55c65961f8dae91..04cf35bce80d5940dec2913ca74a0678be3c1c57 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -984,6 +984,43 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -986,6 +986,43 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @return true if in powdered snow.
       */
      boolean isInPowderedSnow();

--- a/patches/api/0413-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/api/0413-Folia-scheduler-and-owned-region-API.patch
@@ -769,10 +769,10 @@ index d433a9d2fe0bb487865fec33307cc4c45af475a0..f819de247080d58803a2851a4cab28d2
 +    // Paper end - Folia region threading API
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 79bd8e5fe58c99133a620e46237bd667bf70e508..4e01980ea00917743a92787b00d0f964395a6dd5 100644
+index 04cf35bce80d5940dec2913ca74a0678be3c1c57..ef202ad243884c4254f45be760c42abf653cbc8e 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -1044,4 +1044,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -1046,4 +1046,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      boolean wouldCollideUsing(@NotNull BoundingBox boundingBox);
      // Paper end - Collision API

--- a/patches/api/0422-API-for-an-entity-s-scoreboard-name.patch
+++ b/patches/api/0422-API-for-an-entity-s-scoreboard-name.patch
@@ -7,10 +7,10 @@ Was obtainable through different methods, but you had to use different
 methods depending on the implementation of Entity you were working with.
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 4e01980ea00917743a92787b00d0f964395a6dd5..fded39b709ef4129b53eac0e021dbb1a37fe5770 100644
+index ef202ad243884c4254f45be760c42abf653cbc8e..d6e6d7140de4588f6b9469988749bccbe848f3ef 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -1055,4 +1055,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -1057,4 +1057,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      @NotNull io.papermc.paper.threadedregions.scheduler.EntityScheduler getScheduler();
      // Paper end - Folia schedulers

--- a/patches/api/0427-Expand-Pose-API.patch
+++ b/patches/api/0427-Expand-Pose-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expand Pose API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index fded39b709ef4129b53eac0e021dbb1a37fe5770..9022567f32a58b94ed030db22524876d8f1df4aa 100644
+index d6e6d7140de4588f6b9469988749bccbe848f3ef..d9929d9311e4b2b0ae13a8f6f13563257263f298 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -794,6 +794,42 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -796,6 +796,42 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @param sneak true if the entity should be sneaking
       */
      void setSneaking(boolean sneak);


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
58ce1b0f Improve compatibility of new DamageSource API