### PR TITLE
Allow player-list API to self un/list

### DIFF
--- a/patches/server/0914-Add-Listing-API-for-Player.patch
+++ b/patches/server/0914-Add-Listing-API-for-Player.patch
@@ -111,7 +111,7 @@ index bc0e9fb41fe22e0a603837fcbdd82134f51d21d9..d38fe02af4cc35ed5b22acec41bedb76
          // Paper end - Use single player info update packet on join
          player.sentListPacket = true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 15817a84ad5db54ec299f933387f4ad1e0e74b33..458c7039bddf63a0affbf14c24ba73d66cc13fac 100644
+index 15817a84ad5db54ec299f933387f4ad1e0e74b33..15c7724e406655cffddad1a14081d737dab7ef44 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -188,6 +188,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -131,7 +131,7 @@ index 15817a84ad5db54ec299f933387f4ad1e0e74b33..458c7039bddf63a0affbf14c24ba73d6
              if (original != null) otherPlayer.setUUID(original); // Paper - uuid override
          }
  
-@@ -2102,6 +2103,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2102,6 +2103,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (entity != null) ? this.canSee(entity) : false; // If we can't find it, we can't see it
      }
  
@@ -145,7 +145,6 @@ index 15817a84ad5db54ec299f933387f4ad1e0e74b33..458c7039bddf63a0affbf14c24ba73d6
 +    public boolean unlistPlayer(@NotNull Player other) {
 +        Preconditions.checkNotNull(other, "hidden entity cannot be null");
 +        if (this.getHandle().connection == null) return false;
-+        if (this.equals(other)) return false;
 +        if (!this.canSee(other)) return false;
 +
 +        if (unlistedEntities.add(other.getUniqueId())) {
@@ -160,7 +159,6 @@ index 15817a84ad5db54ec299f933387f4ad1e0e74b33..458c7039bddf63a0affbf14c24ba73d6
 +    public boolean listPlayer(@NotNull Player other) {
 +        Preconditions.checkNotNull(other, "hidden entity cannot be null");
 +        if (this.getHandle().connection == null) return false;
-+        if (this.equals(other)) return false;
 +        if (!this.canSee(other)) throw new IllegalStateException("Player cannot see other player");
 +
 +        if (this.unlistedEntities.remove(other.getUniqueId())) {

--- a/patches/server/0946-Add-player-idle-duration-API.patch
+++ b/patches/server/0946-Add-player-idle-duration-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5b5167947c82ca66a89aab456a2eb5b523887d33..ff3db4efd2c10b3351453656937e88064267fb22 100644
+index a0bca5349074afd8012df429bb548c0f2640b432..eee2ed951ebcf0ad58aa7dc95ed9adc927322748 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3337,6 +3337,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3335,6 +3335,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0980-Rewrite-chunk-system.patch
+++ b/patches/server/0980-Rewrite-chunk-system.patch
@@ -21527,10 +21527,10 @@ index 93c10b5a699f4f8a8aa97a0f666999fc4a495a5b..75ddeceb3f6c381b95dca0a93643aaca
  
      // Paper start - implement pointers
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e874d76437fc4c86fd4ed2d03e416dd1ff528b76..616d2e479d91673695ade0db151a0099b568904f 100644
+index 77b459274e578779f5c79a7940bf47c782b9db06..e77bf7f432387bdfa7f69d31b014e8cd254fd4ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3400,31 +3400,31 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3398,31 +3398,31 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public int getViewDistance() {


### PR DESCRIPTION
This is supported behavior by the client, there is no real reason, to my understanding, to prevent this