### PR TITLE
Fix World.getWorldType not detecting amplified and large biomes

### DIFF
--- a/patches/api/0466-Fix-World.getWorldType-not-detecting-amplified-and-l.patch
+++ b/patches/api/0466-Fix-World.getWorldType-not-detecting-amplified-and-l.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: LeonTG <leontg77@gmail.com>
+Date: Sun, 10 Mar 2024 20:52:52 +0100
+Subject: [PATCH] Fix World.getWorldType not detecting amplified and large
+ biomes
+
+
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index c5fe36050eeaff80cfb989fe2f38370215af6fe5..851e79257cf765a389a6c712f417fea05c453c8e 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -2745,12 +2745,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+      * Gets the type of this world.
+      *
+      * @return Type of this world.
+-     * @deprecated world type is only used to select the default word generation
+-     * settings and is not stored in Vanilla worlds, making it impossible for
+-     * this method to always return the correct value.
+      */
+     @Nullable
+-    @Deprecated
++// @Deprecated // Paper - Remove deprecation
+     public WorldType getWorldType();
+ 
+     /**

--- a/patches/server/1054-Fix-World.getWorldType-not-detecting-amplified-and-l.patch
+++ b/patches/server/1054-Fix-World.getWorldType-not-detecting-amplified-and-l.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: LeonTG <leontg77@gmail.com>
+Date: Sun, 10 Mar 2024 20:52:51 +0100
+Subject: [PATCH] Fix World.getWorldType not detecting amplified and large
+ biomes
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index bfb178c69026e9759e9afaebb9da141b62d1f144..dc6cdd455b48d150cc2889c7314489075d42aef1 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -1645,6 +1645,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+ 
+     @Override
+     public org.bukkit.WorldType getWorldType() {
++        // Paper start - Fix World.getWorldType not detecting amplified and large biomes
++        if (this.world.getChunkSource().getGenerator() instanceof net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator noiseGen) {
++            if (noiseGen.generatorSettings().is(net.minecraft.world.level.levelgen.NoiseGeneratorSettings.AMPLIFIED)) {
++                return org.bukkit.WorldType.AMPLIFIED;
++            }
++
++            if (noiseGen.generatorSettings().is(net.minecraft.world.level.levelgen.NoiseGeneratorSettings.LARGE_BIOMES)) {
++                return org.bukkit.WorldType.LARGE_BIOMES;
++            }
++        }
++        // Paper end
+         return this.world.isFlat() ? org.bukkit.WorldType.FLAT : org.bukkit.WorldType.NORMAL;
+     }
+ 


### PR DESCRIPTION
I fixed this in my Paper fork, I figured this was a good enough change to PR upstream so other people can enjoy the fix!

It works by accessing the settings of the NoiseBasedChunkGenerator and checking if it has amplified or large biome settings! and I've tested it to make sure it works too

First time making a PR to a project like this, so hopefully I did it correctly!