### PR TITLE
Add more item use API

### DIFF
--- a/patches/api/0117-LivingEntity-Active-Item-API.patch
+++ b/patches/api/0117-LivingEntity-Active-Item-API.patch
@@ -23,7 +23,7 @@ index 2308fa3ca898bcb6c0ac2d4853f82a3398bf51f3..15115b1049bc5053796b84539acbf576
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 4a4a749449bc561a73e6747386c8ad51e623fc1e..0b2ffb5e5e5a3c42b69bbcdcd8d4b6c68477234a 100644
+index 4a4a749449bc561a73e6747386c8ad51e623fc1e..81a851580f81b2d6f6a2b2ebec38530f1d68530d 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
 @@ -202,15 +202,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
@@ -64,16 +64,16 @@ index 4a4a749449bc561a73e6747386c8ad51e623fc1e..0b2ffb5e5e5a3c42b69bbcdcd8d4b6c6
 +    // Paper start - active item API
 +    /**
 +     * Starts using the item in the specified hand, making it the
-+     * currently active item. When for example called on a skeleton
++     * currently active item. When, for example, called on a skeleton,
 +     * this will cause it to start drawing its bow.
 +     * <p>
 +     * Only HAND or OFF_HAND may be used for the hand parameter.
 +     * <p>
-+     * When using on a player the client will stop using the item
++     * When used on a player, the client will stop using the item
 +     * if right click is held down.
 +     * <p>
-+     * This method does not make any guarantees about the outcome as
-+     * such depends on the entity and its state.
++     * This method does not make any guarantees about the effect of this method
++     * as such depends on the entity and its state.
 +     *
 +     * @param hand the hand that contains the item to be used
 +     */
@@ -81,12 +81,12 @@ index 4a4a749449bc561a73e6747386c8ad51e623fc1e..0b2ffb5e5e5a3c42b69bbcdcd8d4b6c6
 +    void startUsingItem(@NotNull org.bukkit.inventory.EquipmentSlot hand);
 +
 +    /**
-+     * Finishes using the currently active item. When for example a
-+     * skeleton is drawing its bow this will cause it to release and
++     * Finishes using the currently active item. When, for example, a
++     * skeleton is drawing its bow, this will cause it to release and
 +     * fire the arrow.
 +     * <p>
-+     * This method does not make any guarantees about the outcome as
-+     * such depends on the entity and its state.
++     * This method does not make any guarantees about the effect of this method
++     * as such depends on the entity and its state.
 +     */
 +    @org.jetbrains.annotations.ApiStatus.Experimental
 +    void completeUsingActiveItem();

--- a/patches/api/0117-LivingEntity-Active-Item-API.patch
+++ b/patches/api/0117-LivingEntity-Active-Item-API.patch
@@ -23,7 +23,7 @@ index 2308fa3ca898bcb6c0ac2d4853f82a3398bf51f3..15115b1049bc5053796b84539acbf576
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 4a4a749449bc561a73e6747386c8ad51e623fc1e..c75315b921a1854fbbdbe8ecdfba7dacdaa155c1 100644
+index 4a4a749449bc561a73e6747386c8ad51e623fc1e..0b2ffb5e5e5a3c42b69bbcdcd8d4b6c68477234a 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
 @@ -202,15 +202,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
