### PR TITLE
Deprecate several Keyed#getKey methods

### DIFF
--- a/patches/api/0446-Improve-Registry.patch
+++ b/patches/api/0446-Improve-Registry.patch
@@ -9,6 +9,27 @@ items need to exist without having a key and so
 getKey() methods on Keyed objects that have a registry
 are marked as Deprecated or Obsolete.
 
+diff --git a/src/main/java/org/bukkit/MusicInstrument.java b/src/main/java/org/bukkit/MusicInstrument.java
+index ee5368372e136541eafe1d7ffb395de670fe4843..31a81ac909976492f0c6b93ad49008878a3bcae2 100644
+--- a/src/main/java/org/bukkit/MusicInstrument.java
++++ b/src/main/java/org/bukkit/MusicInstrument.java
+@@ -53,6 +53,16 @@ public abstract class MusicInstrument implements Keyed, net.kyori.adventure.tran
+         return instrument;
+     }
+ 
++    // Paper start - deprecate getKey
++    /**
++     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#INSTRUMENT}. MusicInstruments
++     * can exist without a key.
++     */
++    @Deprecated
++    @Override
++    public abstract @NotNull NamespacedKey getKey();
++    // Paper end - deprecate getKey
++
+     // Paper start - translation key
+     @Override
+     public @NotNull String translationKey() {
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
 index 18c672f3855a329bf8f87a9de81b677e8e360b41..e1fb4d8cca6a9c59047b1396f5c40bea957d777a 100644
 --- a/src/main/java/org/bukkit/Registry.java
@@ -75,6 +96,42 @@ index 18c672f3855a329bf8f87a9de81b677e8e360b41..e1fb4d8cca6a9c59047b1396f5c40bea
 +        }
 +        // Paper end - improve Registry
      }
+ }
+diff --git a/src/main/java/org/bukkit/block/banner/PatternType.java b/src/main/java/org/bukkit/block/banner/PatternType.java
+index 1c5c6303de815dd4ffa68f47dd2b6fa187fd4b70..7cdcc70d1bc33c88b217638725713e9cde450bdb 100644
+--- a/src/main/java/org/bukkit/block/banner/PatternType.java
++++ b/src/main/java/org/bukkit/block/banner/PatternType.java
+@@ -67,6 +67,13 @@ public enum PatternType implements Keyed {
+         this.key = NamespacedKey.minecraft(key);
+     }
+ 
++    // Paper start - deprecate getKey
++    /**
++     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#BANNER_PATTERN}. PatternTypes
++     * can exist without a key.
++     */
++    @Deprecated
++    // Paper end - deprecate getKey
+     @Override
+     @NotNull
+     public NamespacedKey getKey() {
+diff --git a/src/main/java/org/bukkit/generator/structure/Structure.java b/src/main/java/org/bukkit/generator/structure/Structure.java
+index 8e39f282c771ddafe5d890dcf065c56f0c633647..baa3d6d38353ba6d9d0863dd7deaba3c830b2400 100644
+--- a/src/main/java/org/bukkit/generator/structure/Structure.java
++++ b/src/main/java/org/bukkit/generator/structure/Structure.java
+@@ -63,4 +63,13 @@ public abstract class Structure implements Keyed {
+      */
+     @NotNull
+     public abstract StructureType getStructureType();
++    // Paper start - deprecate getKey
++    /**
++     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#STRUCTURE}. Structures
++     * can exist without a key.
++     */
++    @Override
++    @Deprecated
++    public abstract @NotNull NamespacedKey getKey();
++    // Paper end - deprecate getKey
  }
 diff --git a/src/main/java/org/bukkit/inventory/meta/trim/TrimMaterial.java b/src/main/java/org/bukkit/inventory/meta/trim/TrimMaterial.java
 index 941fac4eee338870d8c30cb1f64cab572cf54548..74816d6da4d7c8d2fa8a7b93fdc4bf29c8d12803 100644


### PR DESCRIPTION
- Structure (can already be defined inline in datapacks
- PatternType (can be defined inline in 1.20.5 data components)
- MusicInstrument (same as above)