### PR TITLE
Add Configuration for vertical Despawn Ranges

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -2466,10 +2466,10 @@ index 0000000000000000000000000000000000000000..9c339ef178ebc3b0251095f320e4a7a3
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/serializer/DespawnRangeSerializer.java b/src/main/java/io/papermc/paper/configuration/serializer/DespawnRangeSerializer.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..04909c5b5d4b70538ad2bc8b29c6471acd4310f7
+index 0000000000000000000000000000000000000000..0e3a7e28f79bc29ee051463d32ea25b864ca6b81
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/serializer/DespawnRangeSerializer.java
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,78 @@
 +package io.papermc.paper.configuration.serializer;
 +
 +import io.papermc.paper.configuration.WorldConfiguration.Entities.Spawning.DespawnRange;
@@ -2540,10 +2540,11 @@ index 0000000000000000000000000000000000000000..04909c5b5d4b70538ad2bc8b29c6471a
 +    }
 +
 +    private int ifPresent(ConfigurationNode node, int or) {
-+        if (node.virtual())
++        if (node.virtual()) {
 +            return or;
-+        if (node.raw() instanceof Integer i)
++        } else if (node.raw() instanceof Integer i) {
 +            return i;
++        }
 +        throw new RuntimeException(new SerializationException(node, Integer.class, "Expected an integer, got \"" + node.raw() + "\" instead"));
 +    }
 +}

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -854,10 +854,10 @@ index 0000000000000000000000000000000000000000..69add4a7f1147015806bc9b63a8340d1
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..783eac6e458c6f1a0584301fb84a2fe341868f34
+index 0000000000000000000000000000000000000000..1cee7ba88f8cd03009d9a3a01c1128eff598833c
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
-@@ -0,0 +1,466 @@
+@@ -0,0 +1,463 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.base.Suppliers;
@@ -866,11 +866,7 @@ index 0000000000000000000000000000000000000000..783eac6e458c6f1a0584301fb84a2fe3
 +import io.leangen.geantyref.TypeToken;
 +import io.papermc.paper.configuration.legacy.RequiresSpigotInitialization;
 +import io.papermc.paper.configuration.mapping.InnerClassFieldDiscoverer;
-+import io.papermc.paper.configuration.serializer.ComponentSerializer;
-+import io.papermc.paper.configuration.serializer.EnumValueSerializer;
-+import io.papermc.paper.configuration.serializer.NbtPathSerializer;
-+import io.papermc.paper.configuration.serializer.PacketClassSerializer;
-+import io.papermc.paper.configuration.serializer.StringRepresentableSerializer;
++import io.papermc.paper.configuration.serializer.*;
 +import io.papermc.paper.configuration.serializer.collections.FastutilMapSerializer;
 +import io.papermc.paper.configuration.serializer.collections.MapSerializer;
 +import io.papermc.paper.configuration.serializer.collections.TableSerializer;
@@ -1095,6 +1091,7 @@ index 0000000000000000000000000000000000000000..783eac6e458c6f1a0584301fb84a2fe3
 +                    .register(new TypeToken<Reference2IntMap<?>>() {}, new FastutilMapSerializer.SomethingToPrimitive<Reference2IntMap<?>>(Reference2IntOpenHashMap::new, Integer.TYPE))
 +                    .register(new TypeToken<Reference2LongMap<?>>() {}, new FastutilMapSerializer.SomethingToPrimitive<Reference2LongMap<?>>(Reference2LongOpenHashMap::new, Long.TYPE))
 +                    .register(new TypeToken<Table<?, ?, ?>>() {}, new TableSerializer())
++                    .register(new TypeToken<WorldConfiguration.Entities.Spawning.DespawnRange>() {}, new DespawnRangeSerializer())
 +                    .register(StringRepresentableSerializer::isValidFor, new StringRepresentableSerializer())
 +                    .register(IntOr.Default.SERIALIZER)
 +                    .register(IntOr.Disabled.SERIALIZER)
@@ -1414,10 +1411,10 @@ index 0000000000000000000000000000000000000000..990d1bb46e0f9719f4e9af928d80ac6f
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1303e6f9f057becc7a1b8efb10431ae5240c3dc0
+index 0000000000000000000000000000000000000000..9e5783004276ad3d1951f80ebb9f5b55fbac3631
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,557 @@
+@@ -0,0 +1,556 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1607,7 +1604,6 @@ index 0000000000000000000000000000000000000000..1303e6f9f057becc7a1b8efb10431ae5
 +            @MergeMap
 +            public Reference2IntMap<MobCategory> ticksPerSpawn = Util.make(new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length), map -> Arrays.stream(NaturalSpawner.SPAWNING_CATEGORIES).forEach(mobCategory -> map.put(mobCategory, -1)));
 +
