### PR TITLE
Add Configuration for finding Structures outside World Border

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1394,10 +1394,10 @@ index 0000000000000000000000000000000000000000..351fbbc577556ebbd62222615801a96b
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..dc7950f9a52a718317e5f41de9d396cd7b846bf3
+index 0000000000000000000000000000000000000000..73aee4d018cdf15381dfe5a38e0a7f48a23d9634
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,553 @@
+@@ -0,0 +1,554 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1816,6 +1816,7 @@ index 0000000000000000000000000000000000000000..dc7950f9a52a718317e5f41de9d396cd
 +        public IntOr.Disabled netherCeilingVoidDamageHeight = IntOr.Disabled.DISABLED;
 +        public int maxFluidTicks = 65536;
 +        public int maxBlockTicks = 65536;
++        public boolean findStructuresOutsideWorldBorder = false;
 +    }
 +
 +    public Spawn spawn;

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1394,7 +1394,7 @@ index 0000000000000000000000000000000000000000..351fbbc577556ebbd62222615801a96b
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..73aee4d018cdf15381dfe5a38e0a7f48a23d9634
+index 0000000000000000000000000000000000000000..d3fdf62912d190f8b468b77230a927023c361074
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 @@ -0,0 +1,554 @@
@@ -1816,7 +1816,7 @@ index 0000000000000000000000000000000000000000..73aee4d018cdf15381dfe5a38e0a7f48
 +        public IntOr.Disabled netherCeilingVoidDamageHeight = IntOr.Disabled.DISABLED;
 +        public int maxFluidTicks = 65536;
 +        public int maxBlockTicks = 65536;
-+        public boolean findStructuresOutsideWorldBorder = false;
++        public boolean locateStructuresOutsideWorldBorder = false;
 +    }
 +
 +    public Spawn spawn;

--- a/patches/server/0113-Bound-Treasure-Maps-to-World-Border.patch
+++ b/patches/server/0113-Bound-Treasure-Maps-to-World-Border.patch
@@ -34,14 +34,14 @@ index 52325a99ea38530ad69a39ac0215233139f35268..bf5ac907507bf3b5bfcef45b566c0bc1
          return (double) pos.getMaxBlockX() > this.getMinX() && (double) pos.getMinBlockX() < this.getMaxX() && (double) pos.getMaxBlockZ() > this.getMinZ() && (double) pos.getMinBlockZ() < this.getMaxZ();
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
-index b2f9429e0d437cf70bf56410e163e957b80ebdf1..3e57142dd9cb23d43857d5a4cb30962e4b696b74 100644
+index b2f9429e0d437cf70bf56410e163e957b80ebdf1..10f247ef5d1ae27b48f7299754613dee7af52bc5 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 @@ -217,6 +217,7 @@ public abstract class ChunkGenerator {
  
              while (iterator.hasNext()) {
                  ChunkPos chunkcoordintpair = (ChunkPos) iterator.next();
-+                if (!world.getWorldBorder().isChunkInBounds(chunkcoordintpair.x, chunkcoordintpair.z)) { continue; } // Paper - Bound treasure maps to world border
++                if (!world.getWorldBorder().isChunkInBounds(chunkcoordintpair.x, chunkcoordintpair.z) && !world.paperConfig().environment.findStructuresOutsideWorldBorder) { continue; } // Paper - Bound treasure maps to world border
  
                  blockposition_mutableblockposition.set(SectionPos.sectionToBlockCoord(chunkcoordintpair.x, 8), 32, SectionPos.sectionToBlockCoord(chunkcoordintpair.z, 8));
                  double d1 = blockposition_mutableblockposition.distSqr(center);

--- a/patches/server/0113-Bound-Treasure-Maps-to-World-Border.patch
+++ b/patches/server/0113-Bound-Treasure-Maps-to-World-Border.patch
@@ -34,14 +34,14 @@ index 52325a99ea38530ad69a39ac0215233139f35268..bf5ac907507bf3b5bfcef45b566c0bc1
          return (double) pos.getMaxBlockX() > this.getMinX() && (double) pos.getMinBlockX() < this.getMaxX() && (double) pos.getMaxBlockZ() > this.getMinZ() && (double) pos.getMinBlockZ() < this.getMaxZ();
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
-index b2f9429e0d437cf70bf56410e163e957b80ebdf1..10f247ef5d1ae27b48f7299754613dee7af52bc5 100644
+index b2f9429e0d437cf70bf56410e163e957b80ebdf1..e59221da894433b47a8de9298aed76a7e9a63082 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 @@ -217,6 +217,7 @@ public abstract class ChunkGenerator {
  
              while (iterator.hasNext()) {
                  ChunkPos chunkcoordintpair = (ChunkPos) iterator.next();
-+                if (!world.getWorldBorder().isChunkInBounds(chunkcoordintpair.x, chunkcoordintpair.z) && !world.paperConfig().environment.findStructuresOutsideWorldBorder) { continue; } // Paper - Bound treasure maps to world border
++                if (!world.getWorldBorder().isChunkInBounds(chunkcoordintpair.x, chunkcoordintpair.z) && !world.paperConfig().environment.locateStructuresOutsideWorldBorder) { continue; } // Paper - Bound treasure maps to world border
  
                  blockposition_mutableblockposition.set(SectionPos.sectionToBlockCoord(chunkcoordintpair.x, 8), 32, SectionPos.sectionToBlockCoord(chunkcoordintpair.z, 8));
                  double d1 = blockposition_mutableblockposition.distSqr(center);

--- a/patches/server/0113-Bound-Treasure-Maps-to-World-Border.patch
+++ b/patches/server/0113-Bound-Treasure-Maps-to-World-Border.patch
@@ -34,14 +34,14 @@ index 52325a99ea38530ad69a39ac0215233139f35268..bf5ac907507bf3b5bfcef45b566c0bc1
          return (double) pos.getMaxBlockX() > this.getMinX() && (double) pos.getMinBlockX() < this.getMaxX() && (double) pos.getMaxBlockZ() > this.getMinZ() && (double) pos.getMinBlockZ() < this.getMaxZ();
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
-index b2f9429e0d437cf70bf56410e163e957b80ebdf1..e59221da894433b47a8de9298aed76a7e9a63082 100644
+index b2f9429e0d437cf70bf56410e163e957b80ebdf1..4a731b9170222a5a2b0089ef5e9527dbd46a9ad5 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 @@ -217,6 +217,7 @@ public abstract class ChunkGenerator {
  
              while (iterator.hasNext()) {
                  ChunkPos chunkcoordintpair = (ChunkPos) iterator.next();
-+                if (!world.getWorldBorder().isChunkInBounds(chunkcoordintpair.x, chunkcoordintpair.z) && !world.paperConfig().environment.locateStructuresOutsideWorldBorder) { continue; } // Paper - Bound treasure maps to world border
++                if (!world.paperConfig().environment.locateStructuresOutsideWorldBorder && !world.getWorldBorder().isChunkInBounds(chunkcoordintpair.x, chunkcoordintpair.z)) { continue; } // Paper - Bound treasure maps to world border
  
                  blockposition_mutableblockposition.set(SectionPos.sectionToBlockCoord(chunkcoordintpair.x, 8), 32, SectionPos.sectionToBlockCoord(chunkcoordintpair.z, 8));
                  double d1 = blockposition_mutableblockposition.distSqr(center);


### PR DESCRIPTION
resolves #10391 
decided to go with the config option here since adding exclusions for only ender eyes seems unreasonable