### PR TITLE
only show now-in-commands.yml for legacy files

### DIFF
--- a/patches/server/1046-only-show-now-in-commands.yml-for-legacy-files.patch
+++ b/patches/server/1046-only-show-now-in-commands.yml-for-legacy-files.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: david <mrminecraft00@gmail.com>
+Date: Wed, 22 May 2024 02:17:32 +0200
+Subject: [PATCH] only show now-in-commands.yml for legacy files
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index af015237214cebc4d1c4bb9e9c5f939d433e365c..9bb3046766417ff90a8aea72da6c1844231e62de 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -418,6 +418,7 @@ public final class CraftServer implements Server {
+         ConfigurationSection legacyAlias = null;
+         if (!this.configuration.isString("aliases")) {
+             legacyAlias = this.configuration.getConfigurationSection("aliases");
++            if (legacyAlias != null) // Paper - only change legacy configurations
+             this.configuration.set("aliases", "now-in-commands.yml");
+         }
+         this.saveConfig();
+diff --git a/src/main/resources/configurations/bukkit.yml b/src/main/resources/configurations/bukkit.yml
+index eef7c125b2689f29cae5464659eacdf33f5695b2..5889a49f7e135f6dac66e772c8027deb43727bbe 100644
+--- a/src/main/resources/configurations/bukkit.yml
++++ b/src/main/resources/configurations/bukkit.yml
+@@ -42,4 +42,3 @@ ticks-per:
+     axolotl-spawns: 1
+     ambient-spawns: 1
+     autosave: 6000
+-aliases: now-in-commands.yml


### PR DESCRIPTION
I know this is pretty unnecessary but why create new configs with old values
keeping that outdated s**t just makes future updates even messier