### PR TITLE
Disable vertical air friction when item entities have friction disabled

### DIFF
--- a/patches/server/0816-Friction-API.patch
+++ b/patches/server/0816-Friction-API.patch
@@ -55,7 +55,7 @@ index 4959d8fd8f84f99f289b898fd604d8a9808d62a4..8e6cb47ce314d4c493047fa1804b2da8
              this.getAttributes().load(nbt.getList("Attributes", 10));
          }
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index d0dac3dc89b9bb645a1d8498802fb8c6bff6a78e..c7f06c3cfb737bd17a706798bf9cf0e1af5f0cc0 100644
+index d0dac3dc89b9bb645a1d8498802fb8c6bff6a78e..29ce703a79f7893ac990ad80e0f1c1cf63546e6c 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 @@ -58,6 +58,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
@@ -66,7 +66,7 @@ index d0dac3dc89b9bb645a1d8498802fb8c6bff6a78e..c7f06c3cfb737bd17a706798bf9cf0e1
  
      public ItemEntity(EntityType<? extends ItemEntity> type, Level world) {
          super(type, world);
-@@ -179,7 +180,11 @@ public class ItemEntity extends Entity implements TraceableEntity {
+@@ -179,11 +180,15 @@ public class ItemEntity extends Entity implements TraceableEntity {
                  this.move(MoverType.SELF, this.getDeltaMovement());
                  float f1 = 0.98F;
  
@@ -78,6 +78,11 @@ index d0dac3dc89b9bb645a1d8498802fb8c6bff6a78e..c7f06c3cfb737bd17a706798bf9cf0e1
 +                    // Paper end - Friction API
                      f1 = this.level().getBlockState(this.getBlockPosBelowThatAffectsMyMovement()).getBlock().getFriction() * 0.98F;
                  }
+ 
+-                this.setDeltaMovement(this.getDeltaMovement().multiply((double) f1, 0.98D, (double) f1));
++                this.setDeltaMovement(this.getDeltaMovement().multiply((double) f1, frictionState == net.kyori.adventure.util.TriState.FALSE ? 1D : 0.98D, (double) f1)); // Paper - Friction API
+                 if (this.onGround()) {
+                     Vec3 vec3d1 = this.getDeltaMovement();
  
 @@ -388,6 +393,11 @@ public class ItemEntity extends Entity implements TraceableEntity {
  


### PR DESCRIPTION
Fixes #10367.

Title. Don't slow an item entity down vertically when they have friction disabled, just like we currently do horizontally.