-+            @ConfigSerializable
 +            public record DespawnRange(@Required int xzLimit, @Required int yLimit, @Required int xzSoftLimit, @Required int ySoftLimit) {
 +                public DespawnRange(int hard, int soft) {
 +                    this(hard, hard, soft, soft);

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1411,7 +1411,7 @@ index 0000000000000000000000000000000000000000..990d1bb46e0f9719f4e9af928d80ac6f
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9e5783004276ad3d1951f80ebb9f5b55fbac3631
+index 0000000000000000000000000000000000000000..b5f1c369f727161fba8ae6a820cf1f901953d6f8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 @@ -0,0 +1,556 @@
@@ -1604,9 +1604,9 @@ index 0000000000000000000000000000000000000000..9e5783004276ad3d1951f80ebb9f5b55
 +            @MergeMap
 +            public Reference2IntMap<MobCategory> ticksPerSpawn = Util.make(new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length), map -> Arrays.stream(NaturalSpawner.SPAWNING_CATEGORIES).forEach(mobCategory -> map.put(mobCategory, -1)));
 +
-+            public record DespawnRange(@Required int xzLimit, @Required int yLimit, @Required int xzSoftLimit, @Required int ySoftLimit) {
++            public record DespawnRange(@Required int xzLimit, @Required int yLimit, @Required int xzSoftLimit, @Required int ySoftLimit, @Required boolean longSyntax, @Required boolean softLongSyntax) {
 +                public DespawnRange(int hard, int soft) {
-+                    this(hard, hard, soft, soft);
++                    this(hard, hard, soft, soft, false, false);
 +                }
 +            }
 +
@@ -2462,10 +2462,10 @@ index 0000000000000000000000000000000000000000..9c339ef178ebc3b0251095f320e4a7a3
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/serializer/DespawnRangeSerializer.java b/src/main/java/io/papermc/paper/configuration/serializer/DespawnRangeSerializer.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0e3a7e28f79bc29ee051463d32ea25b864ca6b81
+index 0000000000000000000000000000000000000000..35b27ce8857338d846e00d49bb2645f97785a0e9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/serializer/DespawnRangeSerializer.java
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,86 @@
 +package io.papermc.paper.configuration.serializer;
 +
 +import io.papermc.paper.configuration.WorldConfiguration.Entities.Spawning.DespawnRange;
@@ -2487,23 +2487,31 @@ index 0000000000000000000000000000000000000000..0e3a7e28f79bc29ee051463d32ea25b8
 +        int xzSoftLimit;
 +        int yLimit;
 +        int ySoftLimit;
++        boolean longSyntax = false;
++        boolean softLongSyntax = false;
 +
 +        MobCategory category = MobCategory.valueOf(node.key().toString().toUpperCase());
 +
-+        if (hard.hasChild("horizontal") || hard.hasChild("vertical")) {
++        if (hard.hasChild("horizontal") && hard.hasChild("vertical")) {
 +            xzLimit = ifPresent(hard.node("horizontal"), category.getDespawnDistance());
 +            yLimit = ifPresent(hard.node("vertical"), category.getDespawnDistance());
++            longSyntax = true;
++        } else if (hard.hasChild("horizontal") || hard.hasChild("vertical")) {
++            throw new RuntimeException(new SerializationException(node, DespawnRange.class, "Expected both horizontal and vertical despawn ranges to be defined"));
 +        } else {
 +            xzLimit = yLimit = ifPresent(hard, category.getDespawnDistance());
 +        }
 +
-+        if (soft.hasChild("horizontal") || soft.hasChild("vertical")) {
++        if (soft.hasChild("horizontal") && soft.hasChild("vertical")) {
 +            xzSoftLimit = ifPresent(soft.node("horizontal"), category.getNoDespawnDistance());
 +            ySoftLimit = ifPresent(soft.node("vertical"), category.getNoDespawnDistance());
++            softLongSyntax = true;
++        } else if (soft.hasChild("horizontal") || soft.hasChild("vertical")) {
++            throw new RuntimeException(new SerializationException(node, DespawnRange.class, "Expected both horizontal and vertical despawn ranges to be defined"));
 +        } else {
 +            xzSoftLimit = ySoftLimit = ifPresent(soft, category.getNoDespawnDistance());
 +        }
-+        return new DespawnRange(xzLimit, yLimit, xzSoftLimit, ySoftLimit);
++        return new DespawnRange(xzLimit, yLimit, xzSoftLimit, ySoftLimit, longSyntax, softLongSyntax);
 +    }
 +
 +    @Override
@@ -2521,17 +2529,17 @@ index 0000000000000000000000000000000000000000..0e3a7e28f79bc29ee051463d32ea25b8
 +        int yLimit = despawnRange.yLimit();
 +        int ySoftLimit = despawnRange.ySoftLimit();
 +
-+        if (xzLimit == yLimit) {
-+            hard.set(xzLimit);
-+        } else {
++        if (despawnRange.longSyntax()) {
 +            hard.node("horizontal").set(xzLimit);
 +            hard.node("vertical").set(yLimit);
-+        }
-+        if (xzSoftLimit == ySoftLimit) {
-+            soft.set(xzSoftLimit);
 +        } else {
++            hard.set(xzLimit);
++        }
++        if (despawnRange.softLongSyntax()) {
 +            soft.node("horizontal").set(xzSoftLimit);
 +            soft.node("vertical").set(ySoftLimit);
++        } else {
++            soft.set(xzSoftLimit);
 +        }
 +    }
 +

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1414,10 +1414,10 @@ index 0000000000000000000000000000000000000000..990d1bb46e0f9719f4e9af928d80ac6f
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4bcf27f98765abf693e535cfc1756c27a10cb316
+index 0000000000000000000000000000000000000000..1303e6f9f057becc7a1b8efb10431ae5240c3dc0
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,554 @@
+@@ -0,0 +1,557 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1603,12 +1603,15 @@ index 0000000000000000000000000000000000000000..4bcf27f98765abf693e535cfc1756c27
 +            @MergeMap
 +            public Reference2IntMap<MobCategory> spawnLimits = Util.make(new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length), map -> Arrays.stream(NaturalSpawner.SPAWNING_CATEGORIES).forEach(mobCategory -> map.put(mobCategory, -1)));
 +            @MergeMap
-+            public Map<MobCategory, DespawnRange> despawnRanges = Arrays.stream(MobCategory.values()).collect(Collectors.toMap(Function.identity(), category -> new DespawnRange(category.getNoDespawnDistance(), category.getDespawnDistance())));
++            public Map<MobCategory, DespawnRange> despawnRanges = Arrays.stream(MobCategory.values()).collect(Collectors.toMap(Function.identity(), category -> new DespawnRange(category.getDespawnDistance(), category.getNoDespawnDistance())));
 +            @MergeMap
 +            public Reference2IntMap<MobCategory> ticksPerSpawn = Util.make(new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length), map -> Arrays.stream(NaturalSpawner.SPAWNING_CATEGORIES).forEach(mobCategory -> map.put(mobCategory, -1)));
 +
 +            @ConfigSerializable
-+            public record DespawnRange(@Required int soft, @Required int hard) {
++            public record DespawnRange(@Required int xzLimit, @Required int yLimit, @Required int xzSoftLimit, @Required int ySoftLimit) {
++                public DespawnRange(int hard, int soft) {
++                    this(hard, hard, soft, soft);
++                }
 +            }
 +
 +            public WaterAnimalSpawnHeight wateranimalSpawnHeight;
@@ -2461,6 +2464,90 @@ index 0000000000000000000000000000000000000000..9c339ef178ebc3b0251095f320e4a7a3
 +        return MiniMessage.miniMessage().serialize(component);
 +    }
 +}
