### PR TITLE
Fire TabCompleteEvent for legacy commands

### DIFF
--- a/patches/api/0476-Brigadier-based-command-API.patch
+++ b/patches/api/0476-Brigadier-based-command-API.patch
@@ -1974,3 +1974,16 @@ index 3ec32b46264cfff857b50129b5e0fa5584943ec6..bdfe68b386b5ca2878475e548d3c9a38
          Command.broadcastCommandMessage(sender, ChatColor.GREEN + "Reload complete.");
  
          return true;
+diff --git a/src/main/java/org/bukkit/event/server/TabCompleteEvent.java b/src/main/java/org/bukkit/event/server/TabCompleteEvent.java
+index b43c3cb5c88eada186d6f81712c244aaa18fb53e..ea26cb90d988d693f26e37229fbdee975c0b11f4 100644
+--- a/src/main/java/org/bukkit/event/server/TabCompleteEvent.java
++++ b/src/main/java/org/bukkit/event/server/TabCompleteEvent.java
+@@ -18,6 +18,8 @@ import org.jetbrains.annotations.NotNull;
+  * themselves. Plugins wishing to remove commands from tab completion are
+  * advised to ensure the client does not have permission for the relevant
+  * commands, or use {@link PlayerCommandSendEvent}.
++ * @apiNote Only called for bukkit API commands {@link org.bukkit.command.Command} and
++ * {@link org.bukkit.command.CommandExecutor} and not for brigadier commands ({@link io.papermc.paper.command.brigadier.Commands}).
+  */
+ public class TabCompleteEvent extends Event implements Cancellable {
+ 

--- a/patches/server/1043-Brigadier-based-command-API.patch
+++ b/patches/server/1043-Brigadier-based-command-API.patch
@@ -1829,7 +1829,7 @@ index 0000000000000000000000000000000000000000..f0cc27640bb3db275295a298d608c9d9
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..af6f26394ed6c08bf3e7aa2ed09e1f4acf02a414
+index 0000000000000000000000000000000000000000..0c3c82b28e581286b798ee58ca4193efc2faff4a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
 @@ -0,0 +1,148 @@
@@ -1959,7 +1959,7 @@ index 0000000000000000000000000000000000000000..af6f26394ed6c08bf3e7aa2ed09e1f4a
 +            if (sender instanceof final Player player) {
 +                TabCompleteEvent tabEvent = new org.bukkit.event.server.TabCompleteEvent(player, builder.getInput(), results != null ? results : new ArrayList<>(), true, pos); // Paper - AsyncTabCompleteEvent
 +                if (!tabEvent.callEvent()) {
-+                    results = Collections.emptyList();
++                    results = null;
 +                } else {
 +                    results = tabEvent.getCompletions();
 +                }

--- a/patches/server/1043-Brigadier-based-command-API.patch
+++ b/patches/server/1043-Brigadier-based-command-API.patch
@@ -1829,10 +1829,10 @@ index 0000000000000000000000000000000000000000..f0cc27640bb3db275295a298d608c9d9
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..10a113b057b0a4d27cce3bae975e1108aaa7b517
+index 0000000000000000000000000000000000000000..af6f26394ed6c08bf3e7aa2ed09e1f4acf02a414
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
-@@ -0,0 +1,135 @@
+@@ -0,0 +1,148 @@
 +package io.papermc.paper.command.brigadier.bukkit;
 +
 +import co.aikar.timings.Timing;
@@ -1845,6 +1845,8 @@ index 0000000000000000000000000000000000000000..10a113b057b0a4d27cce3bae975e1108
 +import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 +import com.mojang.brigadier.tree.LiteralCommandNode;
 +import io.papermc.paper.command.brigadier.CommandSourceStack;
++import java.util.ArrayList;
++import java.util.Collections;
 +import net.minecraft.commands.CommandSource;
 +import org.bukkit.Bukkit;
 +import org.bukkit.ChatColor;
@@ -1857,6 +1859,9 @@ index 0000000000000000000000000000000000000000..10a113b057b0a4d27cce3bae975e1108
 +import java.util.List;
 +import java.util.concurrent.CompletableFuture;
 +import java.util.logging.Level;
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.Player;
++import org.bukkit.event.server.TabCompleteEvent;
 +
 +public class BukkitCommandNode extends LiteralCommandNode<CommandSourceStack> {
 +
@@ -1951,6 +1956,14 @@ index 0000000000000000000000000000000000000000..10a113b057b0a4d27cce3bae975e1108
 +                Bukkit.getServer().getLogger().log(Level.SEVERE, "Exception when " + sender.getName() + " attempted to tab complete " + builder.getRemaining(), ex);
 +            }
 +
++            if (sender instanceof final Player player) {
++                TabCompleteEvent tabEvent = new org.bukkit.event.server.TabCompleteEvent(player, builder.getInput(), results != null ? results : new ArrayList<>(), true, pos); // Paper - AsyncTabCompleteEvent
++                if (!tabEvent.callEvent()) {
++                    results = Collections.emptyList();
++                } else {
++                    results = tabEvent.getCompletions();
++                }
++            }
 +            // Paper end
 +            if (results == null) {
 +                return builder.buildFuture();


### PR DESCRIPTION
Re-adds firing the `TabCompleteEvent` for legacy commands (commands registered with the bukkit API). Brigadier commands already fire both the AsyncTabCompleteEvent and AsyncPlayerSendSuggestionsEvent.

----
fixes https://github.com/PaperMC/Paper/issues/10833
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-10834.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1556667702.zip)