### PR TITLE
Close PRs opened from orgs or bot accounts

### DIFF
--- a/.github/workflows/close_invalid_prs.yml
+++ b/.github/workflows/close_invalid_prs.yml
@@ -6,9 +6,22 @@ on:
 
 jobs:
   run:
-    if: ${{ github.repository != github.event.pull_request.head.repo.full_name && github.head_ref == 'master' }}
+    if: |
+      github.repository != github.event.pull_request.head.repo.full_name &&
+      (
+        github.head_ref == 'master' ||
+        github.event.pull_request.head.repo.owner.type != 'User'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: superbrothers/close-pull-request@v3
+        id: "master_branch"
+        if: github.head_ref == 'master'
         with:
           comment: "Please do not open pull requests from the `master` branch, create a new branch instead."
+
+      - uses: superbrothers/close-pull-request@v3
+        id: "org_account"
+        if: github.event.pull_request.head.repo.owner.type != 'User' && steps.master_branch.outcome == 'skipped'
+        with:
+          comment: "Please do not open pull requests from non-user accounts like organisations. Create a fork on a user account instead."

--- a/.github/workflows/close_invalid_prs.yml
+++ b/.github/workflows/close_invalid_prs.yml
@@ -24,4 +24,4 @@ jobs:
         id: "org_account"
         if: github.event.pull_request.head.repo.owner.type != 'User' && steps.master_branch.outcome == 'skipped'
         with:
-          comment: "Please do not open pull requests from non-user accounts like organisations. Create a fork on a user account instead."
+          comment: "Please do not open pull requests from non-user accounts like organizations. Create a fork on a user account instead."


### PR DESCRIPTION
Expands the existing close_invalid_prs workflow to also close prs that were opened from repositories not owned by user accounts. This is required as such PRs cannot be edited by maintainers.

The implementation re-uses the existing job instead of creating a new job to limit the amount of checks to the bare minimum.