### PR TITLE
Update github-app-token to v2 via projects workflow

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: "authenticate"
         id: "authenticate"
-        uses: "tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92" # v1
+        uses: "tibdex/github-app-token@3eb77c7243b85c65e84acfa93fdbac02fb6bd532" # v2
         with:
           app_id: "${{ secrets.PROJECTS_APP_ID }}"
           installation_id: "36153445"


### PR DESCRIPTION
As title says it - for commit history of this dependency, check [here](https://github.com/tibdex/github-app-token/compare/v1.8.0...v2.1.0).