### PR TITLE
Always show command exception stack traces in logs

### DIFF
--- a/patches/server/1044-Brigadier-based-command-API.patch
+++ b/patches/server/1044-Brigadier-based-command-API.patch
@@ -2021,7 +2021,7 @@ index e6c7f62ed379a78645933670299e4fcda8540ed1..59d7e8a3d83d3ab7aa28606401bb129c
      public org.bukkit.command.CommandSender getBukkitSender() {
          return this.source.getBukkitSender(this);
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index aa2fca6917fb67fe0e9ba067d11487c3a274f675..24086a82e1687cb1925398218b18c2384fa8f6e3 100644
+index aa2fca6917fb67fe0e9ba067d11487c3a274f675..86af3494f3d86c7b9fb90ce5a877ec23f5a79e7f 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
 @@ -156,7 +156,7 @@ public class Commands {
@@ -2069,14 +2069,19 @@ index aa2fca6917fb67fe0e9ba067d11487c3a274f675..24086a82e1687cb1925398218b18c238
          CommandSourceStack commandlistenerwrapper = (CommandSourceStack) parseresults.getContext().getSource();
  
          commandlistenerwrapper.getServer().getProfiler().push(() -> {
-@@ -339,6 +351,7 @@ public class Commands {
+@@ -339,10 +351,11 @@ public class Commands {
                  });
              }
          } catch (Exception exception) {
 +            if (throwCommandError) throw exception;
              MutableComponent ichatmutablecomponent = Component.literal(exception.getMessage() == null ? exception.getClass().getName() : exception.getMessage());
  
++            Commands.LOGGER.error("Command exception: /{}", s, exception); // Paper - always show execution exception in console log
              if (commandlistenerwrapper.getServer().isDebugging() || Commands.LOGGER.isDebugEnabled()) { // Paper - Debugging
+-                Commands.LOGGER.error("Command exception: /{}", s, exception);
+                 StackTraceElement[] astacktraceelement = exception.getStackTrace();
+ 
+                 for (int i = 0; i < Math.min(astacktraceelement.length, 3); ++i) {
 @@ -477,7 +490,7 @@ public class Commands {
          Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> map = Maps.newIdentityHashMap(); // Use identity to prevent aliasing issues
          RootCommandNode vanillaRoot = new RootCommandNode();


### PR DESCRIPTION
With the brig API, all exceptions in command execution are handled by the default system which only show stacktraces in the log when `debug=true` is set in `server.properties`. I think it's safe to just always show the stacktraces now. I don't recall many cases where vanilla commands have execution exceptions that shouldn't be shown in the log.