### PR TITLE
Fix integer overflow for lag compensating eating check

### DIFF
--- a/patches/server/1020-Lag-compensation-ticks.patch
+++ b/patches/server/1020-Lag-compensation-ticks.patch
@@ -63,7 +63,7 @@ index f168044d36f22080504da171e5ed31a6f02385ba..5cedce1f432f6b809b25269242a16477
  
          if (this.hasDelayedDestroy) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8e7ff76818ad26f69785a60de25ad07a3ba72039..ca242ba1312263ec095fa2850dc0f02351e844ab 100644
+index 2676beb338f5e4d30c22124eb55cc5aa03807408..62a38a21f7a949ca20b4975a603e163483fe6757 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3839,6 +3839,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -84,7 +84,7 @@ index 8e7ff76818ad26f69785a60de25ad07a3ba72039..ca242ba1312263ec095fa2850dc0f023
 -        if (--this.useItemRemaining == 0 && !this.level().isClientSide && !stack.useOnRelease()) {
 +        // Paper start - lag compensate eating
 +        // we add 1 to the expected time to avoid lag compensating when we should not
-+        boolean shouldLagCompensate = this.useItem.getItem().components().has(DataComponents.FOOD) && this.eatStartTime != -1 && (System.nanoTime() - this.eatStartTime) > ((1 + this.totalEatTimeTicks) * 50 * (1000 * 1000));
++        boolean shouldLagCompensate = this.useItem.has(DataComponents.FOOD) && this.eatStartTime != -1 && (System.nanoTime() - this.eatStartTime) > ((1L + this.totalEatTimeTicks) * 50L * (1000L * 1000L));
 +        if ((--this.useItemRemaining == 0 || shouldLagCompensate) && !this.level().isClientSide && !stack.useOnRelease()) {
 +            this.useItemRemaining = 0;
 +            // Paper end - lag compensate eating


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/10796

It's now possible to overflow the integer limit with custom food properties which would cause the server to consider this as a lag and try to catch up.