### PR TITLE
Prevent infinite recursion on cyclic brig redirect

### DIFF
--- a/patches/server/1048-Brigadier-based-command-API.patch
+++ b/patches/server/1048-Brigadier-based-command-API.patch
@@ -251,10 +251,10 @@ index dd6012b6a097575b2d1471be5069eccee4537c0a..00000000000000000000000000000000
 -}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/ApiMirrorRootNode.java b/src/main/java/io/papermc/paper/command/brigadier/ApiMirrorRootNode.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2b1cf02f32506187ed0783ae4732ae0f0bdbfc0e
+index 0000000000000000000000000000000000000000..23525592d880f340745a28c956fa38d3e4057231
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/ApiMirrorRootNode.java
-@@ -0,0 +1,252 @@
+@@ -0,0 +1,253 @@
 +package io.papermc.paper.command.brigadier;
 +
 +import com.google.common.collect.Collections2;
@@ -401,15 +401,16 @@ index 0000000000000000000000000000000000000000..2b1cf02f32506187ed0783ae4732ae0f
 +            throw new IllegalArgumentException("Unknown command node passed. Don't know how to unwrap this.");
 +        }
 +
++        // Store unwrapped node before unwrapping children to avoid infinite recursion in cyclic redirects.
++        converted.wrappedCached = pureNode;
++        pureNode.unwrappedCached = converted;
++
 +        /*
 +        Add the children to the node, unwrapping each child in the process.
 +         */
 +        for (final CommandNode<CommandSourceStack> child : pureNode.getChildren()) {
 +            converted.addChild(this.unwrapNode(child));
 +        }
-+
-+        converted.wrappedCached = pureNode;
-+        pureNode.unwrappedCached = converted;
 +
 +        return converted;
 +    }


### PR DESCRIPTION
Prevent infinite recursion when declaring a cyclic relation between command nodes via child nodes redirecting to an nth parent by marking a command node as unwrapped before unwrapping its children.

Resolves: #10704