### PR TITLE
Fix hit criteria advancement triggered before changing state

### DIFF
--- a/patches/server/0470-Add-TargetHitEvent.patch
+++ b/patches/server/0470-Add-TargetHitEvent.patch
@@ -24,6 +24,7 @@ index 02f6d5b523c3d4185a68adb419b2710768ed249f..da473a8b34e39cecf63fab8f7c4f77d4
          int i = getRedstoneStrength(hitResult, hitResult.getLocation());
          int j = entity instanceof AbstractArrow ? 20 : 8;
 +        // Paper start - Add TargetHitEvent
++        boolean shouldAward = false;
 +        if (entity instanceof Projectile) {
 +            final Projectile projectile = (Projectile) entity;
 +            final org.bukkit.craftbukkit.block.CraftBlock craftBlock = org.bukkit.craftbukkit.block.CraftBlock.at(world, hitResult.getBlockPos());
@@ -31,7 +32,7 @@ index 02f6d5b523c3d4185a68adb419b2710768ed249f..da473a8b34e39cecf63fab8f7c4f77d4
 +            final io.papermc.paper.event.block.TargetHitEvent targetHitEvent = new io.papermc.paper.event.block.TargetHitEvent((org.bukkit.entity.Projectile) projectile.getBukkitEntity(), craftBlock, blockFace, i);
 +            if (targetHitEvent.callEvent()) {
 +                i = targetHitEvent.getSignalStrength();
-+                awardTargetHitCriteria(projectile, hitResult, i);
++                shouldAward = true;
 +            } else {
 +                return i;
 +            }
@@ -40,3 +41,13 @@ index 02f6d5b523c3d4185a68adb419b2710768ed249f..da473a8b34e39cecf63fab8f7c4f77d4
          if (!world.getBlockTicks().hasScheduledTick(hitResult.getBlockPos(), state.getBlock())) {
              setOutputPower(world, state, i, hitResult.getBlockPos(), j);
          }
+ 
++        // Paper start - Award Hit Criteria after Block Update
++        if (shouldAward) {
++            awardTargetHitCriteria((Projectile) entity, hitResult, i);
++        }
++        // Paper end - Award Hit Criteria after Block Update
++
+         return i;
+     }
+ 

--- a/patches/server/0470-Add-TargetHitEvent.patch
+++ b/patches/server/0470-Add-TargetHitEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add TargetHitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/TargetBlock.java b/src/main/java/net/minecraft/world/level/block/TargetBlock.java
-index 02f6d5b523c3d4185a68adb419b2710768ed249f..da473a8b34e39cecf63fab8f7c4f77d485e5753b 100644
+index 02f6d5b523c3d4185a68adb419b2710768ed249f..4ae14ee74a83c8b12ac2e3475863e6d77979af0a 100644
 --- a/src/main/java/net/minecraft/world/level/block/TargetBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/TargetBlock.java
 @@ -42,6 +42,10 @@ public class TargetBlock extends Block {
@@ -19,7 +19,7 @@ index 02f6d5b523c3d4185a68adb419b2710768ed249f..da473a8b34e39cecf63fab8f7c4f77d4
          if (projectile.getOwner() instanceof ServerPlayer serverPlayer) {
              serverPlayer.awardStat(Stats.TARGET_HIT);
              CriteriaTriggers.TARGET_BLOCK_HIT.trigger(serverPlayer, projectile, hit.getLocation(), i);
-@@ -51,6 +55,20 @@ public class TargetBlock extends Block {
+@@ -51,10 +55,31 @@ public class TargetBlock extends Block {
      private static int updateRedstoneOutput(LevelAccessor world, BlockState state, BlockHitResult hitResult, Entity entity) {
          int i = getRedstoneStrength(hitResult, hitResult.getLocation());
          int j = entity instanceof AbstractArrow ? 20 : 8;


### PR DESCRIPTION
Hi,
As mentioned by #10393 , the advancement criteria was being trigged before the Target Block could update. The only change being that the function call to grant the advancement is now after the call for `setOutputPower()`.