### PR TITLE
[ci skip] sync up asm versions

### DIFF
--- a/Paper-MojangAPI/build.gradle.kts
+++ b/Paper-MojangAPI/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.hamcrest:hamcrest-library:1.3")
-    testImplementation("org.ow2.asm:asm-tree:9.2")
+    testImplementation("org.ow2.asm:asm-tree:9.5")
 }
 
 configure<PublishingExtension> {

--- a/patches/api/0008-Use-ASM-for-event-executors.patch
+++ b/patches/api/0008-Use-ASM-for-event-executors.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use ASM for event executors.
 Uses method handles for private or static methods.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index b577114c2b89fe2053123d1a542d37dff7fa8d5a..af6c528ccc4356f5bba3ce0b9bf6de237d77376e 100644
+index 9011451c6a60db08dcc255a84470f8ce92f7b2a4..2cd2636d89cd1452a80f9f5ad7aa64eff0a003bb 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -47,6 +47,9 @@ dependencies {

--- a/patches/api/0009-Paper-Plugins.patch
+++ b/patches/api/0009-Paper-Plugins.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Paper Plugins
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index af6c528ccc4356f5bba3ce0b9bf6de237d77376e..f9ff7e3692d448e2a1e38d0aa26c2d934442e247 100644
+index 2cd2636d89cd1452a80f9f5ad7aa64eff0a003bb..ddc89dfd6911d85aab7c37fe3ca54eb1b80f99d6 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -52,7 +52,7 @@ dependencies {

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -4983,7 +4983,7 @@ index 680a308c466c0056d4213e61f69cf13ee3ff5c61..cd39509d383c47319b71797e5d1df41c
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index a7921cde2b6275d730879b2814cc5f430520b051..c8f0570b7d37a0c0bddb0a65c36fb32de584df8f 100644
+index 96210dd54e8ff6dc0375a8d03bf14fec1b26aaeb..19725db76dc3a12356993aed7edba507b52fe4d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -141,6 +141,19 @@ public class Main {

--- a/patches/server/0128-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0128-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -413,7 +413,7 @@ index 827579f59d34b61912a67b40624f0f41524185fd..f7d937c6a11e24afe767411428210f3c
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 4fb377d967d13ed920ea1246e84b3b94cda25be6..659b32d49016a23475f3bbda1548a78101b468ce 100644
+index adae906894144a1684a0dab15226649fd4bf6354..1bd54fbadc9b1b5207325c78298cc72f61455ac7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -13,7 +13,6 @@ import java.util.logging.Logger;


### PR DESCRIPTION
We had different versions of asm on the classpath which is just annoying when searching for stuff.