### PR TITLE
Fix invalid block entities created during world gen

### DIFF
--- a/patches/server/1055-Fix-creation-of-invalid-block-entity-during-world-ge.patch
+++ b/patches/server/1055-Fix-creation-of-invalid-block-entity-during-world-ge.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pierpaolo Coletta <p.coletta@glyart.com>
+Date: Sat, 30 Mar 2024 21:06:10 +0100
+Subject: [PATCH] Fix creation of invalid block entity during world generation
+
+
+diff --git a/src/main/java/net/minecraft/server/level/WorldGenRegion.java b/src/main/java/net/minecraft/server/level/WorldGenRegion.java
+index 5ece375eaf6bcc61864997a389bb5e24625e4505..9c3f8f79c2b3389a118dce9a1558edda52446833 100644
+--- a/src/main/java/net/minecraft/server/level/WorldGenRegion.java
++++ b/src/main/java/net/minecraft/server/level/WorldGenRegion.java
+@@ -352,6 +352,7 @@ public class WorldGenRegion implements WorldGenLevel {
+                         ichunkaccess.removeBlockEntity(pos);
+                     }
+                 } else {
++                    ichunkaccess.removeBlockEntity(pos); // Paper - Clear the block entity before setting up a DUMMY block entity
+                     CompoundTag nbttagcompound = new CompoundTag();
+ 
+                     nbttagcompound.putInt("x", pos.getX());
+diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
+index 6ec3fc801453fd54c25b642e6fa71c19b463311d..2187d720bbd1f83047fbd1a3db2faaf33908da2c 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
++++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
+@@ -1169,9 +1169,14 @@ public class LevelChunk extends ChunkAccess {
+                         if (this.blockEntity.getType().isValid(iblockdata)) {
+                             this.ticker.tick(LevelChunk.this.level, this.blockEntity.getBlockPos(), iblockdata, this.blockEntity);
+                             this.loggedInvalidBlockState = false;
+-                        } else if (!this.loggedInvalidBlockState) {
+-                            this.loggedInvalidBlockState = true;
+-                            LevelChunk.LOGGER.warn("Block entity {} @ {} state {} invalid for ticking:", new Object[]{LogUtils.defer(this::getType), LogUtils.defer(this::getPos), iblockdata});
++                        } else {
++                            // Paper start - Remove the Block Entity if it's invalid
++                            LevelChunk.this.removeBlockEntity(this.getPos());
++                            if (!this.loggedInvalidBlockState) {
++                                this.loggedInvalidBlockState = true;
++                                LevelChunk.LOGGER.warn("Block entity {} @ {} state {} invalid for ticking:", new Object[]{LogUtils.defer(this::getType), LogUtils.defer(this::getPos), iblockdata});
++                            }
++                            // Paper end
+                         }
+ 
+                         gameprofilerfiller.pop();


### PR DESCRIPTION
This patch fixes https://github.com/PaperMC/Paper/issues/10022 and https://github.com/sachingorkar102/Lootin-plugin/issues/24

When using WorldGenRegion#setBlock on a block position where a BlockEntity exists it doesn't remove the old one, this creates a broken state in the world and makes the clients crash due to an internal server error.

To fix these issue, I'm removing the BlockEntity when WorldGenRegion#setBlock is set (to fix new worlds) and I've changed the LevelChunk#tick method to remove the invalid BlockEntity (to fix the existing worlds)