### PR TITLE
Add EquipmentSlot#getOppositeHand

### DIFF
--- a/patches/api/0376-Add-EquipmentSlot-convenience-methods.patch
+++ b/patches/api/0376-Add-EquipmentSlot-convenience-methods.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add EquipmentSlot convenience methods
 
 
 diff --git a/src/main/java/org/bukkit/inventory/EquipmentSlot.java b/src/main/java/org/bukkit/inventory/EquipmentSlot.java
-index 5642d8af60b6649497aba9b0f6ab7bba7702b9ee..adf0a94f98eb66b3957d4009d83ad5f741e0aa79 100644
+index 5642d8af60b6649497aba9b0f6ab7bba7702b9ee..a10d56b797e58b56bd4cef6de40691f7eac9b5b1 100644
 --- a/src/main/java/org/bukkit/inventory/EquipmentSlot.java
 +++ b/src/main/java/org/bukkit/inventory/EquipmentSlot.java
-@@ -33,4 +33,27 @@ public enum EquipmentSlot {
+@@ -33,4 +33,42 @@ public enum EquipmentSlot {
      public EquipmentSlotGroup getGroup() {
          return group.get();
      }
@@ -21,6 +21,21 @@ index 5642d8af60b6649497aba9b0f6ab7bba7702b9ee..adf0a94f98eb66b3957d4009d83ad5f7
 +     */
 +    public boolean isHand() {
 +        return this == HAND || this == OFF_HAND;
++    }
++
++    /**
++     * Gets the opposite hand
++     *
++     * @return the opposite hand
++     * @throws IllegalArgumentException if this equipment slot is not a hand
++     * @see #isHand()
++     */
++    public @NotNull EquipmentSlot getOppositeHand() {
++        return switch (this) {
++            case HAND -> OFF_HAND;
++            case OFF_HAND -> HAND;
++            default -> throw new IllegalArgumentException("Unable to determine an opposite hand for equipment slot: " + name());
++        };
 +    }
 +
 +    /**


### PR DESCRIPTION
Adds convenience method to get an opposite hand.
Allows this:
```java
EquipmentSlot oppositeHand = hand.getOppositeHand();
```
Instead of this:
```java
var oppositeHand = hand == EquipmentSlot.HAND ? EquipmentSlot.OFF_HAND : EquipmentSlot.HAND;
``` 