### PR TITLE
Add missing experimental field and annotations

### DIFF
--- a/patches/api/0442-add-missing-Experimental-annotations.patch
+++ b/patches/api/0442-add-missing-Experimental-annotations.patch
@@ -27,7 +27,7 @@ index 6b68c92ec894451d99ded3e3df5965cb31d68ed2..fd5e433f930963c102c9c977523a0036
      public static final FeatureFlag UPDATE_121 = Bukkit.getUnsafe().getFeatureFlag(NamespacedKey.minecraft("update_1_21"));
  }
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 1ca448c9e3a3178663a033617d9414ec085c246a..82d009c0bbe4b3026a535e02d6e0ed20c7bd525d 100644
+index 1ca448c9e3a3178663a033617d9414ec085c246a..7a337fe908915f8ea487a0b9236c511cb07d5e66 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -148,54 +148,67 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
@@ -281,7 +281,19 @@ index 1ca448c9e3a3178663a033617d9414ec085c246a..82d009c0bbe4b3026a535e02d6e0ed20
      MACE(4771, 1, 250),
      ITEM_FRAME(27318),
      GLOW_ITEM_FRAME(26473),
-@@ -3159,8 +3204,10 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+@@ -2938,7 +2983,11 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+     MOJANG_BANNER_PATTERN(11903, 1),
+     GLOBE_BANNER_PATTERN(27753, 1),
+     PIGLIN_BANNER_PATTERN(22028, 1),
++    @MinecraftExperimental(Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     FLOW_BANNER_PATTERN(32683, 1),
++    @MinecraftExperimental(Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     GUSTER_BANNER_PATTERN(27267, 1),
+     GOAT_HORN(28237, 1),
+     /**
+@@ -3159,8 +3208,10 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
      RAISER_ARMOR_TRIM_SMITHING_TEMPLATE(29116),
      HOST_ARMOR_TRIM_SMITHING_TEMPLATE(12165),
      @MinecraftExperimental(Requires.UPDATE_1_21)
@@ -292,7 +304,7 @@ index 1ca448c9e3a3178663a033617d9414ec085c246a..82d009c0bbe4b3026a535e02d6e0ed20
      BOLT_ARMOR_TRIM_SMITHING_TEMPLATE(9698),
      ANGLER_POTTERY_SHERD(9952),
      ARCHER_POTTERY_SHERD(21629),
-@@ -3171,9 +3218,11 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+@@ -3171,9 +3222,11 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
      DANGER_POTTERY_SHERD(30506),
      EXPLORER_POTTERY_SHERD(5124),
      @MinecraftExperimental(Requires.UPDATE_1_21)
@@ -304,7 +316,7 @@ index 1ca448c9e3a3178663a033617d9414ec085c246a..82d009c0bbe4b3026a535e02d6e0ed20
      GUSTER_POTTERY_SHERD(28193),
      HEART_POTTERY_SHERD(17607),
      HEARTBREAK_POTTERY_SHERD(21108),
-@@ -3183,6 +3232,7 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+@@ -3183,6 +3236,7 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
      PLENTY_POTTERY_SHERD(28236),
      PRIZE_POTTERY_SHERD(4341),
      @MinecraftExperimental(Requires.UPDATE_1_21)
@@ -312,7 +324,7 @@ index 1ca448c9e3a3178663a033617d9414ec085c246a..82d009c0bbe4b3026a535e02d6e0ed20
      SCRAPE_POTTERY_SHERD(30034),
      SHEAF_POTTERY_SHERD(23652),
      SHELTER_POTTERY_SHERD(28390),
-@@ -3192,99 +3242,121 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+@@ -3192,99 +3246,121 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
       * BlockData: {@link Waterlogged}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
@@ -486,7 +498,7 @@ index b0ccd263cabe911d43cc13261011b64cacaeb7bb..82d75010cc86bbbbb9c094c2bac5e570
      /**
       * Uses {@link BlockData} as DataType
 diff --git a/src/main/java/org/bukkit/Sound.java b/src/main/java/org/bukkit/Sound.java
-index 375172e05a78611deb3003f780867516cb6cd1a4..7c39a281a38b412a989dbdf3d12e826ee6eda714 100644
+index 375172e05a78611deb3003f780867516cb6cd1a4..e31e7b6624ff9da7bec5d3b0548a4fa38812daca 100644
 --- a/src/main/java/org/bukkit/Sound.java
 +++ b/src/main/java/org/bukkit/Sound.java
 @@ -221,40 +221,56 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
@@ -783,11 +795,11 @@ index 375172e05a78611deb3003f780867516cb6cd1a4..7c39a281a38b412a989dbdf3d12e826e
      ENTITY_WIND_CHARGE_WIND_BURST("entity.wind_charge.wind_burst"),
      ENTITY_WITCH_AMBIENT("entity.witch.ambient"),
      ENTITY_WITCH_CELEBRATE("entity.witch.celebrate"),
-@@ -1547,10 +1629,13 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
+@@ -1546,11 +1628,12 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
+     ENTITY_ZOMBIFIED_PIGLIN_ANGRY("entity.zombified_piglin.angry"),
      ENTITY_ZOMBIFIED_PIGLIN_DEATH("entity.zombified_piglin.death"),
      ENTITY_ZOMBIFIED_PIGLIN_HURT("entity.zombified_piglin.hurt"),
-     @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+-    @MinecraftExperimental(Requires.UPDATE_1_21)
      EVENT_MOB_EFFECT_BAD_OMEN("event.mob_effect.bad_omen"),
      @MinecraftExperimental(Requires.UPDATE_1_21)
 +    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
@@ -797,7 +809,7 @@ index 375172e05a78611deb3003f780867516cb6cd1a4..7c39a281a38b412a989dbdf3d12e826e
      EVENT_MOB_EFFECT_TRIAL_OMEN("event.mob_effect.trial_omen"),
      EVENT_RAID_HORN("event.raid.horn"),
      INTENTIONALLY_EMPTY("intentionally_empty"),
-@@ -1591,8 +1676,14 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
+@@ -1591,8 +1674,14 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
      ITEM_BUCKET_FILL_LAVA("item.bucket.fill_lava"),
      ITEM_BUCKET_FILL_POWDER_SNOW("item.bucket.fill_powder_snow"),
      ITEM_BUCKET_FILL_TADPOLE("item.bucket.fill_tadpole"),
@@ -812,7 +824,7 @@ index 375172e05a78611deb3003f780867516cb6cd1a4..7c39a281a38b412a989dbdf3d12e826e
      ITEM_BUNDLE_REMOVE_ONE("item.bundle.remove_one"),
      ITEM_CHORUS_FRUIT_TELEPORT("item.chorus_fruit.teleport"),
      ITEM_CROP_PLANT("item.crop.plant"),
-@@ -1624,13 +1715,17 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
+@@ -1624,13 +1713,17 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
      ITEM_INK_SAC_USE("item.ink_sac.use"),
      ITEM_LODESTONE_COMPASS_LOCK("item.lodestone_compass.lock"),
      @MinecraftExperimental(Requires.UPDATE_1_21)
@@ -830,7 +842,7 @@ index 375172e05a78611deb3003f780867516cb6cd1a4..7c39a281a38b412a989dbdf3d12e826e
      ITEM_OMINOUS_BOTTLE_DISPOSE("item.ominous_bottle.dispose"),
      ITEM_SHIELD_BLOCK("item.shield.block"),
      ITEM_SHIELD_BREAK("item.shield.break"),
-@@ -1647,12 +1742,16 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
+@@ -1647,12 +1740,16 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
      ITEM_TRIDENT_THROW("item.trident.throw"),
      ITEM_TRIDENT_THUNDER("item.trident.thunder"),
      @MinecraftExperimental(Requires.UPDATE_1_21)
@@ -848,25 +860,107 @@ index 375172e05a78611deb3003f780867516cb6cd1a4..7c39a281a38b412a989dbdf3d12e826e
      MUSIC_CREATIVE("music.creative"),
      MUSIC_CREDITS("music.credits"),
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index cb5890e0e7bccfee2ba32dd4776f1ae1fdd539e8..511980c6d190fb80e23d0015dee5ee170bb673ac 100644
+index cb5890e0e7bccfee2ba32dd4776f1ae1fdd539e8..5ec7f1cae36189989db0a66ee05c22035e7daf7c 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -1234,6 +1234,7 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -770,6 +770,8 @@ public interface Tag<T extends Keyed> extends Keyed {
+     /**
+      * Vanilla block tag representing all blocks which block wind charge explosions.
+      */
++    @MinecraftExperimental(MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     Tag<Material> BLOCKS_WIND_CHARGE_EXPLOSIONS = Bukkit.getTag(REGISTRY_BLOCKS, NamespacedKey.minecraft("blocks_wind_charge_explosions"), Material.class);
+     /**
+      * Vanilla block tag representing solid blocks which do not block hopper operation.
+@@ -1141,6 +1143,8 @@ public interface Tag<T extends Keyed> extends Keyed {
+     /**
+      * Vanilla item tag representing all items enchantable with mace enchantments.
+      */
++    @MinecraftExperimental(MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     Tag<Material> ITEMS_ENCHANTABLE_MACE = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("enchantable/mace"), Material.class);
+     /**
+      * Vanilla item tag representing all items that confer freeze immunity on
+@@ -1234,6 +1238,8 @@ public interface Tag<T extends Keyed> extends Keyed {
      /**
       * Vanilla tag representing entities which deflect projectiles.
       */
-+    @org.jetbrains.annotations.ApiStatus.Experimental @MinecraftExperimental(value = MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @MinecraftExperimental(MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
      Tag<EntityType> ENTITY_TYPES_DEFLECTS_PROJECTILES = Bukkit.getTag(REGISTRY_ENTITY_TYPES, NamespacedKey.minecraft("deflects_projectiles"), EntityType.class);
      /**
       * Vanilla tag representing entities which deflect arrows.
-@@ -1244,6 +1245,7 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -1244,6 +1250,8 @@ public interface Tag<T extends Keyed> extends Keyed {
      /**
       * Vanilla tag representing entities which can turn in boats.
       */
-+    @org.jetbrains.annotations.ApiStatus.Experimental @MinecraftExperimental(value = MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @MinecraftExperimental(MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
      Tag<EntityType> ENTITY_TYPES_CAN_TURN_IN_BOATS = Bukkit.getTag(REGISTRY_ENTITY_TYPES, NamespacedKey.minecraft("can_turn_in_boats"), EntityType.class);
      /**
       * Vanilla tag representing all entities sensitive to illager enchantments.
+@@ -1292,14 +1300,20 @@ public interface Tag<T extends Keyed> extends Keyed {
+     /**
+      * Vanilla tag representing all entities which do not receive anger from wind charges.
+      */
++    @MinecraftExperimental(MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     Tag<EntityType> ENTITY_TYPES_NO_ANGER_FROM_WIND_CHARGE = Bukkit.getTag(REGISTRY_ENTITY_TYPES, NamespacedKey.minecraft("no_anger_from_wind_charge"), EntityType.class);
+     /**
+      * Vanilla tag representing all entities which are immune from the oozing effect.
+      */
++    @MinecraftExperimental(MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     Tag<EntityType> ENTITY_TYPES_IMMUNE_TO_OOZING = Bukkit.getTag(REGISTRY_ENTITY_TYPES, NamespacedKey.minecraft("immune_to_oozing"), EntityType.class);
+     /**
+      * Vanilla tag representing all entities which are immune from the infested effect.
+      */
++    @MinecraftExperimental(MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     Tag<EntityType> ENTITY_TYPES_IMMUNE_TO_INFESTED = Bukkit.getTag(REGISTRY_ENTITY_TYPES, NamespacedKey.minecraft("immune_to_infested"), EntityType.class);
+     /**
+      * Vanilla tag representing all projectiles which can be punched back.
+diff --git a/src/main/java/org/bukkit/block/banner/PatternType.java b/src/main/java/org/bukkit/block/banner/PatternType.java
+index db7723e2907525850f8dbd2bd7150c1e47ebf1c8..9951cf6780ae47649625b8fe0ed72d87ad0417b2 100644
+--- a/src/main/java/org/bukkit/block/banner/PatternType.java
++++ b/src/main/java/org/bukkit/block/banner/PatternType.java
+@@ -54,8 +54,10 @@ public enum PatternType implements Keyed {
+     GLOBE("glb", "globe"),
+     PIGLIN("pig", "piglin"),
+     @MinecraftExperimental(Requires.UPDATE_1_21)
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     FLOW("flw", "flow"),
+     @MinecraftExperimental(Requires.UPDATE_1_21)
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     GUSTER("gus", "guster");
+ 
+     private final String identifier;
+diff --git a/src/main/java/org/bukkit/enchantments/Enchantment.java b/src/main/java/org/bukkit/enchantments/Enchantment.java
+index de616cecaeb45018d96685c916532188e369bdd4..48a01a1eb80475adf9b181e9bd81535e9faec233 100644
+--- a/src/main/java/org/bukkit/enchantments/Enchantment.java
++++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
+@@ -198,18 +198,21 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
+      * Increases fall damage of maces
+      */
+     @MinecraftExperimental(Requires.UPDATE_1_21)
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     public static final Enchantment DENSITY = getEnchantment("density");
+ 
+     /**
+      * Reduces armor effectiveness against maces
+      */
+     @MinecraftExperimental(Requires.UPDATE_1_21)
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     public static final Enchantment BREACH = getEnchantment("breach");
+ 
+     /**
+      * Emits wind burst upon hitting enemy
+      */
+     @MinecraftExperimental(Requires.UPDATE_1_21)
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     public static final Enchantment WIND_BURST = getEnchantment("wind_burst");
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/generator/structure/Structure.java b/src/main/java/org/bukkit/generator/structure/Structure.java
 index b670ff8b2bfcaa59c2292211cb9fc2bf4c5b2642..94092a5882180cca7905388184de1f91633f0df1 100644
 --- a/src/main/java/org/bukkit/generator/structure/Structure.java
@@ -879,6 +973,25 @@ index b670ff8b2bfcaa59c2292211cb9fc2bf4c5b2642..94092a5882180cca7905388184de1f91
      public static final Structure TRIAL_CHAMBERS = getStructure("trial_chambers");
  
      private static Structure getStructure(String name) {
+diff --git a/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java b/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
+index f2242ddc4085f7e7cdd748d860857822e3d9b007..9133a889c1936b4cf7dbf17f744ee926d57362a3 100644
+--- a/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
++++ b/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
+@@ -78,10 +78,14 @@ public interface TrimPattern extends Keyed, Translatable {
+     /**
+      * {@link Material#FLOW_ARMOR_TRIM_SMITHING_TEMPLATE}.
+      */
++    @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     public static final TrimPattern FLOW = Registry.TRIM_PATTERN.get(NamespacedKey.minecraft("flow"));
+     /**
+      * {@link Material#BOLT_ARMOR_TRIM_SMITHING_TEMPLATE}.
+      */
++    @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     public static final TrimPattern BOLT = Registry.TRIM_PATTERN.get(NamespacedKey.minecraft("bolt"));
+ 
+     // Paper start - adventure
 diff --git a/src/main/java/org/bukkit/loot/LootTables.java b/src/main/java/org/bukkit/loot/LootTables.java
 index 0fc30514375c1700c282d1e92342f7b48ca1cb27..bd625de1103741e592b4111412e4094f4c454f9b 100644
 --- a/src/main/java/org/bukkit/loot/LootTables.java
@@ -968,6 +1081,54 @@ index 0fc30514375c1700c282d1e92342f7b48ca1cb27..bd625de1103741e592b4111412e4094f
      TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS("spawners/trial_chamber/items_to_drop_when_ominous"),
      // Shearing
      SHEARING_BOGGED("shearing/bogged"),
+diff --git a/src/main/java/org/bukkit/potion/PotionEffectType.java b/src/main/java/org/bukkit/potion/PotionEffectType.java
+index e77cf365cefafbeba09123187e70fd5274f10d53..7a7b98d40a031b09d6bc62df32d2ddeb25a9d41e 100644
+--- a/src/main/java/org/bukkit/potion/PotionEffectType.java
++++ b/src/main/java/org/bukkit/potion/PotionEffectType.java
+@@ -192,31 +192,43 @@ public abstract class PotionEffectType implements Keyed, Translatable, net.kyori
+     /**
+      * Causes trial spawners to become ominous.
+      */
++    @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     public static final PotionEffectType TRIAL_OMEN = getPotionEffectType(34, "trial_omen");
+ 
+     /**
+      * Triggers a raid when a player enters a village.
+      */
++    @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     public static final PotionEffectType RAID_OMEN = getPotionEffectType(35, "raid_omen");
+ 
+     /**
+      * Emits a wind burst upon death.
+      */
++    @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     public static final PotionEffectType WIND_CHARGED = getPotionEffectType(36, "wind_charged");
+ 
+     /**
+      * Creates cobwebs upon death.
+      */
++    @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     public static final PotionEffectType WEAVING = getPotionEffectType(37, "weaving");
+ 
+     /**
+      * Causes slimes to spawn upon death.
+      */
++    @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     public static final PotionEffectType OOZING = getPotionEffectType(38, "oozing");
+ 
+     /**
+      * Chance of spawning silverfish when hurt.
+      */
++    @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+     public static final PotionEffectType INFESTED = getPotionEffectType(39, "infested");
+ 
+     @NotNull
 diff --git a/src/main/java/org/bukkit/potion/PotionType.java b/src/main/java/org/bukkit/potion/PotionType.java
 index dabaa58432b91ed120cc5a3a43a8e94110fa84a3..1fdd56450e8a0763833742c805847a723c43bf6c 100644
 --- a/src/main/java/org/bukkit/potion/PotionType.java

--- a/patches/api/0444-Improve-Registry.patch
+++ b/patches/api/0444-Improve-Registry.patch
@@ -98,10 +98,10 @@ index 76b1d08d9ae2c2cf5c6d88934929695d438b3284..542c0516e19b6177ff8007ca6f8955dc
      }
  }
 diff --git a/src/main/java/org/bukkit/block/banner/PatternType.java b/src/main/java/org/bukkit/block/banner/PatternType.java
-index db7723e2907525850f8dbd2bd7150c1e47ebf1c8..1b958b2024ec3f7729605fce70074c5c0208b6cc 100644
+index 9951cf6780ae47649625b8fe0ed72d87ad0417b2..2a245735ac902d55681880dc80b12ddef65c0124 100644
 --- a/src/main/java/org/bukkit/block/banner/PatternType.java
 +++ b/src/main/java/org/bukkit/block/banner/PatternType.java
-@@ -73,6 +73,13 @@ public enum PatternType implements Keyed {
+@@ -75,6 +75,13 @@ public enum PatternType implements Keyed {
          this.key = NamespacedKey.minecraft(key);
      }
  
@@ -153,10 +153,10 @@ index 941fac4eee338870d8c30cb1f64cab572cf54548..74816d6da4d7c8d2fa8a7b93fdc4bf29
 +    // Paper end - Registry#getKey
  }
 diff --git a/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java b/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
-index f2242ddc4085f7e7cdd748d860857822e3d9b007..087e99ed281c0b282d91345067bfca80762faa0b 100644
+index 9133a889c1936b4cf7dbf17f744ee926d57362a3..6079bd05a056153c9d66f37396c96dbad9dca7a1 100644
 --- a/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
 +++ b/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
-@@ -100,4 +100,14 @@ public interface TrimPattern extends Keyed, Translatable {
+@@ -104,4 +104,14 @@ public interface TrimPattern extends Keyed, Translatable {
      @Deprecated(forRemoval = true)
      @org.jetbrains.annotations.NotNull String getTranslationKey();
      // Paper end - adventure

--- a/patches/api/0477-Add-missing-wind-charge-damage-type.patch
+++ b/patches/api/0477-Add-missing-wind-charge-damage-type.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lulu13022002 <41980282+Lulu13022002@users.noreply.github.com>
+Date: Fri, 3 May 2024 22:56:12 +0200
+Subject: [PATCH] Add missing wind charge damage type
+
+
+diff --git a/src/main/java/org/bukkit/damage/DamageType.java b/src/main/java/org/bukkit/damage/DamageType.java
+index 9f2d80a91e12f09407d737668f4178e81811fe14..e1367e86c21a1c733c8db45b357e9a95e093644a 100644
+--- a/src/main/java/org/bukkit/damage/DamageType.java
++++ b/src/main/java/org/bukkit/damage/DamageType.java
+@@ -65,6 +65,12 @@ public interface DamageType extends Keyed, Translatable {
+     public static final DamageType BAD_RESPAWN_POINT = getDamageType("bad_respawn_point");
+     public static final DamageType OUTSIDE_BORDER = getDamageType("outside_border");
+     public static final DamageType GENERIC_KILL = getDamageType("generic_kill");
++    // Paper start
++    @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.UPDATE_1_21)
++    @ApiStatus.Experimental
++    @org.jetbrains.annotations.Nullable
++    DamageType WIND_CHARGE = getExperimentalDamageType("wind_charge");
++    // Paper end
+ 
+     @NotNull
+     private static DamageType getDamageType(@NotNull String key) {
+@@ -72,6 +78,12 @@ public interface DamageType extends Keyed, Translatable {
+         return Preconditions.checkNotNull(Registry.DAMAGE_TYPE.get(namespacedKey), "No DamageType found for %s. This is a bug.", namespacedKey);
+     }
+ 
++    // Paper start
++    private static @org.jetbrains.annotations.Nullable DamageType getExperimentalDamageType(@NotNull String key) {
++        return Registry.DAMAGE_TYPE.get(NamespacedKey.minecraft(key));
++    }
++    // Paper end
++
+     /**
+      * {@inheritDoc}
+      * <p>

--- a/patches/server/0004-Test-changes.patch
+++ b/patches/server/0004-Test-changes.patch
@@ -337,6 +337,19 @@ index 0000000000000000000000000000000000000000..6cbf11c898439834cffb99ef84e5df14
 +public @interface MethodParameterSource {
 +    String[] value() default {};
 +}
+diff --git a/src/test/java/org/bukkit/registry/RegistryConstantsTest.java b/src/test/java/org/bukkit/registry/RegistryConstantsTest.java
+index 1b1e55f70b3c9f922bd1cc63209816f50d7d29d1..c75cfdfc3dc07b922d8943b67a59cfffbbb9a214 100644
+--- a/src/test/java/org/bukkit/registry/RegistryConstantsTest.java
++++ b/src/test/java/org/bukkit/registry/RegistryConstantsTest.java
+@@ -23,7 +23,7 @@ public class RegistryConstantsTest extends AbstractTestingBase {
+     @Test
+     public void testDamageType() {
+         this.testExcessConstants(DamageType.class, Registry.DAMAGE_TYPE);
+-        // this.testMissingConstants(DamageType.class, Registries.DAMAGE_TYPE); // WIND_CHARGE not registered
++        this.testMissingConstants(DamageType.class, Registries.DAMAGE_TYPE); // Paper - re-enable this one
+     }
+ 
+     @Test
 diff --git a/src/test/java/org/bukkit/support/DummyServer.java b/src/test/java/org/bukkit/support/DummyServer.java
 index ee0cff84379bc0539b2c611a4904aff9f5843814..02a8e6b45bf304b6e0f88043a25188aa16b3d6bf 100644
 --- a/src/test/java/org/bukkit/support/DummyServer.java


### PR DESCRIPTION
The missing field is the wind charge damage type locked under the update_1_21 feature flag.