### PR TITLE
Added and Implemented EntityDamageDoorEvent.

### DIFF
--- a/patches/api/0466-Added-EntityDamageDoorEvent-and-implemented-into-Ser.patch
+++ b/patches/api/0466-Added-EntityDamageDoorEvent-and-implemented-into-Ser.patch
@@ -1,0 +1,124 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: CMarcoo <cmarco.org@gmail.com>
+Date: Thu, 14 Mar 2024 17:04:43 +0100
+Subject: [PATCH] Added EntityDamageDoorEvent and implemented into Server.
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityDamageDoorEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityDamageDoorEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..72570e4d8c56d294ff1a57fbb63c6ba70f1ed40c
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityDamageDoorEvent.java
+@@ -0,0 +1,112 @@
++package io.papermc.paper.event.entity;
++
++import com.google.common.base.Preconditions;
++import org.bukkit.block.data.type.Door;
++import org.bukkit.entity.Entity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when an entity damages a door.
++ * <p>
++ * This event is only called when a new level of progress
++ * has been reached by the damaging entity.
++ */
++public class EntityDamageDoorEvent extends EntityEvent implements Cancellable {
++
++    private final Door damagedDoor;
++    private boolean cancelled;
++    private int breakTime;
++    private int doorBreakTime;
++
++    public EntityDamageDoorEvent(final @NotNull Entity what, final @NotNull Door damagedDoor, final int breakTime, final int doorBreakTime) {
++        super(what);
++        this.damagedDoor = damagedDoor;
++        this.breakTime = breakTime;
++        this.doorBreakTime = doorBreakTime;
++    }
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    /**
++     * Get the door currently being damaged by the Zombie.
++     * @return The door being damaged.
++     */
++    @NotNull
++    public Door getDamagedDoor() {
++        return damagedDoor;
++    }
++
++    /**
++     * Get the value indicating the ticks spent
++     * breaking this door.
++     *
++     * @return The breaking progress value.
++     */
++    public int getBreakTime() {
++        return breakTime;
++    }
++
++    /**
++     * Set the current progress in ticks that
++     * this entity has spent damaging the door.
++     * @param breakTime The ticks spent damaging the door.
++     */
++    public void setBreakTime(final int breakTime) {
++        Preconditions.checkArgument(breakTime < 0, "The breaking progress must be equal or greater than zero!");
++        this.breakTime = breakTime;
++    }
++
++    /**
++     * Get the total amount of ticks required to break
++     * the door that the entity is currently damaging.
++     * @return The amount of ticks necessary for the entity to break the door.
++     */
++    public int getDoorBreakTime() {
++        return doorBreakTime;
++    }
++
++    /**
++     * Set the total amount of ticks required to break
++     * the door that the entity is currently damaging.
++     * @param doorBreakTime The amount of ticks necessary for the entity to break the door.
++     */
++    public void setDoorBreakTime(final int doorBreakTime) {
++        Preconditions.checkArgument(doorBreakTime > 0, "The amount of ticks required to break the door must be positive!");
++        this.doorBreakTime = doorBreakTime;
++    }
++
++    /**
++     * Gets the cancellation state of this event. A cancelled event will not
++     * be executed in the server, but will still pass to other plugins
++     *
++     * @return true if this event is cancelled
++     */
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    /**
++     * Sets the cancellation state of this event. A cancelled event will not
++     * be executed in the server, but will still pass to other plugins.
++     *
++     * @param cancel true if you wish to cancel this event
++     */
++    @Override
++    public void setCancelled(final boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}

--- a/patches/server/1054-Added-EntityDamageDoorEvent-and-implemented-into-Ser.patch
+++ b/patches/server/1054-Added-EntityDamageDoorEvent-and-implemented-into-Ser.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: CMarcoo <cmarco.org@gmail.com>
+Date: Thu, 14 Mar 2024 17:04:43 +0100
+Subject: [PATCH] Added EntityDamageDoorEvent and implemented into Server.
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java
+index a85885ee51df585fa11ae9f8fcd67ff2a71c5a18..0d2de8e8747795393631f851cb941b268aa0a4b0 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java
++++ b/src/main/java/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java
+@@ -1,10 +1,12 @@
+ package net.minecraft.world.entity.ai.goal;
+ 
+ import java.util.function.Predicate;
++import io.papermc.paper.event.entity.EntityDamageDoorEvent;
+ import net.minecraft.world.Difficulty;
+ import net.minecraft.world.entity.Mob;
+ import net.minecraft.world.level.GameRules;
+ import net.minecraft.world.level.block.Block;
++import org.bukkit.craftbukkit.block.impl.CraftDoor;
+ 
+ public class BreakDoorGoal extends DoorInteractGoal {
+ 
+@@ -55,6 +57,20 @@ public class BreakDoorGoal extends DoorInteractGoal {
+     @Override
+     public void tick() {
+         super.tick();
++
++        // Paper start
++        EntityDamageDoorEvent event = new EntityDamageDoorEvent(this.mob.getBukkitEntity(), new CraftDoor(this.mob.level().getBlockState(this.doorPos)), this.breakTime, this.doorBreakTime);
++        event.callEvent();
++
++        if (event.isCancelled()) {
++            this.stop();
++            return;
++        }
++
++        this.breakTime = event.getBreakTime();
++        this.doorBreakTime = event.getDoorBreakTime();
++        // Paper end
++
+         if (this.mob.getRandom().nextInt(20) == 0) {
+             this.mob.level().levelEvent(1019, this.doorPos, 0);
+             if (!this.mob.swinging) {


### PR DESCRIPTION
# EntityDamageDoorEvent: Handle Door Damage Interactions

## Description
I've introduced a new event called `EntityDamageDoorEvent` in the PaperMC server software. This event is triggered when an entity (currently limited to Zombies and Pillagers by default) damages a door. It provides essential information about the damaged door, the break time, and the total door break time.

This implementation takes into account differences in breaking time between zombies (240 ticks) and pillagers (60 ticks).

## Event Details
- **Event Name**: `EntityDamageDoorEvent`
- **Trigger**: When an entity damages a door
- **Purpose**: To allow developers to handle door damage interactions

## Key Components
1. **Entity**: The damaging entity (e.g., Zombie, Pillager).
2. **Door**: The door being damaged.
3. **Break Time**: The ticks spent breaking the door.
4. **Door Break Time**: The total ticks required to break the door.

## Usage Example
```java
@EventHandler
public void onEntityDamageDoor(EntityDamageDoorEvent event) {
    Entity damagingEntity = event.getEntity();
    Door damagedDoor = event.getDamagedDoor();
    int breakTime = event.getBreakTime();
    int totalBreakTime = event.getDoorBreakTime();
    
    float percentage = ((float) breakTime / totalBreakTime) * 100f;
    if (percentage > 50.0f) {
        e.getNearbyEntities(5, 3, 5).stream()
            .filter(Player.class::isInstance)
            .map(Player.class::cast)
            .forEach(p -> p.sendMessage("Your home door is halfway broken, watch out dude :("));
    }
    // Additional logic...
}
```