### PR TITLE
Keep components using single items in creative

### DIFF
--- a/patches/server/1044-General-ItemMeta-fixes.patch
+++ b/patches/server/1044-General-ItemMeta-fixes.patch
@@ -7,9 +7,18 @@ Subject: [PATCH] General ItemMeta fixes
 private-f net/minecraft/world/item/ItemStack components
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 8e2b3dd109dca3089cbce82cd3788874613a3230..a45389d64c04cd4c2a35fbc511595be0535a8665 100644
+index 8e2b3dd109dca3089cbce82cd3788874613a3230..893efb2c4a07c33d41e934279dd914a9dbd4ef79 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
+@@ -414,7 +414,7 @@ public final class ItemStack implements DataComponentHolder {
+             } finally {
+                 world.captureBlockStates = false;
+             }
+-            DataComponentPatch newData = this.getComponentsPatch();
++            DataComponentPatch newData = this.components.asPatch(); // Paper - Directly access components as patch instead of getComponentsPatch as said method yields EMPTY on items with count 0
+             int newCount = this.getCount();
+             this.setCount(oldCount);
+             this.restorePatch(oldData);
 @@ -1251,6 +1251,11 @@ public final class ItemStack implements DataComponentHolder {
      public void setItem(Item item) {
          this.bukkitStack = null; // Paper


### PR DESCRIPTION
The craftbukkit implementation stores the old and new data patch of an item during ItemStack#useOn(UseOnContext) to properly cancel events via comparison and change detection of the component patch.

However, it uses #getComponentsPatch to fetch the new stack component patch, which always yields an empty patch set if an itemstack is considered empty by the game.
As the restoration of an itemstack's count to its previous state is handled after the entire ItemStack#useOn method, items used in creative mode temporarily have a count of zero, which causes craftbukkit to consider their new component patch as EMPTY even tho said item may have data.
The new patch is applied and, after useOn completes, the count is reset if the player is in creative mode, leading to lost data.

This commit fixes said inconsistency by directly accessing the components of the item via components#asPatch, storing the proper component patch even for an item that temporarily has a count of zero.

Resolves: #10663