### PR TITLE
[ci skip] Update book page/char limit for book meta doc

### DIFF
--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -4356,7 +4356,7 @@ index 88cdce67e6a55712cb56e946f2f09c82ddbc1d15..e76c847e57f3d32757129d56922862a4
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/meta/BookMeta.java b/src/main/java/org/bukkit/inventory/meta/BookMeta.java
-index fc94719f702f23da8de5340d7f9e9b9d0c9d7c66..86c9e4229a1936c5893016e5b8087aa9fd06ddab 100644
+index fc94719f702f23da8de5340d7f9e9b9d0c9d7c66..151ccc0fe93a7d216677b20e904f006905d6a988 100644
 --- a/src/main/java/org/bukkit/inventory/meta/BookMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/BookMeta.java
 @@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
@@ -4431,7 +4431,7 @@ index fc94719f702f23da8de5340d7f9e9b9d0c9d7c66..86c9e4229a1936c5893016e5b8087aa9
 +     * Sets the specified page in the book. Pages of the book must be
 +     * contiguous.
 +     * <p>
-+     * The data can be up to 256 characters in length, additional characters
++     * The data can be up to 1024 characters in length, additional characters
 +     * are truncated.
 +     * <p>
 +     * Pages are 1-indexed.
@@ -4442,8 +4442,8 @@ index fc94719f702f23da8de5340d7f9e9b9d0c9d7c66..86c9e4229a1936c5893016e5b8087aa9
 +    void page(int page, net.kyori.adventure.text.@NotNull Component data);
 +
 +    /**
-+     * Adds new pages to the end of the book. Up to a maximum of 50 pages with
-+     * 256 characters per page.
++     * Adds new pages to the end of the book. Up to a maximum of 100 pages with
++     * 1024 characters per page.
 +     *
 +     * @param pages A list of strings, each being a page
 +     */


### PR DESCRIPTION
The old bungee component methods still use the old limit but i'm not sure if it's worth to fix them here.