### PR TITLE
Allow to define new map cursor types

### DIFF
--- a/patches/api/0171-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0171-Fix-Spigot-annotation-mistakes.patch
@@ -40,7 +40,7 @@ index ac420f0059fc50d3e1294f85df7515c9e17ff78f..24daba85ce4129fb0babe67570059ca8
      public static Art getById(int id) {
          return BY_ID.get(id);
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index de678fa681fbd94efa8fd85568ee092ae26fca85..cddf3250c4a7efe239248b5e9662f33f5c0b702f 100644
+index f1a4e9a4b54757b9b73dd3a66ef6083a7119378d..2f023dcab9fe1ea220ba04e575bb5efe78adbd45 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -879,9 +879,8 @@ public final class Bukkit {
@@ -300,7 +300,7 @@ index 02b4ffa6b918269bd64f7c518fcceef1f6990737..f0878c7539696cc0676e6010e88914d3
          if (this.world == null) {
              return null;
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index fb6e030af69b085946a029d89347b19b121f6a14..feebabf946913263461e1d0f13a478cf4bfd0f68 100644
+index fb6e030af69b085946a029d89347b19b121f6a14..7458278ad620d534b205438062327463caaa9bfc 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4749,20 +4749,20 @@ public enum Material implements Keyed, Translatable {
@@ -311,7 +311,7 @@ index fb6e030af69b085946a029d89347b19b121f6a14..feebabf946913263461e1d0f13a478cf
 +     * @apiNote Internal Use Only
       */
 -    @Deprecated
-+    @org.jetbrains.annotations.ApiStatus.Internal // Paper
++    @ApiStatus.Internal // Paper
      public int getId() {
          Preconditions.checkArgument(legacy, "Cannot get ID of Modern Material");
          return id;
@@ -498,7 +498,7 @@ index 6277451c3c6c551078c237cd767b6d70c4f585ea..10f5cfb1885833a1d2c1027c03974da4
      CRACKED(0x0),
      GLYPHED(0x1),
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a7a04a4e9c94cc43ccf84abb3b7956b60c79e8fe..6412546d84874cb93fcdc8426a402bec4e276057 100644
+index 82f4359bc93b97304fbcbf2406ae69cfb0d74a0b..6d72b50b12315caf29842b5cf52e67715de8877d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -740,9 +740,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0438-add-missing-Experimental-annotations.patch
+++ b/patches/api/0438-add-missing-Experimental-annotations.patch
@@ -27,74 +27,74 @@ index 6b68c92ec894451d99ded3e3df5965cb31d68ed2..fd5e433f930963c102c9c977523a0036
      public static final FeatureFlag UPDATE_121 = Bukkit.getUnsafe().getFeatureFlag(NamespacedKey.minecraft("update_1_21"));
  }
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eacf29493ce 100644
+index b9ba0f82814b61e7992526f0b5ce324ca69a0d71..7509b61dfdc0a6675256970cb850b08f9e814580 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -151,54 +151,67 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
       * BlockData: {@link Slab}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      TUFF_SLAB(19305, Slab.class),
      /**
       * BlockData: {@link Stairs}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      TUFF_STAIRS(11268, Stairs.class),
      /**
       * BlockData: {@link Wall}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      TUFF_WALL(24395, Wall.class),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      CHISELED_TUFF(15831),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      POLISHED_TUFF(17801),
      /**
       * BlockData: {@link Slab}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      POLISHED_TUFF_SLAB(31096, Slab.class),
      /**
       * BlockData: {@link Stairs}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      POLISHED_TUFF_STAIRS(7964, Stairs.class),
      /**
       * BlockData: {@link Wall}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      POLISHED_TUFF_WALL(28886, Wall.class),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      TUFF_BRICKS(26276),
      /**
       * BlockData: {@link Slab}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      TUFF_BRICK_SLAB(11843, Slab.class),
      /**
       * BlockData: {@link Stairs}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      TUFF_BRICK_STAIRS(30753, Stairs.class),
      /**
       * BlockData: {@link Wall}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      TUFF_BRICK_WALL(11761, Wall.class),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      CHISELED_TUFF_BRICKS(8601),
      DRIPSTONE_BLOCK(26227),
      /**
@@ -102,7 +102,7 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
       * BlockData: {@link Waterlogged}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      HEAVY_CORE(15788, Waterlogged.class),
      AMETHYST_BLOCK(18919),
      BUDDING_AMETHYST(13963),
@@ -110,16 +110,16 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
      WEATHERED_COPPER(19699),
      OXIDIZED_COPPER(19490),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      CHISELED_COPPER(12143),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      EXPOSED_CHISELED_COPPER(4570),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WEATHERED_CHISELED_COPPER(30876),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      OXIDIZED_CHISELED_COPPER(27719),
      CUT_COPPER(32519),
      EXPOSED_CUT_COPPER(18000),
@@ -127,16 +127,16 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
      WAXED_WEATHERED_COPPER(5960),
      WAXED_OXIDIZED_COPPER(25626),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_CHISELED_COPPER(7500),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_EXPOSED_CHISELED_COPPER(30658),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_WEATHERED_CHISELED_COPPER(5970),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_OXIDIZED_CHISELED_COPPER(7735),
      WAXED_CUT_COPPER(11030),
      WAXED_EXPOSED_CUT_COPPER(30043),
@@ -144,49 +144,49 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
       * BlockData: {@link Door}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      COPPER_DOOR(26809, Door.class),
      /**
       * BlockData: {@link Door}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      EXPOSED_COPPER_DOOR(13236, Door.class),
      /**
       * BlockData: {@link Door}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WEATHERED_COPPER_DOOR(10208, Door.class),
      /**
       * BlockData: {@link Door}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      OXIDIZED_COPPER_DOOR(5348, Door.class),
      /**
       * BlockData: {@link Door}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_COPPER_DOOR(9954, Door.class),
      /**
       * BlockData: {@link Door}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_EXPOSED_COPPER_DOOR(20748, Door.class),
      /**
       * BlockData: {@link Door}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_WEATHERED_COPPER_DOOR(25073, Door.class),
      /**
       * BlockData: {@link Door}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_OXIDIZED_COPPER_DOOR(23888, Door.class),
      /**
       * BlockData: {@link TrapDoor}
@@ -194,49 +194,49 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
       * BlockData: {@link TrapDoor}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      COPPER_TRAPDOOR(12110, TrapDoor.class),
      /**
       * BlockData: {@link TrapDoor}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      EXPOSED_COPPER_TRAPDOOR(19219, TrapDoor.class),
      /**
       * BlockData: {@link TrapDoor}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WEATHERED_COPPER_TRAPDOOR(28254, TrapDoor.class),
      /**
       * BlockData: {@link TrapDoor}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      OXIDIZED_COPPER_TRAPDOOR(26518, TrapDoor.class),
      /**
       * BlockData: {@link TrapDoor}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_COPPER_TRAPDOOR(12626, TrapDoor.class),
      /**
       * BlockData: {@link TrapDoor}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_EXPOSED_COPPER_TRAPDOOR(11010, TrapDoor.class),
      /**
       * BlockData: {@link TrapDoor}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_WEATHERED_COPPER_TRAPDOOR(30709, TrapDoor.class),
      /**
       * BlockData: {@link TrapDoor}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_OXIDIZED_COPPER_TRAPDOOR(21450, TrapDoor.class),
      /**
       * BlockData: {@link Gate}
@@ -245,7 +245,7 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
      COMPASS(24139),
      RECOVERY_COMPASS(12710),
 +    @MinecraftExperimental(Requires.BUNDLE) // Paper - add missing annotation
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      BUNDLE(16835, 1),
      FISHING_ROD(4167, 1, 64),
      CLOCK(14980),
@@ -253,7 +253,7 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
       * BlockData: {@link Crafter}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      CRAFTER(25243, Crafter.class),
      FILLED_MAP(23504),
      SHEARS(27971, 1, 238),
@@ -261,10 +261,10 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
      BEE_SPAWN_EGG(22924),
      BLAZE_SPAWN_EGG(4759),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      BOGGED_SPAWN_EGG(12042),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      BREEZE_SPAWN_EGG(7580),
      CAT_SPAWN_EGG(29583),
      CAMEL_SPAWN_EGG(14760),
@@ -272,12 +272,12 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
      EXPERIENCE_BOTTLE(12858),
      FIRE_CHARGE(4842),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WIND_CHARGE(23928),
      WRITABLE_BOOK(13393, 1),
      WRITTEN_BOOK(24164, 16),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      MACE(4771, 1, 250),
      ITEM_FRAME(27318),
      GLOW_ITEM_FRAME(26473),
@@ -286,10 +286,10 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
      GLOBE_BANNER_PATTERN(27753, 1),
      PIGLIN_BANNER_PATTERN(22028, 1),
 +    @MinecraftExperimental(Requires.UPDATE_1_21) // Paper - add missing annotation
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      FLOW_BANNER_PATTERN(32683, 1),
 +    @MinecraftExperimental(Requires.UPDATE_1_21) // Paper - add missing annotation
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      GUSTER_BANNER_PATTERN(27267, 1),
      GOAT_HORN(28237, 1),
      /**
@@ -297,10 +297,10 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
      RAISER_ARMOR_TRIM_SMITHING_TEMPLATE(29116),
      HOST_ARMOR_TRIM_SMITHING_TEMPLATE(12165),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      FLOW_ARMOR_TRIM_SMITHING_TEMPLATE(29175),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      BOLT_ARMOR_TRIM_SMITHING_TEMPLATE(9698),
      ANGLER_POTTERY_SHERD(9952),
      ARCHER_POTTERY_SHERD(21629),
@@ -308,11 +308,11 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
      DANGER_POTTERY_SHERD(30506),
      EXPLORER_POTTERY_SHERD(5124),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      FLOW_POTTERY_SHERD(4896),
      FRIEND_POTTERY_SHERD(18221),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      GUSTER_POTTERY_SHERD(28193),
      HEART_POTTERY_SHERD(17607),
      HEARTBREAK_POTTERY_SHERD(21108),
@@ -320,7 +320,7 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
      PLENTY_POTTERY_SHERD(28236),
      PRIZE_POTTERY_SHERD(4341),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      SCRAPE_POTTERY_SHERD(30034),
      SHEAF_POTTERY_SHERD(23652),
      SHELTER_POTTERY_SHERD(28390),
@@ -328,121 +328,121 @@ index 4ad5f2d40c10e7b059a9096dcc6a3b0b618411a0..81f9ad99699a78b97e4accaaf1a98eac
       * BlockData: {@link Waterlogged}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      COPPER_GRATE(16221, Waterlogged.class),
      /**
       * BlockData: {@link Waterlogged}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      EXPOSED_COPPER_GRATE(7783, Waterlogged.class),
      /**
       * BlockData: {@link Waterlogged}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WEATHERED_COPPER_GRATE(24954, Waterlogged.class),
      /**
       * BlockData: {@link Waterlogged}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      OXIDIZED_COPPER_GRATE(14122, Waterlogged.class),
      /**
       * BlockData: {@link Waterlogged}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_COPPER_GRATE(11230, Waterlogged.class),
      /**
       * BlockData: {@link Waterlogged}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_EXPOSED_COPPER_GRATE(20520, Waterlogged.class),
      /**
       * BlockData: {@link Waterlogged}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_WEATHERED_COPPER_GRATE(16533, Waterlogged.class),
      /**
       * BlockData: {@link Waterlogged}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_OXIDIZED_COPPER_GRATE(32010, Waterlogged.class),
      /**
       * BlockData: {@link CopperBulb}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      COPPER_BULB(21370, CopperBulb.class),
      /**
       * BlockData: {@link CopperBulb}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      EXPOSED_COPPER_BULB(11944, CopperBulb.class),
      /**
       * BlockData: {@link CopperBulb}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WEATHERED_COPPER_BULB(10800, CopperBulb.class),
      /**
       * BlockData: {@link CopperBulb}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      OXIDIZED_COPPER_BULB(22421, CopperBulb.class),
      /**
       * BlockData: {@link CopperBulb}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_COPPER_BULB(23756, CopperBulb.class),
      /**
       * BlockData: {@link CopperBulb}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_EXPOSED_COPPER_BULB(5530, CopperBulb.class),
      /**
       * BlockData: {@link CopperBulb}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_WEATHERED_COPPER_BULB(13239, CopperBulb.class),
      /**
       * BlockData: {@link CopperBulb}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      WAXED_OXIDIZED_COPPER_BULB(26892, CopperBulb.class),
      /**
       * BlockData: {@link TrialSpawner}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      TRIAL_SPAWNER(19902, TrialSpawner.class),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      TRIAL_KEY(12725),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      OMINOUS_TRIAL_KEY(4986),
      /**
       * BlockData: {@link Vault}
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      VAULT(6288, Vault.class),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      OMINOUS_BOTTLE(26321),
      @MinecraftExperimental(Requires.UPDATE_1_21)
-+    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
++    @ApiStatus.Experimental // Paper - add missing annotation
      BREEZE_ROD(14281),
      /**
       * BlockData: {@link Levelled}
@@ -1081,6 +1081,40 @@ index 0fc30514375c1700c282d1e92342f7b48ca1cb27..bd625de1103741e592b4111412e4094f
      TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS("spawners/trial_chamber/items_to_drop_when_ominous"),
      // Shearing
      SHEARING_BOGGED("shearing/bogged"),
+diff --git a/src/main/java/org/bukkit/map/MapCursor.java b/src/main/java/org/bukkit/map/MapCursor.java
+index 1afa33ca0d900d9301d52ace3ddb0bd50b5ce4e8..c7100c2bc2be9e294957862d943e629ae9916468 100644
+--- a/src/main/java/org/bukkit/map/MapCursor.java
++++ b/src/main/java/org/bukkit/map/MapCursor.java
+@@ -311,13 +311,29 @@ public final class MapCursor {
+         BANNER_RED(24, "banner_red"),
+         BANNER_BLACK(25, "banner_black"),
+         RED_X(26, "red_x"),
++        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
++        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+         VILLAGE_DESERT(27, "village_desert"),
++        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
++        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+         VILLAGE_PLAINS(28, "village_plains"),
++        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
++        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+         VILLAGE_SAVANNA(29, "village_savanna"),
++        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
++        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+         VILLAGE_SNOWY(30, "village_snowy"),
++        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
++        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+         VILLAGE_TAIGA(31, "village_taiga"),
++        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
++        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+         JUNGLE_TEMPLE(32, "jungle_temple"),
++        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
++        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+         SWAMP_HUT(33, "swamp_hut"),
++        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.UPDATE_1_21) // Paper - add missing annotation
++        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
+         TRIAL_CHAMBERS(34, "trial_chambers")
+         ;
+ 
 diff --git a/src/main/java/org/bukkit/potion/PotionEffectType.java b/src/main/java/org/bukkit/potion/PotionEffectType.java
 index e77cf365cefafbeba09123187e70fd5274f10d53..7a7b98d40a031b09d6bc62df32d2ddeb25a9d41e 100644
 --- a/src/main/java/org/bukkit/potion/PotionEffectType.java

--- a/patches/api/0480-Allow-to-define-new-map-cursor-types.patch
+++ b/patches/api/0480-Allow-to-define-new-map-cursor-types.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lulu13022002 <41980282+Lulu13022002@users.noreply.github.com>
+Date: Fri, 24 May 2024 20:19:07 +0200
+Subject: [PATCH] Allow to define new map cursor types
+
+
+diff --git a/src/main/java/org/bukkit/map/MapCursor.java b/src/main/java/org/bukkit/map/MapCursor.java
+index c7100c2bc2be9e294957862d943e629ae9916468..bd3c733d4d9042a510034ce8615c04d68d79796c 100644
+--- a/src/main/java/org/bukkit/map/MapCursor.java
++++ b/src/main/java/org/bukkit/map/MapCursor.java
+@@ -221,8 +221,8 @@ public final class MapCursor {
+      */
+     @Deprecated(forRemoval = true, since = "1.20.2") // Paper
+     public void setRawType(byte type) {
+-        if (type < 0 || type > 26) {
+-            throw new IllegalArgumentException("Type must be in the range 0-26");
++        if (type < 0 || type > Type.UPPER_MAP_CURSOR_TYPE_BOUND) { // Paper
++            throw new IllegalArgumentException("Type must be in the range 0-" + Type.UPPER_MAP_CURSOR_TYPE_BOUND); // Paper
+         }
+         this.type = type;
+     }
+@@ -337,6 +337,8 @@ public final class MapCursor {
+         TRIAL_CHAMBERS(34, "trial_chambers")
+         ;
+ 
++        static final int UPPER_MAP_CURSOR_TYPE_BOUND = Type.values().length - 1; // Paper - cached max value of Type
++
+         private byte value;
+         private final NamespacedKey key;
+ 


### PR DESCRIPTION
The method is deprecated however internally everything in the api still use the byte equivalent and non deprecated api redirect to this method.