### PR TITLE
Do not re-wrap vanilla goals (Fixes #10743)

### DIFF
--- a/patches/server/0359-Implement-Mob-Goal-API.patch
+++ b/patches/server/0359-Implement-Mob-Goal-API.patch
@@ -461,10 +461,10 @@ index 0000000000000000000000000000000000000000..b5f75ad725f5933db8f0688b2c0b27d6
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/PaperMobGoals.java b/src/main/java/com/destroystokyo/paper/entity/ai/PaperMobGoals.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..02b3670cfc04209baa56d89f82b65ee30d656923
+index 0000000000000000000000000000000000000000..30ed9ffd6a65914d7545636150a09327aba047c3
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/ai/PaperMobGoals.java
-@@ -0,0 +1,216 @@
+@@ -0,0 +1,224 @@
 +package com.destroystokyo.paper.entity.ai;
 +
 +import java.util.Collection;
@@ -483,7 +483,15 @@ index 0000000000000000000000000000000000000000..02b3670cfc04209baa56d89f82b65ee3
 +    @Override
 +    public <T extends Mob> void addGoal(T mob, int priority, Goal<T> goal) {
 +        CraftMob craftMob = (CraftMob) mob;
-+        getHandle(craftMob, goal.getTypes()).addGoal(priority, new PaperCustomGoal<>(goal));
++        net.minecraft.world.entity.ai.goal.Goal mojangGoal;
++
++        if (goal instanceof PaperVanillaGoal vanillaGoal) {
++            mojangGoal = vanillaGoal.getHandle();
++        } else {
++            mojangGoal = new PaperCustomGoal<>(goal);
++        }
++
++        getHandle(craftMob, goal.getTypes()).addGoal(priority, mojangGoal);
 +    }
 +
 +    @Override


### PR DESCRIPTION
There is no need to rewrap vanilla goals when they're being reregistered, this breaks some expectations around behavior outside of general wasting of resources.