@@ -56,12 +56,41 @@ index 4a4a749449bc561a73e6747386c8ad51e623fc1e..c75315b921a1854fbbdbe8ecdfba7dac
      public void setItemInUseTicks(int ticks);
  
      /**
-@@ -850,4 +856,101 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -850,4 +856,130 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      void setShieldBlockingDelay(int delay);
      // Paper end
 +
 +    // Paper start - active item API
++    /**
++     * Starts using the item in the specified hand, making it the
++     * currently active item. When for example called on a skeleton
++     * this will cause it to start drawing its bow.
++     * <p>
++     * Only HAND or OFF_HAND may be used for the hand parameter.
++     * <p>
++     * When using on a player the client will stop using the item
++     * if right click is held down.
++     * <p>
++     * This method does not make any guarantees about the outcome as
++     * such depends on the entity and its state.
++     *
++     * @param hand the hand that contains the item to be used
++     */
++    @org.jetbrains.annotations.ApiStatus.Experimental
++    void startUsingItem(@NotNull org.bukkit.inventory.EquipmentSlot hand);
++
++    /**
++     * Finishes using the currently active item. When for example a
++     * skeleton is drawing its bow this will cause it to release and
++     * fire the arrow.
++     * <p>
++     * This method does not make any guarantees about the outcome as
++     * such depends on the entity and its state.
++     */
++    @org.jetbrains.annotations.ApiStatus.Experimental
++    void completeUsingActiveItem();
++
 +    /**
 +     * Gets the item being actively "used" or consumed.
 +     *

--- a/patches/api/0185-Entity-Jump-API.patch
+++ b/patches/api/0185-Entity-Jump-API.patch
@@ -61,10 +61,10 @@ index 0000000000000000000000000000000000000000..a6306c957fcacdcbcc8037b4ee33a167
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 3e5b7dc8f72bd211a18ec6a930c4f02beea4205a..0a0e3fe33158f0424398c0abf50ea55825c452c5 100644
+index c2d6a2d45d733fff7cb6bf1d687bdff35d2be7f4..c7c242fb4ac106edad87032f0accd14d128a5b37 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1118,4 +1118,26 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1147,4 +1147,26 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
          return this.getActiveItemHand();
      }
      // Paper end - active item API

--- a/patches/api/0209-Add-playPickupItemAnimation-to-LivingEntity.patch
+++ b/patches/api/0209-Add-playPickupItemAnimation-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add playPickupItemAnimation to LivingEntity
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 0a0e3fe33158f0424398c0abf50ea55825c452c5..d9dee0486c5f7c9a948a2c1a3497e2745d747965 100644
+index c7c242fb4ac106edad87032f0accd14d128a5b37..5d8433cbea6cfe6a7621d7ab110f7aa0ed120136 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1140,4 +1140,29 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1169,4 +1169,29 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      void setJumping(boolean jumping);
      // Paper end - entity jump API

--- a/patches/api/0224-Add-LivingEntity-clearActiveItem.patch
+++ b/patches/api/0224-Add-LivingEntity-clearActiveItem.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#clearActiveItem
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 898cbd4f690777ce855244331f95e624c6a1fbd4..66dfeb4490505a3eaed547dd86e6c68b85ba5568 100644
+index 5d8433cbea6cfe6a7621d7ab110f7aa0ed120136..f00ae13ee252c52963c7c8ce95cde984b8721f46 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1030,6 +1030,11 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1059,6 +1059,11 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      org.bukkit.inventory.@NotNull ItemStack getActiveItem();
  

--- a/patches/api/0229-Expose-LivingEntity-hurt-direction.patch
+++ b/patches/api/0229-Expose-LivingEntity-hurt-direction.patch
@@ -26,10 +26,10 @@ index 5ecfb98540c00da05b13bc5370debb89c52cc76f..083d5798ccc7f37c6df5e234c7ef2332
       * Get the sleep ticks of the player. This value may be capped.
       *
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 546ecf762d588b8a8239c832fbbe96b8714a07cb..8d2a74e17e4b7089ff91d263b669e8623d7e688a 100644
+index f00ae13ee252c52963c7c8ce95cde984b8721f46..9c8202d672e293c963218a7f3b0d51aa4e7dec5a 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1170,4 +1170,22 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1199,4 +1199,22 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      void playPickupItemAnimation(@NotNull Item item, int quantity);
      // Paper end - pickup animation API

--- a/patches/api/0297-Missing-Entity-API.patch
+++ b/patches/api/0297-Missing-Entity-API.patch
@@ -661,7 +661,7 @@ index a253ac2b60b038177e6c4f20d8367be36f10b1bd..2036e7b464f631054abb94333a8674d3
 +
      // Paper start - active item API
      /**
-      * Gets the item being actively "used" or consumed.
+      * Starts using the item in the specified hand, making it the
 diff --git a/src/main/java/org/bukkit/entity/Llama.java b/src/main/java/org/bukkit/entity/Llama.java
 index d23226ccb0f6c25028f000ce31346cd0a8898e6a..bc84b892cae5fe7019a3ad481e9da79956efa1fe 100644
 --- a/src/main/java/org/bukkit/entity/Llama.java

--- a/patches/api/0379-Add-LivingEntity-swingHand-EquipmentSlot-convenience.patch
+++ b/patches/api/0379-Add-LivingEntity-swingHand-EquipmentSlot-convenience.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#swingHand(EquipmentSlot) convenience method
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 7ed163813bb13ea6e1b60a94f4ef98b3b55f163c..ec3e597a9e683e5966ef4fff3300c30bde1dd49d 100644
+index 5500f5273624b133b48327fe74b0b2e2708d76c4..bdd34708b2e75aaa8a3365c0d7284d85e7cb61e5 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1300,4 +1300,24 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1329,4 +1329,24 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      @Deprecated
      void setHurtDirection(float hurtDirection);
      // Paper end - hurt direction API

--- a/patches/api/0380-Add-entity-knockback-API.patch
+++ b/patches/api/0380-Add-entity-knockback-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add entity knockback API
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index ec3e597a9e683e5966ef4fff3300c30bde1dd49d..b5d882622d9b350b81b6c61348515cbc5aa65777 100644
+index bdd34708b2e75aaa8a3365c0d7284d85e7cb61e5..3943b5cb1306fb1eb830e56cea696fdc587c09f4 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1320,4 +1320,18 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1349,4 +1349,18 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
          }
      }
      // Paper end - swing hand API

--- a/patches/api/0387-ItemStack-damage-API.patch
+++ b/patches/api/0387-ItemStack-damage-API.patch
@@ -8,10 +8,10 @@ to simulate damage done to an itemstack and all
 the logic associated with damaging them
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index b5d882622d9b350b81b6c61348515cbc5aa65777..6807354bf157060cbddb395dd6220040b84e7c8d 100644
+index 3943b5cb1306fb1eb830e56cea696fdc587c09f4..a8b442cf03887ebe212a298d35cea5f6383ccfab 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1334,4 +1334,53 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1363,4 +1363,53 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      void knockback(double strength, double directionX, double directionZ);
      // Paper end - knockback API

--- a/patches/api/0400-Add-Entity-Body-Yaw-API.patch
+++ b/patches/api/0400-Add-Entity-Body-Yaw-API.patch
@@ -53,10 +53,10 @@ index 2d6f7b2bf4cb23ef43a4dcbab2ecd2a7c7c2809c..0be4107270fb7fdba5c7d0e6f3964d33
  
      // Paper start - Collision API
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 92c33fc9680159ab4e901cfba08092d868845c63..e3ff310a83b320c26de63e9239db63de271321c2 100644
+index 30222c65bcc78ff3fe5c0937c64c6fe7b0b2fe36..2e6a6c9e8e150f940842f8f134b18987412e4766 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1383,4 +1383,22 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1412,4 +1412,22 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      void damageItemStack(org.bukkit.inventory.@NotNull EquipmentSlot slot, int amount);
      // Paper end - ItemStack damage API

--- a/patches/server/0204-LivingEntity-Active-Item-API.patch
+++ b/patches/server/0204-LivingEntity-Active-Item-API.patch
@@ -6,18 +6,37 @@ Subject: [PATCH] LivingEntity Active Item API
 API relating to items being actively used by a LivingEntity
 such as a bow or eating food.
 
+== AT ==
+public net/minecraft/world/entity/LivingEntity completeUsingItem()V
+public net/minecraft/server/level/ServerPlayer completeUsingItem()V
+
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 1c6abeff5b541cdea914ac956f2ab1d2e1c5769f..de52fdc1c94f69de7c5c5099fc586fdeba60b6fa 100644
+index 1c6abeff5b541cdea914ac956f2ab1d2e1c5769f..0fe087cd6037b4dd694cc3c5c3eac8203ea6d519 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -866,4 +866,38 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -866,4 +866,53 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          getHandle().setShieldBlockingDelay(delay);
      }
      // Paper end
 +
 +    // Paper start - active item API
++    @Override
++    public void startUsingItem(org.bukkit.inventory.EquipmentSlot hand) {
++        Preconditions.checkArgument(hand != null, "hand must not be null");
++        switch (hand) {
++            case HAND -> getHandle().startUsingItem(InteractionHand.MAIN_HAND);
++            case OFF_HAND -> getHandle().startUsingItem(InteractionHand.OFF_HAND);
++            default -> throw new IllegalArgumentException("hand may only be HAND or OFF_HAND");
++        }
++    }
++
++    @Override
++    public void completeUsingActiveItem() {
++        getHandle().completeUsingItem();
++    }
++
 +    @Override
 +    public ItemStack getActiveItem() {
 +        return this.getHandle().getUseItem().asBukkitMirror();

--- a/patches/server/0328-Entity-Jump-API.patch
+++ b/patches/server/0328-Entity-Jump-API.patch
@@ -50,10 +50,10 @@ index aba20a4352d8983b01ab5d329187588f68d3e405..aac60e85cd6dba7d87f4a1663c2c6295
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 88ea46392182b02131a2a5c953fe90e1ecbd4ae5..1bca024bfbb4b68eacd2b3bb382aa74456db2145 100644
+index 5def5bccd8fce86ce015567e65fefae329819c18..29fa2231cc5d9c3ac36d508f14408d6077b6594c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -961,4 +961,20 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -976,4 +976,20 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          return org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(this.getHandle().getUsedItemHand());
      }
      // Paper end - active item API

--- a/patches/server/0412-Add-playPickupItemAnimation-to-LivingEntity.patch
+++ b/patches/server/0412-Add-playPickupItemAnimation-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add playPickupItemAnimation to LivingEntity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 8cfa39acde6d32625ae87e9d031d8dc767783e61..e54b164ea2f28cdbb89166fb9b0b9cd9d12c0ca9 100644
+index d84503ab329ebeb4c74f10f9897661ee6799e3d3..87033a5d8dd5b67475657c3749f428a8e841a2f2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -977,4 +977,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -992,4 +992,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          }
      }
      // Paper end - entity jump API

--- a/patches/server/0456-Add-LivingEntity-clearActiveItem.patch
+++ b/patches/server/0456-Add-LivingEntity-clearActiveItem.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#clearActiveItem
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index d90a56de3ec0236c82668d0f7ce01a8515de6450..baeb521f44389e6bf5d7b4237ebd5c805ae6f43c 100644
+index 87033a5d8dd5b67475657c3749f428a8e841a2f2..6848cdb3271b37972e98af78e85125409c650c4d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -934,6 +934,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -949,6 +949,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          return this.getHandle().getUseItem().asBukkitMirror();
      }
  

--- a/patches/server/0467-Expose-LivingEntity-hurt-direction.patch
+++ b/patches/server/0467-Expose-LivingEntity-hurt-direction.patch
@@ -36,10 +36,10 @@ index d5a8f019e88de30400733cdc3178eb982ccca341..e7726862f99cb16b7335b06675af73db
      public int getSleepTicks() {
          return this.getHandle().sleepCounter;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 1333f5116e824e1024519808e824a979b9745c9f..24e8f6a89dc186c3f8f4356cb9a60115fc0096c0 100644
+index 6848cdb3271b37972e98af78e85125409c650c4d..4ac52885618bf062eb34672b8fc60331a9c8f76a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -991,4 +991,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1006,4 +1006,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          this.getHandle().take(((CraftItem) item).getHandle(), quantity);
      }
      // Paper end - pickup animation API

--- a/patches/server/0559-More-Enchantment-API.patch
+++ b/patches/server/0559-More-Enchantment-API.patch
@@ -78,10 +78,10 @@ index 3feaaca5aaee12e48fa2e5f5d05329c9980b161e..a151b5d7c6e41b08e57c806bc43e067a
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 9c37509faeeaf11645dbfc6ddb2eac6aac7b3c59..18f2775d6417f775d6ebb6560450c05e63e3299d 100644
+index 0a4df9971c66676dba90fb03c840e25a41103bc0..646763f591e67e27c992663379fa3d4b322a3de3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1010,4 +1010,22 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1025,4 +1025,22 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          throw new UnsupportedOperationException("Cannot set the hurt direction on a non player");
      }
      // Paper end - hurt direction API

--- a/patches/server/0797-Add-entity-knockback-API.patch
+++ b/patches/server/0797-Add-entity-knockback-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add entity knockback API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 163c3a07abf187d6d2f3fb3bc30eb8f0c26b247f..be915e4ab474d8f06c63b5aaee5b9277aef0f706 100644
+index 9ae20d759965bc9b88b52c15372155ad10bcc199..8be0e064f1f7e98e6bfd5915cd4eaf814b5f1d26 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1106,4 +1106,12 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1121,4 +1121,12 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          throw new IllegalArgumentException(entityCategory + " is an unrecognized entity category");
      }
      // Paper end - more enchant API

--- a/patches/server/0815-ItemStack-damage-API.patch
+++ b/patches/server/0815-ItemStack-damage-API.patch
@@ -11,10 +11,10 @@ the logic associated with damaging them
 public net.minecraft.world.entity.LivingEntity entityEventForEquipmentBreak(Lnet/minecraft/world/entity/EquipmentSlot;)B
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index be915e4ab474d8f06c63b5aaee5b9277aef0f706..6359bb77c6d05db733a7f92d30230a2889a5b0ea 100644
+index 8be0e064f1f7e98e6bfd5915cd4eaf814b5f1d26..711eb84fee6c46341928a765970defa47e1fe0c3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1114,4 +1114,52 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1129,4 +1129,52 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          this.getHandle().knockback(strength, directionX, directionZ);
      };
      // Paper end - knockback API

--- a/patches/server/0816-Friction-API.patch
+++ b/patches/server/0816-Friction-API.patch
@@ -133,10 +133,10 @@ index 1a291dd8a287db30e71dcb315599fc4b038764c4..30d62ee4d5cd2ddacb8783b5bbbf475d
      public int getHealth() {
          return this.getHandle().health;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 6359bb77c6d05db733a7f92d30230a2889a5b0ea..9c5ad1ffdd82ce5d12eabca07f45a37e6a939f2e 100644
+index 711eb84fee6c46341928a765970defa47e1fe0c3..b0c03854ee9936b1dac9cbf89e9977d978712d56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1162,4 +1162,18 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1177,4 +1177,18 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          });
      }
      // Paper end - ItemStack damage API

--- a/patches/server/0842-Add-Entity-Body-Yaw-API.patch
+++ b/patches/server/0842-Add-Entity-Body-Yaw-API.patch
@@ -43,10 +43,10 @@ index 4dfbcaba4615bd761c1eb9d5994168c7202fc571..8025b3e9afebc9ad0c08453403422589
      @Override
      public boolean isInvisible() {  // Paper - moved up from LivingEntity
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 9c5ad1ffdd82ce5d12eabca07f45a37e6a939f2e..ec62e68686b7c46df299d946850ec60631ecc6be 100644
+index b0c03854ee9936b1dac9cbf89e9977d978712d56..ab1e1a56f3811d4446a6b0a7461c0bddd8015228 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1176,4 +1176,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1191,4 +1191,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          this.getHandle().frictionState = state;
      }
      // Paper end - friction API


### PR DESCRIPTION
resolves #10295 
i wasn't able to prevent the player from trying to stop using the item so i just added a little warning to the startUsingItem method. 
(Also there is a "Add LivingEntity#clearActiveItem" patch which could be merged into this patch. But because i am not a lunatic and i don't find fun in spending my day rebasing 500 renamed files, i will leave that to a paper dev if anyone wants to merge them)