### PR TITLE
Fix more item desync when an event is cancelled

### DIFF
--- a/patches/server/0896-Fix-inventory-desync.patch
+++ b/patches/server/0896-Fix-inventory-desync.patch
@@ -4,18 +4,69 @@ Date: Wed, 23 Aug 2023 13:22:09 -0700
 Subject: [PATCH] Fix inventory desync
 
 
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 992032821110fc658fecc09530097a526f20d74d..b2c7b0d21a386bd0e87f22e1a1dc5b2d314395ed 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -397,6 +397,7 @@ public class ServerPlayer extends Player {
+ 
+     // Use method to resend items in hands in case of client desync, because the item use got cancelled.
+     // For example, when cancelling the leash event
++    @Deprecated // Paper - this shouldn't be used, use the regular sendAllDataToRemote call to resync all
+     public void resendItemInHands() {
+         this.containerMenu.findSlot(this.getInventory(), this.getInventory().selected).ifPresent(s -> {
+             this.containerSynchronizer.sendSlotChange(this.containerMenu, s, this.getMainHandItem());
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 7b10bb9cbf6f2b4a70ddaa0ba4bc7409a17f3f09..66814adfb2cf92067702fc2695b083661cf859c0 100644
+index 7b10bb9cbf6f2b4a70ddaa0ba4bc7409a17f3f09..e671aa59dc60e6d836cbe5b3947a4ca66d914809 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1468,6 +1468,7 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Targeti
+@@ -1466,8 +1466,9 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Targeti
+         if (itemstack.is(Items.LEAD) && this.canBeLeashed(player)) {
+             // CraftBukkit start - fire PlayerLeashEntityEvent
              if (CraftEventFactory.callPlayerLeashEntityEvent(this, player, player, hand).isCancelled()) {
-                 ((ServerPlayer) player).resendItemInHands(); // SPIGOT-7615: Resend to fix client desync with used item
+-                ((ServerPlayer) player).resendItemInHands(); // SPIGOT-7615: Resend to fix client desync with used item
++                // ((ServerPlayer) player).resendItemInHands(); // SPIGOT-7615: Resend to fix client desync with used item // Paper - handled below
                  ((ServerPlayer) player).connection.send(new ClientboundSetEntityLinkPacket(this, this.getLeashHolder()));
 +                player.containerMenu.sendAllDataToRemote(); // Paper - Fix inventory desync
                  return InteractionResult.PASS;
              }
              // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Cow.java b/src/main/java/net/minecraft/world/entity/animal/Cow.java
+index 5a7b1be351834a6b8889b1380cede1be025cb302..e336934f37075a827843e4b1bb2b6b660d2c60c9 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Cow.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Cow.java
+@@ -101,6 +101,7 @@ public class Cow extends Animal {
+             PlayerBucketFillEvent event = CraftEventFactory.callPlayerBucketFillEvent((ServerLevel) player.level(), player, this.blockPosition(), this.blockPosition(), null, itemstack, Items.MILK_BUCKET, hand);
+ 
+             if (event.isCancelled()) {
++                player.containerMenu.sendAllDataToRemote(); // Paper - Fix inventory desync
+                 return InteractionResult.PASS;
+             }
+             // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java b/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
+index 02e49c7ae5e120302b6479cf3e3934b9217eebf0..376bcbc189008464f4d518c1e07643431ba96306 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
++++ b/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
+@@ -234,6 +234,7 @@ public class Goat extends Animal {
+             PlayerBucketFillEvent event = CraftEventFactory.callPlayerBucketFillEvent((ServerLevel) player.level(), player, this.blockPosition(), this.blockPosition(), null, itemstack, Items.MILK_BUCKET, hand);
+ 
+             if (event.isCancelled()) {
++                player.containerMenu.sendAllDataToRemote(); // Paper - Fix inventory desync
+                 return InteractionResult.PASS;
+             }
+             // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/world/item/ArmorStandItem.java b/src/main/java/net/minecraft/world/item/ArmorStandItem.java
+index 1634a7d5ff06583408cf2f02f2b5f90931b1e02a..066a6e5ed2632a55324ec0d10f2f8a6bf3f30a0f 100644
+--- a/src/main/java/net/minecraft/world/item/ArmorStandItem.java
++++ b/src/main/java/net/minecraft/world/item/ArmorStandItem.java
+@@ -55,6 +55,7 @@ public class ArmorStandItem extends Item {
+                     entityarmorstand.moveTo(entityarmorstand.getX(), entityarmorstand.getY(), entityarmorstand.getZ(), f, 0.0F);
+                     // CraftBukkit start
+                     if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityPlaceEvent(context, entityarmorstand).isCancelled()) {
++                        if (context.getPlayer() != null) context.getPlayer().containerMenu.sendAllDataToRemote(); // Paper - Fix inventory desync
+                         return InteractionResult.FAIL;
+                     }
+                     // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/item/BlockItem.java b/src/main/java/net/minecraft/world/item/BlockItem.java
 index fc7d978f9e57814a933b9cb725c3af1e7d403795..96fb69ec6db2e7c8c728435f0c537b076259b2fb 100644
 --- a/src/main/java/net/minecraft/world/item/BlockItem.java
@@ -29,3 +80,27 @@ index fc7d978f9e57814a933b9cb725c3af1e7d403795..96fb69ec6db2e7c8c728435f0c537b07
                                      ((ServerPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
                                  }
                                  return InteractionResult.FAIL;
+diff --git a/src/main/java/net/minecraft/world/item/EndCrystalItem.java b/src/main/java/net/minecraft/world/item/EndCrystalItem.java
+index f9a940cdff3983d9d4de46bd5ddc1905f9254dcf..273bb38f14b8af08d123e02742d365fb5d91cdf5 100644
+--- a/src/main/java/net/minecraft/world/item/EndCrystalItem.java
++++ b/src/main/java/net/minecraft/world/item/EndCrystalItem.java
+@@ -49,6 +49,7 @@ public class EndCrystalItem extends Item {
+                         entityendercrystal.setShowBottom(false);
+                         // CraftBukkit start
+                         if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityPlaceEvent(context, entityendercrystal).isCancelled()) {
++                            if (context.getPlayer() != null) context.getPlayer().containerMenu.sendAllDataToRemote(); // Paper - Fix inventory desync
+                             return InteractionResult.FAIL;
+                         }
+                         // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/world/item/MinecartItem.java b/src/main/java/net/minecraft/world/item/MinecartItem.java
+index 66074445d3908b9bb1c8d70e1e27d057720ec8e5..d524fcc191cb95d6ec7f12ae7fceeb8077bb08fc 100644
+--- a/src/main/java/net/minecraft/world/item/MinecartItem.java
++++ b/src/main/java/net/minecraft/world/item/MinecartItem.java
+@@ -137,6 +137,7 @@ public class MinecartItem extends Item {
+ 
+                 // CraftBukkit start
+                 if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityPlaceEvent(context, entityminecartabstract).isCancelled()) {
++                    if (context.getPlayer() != null) context.getPlayer().containerMenu.sendAllDataToRemote(); // Paper - Fix inventory desync
+                     return InteractionResult.FAIL;
+                 }
+                 // CraftBukkit end

--- a/patches/server/0897-Add-titleOverride-to-InventoryOpenEvent.patch
+++ b/patches/server/0897-Add-titleOverride-to-InventoryOpenEvent.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/ma
 index d59225c63aa4d3df9f8e87a1b3527d044fd2c410..e10c8309e184fe2c5c9682aa901ed7a320980431 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1617,12 +1617,17 @@ public class ServerPlayer extends Player {
+@@ -1618,12 +1618,17 @@ public class ServerPlayer extends Player {
              this.nextContainerCounter();
              AbstractContainerMenu container = factory.createMenu(this.containerCounter, this.getInventory(), this);
  
@@ -27,7 +27,7 @@ index d59225c63aa4d3df9f8e87a1b3527d044fd2c410..e10c8309e184fe2c5c9682aa901ed7a3
                  if (container == null && !cancelled) { // Let pre-cancelled events fall through
                      // SPIGOT-5263 - close chest if cancelled
                      if (factory instanceof Container) {
-@@ -1644,7 +1649,7 @@ public class ServerPlayer extends Player {
+@@ -1645,7 +1650,7 @@ public class ServerPlayer extends Player {
              } else {
                  // CraftBukkit start
                  this.containerMenu = container;

--- a/patches/server/0899-Do-crystal-portal-proximity-check-before-entity-look.patch
+++ b/patches/server/0899-Do-crystal-portal-proximity-check-before-entity-look.patch
@@ -12,7 +12,7 @@ some servers that have players placing end crystals as a style of combat.
 The very cheap distance check prevents running the entity lookup every time.
 
 diff --git a/src/main/java/net/minecraft/world/item/EndCrystalItem.java b/src/main/java/net/minecraft/world/item/EndCrystalItem.java
-index f9a940cdff3983d9d4de46bd5ddc1905f9254dcf..dd1bdb4bb87a3a59c229ba76b36841d199717624 100644
+index 1339459dcbd85897f32362019f79a68393c91674..26c77cead77db560dd5836f5b56e09775cf5172d 100644
 --- a/src/main/java/net/minecraft/world/item/EndCrystalItem.java
 +++ b/src/main/java/net/minecraft/world/item/EndCrystalItem.java
 @@ -30,7 +30,7 @@ public class EndCrystalItem extends Item {
@@ -24,7 +24,7 @@ index f9a940cdff3983d9d4de46bd5ddc1905f9254dcf..dd1bdb4bb87a3a59c229ba76b36841d1
  
              if (!world.isEmptyBlock(blockposition1)) {
                  return InteractionResult.FAIL;
-@@ -57,7 +57,7 @@ public class EndCrystalItem extends Item {
+@@ -58,7 +58,7 @@ public class EndCrystalItem extends Item {
                          EndDragonFight enderdragonbattle = ((ServerLevel) world).getDragonFight();
  
                          if (enderdragonbattle != null) {

--- a/patches/server/0933-Restore-vanilla-entity-drops-behavior.patch
+++ b/patches/server/0933-Restore-vanilla-entity-drops-behavior.patch
@@ -12,7 +12,7 @@ diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/ma
 index e10c8309e184fe2c5c9682aa901ed7a320980431..3a3c17e62244a16cbad5558d55bcf8e330997acb 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -968,22 +968,20 @@ public class ServerPlayer extends Player {
+@@ -969,22 +969,20 @@ public class ServerPlayer extends Player {
          if (this.isRemoved()) {
              return;
          }
@@ -38,7 +38,7 @@ index e10c8309e184fe2c5c9682aa901ed7a320980431..3a3c17e62244a16cbad5558d55bcf8e3
          this.drops.clear(); // SPIGOT-5188: make sure to clear
          } // Paper - fix player loottables running when mob loot gamerule is false
  
-@@ -2481,8 +2479,8 @@ public class ServerPlayer extends Player {
+@@ -2482,8 +2480,8 @@ public class ServerPlayer extends Player {
      }
  
      @Override

--- a/patches/server/1009-Collision-optimisations.patch
+++ b/patches/server/1009-Collision-optimisations.patch
@@ -2182,7 +2182,7 @@ diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/ma
 index 95f5fda22759b8fe5ce7e01635fe908cf3d92337..d18aa39b93c1d7d2b6f9e24ba99008d277839d92 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -522,7 +522,7 @@ public class ServerPlayer extends Player {
+@@ -523,7 +523,7 @@ public class ServerPlayer extends Player {
  
                  if (blockposition1 != null) {
                      this.moveTo(blockposition1, world.getSharedSpawnAngle(), 0.0F); // Paper - MC-200092 - fix first spawn pos yaw being ignored
@@ -2191,7 +2191,7 @@ index 95f5fda22759b8fe5ce7e01635fe908cf3d92337..d18aa39b93c1d7d2b6f9e24ba99008d2
                          break;
                      }
                  }
-@@ -530,7 +530,7 @@ public class ServerPlayer extends Player {
+@@ -531,7 +531,7 @@ public class ServerPlayer extends Player {
          } else {
              this.moveTo(blockposition, world.getSharedSpawnAngle(), 0.0F); // Paper - MC-200092 - fix first spawn pos yaw being ignored
  


### PR DESCRIPTION
Fix more items desync where items might still disappear on the client for the EntityPlaceEvent and PlayerBucketFillEvent.