+diff --git a/src/main/java/io/papermc/paper/configuration/serializer/DespawnRangeSerializer.java b/src/main/java/io/papermc/paper/configuration/serializer/DespawnRangeSerializer.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..04909c5b5d4b70538ad2bc8b29c6471acd4310f7
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/configuration/serializer/DespawnRangeSerializer.java
+@@ -0,0 +1,77 @@
++package io.papermc.paper.configuration.serializer;
++
++import io.papermc.paper.configuration.WorldConfiguration.Entities.Spawning.DespawnRange;
++import net.minecraft.world.entity.MobCategory;
++import org.checkerframework.checker.nullness.qual.Nullable;
++import org.spongepowered.configurate.ConfigurationNode;
++import org.spongepowered.configurate.serialize.SerializationException;
++import org.spongepowered.configurate.serialize.TypeSerializer;
++import java.lang.reflect.Type;
++
++public class DespawnRangeSerializer implements TypeSerializer<DespawnRange> {
++
++    @Override
++    public DespawnRange deserialize(final Type type, final ConfigurationNode node) throws SerializationException {
++        ConfigurationNode hard = node.node("hard");
++        ConfigurationNode soft = node.node("soft");
++
++        int xzLimit;
++        int xzSoftLimit;
++        int yLimit;
++        int ySoftLimit;
++
++        MobCategory category = MobCategory.valueOf(node.key().toString().toUpperCase());
++
++        if (hard.hasChild("horizontal") || hard.hasChild("vertical")) {
++            xzLimit = ifPresent(hard.node("horizontal"), category.getDespawnDistance());
++            yLimit = ifPresent(hard.node("vertical"), category.getDespawnDistance());
++        } else {
++            xzLimit = yLimit = ifPresent(hard, category.getDespawnDistance());
++        }
++
++        if (soft.hasChild("horizontal") || soft.hasChild("vertical")) {
++            xzSoftLimit = ifPresent(soft.node("horizontal"), category.getNoDespawnDistance());
++            ySoftLimit = ifPresent(soft.node("vertical"), category.getNoDespawnDistance());
++        } else {
++            xzSoftLimit = ySoftLimit = ifPresent(soft, category.getNoDespawnDistance());
++        }
++        return new DespawnRange(xzLimit, yLimit, xzSoftLimit, ySoftLimit);
++    }
++
++    @Override
++    public void serialize(final Type type, @Nullable final DespawnRange despawnRange, final ConfigurationNode node) throws SerializationException {
++        if (despawnRange == null) {
++            node.raw(null);
++            return;
++        }
++
++        ConfigurationNode hard = node.node("hard");
++        ConfigurationNode soft = node.node("soft");
++
++        int xzLimit = despawnRange.xzLimit();
++        int xzSoftLimit = despawnRange.xzSoftLimit();
++        int yLimit = despawnRange.yLimit();
++        int ySoftLimit = despawnRange.ySoftLimit();
++
++        if (xzLimit == yLimit) {
++            hard.set(xzLimit);
++        } else {
++            hard.node("horizontal").set(xzLimit);
++            hard.node("vertical").set(yLimit);
++        }
++        if (xzSoftLimit == ySoftLimit) {
++            soft.set(xzSoftLimit);
++        } else {
++            soft.node("horizontal").set(xzSoftLimit);
++            soft.node("vertical").set(ySoftLimit);
++        }
++    }
++
++    private int ifPresent(ConfigurationNode node, int or) {
++        if (node.virtual())
++            return or;
++        if (node.raw() instanceof Integer i)
++            return i;
++        throw new RuntimeException(new SerializationException(node, Integer.class, "Expected an integer, got \"" + node.raw() + "\" instead"));
++    }
++}
+\ No newline at end of file
 diff --git a/src/main/java/io/papermc/paper/configuration/serializer/EngineModeSerializer.java b/src/main/java/io/papermc/paper/configuration/serializer/EngineModeSerializer.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..27c0679d376bb31ab52131dfea74b3b580ca92b5

