### PR TITLE
Backport some stuff from the generators branch

### DIFF
--- a/paper-api-generator/src/main/java/io/papermc/generator/types/goal/MobGoalNames.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/types/goal/MobGoalNames.java
@@ -232,6 +232,7 @@ public class MobGoalNames {
         bukkitMap.put(net.minecraft.world.entity.monster.warden.Warden.class, org.bukkit.entity.Warden.class);
         bukkitMap.put(net.minecraft.world.entity.animal.allay.Allay.class, org.bukkit.entity.Allay.class);
         bukkitMap.put(net.minecraft.world.entity.animal.sniffer.Sniffer.class, org.bukkit.entity.Sniffer.class);
+        bukkitMap.put(net.minecraft.world.entity.monster.breeze.Breeze.class, org.bukkit.entity.Breeze.class);
         //</editor-fold>
     }
 

--- a/patches/api/0173-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0173-Fix-Spigot-annotation-mistakes.patch
@@ -965,6 +965,23 @@ index f101ffde9e7b3f6c3ab6f1cffb8d6f4e720634b2..8abc129f5953807e7a451166dabcf3e1
      void setBackgroundColor(@Nullable Color color);
  
      /**
+diff --git a/src/main/java/org/bukkit/entity/memory/MemoryKey.java b/src/main/java/org/bukkit/entity/memory/MemoryKey.java
+index 8f601e85df580ef8106eaff8b9eafb5691a4874b..d615c006c9153fb65024241604b744fbfc383efc 100644
+--- a/src/main/java/org/bukkit/entity/memory/MemoryKey.java
++++ b/src/main/java/org/bukkit/entity/memory/MemoryKey.java
+@@ -69,6 +69,12 @@ public final class MemoryKey<T> implements Keyed {
+     public static final MemoryKey<Location> LIKED_NOTEBLOCK_POSITION = new MemoryKey<>(NamespacedKey.minecraft("liked_noteblock"), Location.class);
+     public static final MemoryKey<Integer> LIKED_NOTEBLOCK_COOLDOWN_TICKS = new MemoryKey<>(NamespacedKey.minecraft("liked_noteblock_cooldown_ticks"), Integer.class);
+     public static final MemoryKey<Integer> ITEM_PICKUP_COOLDOWN_TICKS = new MemoryKey<>(NamespacedKey.minecraft("item_pickup_cooldown_ticks"), Integer.class);
++    /**
++     * @deprecated this constant uses the wrong generic type, the sniffer now stores different positions
++     * from possibly different worlds. Use the relevant methods in {@link org.bukkit.entity.Sniffer} directly
++     * for now.
++     */
++    @Deprecated // Paper
+     public static final MemoryKey<Location> SNIFFER_EXPLORED_POSITIONS = new MemoryKey<>(NamespacedKey.minecraft("sniffer_explored_positions"), Location.class);
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java b/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
 index e9a6e5be5f33a342f7e5c496f0f1c64b2f302ace..f0db59a556deaefefbdaca121585c0fd199c13c2 100644
 --- a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java

--- a/patches/api/0346-Add-missing-block-data-mins-and-maxes.patch
+++ b/patches/api/0346-Add-missing-block-data-mins-and-maxes.patch
@@ -65,3 +65,23 @@ index 3ea21dfad26222ee70fbc627595f54de1a28aa96..cd013a7c42648d819d1e91c7cf9f97a8
 +    int getMinimumDistance();
 +    // Paper end
  }
