### PR TITLE
Allow passenger retaining teleport via end gateway

### DIFF
--- a/patches/server/0375-Ensure-safe-gateway-teleport.patch
+++ b/patches/server/0375-Ensure-safe-gateway-teleport.patch
@@ -3,24 +3,18 @@ From: kickash32 <kickash32@gmail.com>
 Date: Fri, 15 May 2020 01:10:03 -0400
 Subject: [PATCH] Ensure safe gateway teleport
 
+== AT ==
+public net.minecraft.world.entity.Entity teleportPassengers()V
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-index a57743b21b6075ba01def0a41fecbf90b2df7f85..54f7bdd0e003ed170d739593199a2bb8ff0bbd68 100644
+index a57743b21b6075ba01def0a41fecbf90b2df7f85..098fde8200a11f91f934ddab6b1486dac4014dfe 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-@@ -106,7 +106,14 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
-             List<Entity> list = world.getEntitiesOfClass(Entity.class, new AABB(pos), TheEndGatewayBlockEntity::canEntityTeleport);
+@@ -220,6 +220,7 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
  
-             if (!list.isEmpty()) {
--                TheEndGatewayBlockEntity.teleportEntity(world, pos, state, (Entity) list.get(world.random.nextInt(list.size())), blockEntity);
-+                // Paper start - Ensure safe gateway teleport
-+                for (Entity entity : list) {
-+                    if (entity.canChangeDimensions()) {
-+                        TheEndGatewayBlockEntity.teleportEntity(world, pos, state, entity, blockEntity);
-+                        break;
-+                    }
-+                }
-+                // Paper end - Ensure safe gateway teleport
-             }
+                     entity1.setPortalCooldown();
+                     ((ServerPlayer) entity1).connection.teleport(teleEvent.getTo());
++                    entity1.teleportPassengers(); // Paper - teleport passengers as well, preventing invisible passengers post teleport.
+                     TheEndGatewayBlockEntity.triggerCooldown(world, pos, state, blockEntity); // CraftBukkit - call at end of method
+                     return;
  
-             if (blockEntity.age % 2400L == 0L) {


### PR DESCRIPTION
Previously paper disabled the abilities for entities to teleport via end gateways if they were being used as a vehicle.

While the behaviour generally worked fine for entities riding other entities, players would quickly end up in an invalid state, not seeing their passenger anymore.

This commit removes the paper introduced limitation by now properly updating the passengers location of a player when they are teleporting through an end gateway.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-10283.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1312163367.zip)