--- a/patches/server/0031-Add-configurable-entity-despawn-distances.patch
+++ b/patches/server/0031-Add-configurable-entity-despawn-distances.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add configurable entity despawn distances
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 0593d828c911c94c9833bf12b9c294e5dac1f4e8..13f4c2f5aaa4cf107265b752e8157b1dee3fb524 100644
+index 0593d828c911c94c9833bf12b9c294e5dac1f4e8..cd5281b61f833701131cc6a6bade7bff96515541 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -863,20 +863,27 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
@@ -21,24 +21,24 @@ index 0593d828c911c94c9833bf12b9c294e5dac1f4e8..13f4c2f5aaa4cf107265b752e8157b1d
 -                if (d0 > (double) j && this.removeWhenFarAway(d0)) {
 -                    this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
 -                }
-+                double xzDistance = entityhuman.distanceToSqr(this.getX(), entityhuman.getY(), this.getZ());
++                double xzDistanceSquared = entityhuman.distanceToSqr(this.getX(), entityhuman.getY(), this.getZ());
 +                double yDistance = Math.abs(entityhuman.getY() - this.getY());
  
 -                int k = this.getType().getCategory().getNoDespawnDistance();
 -                int l = k * k;
-+                int xzLimit = despawnRanges.xzLimit() * despawnRanges.xzLimit();
-+                int xzSoftLimit = despawnRanges.xzSoftLimit() * despawnRanges.xzSoftLimit();
++                int xzLimitSquared = despawnRanges.xzLimit() * despawnRanges.xzLimit();
++                int xzSoftLimitSquared = despawnRanges.xzSoftLimit() * despawnRanges.xzSoftLimit();
 +                int yLimit = despawnRanges.yLimit();
 +                int ySoftLimit = despawnRanges.ySoftLimit();
  
 -                if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && d0 > (double) l && this.removeWhenFarAway(d0)) {
-+                if ((xzDistance > xzLimit || yDistance > yLimit) && this.removeWhenFarAway(xzDistance)) {
++                if ((xzDistanceSquared > xzLimitSquared || yDistance > yLimit) && this.removeWhenFarAway(xzDistanceSquared)) {
                      this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
 -                } else if (d0 < (double) l) {
 +                }
 +
-+                if (xzDistance > xzSoftLimit || yDistance > ySoftLimit) {
-+                    if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && this.removeWhenFarAway(xzDistance)) {
++                if (xzDistanceSquared > xzSoftLimitSquared || yDistance > ySoftLimit) {
++                    if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && this.removeWhenFarAway(xzDistanceSquared)) {
 +                        this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
 +                    }
 +                } else {

--- a/patches/server/0031-Add-configurable-entity-despawn-distances.patch
+++ b/patches/server/0031-Add-configurable-entity-despawn-distances.patch
@@ -5,23 +5,44 @@ Subject: [PATCH] Add configurable entity despawn distances
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 0593d828c911c94c9833bf12b9c294e5dac1f4e8..5fd0e3d27f3c86f1ff767b45dfa6138c30f13e3e 100644
+index 0593d828c911c94c9833bf12b9c294e5dac1f4e8..13f4c2f5aaa4cf107265b752e8157b1dee3fb524 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -864,14 +864,14 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+@@ -863,20 +863,27 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+             Player entityhuman = this.level().getNearestPlayer(this, -1.0D);
  
              if (entityhuman != null) {
-                 double d0 = entityhuman.distanceToSqr((Entity) this);
+-                double d0 = entityhuman.distanceToSqr((Entity) this);
 -                int i = this.getType().getCategory().getDespawnDistance();
-+                int i = this.level().paperConfig().entities.spawning.despawnRanges.get(this.getType().getCategory()).hard(); // Paper - Configurable despawn distances
-                 int j = i * i;
+-                int j = i * i;
++                // Paper start - Configurable despawn distances
++                io.papermc.paper.configuration.WorldConfiguration.Entities.Spawning.DespawnRange despawnRanges = this.level().paperConfig().entities.spawning.despawnRanges.get(this.getType().getCategory());
  
-                 if (d0 > (double) j && this.removeWhenFarAway(d0)) {
-                     this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
-                 }
+-                if (d0 > (double) j && this.removeWhenFarAway(d0)) {
+-                    this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
+-                }
++                double xzDistance = entityhuman.distanceToSqr(this.getX(), entityhuman.getY(), this.getZ());
++                double yDistance = Math.abs(entityhuman.getY() - this.getY());
  
 -                int k = this.getType().getCategory().getNoDespawnDistance();
-+                int k = this.level().paperConfig().entities.spawning.despawnRanges.get(this.getType().getCategory()).soft(); // Paper - Configurable despawn distances
-                 int l = k * k;
+-                int l = k * k;
++                int xzLimit = despawnRanges.xzLimit() * despawnRanges.xzLimit();
++                int xzSoftLimit = despawnRanges.xzSoftLimit() * despawnRanges.xzSoftLimit();
++                int yLimit = despawnRanges.yLimit();
++                int ySoftLimit = despawnRanges.ySoftLimit();
  
-                 if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && d0 > (double) l && this.removeWhenFarAway(d0)) {
+-                if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && d0 > (double) l && this.removeWhenFarAway(d0)) {
++                if ((xzDistance > xzLimit || yDistance > yLimit) && this.removeWhenFarAway(xzDistance)) {
+                     this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
+-                } else if (d0 < (double) l) {
++                }
++
++                if (xzDistance > xzSoftLimit || yDistance > ySoftLimit) {
++                    if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && this.removeWhenFarAway(xzDistance)) {
++                        this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
++                    }
++                } else {
++                    // Paper end - Configurable despawn distances
+                     this.noActionTime = 0;
+                 }
+             }

--- a/patches/server/0034-Player-affects-spawning-API.patch
+++ b/patches/server/0034-Player-affects-spawning-API.patch
@@ -21,7 +21,7 @@ index 3126e8cab3c40e3af47f4c8925e1c6a9523309ba..3207166061bf9c4d7bf3f38e5a9f7aff
      public static Predicate<Entity> withinDistance(double x, double y, double z, double max) {
          double d4 = max * max;
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 5fd0e3d27f3c86f1ff767b45dfa6138c30f13e3e..a753fd0434f611d8c77270012e383e3210f1194b 100644
+index 13f4c2f5aaa4cf107265b752e8157b1dee3fb524..b66bfbbebcd3217042771c47646a2b8e1f3da10d 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -860,7 +860,7 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
@@ -32,7 +32,7 @@ index 5fd0e3d27f3c86f1ff767b45dfa6138c30f13e3e..a753fd0434f611d8c77270012e383e32
 +            Player entityhuman = this.level().findNearbyPlayer(this, -1.0D, EntitySelector.PLAYER_AFFECTS_SPAWNING); // Paper - Affects Spawning API
  
              if (entityhuman != null) {
-                 double d0 = entityhuman.distanceToSqr((Entity) this);
+                 // Paper start - Configurable despawn distances
 diff --git a/src/main/java/net/minecraft/world/entity/animal/horse/SkeletonTrapGoal.java b/src/main/java/net/minecraft/world/entity/animal/horse/SkeletonTrapGoal.java
 index 3b7fc11b7832a72fb9b0806fe9847f4e30759e7b..3cb84856c10347162a8736ae1ef65165183ec8fe 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/horse/SkeletonTrapGoal.java

--- a/patches/server/0202-Add-entity-knockback-events.patch
+++ b/patches/server/0202-Add-entity-knockback-events.patch
@@ -93,10 +93,10 @@ index cccc60602360f25f0aeddbd16dad2bb63a1728a8..ada79af49d1cafe25ca6c1fb456e1c4c
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 55aecada617bd84676928a7818f1511b2d85e7bf..f56d431207323a80b7f566ac6e30eebf232ee695 100644
+index e5da6a5317ad05d8213c7aff64adc26325157a57..b1ab34ebf213ec82467a854408130d3202cde192 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1691,7 +1691,7 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+@@ -1698,7 +1698,7 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
              if (f1 > 0.0F && target instanceof LivingEntity) {
                  LivingEntity entityliving = (LivingEntity) target;
  
@@ -273,7 +273,7 @@ index 6476c644d3da824c5ee4190cb45cde678ff1188f..b216140a8be65e210250358af8daf493
                          // CraftBukkit end
                          entity.setDeltaMovement(entity.getDeltaMovement().add(vec3d1));
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cfdabb93c2d30845af9108552ed9bee9929250ce..e1b7bd5c23ba79b84ad257b7fb45e251da3978e5 100644
+index cfdabb93c2d30845af9108552ed9bee9929250ce..9225746382bcecb0bab655a8232fecc09169225d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1922,19 +1922,33 @@ public class CraftEventFactory {

--- a/patches/server/0243-Improve-death-events.patch
+++ b/patches/server/0243-Improve-death-events.patch
@@ -80,7 +80,7 @@ index a3a1450949703851625bbb257e92b3be4d79a06a..ff3f70b8c266dc3b2ab374ffd6905ecb
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f7a77b31dc196823510f96bd3b2344058e20feac..279fa00fd9043e1995f22c79f47d0b41c27bd933 100644
+index 39dff0a38b53624c935f27cc86ff036c831f407f..bdee5725029eda3a0e7bee407286480c0bb47db1 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -283,6 +283,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -229,10 +229,10 @@ index f7a77b31dc196823510f96bd3b2344058e20feac..279fa00fd9043e1995f22c79f47d0b41
      public int getExpReward(@Nullable Entity entity) { // CraftBukkit
          Level world = this.level();
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index f56d431207323a80b7f566ac6e30eebf232ee695..c2b10c3dba9d4d08e48f8e8836142b85f16b14cb 100644
+index b1ab34ebf213ec82467a854408130d3202cde192..31beb61c8995bca632aeb83bf357f5b3a06868ba 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1119,6 +1119,12 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+@@ -1126,6 +1126,12 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
  
      }
  
@@ -245,7 +245,7 @@ index f56d431207323a80b7f566ac6e30eebf232ee695..c2b10c3dba9d4d08e48f8e8836142b85
      @Override
      protected void dropCustomDeathLoot(ServerLevel world, DamageSource source, boolean causedByPlayer) {
          super.dropCustomDeathLoot(world, source, causedByPlayer);
-@@ -1127,6 +1133,7 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+@@ -1134,6 +1140,7 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
  
          for (int j = 0; j < i; ++j) {
              EquipmentSlot enumitemslot = aenumitemslot[j];
@@ -253,7 +253,7 @@ index f56d431207323a80b7f566ac6e30eebf232ee695..c2b10c3dba9d4d08e48f8e8836142b85
              ItemStack itemstack = this.getItemBySlot(enumitemslot);
              float f = this.getEquipmentDropChance(enumitemslot);
  
-@@ -1151,7 +1158,13 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+@@ -1158,7 +1165,13 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
                      }
  
                      this.spawnAtLocation(itemstack);
@@ -443,7 +443,7 @@ index 92f9502a2d5721ebb1757a069a0f138db66628d7..6c5bd88777ff79c7408cf5ffed0f099a
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d1b473ef83df0ed4ae7cd9dd0525dac5e8a41223..a9a2b35378d6654ba00a48737f596553445214aa 100644
+index d63cf5933fdcff6d71c7ddbfed3640acd1646b70..1f4c686e92e7449556ee5067553ed4473ba2f50e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -901,9 +901,16 @@ public class CraftEventFactory {

--- a/patches/server/0484-Expand-EntityUnleashEvent.patch
+++ b/patches/server/0484-Expand-EntityUnleashEvent.patch
@@ -78,10 +78,10 @@ index 30d7dd9646ba9d6a9396dc140a61eb2cac07dfc6..bc03f1fe2a311bf61449879751360c67
  
      default void closeRangeLeashBehaviour(Entity entity) {}
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index c2b10c3dba9d4d08e48f8e8836142b85f16b14cb..37a8e426ca65587863bd22d2b7f32fae854c322e 100644
+index 31beb61c8995bca632aeb83bf357f5b3a06868ba..fe3a98177e2d6155b361cf9a4223296258958ece 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1617,8 +1617,11 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+@@ -1624,8 +1624,11 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
          boolean flag1 = super.startRiding(entity, force);
  
          if (flag1 && this.isLeashed()) {
@@ -121,7 +121,7 @@ index 3c0af74ed65610b1d5e3b72fdcf28c5a3423f0da..01173fc7177d78588978e087e63efda0
                              flag1 = true;
                          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 97a17f2b782196b51ebbc6740aad1768fc73f7ba..2786398e99af94d8dc1251009cdb5fa71206bcf3 100644
+index 6e5bfdc0a5b39977c4550876470c9a2534160056..e3cf4febcb51db96fcd162b2af77dd92e7d49365 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1596,8 +1596,10 @@ public class CraftEventFactory {

--- a/patches/server/0886-Fix-silent-equipment-change-for-mobs.patch
+++ b/patches/server/0886-Fix-silent-equipment-change-for-mobs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix silent equipment change for mobs
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 37a8e426ca65587863bd22d2b7f32fae854c322e..1a2efd8b77d65606994f13980ddbe018f90d0c35 100644
+index fe3a98177e2d6155b361cf9a4223296258958ece..e63803314c7a803cd9dcc0919e308d3441d5382d 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1102,19 +1102,26 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+@@ -1109,19 +1109,26 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
  
      @Override
      public void setItemSlot(EquipmentSlot slot, ItemStack stack) {


### PR DESCRIPTION
resolves #10177 
config naming/structure might need some changes, i didn't wanna break existing configs so i just did it like this.

currently doesn't work for Raiders as those have extra checking logic in the removeWhenFarAway method, so i am not quite sure what to do about those

EDIT: also wanted to add that i am not sure if the normal despawn range should still impact the y axis. since your x axis is going to be higher then your y axis 99 % of the time anyways i will just have it keep affecting that aswell

Docs-pr at: PaperMC/docs#465