### PR TITLE
Fix hopper pull event being skipped after the first call

### DIFF
--- a/patches/server/1020-Optimize-Hoppers.patch
+++ b/patches/server/1020-Optimize-Hoppers.patch
@@ -85,7 +85,7 @@ index 3e9caee7322d7ffdb93fd7d063675dddc4c71226..8e2b3dd109dca3089cbce82cd3788874
              itemstack.setPopTime(this.getPopTime());
              return itemstack;
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-index 30a75492a4b25450c194b4cc44deb665711db5af..f37858eb18defbf11b2f4fe825ab9416ebbc7210 100644
+index d2939e12449ae6b2b57beff7e689a0d39212161d..65170cbb50d8d5030fc5e33b6389c554aec6ae31 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 @@ -38,6 +38,7 @@ import co.aikar.timings.MinecraftTimings; // Paper
@@ -105,7 +105,7 @@ index 30a75492a4b25450c194b4cc44deb665711db5af..f37858eb18defbf11b2f4fe825ab9416
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index 92086ca118d55ec49cefa5bf18977f8706e3e4b4..da30c7fd750aa7b912310368100a5261c189715f 100644
+index 92086ca118d55ec49cefa5bf18977f8706e3e4b4..8310d132006043e93c612890514c4c7f3eb1c74d 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 @@ -156,6 +156,43 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
@@ -470,7 +470,15 @@ index 92086ca118d55ec49cefa5bf18977f8706e3e4b4..da30c7fd750aa7b912310368100a5261
          return true;
      }
  
-@@ -346,44 +582,47 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -311,6 +547,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+ 
+         if (iinventory != null) {
+             Direction enumdirection = Direction.DOWN;
++            skipPullModeEventFire = skipHopperEvents; // Paper - Perf: Optimize Hoppers
+             int[] aint = HopperBlockEntity.getSlots(iinventory, enumdirection);
+             int i = aint.length;
+ 
+@@ -346,44 +583,47 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          ItemStack itemstack = iinventory.getItem(i);
  
          if (!itemstack.isEmpty() && HopperBlockEntity.canTakeItemFromContainer(ihopper, iinventory, itemstack, i, enumdirection)) {
@@ -556,7 +564,7 @@ index 92086ca118d55ec49cefa5bf18977f8706e3e4b4..da30c7fd750aa7b912310368100a5261
          }
  
          return false;
-@@ -392,12 +631,14 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -392,12 +632,14 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
      public static boolean addItem(Container inventory, ItemEntity itemEntity) {
          boolean flag = false;
          // CraftBukkit start
@@ -572,7 +580,7 @@ index 92086ca118d55ec49cefa5bf18977f8706e3e4b4..da30c7fd750aa7b912310368100a5261
          ItemStack itemstack = itemEntity.getItem().copy();
          ItemStack itemstack1 = HopperBlockEntity.addItem((Container) null, inventory, itemstack, (Direction) null);
  
-@@ -491,7 +732,9 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -491,7 +733,9 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
                      stack = stack.split(to.getMaxStackSize());
                  }
                  // Spigot end
@@ -582,7 +590,7 @@ index 92086ca118d55ec49cefa5bf18977f8706e3e4b4..da30c7fd750aa7b912310368100a5261
                  stack = leftover; // Paper - Make hoppers respect inventory max stack size
                  flag = true;
              } else if (HopperBlockEntity.canMergeItems(itemstack1, stack)) {
-@@ -571,14 +814,20 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -571,14 +815,20 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
  
      @Nullable
      public static Container getContainerAt(Level world, BlockPos pos) {
@@ -605,7 +613,7 @@ index 92086ca118d55ec49cefa5bf18977f8706e3e4b4..da30c7fd750aa7b912310368100a5261
              iinventory = HopperBlockEntity.getEntityContainer(world, x, y, z);
          }
  
-@@ -613,13 +862,13 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -613,13 +863,13 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
  
      @Nullable
      private static Container getEntityContainer(Level world, double x, double y, double z) {


### PR DESCRIPTION
Fix Owen's issue with hopper. When the InventoryMoveEvent#getItem/setItem are not called for a hopper pull from another container, the later events are skipped. However the boolean that track this state was never reset afterward.