### PR TITLE
Add EntityScareByEntityEvent for Armadillos

### DIFF
--- a/patches/api/0481-Add-EntityScareByEntityEvent.patch
+++ b/patches/api/0481-Add-EntityScareByEntityEvent.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Joshua Prince <joshua@jtprince.com>
+Date: Sun, 26 May 2024 19:23:43 -0700
+Subject: [PATCH] Add EntityScareByEntityEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityScareByEntityEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityScareByEntityEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..d1dc14f0e72d5a33f15f7124ce4cbe4ba352254f
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityScareByEntityEvent.java
+@@ -0,0 +1,60 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when an entity is scared by another nearby entity.
++ * <p>
++ * This event is called repeatedly while a scareable entity is within range of
++ * any other living entity. It is cancelled by default if the other entity
++ * does not ordinarily scare this entity.
++ */
++public class EntityScareByEntityEvent extends EntityEvent implements Cancellable {
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private final @NotNull LivingEntity scaredBy;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
++    public EntityScareByEntityEvent(@NotNull Entity entity, @NotNull LivingEntity scaredBy) {
++        super(entity);
++        this.scaredBy = scaredBy;
++    }
++
++    /**
++     * Gets the entity which scared the affected entity.
++     *
++     * @return the scaring entity
++     */
++    @NotNull
++    public Entity getScaredBy() {
++        return this.scaredBy;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}

--- a/patches/server/1051-Add-EntityScareByEntityEvent.patch
+++ b/patches/server/1051-Add-EntityScareByEntityEvent.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Joshua Prince <joshua@jtprince.com>
+Date: Sun, 26 May 2024 19:23:43 -0700
+Subject: [PATCH] Add EntityScareByEntityEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/animal/armadillo/Armadillo.java b/src/main/java/net/minecraft/world/entity/animal/armadillo/Armadillo.java
+index b38281f963377cc82b360e8457da7cad033b8c36..c9dbf3444c73f2c983d511db33dbf74807e3b82c 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/armadillo/Armadillo.java
++++ b/src/main/java/net/minecraft/world/entity/animal/armadillo/Armadillo.java
+@@ -229,17 +229,24 @@ public class Armadillo extends Animal {
+     public boolean isScaredBy(LivingEntity entity) {
+         if (!this.getBoundingBox().inflate(7.0D, 2.0D, 7.0D).intersects(entity.getBoundingBox())) {
+             return false;
+-        } else if (entity.getType().is(EntityTypeTags.UNDEAD)) {
+-            return true;
++        // Paper start - Add EntityScareByEntityEvent
++        }
++        boolean isScared;
++        if (entity.getType().is(EntityTypeTags.UNDEAD)) {
++            isScared = true;
+         } else if (this.getLastHurtByMob() == entity) {
+-            return true;
++            isScared = true;
+         } else if (entity instanceof Player) {
+             Player entityhuman = (Player) entity;
+ 
+-            return entityhuman.isSpectator() ? false : entityhuman.isSprinting() || entityhuman.isPassenger();
++            isScared = entityhuman.isSpectator() ? false : entityhuman.isSprinting() || entityhuman.isPassenger();
+         } else {
+-            return false;
++            isScared = false;
+         }
++        io.papermc.paper.event.entity.EntityScareByEntityEvent event = new io.papermc.paper.event.entity.EntityScareByEntityEvent(this.getBukkitEntity(), entity.getBukkitLivingEntity());
++        event.setCancelled(!isScared);
++        return event.callEvent();
++        // Paper end - Add EntityScareByEntityEvent
+     }
+ 
+     @Override


### PR DESCRIPTION
Add a new event for when an entity "scares" another entity. As of 1.20.6, only armadillos can be scared.

---

As far as I could tell, there is no way* to prevent a player from scaring 1.20.5's armadillos and making them roll up into their shells. This adds a simple way to do so.

*tried: EntityPoseChangeEvent (not called for armadillos, also no scared-by entity reference), EntityTargetEvent (not called for armadillos)

## Choices and Alternatives

1. This event is called pre-cancelled when *any* living entity is within 7 blocks of the armadillo.
    - Pro: Plugins have full control over the conditions that scare an armadillo, such as adding more entities that scare armadillos.
    - Con: Lots of pre-cancelled events. Might be easy to misuse or log spam with `ignoreCancelled = false`.
    - Alternative: Only call the event when the scare actually happens, so that the event can be cancelled but not forced.

2. The event is named generically.
    - Pro: Anything "scareable" in the future can be rolled into this event.
    - Con: This could be misinterpreted as being called when wolves scare skeletons, cats scare creepers, etc.
    - Alternative 1: Include skeleton and creeper scares by pets in this event.
    - Alternative 2: Rename the event `ArmadilloScareByEntityEvent`.

## Testing

- Event is called as expected while an entity is within 7 blocks of an armadillo, ~3 times per second.
- Event continues to be called while the entity is nearby, even while the armadillo is rolled up.
- `getEntity()` and `getScaredBy()` return the correct entities in a test plugin.
- `setCancelled(true)` makes armadillos unscareable.
- `setCancelled(false)` makes armadillos immediately scared as soon as any living entity is nearby.