### PR TITLE
Fix BlockStateMeta equals

### DIFF
--- a/patches/server/1038-General-ItemMeta-fixes.patch
+++ b/patches/server/1038-General-ItemMeta-fixes.patch
@@ -150,7 +150,7 @@ index 1ac3bec02fce28d5ce698305a7482a9eccbb1867..b494568f833dc21d4e2447ac3e5c5002
  
          for (Pattern p : this.patterns) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-index 12911233c01d0ac1af9adbd157d56d28361fc76f..322d5f19d0c156bf6e46202d2e185d8aec455492 100644
+index 12911233c01d0ac1af9adbd157d56d28361fc76f..7c0e4dd99d1b6ce04ddf97e81eff4692878dfb48 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
 @@ -142,9 +142,17 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
@@ -172,7 +172,7 @@ index 12911233c01d0ac1af9adbd157d56d28361fc76f..322d5f19d0c156bf6e46202d2e185d8a
      private CompoundTag internalTag;
  
      CraftMetaBlockState(CraftMetaItem meta, Material material) {
-@@ -153,41 +161,60 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -153,41 +161,61 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
  
          if (!(meta instanceof CraftMetaBlockState)
                  || ((CraftMetaBlockState) meta).material != material) {
@@ -236,6 +236,7 @@ index 12911233c01d0ac1af9adbd157d56d28361fc76f..322d5f19d0c156bf6e46202d2e185d8a
 -                this.blockEntityTag = blockEntityTag;
 +                // Paper start
 +                for (final DataComponentType type : applied) {
++                    if (CraftMetaItem.DEFAULT_HANDLED_DCTS.contains(type)) continue;
 +                    getOrEmpty(tag, type).ifPresent(value -> {
 +                        map.set(type, value);
 +                    });
@@ -246,7 +247,7 @@ index 12911233c01d0ac1af9adbd157d56d28361fc76f..322d5f19d0c156bf6e46202d2e185d8a
          }
      }
  
-@@ -200,7 +227,10 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -200,7 +228,10 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
          } else {
              this.material = Material.AIR;
          }
@@ -258,7 +259,7 @@ index 12911233c01d0ac1af9adbd157d56d28361fc76f..322d5f19d0c156bf6e46202d2e185d8a
          this.internalTag = null;
      }
  
-@@ -208,13 +238,20 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -208,13 +239,20 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
      void applyToItem(CraftMetaItem.Applicator tag) {
          super.applyToItem(tag);
  
@@ -284,7 +285,7 @@ index 12911233c01d0ac1af9adbd157d56d28361fc76f..322d5f19d0c156bf6e46202d2e185d8a
      }
  
      @Override
-@@ -223,14 +260,29 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -223,14 +261,29 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
  
          if (tag.contains(CraftMetaBlockState.BLOCK_ENTITY_TAG.NBT, CraftMagicNumbers.NBT.TAG_COMPOUND)) {
              this.internalTag = tag.getCompound(CraftMetaBlockState.BLOCK_ENTITY_TAG.NBT);
@@ -316,7 +317,7 @@ index 12911233c01d0ac1af9adbd157d56d28361fc76f..322d5f19d0c156bf6e46202d2e185d8a
      }
  
      @Override
-@@ -244,9 +296,10 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -244,9 +297,10 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
      int applyHash() {
          final int original;
          int hash = original = super.applyHash();
@@ -330,7 +331,7 @@ index 12911233c01d0ac1af9adbd157d56d28361fc76f..322d5f19d0c156bf6e46202d2e185d8a
          return original != hash ? CraftMetaBlockState.class.hashCode() ^ hash : hash;
      }
  
-@@ -258,19 +311,19 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -258,19 +312,19 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
          if (meta instanceof CraftMetaBlockState) {
              CraftMetaBlockState that = (CraftMetaBlockState) meta;
  
@@ -353,7 +354,7 @@ index 12911233c01d0ac1af9adbd157d56d28361fc76f..322d5f19d0c156bf6e46202d2e185d8a
      }
  
      @Override
-@@ -281,27 +334,50 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -281,27 +335,53 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
      @Override
      public CraftMetaBlockState clone() {
          CraftMetaBlockState meta = (CraftMetaBlockState) super.clone();
@@ -403,6 +404,9 @@ index 12911233c01d0ac1af9adbd157d56d28361fc76f..322d5f19d0c156bf6e46202d2e185d8a
 +        }
 +        final PatchedDataComponentMap patchedMap = new PatchedDataComponentMap(nmsBlockState.getBlock().asItem().components());
 +        patchedMap.setAll(this.components);
++        final Applicator applicator = new Applicator() {};
++        super.applyToItem(applicator);
++        patchedMap.applyPatch(applicator.build());
 +        blockEntity.applyComponents(nmsBlockState.getBlock().asItem().components(), patchedMap.asPatch());
 +
 +        // This is expected to always return a CraftBlockEntityState for the passed material:
@@ -411,7 +415,7 @@ index 12911233c01d0ac1af9adbd157d56d28361fc76f..322d5f19d0c156bf6e46202d2e185d8a
      }
  
      private static CraftBlockEntityState<?> getBlockState(Material material, CompoundTag blockEntityTag) {
-@@ -331,7 +407,22 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -331,7 +411,22 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
          Class<?> blockStateType = CraftBlockStates.getBlockStateType(stateMaterial);
          Preconditions.checkArgument(blockStateType == blockState.getClass() && blockState instanceof CraftBlockEntityState, "Invalid blockState for " + this.material);
  


### PR DESCRIPTION
Fixes an issue where certain "parts" of an ItemStack's data was stored in multiple places leading to inconsistencies. Now each part of data should only be stored in one location.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-10795.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1539064390.zip)