### PR TITLE
Fix a few issues with ItemMeta

### DIFF
--- a/patches/api/0056-Fix-upstream-javadocs.patch
+++ b/patches/api/0056-Fix-upstream-javadocs.patch
@@ -1498,6 +1498,45 @@ index e7d905b1146b2bdd2da5bdeb6bf3541fb181d59e..c7d3041221742f6655155f19ef2addca
       */
      void setBlockState(@NotNull BlockState blockState);
  }
+diff --git a/src/main/java/org/bukkit/inventory/meta/CrossbowMeta.java b/src/main/java/org/bukkit/inventory/meta/CrossbowMeta.java
+index 35c6594fd1040a1af1029e7260e5e3a9307b107d..d58719ee75bef8bc265bfc81bc5d88a426e01dd9 100644
+--- a/src/main/java/org/bukkit/inventory/meta/CrossbowMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/CrossbowMeta.java
+@@ -28,8 +28,7 @@ public interface CrossbowMeta extends ItemMeta {
+      * Removes all projectiles when given null.
+      *
+      * @param projectiles the projectiles to set
+-     * @throws IllegalArgumentException if one of the projectiles is not an
+-     * arrow or firework rocket
++     * @throws IllegalArgumentException if one of the projectiles is empty
+      */
+     void setChargedProjectiles(@Nullable List<ItemStack> projectiles);
+ 
+@@ -37,8 +36,7 @@ public interface CrossbowMeta extends ItemMeta {
+      * Adds a charged projectile to this item.
+      *
+      * @param item projectile
+-     * @throws IllegalArgumentException if the projectile is not an arrow or
+-     * firework rocket
++     * @throws IllegalArgumentException if the projectile is empty
+      */
+     void addChargedProjectile(@NotNull ItemStack item);
+ }
+diff --git a/src/main/java/org/bukkit/inventory/meta/FireworkMeta.java b/src/main/java/org/bukkit/inventory/meta/FireworkMeta.java
+index cdbcc8dbab2456cc2bc1f3084cbb1ced1698b7f5..d528b066c2aaa3fb097931914ff2181f8f64e520 100644
+--- a/src/main/java/org/bukkit/inventory/meta/FireworkMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/FireworkMeta.java
+@@ -86,8 +86,8 @@ public interface FireworkMeta extends ItemMeta {
+      * Sets the approximate power of the firework. Each level of power is half
+      * a second of flight time.
+      *
+-     * @param power the power of the firework, from 0-127
+-     * @throws IllegalArgumentException if {@literal height<0 or height>127}
++     * @param power the power of the firework, from 0-255
++     * @throws IllegalArgumentException if {@literal power < 0 or power > 255}
+      */
+     void setPower(int power) throws IllegalArgumentException;
+ 
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 index a23d030d2204098be17d8b18021fd0bb79b4431b..f427334c6e875a13aa53052ac1b5a746186b4ffe 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
@@ -1512,19 +1551,53 @@ index a23d030d2204098be17d8b18021fd0bb79b4431b..f427334c6e875a13aa53052ac1b5a746
       * AttributeModifiers without a slot are active in any slot.<br>
       * If there are no attributes set for the given slot, an empty map
 diff --git a/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java b/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
-index c1676991c3cc5f8d6e3f97d8cb356d6e2aa52809..7f9eabcaa4d803ee524a9cc8717379fe6a93a5af 100644
+index c1676991c3cc5f8d6e3f97d8cb356d6e2aa52809..1d61cc4ab36413fe3c1ecdf9824a5e18cb4bc148 100644
 --- a/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
-@@ -8,8 +8,8 @@ import org.jetbrains.annotations.Nullable;
+@@ -8,8 +8,9 @@ import org.jetbrains.annotations.Nullable;
  
  /**
   * Represents leather armor ({@link Material#LEATHER_BOOTS}, {@link
 - * Material#LEATHER_CHESTPLATE}, {@link Material#LEATHER_HELMET}, or {@link
 - * Material#LEATHER_LEGGINGS}) that can be colored.
 + * Material#LEATHER_LEGGINGS}, {@link Material#LEATHER_CHESTPLATE}, {@link
-+ * Material#LEATHER_HELMET}, or {@link Material#LEATHER_HORSE_ARMOR}) that can be colored.
++ * Material#LEATHER_HELMET}, {@link Material#LEATHER_HORSE_ARMOR}, {@link
++ * Material#WOLF_ARMOR}) that can be colored.
   */
  public interface LeatherArmorMeta extends ItemMeta {
+ 
+@@ -18,6 +19,9 @@ public interface LeatherArmorMeta extends ItemMeta {
+      * be {@link ItemFactory#getDefaultLeatherColor()}.
+      *
+      * @return the color of the armor, never null
++     * @apiNote The method yielding {@link ItemFactory#getDefaultLeatherColor()} is incorrect
++     * for {@link Material#WOLF_ARMOR} as its default color differs. Generally, it is recommended to check
++     * {@link #isDyed()} to determined if this leather armor is dyed than to compare this colour to the default.
+      */
+     @NotNull
+     Color getColor();
+@@ -25,8 +29,7 @@ public interface LeatherArmorMeta extends ItemMeta {
+     /**
+      * Sets the color of the armor.
+      *
+-     * @param color the color to set. Setting it to null is equivalent to
+-     *     setting it to {@link ItemFactory#getDefaultLeatherColor()}.
++     * @param color the color to set.
+      */
+     void setColor(@Nullable Color color);
+ 
+diff --git a/src/main/java/org/bukkit/inventory/meta/OminousBottleMeta.java b/src/main/java/org/bukkit/inventory/meta/OminousBottleMeta.java
+index 43f0df04f3cdff7d7db73321a2886f3a737e3c9f..5c741228b2338a7c4de2fe736eb789511abf4880 100644
+--- a/src/main/java/org/bukkit/inventory/meta/OminousBottleMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/OminousBottleMeta.java
+@@ -3,7 +3,7 @@ package org.bukkit.inventory.meta;
+ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+- * Represents a map that can be scalable.
++ * Represents an ominous bottle with an amplifier of the bad omen effect.
+  */
+ public interface OminousBottleMeta extends ItemMeta {
  
 diff --git a/src/main/java/org/bukkit/plugin/messaging/PluginMessageRecipient.java b/src/main/java/org/bukkit/plugin/messaging/PluginMessageRecipient.java
 index b84b37fe27d84574dc5897285f1d9a1437bd322c..281ae60a6be7e39aab4f27b4c7de3d49ada9a557 100644

--- a/patches/api/0438-add-missing-Experimental-annotations.patch
+++ b/patches/api/0438-add-missing-Experimental-annotations.patch
@@ -973,6 +973,31 @@ index b670ff8b2bfcaa59c2292211cb9fc2bf4c5b2642..94092a5882180cca7905388184de1f91
      public static final Structure TRIAL_CHAMBERS = getStructure("trial_chambers");
  
      private static Structure getStructure(String name) {
+diff --git a/src/main/java/org/bukkit/inventory/meta/BundleMeta.java b/src/main/java/org/bukkit/inventory/meta/BundleMeta.java
+index e404cd1e2ba44e4c2d09524bc7cf730d8ffbdabd..cea0ebf50876dd32ab7fba6025b30f297d0a69c4 100644
+--- a/src/main/java/org/bukkit/inventory/meta/BundleMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/BundleMeta.java
+@@ -6,6 +6,7 @@ import org.jetbrains.annotations.ApiStatus;
+ import org.jetbrains.annotations.NotNull;
+ import org.jetbrains.annotations.Nullable;
+ 
++@org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.BUNDLE) // Paper - add missing annotation
+ @ApiStatus.Experimental
+ public interface BundleMeta extends ItemMeta {
+ 
+diff --git a/src/main/java/org/bukkit/inventory/meta/OminousBottleMeta.java b/src/main/java/org/bukkit/inventory/meta/OminousBottleMeta.java
+index 5c741228b2338a7c4de2fe736eb789511abf4880..0a25483bcf88e8f7b8e6755d754467930e1a9c65 100644
+--- a/src/main/java/org/bukkit/inventory/meta/OminousBottleMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/OminousBottleMeta.java
+@@ -5,6 +5,8 @@ import org.jetbrains.annotations.NotNull;
+ /**
+  * Represents an ominous bottle with an amplifier of the bad omen effect.
+  */
++@org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++@org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+ public interface OminousBottleMeta extends ItemMeta {
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java b/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
 index f2242ddc4085f7e7cdd748d860857822e3d9b007..9133a889c1936b4cf7dbf17f744ee926d57362a3 100644
 --- a/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java

--- a/patches/api/0472-Expose-hasColor-to-leather-armor.patch
+++ b/patches/api/0472-Expose-hasColor-to-leather-armor.patch
@@ -5,18 +5,17 @@ Subject: [PATCH] Expose #hasColor to leather armor
 
 
 diff --git a/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java b/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
-index 7f9eabcaa4d803ee524a9cc8717379fe6a93a5af..496f4b256406a4f38f36471f57d8529b3f29b6a1 100644
+index 1d61cc4ab36413fe3c1ecdf9824a5e18cb4bc148..fba0512827b4af289674a5602722f520f32d28b2 100644
 --- a/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
-@@ -33,4 +33,14 @@ public interface LeatherArmorMeta extends ItemMeta {
+@@ -36,4 +36,13 @@ public interface LeatherArmorMeta extends ItemMeta {
      @Override
      @NotNull
      LeatherArmorMeta clone();
 +
 +    // Paper start - Expose #hasColor to leather armor
 +    /**
-+     * Checks whether this leather armor is dyed
-+     * (i.e. has a color different from {@link ItemFactory#getDefaultLeatherColor()})
++     * Checks whether this leather armor is dyed.
 +     *
 +     * @return whether this leather armor is dyed
 +     */

--- a/patches/server/0008-CB-fixes.patch
+++ b/patches/server/0008-CB-fixes.patch
@@ -98,18 +98,6 @@ index 1e3ca7ca98abfd5be233a7eeb6dad201776d2d6a..9ec50bbb262b25fea157ae48e8395f5c
                  this.acceptsAll(Main.asList("nogui"), "Disables the graphical console");
  
                  this.acceptsAll(Main.asList("nojline"), "Disables jline and emulates the vanilla console");
-diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMap.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMap.java
-index 6b34a8d33faa49ffa9082995e67af10d3cb38c03..f0c817e27a602740bc979b2ebaec3917e1906d74 100644
---- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMap.java
-+++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMap.java
-@@ -127,6 +127,7 @@ class CraftMetaMap extends CraftMetaItem implements MapMeta {
- 
-     @Override
-     public int getMapId() {
-+        Preconditions.checkState(this.hasMapView(), "Item does not have map associated - check hasMapView() first!"); // Paper - more friendly message
-         return this.mapId;
-     }
- 
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 index 905adf97c0d1f0d1c774a6835a5dffcfea884e58..c017ce2ca1bc535795c958a2e509af2adf88efa9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java

--- a/patches/server/0072-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0072-Handle-Item-Meta-Inconsistencies.patch
@@ -82,10 +82,10 @@ index b49eb019cce58049c2b3a0e80e3d08998b16f7ea..af18de11dd55938b6091f5ab183bd3fe
  
          public Mutable(ItemEnchantments enchantmentsComponent) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index b6521462d193bff83ace1dc694c6d957a7173969..d302767e8f01fdfcba9c22e2e35677afc18c0641 100644
+index b6521462d193bff83ace1dc694c6d957a7173969..6ad6181a6f2c7e2a3de61bec68f1ca1ef5dc494d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -191,16 +191,11 @@ public final class CraftItemStack extends ItemStack {
+@@ -191,16 +191,13 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Preconditions.checkArgument(ench != null, "Enchantment cannot be null");
  
@@ -95,19 +95,20 @@ index b6521462d193bff83ace1dc694c6d957a7173969..d302767e8f01fdfcba9c22e2e35677af
 -        ItemEnchantments list = CraftItemStack.getEnchantmentList(this.handle);
 -        if (list == null) {
 -            list = ItemEnchantments.EMPTY;
--        }
++        // Paper start - Replace whole method
++        final ItemMeta itemMeta = this.getItemMeta();
++        if (itemMeta != null) {
++            itemMeta.addEnchant(ench, level, true);
++            this.setItemMeta(itemMeta);
+         }
 -        ItemEnchantments.Mutable listCopy = new ItemEnchantments.Mutable(list);
 -        listCopy.set(CraftEnchantment.bukkitToMinecraft(ench), level);
 -        this.handle.set(DataComponents.ENCHANTMENTS, listCopy.toImmutable());
-+        // Paper start - Replace whole method
-+        final ItemMeta itemMeta = this.getItemMeta();
-+        itemMeta.addEnchant(ench, level, true);
-+        this.setItemMeta(itemMeta);
 +        // Paper end
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -229,24 +224,15 @@ public final class CraftItemStack extends ItemStack {
+@@ -229,24 +226,15 @@ public final class CraftItemStack extends ItemStack {
      public int removeEnchantment(Enchantment ench) {
          Preconditions.checkArgument(ench != null, "Enchantment cannot be null");
  
@@ -140,7 +141,7 @@ index b6521462d193bff83ace1dc694c6d957a7173969..d302767e8f01fdfcba9c22e2e35677af
  
          return level;
      }
-@@ -258,7 +244,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -258,7 +246,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public Map<Enchantment, Integer> getEnchantments() {

--- a/patches/server/0171-Add-ArmorStand-Item-Meta.patch
+++ b/patches/server/0171-Add-ArmorStand-Item-Meta.patch
@@ -26,7 +26,7 @@ index 662cf08d1cb2b41da5b17dae3585333cdf605c0b..f5bb5802aae64773252c9399df0fbe9d
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
-index c4f12f96e39cb6189799a796b4cb2cb4f0b92392..84e09a934600df116206df1c3922a11ee969901a 100644
+index c4f12f96e39cb6189799a796b4cb2cb4f0b92392..59bdac414e8205ed608f79ef0d1502acd826d216 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
 @@ -11,9 +11,22 @@ import org.bukkit.Material;
@@ -148,13 +148,14 @@ index c4f12f96e39cb6189799a796b4cb2cb4f0b92392..84e09a934600df116206df1c3922a11e
      }
  
      @Override
-@@ -86,7 +159,13 @@ public class CraftMetaArmorStand extends CraftMetaItem {
+@@ -86,7 +159,14 @@ public class CraftMetaArmorStand extends CraftMetaItem {
          if (meta instanceof CraftMetaArmorStand) {
              CraftMetaArmorStand that = (CraftMetaArmorStand) meta;
  
 -            return this.entityTag != null ? that.entityTag != null && this.entityTag.equals(that.entityTag) : this.entityTag == null;
 +            // Paper start
-+            return this.invisible == that.invisible &&
++            return java.util.Objects.equals(this.entityTag, that.entityTag) &&
++                this.invisible == that.invisible &&
 +                this.noBasePlate == that.noBasePlate &&
 +                this.showArms == that.showArms &&
 +                this.small == that.small &&
@@ -163,25 +164,21 @@ index c4f12f96e39cb6189799a796b4cb2cb4f0b92392..84e09a934600df116206df1c3922a11e
          }
          return true;
      }
-@@ -101,9 +180,14 @@ public class CraftMetaArmorStand extends CraftMetaItem {
-         final int original;
-         int hash = original = super.applyHash();
- 
--        if (this.entityTag != null) {
--            hash = 73 * hash + this.entityTag.hashCode();
--        }
+@@ -104,6 +184,13 @@ public class CraftMetaArmorStand extends CraftMetaItem {
+         if (this.entityTag != null) {
+             hash = 73 * hash + this.entityTag.hashCode();
+         }
 +        // Paper start
-+        hash += this.entityTag != null ? 73 * hash + this.entityTag.hashCode() : 0;
-+        hash += this.isInvisible() ? 61 * hash + 1231 : 0;
-+        hash += this.hasNoBasePlate() ? 61 * hash + 1231 : 0;
-+        hash += this.shouldShowArms() ? 61 * hash + 1231 : 0;
-+        hash += this.isSmall() ? 61 * hash + 1231 : 0;
-+        hash += this.isMarker() ? 61 * hash + 1231 : 0;
++        hash = 61 * hash + (this.invisible != null ? Boolean.hashCode(this.isInvisible()) : 0);
++        hash = 61 * hash + (this.noBasePlate != null ? Boolean.hashCode(this.hasNoBasePlate()) : 0);
++        hash = 61 * hash + (this.showArms != null ? Boolean.hashCode(this.shouldShowArms()) : 0);
++        hash = 61 * hash + (this.small != null ? Boolean.hashCode(this.isSmall()) : 0);
++        hash = 61 * hash + (this.marker != null ? Boolean.hashCode(this.isMarker()) : 0);
 +        // Paper end
  
          return original != hash ? CraftMetaArmorStand.class.hashCode() ^ hash : hash;
      }
-@@ -112,6 +196,28 @@ public class CraftMetaArmorStand extends CraftMetaItem {
+@@ -112,6 +199,28 @@ public class CraftMetaArmorStand extends CraftMetaItem {
      Builder<String, Object> serialize(Builder<String, Object> builder) {
          super.serialize(builder);
  
@@ -210,7 +207,7 @@ index c4f12f96e39cb6189799a796b4cb2cb4f0b92392..84e09a934600df116206df1c3922a11e
          return builder;
      }
  
-@@ -125,4 +231,56 @@ public class CraftMetaArmorStand extends CraftMetaItem {
+@@ -125,4 +234,56 @@ public class CraftMetaArmorStand extends CraftMetaItem {
  
          return clone;
      }

--- a/patches/server/0692-More-Projectile-API.patch
+++ b/patches/server/0692-More-Projectile-API.patch
@@ -16,6 +16,7 @@ public net.minecraft.world.entity.projectile.Projectile hasBeenShot
 public net.minecraft.world.entity.projectile.Projectile leftOwner
 public net.minecraft.world.entity.projectile.Projectile preOnHit(Lnet/minecraft/world/phys/HitResult;)V
 public net.minecraft.world.entity.projectile.Projectile canHitEntity(Lnet/minecraft/world/entity/Entity;)Z
+public net.minecraft.world.entity.projectile.FireworkRocketEntity getDefaultItem()Lnet/minecraft/world/item/ItemStack;
 
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
@@ -203,8 +204,21 @@ index 98f46fadd60ea688fefa8d83dbd6fe9b61b6a96f..d4e0170694409e674d488f913e61c205
 +    }
 +    // Paper end
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
+index 7ba6302ecb72fa6e523054e7e3223d79eedf6589..907904da7f89e8e5e5cfab80977f04af3fdf17c7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
+@@ -388,7 +388,7 @@ public final class CraftEntityTypes {
+             BlockPos pos = BlockPos.containing(spawnData.x(), spawnData.y(), spawnData.z());
+             return new FallingBlockEntity(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z(), spawnData.world().getBlockState(pos)); // Paper - create falling block entities correctly
+         }));
+-        register(new EntityTypeData<>(EntityType.FIREWORK_ROCKET, Firework.class, CraftFirework::new, spawnData -> new FireworkRocketEntity(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z(), net.minecraft.world.item.ItemStack.EMPTY)));
++        register(new EntityTypeData<>(EntityType.FIREWORK_ROCKET, Firework.class, CraftFirework::new, spawnData -> new FireworkRocketEntity(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z(), FireworkRocketEntity.getDefaultItem()))); // Paper - pass correct default to rocket for data storage
+         register(new EntityTypeData<>(EntityType.EVOKER_FANGS, EvokerFangs.class, CraftEvokerFangs::new, spawnData -> new net.minecraft.world.entity.projectile.EvokerFangs(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z(), (float) Math.toRadians(spawnData.yaw()), 0, null)));
+         register(new EntityTypeData<>(EntityType.COMMAND_BLOCK_MINECART, CommandMinecart.class, CraftMinecartCommand::new, spawnData -> new MinecartCommandBlock(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z())));
+         register(new EntityTypeData<>(EntityType.MINECART, RideableMinecart.class, CraftMinecartRideable::new, spawnData -> new Minecart(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z())));
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
-index 3c22799d36f07e349df207ce8a39236bbf6c17bf..2124b31ca4d994ad159556d47a315004b7246265 100644
+index e4e23a7b6d308ee476b5b8c2ad80efe4608b8346..241914415f74e0559fef59aa3f87f3e303f6c2c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
 @@ -32,20 +32,7 @@ public class CraftFireball extends AbstractProjectile implements Fireball {
@@ -356,6 +370,19 @@ index 6e2f91423371ead9890095cf4b1e2299c4dcba28..ad1aeea80877f2cdb9e8ad9c5b46f95d
 +    }
 +    // Paper end
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index a4c6fd2f6066ecc4a36a423cb2980ec60d9c7ec1..382b4f0854284a561325dde141000434a9ddd885 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -640,7 +640,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+         } else if (Firework.class.isAssignableFrom(projectile)) {
+             Location location = this.getEyeLocation();
+ 
+-            launch = new FireworkRocketEntity(world, net.minecraft.world.item.ItemStack.EMPTY, this.getHandle());
++            launch = new FireworkRocketEntity(world, FireworkRocketEntity.getDefaultItem(), this.getHandle()); // Paper - pass correct default to rocket for data storage
+             launch.moveTo(location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
+         }
+ 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLlamaSpit.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLlamaSpit.java
 index 70cbc6c668c60e9d608ca7013b72f9b916c05c2d..47633f05b4fab1dcabc2117e7645fe6d6949622a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLlamaSpit.java
@@ -577,10 +604,10 @@ index 5c31c652a3b956dd638137307d1a8b2ee4c3f675..90696beb3ca48fc28c9842589bc3ea39
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 45a1f5123e5413cf8dd3db68bb47508567198403..76191fe677f3dd91ea55d53881f52952410a3a05 100644
+index 3d226c03dbecf876bb5a50d493aceeb0f8f69d28..6352e56fa3e69690846842d474a1ae51ad4059c6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -293,12 +293,22 @@ public final class CraftItemStack extends ItemStack {
+@@ -295,12 +295,22 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0857-fix-item-meta-for-tadpole-buckets.patch
+++ b/patches/server/0857-fix-item-meta-for-tadpole-buckets.patch
@@ -17,10 +17,10 @@ index c13944058e26895a03f0013b6ca49ac7580ee9bf..6e2a6ce5cf456bd9f6c8c18a58f08e22
          case GLOW_ITEM_FRAME:
          case PAINTING:
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 91c1cba51863aeac0f648089bb4b5297ed33320d..eb305f23898ecb0c1dbc4c659da0a23207d8d362 100644
+index a1173823b3a95b973ae742f886b0555b3203288c..55ae50f99a891a26dcdc0ec6266e3c05b3d12a5e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -602,6 +602,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -604,6 +604,7 @@ public final class CraftItemStack extends ItemStack {
              case COD_BUCKET:
              case PUFFERFISH_BUCKET:
              case SALMON_BUCKET:

--- a/patches/server/0872-Respect-randomizeData-on-more-entities-when-spawning.patch
+++ b/patches/server/0872-Respect-randomizeData-on-more-entities-when-spawning.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Respect randomizeData on more entities when spawning
 * ExperienceOrb
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
-index 2c44056065b75efecdf7bc835d1e899d1b50ccfe..405caaff1459d8928f91be0fc85213b80ee8b8af 100644
+index d9881f5f9b36e215afc98ce84c83b3a5443d1d39..d65d538a216fc3a1ed048cf78a8937abe3c0bc1b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
 @@ -221,6 +221,13 @@ public final class CraftEntityTypes {
@@ -50,10 +50,10 @@ index 2c44056065b75efecdf7bc835d1e899d1b50ccfe..405caaff1459d8928f91be0fc85213b8
              BlockPos pos = BlockPos.containing(spawnData.x(), spawnData.y(), spawnData.z());
              return new FallingBlockEntity(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z(), spawnData.world().getBlockState(pos)); // Paper - create falling block entities correctly
          }));
--        register(new EntityTypeData<>(EntityType.FIREWORK_ROCKET, Firework.class, CraftFirework::new, spawnData -> new FireworkRocketEntity(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z(), net.minecraft.world.item.ItemStack.EMPTY)));
+-        register(new EntityTypeData<>(EntityType.FIREWORK_ROCKET, Firework.class, CraftFirework::new, spawnData -> new FireworkRocketEntity(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z(), FireworkRocketEntity.getDefaultItem()))); // Paper - pass correct default to rocket for data storage
 +        // Paper start - respect randomizeData
 +        register(new EntityTypeData<>(EntityType.FIREWORK_ROCKET, Firework.class, CraftFirework::new, spawnData -> {
-+            FireworkRocketEntity entity = new FireworkRocketEntity(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z(), net.minecraft.world.item.ItemStack.EMPTY);
++            FireworkRocketEntity entity = new FireworkRocketEntity(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z(), FireworkRocketEntity.getDefaultItem()); // Paper - pass correct default to rocket for data storage
 +            if (!spawnData.randomizeData()) {
 +                // logic below was taken from FireworkRocketEntity constructor
 +                entity.setDeltaMovement(0, 0.05, 0);

--- a/patches/server/0943-Fixup-NamespacedKey-handling.patch
+++ b/patches/server/0943-Fixup-NamespacedKey-handling.patch
@@ -30,6 +30,61 @@ index fb72bdea520ccc0928cfbda0569e02a1917a7e86..6f6e19b7b57cb3070ef5b6810d844934
      }
  
      @Override
+diff --git a/src/main/java/net/minecraft/world/inventory/LoomMenu.java b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
+index 4f3f6ea43030853bd9df067358a1f4d16c40e6d4..531336c44c46555fef8c001fe8ca00c93624ad42 100644
+--- a/src/main/java/net/minecraft/world/inventory/LoomMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
+@@ -171,12 +171,28 @@ public class LoomMenu extends AbstractContainerMenu {
+         return stillValid(this.access, player, Blocks.LOOM);
+     }
+ 
++    private static final org.slf4j.Logger LOGGER = com.mojang.logging.LogUtils.getLogger(); // Paper - handle custom banner pattern, skip the event
++    private static boolean PRINTED_PATTERN_TYPE_NAG = false; // Paper - handle custom banner pattern, skip the event
++
+     @Override
+     public boolean clickMenuButton(net.minecraft.world.entity.player.Player player, int id) {
+         if (id >= 0 && id < this.selectablePatterns.size()) {
++            // Paper start - handle custom banner pattern, skip the event (todo remove once this is supported)
++            java.util.Optional<org.bukkit.block.banner.PatternType> patternType = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.BANNER_PATTERN, this.selectablePatterns.get(id));
++            if (patternType.isEmpty()) {
++                if (!PRINTED_PATTERN_TYPE_NAG) {
++                    LOGGER.warn("A datapack added a custom banner pattern, those are not supported yet in the API, skipping the PlayerLoomPatternSelectEvent for {}.", player.getScoreboardName());
++                    PRINTED_PATTERN_TYPE_NAG = true;
++                }
++                this.selectedBannerPatternIndex.set(id);
++                this.setupResultSlot((Holder) this.selectablePatterns.get(id));
++                return true;
++            }
++            // Paper end - handle custom banner pattern
++
+             // Paper start - Add PlayerLoomPatternSelectEvent
+             int selectablePatternIndex = id;
+-            io.papermc.paper.event.player.PlayerLoomPatternSelectEvent event = new io.papermc.paper.event.player.PlayerLoomPatternSelectEvent((Player) player.getBukkitEntity(), ((CraftInventoryLoom) getBukkitView().getTopInventory()), org.bukkit.craftbukkit.block.banner.CraftPatternType.minecraftHolderToBukkit((this.selectablePatterns.get(selectablePatternIndex))));
++            io.papermc.paper.event.player.PlayerLoomPatternSelectEvent event = new io.papermc.paper.event.player.PlayerLoomPatternSelectEvent((Player) player.getBukkitEntity(), ((CraftInventoryLoom) getBukkitView().getTopInventory()), patternType.get());
+             if (!event.callEvent()) {
+                 player.containerMenu.sendAllDataToRemote();
+                 return false;
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
+index 5c725faae98a126ee0e34eea53cfa484d2315709..d41b502eb451ec11dade2b987aee621511312ac6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
+@@ -111,6 +111,16 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+                 + ", this can happen if a plugin creates its own registry entry with out properly registering it.");
+     }
+ 
++    // Paper start - fixup upstream being dum
++    public static <T extends org.bukkit.Keyed, M> java.util.Optional<T> unwrapAndConvertHolder(final io.papermc.paper.registry.RegistryKey<T> registryKey, final Holder<M> value) {
++        return unwrapAndConvertHolder(io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(registryKey), value);
++    }
++
++    public static <T extends org.bukkit.Keyed, M> java.util.Optional<T> unwrapAndConvertHolder(final Registry<T> registry, final Holder<M> value) {
++        return value.unwrapKey().map(key -> registry.get(CraftNamespacedKey.fromMinecraft(key.location())));
++    }
++    // Paper end - fixup upstream being dum
++
+     // Paper - move to PaperRegistries
+ 
+     // Paper - NOTE: As long as all uses of the method below relate to *serialization* via ConfigurationSerializable, it's fine
 diff --git a/src/main/java/org/bukkit/craftbukkit/attribute/CraftAttribute.java b/src/main/java/org/bukkit/craftbukkit/attribute/CraftAttribute.java
 index cc97638e038ea64ad180ebfded2528aa07d1809e..10e4318782107644f67818109784fff60d017e0a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/attribute/CraftAttribute.java
@@ -42,8 +97,25 @@ index cc97638e038ea64ad180ebfded2528aa07d1809e..10e4318782107644f67818109784fff6
  
          // Now also convert from when keys where saved
          return CraftRegistry.get(Registry.ATTRIBUTE, key, ApiVersion.CURRENT);
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBanner.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBanner.java
+index 65a9213ce8197d50a58f94edfd60c25c2be848be..28d8fd2e3eb87e989621ffa6b0e5005bd181391c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBanner.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBanner.java
+@@ -36,7 +36,11 @@ public class CraftBanner extends CraftBlockEntityState<BannerBlockEntity> implem
+         if (banner.getPatterns() != null) {
+             for (int i = 0; i < banner.getPatterns().layers().size(); i++) {
+                 BannerPatternLayers.Layer p = banner.getPatterns().layers().get(i);
+-                this.patterns.add(new Pattern(DyeColor.getByWoolData((byte) p.color().getId()), CraftPatternType.minecraftHolderToBukkit(p.pattern())));
++                // Paper start - fix upstream not handling custom banner pattern
++                java.util.Optional<org.bukkit.block.banner.PatternType> type = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.BANNER_PATTERN, p.pattern());
++                if (type.isEmpty()) continue;
++                this.patterns.add(new Pattern(DyeColor.getByWoolData((byte) p.color().getId()), type.get()));
++                // Paper end
+             }
+         }
+     }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmor.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmor.java
-index 12b95c4455e741b65b844eab362f02bce54eb525..ac9279f7acb7077c08d7741435126adfef9e17b8 100644
+index 12b95c4455e741b65b844eab362f02bce54eb525..13b91cddffbe8ae6f07ce5c0ae45beba151e1aca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmor.java
 @@ -69,8 +69,9 @@ public class CraftMetaArmor extends CraftMetaItem implements ArmorMeta {
@@ -52,44 +124,38 @@ index 12b95c4455e741b65b844eab362f02bce54eb525..ac9279f7acb7077c08d7741435126adf
          getOrEmpty(tag, CraftMetaArmor.TRIM).ifPresent((trimCompound) -> {
 -            TrimMaterial trimMaterial = CraftTrimMaterial.minecraftHolderToBukkit(trimCompound.material());
 -            TrimPattern trimPattern = CraftTrimPattern.minecraftHolderToBukkit(trimCompound.pattern());
-+            TrimMaterial trimMaterial = this.unwrapAndConvertHolder(Registry.TRIM_MATERIAL, trimCompound.material()); // Paper - fix upstream not being correct
-+            TrimPattern trimPattern = this.unwrapAndConvertHolder(Registry.TRIM_PATTERN, trimCompound.pattern()); // Paper - fix upstream not being correct
++            TrimMaterial trimMaterial = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(io.papermc.paper.registry.RegistryKey.TRIM_MATERIAL, trimCompound.material()).orElse(null); // Paper - fix upstream not being correct
++            TrimPattern trimPattern = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(io.papermc.paper.registry.RegistryKey.TRIM_PATTERN, trimCompound.pattern()).orElse(null); // Paper - fix upstream not being correct
 +            if (trimMaterial == null || trimPattern == null) return; // Paper - just delete the trim because upstream is not doing this right
  
              this.trim = new ArmorTrim(trimMaterial, trimPattern);
  
-@@ -79,6 +80,11 @@ public class CraftMetaArmor extends CraftMetaItem implements ArmorMeta {
-             }
-         });
-     }
-+    // Paper start - fixup upstream being dum
-+    private <T extends org.bukkit.Keyed, M> T unwrapAndConvertHolder(final Registry<T> registry, final net.minecraft.core.Holder<M> value) {
-+        return value.unwrap().map(key -> registry.get(org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(key.location())), v -> null);
-+    }
-+    // Paper end - fixup upstream being dum
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
+index 524aadad91c855f6c201999831824f7ce06f9ed6..d53df6f114c285b880167385807775e400c80fc9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
+@@ -80,7 +80,7 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+             for (int i = 0; i < Math.min(patterns.size(), 20); i++) {
+                 BannerPatternLayers.Layer p = patterns.get(i);
+                 DyeColor color = DyeColor.getByWoolData((byte) p.color().getId());
+-                PatternType pattern = CraftPatternType.minecraftHolderToBukkit(p.pattern());
++                PatternType pattern = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.BANNER_PATTERN, p.pattern()).orElse(null); // Paper - fix upstream not handling custom banner pattern
  
-     CraftMetaArmor(Map<String, Object> map) {
-         super(map);
+                 if (color != null && pattern != null) {
+                     this.patterns.add(new Pattern(color, pattern));
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java
-index 67905f804ccc102faa942499f5ba218f710ab9cc..99bf6132184b1b7846270fc9a1b9e97048306a3b 100644
+index 67905f804ccc102faa942499f5ba218f710ab9cc..4eb2993903f5fa9fb9fd65282a42f26b3aa1e7bd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java
-@@ -31,9 +31,14 @@ public class CraftMetaMusicInstrument extends CraftMetaItem implements MusicInst
+@@ -31,7 +31,7 @@ public class CraftMetaMusicInstrument extends CraftMetaItem implements MusicInst
          super(tag);
  
          getOrEmpty(tag, CraftMetaMusicInstrument.GOAT_HORN_INSTRUMENT).ifPresent((instrument) -> {
 -            this.instrument = CraftMusicInstrument.minecraftHolderToBukkit(instrument);
-+            this.instrument = this.unwrapAndConvertHolder(org.bukkit.Registry.INSTRUMENT, instrument); // Paper - fix upstream not handling custom instruments
++            this.instrument = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.INSTRUMENT, instrument).orElse(null); // Paper - fix upstream not handling custom instruments
          });
      }
-+    // Paper start - fixup upstream being dum
-+    private <T extends org.bukkit.Keyed, M> T unwrapAndConvertHolder(final org.bukkit.Registry<T> registry, final net.minecraft.core.Holder<M> value) {
-+        return value.unwrap().map(key -> registry.get(org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(key.location())), v -> null);
-+    }
-+    // Paper end - fixup upstream being dum
  
-     CraftMetaMusicInstrument(Map<String, Object> map) {
-         super(map);
 diff --git a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionType.java b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionType.java
 index 82a50b06c08b632f77d73745e1fa9bd22dfd950a..f1d8ed4a2b8959873b02d57f6a40323a841f3d7f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionType.java

--- a/patches/server/0957-Deprecate-ItemStack-setType.patch
+++ b/patches/server/0957-Deprecate-ItemStack-setType.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deprecate ItemStack#setType
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 2ba771efa61e109804f3141e95f77613ac952ed1..6b794776c1e7a00b7a00a1379cf559be182996cd 100644
+index f53d6587b2bab3ed8428338950795a62b356c694..ce224087345f49aca84ee94c76dac96dcf9a630f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -715,4 +715,24 @@ public final class CraftItemStack extends ItemStack {
+@@ -717,4 +717,24 @@ public final class CraftItemStack extends ItemStack {
      static boolean hasItemMeta(net.minecraft.world.item.ItemStack item) {
          return !(item == null || item.getComponentsPatch().isEmpty());
      }

--- a/patches/server/1037-improve-checking-handled-tags-in-itemmeta.patch
+++ b/patches/server/1037-improve-checking-handled-tags-in-itemmeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] improve checking handled tags in itemmeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 6b794776c1e7a00b7a00a1379cf559be182996cd..aa23d417272bb160bba8358a8ab0792b56bc0a01 100644
+index ce224087345f49aca84ee94c76dac96dcf9a630f..3e552a859846d206ba79c3ee740ae76a37ee7606 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -156,10 +156,11 @@ public final class CraftItemStack extends ItemStack {
@@ -21,7 +21,7 @@ index 6b794776c1e7a00b7a00a1379cf559be182996cd..aa23d417272bb160bba8358a8ab0792b
              }
          }
          this.setData(null);
-@@ -310,6 +311,19 @@ public final class CraftItemStack extends ItemStack {
+@@ -312,6 +313,19 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }
@@ -41,7 +41,7 @@ index 6b794776c1e7a00b7a00a1379cf559be182996cd..aa23d417272bb160bba8358a8ab0792b
      // Paper start
      public static void applyMetaToItem(net.minecraft.world.item.ItemStack itemStack, ItemMeta itemMeta) {
          final CraftMetaItem.Applicator tag = new CraftMetaItem.Applicator();
-@@ -322,14 +336,19 @@ public final class CraftItemStack extends ItemStack {
+@@ -324,14 +338,19 @@ public final class CraftItemStack extends ItemStack {
      }
      public static ItemMeta getItemMeta(net.minecraft.world.item.ItemStack item, Material material) {
          // Paper end
@@ -63,7 +63,7 @@ index 6b794776c1e7a00b7a00a1379cf559be182996cd..aa23d417272bb160bba8358a8ab0792b
              case CREEPER_HEAD:
              case CREEPER_WALL_HEAD:
              case DRAGON_HEAD:
-@@ -344,7 +363,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -346,7 +365,7 @@ public final class CraftItemStack extends ItemStack {
              case WITHER_SKELETON_WALL_SKULL:
              case ZOMBIE_HEAD:
              case ZOMBIE_WALL_HEAD:
@@ -72,7 +72,7 @@ index 6b794776c1e7a00b7a00a1379cf559be182996cd..aa23d417272bb160bba8358a8ab0792b
              case CHAINMAIL_HELMET:
              case CHAINMAIL_CHESTPLATE:
              case CHAINMAIL_LEGGINGS:
-@@ -366,28 +385,28 @@ public final class CraftItemStack extends ItemStack {
+@@ -368,28 +387,28 @@ public final class CraftItemStack extends ItemStack {
              case NETHERITE_LEGGINGS:
              case NETHERITE_BOOTS:
              case TURTLE_HELMET:
@@ -109,7 +109,7 @@ index 6b794776c1e7a00b7a00a1379cf559be182996cd..aa23d417272bb160bba8358a8ab0792b
              case BLACK_BANNER:
              case BLACK_WALL_BANNER:
              case BLUE_BANNER:
-@@ -420,7 +439,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -422,7 +441,7 @@ public final class CraftItemStack extends ItemStack {
              case WHITE_WALL_BANNER:
              case YELLOW_BANNER:
              case YELLOW_WALL_BANNER:
@@ -118,7 +118,7 @@ index 6b794776c1e7a00b7a00a1379cf559be182996cd..aa23d417272bb160bba8358a8ab0792b
              case ARMADILLO_SPAWN_EGG:
              case ALLAY_SPAWN_EGG:
              case AXOLOTL_SPAWN_EGG:
-@@ -501,11 +520,11 @@ public final class CraftItemStack extends ItemStack {
+@@ -503,11 +522,11 @@ public final class CraftItemStack extends ItemStack {
              case ZOMBIE_SPAWN_EGG:
              case ZOMBIE_VILLAGER_SPAWN_EGG:
              case ZOMBIFIED_PIGLIN_SPAWN_EGG:
@@ -133,7 +133,7 @@ index 6b794776c1e7a00b7a00a1379cf559be182996cd..aa23d417272bb160bba8358a8ab0792b
              case FURNACE:
              case CHEST:
              case TRAPPED_CHEST:
-@@ -607,15 +626,15 @@ public final class CraftItemStack extends ItemStack {
+@@ -609,15 +628,15 @@ public final class CraftItemStack extends ItemStack {
              case CRAFTER:
              case TRIAL_SPAWNER:
              case VAULT:
@@ -154,7 +154,7 @@ index 6b794776c1e7a00b7a00a1379cf559be182996cd..aa23d417272bb160bba8358a8ab0792b
              case COD_BUCKET:
              case PUFFERFISH_BUCKET:
              case SALMON_BUCKET:
-@@ -623,17 +642,17 @@ public final class CraftItemStack extends ItemStack {
+@@ -625,17 +644,17 @@ public final class CraftItemStack extends ItemStack {
              case ITEM_FRAME:
              case GLOW_ITEM_FRAME:
              case PAINTING:
@@ -179,7 +179,7 @@ index 6b794776c1e7a00b7a00a1379cf559be182996cd..aa23d417272bb160bba8358a8ab0792b
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmor.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmor.java
-index ac9279f7acb7077c08d7741435126adfef9e17b8..6b14c9cf361c16d6f101aa5b2635cc74b4ecc6e8 100644
+index 13b91cddffbe8ae6f07ce5c0ae45beba151e1aca..569f7157a625b981bff43650e9dd0a8c1831a29d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmor.java
 @@ -65,8 +65,8 @@ public class CraftMetaArmor extends CraftMetaItem implements ArmorMeta {
@@ -192,7 +192,7 @@ index ac9279f7acb7077c08d7741435126adfef9e17b8..6b14c9cf361c16d6f101aa5b2635cc74
 +        super(tag, extraHandledDcts); // Paper
  
          getOrEmpty(tag, CraftMetaArmor.TRIM).ifPresent((trimCompound) -> {
-             TrimMaterial trimMaterial = this.unwrapAndConvertHolder(Registry.TRIM_MATERIAL, trimCompound.material()); // Paper - fix upstream not being correct
+             TrimMaterial trimMaterial = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(io.papermc.paper.registry.RegistryKey.TRIM_MATERIAL, trimCompound.material()).orElse(null); // Paper - fix upstream not being correct
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
 index 84e09a934600df116206df1c3922a11ee969901a..04ca71d03eea61b0e7e62f2beb954b505a717f24 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
@@ -224,7 +224,7 @@ index 3377fdd445db33b2ee1735942b391c6bfa92ab91..44d8aa7123ac22cf9a22720ecadc8c5f
          getOrEmpty(tag, CraftMetaAxolotlBucket.ENTITY_TAG).ifPresent((nbt) -> {
              this.entityTag = nbt.copyTag();
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
-index 524aadad91c855f6c201999831824f7ce06f9ed6..2d6abecc94683f92da6be26b72ea829663b16d76 100644
+index d53df6f114c285b880167385807775e400c80fc9..1ac3bec02fce28d5ce698305a7482a9eccbb1867 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
 @@ -72,8 +72,8 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
@@ -598,7 +598,7 @@ index b97e9a8f163adbb30d2e7db16aeb99544fcb2916..157a7b7351f48e68d2923c72ed3bbe3d
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMap.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMap.java
-index f0c817e27a602740bc979b2ebaec3917e1906d74..6979c9026494e69de46b7458fb56d371bd1225aa 100644
+index 6b34a8d33faa49ffa9082995e67af10d3cb38c03..d829f4da371b44e7480896118547734be400a314 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMap.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMap.java
 @@ -45,8 +45,8 @@ class CraftMetaMap extends CraftMetaItem implements MapMeta {
@@ -613,7 +613,7 @@ index f0c817e27a602740bc979b2ebaec3917e1906d74..6979c9026494e69de46b7458fb56d371
          getOrEmpty(tag, CraftMetaMap.MAP_ID).ifPresent((mapId) -> {
              this.mapId = mapId.id();
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java
-index 99bf6132184b1b7846270fc9a1b9e97048306a3b..9d886c9b66e5d86590a88169c16bfd16aede5cf6 100644
+index 4eb2993903f5fa9fb9fd65282a42f26b3aa1e7bd..f33f1d250a3a4068df79cd1eb37baffda981aab3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java
 @@ -27,8 +27,8 @@ public class CraftMetaMusicInstrument extends CraftMetaItem implements MusicInst
@@ -626,7 +626,7 @@ index 99bf6132184b1b7846270fc9a1b9e97048306a3b..9d886c9b66e5d86590a88169c16bfd16
 +        super(tag, extraHandledDcts); // Paper
  
          getOrEmpty(tag, CraftMetaMusicInstrument.GOAT_HORN_INSTRUMENT).ifPresent((instrument) -> {
-             this.instrument = this.unwrapAndConvertHolder(org.bukkit.Registry.INSTRUMENT, instrument); // Paper - fix upstream not handling custom instruments
+             this.instrument = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.INSTRUMENT, instrument).orElse(null); // Paper - fix upstream not handling custom instruments
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaOminousBottle.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaOminousBottle.java
 index 19f1425ae86e1b8b8fd46a5c6a193d1b77aeefe9..7197c4f5698fd041c4db6d0f6a80c55f77661789 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaOminousBottle.java

--- a/patches/server/1038-General-ItemMeta-fixes.patch
+++ b/patches/server/1038-General-ItemMeta-fixes.patch
@@ -5,6 +5,7 @@ Subject: [PATCH] General ItemMeta fixes
 
 == AT ==
 private-f net/minecraft/world/item/ItemStack components
+public net/minecraft/world/food/FoodProperties DEFAULT_EAT_SECONDS
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
 index 8e2b3dd109dca3089cbce82cd3788874613a3230..893efb2c4a07c33d41e934279dd914a9dbd4ef79 100644
@@ -68,10 +69,10 @@ index 397eb1a101bd60f49dbb2fa8eddf28f6f233167f..ce10aa64576716f530e69d2281c090cf
      protected void load(T tileEntity) {
          if (tileEntity != null && tileEntity != this.snapshot) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index aa23d417272bb160bba8358a8ab0792b56bc0a01..eba5a27e452c4063567fb02d6aabdfb0446d5daf 100644
+index 3e552a859846d206ba79c3ee740ae76a37ee7606..2626fee8cf8690dee8c6db9d503891b6fd882192 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -326,7 +326,14 @@ public final class CraftItemStack extends ItemStack {
+@@ -328,7 +328,14 @@ public final class CraftItemStack extends ItemStack {
      // Paper end - improve handled tags on type change
      // Paper start
      public static void applyMetaToItem(net.minecraft.world.item.ItemStack itemStack, ItemMeta itemMeta) {
@@ -87,7 +88,7 @@ index aa23d417272bb160bba8358a8ab0792b56bc0a01..eba5a27e452c4063567fb02d6aabdfb0
          ((CraftMetaItem) itemMeta).applyToItem(tag);
          itemStack.applyComponents(tag.build());
      }
-@@ -687,7 +694,14 @@ public final class CraftItemStack extends ItemStack {
+@@ -689,15 +696,19 @@ public final class CraftItemStack extends ItemStack {
          }
  
          if (!((CraftMetaItem) itemMeta).isEmpty()) {
@@ -103,8 +104,38 @@ index aa23d417272bb160bba8358a8ab0792b56bc0a01..eba5a27e452c4063567fb02d6aabdfb0
  
              ((CraftMetaItem) itemMeta).applyToItem(tag);
              item.restorePatch(tag.build());
+         }
+-        // SpigotCraft#463 this is required now by the Vanilla client, so mimic ItemStack constructor in ensuring it
+-        if (item.getItem() != null && item.getMaxDamage() > 0) {
+-            item.setDamageValue(item.getDamageValue());
+-        }
++        // Paper - this is no longer needed
+ 
+         return true;
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaAxolotlBucket.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaAxolotlBucket.java
+index 44d8aa7123ac22cf9a22720ecadc8c5f63bafc0a..9665dc043b257bb0d6f7b40fd938ff549ab685c6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaAxolotlBucket.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaAxolotlBucket.java
+@@ -124,14 +124,13 @@ public class CraftMetaAxolotlBucket extends CraftMetaItem implements AxolotlBuck
+ 
+     @Override
+     public Axolotl.Variant getVariant() {
++        com.google.common.base.Preconditions.checkState(this.hasVariant(), "Variant is absent, check hasVariant first!"); // Paper - fix NPE
+         return Axolotl.Variant.values()[this.variant];
+     }
+ 
+     @Override
+     public void setVariant(Axolotl.Variant variant) {
+-        if (variant == null) {
+-            variant = Axolotl.Variant.LUCY;
+-        }
++        com.google.common.base.Preconditions.checkArgument(variant != null, "Variant cannot be null!"); // Paper
+         this.variant = variant.ordinal();
+     }
+ 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
-index 2d6abecc94683f92da6be26b72ea829663b16d76..6a3b0c7f0cc3ffb17a231383ad103fa792d7b7ba 100644
+index 1ac3bec02fce28d5ce698305a7482a9eccbb1867..b494568f833dc21d4e2447ac3e5c5002288b5533 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
 @@ -107,6 +107,7 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
@@ -155,6 +186,19 @@ index 12911233c01d0ac1af9adbd157d56d28361fc76f..99ee41e79891d6017f065492efab5af9
      }
  
      private static Material shieldToBannerHack() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
+index a395c7ce952f4a60a5edf80e8731afa6388d18ea..e213ac74f8f4a62b7b8b2b7889250f5cdeb348fe 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
+@@ -34,7 +34,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta, WritableBo
+     @ItemMetaKey.Specific(ItemMetaKey.Specific.To.NBT)
+     static final ItemMetaKeyType<WritableBookContent> BOOK_CONTENT = new ItemMetaKeyType<>(DataComponents.WRITABLE_BOOK_CONTENT);
+     static final ItemMetaKey BOOK_PAGES = new ItemMetaKey("pages");
+-    static final int MAX_PAGES = Integer.MAX_VALUE; // SPIGOT-6911: Use Minecraft limits
++    static final int MAX_PAGES = WritableBookContent.MAX_PAGES; // SPIGOT-6911: Use Minecraft limits // Paper
+     static final int MAX_PAGE_LENGTH = WritableBookContent.PAGE_EDIT_LENGTH; // SPIGOT-6911: Use Minecraft limits
+ 
+     // We store the pages in their raw original text representation. See SPIGOT-5063, SPIGOT-5350, SPIGOT-3206
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
 index 3f78a0935d738854182254b345064e3c225dcd5f..218df87c596d47b431dbbf2aa42822ef174f948f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
@@ -194,6 +238,108 @@ index 3f78a0935d738854182254b345064e3c225dcd5f..218df87c596d47b431dbbf2aa42822ef
          }
  
          if (this.resolved) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBundle.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBundle.java
+index f8c02fe01fd95aa5de8523c9ad452d91f5d3c16f..4447c754458e9fdead003b4044bf2bee6fcbaaa2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBundle.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBundle.java
+@@ -42,7 +42,7 @@ public class CraftMetaBundle extends CraftMetaItem implements BundleMeta {
+             bundle.items().forEach((item) -> {
+                 ItemStack itemStack = CraftItemStack.asCraftMirror(item);
+ 
+-                if (!itemStack.getType().isAir()) { // SPIGOT-7174 - Avoid adding air
++                if (!itemStack.isEmpty()) { // SPIGOT-7174 - Avoid adding air // Paper
+                     this.addItem(itemStack);
+                 }
+             });
+@@ -55,7 +55,7 @@ public class CraftMetaBundle extends CraftMetaItem implements BundleMeta {
+         Iterable<?> items = SerializableMeta.getObject(Iterable.class, map, CraftMetaBundle.ITEMS.BUKKIT, true);
+         if (items != null) {
+             for (Object stack : items) {
+-                if (stack instanceof ItemStack itemStack && !itemStack.getType().isAir()) { // SPIGOT-7174 - Avoid adding air
++                if (stack instanceof ItemStack itemStack && !itemStack.isEmpty()) { // SPIGOT-7174 - Avoid adding air // Paper
+                     this.addItem(itemStack);
+                 }
+             }
+@@ -116,7 +116,7 @@ public class CraftMetaBundle extends CraftMetaItem implements BundleMeta {
+ 
+     @Override
+     public void addItem(ItemStack item) {
+-        Preconditions.checkArgument(item != null && !item.getType().isAir(), "item is null or air");
++        Preconditions.checkArgument(item != null && !item.isEmpty(), "item is null or empty"); // Paper
+ 
+         if (this.items == null) {
+             this.items = new ArrayList<>();
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java
+index 2c9ca54267579a210d4ea192517fc0fbce8e467a..3109df67e42838f3e69681326efb1caf237548a5 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java
+@@ -22,16 +22,30 @@ public class CraftMetaColorableArmor extends CraftMetaArmor implements Colorable
+             Material.WOLF_ARMOR
+     );
+ 
+-    private Color color = DEFAULT_LEATHER_COLOR;
++    private Integer color; // Paper - keep color component consistent with vanilla (top bytes are ignored)
+ 
+     CraftMetaColorableArmor(CraftMetaItem meta) {
+         super(meta);
+-        CraftMetaLeatherArmor.readColor(this, meta);
++        // Paper start
++        if (!(meta instanceof CraftMetaColorableArmor armorMeta)) {
++            return;
++        }
++
++        this.color = armorMeta.color;
++        // Paper end
+     }
+ 
+     CraftMetaColorableArmor(DataComponentPatch tag, java.util.Set<net.minecraft.core.component.DataComponentType<?>> extraHandledDcts) { // Paper
+         super(tag, extraHandledDcts); // Paper
+-        CraftMetaLeatherArmor.readColor(this, tag);
++        // Paper start
++        getOrEmpty(tag, CraftMetaLeatherArmor.COLOR).ifPresent((dyedItemColor) -> {
++            if (!dyedItemColor.showInTooltip()) {
++                this.addItemFlags(org.bukkit.inventory.ItemFlag.HIDE_DYE);
++            }
++
++            this.color = dyedItemColor.rgb();
++        });
++        // Paper end
+     }
+ 
+     CraftMetaColorableArmor(Map<String, Object> map) {
+@@ -42,7 +56,11 @@ public class CraftMetaColorableArmor extends CraftMetaArmor implements Colorable
+     @Override
+     void applyToItem(CraftMetaItem.Applicator itemTag) {
+         super.applyToItem(itemTag);
+-        CraftMetaLeatherArmor.applyColor(this, itemTag);
++        // Paper start
++        if (this.hasColor()) {
++            itemTag.put(CraftMetaLeatherArmor.COLOR, new net.minecraft.world.item.component.DyedItemColor(this.color, !this.hasItemFlag(org.bukkit.inventory.ItemFlag.HIDE_DYE)));
++        }
++        // Paper end
+     }
+ 
+     @Override
+@@ -68,16 +86,16 @@ public class CraftMetaColorableArmor extends CraftMetaArmor implements Colorable
+ 
+     @Override
+     public Color getColor() {
+-        return this.color;
++        return this.color == null ? DEFAULT_LEATHER_COLOR : Color.fromRGB(this.color & 0xFFFFFF); // Paper - this should really be nullable
+     }
+ 
+     @Override
+     public void setColor(Color color) {
+-        this.color = color == null ? DEFAULT_LEATHER_COLOR : color;
++        this.color = color == null ? null : color.asRGB(); // Paper
+     }
+ 
+     boolean hasColor() {
+-        return CraftMetaLeatherArmor.hasColor(this);
++        return this.color != null; // Paper
+     }
+ 
+     @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaCompass.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaCompass.java
 index bbca26f5debb263b04516e68f6e49f68a38fa5b1..aacc4d010f4dfa4d9d11332b802205a6f35b6de3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaCompass.java
@@ -231,11 +377,69 @@ index bbca26f5debb263b04516e68f6e49f68a38fa5b1..aacc4d010f4dfa4d9d11332b802205a6
      }
  
      @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaCrossbow.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaCrossbow.java
+index a3fa95377e083e51ad7596d21eeb08172bdb18b2..0f5a64fc5eb619e18f5eeb97f377c9d593e4a38f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaCrossbow.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaCrossbow.java
+@@ -122,7 +122,7 @@ public class CraftMetaCrossbow extends CraftMetaItem implements CrossbowMeta {
+     @Override
+     public void addChargedProjectile(ItemStack item) {
+         Preconditions.checkArgument(item != null, "item");
+-        Preconditions.checkArgument(item.getType() == Material.FIREWORK_ROCKET || CraftItemType.bukkitToMinecraft(item.getType()) instanceof ArrowItem, "Item %s is not an arrow or firework rocket", item);
++        Preconditions.checkArgument(!item.isEmpty(), "Item cannot be empty"); // Paper
+ 
+         if (this.chargedProjectiles == null) {
+             this.chargedProjectiles = new ArrayList<>();
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaEntityTag.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaEntityTag.java
+index 3f6c5cbbf63631e4b72dc43558651ea94f31ca78..da474a5b963d8e6769d120e9091e60ed0a468a9f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaEntityTag.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaEntityTag.java
+@@ -98,7 +98,7 @@ public class CraftMetaEntityTag extends CraftMetaItem {
+         if (meta instanceof CraftMetaEntityTag) {
+             CraftMetaEntityTag that = (CraftMetaEntityTag) meta;
+ 
+-            return this.entityTag != null ? that.entityTag != null && this.entityTag.equals(that.entityTag) : this.entityTag == null;
++            return this.entityTag != null ? that.entityTag != null && this.entityTag.equals(that.entityTag) : that.entityTag == null; // Paper
+         }
+         return true;
+     }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
-index 8e0dd4b7a7a25a8beb27b507047bc48d8227627c..cf5d27ccc2225bac3aa57912f444f95d2f37e32e 100644
+index 8e0dd4b7a7a25a8beb27b507047bc48d8227627c..4c09c57c263b18ee2e0156cc4a49ac02a025c651 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
-@@ -154,7 +154,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -55,7 +55,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+ 
+         this.power = that.power;
+ 
+-        if (that.hasEffects()) {
++        if (that.effects != null) { // Paper
+             this.effects = new ArrayList<>(that.effects);
+         }
+     }
+@@ -86,19 +86,14 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+                 .with(CraftMetaFirework.getEffectType(explosion.shape()));
+ 
+         IntList colors = explosion.colors();
+-        // People using buggy command generators specify a list rather than an int here, so recover with dummy data.
+-        // Wrong: Colors: [1234]
+-        // Right: Colors: [I;1234]
+-        if (colors.isEmpty()) {
+-            effect.withColor(Color.WHITE);
+-        }
++        // Paper - this is no longer needed
+ 
+         for (int color : colors) {
+-            effect.withColor(Color.fromRGB(color));
++            effect.withColor(Color.fromRGB(color & 0xFFFFFF)); // Paper - try to keep color component consistent with vanilla (top bytes are ignored), this will however change the color component for out of bound color
+         }
+ 
+         for (int color : explosion.fadeColors()) {
+-            effect.withFade(Color.fromRGB(color));
++            effect.withFade(Color.fromRGB(color & 0xFFFFFF)); // Paper
+         }
+ 
+         return effect.build();
+@@ -154,7 +149,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
          }
  
          Iterable<?> effects = SerializableMeta.getObject(Iterable.class, map, CraftMetaFirework.EXPLOSIONS.BUKKIT, true);
@@ -244,7 +448,7 @@ index 8e0dd4b7a7a25a8beb27b507047bc48d8227627c..cf5d27ccc2225bac3aa57912f444f95d
      }
  
      @Override
-@@ -162,7 +162,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -162,7 +157,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
          return !(this.effects == null || this.effects.isEmpty());
      }
  
@@ -253,7 +457,7 @@ index 8e0dd4b7a7a25a8beb27b507047bc48d8227627c..cf5d27ccc2225bac3aa57912f444f95d
          if (collection == null || (collection instanceof Collection && ((Collection<?>) collection).isEmpty())) {
              return;
          }
-@@ -174,6 +174,15 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -174,6 +169,15 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
  
          for (Object obj : collection) {
              Preconditions.checkArgument(obj instanceof FireworkEffect, "%s in %s is not a FireworkEffect", obj, collection);
@@ -269,7 +473,7 @@ index 8e0dd4b7a7a25a8beb27b507047bc48d8227627c..cf5d27ccc2225bac3aa57912f444f95d
              effects.add((FireworkEffect) obj);
          }
      }
-@@ -186,9 +195,13 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -186,9 +190,13 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
          }
  
          List<FireworkExplosion> effects = new ArrayList<>();
@@ -285,7 +489,43 @@ index 8e0dd4b7a7a25a8beb27b507047bc48d8227627c..cf5d27ccc2225bac3aa57912f444f95d
  
          itemTag.put(CraftMetaFirework.FIREWORKS, new Fireworks(this.power, effects));
      }
-@@ -287,6 +300,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -218,7 +226,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+     }
+ 
+     boolean isFireworkEmpty() {
+-        return !(this.hasEffects() || this.hasPower());
++        return !(this.effects != null || this.hasPower()); // Paper - empty effects list should stay on the item
+     }
+ 
+     boolean hasPower() {
+@@ -234,7 +242,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+         if (meta instanceof CraftMetaFirework that) {
+ 
+             return (this.hasPower() ? that.hasPower() && this.power == that.power : !that.hasPower())
+-                    && (this.hasEffects() ? that.hasEffects() && this.effects.equals(that.effects) : !that.hasEffects());
++                    && (this.effects != null ? that.effects != null && this.effects.equals(that.effects) : that.effects == null); // Paper
+         }
+ 
+         return true;
+@@ -252,7 +260,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+         if (this.hasPower()) {
+             hash = 61 * hash + this.power;
+         }
+-        if (this.hasEffects()) {
++        if (this.effects != null) { // Paper
+             hash = 61 * hash + 13 * this.effects.hashCode();
+         }
+         return hash != original ? CraftMetaFirework.class.hashCode() ^ hash : hash;
+@@ -262,7 +270,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+     Builder<String, Object> serialize(Builder<String, Object> builder) {
+         super.serialize(builder);
+ 
+-        if (this.hasEffects()) {
++        if (this.effects != null) { // Paper
+             builder.put(CraftMetaFirework.EXPLOSIONS.BUKKIT, ImmutableList.copyOf(this.effects));
+         }
+ 
+@@ -287,6 +295,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
      @Override
      public void addEffect(FireworkEffect effect) {
          Preconditions.checkArgument(effect != null, "FireworkEffect cannot be null");
@@ -293,7 +533,7 @@ index 8e0dd4b7a7a25a8beb27b507047bc48d8227627c..cf5d27ccc2225bac3aa57912f444f95d
          if (this.effects == null) {
              this.effects = new ArrayList<FireworkEffect>();
          }
-@@ -296,6 +310,10 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -296,6 +305,10 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
      @Override
      public void addEffects(FireworkEffect... effects) {
          Preconditions.checkArgument(effects != null, "effects cannot be null");
@@ -304,7 +544,7 @@ index 8e0dd4b7a7a25a8beb27b507047bc48d8227627c..cf5d27ccc2225bac3aa57912f444f95d
          if (effects.length == 0) {
              return;
          }
-@@ -314,7 +332,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -314,7 +327,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
      @Override
      public void addEffects(Iterable<FireworkEffect> effects) {
          Preconditions.checkArgument(effects != null, "effects cannot be null");
@@ -313,8 +553,17 @@ index 8e0dd4b7a7a25a8beb27b507047bc48d8227627c..cf5d27ccc2225bac3aa57912f444f95d
      }
  
      @Override
+@@ -349,7 +362,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+     @Override
+     public void setPower(int power) {
+         Preconditions.checkArgument(power >= 0, "power cannot be less than zero: %s", power);
+-        Preconditions.checkArgument(power < 0x80, "power cannot be more than 127: %s", power);
++        Preconditions.checkArgument(power <= 0xFF, "power cannot be more than 255: %s", power); // Paper - set correct limit
+         this.power = power;
+     }
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 12a193db7475870e5107c86c7611bb4b92feacb8..87bb193acd39515c2d80cf1ab41d1e2538112fe9 100644
+index 12a193db7475870e5107c86c7611bb4b92feacb8..860bc5ec4baec5e09a456cc5559d0de2aa10797a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -172,9 +172,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -406,7 +655,94 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..87bb193acd39515c2d80cf1ab41d1e25
          if (lore == null) {
              this.lore = null;
          } else {
-@@ -1421,7 +1428,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1295,7 +1302,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+ 
+     @Override
+     public FoodComponent getFood() {
+-        return (this.hasFood()) ? new CraftFoodComponent(this.food) : new CraftFoodComponent(new FoodProperties(0, 0, false, 0, Collections.emptyList()));
++        return (this.hasFood()) ? new CraftFoodComponent(this.food) : new CraftFoodComponent(new FoodProperties(0, 0, false, FoodProperties.DEFAULT_EAT_SECONDS, Collections.emptyList())); // Paper - create a valid food properties
+     }
+ 
+     @Override
+@@ -1321,7 +1328,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+ 
+     @Override
+     public Multimap<Attribute, AttributeModifier> getAttributeModifiers(@Nullable EquipmentSlot slot) {
+-        this.checkAttributeList();
++        if (this.attributeModifiers == null) return LinkedHashMultimap.create(); // Paper - don't change the components
+         SetMultimap<Attribute, AttributeModifier> result = LinkedHashMultimap.create();
+         for (Map.Entry<Attribute, AttributeModifier> entry : this.attributeModifiers.entries()) {
+             if (entry.getValue().getSlot() == null || entry.getValue().getSlot() == slot) {
+@@ -1334,6 +1341,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+     @Override
+     public Collection<AttributeModifier> getAttributeModifiers(@Nonnull Attribute attribute) {
+         Preconditions.checkNotNull(attribute, "Attribute cannot be null");
++        if (this.attributeModifiers == null) return null; // Paper - fix NPE
+         return this.attributeModifiers.containsKey(attribute) ? ImmutableList.copyOf(this.attributeModifiers.get(attribute)) : null;
+     }
+ 
+@@ -1341,10 +1349,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+     public boolean addAttributeModifier(@Nonnull Attribute attribute, @Nonnull AttributeModifier modifier) {
+         Preconditions.checkNotNull(attribute, "Attribute cannot be null");
+         Preconditions.checkNotNull(modifier, "AttributeModifier cannot be null");
+-        this.checkAttributeList();
++        if (this.attributeModifiers != null) { // Paper
+         for (Map.Entry<Attribute, AttributeModifier> entry : this.attributeModifiers.entries()) {
+             Preconditions.checkArgument(!(entry.getValue().getUniqueId().equals(modifier.getUniqueId()) && entry.getKey() == attribute), "Cannot register AttributeModifier. Modifier is already applied! %s", modifier); // Paper
+         }
++        } // Paper
++        this.checkAttributeList(); // Paper - moved down
+         return this.attributeModifiers.put(attribute, modifier);
+     }
+ 
+@@ -1355,8 +1365,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+             return;
+         }
+ 
+-        this.checkAttributeList();
+-        this.attributeModifiers.clear();
++        // Paper start - fix modifiers meta
++        if (this.attributeModifiers != null) {
++            this.attributeModifiers.clear();
++        }
++        // Paper end
+ 
+         Iterator<Map.Entry<Attribute, AttributeModifier>> iterator = attributeModifiers.entries().iterator();
+         while (iterator.hasNext()) {
+@@ -1366,6 +1379,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+                 iterator.remove();
+                 continue;
+             }
++            this.checkAttributeList(); // Paper - moved down
+             this.attributeModifiers.put(next.getKey(), next.getValue());
+         }
+     }
+@@ -1373,13 +1387,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+     @Override
+     public boolean removeAttributeModifier(@Nonnull Attribute attribute) {
+         Preconditions.checkNotNull(attribute, "Attribute cannot be null");
+-        this.checkAttributeList();
++        if (this.attributeModifiers == null) return false; // Paper
+         return !this.attributeModifiers.removeAll(attribute).isEmpty();
+     }
+ 
+     @Override
+     public boolean removeAttributeModifier(@Nullable EquipmentSlot slot) {
+-        this.checkAttributeList();
++        if (this.attributeModifiers == null) return false; // Paper
+         int removed = 0;
+         Iterator<Map.Entry<Attribute, AttributeModifier>> iter = this.attributeModifiers.entries().iterator();
+ 
+@@ -1399,7 +1413,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+     public boolean removeAttributeModifier(@Nonnull Attribute attribute, @Nonnull AttributeModifier modifier) {
+         Preconditions.checkNotNull(attribute, "Attribute cannot be null");
+         Preconditions.checkNotNull(modifier, "AttributeModifier cannot be null");
+-        this.checkAttributeList();
++        if (this.attributeModifiers == null) return false; // Paper
+         int removed = 0;
+         Iterator<Map.Entry<Attribute, AttributeModifier>> iter = this.attributeModifiers.entries().iterator();
+ 
+@@ -1421,7 +1435,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public String getAsString() {
@@ -415,7 +751,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..87bb193acd39515c2d80cf1ab41d1e25
          this.applyToItem(tag);
          DataComponentPatch patch = tag.build();
          Tag nbt = DataComponentPatch.CODEC.encodeStart(MinecraftServer.getDefaultRegistryAccess().createSerializationContext(NbtOps.INSTANCE), patch).getOrThrow();
-@@ -1430,7 +1437,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1430,7 +1444,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public String getAsComponentString() {
@@ -424,7 +760,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..87bb193acd39515c2d80cf1ab41d1e25
          this.applyToItem(tag);
          DataComponentPatch patch = tag.build();
  
-@@ -1470,6 +1477,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1470,6 +1484,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          if (first == null || second == null) {
              return false;
          }
@@ -432,7 +768,24 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..87bb193acd39515c2d80cf1ab41d1e25
          for (Map.Entry<Attribute, AttributeModifier> entry : first.entries()) {
              if (!second.containsEntry(entry.getKey(), entry.getValue())) {
                  return false;
-@@ -1542,7 +1550,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1495,6 +1510,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+ 
+     @Override
+     public void setDamage(int damage) {
++        Preconditions.checkArgument(damage >= 0, "Damage cannot be negative"); // Paper
++        Preconditions.checkArgument(!this.hasMaxDamage() || damage <= this.maxDamage, "Damage cannot exceed max damage"); // Paper
+         this.damage = damage;
+     }
+ 
+@@ -1511,6 +1528,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+ 
+     @Override
+     public void setMaxDamage(Integer maxDamage) {
++        Preconditions.checkArgument(maxDamage == null || maxDamage > 0, "Max damage should be positive"); // Paper
+         this.maxDamage = maxDamage;
+     }
+ 
+@@ -1542,7 +1560,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hasCustomModelData() ? that.hasCustomModelData() && this.customModelData.equals(that.customModelData) : !that.hasCustomModelData())
                  && (this.hasBlockData() ? that.hasBlockData() && this.blockData.equals(that.blockData) : !that.hasBlockData())
                  && (this.hasRepairCost() ? that.hasRepairCost() && this.repairCost == that.repairCost : !that.hasRepairCost())
@@ -441,16 +794,18 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..87bb193acd39515c2d80cf1ab41d1e25
                  && (this.unhandledTags.equals(that.unhandledTags))
                  && (Objects.equals(this.customTag, that.customTag))
                  && (this.persistentDataContainer.equals(that.persistentDataContainer))
-@@ -1599,7 +1607,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1598,8 +1616,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+         hash = 61 * hash + (this.hasRarity() ? this.rarity.hashCode() : 0);
          hash = 61 * hash + (this.hasFood() ? this.food.hashCode() : 0);
          hash = 61 * hash + (this.hasDamage() ? this.damage : 0);
-         hash = 61 * hash + (this.hasMaxDamage() ? 1231 : 1237);
+-        hash = 61 * hash + (this.hasMaxDamage() ? 1231 : 1237);
 -        hash = 61 * hash + (this.hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
++        hash = 61 * hash + (this.hasMaxDamage() ? this.maxDamage.hashCode() : 0); // Paper - max damage is not a boolean
 +        hash = 61 * hash + (this.attributeModifiers != null ? this.attributeModifiers.hashCode() : 0); // Paper - track only null attributes
          hash = 61 * hash + (this.canPlaceOnPredicates != null ? this.canPlaceOnPredicates.hashCode() : 0); // Paper
          hash = 61 * hash + (this.canBreakPredicates != null ? this.canBreakPredicates.hashCode() : 0); // Paper
          hash = 61 * hash + this.version;
-@@ -1619,7 +1627,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1619,7 +1637,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              if (this.enchantments != null) {
                  clone.enchantments = new EnchantmentMap(this.enchantments); // Paper
              }
@@ -459,7 +814,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..87bb193acd39515c2d80cf1ab41d1e25
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
              }
              if (this.customTag != null) {
-@@ -1823,7 +1831,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1823,7 +1841,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
  
      static void serializeModifiers(Multimap<Attribute, AttributeModifier> modifiers, ImmutableMap.Builder<String, Object> builder, ItemMetaKey key) {
@@ -468,7 +823,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..87bb193acd39515c2d80cf1ab41d1e25
              return;
          }
  
-@@ -1905,7 +1913,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1905,7 +1923,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      // Paper start - improve checking handled tags
      @org.jetbrains.annotations.VisibleForTesting
      public static final Map<Class<? extends CraftMetaItem>, Set<DataComponentType<?>>> HANDLED_DCTS_PER_TYPE = new HashMap<>();
@@ -477,6 +832,215 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..87bb193acd39515c2d80cf1ab41d1e25
          CraftMetaItem.NAME.TYPE,
          CraftMetaItem.ITEM_NAME.TYPE,
          CraftMetaItem.LORE.TYPE,
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaLeatherArmor.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaLeatherArmor.java
+index 157a7b7351f48e68d2923c72ed3bbe3dcae21383..051e3c4e5020fdf1392f888bfb4a633db69e5c5f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaLeatherArmor.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaLeatherArmor.java
+@@ -28,16 +28,30 @@ class CraftMetaLeatherArmor extends CraftMetaItem implements LeatherArmorMeta {
+ 
+     static final ItemMetaKeyType<DyedItemColor> COLOR = new ItemMetaKeyType<>(DataComponents.DYED_COLOR, "color");
+ 
+-    private Color color = DEFAULT_LEATHER_COLOR;
++    private Integer color; // Paper - keep color component consistent with vanilla (top bytes are ignored)
+ 
+     CraftMetaLeatherArmor(CraftMetaItem meta) {
+         super(meta);
+-        CraftMetaLeatherArmor.readColor(this, meta);
++        // Paper start
++        if (!(meta instanceof CraftMetaLeatherArmor leatherMeta)) {
++            return;
++        }
++
++        this.color = leatherMeta.color;
++        // Paper end
+     }
+ 
+     CraftMetaLeatherArmor(DataComponentPatch tag, java.util.Set<net.minecraft.core.component.DataComponentType<?>> extraHandledDcts) { // Paper
+         super(tag, extraHandledDcts); // Paper
+-        CraftMetaLeatherArmor.readColor(this, tag);
++        // Paper start
++        getOrEmpty(tag, CraftMetaLeatherArmor.COLOR).ifPresent((dyedItemColor) -> {
++            if (!dyedItemColor.showInTooltip()) {
++                this.addItemFlags(ItemFlag.HIDE_DYE);
++            }
++
++            this.color = dyedItemColor.rgb();
++        });
++        // Paper end
+     }
+ 
+     CraftMetaLeatherArmor(Map<String, Object> map) {
+@@ -48,7 +62,11 @@ class CraftMetaLeatherArmor extends CraftMetaItem implements LeatherArmorMeta {
+     @Override
+     void applyToItem(CraftMetaItem.Applicator itemTag) {
+         super.applyToItem(itemTag);
+-        CraftMetaLeatherArmor.applyColor(this, itemTag);
++        // Paper start
++        if (this.hasColor()) {
++            itemTag.put(CraftMetaLeatherArmor.COLOR, new DyedItemColor(this.color, !this.hasItemFlag(ItemFlag.HIDE_DYE)));
++        }
++        // Paper end
+     }
+ 
+     @Override
+@@ -72,16 +90,16 @@ class CraftMetaLeatherArmor extends CraftMetaItem implements LeatherArmorMeta {
+ 
+     @Override
+     public Color getColor() {
+-        return this.color;
++        return this.color == null ? DEFAULT_LEATHER_COLOR : Color.fromRGB(this.color & 0xFFFFFF); // Paper
+     }
+ 
+     @Override
+     public void setColor(Color color) {
+-        this.color = color == null ? DEFAULT_LEATHER_COLOR : color;
++        this.color = color == null ? null : color.asRGB(); // Paper
+     }
+ 
+     boolean hasColor() {
+-        return CraftMetaLeatherArmor.hasColor(this);
++        return this.color != null; // Paper
+     }
+ 
+     @Override
+@@ -121,14 +139,16 @@ class CraftMetaLeatherArmor extends CraftMetaItem implements LeatherArmorMeta {
+         return original != hash ? CraftMetaLeatherArmor.class.hashCode() ^ hash : hash;
+     }
+ 
++    @io.papermc.paper.annotation.DoNotUse // Paper
+     static void readColor(LeatherArmorMeta meta, CraftMetaItem other) {
+         if (!(other instanceof CraftMetaLeatherArmor armorMeta)) {
+             return;
+         }
+ 
+-        meta.setColor(armorMeta.color);
++        // meta.setColor(armorMeta.color); // Paper - commented out, color is now an integer and cannot be passed to setColor
+     }
+ 
++    @io.papermc.paper.annotation.DoNotUse // Paper
+     static void readColor(LeatherArmorMeta meta, DataComponentPatch tag) {
+         getOrEmpty(tag, CraftMetaLeatherArmor.COLOR).ifPresent((dyedItemColor) -> {
+             if (!dyedItemColor.showInTooltip()) {
+@@ -151,6 +171,7 @@ class CraftMetaLeatherArmor extends CraftMetaItem implements LeatherArmorMeta {
+         return !DEFAULT_LEATHER_COLOR.equals(meta.getColor());
+     }
+ 
++    @io.papermc.paper.annotation.DoNotUse // Paper
+     static void applyColor(LeatherArmorMeta meta, CraftMetaItem.Applicator tag) {
+         if (CraftMetaLeatherArmor.hasColor(meta)) {
+             tag.put(CraftMetaLeatherArmor.COLOR, new DyedItemColor(meta.getColor().asRGB(), !meta.hasItemFlag(ItemFlag.HIDE_DYE)));
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMap.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMap.java
+index d829f4da371b44e7480896118547734be400a314..b6c18563de5b0d7a5a4253bdd01e98d843ce3797 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMap.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMap.java
+@@ -30,7 +30,7 @@ class CraftMetaMap extends CraftMetaItem implements MapMeta {
+ 
+     private Integer mapId;
+     private byte scaling = CraftMetaMap.SCALING_EMPTY;
+-    private Color color;
++    private Integer color; // Paper - keep color component consistent with vanilla (top bytes are ignored)
+ 
+     CraftMetaMap(CraftMetaItem meta) {
+         super(meta);
+@@ -58,7 +58,7 @@ class CraftMetaMap extends CraftMetaItem implements MapMeta {
+ 
+         getOrEmpty(tag, CraftMetaMap.MAP_COLOR).ifPresent((mapColor) -> {
+             try {
+-                this.color = Color.fromRGB(mapColor.rgb());
++                this.color = mapColor.rgb(); // Paper
+             } catch (IllegalArgumentException ex) {
+                 // Invalid colour
+             }
+@@ -102,7 +102,7 @@ class CraftMetaMap extends CraftMetaItem implements MapMeta {
+         }
+ 
+         if (this.hasColor()) {
+-            tag.put(CraftMetaMap.MAP_COLOR, new MapItemColor(this.color.asRGB()));
++            tag.put(CraftMetaMap.MAP_COLOR, new MapItemColor(this.color)); // Paper
+         }
+     }
+ 
+@@ -127,6 +127,7 @@ class CraftMetaMap extends CraftMetaItem implements MapMeta {
+ 
+     @Override
+     public int getMapId() {
++        Preconditions.checkState(this.hasMapId(), "Item does not have map associated - check hasMapId() first!"); // Paper - fix NPE
+         return this.mapId;
+     }
+ 
+@@ -187,12 +188,12 @@ class CraftMetaMap extends CraftMetaItem implements MapMeta {
+ 
+     @Override
+     public Color getColor() {
+-        return this.color;
++        return this.color == null ? null : Color.fromRGB(this.color & 0xFFFFFF); // Paper
+     }
+ 
+     @Override
+     public void setColor(Color color) {
+-        this.color = color;
++        this.color = color == null ? null : color.asRGB(); // Paper
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaOminousBottle.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaOminousBottle.java
+index 7197c4f5698fd041c4db6d0f6a80c55f77661789..062ef890b42075adb5663453806dda3ad89a6aa0 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaOminousBottle.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaOminousBottle.java
+@@ -75,6 +75,7 @@ public class CraftMetaOminousBottle extends CraftMetaItem implements OminousBott
+ 
+     @Override
+     public int getAmplifier() {
++        Preconditions.checkState(this.hasAmplifier(), "'ominous_bottle_amplifier' data component is absent. Check hasAmplifier first!"); // Paper - fix NPE
+         return this.ominousBottleAmplifier;
+     }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
+index db7f71af22d904de08d4badaa7f66d1286d5bf16..b34d581682b81760e35b1748e21a01f5473edf33 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
+@@ -47,7 +47,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+ 
+     private PotionType type;
+     private List<PotionEffect> customEffects;
+-    private Color color;
++    private Integer color; // Paper - keep color component consistent with vanilla (top bytes are ignored)
+ 
+     CraftMetaPotion(CraftMetaItem meta) {
+         super(meta);
+@@ -70,7 +70,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+ 
+             potionContents.customColor().ifPresent((customColor) -> {
+                 try {
+-                    this.color = Color.fromRGB(customColor);
++                    this.color = customColor; // Paper
+                 } catch (IllegalArgumentException ex) {
+                     // Invalid colour
+                 }
+@@ -126,7 +126,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+         super.applyToItem(tag);
+ 
+         Optional<Holder<Potion>> defaultPotion = (this.hasBasePotionType()) ? Optional.of(CraftPotionType.bukkitToMinecraftHolder(this.type)) : Optional.empty();
+-        Optional<Integer> potionColor = (this.hasColor()) ? Optional.of(this.color.asRGB()) : Optional.empty();
++        Optional<Integer> potionColor = (this.hasColor()) ? Optional.of(this.color) : Optional.empty(); // Paper
+ 
+         List<MobEffectInstance> effectList = new ArrayList<>();
+         if (this.customEffects != null) {
+@@ -295,12 +295,12 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+ 
+     @Override
+     public Color getColor() {
+-        return this.color;
++        return this.color == null ? null : Color.fromRGB(this.color & 0xFFFFFF); // Paper
+     }
+ 
+     @Override
+     public void setColor(Color color) {
+-        this.color = color;
++        this.color = color == null ? null : color.asRGB(); // Paper
+     }
+ 
+     @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 index c769d2a210060f6829a6cbe739d6d9ab2f602644..1feffe289a1e714084bd37b5c5ad23a37dd58325 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
@@ -494,6 +1058,57 @@ index c769d2a210060f6829a6cbe739d6d9ab2f602644..1feffe289a1e714084bd37b5c5ad23a3
 +                }, ((org.bukkit.craftbukkit.CraftServer) org.bukkit.Bukkit.getServer()).getServer()); // Paper - run on main thread
              }
          }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
+index a3c1a8c469630464ac80b7786731462046134998..4bc0aa160e5ed90be622932ff735a9ed98830f33 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
+@@ -251,6 +251,7 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
+ 
+     @Override
+     public EntitySnapshot getSpawnedEntity() {
++        if (this.entityTag == null) return null; // Paper - fix NPE
+         return CraftEntitySnapshot.create(this.entityTag);
+     }
+ 
+@@ -268,8 +269,8 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
+         if (meta instanceof CraftMetaSpawnEgg) {
+             CraftMetaSpawnEgg that = (CraftMetaSpawnEgg) meta;
+ 
+-            return this.hasSpawnedType() ? that.hasSpawnedType() && this.spawnedType.equals(that.spawnedType) : !that.hasSpawnedType()
+-                    && this.entityTag != null ? that.entityTag != null && this.entityTag.equals(that.entityTag) : this.entityTag == null;
++            return (this.hasSpawnedType() ? that.hasSpawnedType() && this.spawnedType.equals(that.spawnedType) : !that.hasSpawnedType()) // Paper
++                    && (this.entityTag != null ? that.entityTag != null && this.entityTag.equals(that.entityTag) : that.entityTag == null); // Paper
+         }
+         return true;
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaTropicalFishBucket.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaTropicalFishBucket.java
+index b5392a3a6f6f3d0a54549e6bb93f28590ee048f0..7514aa6f206c4b82fecd112783f96bb9dd73c01f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaTropicalFishBucket.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaTropicalFishBucket.java
+@@ -126,6 +126,7 @@ class CraftMetaTropicalFishBucket extends CraftMetaItem implements TropicalFishB
+ 
+     @Override
+     public DyeColor getPatternColor() {
++        com.google.common.base.Preconditions.checkState(this.hasVariant(), "This bucket doesn't have variant, check hasVariant first!"); // Paper - fix NPE
+         return CraftTropicalFish.getPatternColor(this.variant);
+     }
+ 
+@@ -139,6 +140,7 @@ class CraftMetaTropicalFishBucket extends CraftMetaItem implements TropicalFishB
+ 
+     @Override
+     public DyeColor getBodyColor() {
++        com.google.common.base.Preconditions.checkState(this.hasVariant(), "This bucket doesn't have variant, check hasVariant first!"); // Paper - fix NPE
+         return CraftTropicalFish.getBodyColor(this.variant);
+     }
+ 
+@@ -152,6 +154,7 @@ class CraftMetaTropicalFishBucket extends CraftMetaItem implements TropicalFishB
+ 
+     @Override
+     public TropicalFish.Pattern getPattern() {
++        com.google.common.base.Preconditions.checkState(this.hasVariant(), "This bucket doesn't have variant, check hasVariant first!"); // Paper - fix NPE
+         return CraftTropicalFish.getPattern(this.variant);
+     }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/SerializableMeta.java b/src/main/java/org/bukkit/craftbukkit/inventory/SerializableMeta.java
 index 05a4a06c0def28fc97e61b4712c45c8730fec60c..a86eb660d8f523cb99a0b668ef1130535d50ce1c 100644
@@ -522,7 +1137,7 @@ index 05a4a06c0def28fc97e61b4712c45c8730fec60c..a86eb660d8f523cb99a0b668ef113053
 +    // Paper end - General ItemMeta Fixes
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/components/CraftFoodComponent.java b/src/main/java/org/bukkit/craftbukkit/inventory/components/CraftFoodComponent.java
-index c68e85cca0f532a94545c0b7f6ed54451ce5a47e..eb08b3453738bffd1a6350dc56c18b9740be5a01 100644
+index c68e85cca0f532a94545c0b7f6ed54451ce5a47e..b647b5205b9c54ccb83e09a9410c722e33e5378d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/components/CraftFoodComponent.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/components/CraftFoodComponent.java
 @@ -103,6 +103,7 @@ public final class CraftFoodComponent implements FoodComponent {
@@ -533,6 +1148,14 @@ index c68e85cca0f532a94545c0b7f6ed54451ce5a47e..eb08b3453738bffd1a6350dc56c18b97
          this.handle = new FoodProperties(this.handle.nutrition(), this.handle.saturation(), this.handle.canAlwaysEat(), eatSeconds, this.handle.effects());
      }
  
+@@ -118,6 +119,7 @@ public final class CraftFoodComponent implements FoodComponent {
+ 
+     @Override
+     public FoodEffect addEffect(PotionEffect effect, float probability) {
++        Preconditions.checkArgument(0 <= probability && probability <= 1, "Probability cannot be outside range [0,1]"); // Paper
+         List<FoodProperties.PossibleEffect> effects = new ArrayList<>(this.handle.effects());
+ 
+         FoodProperties.PossibleEffect newEffect = new net.minecraft.world.food.FoodProperties.PossibleEffect(CraftPotionUtil.fromBukkit(effect), probability);
 diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java
 index 0b11d5ea89539decd2f6c60c5b581bbd78ff1fd6..74ebadacbbd11b5a0d8f8c6cd6409cce17cfa37d 100644
 --- a/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java
@@ -546,6 +1169,19 @@ index 0b11d5ea89539decd2f6c60c5b581bbd78ff1fd6..74ebadacbbd11b5a0d8f8c6cd6409cce
          itemMeta.applyToItem(compound);
  
          assertEquals(itemMeta, new CraftMetaItem(compound.build(), null)); // Paper
+diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
+index d6018439015583fa0344c7c01b2e60a13de29795..aabe3730fa582f442ee0544dd1a9f3123f719c68 100644
+--- a/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
++++ b/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
+@@ -66,7 +66,7 @@ import org.junit.jupiter.api.Test;
+ 
+ public class ItemMetaTest extends AbstractTestingBase {
+ 
+-    static final int MAX_FIREWORK_POWER = 127; // Please update ItemStackFireworkTest if/when this gets changed.
++    static final int MAX_FIREWORK_POWER = 255; // Please update ItemStackFireworkTest if/when this gets changed. // Paper - it changed
+ 
+     @Test
+     public void testPowerLimitExact() {
 diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java
 index f3939074a886b20f17b00dd3c39833725f47d3f0..1123cc60671c1a48bba9b2baa1f10c6d5a6855fe 100644
 --- a/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java

--- a/patches/server/1039-Expose-hasColor-to-leather-armor.patch
+++ b/patches/server/1039-Expose-hasColor-to-leather-armor.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose #hasColor to leather armor
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java
-index 2c9ca54267579a210d4ea192517fc0fbce8e467a..ae94d09b8e0cac77db6a11f85890ff0fb51236f0 100644
+index 3109df67e42838f3e69681326efb1caf237548a5..62965625b187da28e2cead1d94bae2509c5943c3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java
-@@ -116,4 +116,11 @@ public class CraftMetaColorableArmor extends CraftMetaArmor implements Colorable
+@@ -134,4 +134,11 @@ public class CraftMetaColorableArmor extends CraftMetaArmor implements Colorable
          }
          return original != hash ? CraftMetaColorableArmor.class.hashCode() ^ hash : hash;
      }
@@ -21,10 +21,10 @@ index 2c9ca54267579a210d4ea192517fc0fbce8e467a..ae94d09b8e0cac77db6a11f85890ff0f
 +    // Paper end - Expose #hasColor to leather armor
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaLeatherArmor.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaLeatherArmor.java
-index 157a7b7351f48e68d2923c72ed3bbe3dcae21383..0368b2a557d3ee5d83474311fbd561480f9e8a2f 100644
+index cdbf91f1fce21a84b74412a985a8c7c93626768d..f48e4086af9cef0166e2a5108292c8a3d3833390 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaLeatherArmor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaLeatherArmor.java
-@@ -162,4 +162,11 @@ class CraftMetaLeatherArmor extends CraftMetaItem implements LeatherArmorMeta {
+@@ -183,4 +183,11 @@ class CraftMetaLeatherArmor extends CraftMetaItem implements LeatherArmorMeta {
              builder.put(CraftMetaLeatherArmor.COLOR.BUKKIT, meta.getColor());
          }
      }

--- a/patches/server/1046-Fix-equipment-slot-and-group-API.patch
+++ b/patches/server/1046-Fix-equipment-slot-and-group-API.patch
@@ -6,11 +6,11 @@ Subject: [PATCH] Fix equipment slot and group API
 Add test for EquipmentSlotGroup
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 87bb193acd39515c2d80cf1ab41d1e2538112fe9..a39785b4e45e7bf57d6c60abae0771a629148342 100644
+index 860bc5ec4baec5e09a456cc5559d0de2aa10797a..554dc8b6b142c185d1dd0c4a3450232b7b708f1b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -1331,7 +1331,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
-         this.checkAttributeList();
+         if (this.attributeModifiers == null) return LinkedHashMultimap.create(); // Paper - don't change the components
          SetMultimap<Attribute, AttributeModifier> result = LinkedHashMultimap.create();
          for (Map.Entry<Attribute, AttributeModifier> entry : this.attributeModifiers.entries()) {
 -            if (entry.getValue().getSlot() == null || entry.getValue().getSlot() == slot) {
@@ -18,7 +18,7 @@ index 87bb193acd39515c2d80cf1ab41d1e2538112fe9..a39785b4e45e7bf57d6c60abae0771a6
                  result.put(entry.getKey(), entry.getValue());
              }
          }
-@@ -1392,9 +1392,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1399,9 +1399,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
          while (iter.hasNext()) {
              Map.Entry<Attribute, AttributeModifier> entry = iter.next();


### PR DESCRIPTION
NPEs:
- OminousBottleMeta#getAmplifier when ominous_bottle_amplifier data component is absent from the patch
- TropicalFishBucketMeta when variant is null for almost all the color getter
- AxolotlBucketMeta#getVariant when variant is null
- ItemMeta#getAttributeModifiers(Attribute) when attribute modifiers is null
- SpawnEggMeta#getSpawnedEntity when entityTag is null

Codec/item validation:
This often kick the player holding the bad item instantly without saving the last data.
- FoodComponent#addEffect with out of bound probability (outside 0-1)
- the default food component created by Spigot (ItemMeta#getFood) is invalid since 'eat_seconds' cannot be equals to zero
- ItemMeta#set(Max)Damage doesn't check the range
- BundleMeta#addItem/setItems with empty item (amount=0)
- FireworkMeta#setPower takes 0-255 (fixes https://github.com/PaperMC/Paper/issues/7427)

ItemMeta bad equality:
This breaks the contract of equals that say x.equals(y) == y.equals(x)
- CraftMetaEntityTag (equals)
- CraftMetaSpawnEgg (equals)
- CraftMetaArmorStand (equals, hashCode), Paper only: doesn't check entityTag and is not consistent with hashCode
- CraftItemMeta (hashCode) handles the max damage as a simple boolean and not as an integer

Misc:
- empty fireworks effect is cleared by the item meta conversion (firework_rocket[minecraft:fireworks={}])
- firework effect with no main color got white added to it
- charged projectile for CrossbowMeta should allow other items and not only arrow or fireworks especially since now the picked up item is custom
- AxolotlBucketMeta#setVariant is not null but yet allow null to be handled as LUCY variant
- ItemMeta#getAttributeModifiers(EquipmentSlot) create an empty attribute_modifiers component, but getter shouldn't affect the underlying data
- FireworkMeta is not applied to firework because of the empty default item
- damage component can change if out of bound
- invalid colors are cleared when only the top byte should be ignored (not cleared) (PotionMeta, FireworkMeta/FireworkEffectMeta, ColorableArmorMeta, LeatherArmorMeta, MapMeta)
- mitigate crashes of https://github.com/PaperMC/Paper/issues/10677, pattern is lost however
- book page limit is infinite however internal still limit to 100 pages for writable book

<details><summary>Known issues (unfixed):</summary>
- No way to set some components: base_color (shield), intangible_projectile (for crossbow, in charged_projectiles component), tool, debug_stick_state etc...<br>
- The LeatherArmorMeta fallback to the default leather color even for wolf armor which doesn't make sense<br>
- Shield with base_color component gets an empty banner_patterns components once moved into the inventory<br>
</details>

Opened this as a draft since there are more stuff to check