### PR TITLE
Updated Upstream (CraftBukkit)

### DIFF
--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -5141,10 +5141,10 @@ index 9c57b883783145ad4483481a2c2e7f0f188cd174..b653c2c80e8e8524ea6d7625c6a86f82
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 64c039bd3b248bd508a2c298032fa9f984b37694..9a22459f15cff45a234c1d497aca27a5433570f7 100644
+index 8abb72c2c38d9b28be6c4e6cfd502371eb3a27ed..899995f30b54db93a4f44313384b316825693e36 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -850,6 +850,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -853,6 +853,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasDamage() || this.hasMaxDamage() || this.hasAttributeModifiers() || this.customTag != null);
      }
  
@@ -5163,7 +5163,7 @@ index 64c039bd3b248bd508a2c298032fa9f984b37694..9a22459f15cff45a234c1d497aca27a5
      @Override
      public String getDisplayName() {
          return CraftChatMessage.fromComponent(this.displayName);
-@@ -880,6 +892,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -883,6 +895,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.itemName != null;
      }
  
@@ -5182,7 +5182,7 @@ index 64c039bd3b248bd508a2c298032fa9f984b37694..9a22459f15cff45a234c1d497aca27a5
      @Override
      public String getLocalizedName() {
          return this.getDisplayName();
-@@ -899,6 +923,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -902,6 +926,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.lore != null && !this.lore.isEmpty();
      }
  

--- a/patches/server/0021-Hook-into-CB-plugin-rewrites.patch
+++ b/patches/server/0021-Hook-into-CB-plugin-rewrites.patch
@@ -8,7 +8,7 @@ our own relocation. Also lets us rewrite NMS calls for when we're
 debugging in an IDE pre-relocate.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 2b0cf967e382e982200d73857b08c0f01a4e409c..8420a53672cfb0f060d9c85c445d200b6701f521 100644
