### PR TITLE
Handle alpha channel from potion_contents component

### DIFF
--- a/patches/api/0056-Fix-upstream-javadocs.patch
+++ b/patches/api/0056-Fix-upstream-javadocs.patch
@@ -1571,7 +1571,7 @@ index a23d030d2204098be17d8b18021fd0bb79b4431b..f427334c6e875a13aa53052ac1b5a746
       * AttributeModifiers without a slot are active in any slot.<br>
       * If there are no attributes set for the given slot, an empty map
 diff --git a/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java b/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
-index c1676991c3cc5f8d6e3f97d8cb356d6e2aa52809..1d61cc4ab36413fe3c1ecdf9824a5e18cb4bc148 100644
+index c1676991c3cc5f8d6e3f97d8cb356d6e2aa52809..c701d5fbc5fef503f18a3a46fa54c983bf96e895 100644
 --- a/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/LeatherArmorMeta.java
 @@ -8,8 +8,9 @@ import org.jetbrains.annotations.Nullable;
@@ -1581,7 +1581,7 @@ index c1676991c3cc5f8d6e3f97d8cb356d6e2aa52809..1d61cc4ab36413fe3c1ecdf9824a5e18
 - * Material#LEATHER_CHESTPLATE}, {@link Material#LEATHER_HELMET}, or {@link
 - * Material#LEATHER_LEGGINGS}) that can be colored.
 + * Material#LEATHER_LEGGINGS}, {@link Material#LEATHER_CHESTPLATE}, {@link
