### PR TITLE
check if itemstack is stackable first

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -63,4 +63,5 @@ Ollie <69084614+olijeffers0n@users.noreply.github.com>
 Oliwier Miodun <naczs@blueflow.pl>
 aerulion <aerulion@gmail.com>
 Lukas Planz <lukas.planz@web.de>
+granny <contact@granny.dev>
 ```

--- a/patches/server/1048-check-if-itemstack-is-stackable-first.patch
+++ b/patches/server/1048-check-if-itemstack-is-stackable-first.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: granny <contact@granny.dev>
+Date: Sat, 24 Feb 2024 19:33:01 -0800
+Subject: [PATCH] check if itemstack is stackable first
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/player/Inventory.java b/src/main/java/net/minecraft/world/entity/player/Inventory.java
+index 309acf7bd07e38043aa81e0e686edba1136bd04c..96c898086f35fd83f9b1ce7e3fe53d31b2fa4c31 100644
+--- a/src/main/java/net/minecraft/world/entity/player/Inventory.java
++++ b/src/main/java/net/minecraft/world/entity/player/Inventory.java
+@@ -114,7 +114,7 @@ public class Inventory implements Container, Nameable {
+     }
+ 
+     private boolean hasRemainingSpaceForItem(ItemStack existingStack, ItemStack stack) {
+-        return !existingStack.isEmpty() && ItemStack.isSameItemSameTags(existingStack, stack) && existingStack.isStackable() && existingStack.getCount() < existingStack.getMaxStackSize() && existingStack.getCount() < this.getMaxStackSize();
++        return !existingStack.isEmpty() && existingStack.isStackable() && existingStack.getCount() < existingStack.getMaxStackSize() && existingStack.getCount() < this.getMaxStackSize() && ItemStack.isSameItemSameTags(existingStack, stack); // Paper - check if itemstack is stackable first
+     }
+ 
+     // CraftBukkit start - Watch method above! :D


### PR DESCRIPTION
Avoids an issue where unstackable items are checked against themselves when an inventory is full of items.

For more context to paper devs who are in the purpur discord: https://discord.com/channels/685683385313919172/697248751575761057/1211147576213119006

This can and should be merged into a pre-existing patch - I'm not sure which one so I've left it as it's own for now.