### PR TITLE
feat: add damage check for mending

### DIFF
--- a/patches/server/0167-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0167-Ability-to-apply-mending-to-XP-API.patch
@@ -14,7 +14,7 @@ public net.minecraft.world.entity.ExperienceOrb durabilityToXp(I)I
 public net.minecraft.world.entity.ExperienceOrb xpToDurability(I)I
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7e1f6e23980f12786abaa4218d8d77dd1a8feb3c..791b655890ce5b144f8649f687945c17a390ce76 100644
+index 7e1f6e23980f12786abaa4218d8d77dd1a8feb3c..96277af4b3c1ebe081bf4aa42c7b78f1f084cbd6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1624,7 +1624,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -27,7 +27,7 @@ index 7e1f6e23980f12786abaa4218d8d77dd1a8feb3c..791b655890ce5b144f8649f687945c17
 +        ServerPlayer handle = this.getHandle();
 +        // Logic copied from EntityExperienceOrb and remapped to unobfuscated methods/properties
 +        final var stackEntry = net.minecraft.world.item.enchantment.EnchantmentHelper
-+            .getRandomItemWith(net.minecraft.world.item.enchantment.Enchantments.MENDING, handle);
++            .getRandomItemWith(net.minecraft.world.item.enchantment.Enchantments.MENDING, handle, net.minecraft.world.item.ItemStack::isDamaged);
 +        final net.minecraft.world.item.ItemStack itemstack = stackEntry != null ? stackEntry.getValue() : net.minecraft.world.item.ItemStack.EMPTY;
 +        if (!itemstack.isEmpty() && itemstack.getItem().components().has(net.minecraft.core.component.DataComponents.MAX_DAMAGE)) {
 +            net.minecraft.world.entity.ExperienceOrb orb = net.minecraft.world.entity.EntityType.EXPERIENCE_ORB.create(handle.level());


### PR DESCRIPTION
Previously the call to `getRandomItemWith()` was missing the filter for damaged items. This would result in items with full durability being selected for mending.