+diff --git a/src/main/java/org/bukkit/block/data/type/PinkPetals.java b/src/main/java/org/bukkit/block/data/type/PinkPetals.java
+index a84b36f7587eb2ed9e9177973b3166dc94cdf3df..eae9c9cdd0f47a7480ee23ac7b655692f5ee9c1e 100644
+--- a/src/main/java/org/bukkit/block/data/type/PinkPetals.java
++++ b/src/main/java/org/bukkit/block/data/type/PinkPetals.java
+@@ -21,6 +21,15 @@ public interface PinkPetals extends Directional {
+      */
+     void setFlowerAmount(int flower_amount);
+ 
++    // Paper start
++    /**
++     * Gets the minimum allowed value of the 'flower_amount' property.
++     *
++     * @return the minimum 'flower_amount' value
++     */
++    int getMinimumFlowerAmount();
++    // Paper end
++
+     /**
+      * Gets the maximum allowed value of the 'flower_amount' property.
+      *

--- a/patches/api/0444-add-missing-Experimental-annotations.patch
+++ b/patches/api/0444-add-missing-Experimental-annotations.patch
@@ -28,7 +28,7 @@ index 5269df59f0e8099a72c6b628ac1b8c84a0d1a5d5..775fda4b299e1d6dba9b293b2f98505e
      public static final FeatureFlag UPDATE_121 = Bukkit.getUnsafe().getFeatureFlag(NamespacedKey.minecraft("update_1_21"));
  }
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 9f86ad25a57b3f6e6bda1ce657833837cb3b2292..f9af60356da4668cec8b24e73f5747ab82e35a91 100644
+index 9f86ad25a57b3f6e6bda1ce657833837cb3b2292..ec117c47401ea1a04beb0e5ee9d4d394db7c5c4e 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -144,54 +144,67 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
@@ -233,7 +233,16 @@ index 9f86ad25a57b3f6e6bda1ce657833837cb3b2292..f9af60356da4668cec8b24e73f5747ab
      WAXED_OXIDIZED_COPPER_TRAPDOOR(21450, TrapDoor.class),
      /**
       * BlockData: {@link Gate}
-@@ -2628,6 +2665,7 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+@@ -2522,6 +2559,8 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+     EGG(21603, 16),
+     COMPASS(24139),
+     RECOVERY_COMPASS(12710),
++    @MinecraftExperimental // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     BUNDLE(16835, 1),
+     FISHING_ROD(4167, 1, 64),
+     CLOCK(14980),
+@@ -2628,6 +2667,7 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
       * BlockData: {@link Crafter}
       */
      @MinecraftExperimental
@@ -241,7 +250,7 @@ index 9f86ad25a57b3f6e6bda1ce657833837cb3b2292..f9af60356da4668cec8b24e73f5747ab
      CRAFTER(25243, Crafter.class),
      FILLED_MAP(23504),
      SHEARS(27971, 1, 238),
-@@ -2667,6 +2705,7 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+@@ -2667,6 +2707,7 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
      BEE_SPAWN_EGG(22924),
      BLAZE_SPAWN_EGG(4759),
      @MinecraftExperimental
@@ -249,7 +258,7 @@ index 9f86ad25a57b3f6e6bda1ce657833837cb3b2292..f9af60356da4668cec8b24e73f5747ab
      BREEZE_SPAWN_EGG(7580),
      CAT_SPAWN_EGG(29583),
      CAMEL_SPAWN_EGG(14760),
-@@ -3162,88 +3201,106 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+@@ -3162,88 +3203,106 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
       * BlockData: {@link Waterlogged}
       */
      @MinecraftExperimental

--- a/patches/api/0464-Suspicious-Effect-Entry-API.patch
+++ b/patches/api/0464-Suspicious-Effect-Entry-API.patch
@@ -15,12 +15,13 @@ Co-authored-by: Yannick Lamprecht <yannicklamprecht@live.de>
 
 diff --git a/src/main/java/io/papermc/paper/potion/SuspiciousEffectEntry.java b/src/main/java/io/papermc/paper/potion/SuspiciousEffectEntry.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c8446678e39e777bd2c9992d5c577f4c7606ce15
+index 0000000000000000000000000000000000000000..6a96e339ff1466df5743b5d42a31ce6a67e48f16
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/potion/SuspiciousEffectEntry.java
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,38 @@
 +package io.papermc.paper.potion;
 +
++import org.bukkit.potion.PotionEffect;
 +import org.bukkit.potion.PotionEffectType;
 +import org.jetbrains.annotations.Contract;
 +import org.jetbrains.annotations.NotNull;
@@ -31,24 +32,24 @@ index 0000000000000000000000000000000000000000..c8446678e39e777bd2c9992d5c577f4c
 +public sealed interface SuspiciousEffectEntry permits SuspiciousEffectEntryImpl {
 +
 +    /**
-+      * Gets the effect type.
++     * Gets the effect type.
 +     *
-+      * @return type
-+      */
++     * @return effect type
++     */
 +    @NotNull PotionEffectType effect();
 +
 +    /**
-+      * Gets the duration for this effect instance.
-+      *
-+      * @return duration (in ticks)
-+      */
++     * Gets the duration for this effect instance.
++     *
++     * @return duration (in ticks) or {@link PotionEffect#INFINITE_DURATION}
++     */
 +    int duration();
 +
 +    /**
 +     * Creates a new instance of SuspiciousEffectEntry.
 +     *
 +     * @param effectType effect type
-+     * @param duration duration (in ticks)
++     * @param duration duration (in ticks) or {@link PotionEffect#INFINITE_DURATION}
 +     * @return new instance of an entry
 +     */
 +    @Contract(value = "_, _ -> new", pure = true)

--- a/patches/server/0707-Add-missing-block-data-mins-and-maxes.patch
+++ b/patches/server/0707-Add-missing-block-data-mins-and-maxes.patch
@@ -150,3 +150,21 @@ index 7a1f2fd2f7f8f1b46352fe2c4d0cdf23a88020fd..8b621aaeadcf2cc6e2ccdbab92f4ae2b
 +    }
 +    // Paper end
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftPinkPetals.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftPinkPetals.java
+index 78b220a6f460cd91ad1574c0d32f3e4288eaf431..0f7df1b4c58ba731832958043ba345ec77737e54 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftPinkPetals.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftPinkPetals.java
+@@ -27,6 +27,13 @@ public final class CraftPinkPetals extends org.bukkit.craftbukkit.block.data.Cra
+         this.set(CraftPinkPetals.FLOWER_AMOUNT, flower_amount);
+     }
+ 
++    // Paper start
++    @Override
++    public int getMinimumFlowerAmount() {
++        return getMin(CraftPinkPetals.FLOWER_AMOUNT);
++    }
++    // Paper end
++
+     @Override
+     public int getMaximumFlowerAmount() {
+         return getMax(CraftPinkPetals.FLOWER_AMOUNT);

--- a/patches/server/0796-Allow-changing-bed-s-occupied-property.patch
+++ b/patches/server/0796-Allow-changing-bed-s-occupied-property.patch
@@ -4,22 +4,6 @@ Date: Wed, 12 Oct 2022 00:36:55 +0300
 Subject: [PATCH] Allow changing bed's 'occupied' property
 
 
-diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftBed.java b/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftBed.java
-index f636a6b69143e88fc3bebd11620083ab6a419d48..e6ff5225fe8253cbaa79ed15b4c12f3735fc7021 100644
---- a/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftBed.java
-+++ b/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftBed.java
-@@ -22,4 +22,11 @@ public abstract class CraftBed extends CraftBlockData implements Bed {
-     public boolean isOccupied() {
-         return this.get(CraftBed.OCCUPIED);
-     }
-+
-+    // Paper start
-+    @Override
-+    public void setOccupied(boolean occupied) {
-+        set(CraftBed.OCCUPIED, occupied);
-+    }
-+    // Paper end
- }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftBed.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftBed.java
 index 2ccf3fbe3f991b7a014cff3bcd424e6a81bc310a..e5450d3511389bf3bd6461fb6ec65ea82e4ae9f0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftBed.java


### PR DESCRIPTION
Backport some relevant stuff from the generators branch that fit into the main branch

- Mark the bundle item as experimental, the sounds are so there are no reason to not mark them
- Add `PinkPetals#getMinimumFlowerAmount`, like MachineMaker said in the original PR any int property that doesn't start from zero should have a minimum method (exception is the composter caused by the levelled interface).
- Deprecate `MemoryKey#SNIFFER_EXPLORED_POSITIONS`, this key use the wrong generic type and will (once the sniffer already have a memory key) throw an error on the getter, and corrupt the nbt data on the setter
- Add missing breeze in the bukkitMap for the mob goal generator (the tests have been removed)