### PR TITLE
[ci skip] Fix javadoc mistake in PluginMeta

### DIFF
--- a/patches/api/0009-Paper-Plugins.patch
+++ b/patches/api/0009-Paper-Plugins.patch
@@ -329,7 +329,7 @@ index 0000000000000000000000000000000000000000..2c14693155de3654d5ca011c63e13e4a
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java b/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ef393f1f93ca48264fc1b6e3a27787f6a9152e1b
+index 0000000000000000000000000000000000000000..bcf91d048d84144f6acf9bfd2095df9ada2e585f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
 @@ -0,0 +1,203 @@
@@ -403,7 +403,7 @@ index 0000000000000000000000000000000000000000..ef393f1f93ca48264fc1b6e3a27787f6
 +    /**
 +     * Provides the version of this plugin as defined by the plugin.
 +     * There is no inherit format defined/enforced for the version of a plugin, however a common approach
-+     * might be schematic versioning.
++     * might be semantic versioning.
 +     *
 +     * @return the string representation of the plugin's version
 +     */


### PR DESCRIPTION
"Schematic versioning" is not a real thing. The intended versioning scheme is "semantic versioning". Introduced in #8108.