+index 6f89eebc326c0dec6d18b0ca4ced3a1bb70ada55..3d3d77d66588aaf709a9f7688400ee661e181b4b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 @@ -7,6 +7,7 @@ import java.io.InputStream;
@@ -118,7 +118,7 @@ index 2b0cf967e382e982200d73857b08c0f01a4e409c..8420a53672cfb0f060d9c85c445d200b
                          name = FieldRename.rename(pluginVersion, owner, name);
  
                          if (modern) {
-@@ -305,6 +381,13 @@ public class Commodore {
+@@ -297,6 +373,13 @@ public class Commodore {
                              return;
                          }
  
@@ -132,7 +132,7 @@ index 2b0cf967e382e982200d73857b08c0f01a4e409c..8420a53672cfb0f060d9c85c445d200b
                          if (modern) {
                              if (owner.equals("org/bukkit/Material") || (instantiatedMethodType != null && instantiatedMethodType.getDescriptor().startsWith("(Lorg/bukkit/Material;)"))) {
                                  switch (name) {
-@@ -408,6 +491,13 @@ public class Commodore {
+@@ -400,6 +483,13 @@ public class Commodore {
  
                      @Override
                      public void visitLdcInsn(Object value) {
@@ -146,7 +146,7 @@ index 2b0cf967e382e982200d73857b08c0f01a4e409c..8420a53672cfb0f060d9c85c445d200b
                          if (value instanceof String && ((String) value).equals("com.mysql.jdbc.Driver")) {
                              super.visitLdcInsn("com.mysql.cj.jdbc.Driver");
                              return;
-@@ -418,6 +508,14 @@ public class Commodore {
+@@ -410,6 +500,14 @@ public class Commodore {
  
                      @Override
                      public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
@@ -161,7 +161,7 @@ index 2b0cf967e382e982200d73857b08c0f01a4e409c..8420a53672cfb0f060d9c85c445d200b
                          if (bootstrapMethodHandle.getOwner().equals("java/lang/invoke/LambdaMetafactory")
                                  && bootstrapMethodHandle.getName().equals("metafactory") && bootstrapMethodArguments.length == 3) {
                              Type samMethodType = (Type) bootstrapMethodArguments[0];
-@@ -434,7 +532,7 @@ public class Commodore {
+@@ -426,7 +524,7 @@ public class Commodore {
                                  methodArgs.add(new Handle(newOpcode, newOwner, newName, newDescription, newItf));
                                  methodArgs.add(newInstantiated);
  
@@ -170,7 +170,7 @@ index 2b0cf967e382e982200d73857b08c0f01a4e409c..8420a53672cfb0f060d9c85c445d200b
                              }, implMethod.getTag(), implMethod.getOwner(), implMethod.getName(), implMethod.getDesc(), implMethod.isInterface(), samMethodType, instantiatedMethodType);
                              return;
                          }
-@@ -485,6 +583,12 @@ public class Commodore {
+@@ -477,6 +575,12 @@ public class Commodore {
  
              @Override
              public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {

--- a/patches/server/0027-Support-components-in-ItemMeta.patch
+++ b/patches/server/0027-Support-components-in-ItemMeta.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 9a22459f15cff45a234c1d497aca27a5433570f7..9c139f25eaef3c1b93fbf254cb08c6a449288ec8 100644
+index 899995f30b54db93a4f44313384b316825693e36..3f309c255097f6778854d710a5a045fa960a953f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -867,11 +867,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -870,11 +870,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return CraftChatMessage.fromComponent(this.displayName);
      }
  
@@ -32,7 +32,7 @@ index 9a22459f15cff45a234c1d497aca27a5433570f7..9c139f25eaef3c1b93fbf254cb08c6a4
      @Override
      public boolean hasDisplayName() {
          return this.displayName != null;
-@@ -1045,6 +1057,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1048,6 +1060,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.lore == null ? null : new ArrayList<String>(Lists.transform(this.lore, CraftChatMessage::fromComponent));
      }
  
@@ -47,7 +47,7 @@ index 9a22459f15cff45a234c1d497aca27a5433570f7..9c139f25eaef3c1b93fbf254cb08c6a4
      @Override
      public void setLore(List<String> lore) {
          if (lore == null || lore.isEmpty()) {
-@@ -1059,6 +1079,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1062,6 +1082,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -69,7 +69,7 @@ index 9a22459f15cff45a234c1d497aca27a5433570f7..9c139f25eaef3c1b93fbf254cb08c6a4
      @Override
      public boolean hasCustomModelData() {
          return this.customModelData != null;
-@@ -1682,6 +1717,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1685,6 +1720,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
  
          for (Object object : addFrom) {

--- a/patches/server/0074-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0074-Handle-Item-Meta-Inconsistencies.patch
@@ -150,7 +150,7 @@ index b6521462d193bff83ace1dc694c6d957a7173969..d302767e8f01fdfcba9c22e2e35677af
  
      static Map<Enchantment, Integer> getEnchantments(net.minecraft.world.item.ItemStack item) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 9c139f25eaef3c1b93fbf254cb08c6a449288ec8..0c385b713234a74ceba802f67f74e4ecab93e269 100644
+index 3f309c255097f6778854d710a5a045fa960a953f..c318552a2ac2710cea01ac449a469a0fc61f8161 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
@@ -222,7 +222,7 @@ index 9c139f25eaef3c1b93fbf254cb08c6a449288ec8..0c385b713234a74ceba802f67f74e4ec
          for (Map.Entry<?, ?> entry : ench.entrySet()) {
              // Doctor older enchants
              String enchantKey = entry.getKey().toString();
-@@ -970,14 +973,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -973,14 +976,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public Map<Enchantment, Integer> getEnchants() {
@@ -239,7 +239,7 @@ index 9c139f25eaef3c1b93fbf254cb08c6a449288ec8..0c385b713234a74ceba802f67f74e4ec
          }
  
          if (ignoreRestrictions || level >= ench.getStartLevel() && level <= ench.getMaxLevel()) {
-@@ -1513,7 +1516,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1516,7 +1519,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.customModelData = this.customModelData;
              clone.blockData = this.blockData;
              if (this.enchantments != null) {
@@ -248,7 +248,7 @@ index 9c139f25eaef3c1b93fbf254cb08c6a449288ec8..0c385b713234a74ceba802f67f74e4ec
              }
              if (this.hasAttributeModifiers()) {
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
-@@ -1833,4 +1836,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1836,4 +1839,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
          return (result != null) ? result : Optional.empty();
      }

--- a/patches/server/0164-API-to-get-a-BlockState-without-a-snapshot.patch
+++ b/patches/server/0164-API-to-get-a-BlockState-without-a-snapshot.patch
@@ -13,7 +13,7 @@ also Avoid NPE during CraftBlockEntityState load if could not get TE
 If Tile Entity was null, correct Sign to return empty lines instead of null
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-index 8d281ce2a0e44b97957cea2992e273abc86bd157..d22cc83725cee3df20bb6f99de23aceb62923eef 100644
+index d116d427ed692a9ef7d65e06ebef18012ce22aab..6e24673a793017ee857cf75bf9a74105ce76b773 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 @@ -58,6 +58,7 @@ public abstract class BlockEntity {
@@ -33,7 +33,7 @@ index 8d281ce2a0e44b97957cea2992e273abc86bd157..d22cc83725cee3df20bb6f99de23aceb
  
          net.minecraft.nbt.Tag persistentDataTag = nbt.get("PublicBukkitValues");
          if (persistentDataTag instanceof CompoundTag) {
-@@ -353,8 +354,15 @@ public abstract class BlockEntity {
+@@ -363,8 +364,15 @@ public abstract class BlockEntity {
  
      // CraftBukkit start - add method
      public InventoryHolder getOwner() {
@@ -69,10 +69,10 @@ index a1c1a101aa424e74309f6f4c0a53a6a8db5df441..013298c424025cd88f15d61e50d196f7
      public Biome getBiome() {
          return this.getWorld().getBiome(this.getX(), this.getY(), this.getZ());
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-index 7c613e345234bada75388930afdae1ed96c7beb8..25b7198c0e0afb7a09b1a68f5a53f5c44244cafb 100644
+index f8b5595dc92036cc1889c0835f69389c93501fa7..a7bb7d263cb981fcf6dd35a3b32270e89e96945a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-@@ -22,15 +22,26 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
+@@ -24,15 +24,26 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
  
      private final T tileEntity;
      private final T snapshot;
@@ -101,7 +101,7 @@ index 7c613e345234bada75388930afdae1ed96c7beb8..25b7198c0e0afb7a09b1a68f5a53f5c4
      }
  
      protected CraftBlockEntityState(CraftBlockEntityState<T> state, Location location) {
-@@ -166,4 +177,11 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
+@@ -169,4 +180,11 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
      public CraftBlockEntityState<T> copy(Location location) {
          return new CraftBlockEntityState<>(this, location);
      }
@@ -114,7 +114,7 @@ index 7c613e345234bada75388930afdae1ed96c7beb8..25b7198c0e0afb7a09b1a68f5a53f5c4
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
-index 1cf2d13ac6addcf61168b95aafa936d4b9432f8a..e40973b65ece11d9c5a76abad51f72e610bf02ab 100644
+index 0173a8eac2153d889536e48970f967040490e4b7..83ac5fc6cbbd249b5865ab203b150f53f01c9f05 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
 @@ -387,15 +387,30 @@ public final class CraftBlockStates {

--- a/patches/server/0180-Player.setPlayerProfile-API.patch
+++ b/patches/server/0180-Player.setPlayerProfile-API.patch
@@ -77,7 +77,7 @@ index 818df09e9245b5d89b4180b1eaa51470b7539341..461656e1cb095243bfe7a9ee2906e5b0
  
      public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 791b655890ce5b144f8649f687945c17a390ce76..ea82243ea965ee70ef1f94cb699d9ab262415b7a 100644
+index 96277af4b3c1ebe081bf4aa42c7b78f1f084cbd6..d299e8012a8821b8b797370910039528ab6a2a88 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -247,11 +247,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -220,10 +220,10 @@ index 791b655890ce5b144f8649f687945c17a390ce76..ea82243ea965ee70ef1f94cb699d9ab2
      public void onEntityRemove(Entity entity) {
          this.invertedVisibilityEntities.remove(entity.getUUID());
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index fc04bfcb8b5dfa6d093c8d75b2f20c502ef94a63..07239f25bc927c44a9d17f4796db3a107b8e14e0 100644
+index c6956b9241634e455a520f4fd3bd8c4b5a58eb9d..e8e5ec73f5197249e9ebdec2bf055043d9f04c54 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -378,6 +378,13 @@ public class Commodore {
+@@ -370,6 +370,13 @@ public class Commodore {
                          }
                          // Paper end - Rewrite plugins
  

--- a/patches/server/0299-Show-blockstate-location-if-we-failed-to-read-it.patch
+++ b/patches/server/0299-Show-blockstate-location-if-we-failed-to-read-it.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Show blockstate location if we failed to read it
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-index 25b7198c0e0afb7a09b1a68f5a53f5c44244cafb..89bd200befb65fe33ee049f7a07d5c771c971b13 100644
+index a7bb7d263cb981fcf6dd35a3b32270e89e96945a..92133f16c192f5caf9962a08401ff914550747f8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-@@ -30,6 +30,7 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
+@@ -32,6 +32,7 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
  
          this.tileEntity = tileEntity;
  
@@ -16,7 +16,7 @@ index 25b7198c0e0afb7a09b1a68f5a53f5c44244cafb..89bd200befb65fe33ee049f7a07d5c77
          // Paper start
          this.snapshotDisabled = DISABLE_SNAPSHOT;
          if (DISABLE_SNAPSHOT) {
-@@ -42,6 +43,14 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
+@@ -44,6 +45,14 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
              this.load(this.snapshot);
          }
          // Paper end

--- a/patches/server/0388-Add-BlockStateMeta-clearBlockState.patch
+++ b/patches/server/0388-Add-BlockStateMeta-clearBlockState.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add BlockStateMeta#clearBlockState
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-index 1cd561afe36cd6567109e1f3e858de596a38654d..2e5a347bd15962f6bc466bb29302b1e8fb1c94fa 100644
+index 17ed658bd2afb1c115af2140a987edc84af3bef2..ad2bc225a93fc90661c488252b9139533d5803a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-@@ -317,6 +317,13 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -292,6 +292,13 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
          return this.blockEntityTag != null;
      }
  

--- a/patches/server/0604-Add-more-advancement-API.patch
+++ b/patches/server/0604-Add-more-advancement-API.patch
@@ -164,10 +164,10 @@ index 8ca86852319d7463f60832bc98b825b0b4325995..62ada73302c6b3ce3fb2dcc8c31a1d9c
  
      private final DisplayInfo handle;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 07239f25bc927c44a9d17f4796db3a107b8e14e0..2aa19120010a07f5da70b9275aed8e76687f3894 100644
+index e8e5ec73f5197249e9ebdec2bf055043d9f04c54..cdd0463b31a8d2766eaa15881b3b6f0dcf6e3e4a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -383,6 +383,11 @@ public class Commodore {
+@@ -375,6 +375,11 @@ public class Commodore {
                              super.visitMethodInsn(opcode, owner, name, "()Lcom/destroystokyo/paper/profile/PlayerProfile;", itf);
                              return;
                          }

--- a/patches/server/0605-Add-ItemFactory-getSpawnEgg-API.patch
+++ b/patches/server/0605-Add-ItemFactory-getSpawnEgg-API.patch
@@ -29,10 +29,10 @@ index 46a4518e25a0eaaa99b13e4fb522060974ce4ec2..6b2d2b8397bb95ce6ffd87dc1a2f3292
 +    // Paper end - old getSpawnEgg API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 2aa19120010a07f5da70b9275aed8e76687f3894..fa5cd7d64a52116afbcf47627b31de0b89305f07 100644
+index cdd0463b31a8d2766eaa15881b3b6f0dcf6e3e4a..5c05258ce502a9ff7d6f182f61e3722ec42e9e69 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -390,6 +390,15 @@ public class Commodore {
+@@ -382,6 +382,15 @@ public class Commodore {
                          }
                          // Paper end
  

--- a/patches/server/0641-Fix-upstreams-block-state-factories.patch
+++ b/patches/server/0641-Fix-upstreams-block-state-factories.patch
@@ -13,10 +13,10 @@ the material type of the block at that location.
 public net.minecraft.world.level.block.entity.BlockEntityType validBlocks
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-index d22cc83725cee3df20bb6f99de23aceb62923eef..978125c69b2a9ea465595c7eef10a1aea7ccf26c 100644
+index 6e24673a793017ee857cf75bf9a74105ce76b773..e3c5f99b3ad91a9bb454f9ab95b1ccff0bb7b34c 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-@@ -361,7 +361,7 @@ public abstract class BlockEntity {
+@@ -371,7 +371,7 @@ public abstract class BlockEntity {
          // Paper end
          if (this.level == null) return null;
          org.bukkit.block.Block block = this.level.getWorld().getBlockAt(this.worldPosition.getX(), this.worldPosition.getY(), this.worldPosition.getZ());
@@ -26,10 +26,10 @@ index d22cc83725cee3df20bb6f99de23aceb62923eef..978125c69b2a9ea465595c7eef10a1ae
          if (state instanceof InventoryHolder) return (InventoryHolder) state;
          return null;
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-index 89bd200befb65fe33ee049f7a07d5c771c971b13..f97d47677e13441c0b39eb8d18ebee428ea53ca4 100644
+index 92133f16c192f5caf9962a08401ff914550747f8..397eb1a101bd60f49dbb2fa8eddf28f6f233167f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-@@ -18,7 +18,7 @@ import org.bukkit.persistence.PersistentDataContainer;
+@@ -20,7 +20,7 @@ import org.bukkit.persistence.PersistentDataContainer;
  import org.jetbrains.annotations.NotNull;
  import org.jetbrains.annotations.Nullable;
  
@@ -38,7 +38,7 @@ index 89bd200befb65fe33ee049f7a07d5c771c971b13..f97d47677e13441c0b39eb8d18ebee42
  
      private final T tileEntity;
      private final T snapshot;
-@@ -178,14 +178,10 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
+@@ -181,14 +181,10 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
      }
  
      @Override
@@ -56,7 +56,7 @@ index 89bd200befb65fe33ee049f7a07d5c771c971b13..f97d47677e13441c0b39eb8d18ebee42
      // Paper start
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
-index e40973b65ece11d9c5a76abad51f72e610bf02ab..411c2de93c71e480f95229c882cdf43b8801edc8 100644
+index 83ac5fc6cbbd249b5865ab203b150f53f01c9f05..6a25916aec7c8e0bc5cc18e3e06c6e07e0804380 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
 @@ -22,6 +22,7 @@ import net.minecraft.world.level.block.entity.BeehiveBlockEntity;

--- a/patches/server/0725-Sanitize-sent-BlockEntity-NBT.patch
+++ b/patches/server/0725-Sanitize-sent-BlockEntity-NBT.patch
@@ -30,10 +30,10 @@ index ac900dfdc5c90e9e60d47efa734be8f0a5b20dca..ec1cb034d840633240f2b379b09f7d2f
          }
      }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-index 978125c69b2a9ea465595c7eef10a1aea7ccf26c..30a75492a4b25450c194b4cc44deb665711db5af 100644
+index e3c5f99b3ad91a9bb454f9ab95b1ccff0bb7b34c..d2939e12449ae6b2b57beff7e689a0d39212161d 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-@@ -368,6 +368,14 @@ public abstract class BlockEntity {
+@@ -378,6 +378,14 @@ public abstract class BlockEntity {
      }
      // CraftBukkit end
  

--- a/patches/server/0763-Mitigate-effects-of-WorldCreator-keepSpawnLoaded-ret.patch
+++ b/patches/server/0763-Mitigate-effects-of-WorldCreator-keepSpawnLoaded-ret.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Mitigate effects of WorldCreator#keepSpawnLoaded ret type
 TODO: Remove in 1.21?
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index fa5cd7d64a52116afbcf47627b31de0b89305f07..a815e9f3db30c33d69e7b8b862c84e5849b1bfea 100644
+index 5c05258ce502a9ff7d6f182f61e3722ec42e9e69..b2f58a57906eeea52be1aa9408c5748c8c64213a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -388,6 +388,12 @@ public class Commodore {
+@@ -380,6 +380,12 @@ public class Commodore {
                              super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, runtimeCbPkgPrefix() + "advancement/CraftAdvancement", "getDisplay0", desc, false);
                              return;
                          }

--- a/patches/server/0936-Fix-CraftMetaItem-getAttributeModifier-duplication-c.patch
+++ b/patches/server/0936-Fix-CraftMetaItem-getAttributeModifier-duplication-c.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix CraftMetaItem#getAttributeModifier duplication check
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 0464c7b6cc6cb523fa833c870e4028c3f599ea65..72f60a1308d93eefe73ab8a5a509c08d3ddd1521 100644
+index 1c5e9d142783bf6995941bffa78bdd2da215b4d0..423951d636095de0b0bfcd27a49d69e50be73bc3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1274,7 +1274,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1277,7 +1277,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          Preconditions.checkNotNull(modifier, "AttributeModifier cannot be null");
          this.checkAttributeList();
          for (Map.Entry<Attribute, AttributeModifier> entry : this.attributeModifiers.entries()) {

--- a/patches/server/1033-Deep-clone-nbt-tags-in-PDC.patch
+++ b/patches/server/1033-Deep-clone-nbt-tags-in-PDC.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Deep clone nbt tags in PDC
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index cfb40d9bf093a83c8ae38ffe5c1d17f79528e0c3..a1faf7906f8734149538d52173fcb3401200e594 100644
+index f4ba60ef241a86bbb1879f07083fa24194aa1cbf..cbc4eb0f4614182d77ddcf5e9cdda54618497f2b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -284,7 +284,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -17,7 +17,7 @@ index cfb40d9bf093a83c8ae38ffe5c1d17f79528e0c3..a1faf7906f8734149538d52173fcb340
  
          this.customTag = meta.customTag;
  
-@@ -1524,7 +1524,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1527,7 +1527,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              if (this.customTag != null) {
                  clone.customTag = this.customTag.copy();
              }

--- a/patches/server/1040-Fix-ItemFlags.patch
+++ b/patches/server/1040-Fix-ItemFlags.patch
@@ -33,7 +33,7 @@ index fca0cfba14dd2cc6f24b56eaf269594b2d87fd04..8734f0b777432cd8639094b75a3da1b9
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index dd17d7d88ad43e0c426a7a508709fc8993d3a5c9..58de351fd2a4008296aa87f231396d272a1362c3 100644
+index 46142cd7f488170322dc6fec86a71a0e4f353cf4..ff38f010b0f950e0a0f706e144b54ba245d169f2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -224,6 +224,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -119,7 +119,7 @@ index dd17d7d88ad43e0c426a7a508709fc8993d3a5c9..58de351fd2a4008296aa87f231396d27
          for (Map.Entry<DataComponentType<?>, Optional<?>> e : this.unhandledTags.build().entrySet()) {
              e.getValue().ifPresentOrElse((value) -> {
                  itemTag.builder.set((DataComponentType) e.getKey(), value);
-@@ -859,7 +901,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -862,7 +904,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Overridden
      boolean isEmpty() {
@@ -128,7 +128,7 @@ index dd17d7d88ad43e0c426a7a508709fc8993d3a5c9..58de351fd2a4008296aa87f231396d27
      }
  
      // Paper start
-@@ -1468,6 +1510,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1471,6 +1513,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hasFood() ? that.hasFood() && this.food.equals(that.food) : !that.hasFood())
                  && (this.hasDamage() ? that.hasDamage() && this.damage == that.damage : !that.hasDamage())
                  && (this.hasMaxDamage() ? that.hasMaxDamage() && this.maxDamage.equals(that.maxDamage) : !that.hasMaxDamage())
@@ -137,7 +137,7 @@ index dd17d7d88ad43e0c426a7a508709fc8993d3a5c9..58de351fd2a4008296aa87f231396d27
                  && (this.version == that.version);
      }
  
-@@ -1510,6 +1554,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1513,6 +1557,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          hash = 61 * hash + (this.hasDamage() ? this.damage : 0);
          hash = 61 * hash + (this.hasMaxDamage() ? 1231 : 1237);
          hash = 61 * hash + (this.hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
@@ -146,7 +146,7 @@ index dd17d7d88ad43e0c426a7a508709fc8993d3a5c9..58de351fd2a4008296aa87f231396d27
          hash = 61 * hash + this.version;
          return hash;
      }
-@@ -1547,6 +1593,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1550,6 +1596,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.damage = this.damage;
              clone.maxDamage = this.maxDamage;
              clone.version = this.version;
@@ -161,7 +161,7 @@ index dd17d7d88ad43e0c426a7a508709fc8993d3a5c9..58de351fd2a4008296aa87f231396d27
              return clone;
          } catch (CloneNotSupportedException e) {
              throw new Error(e);
-@@ -1656,6 +1710,16 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1659,6 +1713,16 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              }
          }
  
@@ -178,7 +178,7 @@ index dd17d7d88ad43e0c426a7a508709fc8993d3a5c9..58de351fd2a4008296aa87f231396d27
          if (!this.unhandledTags.isEmpty()) {
              Tag unhandled = DataComponentPatch.CODEC.encodeStart(MinecraftServer.getDefaultRegistryAccess().createSerializationContext(NbtOps.INSTANCE), this.unhandledTags.build()).getOrThrow(IllegalStateException::new);
              try {
-@@ -1666,6 +1730,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1669,6 +1733,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  Logger.getLogger(CraftMetaItem.class.getName()).log(Level.SEVERE, null, ex);
              }
          }
@@ -193,7 +193,7 @@ index dd17d7d88ad43e0c426a7a508709fc8993d3a5c9..58de351fd2a4008296aa87f231396d27
  
          if (!this.persistentDataContainer.isEmpty()) { // Store custom tags, wrapped in their compound
              builder.put(CraftMetaItem.BUKKIT_CUSTOM_TAG.BUKKIT, this.persistentDataContainer.serialize());
-@@ -1807,6 +1879,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1810,6 +1882,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaItem.MAX_DAMAGE.TYPE,
                          CraftMetaItem.CUSTOM_DATA.TYPE,
                          CraftMetaItem.ATTRIBUTES.TYPE,

--- a/patches/server/1043-improve-checking-handled-tags-in-itemmeta.patch
+++ b/patches/server/1043-improve-checking-handled-tags-in-itemmeta.patch
@@ -239,10 +239,10 @@ index 524aadad91c855f6c201999831824f7ce06f9ed6..2d6abecc94683f92da6be26b72ea8296
          getOrEmpty(tag, CraftMetaBanner.PATTERNS).ifPresent((entityTag) -> {
              List<BannerPatternLayers.Layer> patterns = entityTag.layers();
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-index 2e5a347bd15962f6bc466bb29302b1e8fb1c94fa..3b647cb57918ed9d4b54dca718af80d20730c42e 100644
+index ad2bc225a93fc90661c488252b9139533d5803a2..a1e10c14375b81f97e37105df43ab8f13461474c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-@@ -189,8 +189,8 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -161,8 +161,8 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
          this.blockEntityTag = te.blockEntityTag;
      }
  
@@ -404,7 +404,7 @@ index b444bd26d6c3def3494d3cc0520e462408272be3..8e0dd4b7a7a25a8beb27b507047bc48d
          getOrEmpty(tag, CraftMetaFirework.FIREWORKS).ifPresent((fireworks) -> {
              this.power = fireworks.flightDuration();
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 58de351fd2a4008296aa87f231396d272a1362c3..b351ee556b732e7081a7a6157460ade219829f17 100644
+index ff38f010b0f950e0a0f706e144b54ba245d169f2..0bc100430483f88bc7edf17645250b2862ccc1d5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -308,7 +308,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -436,7 +436,7 @@ index 58de351fd2a4008296aa87f231396d272a1362c3..b351ee556b732e7081a7a6157460ade2
                  key.getValue().ifPresentOrElse((value) -> {
                      this.unhandledTags.set((DataComponentType) key.getKey(), value);
                  }, () -> {
-@@ -1856,63 +1863,73 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1859,63 +1866,73 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.version = version;
      }
  

--- a/patches/server/1044-General-ItemMeta-fixes.patch
+++ b/patches/server/1044-General-ItemMeta-fixes.patch
@@ -32,7 +32,7 @@ index 8e2b3dd109dca3089cbce82cd3788874613a3230..893efb2c4a07c33d41e934279dd914a9
      // CraftBukkit end
  
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-index f37858eb18defbf11b2f4fe825ab9416ebbc7210..7963afff4b32a0e46be9bdeb413657718cfc14f5 100644
+index 65170cbb50d8d5030fc5e33b6389c554aec6ae31..6349f2e0a5ba30d250f5ffe43771f325c0999a76 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 @@ -140,6 +140,11 @@ public abstract class BlockEntity {
@@ -48,10 +48,10 @@ index f37858eb18defbf11b2f4fe825ab9416ebbc7210..7963afff4b32a0e46be9bdeb41365771
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-index f97d47677e13441c0b39eb8d18ebee428ea53ca4..a0b7ec67755c5090f24bf9ec81f110c68cd064ca 100644
+index 397eb1a101bd60f49dbb2fa8eddf28f6f233167f..ce10aa64576716f530e69d2281c090cfdba5e18f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-@@ -132,6 +132,15 @@ public abstract class CraftBlockEntityState<T extends BlockEntity> extends Craft
+@@ -135,6 +135,15 @@ public abstract class CraftBlockEntityState<T extends BlockEntity> extends Craft
          return nbt;
      }
  
@@ -116,10 +116,10 @@ index 2d6abecc94683f92da6be26b72ea829663b16d76..6a3b0c7f0cc3ffb17a231383ad103fa7
  
          for (Pattern p : this.patterns) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-index 3b647cb57918ed9d4b54dca718af80d20730c42e..aee276c844b9efc3c16b3f728ef237707011958d 100644
+index a1e10c14375b81f97e37105df43ab8f13461474c..88a48b7bd1ae7381ddd63052b02f03dcc6671411 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-@@ -234,7 +234,15 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -209,7 +209,15 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
          super.applyToItem(tag);
  
          if (this.blockEntityTag != null) {
@@ -243,7 +243,7 @@ index 8e0dd4b7a7a25a8beb27b507047bc48d8227627c..cf5d27ccc2225bac3aa57912f444f95d
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index b351ee556b732e7081a7a6157460ade219829f17..38454fdc978a24a35e685e65e9b41323781c3ead 100644
+index 0bc100430483f88bc7edf17645250b2862ccc1d5..ab23597a099a2785c803e08c93ff9f046a4af677 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -165,9 +165,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -258,7 +258,18 @@ index b351ee556b732e7081a7a6157460ade219829f17..38454fdc978a24a35e685e65e9b41323
  
          <T> Applicator put(ItemMetaKeyType<T> key, T value) {
              this.builder.set(key.TYPE, value);
-@@ -1004,6 +1005,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -880,9 +881,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+ 
+     void applyModifiers(Multimap<Attribute, AttributeModifier> modifiers, CraftMetaItem.Applicator tag) {
+         if (modifiers == null || modifiers.isEmpty()) {
+-            if (this.hasItemFlag(ItemFlag.HIDE_ATTRIBUTES)) {
+-                tag.put(CraftMetaItem.ATTRIBUTES, new ItemAttributeModifiers(Collections.emptyList(), false));
+-            }
++            // Paper - don't save ItemFlag if the underlying data isn't present
+             return;
+         }
+ 
+@@ -1007,6 +1006,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public void lore(final List<? extends net.kyori.adventure.text.Component> lore) {
@@ -266,7 +277,7 @@ index b351ee556b732e7081a7a6157460ade219829f17..38454fdc978a24a35e685e65e9b41323
          this.lore = lore != null ? io.papermc.paper.adventure.PaperAdventure.asVanilla(lore) : null;
      }
      // Paper end
-@@ -1128,6 +1130,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1131,6 +1131,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      // Paper end
      @Override
      public void setLore(List<String> lore) {
@@ -274,7 +285,7 @@ index b351ee556b732e7081a7a6157460ade219829f17..38454fdc978a24a35e685e65e9b41323
          if (lore == null || lore.isEmpty()) {
              this.lore = null;
          } else {
-@@ -1143,6 +1146,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1146,6 +1147,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      // Paper start
      @Override
      public void setLoreComponents(List<net.md_5.bungee.api.chat.BaseComponent[]> lore) {
@@ -282,7 +293,7 @@ index b351ee556b732e7081a7a6157460ade219829f17..38454fdc978a24a35e685e65e9b41323
          if (lore == null) {
              this.lore = null;
          } else {
-@@ -1410,7 +1414,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1413,7 +1415,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public String getAsString() {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

CraftBukkit Changes:
66fd94322 SPIGOT-7652: Remove remap for SPELL_MOB_AMBIENT which no longer exists
ecfa4f973 SPIGOT-7654: ItemStack#isSimilar does not work with empty BlockStateMeta
4460ecc49 SPIGOT-7655: ItemMeta#addItemFlags(ItemFlag.HIDE_ATTRIBUTES) not working when no attribute modifiers set
5d84f48a4 SPIGOT-7653: Update ApiVersion.CURRENT with latest version and include tests