### PR TITLE
Print CommandRegisteredEvent deprecation warnings again

### DIFF
--- a/patches/api/0476-Brigadier-based-command-API.patch
+++ b/patches/api/0476-Brigadier-based-command-API.patch
@@ -270,7 +270,7 @@ index 0000000000000000000000000000000000000000..6ac205de582983863bd5b3c0fa70d437
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/brigadier/CommandRegisteredEvent.java b/src/main/java/com/destroystokyo/paper/event/brigadier/CommandRegisteredEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d195c76d9343d2e9e6ade5318ae00470e5c0fe34
+index 0000000000000000000000000000000000000000..acc2bd2ec56e64b9d4bd8677d99448a97ecb5201
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/brigadier/CommandRegisteredEvent.java
 @@ -0,0 +1,171 @@
@@ -300,7 +300,7 @@ index 0000000000000000000000000000000000000000..d195c76d9343d2e9e6ade5318ae00470
 + */
 +@ApiStatus.Experimental
 +@Deprecated(since = "1.20.6")
-+@Warning(reason = "This event has been superseded by the Commands API and will be removed in a future release. Listen to LifecycleEvents.COMMANDS instead.")
++@Warning(reason = "This event has been superseded by the Commands API and will be removed in a future release. Listen to LifecycleEvents.COMMANDS instead.", value = true)
 +public class CommandRegisteredEvent<S extends com.destroystokyo.paper.brigadier.BukkitBrigadierCommandSource> extends ServerEvent implements Cancellable {
 +
 +    private static final HandlerList handlers = new HandlerList();


### PR DESCRIPTION
#10754 accidentally disabled the warning as `value` defaults to false.