-+ * Material#LEATHER_HELMET}, {@link Material#LEATHER_HORSE_ARMOR}, {@link
++ * Material#LEATHER_HELMET}, {@link Material#LEATHER_HORSE_ARMOR} or {@link
 + * Material#WOLF_ARMOR}) that can be colored.
   */
  public interface LeatherArmorMeta extends ItemMeta {
@@ -1592,7 +1592,7 @@ index c1676991c3cc5f8d6e3f97d8cb356d6e2aa52809..1d61cc4ab36413fe3c1ecdf9824a5e18
       * @return the color of the armor, never null
 +     * @apiNote The method yielding {@link ItemFactory#getDefaultLeatherColor()} is incorrect
 +     * for {@link Material#WOLF_ARMOR} as its default color differs. Generally, it is recommended to check
-+     * {@link #isDyed()} to determined if this leather armor is dyed than to compare this colour to the default.
++     * {@link #isDyed()} to determine if this leather armor is dyed than to compare this color to the default.
       */
      @NotNull
      Color getColor();

--- a/patches/server/0691-More-Projectile-API.patch
+++ b/patches/server/0691-More-Projectile-API.patch
@@ -13,6 +13,7 @@ public net.minecraft.world.entity.projectile.ShulkerBullet currentMoveDirection
 public net.minecraft.world.entity.projectile.ShulkerBullet flightSteps
 public net.minecraft.world.entity.projectile.AbstractArrow soundEvent
 public net.minecraft.world.entity.projectile.ThrownTrident dealtDamage
+public net.minecraft.world.entity.projectile.Arrow NO_EFFECT_COLOR
 public net.minecraft.world.entity.projectile.Projectile hasBeenShot
 public net.minecraft.world.entity.projectile.Projectile leftOwner
 public net.minecraft.world.entity.projectile.Projectile preOnHit(Lnet/minecraft/world/phys/HitResult;)V
@@ -230,6 +231,80 @@ index 98f46fadd60ea688fefa8d83dbd6fe9b61b6a96f..0cc1cdf91deb07ebb437ef5e61d149b2
 +        this.getHandle().setSoundEvent(org.bukkit.craftbukkit.CraftSound.bukkitToMinecraft(sound));
 +    }
 +    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
+index 81f5e1d866128af8fb2acc13aca715580fdf9886..88f2a9f310f30a08893f3fa68af13a54cf72fa7f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
+@@ -125,7 +125,7 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
+ 
+     @Override
+     public Color getColor() {
+-        return Color.fromRGB(this.getHandle().potionContents.getColor());
++        return Color.fromRGB(this.getHandle().potionContents.getColor() & 0x00FFFFFF); // Paper - skip alpha channel
+     }
+ 
+     @Override
+@@ -143,7 +143,7 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
+             this.removeCustomEffect(effect.getType());
+         }
+         this.getHandle().addEffect(CraftPotionUtil.fromBukkit(effect));
+-        this.getHandle().updateColor();
++        // this.getHandle().updateColor(); // Paper - already done above
+         return true;
+     }
+ 
+@@ -151,7 +151,7 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
+     public void clearCustomEffects() {
+         PotionContents old = this.getHandle().potionContents;
+         this.getHandle().setPotionContents(new PotionContents(old.potion(), old.customColor(), List.of()));
+-        this.getHandle().updateColor();
++        // this.getHandle().updateColor(); // Paper - already done above
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
+index 5232fbef0d014edd32a5d18d4a1500ab215313f5..071be344c3265a0cd52b31ffbb02ff7a70bdf231 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
+@@ -43,7 +43,7 @@ public class CraftArrow extends CraftAbstractArrow implements Arrow {
+             this.removeCustomEffect(effect.getType());
+         }
+         this.getHandle().addEffect(CraftPotionUtil.fromBukkit(effect));
+-        this.getHandle().updateColor();
++        // this.getHandle().updateColor(); // Paper - already done above
+         return true;
+     }
+ 
+@@ -51,7 +51,7 @@ public class CraftArrow extends CraftAbstractArrow implements Arrow {
+     public void clearCustomEffects() {
+         PotionContents old = this.getHandle().getPotionContents();
+         this.getHandle().setPotionContents(new PotionContents(old.potion(), old.customColor(), List.of()));
+-        this.getHandle().updateColor();
++        // this.getHandle().updateColor(); // Paper - already done above
+     }
+ 
+     @Override
+@@ -117,16 +117,17 @@ public class CraftArrow extends CraftAbstractArrow implements Arrow {
+ 
+     @Override
+     public void setColor(Color color) {
+-        int colorRGB = (color == null) ? -1 : color.asRGB();
++        int colorRGB = (color == null) ? net.minecraft.world.entity.projectile.Arrow.NO_EFFECT_COLOR : color.asARGB(); // Paper
+         PotionContents old = this.getHandle().getPotionContents();
+         this.getHandle().setPotionContents(new PotionContents(old.potion(), Optional.of(colorRGB), old.customEffects()));
+     }
+ 
+     @Override
+     public Color getColor() {
+-        if (this.getHandle().getColor() <= -1) {
++        int color = this.getHandle().getColor(); // Paper
++        if (color == net.minecraft.world.entity.projectile.Arrow.NO_EFFECT_COLOR) { // Paper
+             return null;
+         }
+-        return Color.fromRGB(this.getHandle().getColor());
++        return Color.fromARGB(color); // Paper
+     }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
 index 7ba6302ecb72fa6e523054e7e3223d79eedf6589..907904da7f89e8e5e5cfab80977f04af3fdf17c7 100644


### PR DESCRIPTION
The previous code assumed that PotionContents#getColor always returned a RGB color without alpha channel. However that's not the case it returns an ARGB color even for opaque color, the alpha channel is set to 0xFF. Only AreaEffectCloud always have an opaque RGB color and will force the first byte to 0xFF.

The following things happen:
- AreaEffectCloud#getColor throw an argument exception with extraneous data.
- Arrow#getColor would always return null no matter the color of the effect since the alpha channel is determined by the first byte of the integer. Which means for opaque color (0xFF) the first bit will be set to 1 and so negative color are fine. Only -1 is a special case here.
- Arrow#setColor doesn't work since the alpha channel is not defined.