### PR TITLE
Prioritise direct entity for Damager in damage event and avoid redundant causing entity

### DIFF
--- a/patches/server/1048-Fix-CB-behaviours-in-DamageSource-for-DamageEvents.patch
+++ b/patches/server/1048-Fix-CB-behaviours-in-DamageSource-for-DamageEvents.patch
@@ -24,7 +24,7 @@ index d677759ac6b6d3cfe5a2af76dc1f0034b216ac2d..620dc20bda7a1959ff7c562e57e8b422
      private static EntityDamageEvent handleEntityDamageEvent(Entity entity, DamageSource source, Map<DamageModifier, Double> modifiers, Map<DamageModifier, Function<? super Double, Double>> modifierFunctions, boolean cancelled) {
          CraftDamageSource bukkitDamageSource = new CraftDamageSource(source);
          Entity damager = source.getCausingEntity();
-+        // Paper start - make damager priorice the direct entity of damagesource
++        // Paper start - make damager prioritise the direct entity of damagesource
 +        if (bukkitDamageSource.isIndirect() && source.getDirectEntity() != null) {
 +            damager = source.getDirectEntity();
 +        }

--- a/patches/server/1048-Fix-CB-behaviours-in-DamageSource-for-DamageEvents.patch
+++ b/patches/server/1048-Fix-CB-behaviours-in-DamageSource-for-DamageEvents.patch
@@ -1,9 +1,21 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Doc <nachito94@msn.com>
 Date: Thu, 22 Feb 2024 10:53:16 -0300
-Subject: [PATCH] Priorice direct entity for damager in DamageEvents
+Subject: [PATCH] Fix CB behaviours in DamageSource for DamageEvents
 
 
+diff --git a/src/main/java/net/minecraft/world/damagesource/DamageSource.java b/src/main/java/net/minecraft/world/damagesource/DamageSource.java
+index 1561b85a45f52a8162f43553f8485bfe084b8f1f..adb9be0c1cbfd524e26e2ff49e37c58fb3ef8751 100644
+--- a/src/main/java/net/minecraft/world/damagesource/DamageSource.java
++++ b/src/main/java/net/minecraft/world/damagesource/DamageSource.java
+@@ -61,6 +61,7 @@ public class DamageSource {
+     }
+ 
+     public DamageSource customCausingEntity(Entity entity) {
++        if (this.customCausingEntity != null || this.directEntity == entity || this.causingEntity == entity) return this; // Paper - avoid this method broke a few CB behaviours
+         DamageSource damageSource = this.cloneInstance();
+         damageSource.customCausingEntity = entity;
+         return damageSource;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 index d677759ac6b6d3cfe5a2af76dc1f0034b216ac2d..620dc20bda7a1959ff7c562e57e8b422650ce1d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java

--- a/patches/server/1048-Priorice-direct-entity-for-damager-in-DamageEvents.patch
+++ b/patches/server/1048-Priorice-direct-entity-for-damager-in-DamageEvents.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Doc <nachito94@msn.com>
+Date: Thu, 22 Feb 2024 10:53:16 -0300
+Subject: [PATCH] Priorice direct entity for damager in DamageEvents
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index d677759ac6b6d3cfe5a2af76dc1f0034b216ac2d..620dc20bda7a1959ff7c562e57e8b422650ce1d7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1082,6 +1082,11 @@ public class CraftEventFactory {
+     private static EntityDamageEvent handleEntityDamageEvent(Entity entity, DamageSource source, Map<DamageModifier, Double> modifiers, Map<DamageModifier, Function<? super Double, Double>> modifierFunctions, boolean cancelled) {
+         CraftDamageSource bukkitDamageSource = new CraftDamageSource(source);
+         Entity damager = source.getCausingEntity();
++        // Paper start - make damager priorice the direct entity of damagesource
++        if (bukkitDamageSource.isIndirect() && source.getDirectEntity() != null) {
++            damager = source.getDirectEntity();
++        }
++        // Paper end
+         if (source.is(DamageTypeTags.IS_EXPLOSION)) {
+             if (damager == null) {
+                 return CraftEventFactory.callEntityDamageEvent(source.getDirectBlock(), entity, DamageCause.BLOCK_EXPLOSION, bukkitDamageSource, modifiers, modifierFunctions, cancelled, source.explodedBlockState); // Paper - Include BlockState for damage


### PR DESCRIPTION
This fix #10273 making the damager selector use the same logic than Projectile for every case, directEntity is who cause the damage (the damager).

if any can enable the jar for allow users test another bahaviours.. i test the basic based in my upstream PR for make sure this change not break any thing.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-10275.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1267366590.zip)