### PR TITLE
Change online mode default for Velocity configuration

### DIFF
--- a/patches/server/1055-Change-online-mode-default-for-Velocity-configuratio.patch
+++ b/patches/server/1055-Change-online-mode-default-for-Velocity-configuratio.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: gecko10000 <levtey@gmail.com>
+Date: Fri, 12 Apr 2024 09:26:29 -0700
+Subject: [PATCH] Change online mode default for Velocity configuration
+
+
+diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+index 0cc2307636279915c1f8529e62174cc696e185ee..30fe1c0645a07d663b08c0f988a1ab3a750bf7c4 100644
+--- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
++++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+@@ -127,7 +127,7 @@ public class GlobalConfiguration extends ConfigurationPart {
+ 
+         public class Velocity extends ConfigurationPart {
+             public boolean enabled = false;
+-            public boolean onlineMode = false;
++            public boolean onlineMode = true;
+             public String secret = "";
+ 
+             @PostProcess


### PR DESCRIPTION
Changing this default will not affect anything unless `proxies.velocity.enabled` is also true, and discouraging piracy is always nice.