### PR TITLE
Allow server administrators to disable book size checks

### DIFF
--- a/patches/server/1060-Allow-server-administrators-to-disable-the-book-size.patch
+++ b/patches/server/1060-Allow-server-administrators-to-disable-the-book-size.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Anthony J. Halliday" <hallidaj@clarkson.edu>
+Date: Fri, 26 Apr 2024 16:11:27 -0400
+Subject: [PATCH] Allow server administrators to disable the book size check by
+ setting page-max to -1 in paper-global.yml
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index fe2ef36ab5dc4b933abf24dbfd0e811c53239cf0..8a9d4397c36165f125cbe128e17c98f759a8aa1c 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1136,7 +1136,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+     @Override
+     public void handleEditBook(ServerboundEditBookPacket packet) {
+         // Paper start - Book size limits
+-        if (!this.cserver.isPrimaryThread()) {
++        if (!this.cserver.isPrimaryThread() && io.papermc.paper.configuration.GlobalConfiguration.get().itemValidation.bookSize.pageMax != -1) {
+             List<String> pageList = packet.getPages();
+             long byteTotal = 0;
+             int maxBookPageSize = io.papermc.paper.configuration.GlobalConfiguration.get().itemValidation.bookSize.pageMax;


### PR DESCRIPTION
I run a small Minecraft server, and we've been running into issues with the book size check. After struggling to find a suitable configuration, I've made this patch, which allows an admin to disable the book size check by setting page-max in paper-global.yml to -1. This should also fix issue #10354.