### PR TITLE
Expose #hasColor to leather armor

### DIFF
--- a/patches/api/0056-Fix-upstream-javadocs.patch
+++ b/patches/api/0056-Fix-upstream-javadocs.patch
@@ -1449,6 +1449,21 @@ index 18c2864c99d4dfae16cdb35143486aeebb9a6fd6..d66857825528ee772219440dffa28ad8
       * {@link EquipmentSlot} will be returned. This is because
       * AttributeModifiers without a slot are active in any slot.<br>
       * If there are no attributes set for the given slot, an empty map
+diff --git a/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java b/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
+index c1676991c3cc5f8d6e3f97d8cb356d6e2aa52809..4eadbcf766e69459c036a28f6e43523170558308 100644
+--- a/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
+@@ -8,8 +8,8 @@ import org.jetbrains.annotations.Nullable;
+ 
+ /**
+  * Represents leather armor ({@link Material#LEATHER_BOOTS}, {@link
+- * Material#LEATHER_CHESTPLATE}, {@link Material#LEATHER_HELMET}, or {@link
+- * Material#LEATHER_LEGGINGS}) that can be colored.
++ * Material#LEATHER_LEGGINGS}, {@link Material#LEATHER_CHESTPLATE}, {@link
++ * Material#LEATHER_HELMET}, or {@link Material#LEATHER_HORSE_ARMOR}) that can be colored.
+  */
+ public interface LeatherArmorMeta extends ItemMeta {
+ 
 diff --git a/src/main/java/org/bukkit/scoreboard/Objective.java b/src/main/java/org/bukkit/scoreboard/Objective.java
 index 22b1dc5fd4d453161a5ee520072f8e8f955b3a80..a625bcab8e77b05b3341a52c708fae1542b7e3d5 100644
 --- a/src/main/java/org/bukkit/scoreboard/Objective.java

--- a/patches/api/0475-Expose-hasColor-to-leather-armor.patch
+++ b/patches/api/0475-Expose-hasColor-to-leather-armor.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SoSeDiK <mrsosedik@gmail.com>
+Date: Wed, 1 May 2024 10:58:50 +0300
+Subject: [PATCH] Expose #hasColor to leather armor
+
+
+diff --git a/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java b/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
+index 4eadbcf766e69459c036a28f6e43523170558308..c933fae0fb87f3a58e8f549e8870fba436288fa8 100644
+--- a/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
+@@ -33,4 +33,14 @@ public interface LeatherArmorMeta extends ItemMeta {
+     @Override
+     @NotNull
+     LeatherArmorMeta clone();
++
++    // Paper start - Expose #hasColor to leather armor
++    /**
++     * Checks whether this leather armor is dyed
++     * (i.e. has a color different from {@link ItemFactory#getDefaultLeatherColor()})
++     *
++     * @return whether this leather armor is dyed
++     */
++    boolean isDyed();
++    // Paper end - Expose #hasColor to leather armor
+ }

--- a/patches/server/1045-Expose-hasColor-to-leather-armor.patch
+++ b/patches/server/1045-Expose-hasColor-to-leather-armor.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SoSeDiK <mrsosedik@gmail.com>
+Date: Wed, 1 May 2024 10:58:50 +0300
+Subject: [PATCH] Expose #hasColor to leather armor
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java
+index 2c9ca54267579a210d4ea192517fc0fbce8e467a..ae94d09b8e0cac77db6a11f85890ff0fb51236f0 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java
+@@ -116,4 +116,11 @@ public class CraftMetaColorableArmor extends CraftMetaArmor implements Colorable
+         }
+         return original != hash ? CraftMetaColorableArmor.class.hashCode() ^ hash : hash;
+     }
++
++    // Paper start - Expose #hasColor to leather armor
++    @Override
++    public boolean isDyed() {
++        return hasColor();
++    }
++    // Paper end - Expose #hasColor to leather armor
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaLeatherArmor.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaLeatherArmor.java
+index 157a7b7351f48e68d2923c72ed3bbe3dcae21383..0368b2a557d3ee5d83474311fbd561480f9e8a2f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaLeatherArmor.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaLeatherArmor.java
+@@ -162,4 +162,11 @@ class CraftMetaLeatherArmor extends CraftMetaItem implements LeatherArmorMeta {
+             builder.put(CraftMetaLeatherArmor.COLOR.BUKKIT, meta.getColor());
+         }
+     }
++
++    // Paper start - Expose #hasColor to leather armor
++    @Override
++    public boolean isDyed() {
++        return hasColor();
++    }
++    // Paper end - Expose #hasColor to leather armor
+ }


### PR DESCRIPTION
`#hasColor` makes little sense in API context since leather armor always has a color, hence `#isDyed`

Fixed a missing leather horse armor in javadoc alongside