### PR TITLE
Deprecate ItemStack#setType

### DIFF
--- a/patches/api/0124-PlayerElytraBoostEvent.patch
+++ b/patches/api/0124-PlayerElytraBoostEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] PlayerElytraBoostEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerElytraBoostEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerElytraBoostEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..42375d44ed0db457b96165414e9b45a557bac1ab
+index 0000000000000000000000000000000000000000..9ebac41c22b8866df616020d409e5e1a49cddca5
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerElytraBoostEvent.java
-@@ -0,0 +1,90 @@
+@@ -0,0 +1,104 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Firework;
@@ -17,6 +17,7 @@ index 0000000000000000000000000000000000000000..42375d44ed0db457b96165414e9b45a5
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.inventory.EquipmentSlot;
 +import org.bukkit.inventory.ItemStack;
 +import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
@@ -31,14 +32,17 @@ index 0000000000000000000000000000000000000000..42375d44ed0db457b96165414e9b45a5
 +    @NotNull private final ItemStack itemStack;
 +    @NotNull private final Firework firework;
 +    private boolean consume = true;
++    @NotNull
++    private final EquipmentSlot hand;
 +
 +    private boolean cancelled;
 +
 +    @ApiStatus.Internal
-+    public PlayerElytraBoostEvent(@NotNull Player player, @NotNull ItemStack itemStack, @NotNull Firework firework) {
++    public PlayerElytraBoostEvent(@NotNull Player player, @NotNull ItemStack itemStack, @NotNull Firework firework, @NotNull EquipmentSlot hand) {
 +        super(player);
 +        this.itemStack = itemStack;
 +        this.firework = firework;
++        this.hand = hand;
 +    }
 +
 +    /**
@@ -77,6 +81,16 @@ index 0000000000000000000000000000000000000000..42375d44ed0db457b96165414e9b45a5
 +     */
 +    public void setShouldConsume(boolean consume) {
 +        this.consume = consume;
++    }
++
++    /**
++     * Gets the hand holding the firework used for boosting this player.
++     *
++     * @return interaction hand
++     */
++    @NotNull
++    public EquipmentSlot getHand() {
++        return this.hand;
 +    }
 +
 +    @Override

--- a/patches/api/0173-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0173-Fix-Spigot-annotation-mistakes.patch
@@ -982,6 +982,30 @@ index 8f601e85df580ef8106eaff8b9eafb5691a4874b..d615c006c9153fb65024241604b744fb
      public static final MemoryKey<Location> SNIFFER_EXPLORED_POSITIONS = new MemoryKey<>(NamespacedKey.minecraft("sniffer_explored_positions"), Location.class);
  
      /**
+diff --git a/src/main/java/org/bukkit/event/block/BrewingStartEvent.java b/src/main/java/org/bukkit/event/block/BrewingStartEvent.java
+index 9e54ef5b60bf5583c12e1edfa76f19013a5b2a65..37be83184cae203d5e99518b0ff5c708fafb0331 100644
+--- a/src/main/java/org/bukkit/event/block/BrewingStartEvent.java
++++ b/src/main/java/org/bukkit/event/block/BrewingStartEvent.java
+@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
+ /**
+  * Called when a brewing stand starts to brew.
+  */
++@org.jetbrains.annotations.ApiStatus.Experimental // Paper
+ public class BrewingStartEvent extends InventoryBlockStartEvent {
+ 
+     private static final HandlerList handlers = new HandlerList();
+diff --git a/src/main/java/org/bukkit/event/block/CampfireStartEvent.java b/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
+index 53119742beda00a38111063243665bb995ae2188..2d084214e991fecc51f8e18e3d733e43b1dca248 100644
+--- a/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
++++ b/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
+@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
+ /**
+  * Called when a Campfire starts to cook.
+  */
++@org.jetbrains.annotations.ApiStatus.Experimental // Paper
+ public class CampfireStartEvent extends InventoryBlockStartEvent {
+ 
+     private static final HandlerList handlers = new HandlerList();
 diff --git a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java b/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
 index e9a6e5be5f33a342f7e5c496f0f1c64b2f302ace..f0db59a556deaefefbdaca121585c0fd199c13c2 100644
 --- a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java

--- a/patches/api/0401-Fix-HandlerList-for-InventoryBlockStartEvent-subclas.patch
+++ b/patches/api/0401-Fix-HandlerList-for-InventoryBlockStartEvent-subclas.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Fix HandlerList for InventoryBlockStartEvent subclasses
 
 
 diff --git a/src/main/java/org/bukkit/event/block/BrewingStartEvent.java b/src/main/java/org/bukkit/event/block/BrewingStartEvent.java
-index 9e54ef5b60bf5583c12e1edfa76f19013a5b2a65..fe6573d8fca0aa8d8f37f8b476fc45adc786795f 100644
+index 37be83184cae203d5e99518b0ff5c708fafb0331..43eac972f45d1cbb6278b048f8e6d7882c0aabeb 100644
 --- a/src/main/java/org/bukkit/event/block/BrewingStartEvent.java
 +++ b/src/main/java/org/bukkit/event/block/BrewingStartEvent.java
-@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
-  */
+@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
+ @org.jetbrains.annotations.ApiStatus.Experimental // Paper
  public class BrewingStartEvent extends InventoryBlockStartEvent {
  
 -    private static final HandlerList handlers = new HandlerList();
@@ -17,7 +17,7 @@ index 9e54ef5b60bf5583c12e1edfa76f19013a5b2a65..fe6573d8fca0aa8d8f37f8b476fc45ad
      private int brewingTime;
  
      public BrewingStartEvent(@NotNull final Block furnace, @NotNull ItemStack source, int brewingTime) {
-@@ -36,14 +36,5 @@ public class BrewingStartEvent extends InventoryBlockStartEvent {
+@@ -37,14 +37,5 @@ public class BrewingStartEvent extends InventoryBlockStartEvent {
          this.brewingTime = brewTime;
      }
  
@@ -34,11 +34,11 @@ index 9e54ef5b60bf5583c12e1edfa76f19013a5b2a65..fe6573d8fca0aa8d8f37f8b476fc45ad
 +    // Paper - remove HandlerList
  }
 diff --git a/src/main/java/org/bukkit/event/block/CampfireStartEvent.java b/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
-index 53119742beda00a38111063243665bb995ae2188..1f7a8bf65e9ac3188f759f9b3c4d6edbf255942a 100644
+index 2d084214e991fecc51f8e18e3d733e43b1dca248..4b12575107b3f1fa6d0ed7f667bf0d0ae40acae0 100644
 --- a/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
 +++ b/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
-@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
-  */
+@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
+ @org.jetbrains.annotations.ApiStatus.Experimental // Paper
  public class CampfireStartEvent extends InventoryBlockStartEvent {
  
 -    private static final HandlerList handlers = new HandlerList();
@@ -46,7 +46,7 @@ index 53119742beda00a38111063243665bb995ae2188..1f7a8bf65e9ac3188f759f9b3c4d6edb
      private int cookingTime;
      private CampfireRecipe campfireRecipe;
  
-@@ -49,14 +49,5 @@ public class CampfireStartEvent extends InventoryBlockStartEvent {
+@@ -50,14 +50,5 @@ public class CampfireStartEvent extends InventoryBlockStartEvent {
          this.cookingTime = cookTime;
      }
  

--- a/patches/api/0469-Deprecate-ItemStack-setType.patch
+++ b/patches/api/0469-Deprecate-ItemStack-setType.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Thu, 29 Feb 2024 17:54:26 -0500
+Subject: [PATCH] Deprecate ItemStack#setType
+
+
+diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
+index 245a730a54c4b241a9a67eccceefafd2763bd238..7414b4fa690d393a8e9557cc1fd1ce12fa426940 100644
+--- a/src/main/java/org/bukkit/inventory/ItemStack.java
++++ b/src/main/java/org/bukkit/inventory/ItemStack.java
+@@ -134,8 +134,18 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+      * {@link Material#isItem()} returns false.</b>
+      *
+      * @param type New type to set the items in this stack to
++     * @deprecated <b>Setting the material type of ItemStacks is no longer supported.</b>
++     * <p>
++     * This method is deprecated due to potential illegal behavior that may occur
++     * during the context of which this ItemStack is being used, allowing for certain item validation to be bypassed.
++     * It is recommended to instead create a new ItemStack object with the desired
++     * Material type, and if possible, set it in the appropriate context.
++     *
++     * Using this method in ItemStacks passed in events will result in undefined behavior.
++     * @see ItemStack#withType(Material)
+      */
+     @Utility
++    @Deprecated // Paper
+     public void setType(@NotNull Material type) {
+         Preconditions.checkArgument(type != null, "Material cannot be null");
+         this.type = type;
+@@ -148,6 +158,24 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+             this.data = null;
+         }
+     }
++    // Paper start
++    /**
++     * Creates a new ItemStack with the specified Material type, where the item count and item meta is preserved.
++     *
++     * @param type The Material type of the new ItemStack.
++     * @return A new ItemStack instance with the specified Material type.
++     */
++    @NotNull
++    @org.jetbrains.annotations.Contract(value = "_ -> new", pure = true)
++    public ItemStack withType(@NotNull Material type) {
++        ItemStack itemStack = new ItemStack(type, this.amount);
++        if (this.hasItemMeta()) {
++            itemStack.setItemMeta(this.getItemMeta());
++        }
++
++        return itemStack;
++    }
++    // Paper end
+ 
+     /**
+      * Gets the amount of items in this stack

--- a/patches/api/0470-Item-Mutation-Fixes.patch
+++ b/patches/api/0470-Item-Mutation-Fixes.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Wed, 20 Mar 2024 20:42:31 -0400
+Subject: [PATCH] Item Mutation Fixes
+
+
+diff --git a/src/main/java/org/bukkit/event/block/CampfireStartEvent.java b/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
+index 1f7a8bf65e9ac3188f759f9b3c4d6edbf255942a..7e017818e8af0bb3f24a2cb28da9a43d3ae8fc4b 100644
+--- a/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
++++ b/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
+@@ -20,6 +20,16 @@ public class CampfireStartEvent extends InventoryBlockStartEvent {
+         this.cookingTime = recipe.getCookingTime();
+         this.campfireRecipe = recipe;
+     }
++    // Paper start
++    /**
++     * Sets the source ItemStack for this event.
++     *
++     * @param source the source ItemStack
++     */
++    public void setSource(@NotNull final ItemStack source) {
++        this.source = source;
++    }
++    // Paper end
+ 
+     /**
+      * Gets the CampfireRecipe associated with this event.
+diff --git a/src/main/java/org/bukkit/event/block/InventoryBlockStartEvent.java b/src/main/java/org/bukkit/event/block/InventoryBlockStartEvent.java
+index f30ed841864f426c59143f392f39c96f864ba924..16fd600c25991e641a1be6fb78238256a6ce3d3f 100644
+--- a/src/main/java/org/bukkit/event/block/InventoryBlockStartEvent.java
++++ b/src/main/java/org/bukkit/event/block/InventoryBlockStartEvent.java
+@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
+ public class InventoryBlockStartEvent extends BlockEvent {
+ 
+     private static final HandlerList handlers = new HandlerList();
+-    private final ItemStack source;
++    protected ItemStack source; // Paper
+ 
+     public InventoryBlockStartEvent(@NotNull final Block block, @NotNull ItemStack source) {
+         super(block);
+diff --git a/src/main/java/org/bukkit/event/enchantment/EnchantItemEvent.java b/src/main/java/org/bukkit/event/enchantment/EnchantItemEvent.java
+index 1829529c9915937dcdd0e6d1ceba9e64819fb93f..e7c243038b70ca13b7eabdf88ce518b6198c6db9 100644
+--- a/src/main/java/org/bukkit/event/enchantment/EnchantItemEvent.java
++++ b/src/main/java/org/bukkit/event/enchantment/EnchantItemEvent.java
+@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
+ public class EnchantItemEvent extends InventoryEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final Block table;
+-    private final ItemStack item;
++    private ItemStack item; // Paper
+     private int level;
+     private boolean cancelled;
+     private final Map<Enchantment, Integer> enchants;
+@@ -72,6 +72,17 @@ public class EnchantItemEvent extends InventoryEvent implements Cancellable {
+         return item;
+     }
+ 
++    // Paper start
++    /**
++     * Sets the item to be enchanted
++     *
++     * @param item item
++     */
++    public void setItem(@NotNull final ItemStack item) {
++        this.item = item;
++    }
++    // Paper end
++
+     /**
+      * Gets the cost (minimum level) which is displayed as a number on the right
+      * hand side of the enchantment offer.

--- a/patches/api/0470-Item-Mutation-Fixes.patch
+++ b/patches/api/0470-Item-Mutation-Fixes.patch
@@ -4,27 +4,6 @@ Date: Wed, 20 Mar 2024 20:42:31 -0400
 Subject: [PATCH] Item Mutation Fixes
 
 
-diff --git a/src/main/java/org/bukkit/event/block/CampfireStartEvent.java b/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
-index 1f7a8bf65e9ac3188f759f9b3c4d6edbf255942a..7e017818e8af0bb3f24a2cb28da9a43d3ae8fc4b 100644
---- a/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
-+++ b/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
-@@ -20,6 +20,16 @@ public class CampfireStartEvent extends InventoryBlockStartEvent {
-         this.cookingTime = recipe.getCookingTime();
-         this.campfireRecipe = recipe;
-     }
-+    // Paper start
-+    /**
-+     * Sets the source ItemStack for this event.
-+     *
-+     * @param source the source ItemStack
-+     */
-+    public void setSource(@NotNull final ItemStack source) {
-+        this.source = source;
-+    }
-+    // Paper end
- 
-     /**
-      * Gets the CampfireRecipe associated with this event.
 diff --git a/src/main/java/org/bukkit/event/block/InventoryBlockStartEvent.java b/src/main/java/org/bukkit/event/block/InventoryBlockStartEvent.java
 index f30ed841864f426c59143f392f39c96f864ba924..16fd600c25991e641a1be6fb78238256a6ce3d3f 100644
 --- a/src/main/java/org/bukkit/event/block/InventoryBlockStartEvent.java

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -7892,10 +7892,10 @@ index ed501b794c222278dca98f8ece6096db1d8108a5..be3a8e54d64b3cc145ab09b0bc7abb3f
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index bf46aa3bd46ffabe92d58aa45ea0dfe6c98d94aa..23b83f8e98d681895b4e23cda4f3d50f85c12dd9 100644
+index bf46aa3bd46ffabe92d58aa45ea0dfe6c98d94aa..0bb01e53f1c15071c8cd818cce79af8196fe790f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -23,6 +23,16 @@ import org.bukkit.material.MaterialData;
+@@ -23,6 +23,20 @@ import org.bukkit.material.MaterialData;
  @DelegateDeserialization(ItemStack.class)
  public final class CraftItemStack extends ItemStack {
  
@@ -7906,6 +7906,10 @@ index bf46aa3bd46ffabe92d58aa45ea0dfe6c98d94aa..23b83f8e98d681895b4e23cda4f3d50f
 +        } else {
 +            return asNMSCopy(bukkit);
 +        }
++    }
++
++    public static net.minecraft.world.item.ItemStack getOrCloneOnMutation(ItemStack old, ItemStack newInstance) {
++        return old == newInstance ? unwrap(old) : asNMSCopy(newInstance);
 +    }
 +    // Paper end - MC Utils
 +

--- a/patches/server/0067-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0067-Handle-Item-Meta-Inconsistencies.patch
@@ -70,10 +70,10 @@ index 6291265ae4691bf7dffe196d20571c1c30e8d906..70511628eefc28163d07f50f18d9cc55
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 23b83f8e98d681895b4e23cda4f3d50f85c12dd9..c72a1a503f6e71228a1f82b37068ff7a83e983dc 100644
+index 0bb01e53f1c15071c8cd818cce79af8196fe790f..b59e84bbed37b002a34fe81efdce6f025617fc84 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -188,28 +188,11 @@ public final class CraftItemStack extends ItemStack {
+@@ -192,28 +192,11 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Preconditions.checkArgument(ench != null, "Enchantment cannot be null");
  
@@ -107,7 +107,7 @@ index 23b83f8e98d681895b4e23cda4f3d50f85c12dd9..c72a1a503f6e71228a1f82b37068ff7a
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -242,43 +225,15 @@ public final class CraftItemStack extends ItemStack {
+@@ -246,43 +229,15 @@ public final class CraftItemStack extends ItemStack {
      public int removeEnchantment(Enchantment ench) {
          Preconditions.checkArgument(ench != null, "Enchantment cannot be null");
  
@@ -159,7 +159,7 @@ index 23b83f8e98d681895b4e23cda4f3d50f85c12dd9..c72a1a503f6e71228a1f82b37068ff7a
  
          return level;
      }
-@@ -290,7 +245,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -294,7 +249,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public Map<Enchantment, Integer> getEnchantments() {

--- a/patches/server/0193-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0193-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index c72a1a503f6e71228a1f82b37068ff7a83e983dc..d9a07829d5d0ebcb18b8e3f12622ed7795955d61 100644
+index b59e84bbed37b002a34fe81efdce6f025617fc84..78f2159285e676b877f85df604889ddcf19e8923 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -184,6 +184,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -188,6 +188,13 @@ public final class CraftItemStack extends ItemStack {
          return (this.handle == null) ? Material.AIR.getMaxStackSize() : this.handle.getItem().getMaxStackSize();
      }
  

--- a/patches/server/0214-PlayerElytraBoostEvent.patch
+++ b/patches/server/0214-PlayerElytraBoostEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] PlayerElytraBoostEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/FireworkRocketItem.java b/src/main/java/net/minecraft/world/item/FireworkRocketItem.java
-index 3749cfca8f007973d1a2206d8f2ba15283a550e1..eb655eb01e4841ca163666f21dae00f0632a11e5 100644
+index 7c627d27300247db9122ab2081049345ef306073..4565cf51ee2f973b368a984436c02220ed9f4a70 100644
 --- a/src/main/java/net/minecraft/world/item/FireworkRocketItem.java
 +++ b/src/main/java/net/minecraft/world/item/FireworkRocketItem.java
 @@ -68,12 +68,19 @@ public class FireworkRocketItem extends Item {
@@ -15,7 +15,7 @@ index 3749cfca8f007973d1a2206d8f2ba15283a550e1..eb655eb01e4841ca163666f21dae00f0
 -                world.addFreshEntity(fireworkRocketEntity);
 -                if (!user.getAbilities().instabuild) {
 +                // Paper start - PlayerElytraBoostEvent
-+                com.destroystokyo.paper.event.player.PlayerElytraBoostEvent event = new com.destroystokyo.paper.event.player.PlayerElytraBoostEvent((org.bukkit.entity.Player) user.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack), (org.bukkit.entity.Firework) fireworkRocketEntity.getBukkitEntity());
++                com.destroystokyo.paper.event.player.PlayerElytraBoostEvent event = new com.destroystokyo.paper.event.player.PlayerElytraBoostEvent((org.bukkit.entity.Player) user.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack), (org.bukkit.entity.Firework) fireworkRocketEntity.getBukkitEntity(), org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(hand));
 +                if (event.callEvent() && world.addFreshEntity(fireworkRocketEntity)) {
 +                    user.awardStat(Stats.ITEM_USED.get(this));
 +                    if (event.shouldConsume() && !user.getAbilities().instabuild) {

--- a/patches/server/0221-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0221-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index d9a07829d5d0ebcb18b8e3f12622ed7795955d61..7ce48473222516aefda3c5ad40e5e3fd23502e3d 100644
+index 78f2159285e676b877f85df604889ddcf19e8923..f3195b37c314a1327752ece7ec33dfdae16f0bec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -675,7 +675,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -679,7 +679,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {

--- a/patches/server/0716-More-Projectile-API.patch
+++ b/patches/server/0716-More-Projectile-API.patch
@@ -568,10 +568,10 @@ index 7d72ccdd82daa6afe85859f5bc6ec7b187622384..fb0426a1d864f3c60637e394e5bedb39
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 7ce48473222516aefda3c5ad40e5e3fd23502e3d..6725c0824b986885c8aade846f6e159986ffbe59 100644
+index f3195b37c314a1327752ece7ec33dfdae16f0bec..6b75314023adf313937990e31323dff9bacc564b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -294,12 +294,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -298,12 +298,20 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0840-Remove-CraftItemStack-setAmount-null-assignment.patch
+++ b/patches/server/0840-Remove-CraftItemStack-setAmount-null-assignment.patch
@@ -16,10 +16,10 @@ with less than zero amounts, so this code doesn't create
 a problem with operations on the vanilla ItemStack.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 6725c0824b986885c8aade846f6e159986ffbe59..312e756843f62371048a4d8de9deb024bd9846a7 100644
+index 6b75314023adf313937990e31323dff9bacc564b..fb2e4881096459eff16a7c46faa9921166837ee9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -157,7 +157,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -161,7 +161,7 @@ public final class CraftItemStack extends ItemStack {
          }
  
          this.handle.setCount(amount);

--- a/patches/server/0886-fix-item-meta-for-tadpole-buckets.patch
+++ b/patches/server/0886-fix-item-meta-for-tadpole-buckets.patch
@@ -17,10 +17,10 @@ index c421649a0c88ee9c773bb6985f7114e58f08a7a1..71aac5d4cf29cea9daa378fc8ac58475
          case GLOW_ITEM_FRAME:
          case PAINTING:
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 312e756843f62371048a4d8de9deb024bd9846a7..a2e605bc1418dc0b5570566a6e348df03c9aee4c 100644
+index fb2e4881096459eff16a7c46faa9921166837ee9..f106db3aa5e5b3b0b8133eff77dbc65c8895ff2e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -597,6 +597,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -601,6 +601,7 @@ public final class CraftItemStack extends ItemStack {
              case COD_BUCKET:
              case PUFFERFISH_BUCKET:
              case SALMON_BUCKET:

--- a/patches/server/0933-Allow-proper-checking-of-empty-item-stacks.patch
+++ b/patches/server/0933-Allow-proper-checking-of-empty-item-stacks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow proper checking of empty item stacks
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index a2e605bc1418dc0b5570566a6e348df03c9aee4c..e1f9a603e7adf3468faa9bb6d93dd3339327b47e 100644
+index f106db3aa5e5b3b0b8133eff77dbc65c8895ff2e..38ceeca108c258852eeb7a48015010a689ac43ec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -33,12 +33,19 @@ public final class CraftItemStack extends ItemStack {
+@@ -37,12 +37,19 @@ public final class CraftItemStack extends ItemStack {
      }
      // Paper end - MC Utils
  

--- a/patches/server/0971-Add-drops-to-shear-events.patch
+++ b/patches/server/0971-Add-drops-to-shear-events.patch
@@ -264,10 +264,10 @@ index 99292a908b36e3c75d51c6877c7a0c01d9671aa6..0a041d0e56dfe1319e5174cb0e6085dc
  
      public static Cancellable handleStatisticsIncrease(net.minecraft.world.entity.player.Player entityHuman, net.minecraft.stats.Stat<?> statistic, int current, int newValue) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index e1f9a603e7adf3468faa9bb6d93dd3339327b47e..870954fc59efdc1e0c6b5047f5a89dfaf7522d0e 100644
+index 38ceeca108c258852eeb7a48015010a689ac43ec..f67b048c3831fcab24acd12249cbd32d386c3ffe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -62,6 +62,16 @@ public final class CraftItemStack extends ItemStack {
+@@ -66,6 +66,16 @@ public final class CraftItemStack extends ItemStack {
          return stack;
      }
  

--- a/patches/server/1055-Deprecate-ItemStack-setType.patch
+++ b/patches/server/1055-Deprecate-ItemStack-setType.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Tue, 26 Mar 2024 21:42:23 -0400
+Subject: [PATCH] Deprecate ItemStack#setType
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+index f67b048c3831fcab24acd12249cbd32d386c3ffe..319809804a70e5b78ce12349facff717eec13f9b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+@@ -4,6 +4,7 @@ import static org.bukkit.craftbukkit.inventory.CraftMetaItem.*;
+ import com.google.common.base.Preconditions;
+ import com.google.common.collect.ImmutableMap;
+ import java.util.Map;
++import java.util.Optional;
+ import net.minecraft.nbt.CompoundTag;
+ import net.minecraft.nbt.ListTag;
+ import net.minecraft.world.item.Item;
+@@ -711,4 +712,17 @@ public final class CraftItemStack extends ItemStack {
+     static boolean hasItemMeta(net.minecraft.world.item.ItemStack item) {
+         return !(item == null || item.getTag() == null || item.getTag().isEmpty());
+     }
++    // Paper start - with type
++    @Override
++    public ItemStack withType(final Material type) {
++        if (type == Material.AIR) return CraftItemStack.asCraftMirror(null);
++
++        final net.minecraft.world.item.ItemStack copy = new net.minecraft.world.item.ItemStack(
++            CraftItemType.bukkitToMinecraft(type), this.getAmount()
++        );
++        if (this.handle != null) copy.setTag(this.handle.getTag().copy());
++
++        return CraftItemStack.asCraftMirror(copy);
++    }
++    // Paper end
+ }

--- a/patches/server/1055-Deprecate-ItemStack-setType.patch
+++ b/patches/server/1055-Deprecate-ItemStack-setType.patch
@@ -5,18 +5,10 @@ Subject: [PATCH] Deprecate ItemStack#setType
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index f67b048c3831fcab24acd12249cbd32d386c3ffe..319809804a70e5b78ce12349facff717eec13f9b 100644
+index f67b048c3831fcab24acd12249cbd32d386c3ffe..095f42ae8de39dc37263e06b7c393598c1050b3f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -4,6 +4,7 @@ import static org.bukkit.craftbukkit.inventory.CraftMetaItem.*;
- import com.google.common.base.Preconditions;
- import com.google.common.collect.ImmutableMap;
- import java.util.Map;
-+import java.util.Optional;
- import net.minecraft.nbt.CompoundTag;
- import net.minecraft.nbt.ListTag;
- import net.minecraft.world.item.Item;
-@@ -711,4 +712,17 @@ public final class CraftItemStack extends ItemStack {
+@@ -711,4 +711,17 @@ public final class CraftItemStack extends ItemStack {
      static boolean hasItemMeta(net.minecraft.world.item.ItemStack item) {
          return !(item == null || item.getTag() == null || item.getTag().isEmpty());
      }

--- a/patches/server/1055-Deprecate-ItemStack-setType.patch
+++ b/patches/server/1055-Deprecate-ItemStack-setType.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Deprecate ItemStack#setType
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index f67b048c3831fcab24acd12249cbd32d386c3ffe..933362905cf8a0b3524210dd733c9aa335d064de 100644
+index f67b048c3831fcab24acd12249cbd32d386c3ffe..534d3f02ad14ac246ef947a118c07cca81d600dc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -711,4 +711,19 @@ public final class CraftItemStack extends ItemStack {
@@ -20,7 +20,7 @@ index f67b048c3831fcab24acd12249cbd32d386c3ffe..933362905cf8a0b3524210dd733c9aa3
 +        final net.minecraft.world.item.ItemStack copy = new net.minecraft.world.item.ItemStack(
 +            CraftItemType.bukkitToMinecraft(type), this.getAmount()
 +        );
-+        if (this.handle != null) copy.setTag(this.handle.getTag().copy());
++        if (this.handle != null && this.handle.getTag() != null) copy.setTag(this.handle.getTag().copy());
 +
 +        final CraftItemStack mirrored = CraftItemStack.asCraftMirror(copy);
 +        mirrored.setItemMeta(mirrored.getItemMeta());

--- a/patches/server/1055-Deprecate-ItemStack-setType.patch
+++ b/patches/server/1055-Deprecate-ItemStack-setType.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deprecate ItemStack#setType
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index f67b048c3831fcab24acd12249cbd32d386c3ffe..095f42ae8de39dc37263e06b7c393598c1050b3f 100644
+index f67b048c3831fcab24acd12249cbd32d386c3ffe..933362905cf8a0b3524210dd733c9aa335d064de 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -711,4 +711,17 @@ public final class CraftItemStack extends ItemStack {
+@@ -711,4 +711,19 @@ public final class CraftItemStack extends ItemStack {
      static boolean hasItemMeta(net.minecraft.world.item.ItemStack item) {
          return !(item == null || item.getTag() == null || item.getTag().isEmpty());
      }
@@ -22,7 +22,9 @@ index f67b048c3831fcab24acd12249cbd32d386c3ffe..095f42ae8de39dc37263e06b7c393598
 +        );
 +        if (this.handle != null) copy.setTag(this.handle.getTag().copy());
 +
-+        return CraftItemStack.asCraftMirror(copy);
++        final CraftItemStack mirrored = CraftItemStack.asCraftMirror(copy);
++        mirrored.setItemMeta(mirrored.getItemMeta());
++        return mirrored;
 +    }
 +    // Paper end
  }

--- a/patches/server/1056-Item-Mutation-Fixes.patch
+++ b/patches/server/1056-Item-Mutation-Fixes.patch
@@ -47,25 +47,3 @@ index 343f44db579839eb61376f876b5eff2e615dc2e5..e6935b6632c7a7e07f4da459c95f5643
                                  }
                              } catch (IllegalArgumentException e) {
                                  /* Just swallow invalid enchantments */
-diff --git a/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
-index 9f7b49a6a50cb53d914c8f4b5132c035c5ab71da..90cd24b2110a6699bf633cd6c599375b5acff8a1 100644
---- a/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
-+++ b/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
-@@ -226,12 +226,15 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
- 
-             if (itemstack1.isEmpty()) {
-                 // CraftBukkit start
--                CampfireStartEvent event = new CampfireStartEvent(CraftBlock.at(this.level,this.worldPosition), CraftItemStack.asCraftMirror(stack), (CampfireRecipe) this.getCookableRecipe(stack).get().toBukkitRecipe());
-+                // Paper start
-+                org.bukkit.inventory.ItemStack originalItem = CraftItemStack.asCraftMirror(stack.split(1));
-+                CampfireStartEvent event = new CampfireStartEvent(CraftBlock.at(this.level,this.worldPosition), originalItem, (CampfireRecipe) this.getCookableRecipe(stack).get().toBukkitRecipe());
-+                // Paper end
-                 this.level.getCraftServer().getPluginManager().callEvent(event);
-                 this.cookingTime[j] = event.getTotalCookTime(); // i -> event.getTotalCookTime()
-                 // CraftBukkit end
-                 this.cookingProgress[j] = 0;
--                this.items.set(j, stack.split(1));
-+                this.items.set(j, CraftItemStack.getOrCloneOnMutation(originalItem, event.getSource())); // Paper
-                 this.level.gameEvent(GameEvent.BLOCK_CHANGE, this.getBlockPos(), GameEvent.Context.of(user, this.getBlockState()));
-                 this.markUpdated();
-                 return true;

--- a/patches/server/1056-Item-Mutation-Fixes.patch
+++ b/patches/server/1056-Item-Mutation-Fixes.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Wed, 20 Mar 2024 20:41:35 -0400
+Subject: [PATCH] Item Mutation Fixes
+
+
+diff --git a/src/main/java/net/minecraft/world/inventory/EnchantmentMenu.java b/src/main/java/net/minecraft/world/inventory/EnchantmentMenu.java
+index 343f44db579839eb61376f876b5eff2e615dc2e5..e6935b6632c7a7e07f4da459c95f564356242f98 100644
+--- a/src/main/java/net/minecraft/world/inventory/EnchantmentMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/EnchantmentMenu.java
+@@ -229,7 +229,7 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+                 return false;
+             } else if (this.costs[id] > 0 && !itemstack.isEmpty() && (player.experienceLevel >= j && player.experienceLevel >= this.costs[id] || player.getAbilities().instabuild)) {
+                 this.access.execute((world, blockposition) -> {
+-                    ItemStack itemstack2 = itemstack;
++                    ItemStack itemstack2 = itemstack; // Paper - diff on change
+                     List<EnchantmentInstance> list = this.getEnchantmentList(itemstack, id, this.costs[id]);
+ 
+                     // CraftBukkit start
+@@ -251,11 +251,18 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+                             return;
+                         }
+                         // CraftBukkit end
+-                        boolean flag = itemstack.is(Items.BOOK);
++                        // Paper start
++                        itemstack2 = org.bukkit.craftbukkit.inventory.CraftItemStack.getOrCloneOnMutation(item, event.getItem());
++                        if (itemstack2 != itemstack) {
++                            this.enchantSlots.setItem(0, itemstack2);
++                        }
++                        boolean flag = itemstack2.is(Items.BOOK);
++                        // Paper end
+ 
+                         if (flag) {
++                            CompoundTag nbttagcompound = itemstack2.getTag(); // Paper - move up
+                             itemstack2 = new ItemStack(Items.ENCHANTED_BOOK);
+-                            CompoundTag nbttagcompound = itemstack.getTag();
++                            // Paper - move up
+ 
+                             if (nbttagcompound != null) {
+                                 itemstack2.setTag(nbttagcompound.copy());
+@@ -277,7 +284,7 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+                                     EnchantmentInstance weightedrandomenchant = new EnchantmentInstance(nms, entry.getValue());
+                                     EnchantedBookItem.addEnchantment(itemstack2, weightedrandomenchant);
+                                 } else {
+-                                    item.addUnsafeEnchantment(entry.getKey(), entry.getValue());
++                                    CraftItemStack.asCraftMirror(itemstack2).addUnsafeEnchantment(entry.getKey(), entry.getValue()); // Paper
+                                 }
+                             } catch (IllegalArgumentException e) {
+                                 /* Just swallow invalid enchantments */
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
+index 9f7b49a6a50cb53d914c8f4b5132c035c5ab71da..90cd24b2110a6699bf633cd6c599375b5acff8a1 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
+@@ -226,12 +226,15 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
+ 
+             if (itemstack1.isEmpty()) {
+                 // CraftBukkit start
+-                CampfireStartEvent event = new CampfireStartEvent(CraftBlock.at(this.level,this.worldPosition), CraftItemStack.asCraftMirror(stack), (CampfireRecipe) this.getCookableRecipe(stack).get().toBukkitRecipe());
++                // Paper start
++                org.bukkit.inventory.ItemStack originalItem = CraftItemStack.asCraftMirror(stack.split(1));
++                CampfireStartEvent event = new CampfireStartEvent(CraftBlock.at(this.level,this.worldPosition), originalItem, (CampfireRecipe) this.getCookableRecipe(stack).get().toBukkitRecipe());
++                // Paper end
+                 this.level.getCraftServer().getPluginManager().callEvent(event);
+                 this.cookingTime[j] = event.getTotalCookTime(); // i -> event.getTotalCookTime()
+                 // CraftBukkit end
+                 this.cookingProgress[j] = 0;
+-                this.items.set(j, stack.split(1));
++                this.items.set(j, CraftItemStack.getOrCloneOnMutation(originalItem, event.getSource())); // Paper
+                 this.level.gameEvent(GameEvent.BLOCK_CHANGE, this.getBlockPos(), GameEvent.Context.of(user, this.getBlockState()));
+                 this.markUpdated();
+                 return true;


### PR DESCRIPTION
This leads to discussion in regards to `ItemStack#setType`, which currently is not supported by vanilla, but is reintroduced by spigot.

This method possibly allows for unsafe behavior, as illegal item types can be passed in places that may occur after item validation.

This is most evident in event calls, where it is possible to induce server crashes in some cases due to developers putting illegal item types in ItemStacks in the wrong places.

 