### PR TITLE
Adding a PlayerPreTeleportEvent event called before the teleportation…

### DIFF
--- a/patches/api/0465-Add-PlayerPreTeleportEvent.patch
+++ b/patches/api/0465-Add-PlayerPreTeleportEvent.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Will33_ <william.aventin@elesia.org>
+Date: Mon, 19 Feb 2024 11:24:56 +0100
+Subject: [PATCH] Add PlayerPreTeleportEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/player/PlayerPreTeleportEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerPreTeleportEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..8e659ee9927b3389284e492fc530ce8e683f50d4
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/player/PlayerPreTeleportEvent.java
+@@ -0,0 +1,88 @@
++package io.papermc.paper.event.player;
++
++import org.bukkit.Location;
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerMoveEvent;
++import org.bukkit.event.player.PlayerTeleportEvent;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Holds information for player teleport events
++ */
++public class PlayerPreTeleportEvent extends PlayerMoveEvent {
++    private static final HandlerList handlers = new HandlerList();
++    private PlayerTeleportEvent.TeleportCause cause = PlayerTeleportEvent.TeleportCause.UNKNOWN;
++
++    // Paper start - Teleport API
++    private boolean dismounted = true;
++    private final java.util.Set<io.papermc.paper.entity.TeleportFlag.Relative> teleportFlagSet;
++    // Paper end
++
++    public PlayerPreTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to) {
++        super(player, from, to);
++        teleportFlagSet = java.util.Collections.emptySet(); // Paper - Teleport API
++    }
++
++    public PlayerPreTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to, @NotNull final PlayerTeleportEvent.TeleportCause cause) {
++        this(player, from, to);
++
++        this.cause = cause;
++    }
++
++    // Paper start - Teleport API
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public PlayerPreTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to, @NotNull final PlayerTeleportEvent.TeleportCause cause, @NotNull java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull Relative> teleportFlagSet) {
++        super(player, from, to);
++        this.teleportFlagSet = teleportFlagSet;
++        this.cause = cause;
++    }
++    // Paper end
++
++    /**
++     * Gets the cause of this teleportation event
++     *
++     * @return Cause of the event
++     */
++    @NotNull
++    public PlayerTeleportEvent.TeleportCause getCause() {
++        return cause;
++    }
++
++
++    // Paper start - Teleport API
++    /**
++     * Gets if the player will be dismounted in this teleportation.
++     *
++     * @return dismounted or not
++     * @deprecated dismounting on tp is no longer controlled by the server
++     */
++    @Deprecated(forRemoval = true)
++    public boolean willDismountPlayer() {
++        return this.dismounted;
++    }
++
++    /**
++     * Returns the relative teleportation flags used in this teleportation.
++     * This determines which axis the player will not lose their velocity in.
++     *
++     * @return an immutable set of relative teleportation flags
++     */
++    @NotNull
++    public java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull Relative> getRelativeTeleportationFlags() {
++        return this.teleportFlagSet;
++    }
++    // Paper end
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/patches/server/1048-Add-PlayerPreTeleportEvent.patch
+++ b/patches/server/1048-Add-PlayerPreTeleportEvent.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Will33_ <william.aventin@elesia.org>
+Date: Mon, 19 Feb 2024 11:24:55 +0100
+Subject: [PATCH] Add PlayerPreTeleportEvent
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 206520f6f20b2e48b1eefdd4edb26510b88e4c92..d24297c35e9389038baf1279164363565d962a95 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableSet;
+ import com.google.common.io.BaseEncoding;
+ import com.mojang.authlib.GameProfile;
+ import com.mojang.datafixers.util.Pair;
++import io.papermc.paper.event.player.PlayerPreTeleportEvent;
+ import it.unimi.dsi.fastutil.shorts.ShortArraySet;
+ import it.unimi.dsi.fastutil.shorts.ShortSet;
+ import java.io.ByteArrayOutputStream;
+@@ -1327,8 +1328,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         // Paper end - Teleport API
+         Preconditions.checkArgument(location != null, "location");
+         Preconditions.checkArgument(location.getWorld() != null, "location.world");
++
++        // From = Players current Location
++        Location from = this.getLocation();
++        // To = Players new Location if Teleport is Successful
++        Location to = location;
++
+         // Paper start - Teleport passenger API
+         // Don't allow teleporting between worlds while keeping passengers
++        PlayerPreTeleportEvent playerPreTeleportEvent = new PlayerPreTeleportEvent(this, from, to, cause, Set.copyOf(relativeArguments));
++        this.server.getPluginManager().callEvent(playerPreTeleportEvent);
++        if(playerPreTeleportEvent.isCancelled()){
++            return false;
++        }
++
+         if (ignorePassengers && entity.isVehicle() && location.getWorld() != this.getWorld()) {
+             return false;
+         }
+@@ -1354,10 +1367,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+             return false;
+         }
+ 
+-        // From = Players current Location
+-        Location from = this.getLocation();
+-        // To = Players new Location if Teleport is Successful
+-        Location to = location;
+         // Create & Call the Teleport Event.
+         PlayerTeleportEvent event = new PlayerTeleportEvent(this, from, to, cause, Set.copyOf(relativeArguments)); // Paper - Teleport API
+         this.server.getPluginManager().callEvent(event);


### PR DESCRIPTION
Hello,

I would like to propose the addition of a new event to Paper that would be called before a player's teleportation attempt.

In my current scenario, I have a cosmetic plugin that adds a passenger to the player (a TextDisplay), and all teleportations are blocked because the player has at least one passenger, with no event being called to remove it. This forces the use of NMS (which is discouraged today).

The PlayerPreTeleportEvent event would be invoked before all checks and would allow plugin developers the opportunity to ensure compliance with checks before teleportation occurs.