### PR TITLE
Revert to vanilla handling of LivingEntity#actuallyHurt

### DIFF
--- a/patches/server/0008-CB-fixes.patch
+++ b/patches/server/0008-CB-fixes.patch
@@ -29,28 +29,6 @@ index cc5e1076bdf7b4794ee79934fb70234ba61efe15..b3caf69f9627ba2114dc9d06551ccf18
          this.structureManager = new StructureManager(this, this.serverLevelData.worldGenOptions(), this.structureCheck); // CraftBukkit
          if ((this.dimension() == Level.END && this.dimensionTypeRegistration().is(BuiltinDimensionTypes.END)) || env == org.bukkit.World.Environment.THE_END) { // CraftBukkit - Allow to create EnderDragonBattle in default and custom END
              this.dragonFight = new EndDragonFight(this, this.serverLevelData.worldGenOptions().seed(), this.serverLevelData.endDragonFightData()); // CraftBukkit
-diff --git a/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java b/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java
-index 85e0a68d85fe62df19ad9809b1869a3eee6d5465..09aa76ec6f89163c1221721008ccb541eaf420ca 100644
---- a/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java
-+++ b/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java
-@@ -451,15 +451,9 @@ public class Camel extends AbstractHorse implements PlayerRideableJumping, Saddl
-     }
- 
-     @Override
--    // CraftBukkit start - void -> boolean
--    public boolean actuallyHurt(DamageSource damagesource, float f) {
--        boolean hurt = super.actuallyHurt(damagesource, f);
--        if (!hurt) {
--            return hurt;
--        }
--        // CraftBukkit end
-+    public boolean actuallyHurt(DamageSource damagesource, float f) { // Paper - change return type to boolean
-         this.standUpInstantly();
--        return hurt; // CraftBukkit
-+        return super.actuallyHurt(damagesource, f); // Paper - change return type to boolean
-     }
- 
-     @Override
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/structure/StructureCheck.java b/src/main/java/net/minecraft/world/level/levelgen/structure/StructureCheck.java
 index 0dc7f88877020bddd5a84db51d349f52b673048e..aae73586265593ee7830fb8dd5c2e3d7560057f0 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/structure/StructureCheck.java

--- a/patches/server/0758-Missing-eating-regain-reason.patch
+++ b/patches/server/0758-Missing-eating-regain-reason.patch
@@ -18,7 +18,7 @@ index 118be62539bb0266c2e89bd68abbc4a975fcd833..07559b9629d4ecb40b511256f400a781
  
                      return InteractionResult.sidedSuccess(this.level().isClientSide());
 diff --git a/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java b/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java
-index 09aa76ec6f89163c1221721008ccb541eaf420ca..f3fcfd3b358f496d26748099e1d5a95721a6a0d8 100644
+index 85e0a68d85fe62df19ad9809b1869a3eee6d5465..bc346a6ab6aaa7de363e058d1065fd147b571a57 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java
 @@ -383,7 +383,7 @@ public class Camel extends AbstractHorse implements PlayerRideableJumping, Saddl

--- a/patches/server/0779-Add-EntityToggleSitEvent.patch
+++ b/patches/server/0779-Add-EntityToggleSitEvent.patch
@@ -69,10 +69,10 @@ index 83d8a09980c4ab3c7c97b07c3dcdb3d7dab9e1aa..0440fd2d1bb3f87641ad88de6d5ae646
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java b/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java
-index f3fcfd3b358f496d26748099e1d5a95721a6a0d8..33531cbdd9b2a5607092d2364ce5655a63c2361c 100644
+index bc346a6ab6aaa7de363e058d1065fd147b571a57..8ebe18a1abbac81094e6aab19ba76edc0255e3b7 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java
-@@ -560,7 +560,7 @@ public class Camel extends AbstractHorse implements PlayerRideableJumping, Saddl
+@@ -566,7 +566,7 @@ public class Camel extends AbstractHorse implements PlayerRideableJumping, Saddl
      }
  
      public void sitDown() {
@@ -81,7 +81,7 @@ index f3fcfd3b358f496d26748099e1d5a95721a6a0d8..33531cbdd9b2a5607092d2364ce5655a
              this.makeSound(SoundEvents.CAMEL_SIT);
              this.setPose(Pose.SITTING);
              this.gameEvent(GameEvent.ENTITY_ACTION);
-@@ -569,7 +569,7 @@ public class Camel extends AbstractHorse implements PlayerRideableJumping, Saddl
+@@ -575,7 +575,7 @@ public class Camel extends AbstractHorse implements PlayerRideableJumping, Saddl
      }
  
      public void standUp() {
@@ -90,7 +90,7 @@ index f3fcfd3b358f496d26748099e1d5a95721a6a0d8..33531cbdd9b2a5607092d2364ce5655a
              this.makeSound(SoundEvents.CAMEL_STAND);
              this.setPose(Pose.STANDING);
              this.gameEvent(GameEvent.ENTITY_ACTION);
-@@ -578,6 +578,7 @@ public class Camel extends AbstractHorse implements PlayerRideableJumping, Saddl
+@@ -584,6 +584,7 @@ public class Camel extends AbstractHorse implements PlayerRideableJumping, Saddl
      }
  
      public void standUpInstantly() {

--- a/patches/server/0931-Fix-several-issues-with-EntityBreedEvent.patch
+++ b/patches/server/0931-Fix-several-issues-with-EntityBreedEvent.patch
@@ -69,7 +69,7 @@ index 0440fd2d1bb3f87641ad88de6d5ae64617536a6d..db60b91c2b26ca8cdb66e05deab7742f
                  if (this.level().isClientSide || this.isSitting() || this.isInWater()) {
                      return InteractionResult.PASS;
 diff --git a/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java b/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java
-index 33531cbdd9b2a5607092d2364ce5655a63c2361c..9229948c90e278cbdacd0f82689144c8dc50956f 100644
+index 8ebe18a1abbac81094e6aab19ba76edc0255e3b7..4eb26874f21726bbc6e6ad78bfaf4ecd268c7246 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/camel/Camel.java
 @@ -389,7 +389,7 @@ public class Camel extends AbstractHorse implements PlayerRideableJumping, Saddl

--- a/patches/server/1044-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
+++ b/patches/server/1044-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 27 Apr 2024 09:44:53 -0700
+Subject: [PATCH] Revert to vanilla handling of LivingEntity#actuallyHurt
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index e0124e44e1abe8237859e8dc1e357298188dab52..dc974514ad54a4afc80b6f222ddd770c95cb6278 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -2220,7 +2220,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+     }
+ 
+     // CraftBukkit start
+-    protected boolean actuallyHurt(final DamageSource damagesource, float f) { // void -> boolean, add final
++    protected boolean actuallyHurt(final DamageSource damagesource, float f) { // void -> boolean, add final // Paper - return false ONLY if event cancelled
+        if (!this.isInvulnerableTo(damagesource)) {
+             final boolean human = this instanceof net.minecraft.world.entity.player.Player;
+             float originalDamage = f;
+@@ -2390,14 +2390,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+                         CriteriaTriggers.PLAYER_HURT_ENTITY.trigger((ServerPlayer) damagesource.getEntity(), this, damagesource, originalDamage, f, true); // Paper - fix taken/dealt param order
+                     }
+ 
+-                    return false;
++                    return true; // Paper - return false ONLY if event was cancelled
+                 } else {
+-                    return originalDamage > 0;
++                    return originalDamage > 0 || true; // Paper - return false ONLY if event was cancelled
+                 }
+                 // CraftBukkit end
+             }
+         }
+-        return false; // CraftBukkit
++        return true; // CraftBukkit // Paper - return false ONLY if event was cancelled
+     }
+ 
+     public CombatTracker getCombatTracker() {


### PR DESCRIPTION
`LivingEntity#actuallyHurt` should **only** return `false` when the damage event is cancelled which then prevents logic in `actuallyHurt`'s overrides from running. If the entity is invulnerable to the damage source or no damage happens for some other reason, the logic in the overrides should still be executed.