### PR TITLE
Add InteractionResult API

### DIFF
--- a/patches/api/0480-InteractionResult-API.patch
+++ b/patches/api/0480-InteractionResult-API.patch
@@ -1,0 +1,249 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dueris <122416109+Dueris@users.noreply.github.com>
+Date: Tue, 14 May 2024 17:33:35 +0000
+Subject: [PATCH] InteractionResult API
+
+
+diff --git a/src/main/java/io/papermc/paper/world/interaction/InteractionResult.java b/src/main/java/io/papermc/paper/world/interaction/InteractionResult.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..12a52b83753395ca7f6496e32ca5cd8a5d464ca1
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/world/interaction/InteractionResult.java
+@@ -0,0 +1,26 @@
++package io.papermc.paper.world.interaction;
++
++public enum InteractionResult {
++    SUCCESS,
++    SUCCESS_NO_ITEM_USED,
++    CONSUME,
++    CONSUME_PARTIAL,
++    PASS,
++    FAIL;
++
++    public boolean consumesAction() {
++        return this == SUCCESS || this == CONSUME || this == CONSUME_PARTIAL || this == SUCCESS_NO_ITEM_USED;
++    }
++
++    public boolean shouldSwing() {
++        return this == SUCCESS || this == SUCCESS_NO_ITEM_USED;
++    }
++
++    public boolean indicateItemUse() {
++        return this == SUCCESS || this == CONSUME;
++    }
++
++    public static InteractionResult sidedSuccess(boolean swingHand) {
++        return swingHand ? SUCCESS : CONSUME;
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java b/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
+index 883d54dc0cc32973df5d66f2991d1af8150add43..a0d23333e07e07b95e909b4d5453b69a00741cc4 100644
+--- a/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
++++ b/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
+@@ -18,13 +18,43 @@ public class PlayerLeashEntityEvent extends Event implements Cancellable {
+     private boolean cancelled = false;
+     private final Player player;
+     private final EquipmentSlot hand;
++    private io.papermc.paper.world.interaction.InteractionResult interactionResult;
+ 
+     public PlayerLeashEntityEvent(@NotNull Entity what, @NotNull Entity leashHolder, @NotNull Player leasher, @NotNull EquipmentSlot hand) {
+         this.leashHolder = leashHolder;
+         this.entity = what;
+         this.player = leasher;
+         this.hand = hand;
++        this.interactionResult = null; // Paper - InteractionResult API
+     }
++    // Paper start - InteractionResult API
++
++    public PlayerLeashEntityEvent(@NotNull Entity what, @NotNull Entity leashHolder, @NotNull Player leasher, @NotNull EquipmentSlot hand, io.papermc.paper.world.interaction.InteractionResult interactionResult) {
++        this(what, leashHolder, leasher, hand);
++        this.interactionResult = interactionResult;
++    }
++
++    /**
++     * Returns the InteractionResult.
++     * If returned NULL, there is no override for the InteractionResult
++     * 
++     * @return InteractionResult override for the event.
++     */
++    @org.jetbrains.annotations.Nullable
++    public io.papermc.paper.world.interaction.InteractionResult getInteractionResult() {
++        return this.interactionResult;
++    }
++
++    /**
++     * Sets the InteractionResult of the event. Can be null.
++     * If null, the event will use the original interaction result and remove any
++     * overrides for the result.
++     * @param interactionResult The result to be set
++     */
++    public void setInteractionResult(@org.jetbrains.annotations.Nullable io.papermc.paper.world.interaction.InteractionResult interactionResult) {
++        this.interactionResult = interactionResult;
++    }
++    // Paper end
+ 
+     @Deprecated
+     public PlayerLeashEntityEvent(@NotNull Entity what, @NotNull Entity leashHolder, @NotNull Player leasher) {
+diff --git a/src/main/java/org/bukkit/event/player/PlayerInteractEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerInteractEntityEvent.java
+index 1d3d62969c3b1a833b156c972586ac412589b4d4..fb01f3ac0926961f6a52ceeebe80d343083f5c0c 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerInteractEntityEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerInteractEntityEvent.java
+@@ -6,6 +6,7 @@ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.HandlerList;
+ import org.bukkit.inventory.EquipmentSlot;
+ import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
+ 
+ /**
+  * Represents an event that is called when a player right clicks an entity.
+@@ -15,6 +16,7 @@ public class PlayerInteractEntityEvent extends PlayerEvent implements Cancellabl
+     protected Entity clickedEntity;
+     boolean cancelled = false;
+     private EquipmentSlot hand;
++    private io.papermc.paper.world.interaction.InteractionResult interactionResult;
+ 
+     public PlayerInteractEntityEvent(@NotNull final Player who, @NotNull final Entity clickedEntity) {
+         this(who, clickedEntity, EquipmentSlot.HAND);
+@@ -24,7 +26,36 @@ public class PlayerInteractEntityEvent extends PlayerEvent implements Cancellabl
+         super(who);
+         this.clickedEntity = clickedEntity;
+         this.hand = hand;
++        this.interactionResult = null; // Paper
+     }
++    // Paper start - InteractionResult API
++
++    public PlayerInteractEntityEvent(@NotNull final Player who, @NotNull final Entity clickedEntity, @NotNull final EquipmentSlot hand, io.papermc.paper.world.interaction.InteractionResult interactionResult) {
++        this(who, clickedEntity, hand);
++        this.interactionResult = interactionResult;
++    }
++
++    /**
++     * Returns the InteractionResult.
++     * If returned NULL, there is no override for the InteractionResult
++     * 
++     * @return InteractionResult override for the event.
++     */
++    @Nullable
++    public io.papermc.paper.world.interaction.InteractionResult getInteractionResult() {
++        return this.interactionResult;
++    }
++
++    /**
++     * Sets the InteractionResult of the event. Can be null.
++     * If null, the event will use the original interaction result and remove any
++     * overrides for the result.
++     * @param interactionResult The result to be set
++     */
++    public void setInteractionResult(@Nullable io.papermc.paper.world.interaction.InteractionResult interactionResult) {
++        this.interactionResult = interactionResult;
++    }
++    // Paper end
+ 
+     @Override
+     public boolean isCancelled() {
+diff --git a/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java b/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
+index ddea08e4de2198a0a7565e2fd7a05571ed48f27b..c879a15b186f12c0c9cb2840860310872451111f 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
+@@ -37,6 +37,7 @@ public class PlayerInteractEvent extends PlayerEvent implements Cancellable {
+     private Result useItemInHand;
+     private EquipmentSlot hand;
+     private Vector clickedPosistion;
++    private io.papermc.paper.world.interaction.InteractionResult interactionResult; // Paper - InteractionResult API
+ 
+     public PlayerInteractEvent(@NotNull final Player who, @NotNull final Action action, @Nullable final ItemStack item, @Nullable final Block clickedBlock, @NotNull final BlockFace clickedFace) {
+         this(who, action, item, clickedBlock, clickedFace, EquipmentSlot.HAND);
+@@ -57,7 +58,36 @@ public class PlayerInteractEvent extends PlayerEvent implements Cancellable {
+ 
+         useItemInHand = Result.DEFAULT;
+         useClickedBlock = clickedBlock == null ? Result.DENY : Result.ALLOW;
++        this.interactionResult = null; // Paper - InteractionResult API
+     }
++    // Paper start - InteractionResult API
++
++    public PlayerInteractEvent(@NotNull final Player who, @NotNull final Action action, @Nullable final ItemStack item, @Nullable final Block clickedBlock, @NotNull final BlockFace clickedFace, @Nullable final EquipmentSlot hand, @Nullable final Vector clickedPosition, io.papermc.paper.world.interaction.InteractionResult interactionResult) {
++        this(who, action, item, clickedBlock, clickedFace, hand, clickedPosition);
++        this.interactionResult = interactionResult;
++    }
++
++    /**
++     * Returns the InteractionResult.
++     * If returned NULL, there is no override for the InteractionResult
++     * 
++     * @return InteractionResult override for the event.
++     */
++    @Nullable
++    public io.papermc.paper.world.interaction.InteractionResult getInteractionResult() {
++        return this.interactionResult;
++    }
++
++    /**
++     * Sets the InteractionResult of the event. Can be null.
++     * If null, the event will use the original interaction result and remove any
++     * overrides for the result.
++     * @param interactionResult The result to be set
++     */
++    public void setInteractionResult(@Nullable io.papermc.paper.world.interaction.InteractionResult interactionResult) {
++        this.interactionResult = interactionResult;
++    }
++    // Paper end
+ 
+     /**
+      * Returns the action type
+diff --git a/src/main/java/org/bukkit/event/player/PlayerUnleashEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerUnleashEntityEvent.java
+index d63bd62606763d0902ea800f0c35a1cfd07fc8ec..0dd76bc6d4136b8dade238f26e3b7c17472099d0 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerUnleashEntityEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerUnleashEntityEvent.java
+@@ -6,6 +6,7 @@ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.entity.EntityUnleashEvent;
+ import org.bukkit.inventory.EquipmentSlot;
+ import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
+ 
+ /**
+  * Called prior to an entity being unleashed due to a player's action.
+@@ -16,6 +17,7 @@ public class PlayerUnleashEntityEvent extends EntityUnleashEvent implements Canc
+ 
+     private final Player player;
+     private final EquipmentSlot hand;
++    private io.papermc.paper.world.interaction.InteractionResult interactionResult;
+ 
+     // Paper start - drop leash variable
+     @Deprecated
+@@ -28,7 +30,36 @@ public class PlayerUnleashEntityEvent extends EntityUnleashEvent implements Canc
+         // Paper end
+         this.player = player;
+         this.hand = hand;
++        this.interactionResult = null;
+     }
++    // Paper start - InteractionResult API
++
++    public PlayerUnleashEntityEvent(@NotNull Entity entity, @NotNull Player player, @NotNull EquipmentSlot hand, boolean dropLeash, io.papermc.paper.world.interaction.InteractionResult interactionResult) {
++        this(entity, player, hand, dropLeash);
++        this.interactionResult = interactionResult;
++    }
++
++    /**
++     * Returns the InteractionResult.
++     * If returned NULL, there is no override for the InteractionResult
++     * 
++     * @return InteractionResult override for the event.
++     */
++    @Nullable
++    public io.papermc.paper.world.interaction.InteractionResult getInteractionResult() {
++        return this.interactionResult;
++    }
++
++    /**
++     * Sets the InteractionResult of the event. Can be null.
++     * If null, the event will use the original interaction result and remove any
++     * overrides for the result.
++     * @param interactionResult The result to be set
++     */
++    public void setInteractionResult(@Nullable io.papermc.paper.world.interaction.InteractionResult interactionResult) {
++        this.interactionResult = interactionResult;
++    }
++    // Paper end
+ 
+     @Deprecated
+     public PlayerUnleashEntityEvent(@NotNull Entity entity, @NotNull Player player) {

--- a/patches/server/1049-InteractionResult-API.patch
+++ b/patches/server/1049-InteractionResult-API.patch
@@ -1,0 +1,137 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dueris <122416109+Dueris@users.noreply.github.com>
+Date: Tue, 14 May 2024 17:33:19 +0000
+Subject: [PATCH] InteractionResult API
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index b9b3277c8ed94e0cd30b20b9c00a33eaad48e5ac..3556f28657bf498347489a16a28f02d45c5d7e68 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1989,9 +1989,15 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+             HitResult movingobjectposition = this.player.level().clip(new ClipContext(vec3d, vec3d1, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, this.player));
+ 
+             boolean cancelled;
++            InteractionResult result = null; // Paper - InteractionResult API
+             if (movingobjectposition == null || movingobjectposition.getType() != HitResult.Type.BLOCK) {
+                 org.bukkit.event.player.PlayerInteractEvent event = CraftEventFactory.callPlayerInteractEvent(this.player, Action.RIGHT_CLICK_AIR, itemstack, enumhand);
+                 cancelled = event.useItemInHand() == Event.Result.DENY;
++                // Paper start - InteractionResult API
++                if (event.getInteractionResult() != null) {
++                    result = InteractionResult.toNMS(event.getInteractionResult());
++                }
++                // Paper end
+             } else {
+                 BlockHitResult movingobjectpositionblock = (BlockHitResult) movingobjectposition;
+                 if (this.player.gameMode.firedInteract && this.player.gameMode.interactPosition.equals(movingobjectpositionblock.getBlockPos()) && this.player.gameMode.interactHand == enumhand && ItemStack.isSameItemSameComponents(this.player.gameMode.interactItemStack, itemstack)) {
+@@ -1999,6 +2005,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+                 } else {
+                     org.bukkit.event.player.PlayerInteractEvent event = CraftEventFactory.callPlayerInteractEvent(this.player, Action.RIGHT_CLICK_BLOCK, movingobjectpositionblock.getBlockPos(), movingobjectpositionblock.getDirection(), itemstack, true, enumhand, movingobjectpositionblock.getLocation());
+                     cancelled = event.useItemInHand() == Event.Result.DENY;
++                    // Paper start - InteractionResult API
++                    if (event.getInteractionResult() != null) {
++                        result = InteractionResult.toNMS(event.getInteractionResult());
++                    }
++                    // Paper end
+                 }
+                 this.player.gameMode.firedInteract = false;
+             }
+@@ -2013,7 +2024,10 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+                 return;
+             }
+             // CraftBukkit end
+-            InteractionResult enuminteractionresult = this.player.gameMode.useItem(this.player, worldserver, itemstack, enumhand);
++            // Paper start - InteractionResult API
++            InteractionResult originalResult = this.player.gameMode.useItem(this.player, worldserver, itemstack, enumhand);
++            InteractionResult enuminteractionresult = result == null ? originalResult : result;
++            // Paper end
+ 
+             if (enuminteractionresult.shouldSwing()) {
+                 this.player.swing(enumhand, true);
+@@ -2792,13 +2806,22 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+                                     ServerGamePacketListenerImpl.this.player.containerMenu.sendAllDataToRemote();
+                                 }
+                             }
++                            // Paper start - InteractionResult API
++                            InteractionResult interactionResult = null;
++                            if (event.getInteractionResult() != null) {
++                                interactionResult = InteractionResult.toNMS(event.getInteractionResult());
++                            }
++                            // Paper end
+ 
+                             if (event.isCancelled()) {
+                                 ServerGamePacketListenerImpl.this.player.containerMenu.sendAllDataToRemote(); // Paper - Refresh player inventory
+                                 return;
+                             }
+                             // CraftBukkit end
+-                            InteractionResult enuminteractionresult = playerconnection_a.run(ServerGamePacketListenerImpl.this.player, entity, enumhand);
++                            // Paper start - InteractionResult API
++                            InteractionResult originalResult = playerconnection_a.run(ServerGamePacketListenerImpl.this.player, entity, enumhand);
++                            InteractionResult enuminteractionresult = interactionResult == null ? originalResult : interactionResult;
++                            // Paper end
+ 
+                             // CraftBukkit start
+                             if (!itemInHand.isEmpty() && itemInHand.getCount() <= -1) {
+diff --git a/src/main/java/net/minecraft/world/InteractionResult.java b/src/main/java/net/minecraft/world/InteractionResult.java
+index 8dba37369054ff725623146d12cd1b681f6cc3b5..1ed51a35b6a5b89962318578cab45e9dcbdb4e38 100644
+--- a/src/main/java/net/minecraft/world/InteractionResult.java
++++ b/src/main/java/net/minecraft/world/InteractionResult.java
+@@ -23,4 +23,14 @@ public enum InteractionResult {
+     public static InteractionResult sidedSuccess(boolean swingHand) {
+         return swingHand ? SUCCESS : CONSUME;
+     }
++    // Paper start - InteractionResult API
++
++    public static InteractionResult toNMS(io.papermc.paper.world.interaction.InteractionResult result) {
++        return InteractionResult.valueOf(result.toString());
++    }
++
++    public static io.papermc.paper.world.interaction.InteractionResult toPaper(InteractionResult result) {
++        return io.papermc.paper.world.interaction.InteractionResult.valueOf(result.toString());
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
+index e89f9c3e887601d8461eb967ae0bf582b672f631..3dba5fa67631f861034e7169c4db5572754a8522 100644
+--- a/src/main/java/net/minecraft/world/entity/Mob.java
++++ b/src/main/java/net/minecraft/world/entity/Mob.java
+@@ -1461,7 +1461,13 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Targeti
+             // CraftBukkit end
+             this.dropLeash(true, event.isDropLeash()); // Paper - Expand EntityUnleashEvent
+             this.gameEvent(GameEvent.ENTITY_INTERACT, player);
+-            return InteractionResult.sidedSuccess(this.level().isClientSide);
++            // Paper start - InteractionResult API
++            InteractionResult interactionResult = null;
++            if (event.getInteractionResult() != null) {
++                interactionResult = InteractionResult.toNMS(event.getInteractionResult());
++            }
++            // Paper end
++            return interactionResult == null ? InteractionResult.sidedSuccess(this.level().isClientSide) : interactionResult; // Paper - InteractionResult API
+         } else {
+             InteractionResult enuminteractionresult = this.checkAndHandleImportantInteractions(player, hand);
+ 
+@@ -1485,7 +1491,8 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Targeti
+ 
+         if (itemstack.is(Items.LEAD) && this.canBeLeashed(player)) {
+             // CraftBukkit start - fire PlayerLeashEntityEvent
+-            if (CraftEventFactory.callPlayerLeashEntityEvent(this, player, player, hand).isCancelled()) {
++            org.bukkit.event.entity.PlayerLeashEntityEvent event = CraftEventFactory.callPlayerLeashEntityEvent(this, player, player, hand);// Paper - InteractionResult API
++            if (event.isCancelled()) { // Paper
+                 ((ServerPlayer) player).resendItemInHands(); // SPIGOT-7615: Resend to fix client desync with used item
+                 ((ServerPlayer) player).connection.send(new ClientboundSetEntityLinkPacket(this, this.getLeashHolder()));
+                 player.containerMenu.sendAllDataToRemote(); // Paper - Fix inventory desync
+@@ -1494,7 +1501,13 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Targeti
+             // CraftBukkit end
+             this.setLeashedTo(player, true);
+             itemstack.shrink(1);
+-            return InteractionResult.sidedSuccess(this.level().isClientSide);
++            // Paper start - InteractionResult API
++            InteractionResult interactionResult = null;
++            if (event.getInteractionResult() != null) {
++                interactionResult = InteractionResult.toNMS(event.getInteractionResult());
++            }
++            // Paper end
++            return interactionResult == null ? InteractionResult.sidedSuccess(this.level().isClientSide) : interactionResult;
+         } else {
+             if (itemstack.is(Items.NAME_TAG)) {
+                 InteractionResult enuminteractionresult = itemstack.interactLivingEntity(player, this, hand);


### PR DESCRIPTION
Exposes the InteractionResult API to Paper. Allows certain events to create "overrides" for the returned InteractionResult where the event is called. Allows plugin devs to use a more specific approach to handling the return value of the event without directly canceling it.

The enum InteractionResult in ``io.papermc.paper.world.interaction.InteractionResult`` has the following Enum Values:
- SUCCESS
- SUCCESS_NO_ITEM_USED
- CONSUME
- CONSUME_PARTIAL
- PASS
- FAIL

The override of the InteractionResult will only occur when the event isn't canceled. Getters inside the events modified return null for when no override is present.