### PR TITLE
Fix CommandSourceStack#bypassSelectorPermissions

### DIFF
--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2205,7 +2205,7 @@ index 0047fd758ad43cc7b13355b60c410a9bcc37bec0..982b2bab27e3d55d0ba07060862c0c31
  
      private static CompletableFuture<FilteredText> filterPlainText(CommandSourceStack source, PlayerChatMessage message) {
 diff --git a/src/main/java/net/minecraft/commands/arguments/selector/EntitySelector.java b/src/main/java/net/minecraft/commands/arguments/selector/EntitySelector.java
-index d120fff432d9c4fc7a35ddffdc4186459e45e950..676a1499747b071515479130875157263d3a8352 100644
+index d120fff432d9c4fc7a35ddffdc4186459e45e950..d78ad5eccd18d89050a486a0c40090a09683bd16 100644
 --- a/src/main/java/net/minecraft/commands/arguments/selector/EntitySelector.java
 +++ b/src/main/java/net/minecraft/commands/arguments/selector/EntitySelector.java
 @@ -92,7 +92,7 @@ public class EntitySelector {
@@ -2213,7 +2213,7 @@ index d120fff432d9c4fc7a35ddffdc4186459e45e950..676a1499747b07151547913087515726
  
      private void checkPermissions(CommandSourceStack source) throws CommandSyntaxException {
 -        if (this.usesSelector && !source.hasPermission(2, "minecraft.command.selector")) { // CraftBukkit
-+        if (source.bypassSelectorPermissions || (this.usesSelector && !source.hasPermission(2, "minecraft.command.selector"))) { // CraftBukkit // Paper - add bypass for selector perms
++        if (!source.bypassSelectorPermissions && (this.usesSelector && !source.hasPermission(2, "minecraft.command.selector"))) { // CraftBukkit // Paper - add bypass for selector perms
              throw EntityArgument.ERROR_SELECTORS_NOT_ALLOWED.create();
          }
      }


### PR DESCRIPTION
The previous implementation would throw a command exception if the CommandSourceStack had its bypassSelectorPermissions flag set to true, which is the incorrect behaviour.

Instead, it should only throw an exception if the flag is set to false and all its other checks "fail" too.