### PR TITLE
RegistrySet API

### DIFF
--- a/patches/api/0003-Test-changes.patch
+++ b/patches/api/0003-Test-changes.patch
@@ -66,7 +66,7 @@ index 0000000000000000000000000000000000000000..77154095cfb8b259bdb318e8ff40cb6f
 +    }
 +}
 diff --git a/src/test/java/org/bukkit/AnnotationTest.java b/src/test/java/org/bukkit/AnnotationTest.java
-index 64e7aef6220097edefdff3b98a771b988365930d..a899f63eb2ce58b3cf708e91819cbbdeffda5d9f 100644
+index 64e7aef6220097edefdff3b98a771b988365930d..d9091ba1e5a55e03adca98305233cce9d6888609 100644
 --- a/src/test/java/org/bukkit/AnnotationTest.java
 +++ b/src/test/java/org/bukkit/AnnotationTest.java
 @@ -29,7 +29,13 @@ public class AnnotationTest {
@@ -103,7 +103,7 @@ index 64e7aef6220097edefdff3b98a771b988365930d..a899f63eb2ce58b3cf708e91819cbbde
      };
  
      @Test
-@@ -67,14 +83,40 @@ public class AnnotationTest {
+@@ -67,14 +83,48 @@ public class AnnotationTest {
                  }
  
                  if (mustBeAnnotated(Type.getReturnType(method.desc)) && !isWellAnnotated(method.invisibleAnnotations)) {
@@ -132,8 +132,16 @@ index 64e7aef6220097edefdff3b98a771b988365930d..a899f63eb2ce58b3cf708e91819cbbde
                  for (int i = 0; i < paramTypes.length; i++) {
                      if (mustBeAnnotated(paramTypes[i]) ^ isWellAnnotated(method.invisibleParameterAnnotations == null ? null : method.invisibleParameterAnnotations[i])) {
 +                        // Paper start
-+                        if (method.invisibleTypeAnnotations != null || method.visibleTypeAnnotations != null) {
-+                            for (final org.objectweb.asm.tree.TypeAnnotationNode invisibleTypeAnnotation : java.util.Objects.requireNonNullElse(method.invisibleTypeAnnotations, method.visibleTypeAnnotations)) {
++                        if (method.invisibleTypeAnnotations != null) {
++                            for (final org.objectweb.asm.tree.TypeAnnotationNode invisibleTypeAnnotation : method.invisibleTypeAnnotations) {
++                                final org.objectweb.asm.TypeReference ref = new org.objectweb.asm.TypeReference(invisibleTypeAnnotation.typeRef);
++                                if (ref.getSort() == org.objectweb.asm.TypeReference.METHOD_FORMAL_PARAMETER && ref.getTypeParameterIndex() == i && java.util.Arrays.asList(ACCEPTED_ANNOTATIONS).contains(invisibleTypeAnnotation.desc)) {
++                                    continue dancing;
++                                }
++                            }
++                        }
++                        if (method.visibleTypeAnnotations != null) {
++                            for (final org.objectweb.asm.tree.TypeAnnotationNode invisibleTypeAnnotation : method.visibleTypeAnnotations) {
 +                                final org.objectweb.asm.TypeReference ref = new org.objectweb.asm.TypeReference(invisibleTypeAnnotation.typeRef);
 +                                if (ref.getSort() == org.objectweb.asm.TypeReference.METHOD_FORMAL_PARAMETER && ref.getTypeParameterIndex() == i && java.util.Arrays.asList(ACCEPTED_ANNOTATIONS).contains(invisibleTypeAnnotation.desc)) {
 +                                    continue dancing;
@@ -144,7 +152,7 @@ index 64e7aef6220097edefdff3b98a771b988365930d..a899f63eb2ce58b3cf708e91819cbbde
                          ParameterNode paramNode = parameters == null ? null : parameters.get(i);
                          String paramName = paramNode == null ? null : paramNode.name;
  
-@@ -91,13 +133,18 @@ public class AnnotationTest {
+@@ -91,13 +141,18 @@ public class AnnotationTest {
  
          Collections.sort(errors);
  
@@ -167,7 +175,7 @@ index 64e7aef6220097edefdff3b98a771b988365930d..a899f63eb2ce58b3cf708e91819cbbde
      }
  
      private static void collectClasses(@NotNull File from, @NotNull Map<String, ClassNode> to) throws IOException {
-@@ -140,6 +187,11 @@ public class AnnotationTest {
+@@ -140,6 +195,11 @@ public class AnnotationTest {
              // Exceptions are excluded
              return false;
          }
@@ -179,7 +187,7 @@ index 64e7aef6220097edefdff3b98a771b988365930d..a899f63eb2ce58b3cf708e91819cbbde
  
          for (String excludedClass : EXCLUDED_CLASSES) {
              if (excludedClass.equals(clazz.name)) {
-@@ -152,7 +204,7 @@ public class AnnotationTest {
+@@ -152,7 +212,7 @@ public class AnnotationTest {
  
      private static boolean isMethodIncluded(@NotNull ClassNode clazz, @NotNull MethodNode method, @NotNull Map<String, ClassNode> allClasses) {
          // Exclude private, synthetic and deprecated methods
@@ -188,7 +196,7 @@ index 64e7aef6220097edefdff3b98a771b988365930d..a899f63eb2ce58b3cf708e91819cbbde
              return false;
          }
  
-@@ -170,11 +222,30 @@ public class AnnotationTest {
+@@ -170,11 +230,30 @@ public class AnnotationTest {
          if ("<init>".equals(method.name) && isAnonymous(clazz)) {
              return false;
          }

--- a/patches/api/0073-AsyncTabCompleteEvent.patch
+++ b/patches/api/0073-AsyncTabCompleteEvent.patch
@@ -589,7 +589,7 @@ index 270e6d8ad4358baa256cee5f16cff281f063ce3b..b43c3cb5c88eada186d6f81712c244aa
  
      @Override
 diff --git a/src/test/java/org/bukkit/AnnotationTest.java b/src/test/java/org/bukkit/AnnotationTest.java
-index a899f63eb2ce58b3cf708e91819cbbdeffda5d9f..057dc3ebea3516863dda24252fe05d344c16fab3 100644
+index d9091ba1e5a55e03adca98305233cce9d6888609..b82f07a2879412f6b30643ca93a97439aa49a98a 100644
 --- a/src/test/java/org/bukkit/AnnotationTest.java
 +++ b/src/test/java/org/bukkit/AnnotationTest.java
 @@ -48,6 +48,8 @@ public class AnnotationTest {

--- a/patches/api/0434-Improve-Registry.patch
+++ b/patches/api/0434-Improve-Registry.patch
@@ -31,14 +31,44 @@ index 62d2b3f950860dee0898d77b0a29635c3f9a7e23..704dba92f9246ef398ed8d162ebee3cf
      @Override
      public @NotNull String translationKey() {
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 5ba5cf06bf12fc2e81500e09209e26047e683fa9..802511eaf697d703cadb4b418fe51ea6d31ff3c8 100644
+index 5ba5cf06bf12fc2e81500e09209e26047e683fa9..b02160f42281bc4e20123752a593c5d655305381 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -354,6 +354,49 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -354,6 +354,79 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      @Nullable
      T get(@NotNull NamespacedKey key);
  
 +    // Paper start - improve Registry
++    /**
++     * Gets the object by its key or throws if it doesn't exist.
++     *
++     * @param key the key to get the object of in this registry
++     * @return the object for the key
++     * @throws java.util.NoSuchElementException if the key doesn't point to an object in the registry
++     */
++    default @NotNull T getOrThrow(final net.kyori.adventure.key.@NotNull Key key) {
++        final T value = this.get(key);
++        if (value == null) {
++            throw new java.util.NoSuchElementException("No value for " + key + " in " + this);
++        }
++        return value;
++    }
++
++    /**
++     * Gets the object by its key or throws if it doesn't exist.
++     *
++     * @param key the key to get the object of in this registry
++     * @return the object for the key
++     * @throws java.util.NoSuchElementException if the key doesn't point to an object in the registry
++     */
++    default @NotNull T getOrThrow(final io.papermc.paper.registry.@NotNull TypedKey<T> key) {
++        final T value = this.get(key);
++        if (value == null) {
++            throw new java.util.NoSuchElementException("No value for " + key + " in " + this);
++        }
++        return value;
++    }
++
 +    /**
 +     * Gets the key for this object or throws if it doesn't exist.
 +     * <p>
@@ -84,7 +114,7 @@ index 5ba5cf06bf12fc2e81500e09209e26047e683fa9..802511eaf697d703cadb4b418fe51ea6
      /**
       * Returns a new stream, which contains all registry items, which are registered to the registry.
       *
-@@ -428,5 +471,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -428,5 +501,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
          public Class<T> getType() {
              return this.type;
          }

--- a/patches/api/0478-Registry-Modification-API.patch
+++ b/patches/api/0478-Registry-Modification-API.patch
@@ -366,7 +366,7 @@ index 0000000000000000000000000000000000000000..f4d4ebf6cbed1b4a9955ceb2d0586782
 +public interface RegistryEntryAddEventType<T, B extends RegistryBuilder<T>> extends LifecycleEventType<BootstrapContext, RegistryEntryAddEvent<T, B>, RegistryEntryAddConfiguration<T>> {
 +}
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 802511eaf697d703cadb4b418fe51ea6d31ff3c8..85c4f231dc343c73f1678819f1ac95d5a7ffd080 100644
+index b02160f42281bc4e20123752a593c5d655305381..240500771bac439156b4c5d93ff047ae45d56154 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
 @@ -353,6 +353,27 @@ public interface Registry<T extends Keyed> extends Iterable<T> {

--- a/patches/api/0479-RegistrySet-API.patch
+++ b/patches/api/0479-RegistrySet-API.patch
@@ -1,0 +1,461 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 11 May 2024 19:25:48 -0700
+Subject: [PATCH] RegistrySet API
+
+This API is supposed to be the API equivalent of nms'
+HolderSet and HolderSet$Named.
+
+diff --git a/src/main/java/io/papermc/paper/registry/set/RegistryKeySet.java b/src/main/java/io/papermc/paper/registry/set/RegistryKeySet.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..b891101b43148f63c96b7dd611914c85d7b29dbf
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/registry/set/RegistryKeySet.java
+@@ -0,0 +1,50 @@
++package io.papermc.paper.registry.set;
++
++import io.papermc.paper.registry.TypedKey;
++import java.util.Collection;
++import java.util.Iterator;
++import org.bukkit.Keyed;
++import org.bukkit.Registry;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.Unmodifiable;
++
++@ApiStatus.Experimental
++@ApiStatus.NonExtendable
++public non-sealed interface RegistryKeySet<T extends Keyed> extends Iterable<TypedKey<T>>, RegistrySet<T> { // TODO remove Keyed
++
++    @Override
++    default int size() {
++        return this.values().size();
++    }
++
++    /**
++     * Get the keys for the values in this set.
++     *
++     * @return the keys
++     */
++    @NonNull @Unmodifiable Collection<TypedKey<T>> values();
++
++    /**
++     * Resolve this set into a collection of values. Prefer using
++     * {@link #values()}.
++     *
++     * @param registry the registry to resolve the values from (must match {@link #registryKey()})
++     * @return the resolved values
++     * @see RegistryKeySet#values()
++     */
++    @NonNull @Unmodifiable Collection<T> resolve(final @NonNull Registry<T> registry);
++
++    /**
++     * Checks if this set contains the value with the given key.
++     *
++     * @param valueKey the key to check
++     * @return true if the value is in this set
++     */
++    boolean contains(@NonNull TypedKey<T> valueKey);
++
++    @Override
++    default @NonNull Iterator<TypedKey<T>> iterator() {
++        return this.values().iterator();
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/registry/set/RegistryKeySetImpl.java b/src/main/java/io/papermc/paper/registry/set/RegistryKeySetImpl.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..c712181ad4c6a9d00bc04f8a48515a388c692f48
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/registry/set/RegistryKeySetImpl.java
+@@ -0,0 +1,53 @@
++package io.papermc.paper.registry.set;
++
++import com.google.common.base.Preconditions;
++import io.papermc.paper.registry.RegistryAccess;
++import io.papermc.paper.registry.RegistryKey;
++import io.papermc.paper.registry.TypedKey;
++import java.util.ArrayList;
++import java.util.Collection;
++import java.util.Collections;
++import java.util.List;
++import org.bukkit.Keyed;
++import org.bukkit.NamespacedKey;
++import org.bukkit.Registry;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.Nullable;
++
++@ApiStatus.Internal
++@DefaultQualifier(NonNull.class)
++record RegistryKeySetImpl<T extends Keyed>(RegistryKey<T> registryKey, List<TypedKey<T>> values) implements RegistryKeySet<T> { // TODO remove Keyed
++
++    static <T extends Keyed> RegistryKeySet<T> create(final RegistryKey<T> registryKey, final Iterable<? extends T> values) { // TODO remove Keyed
++        final Registry<T> registry = RegistryAccess.registryAccess().getRegistry(registryKey);
++        final ArrayList<TypedKey<T>> keys = new ArrayList<>();
++        for (final T value : values) {
++            final @Nullable NamespacedKey key = registry.getKey(value);
++            Preconditions.checkArgument(key != null, value + " does not have a key in " + registryKey);
++            keys.add(TypedKey.create(registryKey, key));
++        }
++        return new RegistryKeySetImpl<>(registryKey, keys);
++    }
++
++    RegistryKeySetImpl {
++        values = List.copyOf(values);
++    }
++
++    @Override
++    public boolean contains(final TypedKey<T> valueKey) {
++        return this.values.contains(valueKey);
++    }
++
++    @Override
++    public Collection<T> resolve(final Registry<T> registry) {
++        final List<T> values = new ArrayList<>(this.values.size());
++        for (final TypedKey<T> key : this.values) {
++            final @Nullable T value = registry.get(key.key());
++            Preconditions.checkState(value != null, "Trying to access unbound TypedKey: " + key);
++            values.add(value);
++        }
++        return Collections.unmodifiableList(values);
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/registry/set/RegistrySet.java b/src/main/java/io/papermc/paper/registry/set/RegistrySet.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..7df3ccfc9f4da6eae3e0dec6d053a714053413cb
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/registry/set/RegistrySet.java
+@@ -0,0 +1,102 @@
++package io.papermc.paper.registry.set;
++
++import com.google.common.collect.Lists;
++import io.papermc.paper.registry.RegistryKey;
++import io.papermc.paper.registry.TypedKey;
++import io.papermc.paper.registry.tag.Tag;
++import java.util.Collection;
++import java.util.Iterator;
++import org.bukkit.Keyed;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.Contract;
++import org.jetbrains.annotations.Unmodifiable;
++
++/**
++ * Represents a collection tied to a registry.
++ * <p>
++ * There are 2<!--3--> types of registry sets:
++ * <ul>
++ *     <li>{@link Tag} which is a tag from vanilla or a datapack.
++ *     These are obtained via {@link org.bukkit.Registry#getTag(io.papermc.paper.registry.tag.TagKey)}.</li>
++ *     <li>{@link RegistryKeySet} which is a set of of values that are present in the registry. These are
++ *     created via {@link #keySet(RegistryKey, Iterable)} or {@link #keySetFromValues(RegistryKey, Iterable)}.</li>
++ *     <!-- <li>{@link RegistryValueSet} which is a set of values which are anonymous (don't have keys in the registry). These are
++ *     created via {@link #valueSet(RegistryKey, Iterable)}.</li>-->
++ * </ul>
++ *
++ * @param <T> registry value type
++ */
++@ApiStatus.Experimental
++public sealed interface RegistrySet<T> permits RegistryKeySet, RegistryValueSet {
++
++    // TODO uncomment when direct holder sets need to be exposed to the API
++    // /**
++    //  * Creates a {@link RegistryValueSet} from anonymous values.
++    //  * <p>All values provided <b>must not</b> have keys in the given registry.</p>
++    //  *
++    //  * @param registryKey the registry key for the type of these values
++    //  * @param values the values
++    //  * @return a new registry set
++    //  * @param <T> the type of the values
++    //  */
++    // @Contract(value = "_, _ -> new", pure = true)
++    // static <T> @NonNull RegistryValueSet<T> valueSet(final @NonNull RegistryKey<T> registryKey, final @NonNull Iterable<? extends T> values) {
++    //     return RegistryValueSetImpl.create(registryKey, values);
++    // }
++
++    /**
++     * Creates a {@link RegistryKeySet} from registry-backed values.
++     * <p>All values provided <b>must</b> have keys in the given registry.
++     * <!--For anonymous values, use {@link #valueSet(RegistryKey, Iterable)}--></p>
++     * <p>If references to actual objects are not available yet, use {@link #keySet(RegistryKey, Iterable)} to
++     * create an equivalent {@link RegistryKeySet} using just {@link TypedKey TypedKeys}.</p>
++     *
++     * @param registryKey the registry key for the owner of these values
++     * @param values the values
++     * @return a new registry set
++     * @param <T> the type of the values
++     * @throws IllegalArgumentException if the registry isn't available yet or if any value doesn't have a key in that registry
++     */
++    @Contract(value = "_, _ -> new", pure = true)
++    static <T extends Keyed> @NonNull RegistryKeySet<T> keySetFromValues(final @NonNull RegistryKey<T> registryKey, final @NonNull Iterable<? extends T> values) { // TODO remove Keyed
++        return RegistryKeySetImpl.create(registryKey, values);
++    }
++
++    /**
++     * Creates a direct {@link RegistrySet} from {@link TypedKey TypedKeys}.
++     *
++     * @param registryKey the registry key for the owner of these keys
++     * @param keys the keys for the values
++     * @return a new registry set
++     * @param <T> the type of the values
++     */
++    @SuppressWarnings("BoundedWildcard")
++    @Contract(value = "_, _ -> new", pure = true)
++    static <T extends Keyed> @NonNull RegistryKeySet<T> keySet(final @NonNull RegistryKey<T> registryKey, final @NonNull Iterable<TypedKey<T>> keys) { // TODO remove Keyed
++        return new RegistryKeySetImpl<>(registryKey, Lists.newArrayList(keys));
++    }
++
++    /**
++     * Get the registry key for this set.
++     *
++     * @return the registry key
++     */
++    @NonNull RegistryKey<T> registryKey();
++
++    /**
++     * Get the size of this set.
++     *
++     * @return the size
++     */
++    int size();
++
++    /**
++     * Checks if the registry set is empty.
++     *
++     * @return true, if empty
++     */
++    default boolean isEmpty() {
++        return this.size() == 0;
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/registry/set/RegistryValueSet.java b/src/main/java/io/papermc/paper/registry/set/RegistryValueSet.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..58e2e42737d48b243854466eb7f7d3a844a86b6e
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/registry/set/RegistryValueSet.java
+@@ -0,0 +1,34 @@
++package io.papermc.paper.registry.set;
++
++import java.util.Collection;
++import java.util.Iterator;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.Unmodifiable;
++
++/**
++ * A collection of anonymous values relating to a registry. These
++ * are values of the same type as the registry, but will not be found
++ * in the registry, hence, anonymous.
++ * @param <T> registry value type
++ */
++@ApiStatus.Experimental
++public sealed interface RegistryValueSet<T> extends Iterable<T>, RegistrySet<T> permits RegistryValueSetImpl {
++
++    @Override
++    default int size() {
++        return this.values().size();
++    }
++
++    /**
++     * Get the collection of values in this direct set.
++     *
++     * @return the values
++     */
++    @NonNull @Unmodifiable Collection<T> values();
++
++    @Override
++    default @NonNull Iterator<T> iterator() {
++        return this.values().iterator();
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/registry/set/RegistryValueSetImpl.java b/src/main/java/io/papermc/paper/registry/set/RegistryValueSetImpl.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..4ce5b26a1fcaae7b28ac8ed3c25014b66c266318
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/registry/set/RegistryValueSetImpl.java
+@@ -0,0 +1,18 @@
++package io.papermc.paper.registry.set;
++
++import com.google.common.collect.Lists;
++import io.papermc.paper.registry.RegistryKey;
++import java.util.List;
++import org.jetbrains.annotations.ApiStatus;
++
++@ApiStatus.Internal
++record RegistryValueSetImpl<T>(RegistryKey<T> registryKey, List<T> values) implements RegistryValueSet<T> {
++
++    RegistryValueSetImpl {
++        values = List.copyOf(values);
++    }
++
++    static <T> RegistryValueSet<T> create(final RegistryKey<T> registryKey, final Iterable<? extends T> values) {
++        return new RegistryValueSetImpl<>(registryKey, Lists.newArrayList(values));
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/registry/tag/Tag.java b/src/main/java/io/papermc/paper/registry/tag/Tag.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ae374f68ef9baa16ed90c371f1622de0c0159873
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/registry/tag/Tag.java
+@@ -0,0 +1,25 @@
++package io.papermc.paper.registry.tag;
++
++import io.papermc.paper.registry.set.RegistryKeySet;
++import org.bukkit.Keyed;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.jetbrains.annotations.ApiStatus;
++
++/**
++ * A named {@link RegistryKeySet} which are created
++ * via the datapack tag system.
++ *
++ * @param <T>
++ * @see org.bukkit.Tag
++ * @see org.bukkit.Registry#getTag(TagKey)
++ */
++@ApiStatus.Experimental
++public interface Tag<T extends Keyed> extends RegistryKeySet<T> { // TODO remove Keyed
++
++    /**
++     * Get the identifier for this named set.
++     *
++     * @return the tag key identifier
++     */
++    @NonNull TagKey<T> tagKey();
++}
+diff --git a/src/main/java/io/papermc/paper/registry/tag/TagKey.java b/src/main/java/io/papermc/paper/registry/tag/TagKey.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..a49d328e95f7fda6567ee6c4f5f1878a2c187277
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/registry/tag/TagKey.java
+@@ -0,0 +1,32 @@
++package io.papermc.paper.registry.tag;
++
++import io.papermc.paper.registry.RegistryKey;
++import net.kyori.adventure.key.Key;
++import net.kyori.adventure.key.Keyed;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.Contract;
++
++@ApiStatus.Experimental
++public sealed interface TagKey<T> extends Keyed permits TagKeyImpl {
++
++    /**
++     * Creates a new tag key for a registry.
++     *
++     * @param registryKey the registry for the tag
++     * @param key the specific key for the tag
++     * @return a new tag key
++     * @param <T> the registry value type
++     */
++    @Contract(value = "_, _ -> new", pure = true)
++    static <T> @NonNull TagKey<T> create(final @NonNull RegistryKey<T> registryKey, final @NonNull Key key) {
++        return new TagKeyImpl<>(registryKey, key);
++    }
++
++    /**
++     * Get the registry key for this tag key.
++     *
++     * @return the registry key
++     */
++    @NonNull RegistryKey<T> registryKey();
++}
+diff --git a/src/main/java/io/papermc/paper/registry/tag/TagKeyImpl.java b/src/main/java/io/papermc/paper/registry/tag/TagKeyImpl.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..11d19e339c7c62f2eb4467277552c27e4e83069c
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/registry/tag/TagKeyImpl.java
+@@ -0,0 +1,12 @@
++package io.papermc.paper.registry.tag;
++
++import io.papermc.paper.registry.RegistryKey;
++import net.kyori.adventure.key.Key;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
++import org.jetbrains.annotations.ApiStatus;
++
++@ApiStatus.Internal
++@DefaultQualifier(NonNull.class)
++record TagKeyImpl<T>(RegistryKey<T> registryKey, Key key) implements TagKey<T> {
++}
+diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
+index 240500771bac439156b4c5d93ff047ae45d56154..48849c25caddf5884a332ddd6e78d3cdf3553023 100644
+--- a/src/main/java/org/bukkit/Registry.java
++++ b/src/main/java/org/bukkit/Registry.java
+@@ -448,6 +448,30 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+     }
+     // Paper end - improve Registry
+ 
++    // Paper start - RegistrySet API
++    /**
++     * Checks if this registry has a tag with the given key.
++     *
++     * @param key the key to check for
++     * @return true if this registry has a tag with the given key, false otherwise
++     */
++    @ApiStatus.Experimental
++    default boolean hasTag(final io.papermc.paper.registry.tag.@NotNull TagKey<T> key) {
++        throw new UnsupportedOperationException(this + " doesn't have tags");
++    }
++
++    /**
++     * Gets the named registry set (tag) for the given key.
++     *
++     * @param key the key to get the tag for
++     * @return the tag for the key
++     */
++    @ApiStatus.Experimental
++    default @NotNull io.papermc.paper.registry.tag.Tag<T> getTag(final io.papermc.paper.registry.tag.@NotNull TagKey<T> key) {
++        throw new UnsupportedOperationException(this + " doesn't have tags");
++    }
++    // Paper end - RegistrySet API
++
+     /**
+      * Returns a new stream, which contains all registry items, which are registered to the registry.
+      *
+@@ -477,7 +501,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+         return (namespacedKey != null) ? get(namespacedKey) : null;
+     }
+ 
+-    static final class SimpleRegistry<T extends Enum<T> & Keyed> implements Registry<T> {
++    static class SimpleRegistry<T extends Enum<T> & Keyed> implements Registry<T> { // Paper - not final
+ 
+         private final Class<T> type;
+         private final Map<NamespacedKey, T> map;
+@@ -529,5 +553,23 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+             return value.getKey();
+         }
+         // Paper end - improve Registry
++
++        // Paper start - RegistrySet API
++        @SuppressWarnings("deprecation")
++        @Override
++        public boolean hasTag(final io.papermc.paper.registry.tag.@NotNull TagKey<T> key) {
++            return Bukkit.getUnsafe().getTag(key) != null;
++        }
++
++        @SuppressWarnings("deprecation")
++        @Override
++        public io.papermc.paper.registry.tag.@NotNull Tag<T> getTag(final io.papermc.paper.registry.tag.@NotNull TagKey<T> key) {
++            final io.papermc.paper.registry.tag.Tag<T> tag = Bukkit.getUnsafe().getTag(key);
++            if (tag == null) {
++                throw new java.util.NoSuchElementException("No tag " + key + " found");
++            }
++            return tag;
++        }
++        // Paper end - RegistrySet API
+     }
+ }
+diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
+index 0e9ccfee7a03d341e7c4d271f53b4ed168b404ef..7332034bb1753f48f7904dafab1ef4b3ee117ea3 100644
+--- a/src/main/java/org/bukkit/UnsafeValues.java
++++ b/src/main/java/org/bukkit/UnsafeValues.java
+@@ -275,4 +275,6 @@ public interface UnsafeValues {
+     // Paper end - lifecycle event API
+ 
+     @NotNull java.util.List<net.kyori.adventure.text.Component> computeTooltipLines(@NotNull ItemStack itemStack, @NotNull io.papermc.paper.inventory.tooltip.TooltipContext tooltipContext, @Nullable org.bukkit.entity.Player player); // Paper - expose itemstack tooltip lines
++
++    <A extends Keyed, M> io.papermc.paper.registry.tag.@Nullable Tag<A> getTag(io.papermc.paper.registry.tag.@NotNull TagKey<A> tagKey); // Paper - hack to get tags for non-server backed registries
+ }

--- a/patches/server/1002-RegistrySet-API.patch
+++ b/patches/server/1002-RegistrySet-API.patch
@@ -1,0 +1,227 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 11 May 2024 19:26:18 -0700
+Subject: [PATCH] RegistrySet API
+
+
+diff --git a/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistry.java b/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistry.java
+index 5562e8da5ebaef2a3add46e88d64358b7737b59e..e5880f76cdb8ebf01fcefdf77ba9b95674b997a8 100644
+--- a/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistry.java
++++ b/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistry.java
+@@ -1,12 +1,13 @@
+ package io.papermc.paper.registry.legacy;
+ 
++import io.papermc.paper.registry.tag.Tag;
++import io.papermc.paper.registry.tag.TagKey;
+ import java.util.Iterator;
+ import java.util.function.Supplier;
+ import java.util.stream.Stream;
+ import org.bukkit.Keyed;
+ import org.bukkit.NamespacedKey;
+ import org.bukkit.Registry;
+-import org.bukkit.craftbukkit.CraftRegistry;
+ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+ import org.checkerframework.checker.nullness.qual.Nullable;
+ import org.jetbrains.annotations.NotNull;
+@@ -52,4 +53,14 @@ public final class DelayedRegistry<T extends Keyed, R extends Registry<T>> imple
+     public NamespacedKey getKey(final T value) {
+         return this.delegate().getKey(value);
+     }
++
++    @Override
++    public boolean hasTag(final TagKey<T> key) {
++        return this.delegate().hasTag(key);
++    }
++
++    @Override
++    public @NotNull Tag<T> getTag(final TagKey<T> key) {
++        return this.delegate().getTag(key);
++    }
+ }
+diff --git a/src/main/java/io/papermc/paper/registry/set/NamedRegistryKeySetImpl.java b/src/main/java/io/papermc/paper/registry/set/NamedRegistryKeySetImpl.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..918d80542a1185988fcda3d7642548c7935f73af
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/registry/set/NamedRegistryKeySetImpl.java
+@@ -0,0 +1,75 @@
++package io.papermc.paper.registry.set;
++
++import com.google.common.collect.ImmutableList;
++import io.papermc.paper.adventure.PaperAdventure;
++import io.papermc.paper.registry.RegistryAccess;
++import io.papermc.paper.registry.RegistryKey;
++import io.papermc.paper.registry.TypedKey;
++import io.papermc.paper.registry.tag.Tag;
++import io.papermc.paper.registry.tag.TagKey;
++import java.util.Collection;
++import java.util.Set;
++import net.kyori.adventure.key.Key;
++import net.minecraft.core.Holder;
++import net.minecraft.core.HolderSet;
++import org.bukkit.Keyed;
++import org.bukkit.NamespacedKey;
++import org.bukkit.Registry;
++import org.bukkit.craftbukkit.util.CraftNamespacedKey;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Unmodifiable;
++
++@DefaultQualifier(NonNull.class)
++public record NamedRegistryKeySetImpl<T extends Keyed, M>( // TODO remove Keyed
++    TagKey<T> tagKey,
++    HolderSet.Named<M> namedSet
++) implements Tag<T>, org.bukkit.Tag<T> {
++
++    @Override
++    public @Unmodifiable Collection<TypedKey<T>> values() {
++        final ImmutableList.Builder<TypedKey<T>> builder = ImmutableList.builder();
++        for (final Holder<M> holder : this.namedSet) {
++            builder.add(TypedKey.create(this.tagKey.registryKey(), CraftNamespacedKey.fromMinecraft(((Holder.Reference<?>) holder).key().location())));
++        }
++        return builder.build();
++    }
++
++    @Override
++    public RegistryKey<T> registryKey() {
++        return this.tagKey.registryKey();
++    }
++
++    @Override
++    public boolean contains(final TypedKey<T> valueKey) {
++        return this.namedSet.stream().anyMatch(h -> {
++            return ((Holder.Reference<?>) h).key().location().equals(PaperAdventure.asVanilla(valueKey.key()));
++        });
++    }
++
++    @Override
++    public @Unmodifiable Collection<T> resolve(final Registry<T> registry) {
++        final ImmutableList.Builder<T> builder = ImmutableList.builder();
++        for (final Holder<M> holder : this.namedSet) {
++            builder.add(registry.getOrThrow(CraftNamespacedKey.fromMinecraft(((Holder.Reference<?>) holder).key().location())));
++        }
++        return builder.build();
++    }
++
++    @Override
++    public boolean isTagged(final T item) {
++        return this.getValues().contains(item);
++    }
++
++    @Override
++    public Set<T> getValues() {
++        return Set.copyOf(this.resolve(RegistryAccess.registryAccess().getRegistry(this.registryKey())));
++    }
++
++    @Override
++    public @NotNull NamespacedKey getKey() {
++        final Key key = this.tagKey().key();
++        return new NamespacedKey(key.namespace(), key.value());
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/registry/set/PaperRegistrySets.java b/src/main/java/io/papermc/paper/registry/set/PaperRegistrySets.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..c3d5545824189f83308f5a62e3a237efaea2bfe1
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/registry/set/PaperRegistrySets.java
+@@ -0,0 +1,52 @@
++package io.papermc.paper.registry.set;
++
++import io.papermc.paper.adventure.PaperAdventure;
++import io.papermc.paper.registry.PaperRegistries;
++import io.papermc.paper.registry.RegistryKey;
++import io.papermc.paper.registry.TypedKey;
++import io.papermc.paper.registry.tag.TagKey;
++import java.util.ArrayList;
++import java.util.List;
++import net.minecraft.core.Holder;
++import net.minecraft.core.HolderSet;
++import net.minecraft.core.Registry;
++import net.minecraft.resources.ResourceKey;
++import org.bukkit.Keyed;
++import org.bukkit.craftbukkit.CraftRegistry;
++import org.bukkit.craftbukkit.util.CraftNamespacedKey;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
++
++@DefaultQualifier(NonNull.class)
++public final class PaperRegistrySets {
++
++    public static <A extends Keyed, M> HolderSet<M> convertToNms(final ResourceKey<? extends Registry<M>> resourceKey, final RegistryKeySet<A> registryKeySet) { // TODO remove Keyed
++        if (registryKeySet instanceof NamedRegistryKeySetImpl<A, ?>) {
++            return ((NamedRegistryKeySetImpl<A, M>) registryKeySet).namedSet();
++        } else {
++            final Registry<M> registry = CraftRegistry.getMinecraftRegistry().registryOrThrow(resourceKey);
++            return HolderSet.direct(key -> {
++                return registry.getHolderOrThrow(ResourceKey.create(resourceKey, PaperAdventure.asVanilla(key.key())));
++            }, registryKeySet.values());
++        }
++    }
++
++    public static <A extends Keyed, M> RegistryKeySet<A> convertToApi(final RegistryKey<A> registryKey, final HolderSet<M> holders) { // TODO remove Keyed
++        if (holders instanceof final HolderSet.Named<M> named) {
++            final RegistryKey<A> apiRegistryKey = PaperRegistries.fromNms(named.key().registry());
++            return new NamedRegistryKeySetImpl<>(TagKey.create(apiRegistryKey, CraftNamespacedKey.fromMinecraft(named.key().location())), named);
++        } else {
++            final List<TypedKey<A>> keys = new ArrayList<>();
++            for (final Holder<M> holder : holders) {
++                if (!(holder instanceof final Holder.Reference<M> reference)) {
++                    throw new UnsupportedOperationException("Cannot convert a holder set containing direct holders");
++                }
++                keys.add(TypedKey.create(registryKey, CraftNamespacedKey.fromMinecraft(reference.key().location())));
++            }
++            return RegistrySet.keySet(registryKey, keys);
++        }
++    }
++
++    private PaperRegistrySets() {
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
+index 43d686a9958cff96f5b15d93e920c8f2313aa65b..f0248e3d3782b1f6b4ff209502f626d66c05647b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
+@@ -233,4 +233,17 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+         return this.byValue.get(value);
+     }
+     // Paper end - improve Registry
++
++    // Paper start - RegistrySet API
++    @Override
++    public boolean hasTag(final io.papermc.paper.registry.tag.TagKey<B> key) {
++        return this.minecraftRegistry.getTag(net.minecraft.tags.TagKey.create(this.minecraftRegistry.key(), io.papermc.paper.adventure.PaperAdventure.asVanilla(key.key()))).isPresent();
++    }
++
++    @Override
++    public io.papermc.paper.registry.tag.Tag<B> getTag(final io.papermc.paper.registry.tag.TagKey<B> key) {
++        final net.minecraft.core.HolderSet.Named<M> namedHolderSet = this.minecraftRegistry.getTag(net.minecraft.tags.TagKey.create(this.minecraftRegistry.key(), io.papermc.paper.adventure.PaperAdventure.asVanilla(key.key()))).orElseThrow();
++        return new io.papermc.paper.registry.set.NamedRegistryKeySetImpl<>(key, namedHolderSet);
++    }
++    // Paper end - RegistrySet API
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+index 5a04134973dd1db7f778a57ec5f185feec370990..1571fe0513c37a55d6934c1eea5359ec46719466 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+@@ -685,6 +685,21 @@ public final class CraftMagicNumbers implements UnsafeValues {
+     }
+     // Paper end - lifecycle event API
+ 
++    // Paper start - hack to get tags for non server-backed registries
++    @Override
++    public <A extends Keyed, M> io.papermc.paper.registry.tag.Tag<A> getTag(final io.papermc.paper.registry.tag.TagKey<A> tagKey) { // TODO remove Keyed
++        if (tagKey.registryKey() != io.papermc.paper.registry.RegistryKey.ENTITY_TYPE || tagKey.registryKey() != io.papermc.paper.registry.RegistryKey.FLUID) {
++            throw new UnsupportedOperationException(tagKey.registryKey() + " doesn't have tags");
++        }
++        final net.minecraft.resources.ResourceKey<? extends net.minecraft.core.Registry<M>> nmsKey = io.papermc.paper.registry.PaperRegistries.toNms(tagKey.registryKey());
++        final net.minecraft.core.Registry<M> nmsRegistry = org.bukkit.craftbukkit.CraftRegistry.getMinecraftRegistry().registryOrThrow(nmsKey);
++        return nmsRegistry
++            .getTag(net.minecraft.tags.TagKey.create(nmsKey, io.papermc.paper.adventure.PaperAdventure.asVanilla(tagKey.key())))
++            .map(named -> new io.papermc.paper.registry.set.NamedRegistryKeySetImpl<>(tagKey, named))
++            .orElse(null);
++    }
++    // Paper end - hack to get tags for non server-backed registries
++
+     /**
+      * This helper class represents the different NBT Tags.
+      * <p>


### PR DESCRIPTION
This API is supposed to introduce an API equivalent to nms' HolderSet and HolderSet$Named.

`RegistrySet` is the base interface with subtypes in `RegistryKeySet` and `RegistryValueSet`. `RegistryKeySet` is equivalent to a `HolderSet` filled only with "reference" holders whereas a `RegistryValueSet` is filled with only "direct" holders. We can safely assume that a `HolderSet` will only contain 1 type of holder at a time because all the codecs that encode HolderSets require that.