### PR TITLE
Fixes issues in the suppress dismount cancellation patch

### DIFF
--- a/patches/server/0271-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0271-force-entity-dismount-during-teleportation.patch
@@ -19,18 +19,39 @@ this is going to be the best soultion all around.
 
 Improvements/suggestions welcome!
 
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 665fcf8382fbcb214eda16dae9e40e33e257ec6f..2313c451dbcb28e79d8ff139696e2efb0c4ae756 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -2480,9 +2480,15 @@ public class ServerPlayer extends Player {
+ 
+     @Override
+     public void stopRiding() {
++        // Paper start - Force entity dismount during teleportation
++        this.stopRiding(false);
++    }
++    @Override
++    public void stopRiding(boolean suppressCancellation) {
++        // Paper end - Force entity dismount during teleportation
+         Entity entity = this.getVehicle();
+ 
+-        super.stopRiding();
++        super.stopRiding(suppressCancellation); // Paper - Force entity dismount during teleportation
+         if (entity instanceof LivingEntity entityliving) {
+             Iterator iterator = entityliving.getActiveEffects().iterator();
+ 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 50c5ad0eea45c1828b9a1c6c47727e4800940252..d372e2793948f532f473cd6eca578ebd3ff3fbfb 100644
+index 50c5ad0eea45c1828b9a1c6c47727e4800940252..932d9bb32c1473a31ea4da429c1f2dc3b3a73f60 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2601,11 +2601,16 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2601,17 +2601,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void removeVehicle() {
 +        // Paper start - Force entity dismount during teleportation
-+        stopRiding(false);
++        this.removeVehicle(false);
 +    }
-+    public void stopRiding(boolean suppressCancellation) {
++    public void removeVehicle(boolean suppressCancellation) {
 +        // Paper end - Force entity dismount during teleportation
          if (this.vehicle != null) {
              Entity entity = this.vehicle;
@@ -41,7 +62,20 @@ index 50c5ad0eea45c1828b9a1c6c47727e4800940252..d372e2793948f532f473cd6eca578ebd
          }
  
      }
-@@ -2636,7 +2641,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+ 
+     public void stopRiding() {
+-        this.removeVehicle();
++        // Paper start - Force entity dismount during teleportation
++        this.stopRiding(false);
++    }
++
++    public void stopRiding(boolean suppressCancellation) {
++        this.removeVehicle(suppressCancellation);
++        // Paper end - Force entity dismount during teleportation
+     }
+ 
+     protected void addPassenger(Entity passenger) {
+@@ -2636,7 +2647,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          }
      }
  
@@ -53,7 +87,7 @@ index 50c5ad0eea45c1828b9a1c6c47727e4800940252..d372e2793948f532f473cd6eca578ebd
          if (entity.getVehicle() == this) {
              throw new IllegalStateException("Use x.stopRiding(y), not y.removePassenger(x)");
          } else {
-@@ -2646,7 +2654,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2646,7 +2660,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              if (this.getBukkitEntity() instanceof Vehicle && entity.getBukkitEntity() instanceof LivingEntity) {
                  VehicleExitEvent event = new VehicleExitEvent(
                          (Vehicle) this.getBukkitEntity(),
@@ -62,7 +96,7 @@ index 50c5ad0eea45c1828b9a1c6c47727e4800940252..d372e2793948f532f473cd6eca578ebd
                  );
                  // Suppress during worldgen
                  if (this.valid) {
-@@ -2659,7 +2667,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2659,7 +2673,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  }
              }
  
@@ -72,7 +106,7 @@ index 50c5ad0eea45c1828b9a1c6c47727e4800940252..d372e2793948f532f473cd6eca578ebd
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9bb2b2baecfd4cfb9dbbf7cf5c8be939f1ecc4d6..47b1a4ec278cf9762c9eb9c1448cf78912b7d77a 100644
+index 9bb2b2baecfd4cfb9dbbf7cf5c8be939f1ecc4d6..27912ca1a9825db67e77886da01ab843bd0b005b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3585,9 +3585,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -80,7 +114,7 @@ index 9bb2b2baecfd4cfb9dbbf7cf5c8be939f1ecc4d6..47b1a4ec278cf9762c9eb9c1448cf789
      @Override
      public void stopRiding() {
 +        // Paper start - Force entity dismount during teleportation
-+        stopRiding(false);
++        this.stopRiding(false);
 +    }
 +    @Override
 +    public void stopRiding(boolean suppressCancellation) {
@@ -92,8 +126,27 @@ index 9bb2b2baecfd4cfb9dbbf7cf5c8be939f1ecc4d6..47b1a4ec278cf9762c9eb9c1448cf789
          if (entity != null && entity != this.getVehicle() && !this.level().isClientSide) {
              this.dismountVehicle(entity);
          }
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Shulker.java b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
+index 509c8fae366e6aeca324b4d8e39bd3182d6d9b9b..c2005b86ac9ff6aa03ef7937c2b7a228addc4f01 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Shulker.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
+@@ -288,7 +288,13 @@ public class Shulker extends AbstractGolem implements VariantHolder<Optional<Dye
+ 
+     @Override
+     public void stopRiding() {
+-        super.stopRiding();
++        // Paper start - Force entity dismount during teleportation
++        this.stopRiding(false);
++    }
++    @Override
++    public void stopRiding(boolean suppressCancellation) {
++        super.stopRiding(suppressCancellation);
++        // Paper end - Force entity dismount during teleportation
+         if (this.level().isClientSide) {
+             this.clientOldAttachPosition = this.blockPosition();
+         }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index b27a6719edd47f7ecb3f8c5560a36fc201efea36..bbafbeff99a7c1bd2d9e27982671a017071f829c 100644
+index b27a6719edd47f7ecb3f8c5560a36fc201efea36..62a855594b5b87b92e18f47b84a18b99df1e33c7 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -1150,7 +1150,13 @@ public abstract class Player extends LivingEntity {
@@ -102,11 +155,11 @@ index b27a6719edd47f7ecb3f8c5560a36fc201efea36..bbafbeff99a7c1bd2d9e27982671a017
      public void removeVehicle() {
 -        super.removeVehicle();
 +        // Paper start - Force entity dismount during teleportation
-+        stopRiding(false);
++        this.removeVehicle(false);
 +    }
 +    @Override
-+    public void stopRiding(boolean suppressCancellation) {
-+        super.stopRiding(suppressCancellation);
++    public void removeVehicle(boolean suppressCancellation) {
++        super.removeVehicle(suppressCancellation);
 +        // Paper end - Force entity dismount during teleportation
          this.boardingCooldown = 0;
      }

--- a/patches/server/0353-Fix-item-duplication-and-teleport-issues.patch
+++ b/patches/server/0353-Fix-item-duplication-and-teleport-issues.patch
@@ -16,7 +16,7 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 511208e323b26df24263b87eeb7d2645572d9ff8..c6877df96229eb922fa0d4029f31d9698eab78ab 100644
+index d45923ad2d82b3eb73a832c557eeea3c069b4dc9..6fcaa0e343b6f4e0e80eecdb7ea3e70d98272280 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2447,11 +2447,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -34,7 +34,7 @@ index 511208e323b26df24263b87eeb7d2645572d9ff8..c6877df96229eb922fa0d4029f31d969
  
              entityitem.setDefaultPickUpDelay();
              // CraftBukkit start
-@@ -3238,6 +3239,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3244,6 +3245,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      @Nullable
      public Entity teleportTo(ServerLevel worldserver, Vec3 location) {
          // CraftBukkit end
@@ -47,7 +47,7 @@ index 511208e323b26df24263b87eeb7d2645572d9ff8..c6877df96229eb922fa0d4029f31d969
          if (this.level() instanceof ServerLevel && !this.isRemoved()) {
              this.level().getProfiler().push("changeDimension");
              // CraftBukkit start
-@@ -3264,6 +3271,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3270,6 +3277,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  // CraftBukkit end
  
                  this.level().getProfiler().popPush("reloading");
@@ -59,7 +59,7 @@ index 511208e323b26df24263b87eeb7d2645572d9ff8..c6877df96229eb922fa0d4029f31d969
                  Entity entity = this.getType().create(worldserver);
  
                  if (entity != null) {
-@@ -3281,10 +3293,6 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3287,10 +3299,6 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                      // CraftBukkit start - Forward the CraftEntity to the new entity
                      this.getBukkitEntity().setHandle(entity);
                      entity.bukkitEntity = this.getBukkitEntity();
@@ -70,7 +70,7 @@ index 511208e323b26df24263b87eeb7d2645572d9ff8..c6877df96229eb922fa0d4029f31d969
                      // CraftBukkit end
                  }
  
-@@ -3405,7 +3413,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3411,7 +3419,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean canChangeDimensions() {
@@ -80,7 +80,7 @@ index 511208e323b26df24263b87eeb7d2645572d9ff8..c6877df96229eb922fa0d4029f31d969
  
      public float getBlockExplosionResistance(Explosion explosion, BlockGetter world, BlockPos pos, BlockState blockState, FluidState fluidState, float max) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2f3615cb8e4206ed2eb87c1341de4258879d3907..c640d68c35b4454bfa0ae1764dee341041d9c31e 100644
+index dfe327a17ec97d9317e451303721c7fea5268d2f..5280bae3ad8f9c137e58add8a8d056df81de9928 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1740,9 +1740,9 @@ public abstract class LivingEntity extends Entity implements Attackable {

--- a/patches/server/0380-Ensure-Entity-position-and-AABB-are-never-invalid.patch
+++ b/patches/server/0380-Ensure-Entity-position-and-AABB-are-never-invalid.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Ensure Entity position and AABB are never invalid
 Co-authored-by: Spottedleaf <Spottedleaf@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c6877df96229eb922fa0d4029f31d9698eab78ab..8576e7919dfaf6a17e6442a2047a7d6bef3b53cb 100644
+index 6fcaa0e343b6f4e0e80eecdb7ea3e70d98272280..d0e5769b7abf255ac5d64c499e872ecb9acf4829 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -665,8 +665,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -20,7 +20,7 @@ index c6877df96229eb922fa0d4029f31d9698eab78ab..8576e7919dfaf6a17e6442a2047a7d6b
      }
  
      protected AABB makeBoundingBox() {
-@@ -4175,7 +4175,29 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4181,7 +4181,29 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return this.getZ((2.0D * this.random.nextDouble() - 1.0D) * widthScale);
      }
  
@@ -50,7 +50,7 @@ index c6877df96229eb922fa0d4029f31d9698eab78ab..8576e7919dfaf6a17e6442a2047a7d6b
          if (this.position.x != x || this.position.y != y || this.position.z != z) {
              this.position = new Vec3(x, y, z);
              int i = Mth.floor(x);
-@@ -4193,6 +4215,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4199,6 +4221,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              this.levelCallback.onMove();
          }
  

--- a/patches/server/0421-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0421-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index cde8925d0754c2428cf830ac58d83b9420947e30..e40387e9a822603379fabb9a9c64c55e64c3bec3 100644
+index f5078b093b61dfe58e6fac24f59af945dd2f3df4..81ff696c34afffe6b1ee76347984b0d8cb5723e7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4439,4 +4439,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4445,4 +4445,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0423-Entity-isTicking.patch
+++ b/patches/server/0423-Entity-isTicking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e40387e9a822603379fabb9a9c64c55e64c3bec3..81c9f06bdba9eb51c9ee3d1d969f8d8e6302a70f 100644
+index 81ff696c34afffe6b1ee76347984b0d8cb5723e7..905d740814b7c911e8449fc53d6e5de7e77ecaf9 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4444,5 +4444,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4450,5 +4450,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0460-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0460-MC-4-Fix-item-position-desync.patch
@@ -28,10 +28,10 @@ index ffec3deb9bcd31d51974c1deda2e76bc8374e5c5..a3d247c93ac1a2d872ff0e3841efc3d7
  
      public Vec3 decode(long x, long y, long z) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3bc4b964d49d7de789506a482de9eb700051a2b8..67dd20b6fae2ee39eaae3286eba7b485a6dd41cc 100644
+index adfafb697eb7ba83b6c5305ce16e0b6fd191aae6..19da8864597b876dc302bed011ee38899b168da7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4212,6 +4212,16 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4218,6 +4218,16 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              return;
          }
          // Paper end - Block invalid positions and bounding box

--- a/patches/server/0563-Fix-dangerous-end-portal-logic.patch
+++ b/patches/server/0563-Fix-dangerous-end-portal-logic.patch
@@ -11,7 +11,7 @@ Move the tick logic into the post tick, where portaling was
 designed to happen in the first place.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index eb5cc58e5b53407de5d2a0ddcbbfbc7cdd3bb072..99cdadb3c84f3b40eaec7ba5df6601a0454f3569 100644
+index 19f205560df2e35c2df05631de6e400c2f6a11f3..7e33e3ab3f14fccd85333b5192cd9c1119f0e5e4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -423,6 +423,36 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -51,7 +51,7 @@ index eb5cc58e5b53407de5d2a0ddcbbfbc7cdd3bb072..99cdadb3c84f3b40eaec7ba5df6601a0
      public float getBukkitYaw() {
          return this.yRot;
      }
-@@ -2828,6 +2858,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2834,6 +2864,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              }
  
              this.processPortalCooldown();

--- a/patches/server/0589-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0589-Optimize-indirect-passenger-iteration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 99cdadb3c84f3b40eaec7ba5df6601a0454f3569..95d5ad9517d57a319970375be37e44ef0e8fb79e 100644
+index 7e33e3ab3f14fccd85333b5192cd9c1119f0e5e4..b92aba1a77bc8139f28232b96f1a126eef7852a4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3870,20 +3870,34 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3876,20 +3876,34 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      private Stream<Entity> getIndirectPassengersStream() {
@@ -43,7 +43,7 @@ index 99cdadb3c84f3b40eaec7ba5df6601a0454f3569..95d5ad9517d57a319970375be37e44ef
          return () -> {
              return this.getIndirectPassengersStream().iterator();
          };
-@@ -3896,6 +3910,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3902,6 +3916,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean hasExactlyOnePlayerPassenger() {

--- a/patches/server/0597-Add-back-EntityPortalExitEvent.patch
+++ b/patches/server/0597-Add-back-EntityPortalExitEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add back EntityPortalExitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 95d5ad9517d57a319970375be37e44ef0e8fb79e..541789139e9ccb0371a93da989b1f9701fceb034 100644
+index b92aba1a77bc8139f28232b96f1a126eef7852a4..74c5f418ea6b5861d8e5d4ced17b5a8772d6dcde 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3307,6 +3307,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3313,6 +3313,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              } else {
                  // CraftBukkit start
                  worldserver = shapedetectorshape.world;
@@ -37,7 +37,7 @@ index 95d5ad9517d57a319970375be37e44ef0e8fb79e..541789139e9ccb0371a93da989b1f970
                  if (worldserver == this.level) {
                      // SPIGOT-6782: Just move the entity if a plugin changed the world to the one the entity is already in
                      this.moveTo(shapedetectorshape.pos.x, shapedetectorshape.pos.y, shapedetectorshape.pos.z, shapedetectorshape.yRot, shapedetectorshape.xRot);
-@@ -3326,8 +3348,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3332,8 +3354,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
                  if (entity != null) {
                      entity.restoreFrom(this);

--- a/patches/server/0652-Forward-CraftEntity-in-teleport-command.patch
+++ b/patches/server/0652-Forward-CraftEntity-in-teleport-command.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Forward CraftEntity in teleport command
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e4885d1fd68955107e871dd4457df7e468348e15..b488fe4ddc8a4fad42f45b2a7158766df3a85de4 100644
+index c5d652b24c5442e1f566e7f1fe71748f0d406f86..e3243ee624861771fb6b7c39a91ad33f827eebaa 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3279,6 +3279,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3285,6 +3285,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void restoreFrom(Entity original) {
@@ -22,7 +22,7 @@ index e4885d1fd68955107e871dd4457df7e468348e15..b488fe4ddc8a4fad42f45b2a7158766d
          CompoundTag nbttagcompound = original.saveWithoutId(new CompoundTag());
  
          nbttagcompound.remove("Dimension");
-@@ -3369,10 +3376,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3375,10 +3382,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                          }
                      }
                      // CraftBukkit end

--- a/patches/server/0740-Add-EntityPortalReadyEvent.patch
+++ b/patches/server/0740-Add-EntityPortalReadyEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add EntityPortalReadyEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e6c0dbe34790351f847a9a44aa6c733b71775318..8d80018d7bd1cdce2dafa4d0be5499f1d86c75fe 100644
+index 652dd9a4c1039b1f57844aa51041cb36b5c53568..0fae685f32cf370ae0023969d20ecd907a3be442 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2862,6 +2862,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2868,6 +2868,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  if (true && !this.isPassenger() && this.portalTime++ >= i) { // CraftBukkit
                      this.level().getProfiler().push("portal");
                      this.portalTime = i;
@@ -22,7 +22,7 @@ index e6c0dbe34790351f847a9a44aa6c733b71775318..8d80018d7bd1cdce2dafa4d0be5499f1
                      this.setPortalCooldown();
                      // CraftBukkit start
                      if (this instanceof ServerPlayer) {
-@@ -2869,6 +2876,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2875,6 +2882,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                      } else {
                          this.changeDimension(worldserver1);
                      }

--- a/patches/server/0780-Fix-EntityCombustEvent-cancellation-cant-fully-preve.patch
+++ b/patches/server/0780-Fix-EntityCombustEvent-cancellation-cant-fully-preve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix EntityCombustEvent cancellation cant fully prevent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8d80018d7bd1cdce2dafa4d0be5499f1d86c75fe..b49efb6f5f106396894831f28841d5a14d5a8c00 100644
+index 0fae685f32cf370ae0023969d20ecd907a3be442..0d1b6e05e2a8bc7cae3936e94033d9f936e61645 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3127,6 +3127,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3133,6 +3133,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              pluginManager.callEvent(entityCombustEvent);
              if (!entityCombustEvent.isCancelled()) {
                  this.igniteForSeconds(entityCombustEvent.getDuration(), false);

--- a/patches/server/0794-Player-Entity-Tracking-Events.patch
+++ b/patches/server/0794-Player-Entity-Tracking-Events.patch
@@ -21,10 +21,10 @@ index de19a5ea96fa38621513e970e04d153576f4f6ae..bff776f07bcc7841acc5757c1f53bde1
                  } else if (this.seenBy.remove(player.connection)) {
                      this.serverEntity.removePairing(player);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b49efb6f5f106396894831f28841d5a14d5a8c00..1cb763e6a33d16ecfb5322f9c78115344eef7249 100644
+index 0d1b6e05e2a8bc7cae3936e94033d9f936e61645..12f165b3a8bc66f7836ce914b324509a48bf1b9f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3853,7 +3853,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3859,7 +3859,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      public void startSeenByPlayer(ServerPlayer player) {}
  

--- a/patches/server/0803-Improve-PortalEvents.patch
+++ b/patches/server/0803-Improve-PortalEvents.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Improve PortalEvents
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1cb763e6a33d16ecfb5322f9c78115344eef7249..f256bd908a9683085fa47d2a84cbdee78a7ba20b 100644
+index 12f165b3a8bc66f7836ce914b324509a48bf1b9f..cb426597c0ecf9469f87f8ea0dc29a87a8c098f2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3513,7 +3513,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3519,7 +3519,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          Location enter = bukkitEntity.getLocation();
          Location exit = CraftLocation.toBukkit(exitPosition, exitWorldServer.getWorld());
  

--- a/patches/server/0866-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/server/0866-Folia-scheduler-and-owned-region-API.patch
@@ -1185,7 +1185,7 @@ index 942af999a4a3aa03cb7ef5f0b9d377c78677fd0e..0246db4a1f6eb168fa88260282311fee
          this.players.remove(entityplayer);
          this.playersByName.remove(entityplayer.getScoreboardName().toLowerCase(java.util.Locale.ROOT)); // Spigot
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 51032754e62b9e5da3f1c1adffbae4168cfbb0d1..b2c2d45bf390b9968dbb20c150b1fac2559a08a7 100644
+index fbee7db6e9d8312e55cabfbc08decdb99dbd115b..897bc3c59f2c2cfdcdfcfe96804394dbb14457f7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -250,11 +250,23 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -1213,7 +1213,7 @@ index 51032754e62b9e5da3f1c1adffbae4168cfbb0d1..b2c2d45bf390b9968dbb20c150b1fac2
      @Override
      public CommandSender getBukkitSender(CommandSourceStack wrapper) {
          return this.getBukkitEntity();
-@@ -4472,6 +4484,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4478,6 +4490,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public final void setRemoved(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
          CraftEventFactory.callEntityRemoveEvent(this, cause);
          // CraftBukkit end
@@ -1221,7 +1221,7 @@ index 51032754e62b9e5da3f1c1adffbae4168cfbb0d1..b2c2d45bf390b9968dbb20c150b1fac2
          if (this.removalReason == null) {
              this.removalReason = entity_removalreason;
          }
-@@ -4482,12 +4495,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4488,12 +4501,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
          this.getPassengers().forEach(Entity::stopRiding);
          this.levelCallback.onRemove(entity_removalreason);

--- a/patches/server/0937-Fix-NPE-on-null-loc-for-EntityTeleportEvent.patch
+++ b/patches/server/0937-Fix-NPE-on-null-loc-for-EntityTeleportEvent.patch
@@ -26,7 +26,7 @@ index a306b30af19277386a2f3e560b4902a8b5796f2a..54851f6cc0d5fddb32a9a1e84a4f5ae4
                  x = to.getX();
                  y = to.getY();
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9a5b42bce2604d17ed4cf2c8c7eea55557ec3eff..5a47752a1c7da9b9da692c34ef046988924b6266 100644
+index ae63033bab20bec39e0562421e7a3f449648a69d..c256b4307e896b3e9f0a399a93db761a8c5c593f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -4189,7 +4189,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -52,10 +52,10 @@ index 8fa9282acd87132516329083f774345df3310cf2..edd29c2f4d0151d512618115a8fb4b74
              }
              Location to = event.getTo();
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Shulker.java b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
-index 509c8fae366e6aeca324b4d8e39bd3182d6d9b9b..c1f73e10d8473251425300cedbed2b82da6a79ce 100644
+index 94b9bb65d14ef58fc00c2de2953b2ce2a9b87b0a..2b149742536af8689562876d97b31bc6367757e7 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Shulker.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
-@@ -409,7 +409,7 @@ public class Shulker extends AbstractGolem implements VariantHolder<Optional<Dye
+@@ -415,7 +415,7 @@ public class Shulker extends AbstractGolem implements VariantHolder<Optional<Dye
                      if (enumdirection != null) {
                          // CraftBukkit start
                          EntityTeleportEvent teleportEvent = CraftEventFactory.callEntityTeleportEvent(this, blockposition1.getX(), blockposition1.getY(), blockposition1.getZ());

--- a/patches/server/0947-Add-ShulkerDuplicateEvent.patch
+++ b/patches/server/0947-Add-ShulkerDuplicateEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ShulkerDuplicateEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Shulker.java b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
-index c1f73e10d8473251425300cedbed2b82da6a79ce..5215fa54666979ef4da074ddfdb082e7274f2957 100644
+index 2b149742536af8689562876d97b31bc6367757e7..1acf95fd38c09d29411171964dd79172e0bdf221 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Shulker.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
-@@ -485,6 +485,11 @@ public class Shulker extends AbstractGolem implements VariantHolder<Optional<Dye
+@@ -491,6 +491,11 @@ public class Shulker extends AbstractGolem implements VariantHolder<Optional<Dye
                  if (entityshulker != null) {
                      entityshulker.setVariant(this.getVariant());
                      entityshulker.moveTo(vec3d);

--- a/patches/server/0965-Fix-DamageSource-API.patch
+++ b/patches/server/0965-Fix-DamageSource-API.patch
@@ -68,10 +68,10 @@ index abda6094e02ebd2589ba0e4760e574fcf44dc8e4..5ec8cbd07a1830876f58e1fd33de6df4
  
      public DamageSource sonicBoom(Entity attacker) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0782fd7bf29aa4d30ea5a9a303cc43620fe5b06e..3c1bcf8d1a07b35a8688160c9f05f792451338a3 100644
+index a28a26fd6b409471c14e5702b45f42b23e2bfbeb..d6c24ad4e32fba5416c7cdd898d72f6207ae278a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3195,7 +3195,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3201,7 +3201,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              return;
          }
  

--- a/patches/server/0977-Rewrite-chunk-system.patch
+++ b/patches/server/0977-Rewrite-chunk-system.patch
@@ -18983,7 +18983,7 @@ index b33bf957b1541756e3b983b87b1c83629757739a..0ccdc8d135dd3edb410fbc1d248c20a4
          return crashreportsystemdetails;
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3a3c17e62244a16cbad5558d55bcf8e330997acb..683d2cc82e1ffce45d533eab0a1ee7c367af62c8 100644
+index e247bafe1e7035b4e3f161b5a641af7ed116ebc1..2b5160468b9eb5bf869c24ea3b52a9d82df7bf16 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -293,6 +293,50 @@ public class ServerPlayer extends Player {
@@ -19500,7 +19500,7 @@ index 7984f17cd9c4cef8100909b6c33b3144c8096fcf..639f72618a7c22fa94effa9d0406b97f
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3c1bcf8d1a07b35a8688160c9f05f792451338a3..03840f520624662d4ce3ac9f3065a01c71b5f299 100644
+index d6c24ad4e32fba5416c7cdd898d72f6207ae278a..e4ae674d006821b254ffdd88c37c4a2dfec86bd9 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -482,6 +482,58 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -19576,7 +19576,7 @@ index 3c1bcf8d1a07b35a8688160c9f05f792451338a3..03840f520624662d4ce3ac9f3065a01c
          return false;
      }
  
-@@ -4037,6 +4089,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4043,6 +4095,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          }).count();
      }
  
@@ -19590,7 +19590,7 @@ index 3c1bcf8d1a07b35a8688160c9f05f792451338a3..03840f520624662d4ce3ac9f3065a01c
      public boolean hasExactlyOnePlayerPassenger() {
          if (this.passengers.isEmpty()) { return false; } // Paper - Optimize indirect passenger iteration
          return this.countPlayerPassengers() == 1;
-@@ -4387,6 +4446,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4393,6 +4452,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              return;
          }
          // Paper end - Block invalid positions and bounding box
@@ -19603,7 +19603,7 @@ index 3c1bcf8d1a07b35a8688160c9f05f792451338a3..03840f520624662d4ce3ac9f3065a01c
          // Paper start - Fix MC-4
          if (this instanceof ItemEntity) {
              if (io.papermc.paper.configuration.GlobalConfiguration.get().misc.fixEntityPositionDesync) {
-@@ -4514,6 +4579,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4520,6 +4585,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
      public final void setRemoved(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
@@ -19617,7 +19617,7 @@ index 3c1bcf8d1a07b35a8688160c9f05f792451338a3..03840f520624662d4ce3ac9f3065a01c
          CraftEventFactory.callEntityRemoveEvent(this, cause);
          // CraftBukkit end
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
-@@ -4525,7 +4597,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4531,7 +4603,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              this.stopRiding();
          }
  
@@ -19626,7 +19626,7 @@ index 3c1bcf8d1a07b35a8688160c9f05f792451338a3..03840f520624662d4ce3ac9f3065a01c
          this.levelCallback.onRemove(entity_removalreason);
          // Paper start - Folia schedulers
          if (!(this instanceof ServerPlayer) && entity_removalreason != RemovalReason.CHANGED_DIMENSION && !alreadyRemoved) {
-@@ -4556,7 +4628,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4562,7 +4634,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
      public boolean shouldBeSaved() {

--- a/patches/server/1008-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/1008-Detail-more-information-in-watchdog-dumps.patch
@@ -122,7 +122,7 @@ index bdad61438e7fd89f5f0cac6632dd395fcf024361..019034eea40c1669ce3d774565ce71c0
  
      private void tickPassenger(Entity vehicle, Entity passenger) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 257943b4c984d6faee29eca17c8f951e7f43168b..0fbcf60a994f67bdd81d40e4a8bf38f0cbb8993d 100644
+index 1b4659db5a90d0846b8904a6b8550d743ef38eb3..1a989abfb9ffe75e080e811647815a3e48de53df 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1074,8 +1074,43 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -183,7 +183,7 @@ index 257943b4c984d6faee29eca17c8f951e7f43168b..0fbcf60a994f67bdd81d40e4a8bf38f0
      }
  
      private boolean isStateClimbable(BlockState state) {
-@@ -4405,7 +4447,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4411,7 +4453,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void setDeltaMovement(Vec3 velocity) {
@@ -193,7 +193,7 @@ index 257943b4c984d6faee29eca17c8f951e7f43168b..0fbcf60a994f67bdd81d40e4a8bf38f0
      }
  
      public void addDeltaMovement(Vec3 velocity) {
-@@ -4508,7 +4552,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4514,7 +4558,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          }
          // Paper end - Fix MC-4
          if (this.position.x != x || this.position.y != y || this.position.z != z) {


### PR DESCRIPTION
The `suppressCancellation` functionality here isn't used almost anywhere, especially in teleportation despite the patch title. However it will be once the re-work of internal teleportation logic is done. This fixes an issue in that patch where the original OBFHELPER name selected for the overloads turned out to conflict with a mojang named method so the overrides where *almost* linked together in such a way to cause a StackOverflow. I don't think there was a possibility of one, but this removes all chance.