### PR TITLE
Add permission check for spawn protection

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -482,10 +482,10 @@ index 0000000000000000000000000000000000000000..c01b4393439838976965823298f12e47
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7a53374319d5495253f277199114eaf43097456d
+index 0000000000000000000000000000000000000000..2c9af51fb755dcc026e20b60195944614a227b46
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,311 @@
+@@ -0,0 +1,313 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -784,6 +784,8 @@ index 0000000000000000000000000000000000000000..7a53374319d5495253f277199114eaf4
 +        @Comment("See https://luckformula.emc.gs")
 +        public boolean useAlternativeLuckFormula = false;
 +        public boolean useDimensionTypeForCustomSpawners = false;
++        @Comment("This setting controls if players should be able to build with permission inside of the spawn protection")
++        public boolean allowOverrideOpBehaviorForSpawnProtection = false;
 +        public boolean strictAdvancementDimensionCheck = false;
 +        public IntOr.Default compressionLevel = IntOr.Default.USE_DEFAULT;
 +    }
@@ -4983,7 +4985,7 @@ index 680a308c466c0056d4213e61f69cf13ee3ff5c61..cd39509d383c47319b71797e5d1df41c
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index a7921cde2b6275d730879b2814cc5f430520b051..c8f0570b7d37a0c0bddb0a65c36fb32de584df8f 100644
+index 96210dd54e8ff6dc0375a8d03bf14fec1b26aaeb..19725db76dc3a12356993aed7edba507b52fe4d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -141,6 +141,19 @@ public class Main {

--- a/patches/server/1057-Add-permission-check-for-spawn-protection.patch
+++ b/patches/server/1057-Add-permission-check-for-spawn-protection.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TheMeinerLP <p.glanz@madfix.me>
+Date: Sun, 17 Mar 2024 20:53:42 +0100
+Subject: [PATCH] Add permission check for spawn protection
+
+
+diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+index 68d268b6fff126e8645b6deec3fb549ea2286b77..2c923159a4acca65f637f8dd93731bf2213589c8 100644
+--- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -575,6 +575,8 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+             return false;
+         } else if (this.getPlayerList().isOp(player.getGameProfile())) {
+             return false;
++        } else if (io.papermc.paper.configuration.GlobalConfiguration.get().misc.allowOverrideOpBehaviorForSpawnProtection && player.getBukkitEntity().hasPermission("paper.environment.spawnprotection.bypass")) { // Paper start - Add permission check for spawn protection
++            return false; // Paper end - Add permission check for spawn protection
+         } else if (this.getSpawnProtectionRadius() <= 0) {
+             return false;
+         } else {


### PR DESCRIPTION
Problem:
If you want to allow builders or other members to build at the spawn but don't want to give them an operator. So Vanilla does not currently offer any possibility. 

Solution:
Without doing anything hacky, the PR adds a configuration option to Misc on Paper which overrides this problem in combination with a permission.

Test possibility:
- 2 players join the server
- One of two gets OP, player 2 can no longer mine within the spawn protection

Here is the JoinEvent test how to test this:
```java
    @EventHandler
    public void onJoin(PlayerJoinEvent event) {
        PermissionAttachment permissionAttachment = event.getPlayer().addAttachment(this);
        permissionAttachment.setPermission("bukkit.environment.spawnprotection.ignore", true);
    }
``` 
