### PR TITLE
Fix corrupted plugin.yml breaking plugin loading

### DIFF
--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -5552,10 +5552,10 @@ index 0000000000000000000000000000000000000000..f30fcf60b64150e381c7b813016aa9dd
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java b/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5b58df8df7efca0f67e3a14dd71051dfd7a26079
+index 0000000000000000000000000000000000000000..3ba4f0e5ab069c65f7eabf471793ddde64c239cd
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
-@@ -0,0 +1,171 @@
+@@ -0,0 +1,177 @@
 +package io.papermc.paper.plugin.provider.source;
 +
 +import io.papermc.paper.plugin.PluginInitializerManager;
@@ -5645,7 +5645,13 @@ index 0000000000000000000000000000000000000000..5b58df8df7efca0f67e3a14dd71051df
 +        }
 +
 +        try {
-+            String pluginName = this.getPluginName(file);
++            String pluginName;
++            try {
++                pluginName = this.getPluginName(file);
++            } catch (Exception e) {
++                return file; // Could not determine plugin name from the current jar file
++            }
++
 +            UpdateFileVisitor visitor = new UpdateFileVisitor(pluginName);
 +            Files.walkFileTree(updateDirectory, Set.of(), 1, visitor);
 +            if (visitor.getValidPlugin() != null) {


### PR DESCRIPTION
Fix corrupted plugin.yml file in one plugin (or more) not loading any plugins by the server.

The bug puts the server in a dangerous state where vanilla worlds (overworld, nether and the end) are loaded, server is accessible to players, but no plugins are loaded and enabled. To reproduce the bug 1) create `update` directory inside `plugins`, 2) put a valid and a corrupted plugin JAR in `plugins`. By "corrupted" I mean plugin that is eg. missing the `plugin.yml` file, or the file has the wrong YAML syntax. 3) Start the server

The issue has been discovered by one of our clients, we reproduced it, fixed and sent to you to merge it to upstream.