### PR TITLE
Allow firework effects with no colors

### DIFF
--- a/patches/api/0481-General-ItemMeta-fixes.patch
+++ b/patches/api/0481-General-ItemMeta-fixes.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 28 May 2024 19:59:01 -0700
+Subject: [PATCH] General ItemMeta fixes
+
+
+diff --git a/src/main/java/org/bukkit/FireworkEffect.java b/src/main/java/org/bukkit/FireworkEffect.java
+index 637fa73d4366c2d88e2716e5c8d3465706d788a7..0f03c546ecdd6383fb36a362d18d6fb57f2ccfee 100644
+--- a/src/main/java/org/bukkit/FireworkEffect.java
++++ b/src/main/java/org/bukkit/FireworkEffect.java
+@@ -322,9 +322,7 @@ public final class FireworkEffect implements ConfigurationSerializable {
+     private String string = null;
+ 
+     FireworkEffect(boolean flicker, boolean trail, @NotNull ImmutableList<Color> colors, @NotNull ImmutableList<Color> fadeColors, @NotNull Type type) {
+-        if (colors.isEmpty()) {
+-            throw new IllegalStateException("Cannot make FireworkEffect without any color");
+-        }
++        // Paper - can have empty colors
+         this.flicker = flicker;
+         this.trail = trail;
+         this.colors = colors;


### PR DESCRIPTION
We now allow firework effects with 0 main colors which previously threw an exception in the API FireworkEffect constructor.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-10814.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1549616631.zip)