### PR TITLE
distinguish between null and empty map in API

### DIFF
--- a/patches/api/0472-General-ItemMeta-fixes.patch
+++ b/patches/api/0472-General-ItemMeta-fixes.patch
@@ -71,3 +71,19 @@ index ff6818b6d9e0207eafdd749928f33aeac3f27191..992f39da07bafe9769effaa7dc6adc01
      /**
       * Checks to see if this item has a maximum amount of damage.
       *
+diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+index 1a4260b00b193b94ce4b1b2954644f4e41baff4c..5d5fcb2720b62e47d47f441032c4de02574b051a 100644
+--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+@@ -673,8 +673,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+ 
+     /**
+      * Set all {@link Attribute}s and their {@link AttributeModifier}s.
+-     * To clear all currently set Attributes and AttributeModifiers use
+-     * null or an empty Multimap.
++     * To clear all custom attribute modifiers, use {@code null}. To set
++     * no modifiers (which will override the default modifiers), use an
++     * empty map.
+      * If not null nor empty, this will filter all entries that are not-null
+      * and add them to the ItemStack.
+      *

--- a/patches/server/0969-General-ItemMeta-fixes.patch
+++ b/patches/server/0969-General-ItemMeta-fixes.patch
@@ -795,7 +795,7 @@ index 9600b23666668d7d581e2920a4e03e59cc2339fb..0eceacbb096481d3bd31f5f99e964c88
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfacefbe682e 100644
+index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..20d0ca163242bb58369f0709f452ad3995dd8018 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -182,9 +182,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -940,7 +940,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
          return this.attributeModifiers.containsKey(attribute) ? ImmutableList.copyOf(this.attributeModifiers.get(attribute)) : null;
      }
  
-@@ -1462,10 +1470,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1462,22 +1470,33 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      public boolean addAttributeModifier(@Nonnull Attribute attribute, @Nonnull AttributeModifier modifier) {
          Preconditions.checkNotNull(attribute, "Attribute cannot be null");
          Preconditions.checkNotNull(modifier, "AttributeModifier cannot be null");
@@ -954,7 +954,17 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
          return this.attributeModifiers.put(attribute, modifier);
      }
  
-@@ -1476,8 +1486,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+     @Override
+     public void setAttributeModifiers(@Nullable Multimap<Attribute, AttributeModifier> attributeModifiers) {
+-        if (attributeModifiers == null || attributeModifiers.isEmpty()) {
++        // Paper start - distinguish between null and empty
++        if (attributeModifiers == null) {
++            this.attributeModifiers = null;
++            return;
++        }
++        if (attributeModifiers.isEmpty()) {
++            // Paper end - distinguish between null and empty
+             this.attributeModifiers = LinkedHashMultimap.create();
              return;
          }
  
@@ -968,7 +978,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
  
          Iterator<Map.Entry<Attribute, AttributeModifier>> iterator = attributeModifiers.entries().iterator();
          while (iterator.hasNext()) {
-@@ -1487,6 +1500,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1487,6 +1506,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  iterator.remove();
                  continue;
              }
@@ -976,7 +986,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
              this.attributeModifiers.put(next.getKey(), next.getValue());
          }
      }
-@@ -1494,13 +1508,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1494,13 +1514,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      @Override
      public boolean removeAttributeModifier(@Nonnull Attribute attribute) {
          Preconditions.checkNotNull(attribute, "Attribute cannot be null");
@@ -992,7 +1002,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
          int removed = 0;
          Iterator<Map.Entry<Attribute, AttributeModifier>> iter = this.attributeModifiers.entries().iterator();
  
-@@ -1520,7 +1534,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1520,7 +1540,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      public boolean removeAttributeModifier(@Nonnull Attribute attribute, @Nonnull AttributeModifier modifier) {
          Preconditions.checkNotNull(attribute, "Attribute cannot be null");
          Preconditions.checkNotNull(modifier, "AttributeModifier cannot be null");
@@ -1001,7 +1011,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
          int removed = 0;
          Iterator<Map.Entry<Attribute, AttributeModifier>> iter = this.attributeModifiers.entries().iterator();
  
-@@ -1542,7 +1556,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1542,7 +1562,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public String getAsString() {
@@ -1010,7 +1020,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
          this.applyToItem(tag);
          DataComponentPatch patch = tag.build();
          Tag nbt = DataComponentPatch.CODEC.encodeStart(MinecraftServer.getDefaultRegistryAccess().createSerializationContext(NbtOps.INSTANCE), patch).getOrThrow();
-@@ -1551,7 +1565,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1551,7 +1571,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public String getAsComponentString() {
@@ -1019,7 +1029,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
          this.applyToItem(tag);
          DataComponentPatch patch = tag.build();
  
-@@ -1591,6 +1605,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1591,6 +1611,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          if (first == null || second == null) {
              return false;
          }
@@ -1027,7 +1037,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
          for (Map.Entry<Attribute, AttributeModifier> entry : first.entries()) {
              if (!second.containsEntry(entry.getKey(), entry.getValue())) {
                  return false;
-@@ -1606,19 +1621,33 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1606,19 +1627,33 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public boolean hasDamage() {
@@ -1063,7 +1073,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
      @Override
      public boolean hasMaxDamage() {
          return this.maxDamage != null;
-@@ -1632,6 +1661,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1632,6 +1667,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public void setMaxDamage(Integer maxDamage) {
@@ -1071,7 +1081,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
          this.maxDamage = maxDamage;
      }
  
-@@ -1663,7 +1693,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1663,7 +1699,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hasCustomModelData() ? that.hasCustomModelData() && this.customModelData.equals(that.customModelData) : !that.hasCustomModelData())
                  && (this.hasBlockData() ? that.hasBlockData() && this.blockData.equals(that.blockData) : !that.hasBlockData())
                  && (this.hasRepairCost() ? that.hasRepairCost() && this.repairCost == that.repairCost : !that.hasRepairCost())
@@ -1080,7 +1090,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
                  && (this.unhandledTags.equals(that.unhandledTags))
                  && (this.removedTags.equals(that.removedTags))
                  && (Objects.equals(this.customTag, that.customTag))
-@@ -1678,7 +1708,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1678,7 +1714,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hasFood() ? that.hasFood() && this.food.equals(that.food) : !that.hasFood())
                  && (this.hasTool() ? that.hasTool() && this.tool.equals(that.tool) : !that.hasTool())
                  && (this.hasJukeboxPlayable() ? that.hasJukeboxPlayable() && this.jukebox.equals(that.jukebox) : !that.hasJukeboxPlayable())
@@ -1089,7 +1099,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
                  && (this.hasMaxDamage() ? that.hasMaxDamage() && this.maxDamage.equals(that.maxDamage) : !that.hasMaxDamage())
                  && (this.canPlaceOnPredicates != null ? that.canPlaceOnPredicates != null && this.canPlaceOnPredicates.equals(that.canPlaceOnPredicates) : that.canPlaceOnPredicates == null) // Paper
                  && (this.canBreakPredicates != null ? that.canBreakPredicates != null && this.canBreakPredicates.equals(that.canBreakPredicates) : that.canBreakPredicates == null) // Paper
-@@ -1724,9 +1754,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1724,9 +1760,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          hash = 61 * hash + (this.hasFood() ? this.food.hashCode() : 0);
          hash = 61 * hash + (this.hasTool() ? this.tool.hashCode() : 0);
          hash = 61 * hash + (this.hasJukeboxPlayable() ? this.jukebox.hashCode() : 0);
@@ -1102,7 +1112,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
          hash = 61 * hash + (this.canPlaceOnPredicates != null ? this.canPlaceOnPredicates.hashCode() : 0); // Paper
          hash = 61 * hash + (this.canBreakPredicates != null ? this.canBreakPredicates.hashCode() : 0); // Paper
          hash = 61 * hash + this.version;
-@@ -1746,7 +1776,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1746,7 +1782,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              if (this.enchantments != null) {
                  clone.enchantments = new EnchantmentMap(this.enchantments); // Paper
              }
@@ -1111,7 +1121,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
              }
              if (this.customTag != null) {
-@@ -1874,7 +1904,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1874,7 +1910,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              builder.put(CraftMetaItem.JUKEBOX_PLAYABLE.BUKKIT, this.jukebox);
          }
  
@@ -1120,7 +1130,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
              builder.put(CraftMetaItem.DAMAGE.BUKKIT, this.damage);
          }
  
-@@ -1975,7 +2005,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1975,7 +2011,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
  
      static void serializeModifiers(Multimap<Attribute, AttributeModifier> modifiers, ImmutableMap.Builder<String, Object> builder, ItemMetaKey key) {
@@ -1129,7 +1139,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
              return;
          }
  
-@@ -2057,7 +2087,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -2057,7 +2093,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      // Paper start - improve checking handled tags
      @org.jetbrains.annotations.VisibleForTesting
      public static final Map<Class<? extends CraftMetaItem>, Set<DataComponentType<?>>> HANDLED_DCTS_PER_TYPE = new HashMap<>();
@@ -1138,7 +1148,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
          CraftMetaItem.NAME.TYPE,
          CraftMetaItem.ITEM_NAME.TYPE,
          CraftMetaItem.LORE.TYPE,
-@@ -2125,7 +2155,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -2125,7 +2161,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      // Paper end - improve checking handled data component types
  
      protected static <T> Optional<? extends T> getOrEmpty(DataComponentPatch tag, ItemMetaKeyType<T> type) {

--- a/patches/server/0976-Fix-equipment-slot-and-group-API.patch
+++ b/patches/server/0976-Fix-equipment-slot-and-group-API.patch
@@ -52,7 +52,7 @@ index 9d74577af071954e1e37201a96368c1360076209..eafa54c870c3e2aef30c3f9f96f51660
                  throw new IllegalArgumentException("Not implemented. This is a bug");
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 776f4dcc0b61a5b8ee4020a283cfcfacefbe682e..9aef0223cd790d9f4a74dfe22e7926027c08dca5 100644
+index 20d0ca163242bb58369f0709f452ad3995dd8018..1ea7597b5e0f38789a9f8bdf83c3ac35ae19164f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -1452,7 +1452,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -64,7 +64,7 @@ index 776f4dcc0b61a5b8ee4020a283cfcfacefbe682e..9aef0223cd790d9f4a74dfe22e792602
                  result.put(entry.getKey(), entry.getValue());
              }
          }
-@@ -1520,9 +1520,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1526,9 +1526,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
          while (iter.hasNext()) {
              Map.Entry<Attribute, AttributeModifier> entry = iter.next();


### PR DESCRIPTION
Since we distinguish between null and empty when applying attributes to an itemstack, we also have to make a distinction in the full map setter. Calling the setter with `null`, shouldn't create an empty attribute modifier map.