### PR TITLE
Add EntityAvoidEntityEvent

### DIFF
--- a/patches/api/0484-Add-EntityAvoidEntityEvent.patch
+++ b/patches/api/0484-Add-EntityAvoidEntityEvent.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Joshua Prince <joshua@jtprince.com>
+Date: Sun, 26 May 2024 19:23:43 -0700
+Subject: [PATCH] Add EntityAvoidEntityEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityAvoidEntityEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityAvoidEntityEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..1a720bf808c9486515ee3b427284cbf960428d87
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityAvoidEntityEvent.java
+@@ -0,0 +1,69 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when an entity avoids another nearby living entity.
++ * <p>
++ * Conditions vary for entities avoiding other entities. For example, creepers
++ * avoid cats and ocelots, ocelots avoid moving players, and evokers avoid
++ * players.
++ * <p>
++ * Generally, the avoiding entity will attempt to move away from its target.
++ * Some entities may react differently; for example, armadillos roll up to
++ * avoid their target instead of running away.
++ * <p>
++ * This event may be called several times per second by a single pair of
++ * entities. When the event is cancelled, the entity will behave as though its
++ * target is not there. However, an entity may still avoid a target if the
++ * target hurts the entity.
++ */
++public class EntityAvoidEntityEvent extends EntityEvent implements Cancellable {
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private final @NotNull LivingEntity target;
++    private boolean cancelled;
++
++    @ApiStatus.Internal
++    public EntityAvoidEntityEvent(@NotNull Entity entity, @NotNull LivingEntity target) {
++        super(entity);
++        this.target = target;
++    }
++
++    /**
++     * Gets the entity which the affected entity is avoiding.
++     *
++     * @return the avoided entity
++     */
++    @NotNull
++    public Entity getTarget() {
++        return this.target;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}

--- a/patches/server/1053-Add-EntityAvoidEntityEvent.patch
+++ b/patches/server/1053-Add-EntityAvoidEntityEvent.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Joshua Prince <joshua@jtprince.com>
+Date: Sun, 26 May 2024 19:23:43 -0700
+Subject: [PATCH] Add EntityAvoidEntityEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/AvoidEntityGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/AvoidEntityGoal.java
+index ac1287a93bfe32035302f0d3121dc1834c60c6d8..0ee1a942568307392365e716a335ab4975feeef0 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/goal/AvoidEntityGoal.java
++++ b/src/main/java/net/minecraft/world/entity/ai/goal/AvoidEntityGoal.java
+@@ -89,7 +89,14 @@ public class AvoidEntityGoal<T extends LivingEntity> extends Goal {
+                 return false;
+             } else {
+                 this.path = this.pathNav.createPath(vec3.x, vec3.y, vec3.z, 0);
+-                return this.path != null;
++                // Paper start - Add EntityAvoidEntityEvent
++                if (this.path != null) {
++                    io.papermc.paper.event.entity.EntityAvoidEntityEvent event = new io.papermc.paper.event.entity.EntityAvoidEntityEvent(this.mob.getBukkitEntity(), this.toAvoid.getBukkitLivingEntity());
++                    return event.callEvent();
++                } else {
++                    return false;
++                }
++                // Paper end - Add EntityAvoidEntityEvent
+             }
+         }
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/ai/sensing/VillagerHostilesSensor.java b/src/main/java/net/minecraft/world/entity/ai/sensing/VillagerHostilesSensor.java
+index 5a4c603e889dc03d006639ec06bc7f70a7ce7474..f7f289c66280e2a6fc6e206d2ead44e4179b76b8 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/sensing/VillagerHostilesSensor.java
++++ b/src/main/java/net/minecraft/world/entity/ai/sensing/VillagerHostilesSensor.java
+@@ -22,7 +22,7 @@ public class VillagerHostilesSensor extends NearestVisibleLivingEntitySensor {
+ 
+     @Override
+     protected boolean isMatchingEntity(LivingEntity entity, LivingEntity target) {
+-        return this.isHostile(target) && this.isClose(entity, target);
++        return this.isHostile(target) && this.isClose(entity, target) && new io.papermc.paper.event.entity.EntityAvoidEntityEvent(entity.getBukkitEntity(), target.getBukkitLivingEntity()).callEvent(); // Paper - Add EntityAvoidEntityEvent
+     }
+ 
+     private boolean isClose(LivingEntity villager, LivingEntity target) {
+diff --git a/src/main/java/net/minecraft/world/entity/animal/armadillo/Armadillo.java b/src/main/java/net/minecraft/world/entity/animal/armadillo/Armadillo.java
+index b38281f963377cc82b360e8457da7cad033b8c36..541bea739fa1e0a2c3342746ac4354a8ed879c9f 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/armadillo/Armadillo.java
++++ b/src/main/java/net/minecraft/world/entity/animal/armadillo/Armadillo.java
+@@ -229,17 +229,28 @@ public class Armadillo extends Animal {
+     public boolean isScaredBy(LivingEntity entity) {
+         if (!this.getBoundingBox().inflate(7.0D, 2.0D, 7.0D).intersects(entity.getBoundingBox())) {
+             return false;
+-        } else if (entity.getType().is(EntityTypeTags.UNDEAD)) {
+-            return true;
++        // Paper start - Add EntityAvoidEntityEvent
++        }
++        boolean isScared;
++        if (entity.getType().is(EntityTypeTags.UNDEAD)) {
++            isScared = true;
+         } else if (this.getLastHurtByMob() == entity) {
+-            return true;
++            isScared = true;
+         } else if (entity instanceof Player) {
+             Player entityhuman = (Player) entity;
+ 
+-            return entityhuman.isSpectator() ? false : entityhuman.isSprinting() || entityhuman.isPassenger();
++            isScared = entityhuman.isSpectator() ? false : entityhuman.isSprinting() || entityhuman.isPassenger();
++        } else {
++            isScared = false;
++        }
++
++        if (isScared) {
++            io.papermc.paper.event.entity.EntityAvoidEntityEvent event = new io.papermc.paper.event.entity.EntityAvoidEntityEvent(this.getBukkitEntity(), entity.getBukkitLivingEntity());
++            return event.callEvent();
+         } else {
+             return false;
+         }
++        // Paper end - Add EntityAvoidEntityEvent
+     }
+ 
+     @Override


### PR DESCRIPTION
Add a new event for when an entity avoids another entity.

---

This is a replacement for https://github.com/PaperMC/Paper/pull/10798. The original intent was to fire an event when an armadillo rolls up, but this covers even more entities to be as generic as possible.

## Affected Entities

I tested with these entities (all entities that have an AvoidEntityGoal, plus extra handling for armadillos and villagers). Cancelling the event behaves as expected, and in some cases, ends violently.
* Fish -> Player
* Dolphin -> Guardian
* Fox -> Player, Wolf, Polar Bear
* Skeleton -> Wolf
* Creeper -> Ocelot, Cat
* Evoker -> Player
* Spider -> Armadillo
* Wandering Trader -> Zombie and Illager variants
* Ocelot, Cat -> Player
* Panda -> Player
* Rabbit -> Player
* Wolf -> Llama
* Armadillo -> Player, Undead
* Villager -> Zombie and Illager variants

*(should this be documented somewhere?)*