### PR TITLE
Add onboarding message for initial server start

### DIFF
--- a/patches/server/1054-Add-onboarding-message-for-initial-server-start.patch
+++ b/patches/server/1054-Add-onboarding-message-for-initial-server-start.patch
@@ -1,0 +1,103 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: leguan <longboard.noah@gmail.com>
+Date: Sun, 10 Mar 2024 20:10:41 +0100
+Subject: [PATCH] Add onboarding message for initial server start
+
+
+diff --git a/src/main/java/io/papermc/paper/configuration/Configurations.java b/src/main/java/io/papermc/paper/configuration/Configurations.java
+index c01b4393439838976965823298f12e4762e72eff..218bf89fd7583d6db9f64754c4db8fcce5415bdb 100644
+--- a/src/main/java/io/papermc/paper/configuration/Configurations.java
++++ b/src/main/java/io/papermc/paper/configuration/Configurations.java
+@@ -126,6 +126,7 @@ public abstract class Configurations<G, W> {
+         if (Files.notExists(configFile)) {
+             node = CommentedConfigurationNode.root(loader.defaultOptions());
+             node.node(Configuration.VERSION_FIELD).raw(this.globalConfigVersion());
++            GlobalConfiguration.isFirstStart = true;
+         } else {
+             node = loader.load();
+             this.verifyGlobalConfigVersion(node);
+diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+index b53b6cc4463675096b061b3b65f14a4695c742e2..f2e30d8743a97c0541808dc5c03300c0d881b843 100644
+--- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
++++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+@@ -25,6 +25,7 @@ public class GlobalConfiguration extends ConfigurationPart {
+     private static final Logger LOGGER = LogUtils.getLogger();
+     static final int CURRENT_VERSION = 29; // (when you change the version, change the comment, so it conflicts on rebases): <insert changes here>
+     private static GlobalConfiguration instance;
++    public static boolean isFirstStart = false;
+     public static GlobalConfiguration get() {
+         return instance;
+     }
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index d06185566b447c432d4dc2e3ba04d121bcdbc71b..469eaf3a65793edd8f40d40fb476c05913032047 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -1155,6 +1155,16 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+             long tickSection = Util.getNanos();
+             long currentTime;
+             // Paper end - further improve server tick loop
++            // Paper start - Add onboarding message for initial server start
++            if (io.papermc.paper.configuration.GlobalConfiguration.get().isFirstStart) {
++                LOGGER.info("###########################################################################");
++                LOGGER.info("This is the first time you're starting this server. ");
++                LOGGER.info("It's recommended you read our 'Getting Started' documentation for guidance.");
++                LOGGER.info("View this and more helpful information here: <link>");
++                LOGGER.info("###########################################################################");
++            }
++            // Paper end - Add onboarding message for initial server start
++
+             while (this.running) {
+                 // Paper start - rewrite chunk system
+                 // guarantee that nothing can stop the server from halting if it can at least still tick
+diff --git a/src/main/java/net/minecraft/server/gui/MinecraftServerGui.java b/src/main/java/net/minecraft/server/gui/MinecraftServerGui.java
+index c42a9949c4d37d45883867a54222a7ab33944b39..7704a5951ac3d02020ed0f40d76500dd6ba005af 100644
+--- a/src/main/java/net/minecraft/server/gui/MinecraftServerGui.java
++++ b/src/main/java/net/minecraft/server/gui/MinecraftServerGui.java
+@@ -90,6 +90,7 @@ public class MinecraftServerGui extends JComponent {
+         this.setLayout(new BorderLayout());
+ 
+         try {
++            this.add(this.buildOnboardingPanel(), "North"); // Paper - Add onboarding message for initial server start
+             this.add(this.buildChatPanel(), "Center");
+             this.add(this.buildInfoPanel(), "West");
+         } catch (Exception exception) {
+@@ -115,6 +116,39 @@ public class MinecraftServerGui extends JComponent {
+         return jpanel;
+     }
+ 
++    // Paper start - Add onboarding message for initial server start
++    private JComponent buildOnboardingPanel() {
++        String onboardingLink = "https://docs.papermc.io/paper/next-steps";
++        JPanel jPanel = new JPanel();
++
++        javax.swing.JLabel jLabel = new javax.swing.JLabel("If you need help setting up your server you can visit:");
++        jLabel.setFont(MinecraftServerGui.MONOSPACED);
++
++        javax.swing.JLabel link = new javax.swing.JLabel("<html><u> " + onboardingLink + "</u></html>");
++        link.setFont(MinecraftServerGui.MONOSPACED);
++        link.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
++        link.addMouseListener(new java.awt.event.MouseAdapter() {
++            @Override
++            public void mouseClicked(final java.awt.event.MouseEvent e) {
++                try {
++                    java.awt.Desktop.getDesktop().browse(java.net.URI.create(onboardingLink));
++                } catch (java.io.IOException exception) {
++                    LOGGER.error("Unable to find a default browser. Please manually visit the website: " + onboardingLink, exception);
++                } catch (UnsupportedOperationException exception) {
++                    LOGGER.error("This platform does not support the BROWSE action. Please manually visit the website: " + onboardingLink, exception);
++                } catch (SecurityException exception) {
++                    LOGGER.error("This action has been denied by the security manager. Please manually visit the website: " + onboardingLink, exception);
++                }
++            }
++        });
++
++        jPanel.add(jLabel);
++        jPanel.add(link);
++
++        return jPanel;
++    }
++    // Paper end - Add onboarding message for initial server start
++
+     private JComponent buildPlayerPanel() {
+         JList<?> jlist = new PlayerListComponent(this.server);
+         JScrollPane jscrollpane = new JScrollPane(jlist, 22, 30);

--- a/patches/server/1054-Add-onboarding-message-for-initial-server-start.patch
+++ b/patches/server/1054-Add-onboarding-message-for-initial-server-start.patch
@@ -29,7 +29,7 @@ index b53b6cc4463675096b061b3b65f14a4695c742e2..f2e30d8743a97c0541808dc5c03300c0
          return instance;
      }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d06185566b447c432d4dc2e3ba04d121bcdbc71b..469eaf3a65793edd8f40d40fb476c05913032047 100644
+index d06185566b447c432d4dc2e3ba04d121bcdbc71b..93b661e9cb7743aeff7da3972942cb73049a5e4c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1155,6 +1155,16 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -37,12 +37,12 @@ index d06185566b447c432d4dc2e3ba04d121bcdbc71b..469eaf3a65793edd8f40d40fb476c059
              long currentTime;
              // Paper end - further improve server tick loop
 +            // Paper start - Add onboarding message for initial server start
-+            if (io.papermc.paper.configuration.GlobalConfiguration.get().isFirstStart) {
-+                LOGGER.info("###########################################################################");
-+                LOGGER.info("This is the first time you're starting this server. ");
++            if (io.papermc.paper.configuration.GlobalConfiguration.isFirstStart) {
++                LOGGER.info("*************************************************************************************");
++                LOGGER.info("This is the first time you're starting this server.");
 +                LOGGER.info("It's recommended you read our 'Getting Started' documentation for guidance.");
-+                LOGGER.info("View this and more helpful information here: <link>");
-+                LOGGER.info("###########################################################################");
++                LOGGER.info("View this and more helpful information here: https://docs.papermc.io/paper/next-steps");
++                LOGGER.info("*************************************************************************************");
 +            }
 +            // Paper end - Add onboarding message for initial server start
 +


### PR DESCRIPTION
This is a PR as a response to #10309.

What i have done here is by no means final and just an attempt to find a way to check if it is the "initial" start of a server. 
~~I decided to go for the `server.properties` file because this is the first file that came to my mind that you wouldnt really delete.~~ I am now using the global configuration to determine if it's the initial start. 

Basically, I am checking if the file exists and set a boolean if it doens't. After the server has been started, I check that boolean and print a message if it's the initial start. 
Obviously, you could just delete the file and get that message again so it wouldn't be the "initial" start anymore. So, if you have any other idea how to handle this, please leave feedback. 

The GUI is also modified to contain a message and links to the onboarding page. 
The message is also not final. 

This would also allow for a `InitialServerStartEvent` later on once this is merged.