### PR TITLE
Fix the incorrect codec usage in the Style convert

### DIFF
--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -1157,7 +1157,7 @@ index 0000000000000000000000000000000000000000..2fd6c3e65354071af71c7d8ebb97b559
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..cb9f8567ba6aae41a6cde519ac0cff0169a7cea7
+index 0000000000000000000000000000000000000000..fc6e13e4f2408ccbfa645eae2d7ebf4dcfc21908
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 @@ -0,0 +1,478 @@
@@ -1624,7 +1624,7 @@ index 0000000000000000000000000000000000000000..cb9f8567ba6aae41a6cde519ac0cff01
 +    public static net.minecraft.network.chat.Style asVanilla(final Style style) {
 +        final RegistryOps<Object> ops = RegistryOps.create(JavaOps.INSTANCE, CraftRegistry.getMinecraftRegistry());
 +        final Object encoded = AdventureCodecs.STYLE_MAP_CODEC.codec()
-+            .parse(ops, style).getOrThrow(IllegalStateException::new);
++            .encodeStart(ops, style).getOrThrow(IllegalStateException::new);
 +
 +        return net.minecraft.network.chat.Style.Serializer.CODEC
 +            .parse(ops, encoded).getOrThrow(IllegalStateException::new);
@@ -1633,7 +1633,7 @@ index 0000000000000000000000000000000000000000..cb9f8567ba6aae41a6cde519ac0cff01
 +    public static Style asAdventure(final net.minecraft.network.chat.Style style) {
 +        final RegistryOps<Object> ops = RegistryOps.create(JavaOps.INSTANCE, CraftRegistry.getMinecraftRegistry());
 +        final Object encoded = net.minecraft.network.chat.Style.Serializer.CODEC
-+            .parse(ops, style).getOrThrow(IllegalStateException::new);
++            .encodeStart(ops, style).getOrThrow(IllegalStateException::new);
 +
 +        return AdventureCodecs.STYLE_MAP_CODEC.codec()
 +            .parse(ops, encoded).getOrThrow(IllegalStateException::new);


### PR DESCRIPTION
https://github.com/PaperMC/Paper/commit/1444b3632e68ceb2e258e9cf733493a26a81d0ae#r141429072

### How to reproduce it 
```java
final Scoreboard scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
final Objective objective = scoreboard.registerNewObjective("test", Criteria.DUMMY, Component.empty());
objective.numberFormat(NumberFormat.styled(Style.style().color(NamedTextColor.BLUE).build())); // call asVanilla
objective.numberFormat(); // call asAdventure
```
```
Caused by: java.lang.IllegalStateException: Not a map: StyleImpl{obfuscated=not_set, bold=not_set, strikethrough=not_set, underlined=not_set, italic=not_set, color=NamedTextColor{name="blue", value="#5555ff"}, clickEvent=null, hoverEvent=null, insertion=null, font=null}
	at com.mojang.serialization.DataResult$Error.getOrThrow(DataResult.java:275) ~[datafixerupper-7.0.14.jar:?]
	at io.papermc.paper.adventure.PaperAdventure.asVanilla(PaperAdventure.java:466) ~[includeMappings.jar:git-Paper-"f187fd6"]
	at io.papermc.paper.util.PaperScoreboardFormat.asVanilla(PaperScoreboardFormat.java:14) ~[includeMappings.jar:git-Paper-"f187fd6"]
```