### PR TITLE
Fix missing profiler.pop() in PathFinder::findPath

### DIFF
--- a/patches/server/1009-Optimize-Pathfinder-Remove-Streams-Optimized-collect.patch
+++ b/patches/server/1009-Optimize-Pathfinder-Remove-Streams-Optimized-collect.patch
@@ -16,7 +16,7 @@ This lets us get faster foreach iteration, as well as avoids map lookups on
 the values when needed.
 
 diff --git a/src/main/java/net/minecraft/world/level/pathfinder/PathFinder.java b/src/main/java/net/minecraft/world/level/pathfinder/PathFinder.java
-index 8519383a9abd45434c1e9888e77548941a80c79c..eb18494bd7257fa5eb00dea16cf4d5667b796f2b 100644
+index 8519383a9abd45434c1e9888e77548941a80c79c..8aa4ac3a6affbe888d6084a27b668c58dfda6c79 100644
 --- a/src/main/java/net/minecraft/world/level/pathfinder/PathFinder.java
 +++ b/src/main/java/net/minecraft/world/level/pathfinder/PathFinder.java
 @@ -38,9 +38,12 @@ public class PathFinder {
@@ -91,7 +91,7 @@ index 8519383a9abd45434c1e9888e77548941a80c79c..eb18494bd7257fa5eb00dea16cf4d566
                          if (node2.inOpenSet()) {
                              this.openSet.changeCost(node2, node2.g + node2.h);
                          } else {
-@@ -105,23 +113,31 @@ public class PathFinder {
+@@ -105,23 +113,32 @@ public class PathFinder {
              }
          }
  
@@ -100,8 +100,6 @@ index 8519383a9abd45434c1e9888e77548941a80c79c..eb18494bd7257fa5eb00dea16cf4d566
 -        }).min(Comparator.comparingInt(Path::getNodeCount)) : set.stream().map((target) -> {
 -            return this.reconstructPath(target.getBestNode(), positions.get(target), false);
 -        }).min(Comparator.comparingDouble(Path::getDistToTarget).thenComparingInt(Path::getNodeCount));
--        profiler.pop();
--        return optional.isEmpty() ? null : optional.get();
 +        // Paper start - Perf: remove streams and optimize collection
 +        Path best = null;
 +        boolean entryListIsEmpty = entryList.isEmpty();
@@ -112,6 +110,8 @@ index 8519383a9abd45434c1e9888e77548941a80c79c..eb18494bd7257fa5eb00dea16cf4d566
 +            if (best == null || comparator.compare(path, best) < 0)
 +                best = path;
 +        }
+         profiler.pop();
+-        return optional.isEmpty() ? null : optional.get();
 +        return best;
 +        // Paper end - Perf: remove streams and optimize collection
      }


### PR DESCRIPTION
The streams/collect optimization for findPath accidentally removed a call to profiler.pop() this causes the vanilla profiler to give errors and makes the final profile unusable. This PR fixes that patch to put the profiler.pop() back in. We've been running a built with this patch in as a test and everything seems to work as expected.
The vanilla profiler is useful in combiniation with spark/build in timings as it gives information neither of these profilers give. 

Before fix: 
```
perf start
[13:36:05 INFO]: Started 10 second performance profiling run (use '/perf stop' to stop early)
[13:36:06 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:06 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:06 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:06 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:07 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:07 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:07 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:07 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:08 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:08 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:08 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:08 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:09 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:09 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:09 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:09 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:10 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:10 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:10 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:10 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:11 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:11 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:11 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:11 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:12 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:12 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:12 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:12 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:13 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:13 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:13 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:13 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:14 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:14 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:14 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:14 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:15 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:15 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root.tick'). Mismatched push/pop?
[13:36:15 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:15 ERROR]: Profiler tick ended before path was fully popped (remainder: 'root'). Mismatched push/pop?
[13:36:16 INFO]: Stopped performance profiling after 10.04 second(s) and 206 tick(s) (20.52 tick(s) per second)
[13:36:16 INFO]: Flushed metrics to C:\Users\suppergerrie2\AppData\Local\Temp\minecraft-profiling11374737644406307100\server\metrics\event-loops.csv
[13:36:16 INFO]: Flushed metrics to C:\Users\suppergerrie2\AppData\Local\Temp\minecraft-profiling11374737644406307100\server\metrics\cpu.csv
[13:36:16 INFO]: Flushed metrics to C:\Users\suppergerrie2\AppData\Local\Temp\minecraft-profiling11374737644406307100\server\metrics\jvm.csv
[13:36:16 INFO]: Flushed metrics to C:\Users\suppergerrie2\AppData\Local\Temp\minecraft-profiling11374737644406307100\server\metrics\ticking.csv
[13:36:16 ERROR]: Negative index in crash report handler (18/19)
[13:36:16 ERROR]: Negative index in crash report handler (18/19)
[13:36:17 ERROR]: Negative index in crash report handler (18/19)
[13:36:18 INFO]: Compressed to debug\profiling\2024-03-13_13_36_17-world-1_20_4.zip
[13:36:18 INFO]: Created debug report in 2024-03-13_13_36_17-world-1_20_4.zip
```

After fix:
```
perf start
[13:27:59 INFO]: Started 10 second performance profiling run (use '/perf stop' to stop early)
[13:28:09 INFO]: Stopped performance profiling after 10.02 second(s) and 203 tick(s) (20.26 tick(s) per second)
[13:28:09 INFO]: Flushed metrics to C:\Users\suppergerrie2\AppData\Local\Temp\minecraft-profiling7339135420459383361\server\metrics\event-loops.csv
[13:28:09 INFO]: Flushed metrics to C:\Users\suppergerrie2\AppData\Local\Temp\minecraft-profiling7339135420459383361\server\metrics\cpu.csv
[13:28:09 INFO]: Flushed metrics to C:\Users\suppergerrie2\AppData\Local\Temp\minecraft-profiling7339135420459383361\server\metrics\ticking.csv
[13:28:09 INFO]: Flushed metrics to C:\Users\suppergerrie2\AppData\Local\Temp\minecraft-profiling7339135420459383361\server\metrics\jvm.csv
[13:28:10 ERROR]: Negative index in crash report handler (18/19)
[13:28:10 ERROR]: Negative index in crash report handler (18/19)
[13:28:10 ERROR]: Negative index in crash report handler (18/19)
[13:28:12 INFO]: Compressed to debug\profiling\2024-03-13_13_28_11-world-1_20_4.zip
[13:28:12 INFO]: Created debug report in 2024-03-13_13_28_11-world-1_20_4.zip
```