### PR TITLE
"Downgrade" Vineflower to 1.10.1 release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ repositories {
 dependencies {
     paramMappings("net.fabricmc:yarn:1.20.4+build.1:mergedv2")
     remapper("net.fabricmc:tiny-remapper:0.10.1:fat")
-    decompiler("org.vineflower:vineflower:1.11.0-20240412.144930-14")
+    decompiler("org.vineflower:vineflower:1.10.1")
     spigotDecompiler("io.papermc:patched-spigot-fernflower:0.1+build.6")
     paperclip("io.papermc:paperclip:3.0.3")
 }
@@ -80,7 +80,7 @@ paperweight {
 
     paramMappingsRepo = paperMavenPublicUrl
     remapRepo = paperMavenPublicUrl
-    decompileRepo = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+    decompileRepo = paperMavenPublicUrl
 
     craftBukkit {
         fernFlowerJar = layout.file(spigotDecompiler.elements.map { it.single().asFile })

--- a/patches/server/0072-Use-a-Shared-Random-for-Entities.patch
+++ b/patches/server/0072-Use-a-Shared-Random-for-Entities.patch
@@ -99,15 +99,15 @@ index 9fb52c98455d547bdde6d56689528e78a5ddfed5..52220795bf8a73c63837b4e07b1abf99
          this.fluidHeight = new Object2DoubleArrayMap(2);
          this.fluidOnEyes = new HashSet();
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Squid.java b/src/main/java/net/minecraft/world/entity/animal/Squid.java
-index 1d1a4a52f3a2361688fa81ca0a2cd2e00abe652d..051fb9f1e0d91b1cb1e2dec9a03f3b26fe64c82a 100644
+index d404cd4c805442004d9a5f259a9e0907758ad915..36506dc4b99f9de19a23a99c1bccdcb4e7102e72 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Squid.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Squid.java
 @@ -44,7 +44,7 @@ public class Squid extends WaterAnimal {
  
      public Squid(EntityType<? extends Squid> type, Level world) {
          super(type, world);
--        this.random.setSeed(this.getId());
-+        //this.random.setSeed(this.getId()); // Paper - Share random for entities to make them more random
+-        this.random.setSeed((long)this.getId());
++        //this.random.setSeed((long)this.getId()); // Paper - Share random for entities to make them more random
          this.tentacleSpeed = 1.0F / (this.random.nextFloat() + 1.0F) * 0.2F;
      }
  

--- a/patches/server/0077-EntityPathfindEvent.patch
+++ b/patches/server/0077-EntityPathfindEvent.patch
@@ -19,7 +19,7 @@ index d3a279a1a14f99aee8dd516552e5c60de92b4969..a3e0c5af4cc9323c02e88e768cbda9e4
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/ai/navigation/GroundPathNavigation.java b/src/main/java/net/minecraft/world/entity/ai/navigation/GroundPathNavigation.java
-index e8e515dc312e266f7991f150e83a2371f914c15a..8d433e354ecc91f823822a95224c9d2e2a59bbbd 100644
+index bd38ff5615bbf33b374283e3d461981b30035bb8..74ae984ac41bcdd2cc45f1bec461cdc5f69977c6 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/navigation/GroundPathNavigation.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/navigation/GroundPathNavigation.java
 @@ -41,7 +41,7 @@ public class GroundPathNavigation extends PathNavigation {
@@ -67,7 +67,7 @@ index e8e515dc312e266f7991f150e83a2371f914c15a..8d433e354ecc91f823822a95224c9d2e
  
      private int getSurfaceY() {
 diff --git a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
-index 480a95a7fb342b3f92306079055a06f15541200a..b5347d972c657706f8b2ed4ebf2365ba9a480895 100644
+index c3e1fa25b03c24c9127441d62142a96e5f81f18c..fa5088945adc5e41e34cc2dc21a1762d106254c8 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 @@ -109,7 +109,13 @@ public abstract class PathNavigation {
@@ -111,7 +111,7 @@ index 480a95a7fb342b3f92306079055a06f15541200a..b5347d972c657706f8b2ed4ebf2365ba
 +        // Paper end - EntityPathfindEvent
          if (positions.isEmpty()) {
              return null;
-         } else if (this.mob.getY() < this.level.getMinBuildHeight()) {
+         } else if (this.mob.getY() < (double)this.level.getMinBuildHeight()) {
 @@ -138,6 +155,23 @@ public abstract class PathNavigation {
          } else if (this.path != null && !this.path.isDone() && positions.contains(this.targetPos)) {
              return this.path;
@@ -135,9 +135,9 @@ index 480a95a7fb342b3f92306079055a06f15541200a..b5347d972c657706f8b2ed4ebf2365ba
 +            // Paper end - EntityPathfindEvent
              this.level.getProfiler().push("pathfind");
              BlockPos blockPos = useHeadPos ? this.mob.blockPosition().above() : this.mob.blockPosition();
-             int i = (int)(followRange + range);
+             int i = (int)(followRange + (float)range);
 diff --git a/src/main/java/net/minecraft/world/entity/ai/navigation/WallClimberNavigation.java b/src/main/java/net/minecraft/world/entity/ai/navigation/WallClimberNavigation.java
-index 0398771544d9d8751dbfea0a27aec2b5eee21383..35c95dd6be4898fcc6f55c262a1f99d7b0d34f29 100644
+index 1a1bc30b425858d82dbfb84b4a94d7793cab7125..5bbfa43d1e97970f035fcb101c3252c01ffead0d 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/navigation/WallClimberNavigation.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/navigation/WallClimberNavigation.java
 @@ -16,9 +16,9 @@ public class WallClimberNavigation extends GroundPathNavigation {

--- a/patches/server/0083-Optimize-DataBits.patch
+++ b/patches/server/0083-Optimize-DataBits.patch
@@ -11,7 +11,7 @@ After: http://i.imgur.com/nJ46crB.png
 Optimize redundant converting of static fields into an unsigned long each call by precomputing it in ctor
 
 diff --git a/src/main/java/net/minecraft/util/SimpleBitStorage.java b/src/main/java/net/minecraft/util/SimpleBitStorage.java
-index b0fc31f8fdf96c5b595b04fe4208963a33de8a2a..dafb714706107a9e83a7c0b808ba795a78eb7b52 100644
+index dea4f322f750a0a09407fdb48d5d6e809dfe8ed4..9f438d9c6eb05e43d24e4af68188a3d4c46a938c 100644
 --- a/src/main/java/net/minecraft/util/SimpleBitStorage.java
 +++ b/src/main/java/net/minecraft/util/SimpleBitStorage.java
 @@ -204,8 +204,8 @@ public class SimpleBitStorage implements BitStorage {
@@ -42,7 +42,7 @@ index b0fc31f8fdf96c5b595b04fe4208963a33de8a2a..dafb714706107a9e83a7c0b808ba795a
      private int cellIndex(int index) {
 -        long l = Integer.toUnsignedLong(this.divideMul);
 -        long m = Integer.toUnsignedLong(this.divideAdd);
--        return (int)(index * l + m >> 32 >> this.divideShift);
+-        return (int)((long)index * l + m >> 32 >> this.divideShift);
 +        //long l = Integer.toUnsignedLong(this.divideMul); // Paper - Perf: Optimize SimpleBitStorage
 +        //long m = Integer.toUnsignedLong(this.divideAdd); // Paper - Perf: Optimize SimpleBitStorage
 +        return (int) (index * this.divideMulUnsigned + this.divideAddUnsigned >> 32 >> this.divideShift); // Paper - Perf: Optimize SimpleBitStorage

--- a/patches/server/0118-Firework-API-s.patch
+++ b/patches/server/0118-Firework-API-s.patch
@@ -56,11 +56,11 @@ index ac7371882d15746e9353865635d0bb716f890c53..ba570f1c9654e1004e068a1efe2118f3
                  object = CrossbowItem.getArrow(world, shooter, crossbow, projectile);
                  if (creative || simulated != 0.0F) {
 diff --git a/src/main/java/net/minecraft/world/item/FireworkRocketItem.java b/src/main/java/net/minecraft/world/item/FireworkRocketItem.java
-index 2a5a55b60cc83649e6e768a144667e021f46e27e..0bfb2667914b8001d1808bdbcf7fda6f0ff781a9 100644
+index b342d23692ffd38b6eec66838162e9012f29ac09..3749cfca8f007973d1a2206d8f2ba15283a550e1 100644
 --- a/src/main/java/net/minecraft/world/item/FireworkRocketItem.java
 +++ b/src/main/java/net/minecraft/world/item/FireworkRocketItem.java
 @@ -53,6 +53,7 @@ public class FireworkRocketItem extends Item {
-                 vec3.z + direction.getStepZ() * 0.15,
+                 vec3.z + (double)direction.getStepZ() * 0.15,
                  itemStack
              );
 +            fireworkRocketEntity.spawningEntity = context.getPlayer() == null ? null : context.getPlayer().getUUID(); // Paper

--- a/patches/server/0197-Configurable-LootPool-luck-formula.patch
+++ b/patches/server/0197-Configurable-LootPool-luck-formula.patch
@@ -36,14 +36,14 @@ This change will result in some major changes to fishing formulas.
 I would love to see this change in Vanilla, so Mojang please pull :)
 
 diff --git a/src/main/java/net/minecraft/world/level/storage/loot/entries/LootPoolSingletonContainer.java b/src/main/java/net/minecraft/world/level/storage/loot/entries/LootPoolSingletonContainer.java
-index 55c097609812e899beda2eafea58e163edd6b71f..4f73aae0342ddcefba19e14d5400c960c2acf70c 100644
+index f73cfe6a1fd96ebc0e24d3488f00cd3403cb3454..4f73aae0342ddcefba19e14d5400c960c2acf70c 100644
 --- a/src/main/java/net/minecraft/world/level/storage/loot/entries/LootPoolSingletonContainer.java
 +++ b/src/main/java/net/minecraft/world/level/storage/loot/entries/LootPoolSingletonContainer.java
 @@ -127,9 +127,35 @@ public abstract class LootPoolSingletonContainer extends LootPoolEntryContainer
      protected abstract class EntryBase implements LootPoolEntry {
          @Override
          public int getWeight(float luck) {
--            return Math.max(Mth.floor(LootPoolSingletonContainer.this.weight + LootPoolSingletonContainer.this.quality * luck), 0);
+-            return Math.max(Mth.floor((float)LootPoolSingletonContainer.this.weight + (float)LootPoolSingletonContainer.this.quality * luck), 0);
 +            // Paper start - Configurable LootPool luck formula
 +            // SEE: https://luckformula.emc.gs for details and data
 +            if (LootPoolSingletonContainer.this.lastLuck != null && LootPoolSingletonContainer.this.lastLuck == luck) {

--- a/patches/server/0202-Add-EntityKnockbackByEntityEvent-and-EntityPushedByE.patch
+++ b/patches/server/0202-Add-EntityKnockbackByEntityEvent-and-EntityPushedByE.patch
@@ -85,20 +85,20 @@ index e3dfef027fb7f6aedd3e3411af6457671b5507a7..88af8a11dfc3b645c5a2b5fb629a73fc
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/RamTarget.java b/src/main/java/net/minecraft/world/entity/ai/behavior/RamTarget.java
-index a93212d3cbf18a8cf392515fd466475264bba5ef..347986ef559ebcecdb67e2f5d31a31049acc48f5 100644
+index 312398b7f1281144a0529a743d2a09376d575ff5..0c63779af7e1c790160fb2ab86bf455219b3cc36 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/behavior/RamTarget.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/behavior/RamTarget.java
 @@ -83,7 +83,7 @@ public class RamTarget extends Behavior<Goat> {
-             float f = 0.25F * (i - j);
+             float f = 0.25F * (float)(i - j);
              float g = Mth.clamp(entity.getSpeed() * 1.65F, 0.2F, 3.0F) + f;
              float h = livingEntity.isDamageSourceBlocked(world.damageSources().mobAttack(entity)) ? 0.5F : 1.0F;
--            livingEntity.knockback(h * g * this.getKnockbackForce.applyAsDouble(entity), this.ramDirection.x(), this.ramDirection.z());
+-            livingEntity.knockback((double)(h * g) * this.getKnockbackForce.applyAsDouble(entity), this.ramDirection.x(), this.ramDirection.z());
 +            livingEntity.knockback(h * g * this.getKnockbackForce.applyAsDouble(entity), this.ramDirection.x(), this.ramDirection.z(), entity, org.bukkit.event.entity.EntityKnockbackEvent.KnockbackCause.ENTITY_ATTACK); // Paper - Add EntityKnockbackByEntityEvent and EntityPushedByEntityAttackEvent
              this.finishRam(world, entity);
              world.playSound(null, entity, this.getImpactSound.apply(entity), SoundSource.NEUTRAL, 1.0F, 1.0F);
          } else if (this.hasRammedHornBreakingBlock(world, entity)) {
 diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/warden/SonicBoom.java b/src/main/java/net/minecraft/world/entity/ai/behavior/warden/SonicBoom.java
-index ce329b00fa25e9defabead0e594d734b8ed6724e..fe9c5afadd9041ab32d9e03fe6dab2a2d00262f2 100644
+index c7ce058dda0dcb58197faea4f1799ebc580829c0..4f4c09cd7b75de38c0a3580386494e7e05f0acee 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/behavior/warden/SonicBoom.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/behavior/warden/SonicBoom.java
 @@ -81,7 +81,7 @@ public class SonicBoom extends Behavior<Warden> {
@@ -166,13 +166,13 @@ index 041f1650b853138e4286fe83a08d79d276054ce7..aba20a4352d8983b01ab5d329187588f
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/monster/hoglin/HoglinBase.java b/src/main/java/net/minecraft/world/entity/monster/hoglin/HoglinBase.java
-index 889dca53d7a113f0b70791c75885de1c66fecdff..06cb2a4a941ccdd7371f05f7c3c6951dc6c66b04 100644
+index 38c27b4aa37e8b046e3eccdde3f527eb555da6f8..05dee42941a842bf4bba9480a2c04a142541ac29 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/hoglin/HoglinBase.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/hoglin/HoglinBase.java
 @@ -40,7 +40,7 @@ public interface HoglinBase {
-             double j = f * (attacker.level().random.nextFloat() * 0.5F + 0.2F);
+             double j = f * (double)(attacker.level().random.nextFloat() * 0.5F + 0.2F);
              Vec3 vec3 = new Vec3(g, 0.0, h).normalize().scale(j).yRot(i);
-             double k = f * attacker.level().random.nextFloat() * 0.5;
+             double k = f * (double)attacker.level().random.nextFloat() * 0.5;
 -            target.push(vec3.x, k, vec3.z);
 +            target.push(vec3.x, k, vec3.z, attacker); // Paper - Add EntityKnockbackByEntityEvent and EntityPushedByEntityAttackEvent
              target.hurtMarked = true;

--- a/patches/server/0213-EnderDragon-Events.patch
+++ b/patches/server/0213-EnderDragon-Events.patch
@@ -23,10 +23,10 @@ index 3eaf64a6f66c6a844e30967e6b87432e559a59e7..5c5c71db73a2bfebbb33cebd6325a0f4
  
      }
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonStrafePlayerPhase.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonStrafePlayerPhase.java
-index e78ed9b2392e752718361cf7bf25c1dfc2911ce2..13f60a16f07c50a278b158d64180009020a4dca6 100644
+index 02f407757a37c9dc8b3f4a899ac3b04719d8ceed..c5269c3117901b8521720d1b32689d7f600f20a3 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonStrafePlayerPhase.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonStrafePlayerPhase.java
-@@ -76,7 +76,9 @@ public class DragonStrafePlayerPhase extends AbstractDragonPhaseInstance {
+@@ -78,7 +78,9 @@ public class DragonStrafePlayerPhase extends AbstractDragonPhaseInstance {
  
                          DragonFireball dragonFireball = new DragonFireball(this.dragon.level(), this.dragon, r, s, t);
                          dragonFireball.moveTo(o, p, q, 0.0F, 0.0F);

--- a/patches/server/0381-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/patches/server/0381-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -66,10 +66,10 @@ index b3732a6246a2b011e36c5c35fa2ac7749e75db16..3ae61e7b50bfc440c597f88843f92903
              }
  
 diff --git a/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java b/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
-index a9ad3a1534885a05b0c02e21cef1e7cbf849fdc2..7415011211925e962dcd1a3fdfde2c9bb6ec8335 100644
+index 541f4ffd06509aa72cf26ea108f84160eac82bc3..0e15da7cae105196d444b924b8e0db190583ba30 100644
 --- a/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
-@@ -292,7 +292,7 @@ public class PistonMovingBlockEntity extends BlockEntity {
+@@ -296,7 +296,7 @@ public class PistonMovingBlockEntity extends BlockEntity {
                  if (world.getBlockState(pos).is(Blocks.MOVING_PISTON)) {
                      BlockState blockState = Block.updateFromNeighbourShapes(blockEntity.movedState, world, pos);
                      if (blockState.isAir()) {

--- a/patches/server/0382-Fix-missing-chunks-due-to-integer-overflow.patch
+++ b/patches/server/0382-Fix-missing-chunks-due-to-integer-overflow.patch
@@ -15,14 +15,14 @@ allows the distance calculation to avoid overflow and work as intended.
 This issue is being tracked in Mojira ticket MC-159283
 
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/DensityFunctions.java b/src/main/java/net/minecraft/world/level/levelgen/DensityFunctions.java
-index 5facc03909ade37e8ae75e1de11388d3a0ec3a42..2cf20ef14ad18346f942395546ad31f2d774f81a 100644
+index db1d0e5cec19059d14e1a7cd41f049d23600e3fe..92c2df6a6abd9c60e90b0b84ab66987557adb9c8 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/DensityFunctions.java
 +++ b/src/main/java/net/minecraft/world/level/levelgen/DensityFunctions.java
 @@ -521,7 +521,7 @@ public final class DensityFunctions {
              int j = z / 2;
              int k = x % 2;
              int l = z % 2;
--            float f = 100.0F - Mth.sqrt(x * x + z * z) * 8.0F;
+-            float f = 100.0F - Mth.sqrt((float)(x * x + z * z)) * 8.0F;
 +            float f = 100.0F - Mth.sqrt((long) x * (long) x + (long) z * (long) z) * 8.0F; // Paper - cast ints to long to avoid integer overflow
              f = Mth.clamp(f, -100.0F, 80.0F);
  

--- a/patches/server/0458-Significantly-improve-performance-of-the-end-generat.patch
+++ b/patches/server/0458-Significantly-improve-performance-of-the-end-generat.patch
@@ -12,7 +12,7 @@ Co-authored-by: Dylan Xaldin <Puremin0rez515@gmail.com>
 Co-authored-by: pop4959 <pop4959@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/DensityFunctions.java b/src/main/java/net/minecraft/world/level/levelgen/DensityFunctions.java
-index 2cf20ef14ad18346f942395546ad31f2d774f81a..ed8cfa36f41643b191714b2ae6176f58f93bd4b2 100644
+index 92c2df6a6abd9c60e90b0b84ab66987557adb9c8..d5dccab8020e31f818420b8ee59c6d3928f1dfff 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/DensityFunctions.java
 +++ b/src/main/java/net/minecraft/world/level/levelgen/DensityFunctions.java
 @@ -509,6 +509,16 @@ public final class DensityFunctions {
@@ -39,9 +39,9 @@ index 2cf20ef14ad18346f942395546ad31f2d774f81a..ed8cfa36f41643b191714b2ae6176f58
 +            NoiseCache cache = noiseCache.get().computeIfAbsent(sampler, noiseKey -> new NoiseCache()); // Paper - Perf: Optimize end generation
              for (int m = -12; m <= 12; m++) {
                  for (int n = -12; n <= 12; n++) {
-                     long o = i + m;
-                     long p = j + n;
--                    if (o * o + p * p > 4096L && sampler.getValue(o, p) < -0.9F) {
+                     long o = (long)(i + m);
+                     long p = (long)(j + n);
+-                    if (o * o + p * p > 4096L && sampler.getValue((double)o, (double)p) < -0.9F) {
 -                        float g = (Mth.abs((float)o) * 3439.0F + Mth.abs((float)p) * 147.0F) % 13.0F + 9.0F;
 +                    // Paper start - Perf: Optimize end generation by using a noise cache
 +                    long key = net.minecraft.world.level.ChunkPos.asLong((int) o, (int) p);
@@ -58,6 +58,6 @@ index 2cf20ef14ad18346f942395546ad31f2d774f81a..ed8cfa36f41643b191714b2ae6176f58
 +                    }
 +                    if (g != Float.MIN_VALUE) {
 +                        // Paper end - Perf: Optimize end generation
-                         float h = k - m * 2;
-                         float q = l - n * 2;
+                         float h = (float)(k - m * 2);
+                         float q = (float)(l - n * 2);
                          float r = 100.0F - Mth.sqrt(h * h + q * q) * g;

--- a/patches/server/0462-Add-PlayerShearBlockEvent.patch
+++ b/patches/server/0462-Add-PlayerShearBlockEvent.patch
@@ -39,10 +39,10 @@ index 44e72176a0da08a77fa192ee31c0fcd53f0dc22d..27f1c1ac12251f1438ee8bf14f4afb5f
                      entityhuman1.broadcastBreakEvent(hand);
                  });
 diff --git a/src/main/java/net/minecraft/world/level/block/PumpkinBlock.java b/src/main/java/net/minecraft/world/level/block/PumpkinBlock.java
-index d9c4e0cf178b9a1eed230dc7b8cfbd8f3f49c7bb..c67ee44d49693bfcb92cbbf0ed44929bf0034f13 100644
+index c0098fe96201bfc448e7d2e3d672c310c9c9e75a..a68c6bfab4693a1ae9bd0ee2a0dffef4f939829e 100644
 --- a/src/main/java/net/minecraft/world/level/block/PumpkinBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/PumpkinBlock.java
-@@ -35,21 +35,30 @@ public class PumpkinBlock extends Block {
+@@ -35,16 +35,24 @@ public class PumpkinBlock extends Block {
          ItemStack itemStack = player.getItemInHand(hand);
          if (itemStack.is(Items.SHEARS)) {
              if (!world.isClientSide) {
@@ -60,14 +60,16 @@ index d9c4e0cf178b9a1eed230dc7b8cfbd8f3f49c7bb..c67ee44d49693bfcb92cbbf0ed44929b
 +                for (org.bukkit.inventory.ItemStack item : event.getDrops()) { // Paper - Add PlayerShearBlockEvent
                  ItemEntity itemEntity = new ItemEntity(
                      world,
-                     pos.getX() + 0.5 + direction2.getStepX() * 0.65,
-                     pos.getY() + 0.1,
-                     pos.getZ() + 0.5 + direction2.getStepZ() * 0.65,
+                     (double)pos.getX() + 0.5 + (double)direction2.getStepX() * 0.65,
+                     (double)pos.getY() + 0.1,
+                     (double)pos.getZ() + 0.5 + (double)direction2.getStepZ() * 0.65,
 -                    new ItemStack(Items.PUMPKIN_SEEDS, 4)
-+                    org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(item) // Paper - Add PlayerShearBlockEvent
++                        org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(item) // Paper - Add PlayerShearBlockEvent
                  );
                  itemEntity.setDeltaMovement(
-                     0.05 * direction2.getStepX() + world.random.nextDouble() * 0.02, 0.05, 0.05 * direction2.getStepZ() + world.random.nextDouble() * 0.02
+                     0.05 * (double)direction2.getStepX() + world.random.nextDouble() * 0.02,
+@@ -52,6 +60,7 @@ public class PumpkinBlock extends Block {
+                     0.05 * (double)direction2.getStepZ() + world.random.nextDouble() * 0.02
                  );
                  world.addFreshEntity(itemEntity);
 +                } // Paper - Add PlayerShearBlockEvent

--- a/patches/server/0462-Add-PlayerShearBlockEvent.patch
+++ b/patches/server/0462-Add-PlayerShearBlockEvent.patch
@@ -39,7 +39,7 @@ index 44e72176a0da08a77fa192ee31c0fcd53f0dc22d..27f1c1ac12251f1438ee8bf14f4afb5f
                      entityhuman1.broadcastBreakEvent(hand);
                  });
 diff --git a/src/main/java/net/minecraft/world/level/block/PumpkinBlock.java b/src/main/java/net/minecraft/world/level/block/PumpkinBlock.java
-index c0098fe96201bfc448e7d2e3d672c310c9c9e75a..a68c6bfab4693a1ae9bd0ee2a0dffef4f939829e 100644
+index c0098fe96201bfc448e7d2e3d672c310c9c9e75a..966783c646dae5a79259c1a322a9cfc8dd83d997 100644
 --- a/src/main/java/net/minecraft/world/level/block/PumpkinBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/PumpkinBlock.java
 @@ -35,16 +35,24 @@ public class PumpkinBlock extends Block {
@@ -64,7 +64,7 @@ index c0098fe96201bfc448e7d2e3d672c310c9c9e75a..a68c6bfab4693a1ae9bd0ee2a0dffef4
                      (double)pos.getY() + 0.1,
                      (double)pos.getZ() + 0.5 + (double)direction2.getStepZ() * 0.65,
 -                    new ItemStack(Items.PUMPKIN_SEEDS, 4)
-+                        org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(item) // Paper - Add PlayerShearBlockEvent
++                    org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(item) // Paper - Add PlayerShearBlockEvent
                  );
                  itemEntity.setDeltaMovement(
                      0.05 * (double)direction2.getStepX() + world.random.nextDouble() * 0.02,

--- a/patches/server/0471-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0471-MC-4-Fix-item-position-desync.patch
@@ -9,7 +9,7 @@ loss, which forces the server to lose the same precision as the client
 keeping them in sync.
 
 diff --git a/src/main/java/net/minecraft/network/protocol/game/VecDeltaCodec.java b/src/main/java/net/minecraft/network/protocol/game/VecDeltaCodec.java
-index fb44116303ab1fed9d867087531c7601c015ddb9..a3d247c93ac1a2d872ff0e3841efc3d7b84fcbc1 100644
+index ffec3deb9bcd31d51974c1deda2e76bc8374e5c5..a3d247c93ac1a2d872ff0e3841efc3d7b84fcbc1 100644
 --- a/src/main/java/net/minecraft/network/protocol/game/VecDeltaCodec.java
 +++ b/src/main/java/net/minecraft/network/protocol/game/VecDeltaCodec.java
 @@ -9,12 +9,12 @@ public class VecDeltaCodec {
@@ -22,7 +22,7 @@ index fb44116303ab1fed9d867087531c7601c015ddb9..a3d247c93ac1a2d872ff0e3841efc3d7
  
      @VisibleForTesting
      static double decode(long value) {
--        return value / 4096.0;
+-        return (double)value / 4096.0;
 +        return value / 4096.0; // Paper - Fix MC-4; diff on change
      }
  

--- a/patches/server/0517-Improve-ServerGUI.patch
+++ b/patches/server/0517-Improve-ServerGUI.patch
@@ -58,10 +58,10 @@ index 2bbc57b4869caf690f53618d60359c5133ec62a8..c42a9949c4d37d45883867a54222a7ab
              public void windowClosing(WindowEvent windowevent) {
                  if (!servergui.isClosing.getAndSet(true)) {
 diff --git a/src/main/java/net/minecraft/server/gui/StatsComponent.java b/src/main/java/net/minecraft/server/gui/StatsComponent.java
-index 6d77a48ce4241477cf66fbf562b542de01f420ce..a34dc23499a9d55cceb1f2b2907e4d34b0d67616 100644
+index 6e9c6d556ed55325e36d191fc9d1508c00879671..096c89bd01cec2abd151bf6fffc4847d1bcd548f 100644
 --- a/src/main/java/net/minecraft/server/gui/StatsComponent.java
 +++ b/src/main/java/net/minecraft/server/gui/StatsComponent.java
-@@ -34,8 +34,17 @@ public class StatsComponent extends JComponent {
+@@ -34,10 +34,19 @@ public class StatsComponent extends JComponent {
  
      private void tick() {
          long l = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
@@ -73,13 +73,15 @@ index 6d77a48ce4241477cf66fbf562b542de01f420ce..a34dc23499a9d55cceb1f2b2907e4d34
 +            tpsAvg[g] = format( tps[g] );
 +        }
          this.msgs[0] = "Memory use: " + l / 1024L / 1024L + " mb (" + Runtime.getRuntime().freeMemory() * 100L / Runtime.getRuntime().maxMemory() + "% free)";
-         this.msgs[1] = "Avg tick: " + DECIMAL_FORMAT.format((double)this.server.getAverageTickTimeNanos() / TimeUtil.NANOSECONDS_PER_MILLISECOND) + " ms";
+         this.msgs[1] = "Avg tick: "
+             + DECIMAL_FORMAT.format((double)this.server.getAverageTickTimeNanos() / (double)TimeUtil.NANOSECONDS_PER_MILLISECOND)
+             + " ms";
 +        this.msgs[2] = "TPS from last 1m, 5m, 15m: " + String.join(", ", tpsAvg);
 +        // Paper end - Improve ServerGUI
          this.values[this.vp++ & 0xFF] = (int)(l * 100L / Runtime.getRuntime().maxMemory());
          this.repaint();
      }
-@@ -64,4 +73,10 @@ public class StatsComponent extends JComponent {
+@@ -66,4 +75,10 @@ public class StatsComponent extends JComponent {
      public void close() {
          this.timer.stop();
      }

--- a/patches/server/0575-Fix-invulnerable-end-crystals.patch
+++ b/patches/server/0575-Fix-invulnerable-end-crystals.patch
@@ -52,13 +52,13 @@ index e7e01effab5f727d9b84a0575d165127e3dfe4c9..036640d49a5e891e9a0f767abe33f1f5
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/feature/SpikeFeature.java b/src/main/java/net/minecraft/world/level/levelgen/feature/SpikeFeature.java
-index de93988e6116d63ae29add32ee02ccca631f1d9e..ad31fc599288e46a69814268cd10148a5edb375a 100644
+index c3bf90178abe89ccc987718237d472ed10c70d69..260c3a7dc592fba220ad4a7febb43ee2c9279115 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/feature/SpikeFeature.java
 +++ b/src/main/java/net/minecraft/world/level/levelgen/feature/SpikeFeature.java
-@@ -111,6 +111,7 @@ public class SpikeFeature extends Feature<SpikeConfiguration> {
-             endCrystal.setBeamTarget(config.getCrystalBeamTarget());
-             endCrystal.setInvulnerable(config.isCrystalInvulnerable());
-             endCrystal.moveTo(spike.getCenterX() + 0.5, spike.getHeight() + 1, spike.getCenterZ() + 0.5, random.nextFloat() * 360.0F, 0.0F);
+@@ -114,6 +114,7 @@ public class SpikeFeature extends Feature<SpikeConfiguration> {
+             endCrystal.moveTo(
+                 (double)spike.getCenterX() + 0.5, (double)(spike.getHeight() + 1), (double)spike.getCenterZ() + 0.5, random.nextFloat() * 360.0F, 0.0F
+             );
 +            endCrystal.generatedByDragonFight = true; // Paper - Fix invulnerable end crystals
              world.addFreshEntity(endCrystal);
              BlockPos blockPos2 = endCrystal.blockPosition();

--- a/patches/server/0594-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0594-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -28,7 +28,7 @@ index 4bd813161a5d76a83cdbd0a9209b9ea9e60ffe1b..e2764186bd6b838ed5cd86c15597a08d
       * Get a named timer for the specified tile entity type to track type specific timings.
       * @param entity
 diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java b/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
-index db231b1353a1d5ca4fb217f5ebf8d7584706478d..0a2e894d8bd1268fcbd4460745304816be46beff 100644
+index f639cafa64d98a001e622882c647701547f5c3ac..03092417cd8ab5c6d266f3af9f20f47b34cfaba3 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
 @@ -14,6 +14,10 @@ public abstract class Behavior<E extends LivingEntity> implements BehaviorContro
@@ -71,7 +71,7 @@ index db231b1353a1d5ca4fb217f5ebf8d7584706478d..0a2e894d8bd1268fcbd4460745304816
          if (this.hasRequiredMemories(entity) && this.checkExtraStartConditions(world, entity)) {
              this.status = Behavior.Status.RUNNING;
              int i = this.minDuration + world.getRandom().nextInt(this.maxDuration + 1 - this.minDuration);
-             this.endTimestamp = time + i;
+             this.endTimestamp = time + (long)i;
 +            this.timing.startTiming(); // Paper - behavior timings
              this.start(world, entity, time);
 +            this.timing.stopTiming(); // Paper - behavior timings
@@ -93,7 +93,7 @@ index db231b1353a1d5ca4fb217f5ebf8d7584706478d..0a2e894d8bd1268fcbd4460745304816
  
      protected void tick(ServerLevel world, E entity, long time) {
 diff --git a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
-index eebe5d721a6cea42013f5293586865deb39fe9d2..de2dfaf3cb41bafd48fa4699096a0a7304cd3201 100644
+index 671fc7725d7c801a2ba009da5bd1bc1a9530f187..9e90cb2f51d1bacacb287e912d14ab9152523205 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
 @@ -26,8 +26,21 @@ public abstract class Sensor<E extends LivingEntity> {
@@ -116,13 +116,13 @@ index eebe5d721a6cea42013f5293586865deb39fe9d2..de2dfaf3cb41bafd48fa4699096a0a73
 +        this.timing = co.aikar.timings.MinecraftTimings.getSensorTimings(configKey, senseInterval);
 +        // Paper end
          this.scanRate = senseInterval;
-         this.timeToTick = RANDOM.nextInt(senseInterval);
+         this.timeToTick = (long)RANDOM.nextInt(senseInterval);
      }
 @@ -38,8 +51,12 @@ public abstract class Sensor<E extends LivingEntity> {
  
      public final void tick(ServerLevel world, E entity) {
          if (--this.timeToTick <= 0L) {
--            this.timeToTick = this.scanRate;
+-            this.timeToTick = (long)this.scanRate;
 +            // Paper start - configurable sensor tick rate and timings
 +            this.timeToTick = java.util.Objects.requireNonNullElse(world.paperConfig().tickRates.sensor.get(entity.getType(), this.configKey), this.scanRate);
 +            this.timing.startTiming();

--- a/patches/server/0611-Add-BlockBreakBlockEvent.patch
+++ b/patches/server/0611-Add-BlockBreakBlockEvent.patch
@@ -68,10 +68,10 @@ index 0aeb9faa1ce22359361741a591aa3d465d955970..a98ab20814cc29a25e9d29adfbb7e70d
  
      private static short getCacheKey(BlockPos from, BlockPos to) {
 diff --git a/src/main/java/net/minecraft/world/level/material/WaterFluid.java b/src/main/java/net/minecraft/world/level/material/WaterFluid.java
-index 855014986c201fdb5dffebf362951cd1edebd95d..001adec26a71a0f5e1dd77bf51a62bb25172d702 100644
+index 7f40e8196cb966424ae63043d1f54e661dbce715..21b4afd053e01073eb514264d4960f0f3b1ee3d8 100644
 --- a/src/main/java/net/minecraft/world/level/material/WaterFluid.java
 +++ b/src/main/java/net/minecraft/world/level/material/WaterFluid.java
-@@ -74,6 +74,13 @@ public abstract class WaterFluid extends FlowingFluid {
+@@ -80,6 +80,13 @@ public abstract class WaterFluid extends FlowingFluid {
          return world.getGameRules().getBoolean(GameRules.RULE_WATER_SOURCE_CONVERSION);
      }
  

--- a/patches/server/0699-Add-missing-structure-set-seed-configs.patch
+++ b/patches/server/0699-Add-missing-structure-set-seed-configs.patch
@@ -148,7 +148,7 @@ index a310bfbf0d08187375ea17f4b04b276a0b7d0b9f..798e22fb4d685b5845ebf687e8004e94
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java b/src/main/java/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java
-index bd8c0c15246059c235036cbe71e2b7ae8dab5797..3ae784b02231555a1bc416668fc5bdb11ba15fc8 100644
+index 5e7c0d5a31156b75ac4895bd13c8b7138894a576..dc44ae806dc2779e5f0ec0de3fdb4b53da806a5b 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java
 +++ b/src/main/java/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java
 @@ -79,9 +79,23 @@ public abstract class StructurePlacement {
@@ -197,7 +197,7 @@ index bd8c0c15246059c235036cbe71e2b7ae8dab5797..3ae784b02231555a1bc416668fc5bdb1
 +            worldgenRandom.setLargeFeatureWithSalt(seed, chunkX, chunkZ, saltOverride);
 +        }
 +        // Paper end - Add missing structure set seed configs
-         return worldgenRandom.nextDouble() < frequency;
+         return worldgenRandom.nextDouble() < (double)frequency;
      }
  
 -    private static boolean legacyArbitrarySaltProbabilityReducer(long seed, int salt, int chunkX, int chunkZ, float frequency) {

--- a/patches/server/0729-Allow-changing-the-EnderDragon-podium.patch
+++ b/patches/server/0729-Allow-changing-the-EnderDragon-podium.patch
@@ -58,10 +58,10 @@ index 6d01175ea2092bc5f5ebb7aa066450bfec2443a1..61e4f8be9f5927b65ae03da98250d3cd
              f1 = Math.max((float) Math.sqrt(blockposition.distToCenterSqr(this.position())) / 4.0F, 1.0F);
              float f3 = 6.0F / f1;
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonDeathPhase.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonDeathPhase.java
-index 060e2da81c7e55a43412c47e857f91fefd88495b..8e5249e96ffb80b933616913f764e704b670a8b8 100644
+index 803d227281d70606691eed95c4b10a27ca5d1125..5663f2ff1eba4a5e00c76c9d735cb553faae6a04 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonDeathPhase.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonDeathPhase.java
-@@ -35,7 +35,7 @@ public class DragonDeathPhase extends AbstractDragonPhaseInstance {
+@@ -43,7 +43,7 @@ public class DragonDeathPhase extends AbstractDragonPhaseInstance {
          if (this.targetLocation == null) {
              BlockPos blockPos = this.dragon
                  .level()
@@ -71,7 +71,7 @@ index 060e2da81c7e55a43412c47e857f91fefd88495b..8e5249e96ffb80b933616913f764e704
          }
  
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonHoldingPatternPhase.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonHoldingPatternPhase.java
-index 90684c6bfa4025aae0abf098f44e0557c62a0760..422bf66055391b0bb58e3a68156744df8bbfecdb 100644
+index 707ef45ccd7fbcbe1947c8941846277f19ee54c9..ddf668205a7cb29b9018bf9eea49667b5fd2d471 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonHoldingPatternPhase.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonHoldingPatternPhase.java
 @@ -54,7 +54,7 @@ public class DragonHoldingPatternPhase extends AbstractDragonPhaseInstance {
@@ -84,7 +84,7 @@ index 90684c6bfa4025aae0abf098f44e0557c62a0760..422bf66055391b0bb58e3a68156744df
              if (this.dragon.getRandom().nextInt(i + 3) == 0) {
                  this.dragon.getPhaseManager().setPhase(EnderDragonPhase.LANDING_APPROACH);
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonLandingApproachPhase.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonLandingApproachPhase.java
-index fd36333fc21696e0ec7760cb4702dd7ac5a1a0fb..0832f7103e9b94c65c7856e942c15f8bcdb2ad7f 100644
+index e731d0f74692615ce5f42f690e36bd906a39c1dd..557de8a8e21e7f049b6acf27b4ec927ef5a9f9cb 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonLandingApproachPhase.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonLandingApproachPhase.java
 @@ -53,7 +53,7 @@ public class DragonLandingApproachPhase extends AbstractDragonPhaseInstance {
@@ -93,9 +93,9 @@ index fd36333fc21696e0ec7760cb4702dd7ac5a1a0fb..0832f7103e9b94c65c7856e942c15f8b
                  .level()
 -                .getHeightmapPos(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, EndPodiumFeature.getLocation(this.dragon.getFightOrigin()));
 +                .getHeightmapPos(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, this.dragon.getPodium()); // Paper - Allow changing the EnderDragon podium
-             Player player = this.dragon.level().getNearestPlayer(NEAR_EGG_TARGETING, this.dragon, blockPos.getX(), blockPos.getY(), blockPos.getZ());
-             int j;
-             if (player != null) {
+             Player player = this.dragon
+                 .level()
+                 .getNearestPlayer(NEAR_EGG_TARGETING, this.dragon, (double)blockPos.getX(), (double)blockPos.getY(), (double)blockPos.getZ());
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonLandingPhase.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonLandingPhase.java
 index d913147d692e7e58bec4fac44c7e93a1822e8f65..3b960060f152d0352c2f8cdc1c71543cd7fa0dbd 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonLandingPhase.java
@@ -110,7 +110,7 @@ index d913147d692e7e58bec4fac44c7e93a1822e8f65..3b960060f152d0352c2f8cdc1c71543c
          }
  
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonTakeoffPhase.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonTakeoffPhase.java
-index b4789d22590d094d76e68e60c022366cba0b7bf6..2e0af7c7f7a98a19f7736c5c9dc7c313c3ca4406 100644
+index 8d66284eb96cfc0392c211842e87875a095c3ca2..718bf877179f85ee3f0de384ca3a8aaebaa067a5 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonTakeoffPhase.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/phases/DragonTakeoffPhase.java
 @@ -25,7 +25,7 @@ public class DragonTakeoffPhase extends AbstractDragonPhaseInstance {

--- a/patches/server/0822-Fixes-and-additions-to-the-SpawnReason-API.patch
+++ b/patches/server/0822-Fixes-and-additions-to-the-SpawnReason-API.patch
@@ -34,12 +34,12 @@ index 58723ea75f7db9bf3889b99139669b14a284a3a1..6bf11d526b82403e9a5443ac77645cf2
                  this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
              }
 diff --git a/src/main/java/net/minecraft/world/level/block/FrogspawnBlock.java b/src/main/java/net/minecraft/world/level/block/FrogspawnBlock.java
-index cbd49f8e870e903bafc3dd55c3ae7f4cc3703b15..e248444632a8f917b0eb2426aa59ae2c0ecaa925 100644
+index 1a842694c076d71b14733904c2052183d86d1f5d..eb2f6038133be72c32d31bd1a25bc80f5aa4028f 100644
 --- a/src/main/java/net/minecraft/world/level/block/FrogspawnBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FrogspawnBlock.java
 @@ -117,7 +117,7 @@ public class FrogspawnBlock extends Block {
                  int k = random.nextInt(1, 361);
-                 tadpole.moveTo(d, pos.getY() - 0.5, e, k, 0.0F);
+                 tadpole.moveTo(d, (double)pos.getY() - 0.5, e, (float)k, 0.0F);
                  tadpole.setPersistenceRequired();
 -                world.addFreshEntity(tadpole);
 +                world.addFreshEntity(tadpole, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.EGG); // Paper - use correct spawn reason

--- a/patches/server/0888-Determine-lava-and-water-fluid-explosion-resistance-.patch
+++ b/patches/server/0888-Determine-lava-and-water-fluid-explosion-resistance-.patch
@@ -22,10 +22,10 @@ index 72f8b72c6436ca3b8eaeb39c7d3efe2c1462ae1d..3bb4a9a1a6249e8ba2de237f801210e7
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/level/material/WaterFluid.java b/src/main/java/net/minecraft/world/level/material/WaterFluid.java
-index 001adec26a71a0f5e1dd77bf51a62bb25172d702..ba34aea9db5c3af56f3c7e84424ec91988a2370e 100644
+index 21b4afd053e01073eb514264d4960f0f3b1ee3d8..109f71401c65f476ccf6813137386fc9fef10254 100644
 --- a/src/main/java/net/minecraft/world/level/material/WaterFluid.java
 +++ b/src/main/java/net/minecraft/world/level/material/WaterFluid.java
-@@ -119,7 +119,7 @@ public abstract class WaterFluid extends FlowingFluid {
+@@ -125,7 +125,7 @@ public abstract class WaterFluid extends FlowingFluid {
  
      @Override
      protected float getExplosionResistance() {

--- a/patches/server/0930-Skip-POI-finding-if-stuck-in-vehicle.patch
+++ b/patches/server/0930-Skip-POI-finding-if-stuck-in-vehicle.patch
@@ -19,13 +19,13 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/AcquirePoi.java b/src/main/java/net/minecraft/world/entity/ai/behavior/AcquirePoi.java
-index 4acbdaeab6bbbe3875d1e9323bf2f7a4d56f840e..0e2141bbbf9839a90a78cd04bb70d5f94614248e 100644
+index 21e50342598f7cd9efa1a39e70bd72d152d98812..e8aa27547e3fa1a42720889c7038d4fb0273e7b5 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/behavior/AcquirePoi.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/behavior/AcquirePoi.java
 @@ -57,6 +57,7 @@ public class AcquirePoi {
                                      return false;
                                  } else {
-                                     mutableLong.setValue(time + 20L + world.getRandom().nextInt(20));
+                                     mutableLong.setValue(time + 20L + (long)world.getRandom().nextInt(20));
 +                                    if (entity.getNavigation().isStuck()) mutableLong.add(200); // Paper - Perf: Wait an additional 10s to check again if they're stuck
                                      PoiManager poiManager = world.getPoiManager();
                                      long2ObjectMap.long2ObjectEntrySet().removeIf(entry -> !entry.getValue().isStillValid(time));

--- a/patches/server/0980-Rewrite-chunk-system.patch
+++ b/patches/server/0980-Rewrite-chunk-system.patch
@@ -14439,7 +14439,7 @@ index 0000000000000000000000000000000000000000..962d3cae6340fc11607b59355e291629
 +
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 2540b7748e27839552ae88412ecac0aa69485b32..d00fc39b19c02895553f40bf5f62daa1dd50d59c 100644
+index 0b283171294eca65a898ddd9ab1b7295ad183b0d..31f34ac1c70df3ef6eb6f6dfd0f870b1b275adfa 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 @@ -28,6 +28,45 @@ public class GlobalConfiguration extends ConfigurationPart {
@@ -15520,7 +15520,7 @@ index 2906cb10461b5334a7555046384c28848eec149f..329471af4f40e0a74612707cce96bb00
                  DedicatedServer dedicatedserver1 = new DedicatedServer(optionset, worldLoader.get(), thread, convertable_conversionsession, resourcepackrepository, worldstem, dedicatedserversettings, DataFixers.getDataFixer(), services, LoggerChunkProgressListener::new);
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 28645a835a169029b734262a9f42751caa52c4c9..56d579e64b367dd21b2909eb0dbc1d7686d0c3d0 100644
+index 64a9a0bc5bd99102ab6e7e4262d74ae26e5ff7c1..52c2ae28cad0c8b810df5d60d181f3bc5c8d6eed 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -311,7 +311,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -19173,7 +19173,7 @@ index c3e7bd8865cc8990fc59f1ff0dfc1697cbb5ca49..5ece375eaf6bcc61864997a389bb5e24
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/network/PlayerChunkSender.java b/src/main/java/net/minecraft/server/network/PlayerChunkSender.java
-index bf4bf32e926c7baf152a6c5912e2cd33598bdf9e..61c5402538b8dcace7bcc623f41940daaf7246ec 100644
+index e890162e1cea3538ed7dea7b78ee2e5346a8ce7b..9baae5af750b46ededbd660d15934da71befde72 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerChunkSender.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerChunkSender.java
 @@ -43,16 +43,23 @@ public class PlayerChunkSender {
@@ -19217,7 +19217,7 @@ index bf4bf32e926c7baf152a6c5912e2cd33598bdf9e..61c5402538b8dcace7bcc623f41940da
      public void onChunkBatchReceivedByClient(float desiredBatchSize) {
 +        if (true) return; // Paper - rewrite player chunk loader
          this.unacknowledgedBatches--;
-         this.desiredChunksPerTick = Double.isNaN(desiredBatchSize) ? 0.01F : Mth.clamp(desiredBatchSize, 0.01F, 64.0F);
+         this.desiredChunksPerTick = Double.isNaN((double)desiredBatchSize) ? 0.01F : Mth.clamp(desiredBatchSize, 0.01F, 64.0F);
          if (this.unacknowledgedBatches == 0) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
 index d38fe02af4cc35ed5b22acec41bedb76151f8af5..4a569bf782bfdd870f32fe0ab5c3b8b86a07f218 100644
@@ -19262,7 +19262,7 @@ index d38fe02af4cc35ed5b22acec41bedb76151f8af5..4a569bf782bfdd870f32fe0ab5c3b8b8
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/util/SortedArraySet.java b/src/main/java/net/minecraft/util/SortedArraySet.java
-index 3db68cf055c16c05d47c794596ddaa069275457e..7cf6880627c08556be62e08a536f4cd1eccfa7f1 100644
+index ea72dcb064a35bc6245bc5c94d592efedd8faf41..0793dfe47e68a2b48b010aad5b12dcfa1701293a 100644
 --- a/src/main/java/net/minecraft/util/SortedArraySet.java
 +++ b/src/main/java/net/minecraft/util/SortedArraySet.java
 @@ -14,6 +14,14 @@ public class SortedArraySet<T> extends AbstractSet<T> {
@@ -19507,7 +19507,7 @@ index 5275e7a34f86830d43edcab3a0e94f8d8e9cfae5..b108f779abe3d9798c0bcbc983f41d48
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/ai/village/poi/PoiManager.java b/src/main/java/net/minecraft/world/entity/ai/village/poi/PoiManager.java
-index c64794d02a861f0880b6877550a87752fdf26407..55e45feeaae7ec00805ef108939e50916f6e3148 100644
+index ed008e1a9573ea3c75de94680b91c8ee598ee44a..c07cc1bf3b98525d72924edee4233364fd8174d0 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/village/poi/PoiManager.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/village/poi/PoiManager.java
 @@ -38,12 +38,28 @@ import net.minecraft.world.level.chunk.storage.SectionStorage;
@@ -19931,7 +19931,7 @@ index cedde2235227eb5820beefb98549994e1cca1198..9c743c980697a14d7348554fb77f242d
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/level/LevelReader.java b/src/main/java/net/minecraft/world/level/LevelReader.java
-index fa73462650dd29296b737435574755a613832b77..84e5d879c2de08fa95f12de8cea2c6d4da8ec76d 100644
+index ced67cf88c91c5270a0060a7307f36739237cbb2..dab86988686cf7c926b7432b8a4afffd7a23327a 100644
 --- a/src/main/java/net/minecraft/world/level/LevelReader.java
 +++ b/src/main/java/net/minecraft/world/level/LevelReader.java
 @@ -26,6 +26,15 @@ public interface LevelReader extends BlockAndTintGetter, CollisionGetter, Signal
@@ -21251,7 +21251,7 @@ index 769a8c5788e6a01666b9b5ac24b02c632c6c9e48..09867812600b24b3b7d05b58f9858265
              referencesByStructure.computeInt(structure, (feature, references) -> references == null ? 1 : references + 1);
              return referencesByStructure;
 diff --git a/src/main/java/net/minecraft/world/ticks/LevelChunkTicks.java b/src/main/java/net/minecraft/world/ticks/LevelChunkTicks.java
-index da086494de9668d28305ccd23d32e9cfe45d0880..e7b3f9ceff72b255d443026b4e51291823bfd582 100644
+index 47c2b2da9799690291396effb9e1b06d71efc6fd..2cdd18f724296f10cd4a522d1e8196723d39cf45 100644
 --- a/src/main/java/net/minecraft/world/ticks/LevelChunkTicks.java
 +++ b/src/main/java/net/minecraft/world/ticks/LevelChunkTicks.java
 @@ -26,6 +26,19 @@ public class LevelChunkTicks<T> implements SerializableTickContainer<T>, TickCon

--- a/patches/server/0989-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0989-Entity-Activation-Range-2.0.patch
@@ -216,7 +216,7 @@ index 9be9a6a59666297e05a9fc19d9345ae7d5f3bf40..040d62effc651d14d3557f8ff582cb07
          this.availableGoals.stream().filter(wrappedGoal -> wrappedGoal.getGoal() == goal).filter(WrappedGoal::isRunning).forEach(WrappedGoal::stop);
          this.availableGoals.removeIf(wrappedGoal -> wrappedGoal.getGoal() == goal);
 diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
-index 7b276b37433f054513e3eff88362424686eddebc..de7c3654b5d134e380c0d7e8800beb6c10d8a22a 100644
+index 6d8ea05e5e86e9f6359b560043bb55a10784e952..aee0147649d458b87d92496eda0c1723ebe570d2 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
 @@ -23,6 +23,14 @@ public abstract class MoveToBlockGoal extends Goal {
@@ -234,7 +234,7 @@ index 7b276b37433f054513e3eff88362424686eddebc..de7c3654b5d134e380c0d7e8800beb6c
  
      public MoveToBlockGoal(PathfinderMob mob, double speed, int range, int maxYDifference) {
          this.mob = mob;
-@@ -113,6 +121,7 @@ public abstract class MoveToBlockGoal extends Goal {
+@@ -115,6 +123,7 @@ public abstract class MoveToBlockGoal extends Goal {
                          mutableBlockPos.setWithOffset(blockPos, m, k - 1, n);
                          if (this.mob.isWithinRestriction(mutableBlockPos) && this.isValidTarget(this.mob.level(), mutableBlockPos)) {
                              this.blockPos = mutableBlockPos;
@@ -357,7 +357,7 @@ index 5c209e323a5559480231c6d99357ba8b89edb027..4bedd5801cc8ce14387f02dfb361a00a
      public final org.spigotmc.SpigotWorldConfig spigotConfig; // Spigot
      // Paper start - add paper world config
 diff --git a/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java b/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
-index 7415011211925e962dcd1a3fdfde2c9bb6ec8335..5c59550db0ed7a6c1cf654fd5b251c3ba1e762fb 100644
+index 0e15da7cae105196d444b924b8e0db190583ba30..9f45dda6ff45ac1ffb7ac99575b7d09bdc61c56a 100644
 --- a/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 @@ -147,6 +147,10 @@ public class PistonMovingBlockEntity extends BlockEntity {

--- a/patches/server/0993-Optimize-Collision-to-not-load-chunks.patch
+++ b/patches/server/0993-Optimize-Collision-to-not-load-chunks.patch
@@ -38,7 +38,7 @@ index a66fe080ee73171090abec48352ad0bd457a2a6f..d4c8f2cb1e3adf45863226ae9ad31968
  
      public @org.jetbrains.annotations.Nullable net.minecraft.server.level.ChunkMap.TrackedEntity tracker; // Paper
 diff --git a/src/main/java/net/minecraft/world/level/BlockCollisions.java b/src/main/java/net/minecraft/world/level/BlockCollisions.java
-index cd342fa776b5d84e52aa1660c19be9ab45eaad2d..f6cc3d550df8481086acdcb62f44a1051ae79f80 100644
+index 1c10835b59aaefa3a65ff64f784620bdc54ddcdc..cd89623a44f02d7db77f0d0f87545cf80841f403 100644
 --- a/src/main/java/net/minecraft/world/level/BlockCollisions.java
 +++ b/src/main/java/net/minecraft/world/level/BlockCollisions.java
 @@ -66,18 +66,37 @@ public class BlockCollisions<T> extends AbstractIterator<T> {
@@ -88,9 +88,9 @@ index cd342fa776b5d84e52aa1660c19be9ab45eaad2d..f6cc3d550df8481086acdcb62f44a105
 +                        // Paper end
                          VoxelShape voxelShape = blockState.getCollisionShape(this.collisionGetter, this.pos, this.context);
                          if (voxelShape == Shapes.block()) {
-                             if (this.box.intersects(i, j, k, i + 1.0, j + 1.0, k + 1.0)) {
+                             if (this.box.intersects((double)i, (double)j, (double)k, (double)i + 1.0, (double)j + 1.0, (double)k + 1.0)) {
 diff --git a/src/main/java/net/minecraft/world/level/CollisionGetter.java b/src/main/java/net/minecraft/world/level/CollisionGetter.java
-index ea9a5e643d7ccce4e4d20644901c22cf63c6d890..69754fbebb51f7f804c97a749fd65ce15ae22f1b 100644
+index e57cb7fe53e915d24246e44c7f49971f5b2ab2cf..1ad0c976c6e2d6d31397dff850a9de7c16d16fba 100644
 --- a/src/main/java/net/minecraft/world/level/CollisionGetter.java
 +++ b/src/main/java/net/minecraft/world/level/CollisionGetter.java
 @@ -44,11 +44,13 @@ public interface CollisionGetter extends BlockGetter {

--- a/patches/server/0998-Optimize-Voxel-Shape-Merging.patch
+++ b/patches/server/0998-Optimize-Voxel-Shape-Merging.patch
@@ -68,7 +68,7 @@ index e164c524aef4fa81fe96ac43454eecff1c38b9c1..9cfbbc61fcfc678f0988d6d45c7994d1
          this.firstIndices = new int[k];
          this.secondIndices = new int[k];
 diff --git a/src/main/java/net/minecraft/world/phys/shapes/Shapes.java b/src/main/java/net/minecraft/world/phys/shapes/Shapes.java
-index 1fbde2861b31726b8163e1b46aec91b7283a2c29..1a014f19f3c5425cc79a82c546066ab701fab1f8 100644
+index 0fdd2cdd8d215ca1523eda8ad7316cdd5f41a6b5..86df4ef44d0a5107ee929dfd40d8ccb0779e8bfc 100644
 --- a/src/main/java/net/minecraft/world/phys/shapes/Shapes.java
 +++ b/src/main/java/net/minecraft/world/phys/shapes/Shapes.java
 @@ -286,9 +286,21 @@ public final class Shapes {
@@ -93,7 +93,7 @@ index 1fbde2861b31726b8163e1b46aec91b7283a2c29..1a014f19f3c5425cc79a82c546066ab7
 +        // Paper note - Rewrite below as optimized order if instead of nasty ternary
          if (first instanceof CubePointRange && second instanceof CubePointRange) {
              long l = lcm(i, j);
-             if (size * l <= 256L) {
+             if ((long)size * l <= 256L) {
 @@ -296,15 +308,22 @@ public final class Shapes {
              }
          }

--- a/patches/server/1002-Optimize-Bit-Operations-by-inlining.patch
+++ b/patches/server/1002-Optimize-Bit-Operations-by-inlining.patch
@@ -7,7 +7,7 @@ Inline bit operations and reduce instruction count to make these hot
 operations faster
 
 diff --git a/src/main/java/net/minecraft/core/BlockPos.java b/src/main/java/net/minecraft/core/BlockPos.java
-index aa27b96cf64ddbbc630e2c313ebff7636438aee0..70f9e737b3b9f80395afc3542aafe4a0c774c722 100644
+index d80e3f5f53b9d28dea574cff5c65dfa3f8148f88..70f9e737b3b9f80395afc3542aafe4a0c774c722 100644
 --- a/src/main/java/net/minecraft/core/BlockPos.java
 +++ b/src/main/java/net/minecraft/core/BlockPos.java
 @@ -36,15 +36,16 @@ public class BlockPos extends Vec3i {
@@ -76,15 +76,15 @@ index aa27b96cf64ddbbc630e2c313ebff7636438aee0..70f9e737b3b9f80395afc3542aafe4a0
  
      public static long asLong(int x, int y, int z) {
 -        long l = 0L;
--        l |= (x & PACKED_X_MASK) << X_OFFSET;
--        l |= (y & PACKED_Y_MASK) << 0;
--        return l | (z & PACKED_Z_MASK) << Z_OFFSET;
+-        l |= ((long)x & PACKED_X_MASK) << X_OFFSET;
+-        l |= ((long)y & PACKED_Y_MASK) << 0;
+-        return l | ((long)z & PACKED_Z_MASK) << Z_OFFSET;
 +        return (((long) x & (long) 67108863) << 38) | (((long) y & (long) 4095)) | (((long) z & (long) 67108863) << 12); // Paper - inline constants and simplify
      }
  
      public static long getFlatIndex(long y) {
 diff --git a/src/main/java/net/minecraft/core/SectionPos.java b/src/main/java/net/minecraft/core/SectionPos.java
-index 469e6156704418b6b8f573baee8289726a7a6587..02500dba0c6645add80a73bc837a90331a864652 100644
+index 27e0d53d5893a13a340deddc93a1128968db7e5b..fe3577e533fb829c85fd4881b1bcca3b70aaf1a5 100644
 --- a/src/main/java/net/minecraft/core/SectionPos.java
 +++ b/src/main/java/net/minecraft/core/SectionPos.java
 @@ -38,7 +38,7 @@ public class SectionPos extends Vec3i {
@@ -180,9 +180,9 @@ index 469e6156704418b6b8f573baee8289726a7a6587..02500dba0c6645add80a73bc837a9033
 +
      public static long asLong(int x, int y, int z) {
 -        long l = 0L;
--        l |= (x & 4194303L) << 42;
--        l |= (y & 1048575L) << 0;
--        return l | (z & 4194303L) << 20;
+-        l |= ((long)x & 4194303L) << 42;
+-        l |= ((long)y & 1048575L) << 0;
+-        return l | ((long)z & 4194303L) << 20;
 +        return (((long) x & 4194303L) << 42) | (((long) y & 1048575L)) | (((long) z & 4194303L) << 20); // Paper - Simplify to reduce instruction count
      }
  

--- a/patches/server/1005-Optimize-Pathfinder-Remove-Streams-Optimized-collect.patch
+++ b/patches/server/1005-Optimize-Pathfinder-Remove-Streams-Optimized-collect.patch
@@ -16,7 +16,7 @@ This lets us get faster foreach iteration, as well as avoids map lookups on
 the values when needed.
 
 diff --git a/src/main/java/net/minecraft/world/level/pathfinder/PathFinder.java b/src/main/java/net/minecraft/world/level/pathfinder/PathFinder.java
-index a2e7040df11a0138c706a10b190111b6c3bd99a9..ab6e1221a637511553ddd1af6ff3f0d9d9a6de76 100644
+index a2e7040df11a0138c706a10b190111b6c3bd99a9..d1e1f12451058f7f276f8277536a4c0a4d736601 100644
 --- a/src/main/java/net/minecraft/world/level/pathfinder/PathFinder.java
 +++ b/src/main/java/net/minecraft/world/level/pathfinder/PathFinder.java
 @@ -38,8 +38,12 @@ public class PathFinder {
@@ -64,12 +64,11 @@ index a2e7040df11a0138c706a10b190111b6c3bd99a9..ab6e1221a637511553ddd1af6ff3f0d9
              node.closed = true;
  
 -            for (Target target : set) {
--                if (node.distanceManhattan(target) <= (float)distance) {
 +            // Paper start - optimize collection
 +            for (int i1 = 0; i1 < positions.size(); i1++) {
 +                final Map.Entry<Target, BlockPos> entry = positions.get(i1);
 +                Target target = entry.getKey();
-+                if (node.distanceManhattan(target) <= distance) {
+                 if (node.distanceManhattan(target) <= (float)distance) {
                      target.setReached();
 -                    set3.add(target);
 +                    entryList.add(entry);

--- a/patches/server/1005-Optimize-Pathfinder-Remove-Streams-Optimized-collect.patch
+++ b/patches/server/1005-Optimize-Pathfinder-Remove-Streams-Optimized-collect.patch
@@ -16,7 +16,7 @@ This lets us get faster foreach iteration, as well as avoids map lookups on
 the values when needed.
 
 diff --git a/src/main/java/net/minecraft/world/level/pathfinder/PathFinder.java b/src/main/java/net/minecraft/world/level/pathfinder/PathFinder.java
-index 3e27c9a74c38f11a436df8cd413f9f5f16fd8c3e..c4d6b145d54aaf415dd4b08811c024255092e1b8 100644
+index a2e7040df11a0138c706a10b190111b6c3bd99a9..ab6e1221a637511553ddd1af6ff3f0d9d9a6de76 100644
 --- a/src/main/java/net/minecraft/world/level/pathfinder/PathFinder.java
 +++ b/src/main/java/net/minecraft/world/level/pathfinder/PathFinder.java
 @@ -38,8 +38,12 @@ public class PathFinder {
@@ -24,7 +24,7 @@ index 3e27c9a74c38f11a436df8cd413f9f5f16fd8c3e..c4d6b145d54aaf415dd4b08811c02425
              return null;
          } else {
 -            Map<Target, BlockPos> map = positions.stream()
--                .collect(Collectors.toMap(pos -> this.nodeEvaluator.getGoal(pos.getX(), pos.getY(), pos.getZ()), Function.identity()));
+-                .collect(Collectors.toMap(pos -> this.nodeEvaluator.getGoal((double)pos.getX(), (double)pos.getY(), (double)pos.getZ()), Function.identity()));
 +            // Paper start - Perf: remove streams and optimize collection
 +            List<Map.Entry<Target, BlockPos>> map = Lists.newArrayList();
 +            for (BlockPos pos : positions) {
@@ -56,7 +56,7 @@ index 3e27c9a74c38f11a436df8cd413f9f5f16fd8c3e..c4d6b145d54aaf415dd4b08811c02425
          int i = 0;
 -        Set<Target> set3 = Sets.newHashSetWithExpectedSize(set.size());
 +        List<Map.Entry<Target, BlockPos>> entryList = Lists.newArrayListWithExpectedSize(positions.size()); // Paper - optimize collection
-         int j = (int)(this.maxVisitedNodes * rangeMultiplier);
+         int j = (int)((float)this.maxVisitedNodes * rangeMultiplier);
  
          while (!this.openSet.isEmpty()) {
 @@ -69,14 +74,18 @@ public class PathFinder {
@@ -64,11 +64,12 @@ index 3e27c9a74c38f11a436df8cd413f9f5f16fd8c3e..c4d6b145d54aaf415dd4b08811c02425
              node.closed = true;
  
 -            for (Target target : set) {
+-                if (node.distanceManhattan(target) <= (float)distance) {
 +            // Paper start - optimize collection
 +            for (int i1 = 0; i1 < positions.size(); i1++) {
 +                final Map.Entry<Target, BlockPos> entry = positions.get(i1);
 +                Target target = entry.getKey();
-                 if (node.distanceManhattan(target) <= distance) {
++                if (node.distanceManhattan(target) <= distance) {
                      target.setReached();
 -                    set3.add(target);
 +                    entryList.add(entry);

--- a/patches/server/1015-Collision-optimisations.patch
+++ b/patches/server/1015-Collision-optimisations.patch
@@ -2153,7 +2153,7 @@ index 0000000000000000000000000000000000000000..1f42bdfdb052056e62a939ab0d1944f8
 +
 +}
 diff --git a/src/main/java/net/minecraft/core/Direction.java b/src/main/java/net/minecraft/core/Direction.java
-index 0f32bad1f4e5f4e9abb54d6dc2c06dd2b7176b8e..f0fe2acadac0f57eb06b6aee1940e2c4985e4ca1 100644
+index 75694cfd7d8adde6b9246518c20fe75774297a57..84a760fdc50bdafc9150f977e9c5d557a30ee220 100644
 --- a/src/main/java/net/minecraft/core/Direction.java
 +++ b/src/main/java/net/minecraft/core/Direction.java
 @@ -53,6 +53,21 @@ public enum Direction implements StringRepresentable {
@@ -2466,16 +2466,16 @@ index ffa4f34d964fbcc53e2dfe11677832db21a6eb93..7618364e5373fe17cfe45a5a4ee9ab25
  
      }
 diff --git a/src/main/java/net/minecraft/world/level/BlockCollisions.java b/src/main/java/net/minecraft/world/level/BlockCollisions.java
-index f6cc3d550df8481086acdcb62f44a1051ae79f80..012733f1808e96aecc3b2fd081e355905d1b0766 100644
+index cd89623a44f02d7db77f0d0f87545cf80841f403..48710a60561824a3670ebef3601f284dd7089481 100644
 --- a/src/main/java/net/minecraft/world/level/BlockCollisions.java
 +++ b/src/main/java/net/minecraft/world/level/BlockCollisions.java
 @@ -99,7 +99,7 @@ public class BlockCollisions<T> extends AbstractIterator<T> {
                          // Paper end
                          VoxelShape voxelShape = blockState.getCollisionShape(this.collisionGetter, this.pos, this.context);
                          if (voxelShape == Shapes.block()) {
--                            if (this.box.intersects(i, j, k, i + 1.0, j + 1.0, k + 1.0)) {
+-                            if (this.box.intersects((double)i, (double)j, (double)k, (double)i + 1.0, (double)j + 1.0, (double)k + 1.0)) {
 +                            if (io.papermc.paper.util.CollisionUtil.voxelShapeIntersect(this.box, i, j, k, i + 1.0, j + 1.0, k + 1.0)) { // Paper - keep vanilla behavior for voxelshape intersection - See comment in CollisionUtil
-                                 return this.resultProvider.apply(this.pos, voxelShape.move(i, j, k));
+                                 return this.resultProvider.apply(this.pos, voxelShape.move((double)i, (double)j, (double)k));
                              }
                          } else {
 diff --git a/src/main/java/net/minecraft/world/level/ClipContext.java b/src/main/java/net/minecraft/world/level/ClipContext.java
@@ -2494,7 +2494,7 @@ index 86a4f30c8784c602436ecf1c78efb0bdca4b7089..b0bea28e9261767c60d30fb0e76f4f3a
  
      public ClipContext(Vec3 start, Vec3 end, ClipContext.Block shapeType, ClipContext.Fluid fluidHandling, Entity entity) {
 diff --git a/src/main/java/net/minecraft/world/level/CollisionGetter.java b/src/main/java/net/minecraft/world/level/CollisionGetter.java
-index 69754fbebb51f7f804c97a749fd65ce15ae22f1b..160b4c8f40b7b1bc53a8c23b801c5248c13e9a40 100644
+index 1ad0c976c6e2d6d31397dff850a9de7c16d16fba..dc877fe2e3c53b353baa59c125232e425fee67d7 100644
 --- a/src/main/java/net/minecraft/world/level/CollisionGetter.java
 +++ b/src/main/java/net/minecraft/world/level/CollisionGetter.java
 @@ -35,6 +35,12 @@ public interface CollisionGetter extends BlockGetter {
@@ -3218,7 +3218,7 @@ index a98ab20814cc29a25e9d29adfbb7e70d46768df2..6d8ff6c06af5545634f255ed17dc1e48
  
          if (!state.getBlock().hasDynamicShape() && !fromState.getBlock().hasDynamicShape()) {
 diff --git a/src/main/java/net/minecraft/world/phys/AABB.java b/src/main/java/net/minecraft/world/phys/AABB.java
-index 1b7f1babf732ab95940ac67437a0b22ee078f19d..ba29de4a759644acdfce9c2e3672f20b200b7b50 100644
+index 62752e28a68400f0e1a44f0196f0e51e3dd702b8..92394960fc76886f393cba02ac33c57739a4b383 100644
 --- a/src/main/java/net/minecraft/world/phys/AABB.java
 +++ b/src/main/java/net/minecraft/world/phys/AABB.java
 @@ -25,6 +25,17 @@ public class AABB {
@@ -3237,9 +3237,9 @@ index 1b7f1babf732ab95940ac67437a0b22ee078f19d..ba29de4a759644acdfce9c2e3672f20b
 +    // Paper end
 +
      public AABB(BlockPos pos) {
-         this(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1, pos.getY() + 1, pos.getZ() + 1);
+         this((double)pos.getX(), (double)pos.getY(), (double)pos.getZ(), (double)(pos.getX() + 1), (double)(pos.getY() + 1), (double)(pos.getZ() + 1));
      }
-@@ -314,7 +325,7 @@ public class AABB {
+@@ -321,7 +332,7 @@ public class AABB {
      }
  
      @Nullable
@@ -3434,7 +3434,7 @@ index 31b570517c1047e8e1cd5280baf80977af2b6121..d8b80632f6186641ee2ddaef9eba7ba9
  
      private boolean isZStripFull(int z1, int z2, int x, int y) {
 diff --git a/src/main/java/net/minecraft/world/phys/shapes/CubeVoxelShape.java b/src/main/java/net/minecraft/world/phys/shapes/CubeVoxelShape.java
-index e00c3419ff523a57dc4346720827854641fa21ad..fc751564e02306006cffd90ef29acb27cc77cd0b 100644
+index 32632368f06b79f53342fde060bbcd1b7c64767a..b9af1d14c7815c99273bce8165cf384d669c1a75 100644
 --- a/src/main/java/net/minecraft/world/phys/shapes/CubeVoxelShape.java
 +++ b/src/main/java/net/minecraft/world/phys/shapes/CubeVoxelShape.java
 @@ -7,6 +7,7 @@ import net.minecraft.util.Mth;
@@ -3537,7 +3537,7 @@ index 7ec02a7849437a18860aa0df7d9ddd71b2447d4c..5e45e49ab09344cb95736f4124b1c6e0
      public OffsetDoubleList(DoubleList oldList, double offset) {
          this.delegate = oldList;
 diff --git a/src/main/java/net/minecraft/world/phys/shapes/Shapes.java b/src/main/java/net/minecraft/world/phys/shapes/Shapes.java
-index 1a014f19f3c5425cc79a82c546066ab701fab1f8..9ac39c6d6289c86954ccb8a2e2afba8d96aa1950 100644
+index 86df4ef44d0a5107ee929dfd40d8ccb0779e8bfc..fbf1a559aefe444410b63a773374e011e4964e16 100644
 --- a/src/main/java/net/minecraft/world/phys/shapes/Shapes.java
 +++ b/src/main/java/net/minecraft/world/phys/shapes/Shapes.java
 @@ -16,9 +16,15 @@ public final class Shapes {
@@ -3638,12 +3638,12 @@ index 1a014f19f3c5425cc79a82c546066ab701fab1f8..9ac39c6d6289c86954ccb8a2e2afba8d
 -                    l,
 -                    m,
 -                    n,
--                    (int)Math.round(minX * l),
--                    (int)Math.round(minY * m),
--                    (int)Math.round(minZ * n),
--                    (int)Math.round(maxX * l),
--                    (int)Math.round(maxY * m),
--                    (int)Math.round(maxZ * n)
+-                    (int)Math.round(minX * (double)l),
+-                    (int)Math.round(minY * (double)m),
+-                    (int)Math.round(minZ * (double)n),
+-                    (int)Math.round(maxX * (double)l),
+-                    (int)Math.round(maxY * (double)m),
+-                    (int)Math.round(maxZ * (double)n)
 +                return new ArrayVoxelShape(
 +                        BLOCK.shape,
 +                        minX == 0.0 && maxX == 1.0 ? io.papermc.paper.util.CollisionUtil.ZERO_ONE : DoubleArrayList.wrap(new double[] { minX, maxX }),
@@ -3953,7 +3953,7 @@ index 53aa193f33a1a15376a59b8d6dd8cbc6cbec168b..a745ff8d115e1d0da6138e4f06726e07
  
      private static DiscreteVoxelShape makeSlice(DiscreteVoxelShape voxelSet, Direction.Axis axis, int sliceWidth) {
 diff --git a/src/main/java/net/minecraft/world/phys/shapes/VoxelShape.java b/src/main/java/net/minecraft/world/phys/shapes/VoxelShape.java
-index c88218ead06bec470b79f641651086dc121c42cc..e6b17f32f2b6930739a98c6139442383c1847add 100644
+index 2936c56e5690b42518010698e5177755422e4c5d..e6b17f32f2b6930739a98c6139442383c1847add 100644
 --- a/src/main/java/net/minecraft/world/phys/shapes/VoxelShape.java
 +++ b/src/main/java/net/minecraft/world/phys/shapes/VoxelShape.java
 @@ -16,37 +16,438 @@ import net.minecraft.world.phys.BlockHitResult;
@@ -4620,9 +4620,9 @@ index c88218ead06bec470b79f641651086dc121c42cc..e6b17f32f2b6930739a98c6139442383
 -                Vec3 vec32 = start.add(vec3.scale(0.001));
 -                return this.shape
 -                        .isFullWide(
--                            this.findIndex(Direction.Axis.X, vec32.x - pos.getX()),
--                            this.findIndex(Direction.Axis.Y, vec32.y - pos.getY()),
--                            this.findIndex(Direction.Axis.Z, vec32.z - pos.getZ())
+-                            this.findIndex(Direction.Axis.X, vec32.x - (double)pos.getX()),
+-                            this.findIndex(Direction.Axis.Y, vec32.y - (double)pos.getY()),
+-                            this.findIndex(Direction.Axis.Z, vec32.z - (double)pos.getZ())
 -                        )
 -                    ? new BlockHitResult(vec32, Direction.getNearest(vec3.x, vec3.y, vec3.z).getOpposite(), pos, true)
 -                    : AABB.clip(this.toAabbs(), start, end, pos);

--- a/patches/server/1024-Actually-optimise-explosions.patch
+++ b/patches/server/1024-Actually-optimise-explosions.patch
@@ -497,7 +497,7 @@ index 093c814d6835f20b1208236db96bb40b4611936c..b678da2cbb93cea7971bc3c4d324cfca
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/ExplosionDamageCalculator.java b/src/main/java/net/minecraft/world/level/ExplosionDamageCalculator.java
-index 92e06e14fd76fa34b871657c3410a4527cd30e09..da25fee7dd436fbe9f5566311f254ec7a99835d2 100644
+index 4085949accf23728de9a2ff14249cd6ca9b71f8a..5b93c038331c1750260a42726f5bfb97998d93a9 100644
 --- a/src/main/java/net/minecraft/world/level/ExplosionDamageCalculator.java
 +++ b/src/main/java/net/minecraft/world/level/ExplosionDamageCalculator.java
 @@ -22,11 +22,17 @@ public class ExplosionDamageCalculator {
@@ -513,9 +513,9 @@ index 92e06e14fd76fa34b871657c3410a4527cd30e09..da25fee7dd436fbe9f5566311f254ec7
 +        // Paper end - actually optimise explosions
          float f = explosion.radius() * 2.0F;
          Vec3 vec3 = explosion.center();
-         double d = Math.sqrt(entity.distanceToSqr(vec3)) / f;
--        double e = (1.0 - d) * Explosion.getSeenPercent(vec3, entity);
+         double d = Math.sqrt(entity.distanceToSqr(vec3)) / (double)f;
+-        double e = (1.0 - d) * (double)Explosion.getSeenPercent(vec3, entity);
 +        double e = (1.0 - d) * seenPercent; // Paper - actually optimise explosions
-         return (float)((e * e + e) / 2.0 * 7.0 * f + 1.0);
+         return (float)((e * e + e) / 2.0 * 7.0 * (double)f + 1.0);
      }
  }


### PR DESCRIPTION
The main thing we lose from the 1.11 snapshots is a recent fix for redundant casts.