### PR TITLE
Configurable max block/fluid ticks

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -15,7 +15,7 @@ public net.minecraft.server.dedicated.DedicatedServerProperties reload(Lnet/mine
 public net.minecraft.world.level.NaturalSpawner SPAWNING_CATEGORIES
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 2df1cae62cff433a7f3f55f561f70719bb6a745b..65e9d5918d46b123fb4f8122344a7d3863aec758 100644
+index 8d2aa99b4bd0d1c46c66274907a1f11d605a75da..e865c5ce514770f4fde9146b6e7138e88932c33b 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -11,6 +11,7 @@ dependencies {
@@ -1390,10 +1390,10 @@ index 0000000000000000000000000000000000000000..351fbbc577556ebbd62222615801a96b
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..385ca2c1022e0985550a5cc2bbff953f1aa33f5c
+index 0000000000000000000000000000000000000000..1a914ab53c24476473edc433d64daca6ec1c51d9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,548 @@
+@@ -0,0 +1,550 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1808,6 +1808,8 @@ index 0000000000000000000000000000000000000000..385ca2c1022e0985550a5cc2bbff953f
 +        public boolean portalSearchVanillaDimensionScaling = true;
 +        public boolean disableTeleportationSuffocationCheck = false;
 +        public IntOr.Disabled netherCeilingVoidDamageHeight = IntOr.Disabled.DISABLED;
++        public int maxFluidTicks = 65536;
++        public int maxBlockTicks = 65536;
 +    }
 +
 +    public Spawn spawn;

--- a/patches/server/1051-Configurable-max-block-fluid-ticks.patch
+++ b/patches/server/1051-Configurable-max-block-fluid-ticks.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gero <gecam59@gmail.com>
+Date: Mon, 19 Feb 2024 17:39:59 +0100
+Subject: [PATCH] Configurable max block/fluid ticks
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 6907d1be36fbdf0856c0e11983218d2fd1f9cb46..4bca3d20d1a01270a10c1e643a312fe462305b5d 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -849,9 +849,9 @@ public class ServerLevel extends Level implements WorldGenLevel {
+         if (!this.isDebug() && flag) {
+             j = this.getGameTime();
+             gameprofilerfiller.push("blockTicks");
+-            this.blockTicks.tick(j, 65536, this::tickBlock);
++            this.blockTicks.tick(j, paperConfig().environment.maxBlockTicks, this::tickBlock); // Paper - configurable max block ticks
+             gameprofilerfiller.popPush("fluidTicks");
+-            this.fluidTicks.tick(j, 65536, this::tickFluid);
++            this.fluidTicks.tick(j, paperConfig().environment.maxFluidTicks, this::tickFluid); // Paper - configurable max fluid ticks
+             gameprofilerfiller.pop();
+         }
+         this.timings.scheduledBlocks.stopTiming(); // Paper


### PR DESCRIPTION
This allows to limit the maximum fluid and blocks ticks per server tick. I used this option limit the performance impact of large redstone contraptions; Specifically large glow berry farms with a lot of flowing water.