### PR TITLE
Use getter/setter on Mob for equipment drop chances

### DIFF
--- a/patches/server/0524-add-get-set-drop-chance-to-EntityEquipment.patch
+++ b/patches/server/0524-add-get-set-drop-chance-to-EntityEquipment.patch
@@ -3,12 +3,14 @@ From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Thu, 22 Apr 2021 00:28:11 -0700
 Subject: [PATCH] add get-set drop chance to EntityEquipment
 
+== AT ==
+public net.minecraft.world.entity.Mob getEquipmentDropChance(Lnet/minecraft/world/entity/EquipmentSlot;)F
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftEntityEquipment.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftEntityEquipment.java
-index cb704cef3845727c465fe3ea7210a11545da56c8..6827979a5b270ced53b46ecb9eff548727dadb81 100644
+index cb704cef3845727c465fe3ea7210a11545da56c8..fdcc414f4fa246082ad0732133c870d915ae3084 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftEntityEquipment.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftEntityEquipment.java
-@@ -244,6 +244,17 @@ public class CraftEntityEquipment implements EntityEquipment {
+@@ -244,15 +244,22 @@ public class CraftEntityEquipment implements EntityEquipment {
      public void setBootsDropChance(float chance) {
          this.setDropChance(net.minecraft.world.entity.EquipmentSlot.FEET, chance);
      }
@@ -26,6 +28,28 @@ index cb704cef3845727c465fe3ea7210a11545da56c8..6827979a5b270ced53b46ecb9eff5487
  
      private void setDropChance(net.minecraft.world.entity.EquipmentSlot slot, float chance) {
          Preconditions.checkArgument(this.entity.getHandle() instanceof Mob, "Cannot set drop chance for non-Mob entity");
+ 
+-        if (slot == net.minecraft.world.entity.EquipmentSlot.MAINHAND || slot == net.minecraft.world.entity.EquipmentSlot.OFFHAND) {
+-            ((Mob) this.entity.getHandle()).handDropChances[slot.getIndex()] = chance;
+-        } else {
+-            ((Mob) this.entity.getHandle()).armorDropChances[slot.getIndex()] = chance;
+-        }
++        ((Mob) this.entity.getHandle()).setDropChance(slot, chance); // Paper - use setter on Mob
+     }
+ 
+     private float getDropChance(net.minecraft.world.entity.EquipmentSlot slot) {
+@@ -260,10 +267,6 @@ public class CraftEntityEquipment implements EntityEquipment {
+             return 1;
+         }
+ 
+-        if (slot == net.minecraft.world.entity.EquipmentSlot.MAINHAND || slot == net.minecraft.world.entity.EquipmentSlot.OFFHAND) {
+-            return ((Mob) this.entity.getHandle()).handDropChances[slot.getIndex()];
+-        } else {
+-            return ((Mob) this.entity.getHandle()).armorDropChances[slot.getIndex()];
+-        }
++        return ((Mob) this.entity.getHandle()).getEquipmentDropChance(slot); // Paper - use getter on Mob
+     }
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
 index 23abd543cd8e3cbb49e4927aef59ed95d3465360..972fe4237461f07f78b60845b2ebfefb06698ded 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java


### PR DESCRIPTION
Makes `CraftEntityEquipment#setDropChance`/`CraftEntityEquipment#getDropChance` use `net.minecraft.world.entity.Mob#setDropChance`/`net.minecraft.world.entity.Mob#getEquipmentDropChance` for setting equipment drop chances.

Also fixes an issue with setting the drop chance for equipment in slot `BODY`, which caused it to instead set the drop chance for the `HEAD` slot.