### PR TITLE
[ci skip] Add since to deprecated for removals

### DIFF
--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -596,7 +596,7 @@ index 0000000000000000000000000000000000000000..7411f58f9f36beaadcc47c2264a4af31
 +}
 diff --git a/src/main/java/io/papermc/paper/text/PaperComponents.java b/src/main/java/io/papermc/paper/text/PaperComponents.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f12a2e6e06
+index 0000000000000000000000000000000000000000..1a11cfde07db55194cd26757863a268b9042d0bb
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/text/PaperComponents.java
 @@ -0,0 +1,177 @@
@@ -704,7 +704,7 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +     * @return a serializer to plain text
 +     * @deprecated will be removed in adventure 5.0.0, use {@link PlainTextComponentSerializer#plainText()}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.1")
 +    public static @NotNull PlainComponentSerializer plainSerializer() {
 +        return Bukkit.getUnsafe().plainComponentSerializer();
 +    }
@@ -719,7 +719,7 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +     * @return a serializer to plain text
 +     * @deprecated use {@link PlainTextComponentSerializer#plainText()}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.2")
 +    public static @NotNull PlainTextComponentSerializer plainTextSerializer() {
 +        return Bukkit.getUnsafe().plainTextSerializer();
 +    }
@@ -735,7 +735,7 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +     * @return a json component serializer
 +     * @deprecated use {@link GsonComponentSerializer#gson()}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.2")
 +    public static @NotNull GsonComponentSerializer gsonSerializer() {
 +        return Bukkit.getUnsafe().gsonComponentSerializer();
 +    }
@@ -752,7 +752,7 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +     * @return a json component serializer
 +     * @deprecated use {@link GsonComponentSerializer#colorDownsamplingGson()}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.2")
 +    public static @NotNull GsonComponentSerializer colorDownsamplingGsonSerializer() {
 +        return Bukkit.getUnsafe().colorDownsamplingGsonComponentSerializer();
 +    }
@@ -772,7 +772,7 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +     * @return a section serializer
 +     * @deprecated use {@link LegacyComponentSerializer#legacySection()}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.2")
 +    public static @NotNull LegacyComponentSerializer legacySectionSerializer() {
 +        return Bukkit.getUnsafe().legacyComponentSerializer();
 +    }

--- a/patches/api/0026-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/api/0026-Player-Tab-List-and-Title-APIs.patch
@@ -7,7 +7,7 @@ Co-authored-by: Fruxz <cedricspitzer@outlook.de>
 
 diff --git a/src/main/java/com/destroystokyo/paper/Title.java b/src/main/java/com/destroystokyo/paper/Title.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9e90c3df567a65b48a0b9341f784eb902cb35d8c
+index 0000000000000000000000000000000000000000..20a028450667edf102b59b6b50ac6e890f2c34ab
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/Title.java
 @@ -0,0 +1,420 @@
@@ -37,7 +37,7 @@ index 0000000000000000000000000000000000000000..9e90c3df567a65b48a0b9341f784eb90
 + *
 + * @deprecated use {@link net.kyori.adventure.title.Title}
 + */
-+@Deprecated
++@Deprecated(since = "1.16.5")
 +public final class Title {
 +
 +    /**

--- a/patches/api/0028-Complete-resource-pack-API.patch
+++ b/patches/api/0028-Complete-resource-pack-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index fc8c807ae9793452bbf3fbab5e72d05676e6fa83..6a7d63691fa3be09da0ade66cf07a41ae08d4190 100644
+index fc8c807ae9793452bbf3fbab5e72d05676e6fa83..93ff1e91c41273aa1b1cffe7c15b546f3a44d6b7 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2207,6 +2207,180 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -169,7 +169,7 @@ index fc8c807ae9793452bbf3fbab5e72d05676e6fa83..6a7d63691fa3be09da0ade66cf07a41a
 +     * @return the most recent hash or null
 +     * @deprecated This is no longer sent from the client and will always be null
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.13.2")
 +    @org.jetbrains.annotations.Contract("-> null")
 +    default @Nullable String getResourcePackHash() {
 +        return null;

--- a/patches/api/0046-Add-ProjectileCollideEvent.patch
+++ b/patches/api/0046-Add-ProjectileCollideEvent.patch
@@ -7,7 +7,7 @@ Now deprecated and replaced with ProjectileHitEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/ProjectileCollideEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/ProjectileCollideEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3caff9cbb990e03d4331bd601272aec5090affcf
+index 0000000000000000000000000000000000000000..b7df0e6ca024448784aaf4784930e565b8e5bdb3
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/ProjectileCollideEvent.java
 @@ -0,0 +1,74 @@
@@ -29,7 +29,7 @@ index 0000000000000000000000000000000000000000..3caff9cbb990e03d4331bd601272aec5
 + *
 + * @deprecated Deprecated, use {@link org.bukkit.event.entity.ProjectileHitEvent} and check if there is a hit entity
 + */
-+@Deprecated
++@Deprecated(since = "1.19.3")
 +public class ProjectileCollideEvent extends EntityEvent implements Cancellable {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();

--- a/patches/api/0049-IllegalPacketEvent.patch
+++ b/patches/api/0049-IllegalPacketEvent.patch
@@ -9,7 +9,7 @@ Lets plugins change the kick message and if it should kick or not.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/IllegalPacketEvent.java b/src/main/java/com/destroystokyo/paper/event/player/IllegalPacketEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8dc5971ba441395f7bc13568c5ee88ca34837e95
+index 0000000000000000000000000000000000000000..44637928268c3efa951c340855f7caa63519a115
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/IllegalPacketEvent.java
 @@ -0,0 +1,67 @@
@@ -25,7 +25,7 @@ index 0000000000000000000000000000000000000000..8dc5971ba441395f7bc13568c5ee88ca
 +/**
 + * @deprecated Not used
 + */
-+@Deprecated
++@Deprecated(since = "1.16.4")
 +public class IllegalPacketEvent extends PlayerEvent {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();

--- a/patches/api/0060-Basic-PlayerProfile-API.patch
+++ b/patches/api/0060-Basic-PlayerProfile-API.patch
@@ -7,7 +7,7 @@ Provides basic elements of a PlayerProfile to be used by future API/events
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..464de9dc0539d4cb0f37a2d9266638b5f5b90b73
+index 0000000000000000000000000000000000000000..b4f9ffbebab8eef99dbd81c816c16c274a1ec4cd
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
 @@ -0,0 +1,234 @@
@@ -40,7 +40,7 @@ index 0000000000000000000000000000000000000000..464de9dc0539d4cb0f37a2d9266638b5
 +     * @return The previous Name
 +     */
 +    @NotNull
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.1")
 +    String setName(@Nullable String name);
 +
 +    /**
@@ -55,7 +55,7 @@ index 0000000000000000000000000000000000000000..464de9dc0539d4cb0f37a2d9266638b5
 +     * @return The previous UUID
 +     */
 +    @Nullable
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.1")
 +    UUID setId(@Nullable UUID uuid);
 +
 +    /**
@@ -327,7 +327,7 @@ index 0000000000000000000000000000000000000000..8f913a078dd692a9feafb98a6e6c9583
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 53f56d95bdf484caed9effbedfe507f6745bb8c0..5aa1aafddd28a5aa52274f37c09bf0fda75f7ea3 100644
+index 53f56d95bdf484caed9effbedfe507f6745bb8c0..44e833a2be716d378688fe35822bdf0904fbb22f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -2385,6 +2385,89 @@ public final class Bukkit {
@@ -421,7 +421,7 @@ index 53f56d95bdf484caed9effbedfe507f6745bb8c0..5aa1aafddd28a5aa52274f37c09bf0fd
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index b0734f8253ed540916db7bc75cd7dd24e86031c7..c2cf0e547137b8a023ea009c7a5d0080def5f5f8 100644
+index b0734f8253ed540916db7bc75cd7dd24e86031c7..aeb5399b1c5e90079b199a591f7986acdf111cba 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -2077,5 +2077,80 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0066-Add-getI18NDisplayName-API.patch
+++ b/patches/api/0066-Add-getI18NDisplayName-API.patch
@@ -8,7 +8,7 @@ Currently the server only supports the English language. To override this,
 You must replace the language file embedded in the server jar.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 86fbc3902989a3baca851ab8c3866af445451787..aea393247c60037fb70cd8d5b8814c9849c85e03 100644
+index 86fbc3902989a3baca851ab8c3866af445451787..e08c8b15c126a4051aba0d6ef8a53ddabe69c5c1 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
 @@ -235,4 +235,20 @@ public interface ItemFactory {
@@ -28,7 +28,7 @@ index 86fbc3902989a3baca851ab8c3866af445451787..aea393247c60037fb70cd8d5b8814c98
 +     * {@link net.kyori.adventure.text.Component#translatable(net.kyori.adventure.translation.Translatable)} instead.
 +     */
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.18.1")
 +    String getI18NDisplayName(@Nullable ItemStack item);
 +    // Paper end - add getI18NDisplayName
  }

--- a/patches/api/0067-ensureServerConversions-API.patch
+++ b/patches/api/0067-ensureServerConversions-API.patch
@@ -7,11 +7,11 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index aea393247c60037fb70cd8d5b8814c9849c85e03..b6b90f2ef735407ac41efa21371cfd6b07c2c66e 100644
+index e08c8b15c126a4051aba0d6ef8a53ddabe69c5c1..43376f16d02e7ac26bcb0236e684fee4195dd008 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
 @@ -251,4 +251,18 @@ public interface ItemFactory {
-     @Deprecated
+     @Deprecated(since = "1.18.1")
      String getI18NDisplayName(@Nullable ItemStack item);
      // Paper end - add getI18NDisplayName
 +

--- a/patches/api/0092-Player.setPlayerProfile-API.patch
+++ b/patches/api/0092-Player.setPlayerProfile-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 5aa1aafddd28a5aa52274f37c09bf0fda75f7ea3..8521ef27d1e6c06e7228acb47388b02c50dc0e84 100644
+index 44e833a2be716d378688fe35822bdf0904fbb22f..817824d5439919e0c8f466ba2a722a237853747b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1376,8 +1376,10 @@ public final class Bukkit {
@@ -16,7 +16,7 @@ index 5aa1aafddd28a5aa52274f37c09bf0fda75f7ea3..8521ef27d1e6c06e7228acb47388b02c
 +     * @deprecated use {@link #createProfile(UUID, String)}
       */
      @NotNull
-+    @Deprecated // Paper
++    @Deprecated(since = "1.18.1") // Paper
      public static PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name) {
          return server.createPlayerProfile(uniqueId, name);
      }
@@ -27,7 +27,7 @@ index 5aa1aafddd28a5aa52274f37c09bf0fda75f7ea3..8521ef27d1e6c06e7228acb47388b02c
 +     * @deprecated use {@link #createProfile(UUID)}
       */
      @NotNull
-+    @Deprecated // Paper
++    @Deprecated(since = "1.18.1") // Paper
      public static PlayerProfile createPlayerProfile(@NotNull UUID uniqueId) {
          return server.createPlayerProfile(uniqueId);
      }
@@ -38,7 +38,7 @@ index 5aa1aafddd28a5aa52274f37c09bf0fda75f7ea3..8521ef27d1e6c06e7228acb47388b02c
 +     * @deprecated use {@link #createProfile(String)}
       */
      @NotNull
-+    @Deprecated // Paper
++    @Deprecated(since = "1.18.1") // Paper
      public static PlayerProfile createPlayerProfile(@NotNull String name) {
          return server.createPlayerProfile(name);
      }
@@ -56,7 +56,7 @@ index ff59479f4782ac7726504aab239de79fdc840cde..abbf3d6f11350ab2dd47a277771d9f46
      /**
       * Checks if this player has had their profile banned.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index c2cf0e547137b8a023ea009c7a5d0080def5f5f8..e4b42323e8d168f9daee3d1b38f3591b45bc6a1b 100644
+index aeb5399b1c5e90079b199a591f7986acdf111cba..e7f618a8d7245494e178052c6a63e1b150618c36 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1163,8 +1163,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -66,7 +66,7 @@ index c2cf0e547137b8a023ea009c7a5d0080def5f5f8..e4b42323e8d168f9daee3d1b38f3591b
 +     * @deprecated use {@link #createProfile(UUID, String)}
       */
      @NotNull
-+    @Deprecated // Paper
++    @Deprecated(since = "1.18.1") // Paper
      PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name);
  
      /**
@@ -77,7 +77,7 @@ index c2cf0e547137b8a023ea009c7a5d0080def5f5f8..e4b42323e8d168f9daee3d1b38f3591b
 +     * @deprecated use {@link #createProfile(UUID)}
       */
      @NotNull
-+    @Deprecated // Paper
++    @Deprecated(since = "1.18.1") // Paper
      PlayerProfile createPlayerProfile(@NotNull UUID uniqueId);
  
      /**
@@ -88,12 +88,12 @@ index c2cf0e547137b8a023ea009c7a5d0080def5f5f8..e4b42323e8d168f9daee3d1b38f3591b
 +     * @deprecated use {@link #createProfile(String)}
       */
      @NotNull
-+    @Deprecated
++    @Deprecated(since = "1.18.1") // Paper
      PlayerProfile createPlayerProfile(@NotNull String name);
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8b92f258a85b4184d67d0af396c18400ded38a67..56eed06cd3dbb238330973c1428bffc6d5286019 100644
+index 3dcc0a7ff628711c1b8349c5b98496fccd061787..3173e047fa4c7b295546532cea9e10b016adaf98 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -3061,6 +3061,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -124,7 +124,7 @@ index 8b92f258a85b4184d67d0af396c18400ded38a67..56eed06cd3dbb238330973c1428bffc6
      public class Spigot extends Entity.Spigot {
  
 diff --git a/src/main/java/org/bukkit/profile/PlayerProfile.java b/src/main/java/org/bukkit/profile/PlayerProfile.java
-index fc46add38bf59dc1a04ea566fd230dcd8ae2708c..d36b3e3c7e53840132011add365ca2a26d799064 100644
+index fc46add38bf59dc1a04ea566fd230dcd8ae2708c..f4ab961647826b8717466be0d8c202b12749e9b4 100644
 --- a/src/main/java/org/bukkit/profile/PlayerProfile.java
 +++ b/src/main/java/org/bukkit/profile/PlayerProfile.java
 @@ -16,7 +16,9 @@ import org.jetbrains.annotations.Nullable;
@@ -133,7 +133,7 @@ index fc46add38bf59dc1a04ea566fd230dcd8ae2708c..d36b3e3c7e53840132011add365ca2a2
   * {@link Server#createPlayerProfile(UUID, String)}.
 + * @deprecated see {@link com.destroystokyo.paper.profile.PlayerProfile}
   */
-+@Deprecated // Paper
++@Deprecated(since = "1.18.1") // Paper
  public interface PlayerProfile extends Cloneable, ConfigurationSerializable {
  
      /**
@@ -141,7 +141,7 @@ index fc46add38bf59dc1a04ea566fd230dcd8ae2708c..d36b3e3c7e53840132011add365ca2a2
       * @return the player's unique id, or <code>null</code> if not available
       */
      @Nullable
-+    @Deprecated // Paper
++    @Deprecated(since = "1.18.1") // Paper
      UUID getUniqueId();
  
      /**

--- a/patches/api/0096-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0096-Add-Ban-Methods-to-Player-Objects.patch
@@ -8,7 +8,7 @@ Allows a more logical API for banning players.
 player.banPlayer("Breaking the rules");
 
 diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
-index abbf3d6f11350ab2dd47a277771d9f46221036bd..ef85e57f812c501fac7abe7dd27c93702f66646f 100644
+index abbf3d6f11350ab2dd47a277771d9f46221036bd..a9d63b1630b05b86a0396355fcfee261bab96293 100644
 --- a/src/main/java/org/bukkit/OfflinePlayer.java
 +++ b/src/main/java/org/bukkit/OfflinePlayer.java
 @@ -67,6 +67,73 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
@@ -24,7 +24,7 @@ index abbf3d6f11350ab2dd47a277771d9f46221036bd..ef85e57f812c501fac7abe7dd27c9370
 +     * @deprecated use {@link #ban(String, Date, String)}
 +     */
 +    @NotNull
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default BanEntry banPlayer(@Nullable String reason) {
 +        return banPlayer(reason, null, null);
 +    }
@@ -37,7 +37,7 @@ index abbf3d6f11350ab2dd47a277771d9f46221036bd..ef85e57f812c501fac7abe7dd27c9370
 +     * @deprecated use {@link #ban(String, Date, String)}
 +     */
 +    @NotNull
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default BanEntry banPlayer(@Nullable String reason, @Nullable String source) {
 +        return banPlayer(reason, null, source);
 +    }
@@ -50,7 +50,7 @@ index abbf3d6f11350ab2dd47a277771d9f46221036bd..ef85e57f812c501fac7abe7dd27c9370
 +     * @deprecated use {@link #ban(String, Date, String)}
 +     */
 +    @NotNull
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default BanEntry banPlayer(@Nullable String reason, @Nullable java.util.Date expires) {
 +        return banPlayer(reason, expires, null);
 +    }
@@ -64,7 +64,7 @@ index abbf3d6f11350ab2dd47a277771d9f46221036bd..ef85e57f812c501fac7abe7dd27c9370
 +     * @deprecated use {@link #ban(String, Date, String)}
 +     */
 +    @NotNull
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default BanEntry banPlayer(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source) {
 +        return banPlayer(reason, expires, source, true);
 +    }
@@ -73,7 +73,7 @@ index abbf3d6f11350ab2dd47a277771d9f46221036bd..ef85e57f812c501fac7abe7dd27c9370
 +     * @deprecated use {@link #ban(String, Date, String)}
 +     */
 +    @NotNull
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default BanEntry banPlayer(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source, boolean kickIfOnline) {
 +        BanEntry banEntry = Bukkit.getServer().getBanList(BanList.Type.NAME).addBan(getName(), reason, expires, source);
 +        if (kickIfOnline && isOnline()) {
@@ -86,7 +86,7 @@ index abbf3d6f11350ab2dd47a277771d9f46221036bd..ef85e57f812c501fac7abe7dd27c9370
      /**
       * Adds this user to the {@link ProfileBanList}. If a previous ban exists, this will
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a98218a280594 100644
+index 89474de6c3a14aaf0839b51b659d0fc191f6de54..e46afd3d78af6fe8658adbe8557f91201bbebecb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1217,6 +1217,186 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -102,7 +102,7 @@ index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a9821
 +     */
 +    // For reference, Bukkit defines this as nullable, while they impl isn't, we'll follow API.
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default org.bukkit.BanEntry banPlayerFull(@Nullable String reason) {
 +        return banPlayerFull(reason, null, null);
 +    }
@@ -116,7 +116,7 @@ index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a9821
 +     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default org.bukkit.BanEntry banPlayerFull(@Nullable String reason, @Nullable String source) {
 +        return banPlayerFull(reason, null, source);
 +    }
@@ -130,7 +130,7 @@ index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a9821
 +     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default org.bukkit.BanEntry banPlayerFull(@Nullable String reason, @Nullable java.util.Date expires) {
 +        return banPlayerFull(reason, expires, null);
 +    }
@@ -145,7 +145,7 @@ index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a9821
 +     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default org.bukkit.BanEntry banPlayerFull(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source) {
 +        banPlayer(reason, expires, source);
 +        return banPlayerIP(reason, expires, source, true);
@@ -161,7 +161,7 @@ index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a9821
 +     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, boolean kickPlayer) {
 +        return banPlayerIP(reason, null, null, kickPlayer);
 +    }
@@ -176,7 +176,7 @@ index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a9821
 +     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable String source, boolean kickPlayer) {
 +        return banPlayerIP(reason, null, source, kickPlayer);
 +    }
@@ -191,7 +191,7 @@ index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a9821
 +     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable java.util.Date expires, boolean kickPlayer) {
 +        return banPlayerIP(reason, expires, null, kickPlayer);
 +    }
@@ -205,7 +205,7 @@ index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a9821
 +     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason) {
 +        return banPlayerIP(reason, null, null);
 +    }
@@ -219,7 +219,7 @@ index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a9821
 +     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable String source) {
 +        return banPlayerIP(reason, null, source);
 +    }
@@ -233,7 +233,7 @@ index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a9821
 +     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable java.util.Date expires) {
 +        return banPlayerIP(reason, expires, null);
 +    }
@@ -248,7 +248,7 @@ index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a9821
 +     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source) {
 +        return banPlayerIP(reason, expires, source, true);
 +    }
@@ -264,7 +264,7 @@ index d68a055ef2b309da6db2de385f27d841adca1f66..9dcec906cea7d4eb6da99ef3100a9821
 +     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source, boolean kickPlayer) {
 +        org.bukkit.BanEntry banEntry = org.bukkit.Bukkit.getServer().getBanList(org.bukkit.BanList.Type.IP).addBan(getAddress().getAddress().getHostAddress(), reason, expires, source);
 +        if (kickPlayer && isOnline()) {

--- a/patches/api/0118-RangedEntity-API.patch
+++ b/patches/api/0118-RangedEntity-API.patch
@@ -8,7 +8,7 @@ and to perform an attack.
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/RangedEntity.java b/src/main/java/com/destroystokyo/paper/entity/RangedEntity.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a087a04c525ea14b197c65063b43ebf097ddc5c2
+index 0000000000000000000000000000000000000000..46e0e62d620def237dab44ad24708f1b93a8a1a7
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/RangedEntity.java
 @@ -0,0 +1,35 @@
@@ -34,7 +34,7 @@ index 0000000000000000000000000000000000000000..a087a04c525ea14b197c65063b43ebf0
 +     * @param raiseHands Whether the entities hands are raised to charge attack
 +     * @deprecated use {@link #setAggressive(boolean)}
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.19.2")
 +    void setChargingAttack(boolean raiseHands);
 +
 +    /**
@@ -42,7 +42,7 @@ index 0000000000000000000000000000000000000000..a087a04c525ea14b197c65063b43ebf0
 +     * @return If entities hands are raised
 +     * @deprecated use {@link #isHandRaised()}
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.19.2")
 +    default boolean isChargingAttack() {
 +        return isHandRaised();
 +    }

--- a/patches/api/0132-Add-TNTPrimeEvent.patch
+++ b/patches/api/0132-Add-TNTPrimeEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add TNTPrimeEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/block/TNTPrimeEvent.java b/src/main/java/com/destroystokyo/paper/event/block/TNTPrimeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..676c67d04cbbad0641c2760f9ea62246d248ac87
+index 0000000000000000000000000000000000000000..b17bdd323c25e956a3e851fc44aefa8b1b1d2965
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/block/TNTPrimeEvent.java
 @@ -0,0 +1,125 @@
@@ -34,7 +34,7 @@ index 0000000000000000000000000000000000000000..676c67d04cbbad0641c2760f9ea62246
 + * @author Mark Vainomaa
 + * @deprecated use {@link org.bukkit.event.block.TNTPrimeEvent}
 + */
-+@Deprecated(forRemoval = true)
++@Deprecated(forRemoval = true, since = "1.19.4")
 +public class TNTPrimeEvent extends BlockEvent implements Cancellable {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();

--- a/patches/api/0136-Allow-Blocks-to-be-accessed-via-a-long-key.patch
+++ b/patches/api/0136-Allow-Blocks-to-be-accessed-via-a-long-key.patch
@@ -18,7 +18,7 @@ Y range: [0, 1023]
 X, Z range: [-67 108 864, 67 108 863]
 
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 41125de49db8eafce4be59cc110ce5be06836a47..042d69e6d4584eb6d678b8ea13a3e4bea78703b8 100644
+index 41125de49db8eafce4be59cc110ce5be06836a47..4df9a225e93aafb1e4af9591c482ac07e7f65422 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -15,7 +15,6 @@ import org.jetbrains.annotations.Nullable;
@@ -40,7 +40,7 @@ index 41125de49db8eafce4be59cc110ce5be06836a47..042d69e6d4584eb6d678b8ea13a3e4be
 +     * @see Block#getBlockKey(int, int, int)
 +     * @deprecated only encodes y block ranges from -512 to 511 and represents an already changed implementation detail
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.18.1")
 +    public long toBlockKey() {
 +        return Block.getBlockKey(getBlockX(), getBlockY(), getBlockZ());
 +    }
@@ -50,7 +50,7 @@ index 41125de49db8eafce4be59cc110ce5be06836a47..042d69e6d4584eb6d678b8ea13a3e4be
       * @return A new location where X/Y/Z are the center of the block
       */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 273c50b6e4f26457415779000cf09aeaffd21733..575fd50b8456beed7c5049a392fca011271a8fe4 100644
+index 273c50b6e4f26457415779000cf09aeaffd21733..0eb6e1b0529d14ed10e901d37c6fdf896e2de8e4 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -99,6 +99,41 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -67,7 +67,7 @@ index 273c50b6e4f26457415779000cf09aeaffd21733..575fd50b8456beed7c5049a392fca011
 +     * @deprecated only encodes y block ranges from -512 to 511 and represents an already changed implementation detail
 +     */
 +    @NotNull
-+    @Deprecated
++    @Deprecated(since = "1.18.1")
 +    public default Block getBlockAtKey(long key) {
 +        int x = Block.getBlockKeyX(key);
 +        int y = Block.getBlockKeyY(key);
@@ -83,7 +83,7 @@ index 273c50b6e4f26457415779000cf09aeaffd21733..575fd50b8456beed7c5049a392fca011
 +     * @see Block#getBlockKey(int, int, int)
 +     */
 +    @NotNull
-+    @Deprecated
++    @Deprecated(since = "1.18.1")
 +    public default Location getLocationAtKey(long key) {
 +        int x = Block.getBlockKeyX(key);
 +        int y = Block.getBlockKeyY(key);
@@ -96,7 +96,7 @@ index 273c50b6e4f26457415779000cf09aeaffd21733..575fd50b8456beed7c5049a392fca011
       * Gets the highest non-empty (impassable) block at the given coordinates.
       *
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index f3b3606dc5881e931853fc2631aad9ca9083474d..a71001677e2b1b0b6225a7be63b8ea5ce4456862 100644
+index f3b3606dc5881e931853fc2631aad9ca9083474d..bb3cf2c5e2acbcd7cf53ad8551a5b11fa6104ada 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -156,6 +156,82 @@ public interface Block extends Metadatable, Translatable {
@@ -111,7 +111,7 @@ index f3b3606dc5881e931853fc2631aad9ca9083474d..a71001677e2b1b0b6225a7be63b8ea5c
 +     * @return This block's x, y, and z coordinates packed into a long value
 +     * @deprecated see {@link #getBlockKey(int, int, int)}
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.18.1")
 +    public default long getBlockKey() {
 +        return Block.getBlockKey(this.getX(), this.getY(), this.getZ());
 +    }
@@ -137,7 +137,7 @@ index f3b3606dc5881e931853fc2631aad9ca9083474d..a71001677e2b1b0b6225a7be63b8ea5c
 +     * @return This block's x, y, and z coordinates packed into a long value
 +     * @deprecated only encodes y block ranges from -512 to 511 and represents an already changed implementation detail
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.18.1")
 +    public static long getBlockKey(int x, int y, int z) {
 +        return ((long)x & 0x7FFFFFF) | (((long)z & 0x7FFFFFF) << 27) | ((long)y << 54);
 +    }
@@ -149,7 +149,7 @@ index f3b3606dc5881e931853fc2631aad9ca9083474d..a71001677e2b1b0b6225a7be63b8ea5c
 +     * @return The x component from the packed value.
 +     * @deprecated see {@link #getBlockKey(int, int, int)}
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.18.1")
 +    public static int getBlockKeyX(long packed) {
 +        return (int) ((packed << 37) >> 37);
 +    }
@@ -161,7 +161,7 @@ index f3b3606dc5881e931853fc2631aad9ca9083474d..a71001677e2b1b0b6225a7be63b8ea5c
 +     * @return The y component from the packed value.
 +     * @deprecated see {@link #getBlockKey(int, int, int)}
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.18.1")
 +    public static int getBlockKeyY(long packed) {
 +        return (int) (packed >> 54);
 +    }
@@ -173,7 +173,7 @@ index f3b3606dc5881e931853fc2631aad9ca9083474d..a71001677e2b1b0b6225a7be63b8ea5c
 +     * @return The z component from the packed value.
 +     * @deprecated see {@link #getBlockKey(int, int, int)}
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.18.1")
 +    public static int getBlockKeyZ(long packed) {
 +        return (int) ((packed << 10) >> 37);
 +    }

--- a/patches/api/0143-Async-Chunks-API.patch
+++ b/patches/api/0143-Async-Chunks-API.patch
@@ -8,7 +8,7 @@ Adds API's to load or generate chunks asynchronously.
 Also adds utility methods to Entity to teleport asynchronously.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index b3098ce9134acf24f49d23fc1babe79c6bf502f1..5efe33cef4d9c153d760fc71606721ff8abafbfc 100644
+index 94c91385810642dcd120e534b5a20e21fbcd963a..727aa59b9080d53b9e1f6c619d73afcd077b59da 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -950,6 +950,472 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -31,7 +31,7 @@ index b3098ce9134acf24f49d23fc1babe79c6bf502f1..5efe33cef4d9c153d760fc71606721ff
 +     *
 +     * @deprecated Use either the Future or the Consumer based methods
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.13.1")
 +    public static interface ChunkLoadCallback extends java.util.function.Consumer<Chunk> {
 +        public void onLoad(@NotNull Chunk chunk);
 +
@@ -61,7 +61,7 @@ index b3098ce9134acf24f49d23fc1babe79c6bf502f1..5efe33cef4d9c153d760fc71606721ff
 +     * @param cb Callback to receive the chunk when it is loaded.
 +     *           will be executed synchronously
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.13.1")
 +    public default void getChunkAtAsync(int x, int z, @NotNull ChunkLoadCallback cb) {
 +        getChunkAtAsync(x, z, true).thenAccept(cb::onLoad).exceptionally((ex) -> {
 +            Bukkit.getLogger().log(java.util.logging.Level.WARNING, "Exception in chunk load callback", ex);
@@ -87,7 +87,7 @@ index b3098ce9134acf24f49d23fc1babe79c6bf502f1..5efe33cef4d9c153d760fc71606721ff
 +     * @param cb Callback to receive the chunk when it is loaded.
 +     *           will be executed synchronously
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.13.1")
 +    public default void getChunkAtAsync(@NotNull Location loc, @NotNull ChunkLoadCallback cb) {
 +        getChunkAtAsync(loc, true).thenAccept(cb::onLoad).exceptionally((ex) -> {
 +            Bukkit.getLogger().log(java.util.logging.Level.WARNING, "Exception in chunk load callback", ex);
@@ -113,7 +113,7 @@ index b3098ce9134acf24f49d23fc1babe79c6bf502f1..5efe33cef4d9c153d760fc71606721ff
 +     * @param cb Callback to receive the chunk when it is loaded.
 +     *           will be executed synchronously
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.13.1")
 +    public default void getChunkAtAsync(@NotNull Block block, @NotNull ChunkLoadCallback cb) {
 +        getChunkAtAsync(block, true).thenAccept(cb::onLoad).exceptionally((ex) -> {
 +            Bukkit.getLogger().log(java.util.logging.Level.WARNING, "Exception in chunk load callback", ex);

--- a/patches/api/0144-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/patches/api/0144-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add ray tracing methods to LivingEntity
 
 diff --git a/src/main/java/com/destroystokyo/paper/block/TargetBlockInfo.java b/src/main/java/com/destroystokyo/paper/block/TargetBlockInfo.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c896d172519a8552a132031cb956378db272878f
+index 0000000000000000000000000000000000000000..bb12061985cdffbacfa2d113beaa35b2c92df567
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/block/TargetBlockInfo.java
 @@ -0,0 +1,67 @@
@@ -21,7 +21,7 @@ index 0000000000000000000000000000000000000000..c896d172519a8552a132031cb956378d
 + * Represents information about a targeted block
 + * @deprecated use {@link org.bukkit.util.RayTraceResult}
 + */
-+@Deprecated(forRemoval = true)
++@Deprecated(forRemoval = true, since = "1.19.3")
 +public class TargetBlockInfo {
 +    private final Block block;
 +    private final BlockFace blockFace;
@@ -64,7 +64,7 @@ index 0000000000000000000000000000000000000000..c896d172519a8552a132031cb956378d
 +    /**
 +     * @deprecated use {@link org.bukkit.FluidCollisionMode}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19.3")
 +    public enum FluidMode {
 +        NEVER(FluidCollisionMode.NEVER),
 +        SOURCE_ONLY(FluidCollisionMode.SOURCE_ONLY),
@@ -78,7 +78,7 @@ index 0000000000000000000000000000000000000000..c896d172519a8552a132031cb956378d
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 0ed64618b3f62ee984fe4f99dc6a52d5fad7b3cc..b41152d81c1ec89a65eaee2a606f4f1b0d421bc7 100644
+index 0ed64618b3f62ee984fe4f99dc6a52d5fad7b3cc..fab432fc00cf41d240ba172d5be43464ca2417b3 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
 @@ -85,6 +85,98 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
@@ -94,7 +94,7 @@ index 0ed64618b3f62ee984fe4f99dc6a52d5fad7b3cc..b41152d81c1ec89a65eaee2a606f4f1b
 +     *     or null if no block is within maxDistance
 +     * @deprecated use {@link #getTargetBlockExact(int)}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19.3")
 +    @Nullable
 +    public default Block getTargetBlock(int maxDistance) {
 +        return getTargetBlock(maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode.NEVER);
@@ -109,7 +109,7 @@ index 0ed64618b3f62ee984fe4f99dc6a52d5fad7b3cc..b41152d81c1ec89a65eaee2a606f4f1b
 +     *     or null if no block is within maxDistance
 +     * @deprecated use {@link #getTargetBlockExact(int, FluidCollisionMode)}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19.3")
 +    @Nullable
 +    public Block getTargetBlock(int maxDistance, @NotNull com.destroystokyo.paper.block.TargetBlockInfo.FluidMode fluidMode);
 +
@@ -134,7 +134,7 @@ index 0ed64618b3f62ee984fe4f99dc6a52d5fad7b3cc..b41152d81c1ec89a65eaee2a606f4f1b
 +     *     or null if no block is targeted
 +     * @deprecated use {@link #getTargetBlockFace(int, FluidCollisionMode)}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19.3")
 +    @Nullable
 +    public org.bukkit.block.BlockFace getTargetBlockFace(int maxDistance, @NotNull com.destroystokyo.paper.block.TargetBlockInfo.FluidMode fluidMode);
 +
@@ -157,7 +157,7 @@ index 0ed64618b3f62ee984fe4f99dc6a52d5fad7b3cc..b41152d81c1ec89a65eaee2a606f4f1b
 +     *     or null if no block is targeted
 +     * @deprecated use {@link #rayTraceBlocks(double)}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19.3")
 +    @Nullable
 +    public default com.destroystokyo.paper.block.TargetBlockInfo getTargetBlockInfo(int maxDistance) {
 +        return getTargetBlockInfo(maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode.NEVER);
@@ -172,7 +172,7 @@ index 0ed64618b3f62ee984fe4f99dc6a52d5fad7b3cc..b41152d81c1ec89a65eaee2a606f4f1b
 +     *     or null if no block is targeted
 +     * @deprecated use {@link #rayTraceBlocks(double, FluidCollisionMode)}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19.3")
 +    @Nullable
 +    public com.destroystokyo.paper.block.TargetBlockInfo getTargetBlockInfo(int maxDistance, @NotNull com.destroystokyo.paper.block.TargetBlockInfo.FluidMode fluidMode);
 +    // Paper end

--- a/patches/api/0154-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/api/0154-Add-LivingEntity-getTargetEntity.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/TargetEntityInfo.java b/src/main/java/com/destroystokyo/paper/entity/TargetEntityInfo.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..af8765b213390cf75fe02a6eb68aecf7a06d5acf
+index 0000000000000000000000000000000000000000..caa56541c435a3d9103cb0220ab88563a976c6b8
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/TargetEntityInfo.java
 @@ -0,0 +1,40 @@
@@ -20,7 +20,7 @@ index 0000000000000000000000000000000000000000..af8765b213390cf75fe02a6eb68aecf7
 + * Represents information about a targeted entity
 + * @deprecated use {@link org.bukkit.util.RayTraceResult}
 + */
-+@Deprecated(forRemoval = true)
++@Deprecated(forRemoval = true, since = "1.19.3")
 +public class TargetEntityInfo {
 +    private final Entity entity;
 +    private final Vector hitVec;
@@ -51,11 +51,11 @@ index 0000000000000000000000000000000000000000..af8765b213390cf75fe02a6eb68aecf7
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index b41152d81c1ec89a65eaee2a606f4f1b0d421bc7..8cd525dd8ded0ddbd405c66e9c0fbeb40f788521 100644
+index fab432fc00cf41d240ba172d5be43464ca2417b3..b5ea7b60b47f056553a1cec766c57e0f75735633 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
 @@ -175,6 +175,77 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
-     @Deprecated(forRemoval = true)
+     @Deprecated(forRemoval = true, since = "1.19.3")
      @Nullable
      public com.destroystokyo.paper.block.TargetBlockInfo getTargetBlockInfo(int maxDistance, @NotNull com.destroystokyo.paper.block.TargetBlockInfo.FluidMode fluidMode);
 +
@@ -88,7 +88,7 @@ index b41152d81c1ec89a65eaee2a606f4f1b0d421bc7..8cd525dd8ded0ddbd405c66e9c0fbeb4
 +     *     or null if no entity is targeted
 +     * @deprecated use {@link #rayTraceEntities(int)}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19.3")
 +    @Nullable
 +    public default com.destroystokyo.paper.entity.TargetEntityInfo getTargetEntityInfo(int maxDistance) {
 +        return getTargetEntityInfo(maxDistance, false);
@@ -115,7 +115,7 @@ index b41152d81c1ec89a65eaee2a606f4f1b0d421bc7..8cd525dd8ded0ddbd405c66e9c0fbeb4
 +     *     or null if no entity is targeted
 +     * @deprecated use {@link #rayTraceEntities(int, boolean)}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19.3")
 +    @Nullable
 +    public com.destroystokyo.paper.entity.TargetEntityInfo getTargetEntityInfo(int maxDistance, boolean ignoreBlocks);
 +

--- a/patches/api/0176-Add-BlockSoundGroup-interface.patch
+++ b/patches/api/0176-Add-BlockSoundGroup-interface.patch
@@ -7,7 +7,7 @@ This PR adds the getSoundGroup() method in Block which returns a BlockSoundGroup
 
 diff --git a/src/main/java/com/destroystokyo/paper/block/BlockSoundGroup.java b/src/main/java/com/destroystokyo/paper/block/BlockSoundGroup.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ec36942128cbacae171584c89480b4aae3ae3e2f
+index 0000000000000000000000000000000000000000..2bde2b7c960b321d0c1396212858c780280f0520
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/block/BlockSoundGroup.java
 @@ -0,0 +1,64 @@
@@ -23,7 +23,7 @@ index 0000000000000000000000000000000000000000..ec36942128cbacae171584c89480b4aa
 + * The sound group includes break, step, place, hit, and fall sounds.
 + * @deprecated use {@link org.bukkit.SoundGroup}
 + */
-+@Deprecated(forRemoval = true)
++@Deprecated(forRemoval = true, since = "1.18.2")
 +public interface BlockSoundGroup {
 +    /**
 +     * Gets the sound that plays when breaking this block
@@ -32,7 +32,7 @@ index 0000000000000000000000000000000000000000..ec36942128cbacae171584c89480b4aa
 +     * @deprecated use {@link org.bukkit.SoundGroup#getBreakSound()}
 +     */
 +    @NotNull
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.2")
 +    Sound getBreakSound();
 +
 +    /**
@@ -42,7 +42,7 @@ index 0000000000000000000000000000000000000000..ec36942128cbacae171584c89480b4aa
 +     * @deprecated use {@link org.bukkit.SoundGroup#getStepSound()}
 +     */
 +    @NotNull
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.2")
 +    Sound getStepSound();
 +
 +    /**
@@ -52,7 +52,7 @@ index 0000000000000000000000000000000000000000..ec36942128cbacae171584c89480b4aa
 +     * @deprecated use {@link org.bukkit.SoundGroup#getPlaceSound()}
 +     */
 +    @NotNull
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.2")
 +    Sound getPlaceSound();
 +
 +    /**
@@ -62,7 +62,7 @@ index 0000000000000000000000000000000000000000..ec36942128cbacae171584c89480b4aa
 +     * @deprecated use {@link org.bukkit.SoundGroup#getHitSound()}
 +     */
 +    @NotNull
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.2")
 +    Sound getHitSound();
 +
 +    /**
@@ -72,11 +72,11 @@ index 0000000000000000000000000000000000000000..ec36942128cbacae171584c89480b4aa
 +     * @deprecated use {@link org.bukkit.SoundGroup#getFallSound()}
 +     */
 +    @NotNull
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.2")
 +    Sound getFallSound();
 +}
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index c7ef0386a09a07a2317c56274ed41218dfd7153d..f468e9751f75fd355512e033c180de967de5b2d8 100644
+index c7ef0386a09a07a2317c56274ed41218dfd7153d..2b247b757a3707c8556b33b54ed7dc83a72f3075 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -616,4 +616,25 @@ public interface Block extends Metadatable, Translatable {
@@ -94,7 +94,7 @@ index c7ef0386a09a07a2317c56274ed41218dfd7153d..f468e9751f75fd355512e033c180de96
 +     * @deprecated use {@link #getBlockSoundGroup()}
 +     */
 +    @NotNull
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.18.2")
 +    com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup();
 +
 +    /**

--- a/patches/api/0201-Add-PrepareResultEvent-PrepareGrindstoneEvent.patch
+++ b/patches/api/0201-Add-PrepareResultEvent-PrepareGrindstoneEvent.patch
@@ -11,7 +11,7 @@ Grindstone is a backwards compat from a previous PrepareGrindstoneEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/inventory/PrepareGrindstoneEvent.java b/src/main/java/com/destroystokyo/paper/event/inventory/PrepareGrindstoneEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b31e6777f5d163c61309da9ff204ad5773ba7f54
+index 0000000000000000000000000000000000000000..f75933948cdf0aa0c9bb2f06da5418f164af1148
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/inventory/PrepareGrindstoneEvent.java
 @@ -0,0 +1,31 @@
@@ -30,7 +30,7 @@ index 0000000000000000000000000000000000000000..b31e6777f5d163c61309da9ff204ad57
 + *
 + * @deprecated use {@link org.bukkit.event.inventory.PrepareGrindstoneEvent}
 + */
-+@Deprecated
++@Deprecated(since = "1.16.1")
 +@Warning
 +public class PrepareGrindstoneEvent extends PrepareResultEvent {
 +

--- a/patches/api/0202-Add-BellRingEvent.patch
+++ b/patches/api/0202-Add-BellRingEvent.patch
@@ -8,7 +8,7 @@ village bell. Passes along the bell block and the player who rang it.
 
 diff --git a/src/main/java/io/papermc/paper/event/block/BellRingEvent.java b/src/main/java/io/papermc/paper/event/block/BellRingEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7d3f04d5ab620f37d2253b575ae370d95ecf21ef
+index 0000000000000000000000000000000000000000..6ec5afa994d2a1ce33967f31bb0c58919fdb7e01
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/BellRingEvent.java
 @@ -0,0 +1,22 @@
@@ -26,7 +26,7 @@ index 0000000000000000000000000000000000000000..7d3f04d5ab620f37d2253b575ae370d9
 + *
 + * @deprecated use {@link org.bukkit.event.block.BellRingEvent}
 + */
-+@Deprecated
++@Deprecated(since = "1.19.4")
 +public class BellRingEvent extends org.bukkit.event.block.BellRingEvent {
 +
 +    @ApiStatus.Internal

--- a/patches/api/0278-More-Enchantment-API.patch
+++ b/patches/api/0278-More-Enchantment-API.patch
@@ -8,13 +8,16 @@ Co-authored-by: Janet Blackquill <uhhadd@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/enchantments/EnchantmentRarity.java b/src/main/java/io/papermc/paper/enchantments/EnchantmentRarity.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..50c49739cc25679c9d241466e3069c9c232a22c4
+index 0000000000000000000000000000000000000000..aec3b41d7c3388e26fa203e3c062f1e6a6d0ba41
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/enchantments/EnchantmentRarity.java
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,28 @@
 +package io.papermc.paper.enchantments;
 +
-+@Deprecated(forRemoval = true, since = "As of 1.20.5 enchantments do not have a rarity.")
++/**
++ * @deprecated Enchantments do not have a "rarity" since 1.20.5
++ */
++@Deprecated(forRemoval = true, since = "1.20.5")
 +public enum EnchantmentRarity {
 +
 +    COMMON(10),

--- a/patches/api/0287-Add-BellRevealRaiderEvent.patch
+++ b/patches/api/0287-Add-BellRevealRaiderEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add BellRevealRaiderEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/block/BellRevealRaiderEvent.java b/src/main/java/io/papermc/paper/event/block/BellRevealRaiderEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e41599405514cd7eea93d842243f6c5c938b93f1
+index 0000000000000000000000000000000000000000..4781529aaa4b2ea104df3b9cd055668278344df7
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/BellRevealRaiderEvent.java
 @@ -0,0 +1,63 @@
@@ -25,7 +25,7 @@ index 0000000000000000000000000000000000000000..e41599405514cd7eea93d842243f6c5c
 + *
 + * @deprecated use {@link org.bukkit.event.block.BellResonateEvent}
 + */
-+@Deprecated
++@Deprecated(since = "1.19.4")
 +public class BellRevealRaiderEvent extends BlockEvent implements Cancellable {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();

--- a/patches/api/0290-Add-WaterBottleSplashEvent.patch
+++ b/patches/api/0290-Add-WaterBottleSplashEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add WaterBottleSplashEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/WaterBottleSplashEvent.java b/src/main/java/io/papermc/paper/event/entity/WaterBottleSplashEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..362afc28190dd6f0ed0407273f2be1aab73bb8f5
+index 0000000000000000000000000000000000000000..0c7725980d5a2f3652e53f75329ad405389f431a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/WaterBottleSplashEvent.java
 @@ -0,0 +1,137 @@
@@ -116,7 +116,7 @@ index 0000000000000000000000000000000000000000..362afc28190dd6f0ed0407273f2be1aa
 +     * @return a confusing collection, don't use it
 +     * @deprecated Use {@link #getToDamage()}
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.19.3")
 +    @Override
 +    public @NotNull Collection<LivingEntity> getAffectedEntities() {
 +        return super.getAffectedEntities();
@@ -128,7 +128,7 @@ index 0000000000000000000000000000000000000000..362afc28190dd6f0ed0407273f2be1aa
 +     * @return a confusing value
 +     * @deprecated check if {@link #getToDamage()} contains an entity
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.19.3")
 +    @Override
 +    public double getIntensity(final @NotNull LivingEntity entity) {
 +        return super.getIntensity(entity);
@@ -141,7 +141,7 @@ index 0000000000000000000000000000000000000000..362afc28190dd6f0ed0407273f2be1aa
 +     * or {@link #doNotDamageAsWaterSensitive(LivingEntity)} to change which entities are
 +     * damaged
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.19.3")
 +    @Override
 +    public void setIntensity(final @NotNull LivingEntity entity, final double intensity) {
 +        super.setIntensity(entity, intensity);

--- a/patches/api/0292-Missing-Entity-API.patch
+++ b/patches/api/0292-Missing-Entity-API.patch
@@ -630,7 +630,7 @@ index 6b3c9bef9a8a34ddc6ff42cf358541a2665bf5e3..9c618a27d590f186f29c5d9094fc565e
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 62a301f2f87b053bcfbf16c9870c3f740eb70022..ce5cf587ce44f2410c1d0bcf459b6309ec70bfee 100644
+index 4ba92fe8979ed127c18cb78c2b8204daa2425ed7..73247ab2cd2cf0035cf88c98250736f9bc9ee517 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
 @@ -994,6 +994,7 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
@@ -812,7 +812,7 @@ index 5fd723c9fdda81595db8b150d967ff3bd5cea608..91d31e5418a5ab7cefd7c02a41bbec84
 +    // Paper end - Missing Entity API
  }
 diff --git a/src/main/java/org/bukkit/entity/Panda.java b/src/main/java/org/bukkit/entity/Panda.java
-index 1f027927a1194f4f8e86c1375a2772e6e261c151..aa5686df134185334a74429576ff0709a604dbfd 100644
+index 1f027927a1194f4f8e86c1375a2772e6e261c151..4f06870cc8d8aab93aa83b1b8165e6714884372c 100644
 --- a/src/main/java/org/bukkit/entity/Panda.java
 +++ b/src/main/java/org/bukkit/entity/Panda.java
 @@ -107,6 +107,98 @@ public interface Panda extends Animals, Sittable {
@@ -867,7 +867,7 @@ index 1f027927a1194f4f8e86c1375a2772e6e261c151..aa5686df134185334a74429576ff0709
 +     * @param onBack is on its back
 +     * @deprecated use {@link #setOnBack(boolean)}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19")
 +    default void setIsOnBack(boolean onBack) {
 +        this.setOnBack(onBack);
 +    }
@@ -878,7 +878,7 @@ index 1f027927a1194f4f8e86c1375a2772e6e261c151..aa5686df134185334a74429576ff0709
 +     * @param sitting is currently sitting
 +     * @deprecated use {@link #setSitting(boolean)}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19")
 +    default void setIsSitting(boolean sitting) {
 +        this.setSitting(sitting);
 +    }
@@ -1464,7 +1464,7 @@ index 7cc1d9a966454af70b7c25735fe474fe3eb97eb4..ac6fd8ca95771c185c145f4589ddd5b2
 +    // Paper end - missing entity behaviour api - converting without entity event
  }
 diff --git a/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java b/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java
-index db69687a7ad4b18d17ab1677cae5d8dd4dcd3678..304b05aeaea5febf493fc40d433a23acb384b4f0 100644
+index db69687a7ad4b18d17ab1677cae5d8dd4dcd3678..261bacee2a48580f781876683efea68c32ed7282 100644
 --- a/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java
 +++ b/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java
 @@ -24,4 +24,23 @@ public interface HopperMinecart extends Minecart, InventoryHolder, LootableEntit
@@ -1478,7 +1478,7 @@ index db69687a7ad4b18d17ab1677cae5d8dd4dcd3678..304b05aeaea5febf493fc40d433a23ac
 +     * @return ticks left on cooldown
 +     * @deprecated Hopper minecarts don't have cooldowns anymore
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19.4")
 +    int getPickupCooldown();
 +
 +    /**
@@ -1487,7 +1487,7 @@ index db69687a7ad4b18d17ab1677cae5d8dd4dcd3678..304b05aeaea5febf493fc40d433a23ac
 +     * @param cooldown cooldown length in ticks
 +     * @deprecated Hopper minecarts don't have cooldowns anymore
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.19.4")
 +    void setPickupCooldown(int cooldown);
 +    // Paper end
  }

--- a/patches/api/0346-Add-enchantWithLevels-API.patch
+++ b/patches/api/0346-Add-enchantWithLevels-API.patch
@@ -7,7 +7,7 @@ Deprecate upstream's newer and poorly implemented similar
 API.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 53b8934cb829f37971cb3ecd5652c9974dec6ab0..e20f64828548c647a29dad5a475f4596cad88cd8 100644
+index a9ed193bbb85a5d363fd315e198430809cdbddc5..229dbdcb9094508e02d7a5ea1761d5764e5e4702 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
 @@ -185,8 +185,11 @@ public interface ItemFactory {
@@ -18,7 +18,7 @@ index 53b8934cb829f37971cb3ecd5652c9974dec6ab0..e20f64828548c647a29dad5a475f4596
 +     * designed and was originally broken.
       */
      @NotNull
-+    @Deprecated // Paper
++    @Deprecated(since = "1.19.3") // Paper
      ItemStack enchantItem(@NotNull final Entity entity, @NotNull final ItemStack item, final int level, final boolean allowTreasures);
  
      /**
@@ -30,7 +30,7 @@ index 53b8934cb829f37971cb3ecd5652c9974dec6ab0..e20f64828548c647a29dad5a475f4596
 +     * designed and was originally broken.
       */
      @NotNull
-+    @Deprecated // Paper
++    @Deprecated(since = "1.19.3") // Paper
      ItemStack enchantItem(@NotNull final World world, @NotNull final ItemStack item, final int level, final boolean allowTreasures);
  
      /**
@@ -42,7 +42,7 @@ index 53b8934cb829f37971cb3ecd5652c9974dec6ab0..e20f64828548c647a29dad5a475f4596
 +     * designed and was originally broken.
       */
      @NotNull
-+    @Deprecated // Paper
++    @Deprecated(since = "1.19.3") // Paper
      ItemStack enchantItem(@NotNull final ItemStack item, final int level, final boolean allowTreasures);
  
      // Paper start - Adventure

--- a/patches/api/0354-Expand-FallingBlock-API.patch
+++ b/patches/api/0354-Expand-FallingBlock-API.patch
@@ -10,7 +10,7 @@ Subject: [PATCH] Expand FallingBlock API
 Co-authored-by: Lukas Planz <lukas.planz@web.de>
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index d7f4a9c634b3a7b2668f296dce108cc6fc3046df..00fbc02a1751902edda327236e51a6991f5366f8 100644
+index 2272c52c28f5f14e1ea8891feec47b18733319d9..6eeb919f478dbe33c9994f2141e77216c7d7e174 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -2282,8 +2282,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -20,7 +20,7 @@ index d7f4a9c634b3a7b2668f296dce108cc6fc3046df..00fbc02a1751902edda327236e51a699
 +     * @deprecated Use {@link #spawn(Location, Class, Consumer)} (or a variation thereof) in combination with {@link FallingBlock#setBlockData(BlockData)}
       */
      @NotNull
-+    @Deprecated // Paper
++    @Deprecated(since = "1.20.2") // Paper
      public FallingBlock spawnFallingBlock(@NotNull Location location, @NotNull MaterialData data) throws IllegalArgumentException;
  
      /**
@@ -31,7 +31,7 @@ index d7f4a9c634b3a7b2668f296dce108cc6fc3046df..00fbc02a1751902edda327236e51a699
 +     * @deprecated Use {@link #spawn(Location, Class, Consumer)} (or a variation thereof) in combination with {@link FallingBlock#setBlockData(BlockData)}
       */
      @NotNull
-+    @org.jetbrains.annotations.ApiStatus.Obsolete // Paper
++    @org.jetbrains.annotations.ApiStatus.Obsolete(since = "1.20.2") // Paper
      public FallingBlock spawnFallingBlock(@NotNull Location location, @NotNull BlockData data) throws IllegalArgumentException;
  
      /**

--- a/patches/api/0392-Replace-ItemFlag.HIDE_POTION_EFFECTS.patch
+++ b/patches/api/0392-Replace-ItemFlag.HIDE_POTION_EFFECTS.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Replace ItemFlag.HIDE_POTION_EFFECTS
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFlag.java b/src/main/java/org/bukkit/inventory/ItemFlag.java
-index 1b3580d1861af402396121805715e4087b3bc587..a435f6c8947e4ac50b8c04f37b107055970937dd 100644
+index 1b3580d1861af402396121805715e4087b3bc587..5b8dac777bb1640dc00bbe98feb6460c36eebb98 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFlag.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFlag.java
 @@ -38,4 +38,27 @@ public enum ItemFlag {
@@ -32,7 +32,7 @@ index 1b3580d1861af402396121805715e4087b3bc587..a435f6c8947e4ac50b8c04f37b107055
 +     * </ul>
 +     * @deprecated use {@link #HIDE_ADDITIONAL_TOOLTIP}
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.20.5")
 +    public static final ItemFlag HIDE_ITEM_SPECIFICS = HIDE_ADDITIONAL_TOOLTIP;
 +    // Paper end
  }

--- a/patches/api/0440-Improve-Registry.patch
+++ b/patches/api/0440-Improve-Registry.patch
@@ -116,7 +116,7 @@ index 9951cf6780ae47649625b8fe0ed72d87ad0417b2..2a245735ac902d55681880dc80b12dde
      @NotNull
      public NamespacedKey getKey() {
 diff --git a/src/main/java/org/bukkit/generator/structure/Structure.java b/src/main/java/org/bukkit/generator/structure/Structure.java
-index 94092a5882180cca7905388184de1f91633f0df1..46e510e67b156b469d1413e616a5ff6a6487fdbf 100644
+index 94092a5882180cca7905388184de1f91633f0df1..729588330e543408fbb4c7c4f6b27eaa721bd2c4 100644
 --- a/src/main/java/org/bukkit/generator/structure/Structure.java
 +++ b/src/main/java/org/bukkit/generator/structure/Structure.java
 @@ -64,4 +64,13 @@ public abstract class Structure implements Keyed {
@@ -129,7 +129,7 @@ index 94092a5882180cca7905388184de1f91633f0df1..46e510e67b156b469d1413e616a5ff6a
 +     * can exist without a key.
 +     */
 +    @Override
-+    @Deprecated
++    @Deprecated(since = "1.20.4")
 +    public abstract @NotNull NamespacedKey getKey();
 +    // Paper end - deprecate getKey
  }

--- a/patches/api/0456-improve-BanList-types.patch
+++ b/patches/api/0456-improve-BanList-types.patch
@@ -54,7 +54,7 @@ index 0000000000000000000000000000000000000000..1159e7cd29fbf11f3fa1448fcf9d0768
 +record BanListTypeImpl<T>(@NotNull Class<T> typeClass) implements BanListType<T> {
 +}
 diff --git a/src/main/java/org/bukkit/BanList.java b/src/main/java/org/bukkit/BanList.java
-index a77c0411a68a9bad33ddfb335b7a996a843e478c..0e0baadde9e34d28db56dc68e66aaf66c60d12df 100644
+index a77c0411a68a9bad33ddfb335b7a996a843e478c..739d9d3ec789e58c10c8d818a9ca59ce447600d5 100644
 --- a/src/main/java/org/bukkit/BanList.java
 +++ b/src/main/java/org/bukkit/BanList.java
 @@ -16,7 +16,9 @@ public interface BanList<T> {
@@ -63,12 +63,12 @@ index a77c0411a68a9bad33ddfb335b7a996a843e478c..0e0baadde9e34d28db56dc68e66aaf66
       * Represents a ban-type that a {@link BanList} may track.
 +     * @deprecated use {@link io.papermc.paper.ban.BanListType} to enforce the correct return value at compile time.
       */
-+    @Deprecated // Paper - BanList Type Improvements
++    @Deprecated(since = "1.20.4") // Paper - BanList Type Improvements
      public enum Type {
          /**
           * Banned player names
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 2726ee0338cbcf4233588d0eb7dcce3b0c571908..71f1c361ebccbe83193c37ec3a90faa4085001c3 100644
+index dea75658cc232590ecd566845e180cc9aa562c17..47039514503d99e84cb99f4941707a7726286516 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1648,11 +1648,27 @@ public final class Bukkit {
@@ -78,7 +78,7 @@ index 2726ee0338cbcf4233588d0eb7dcce3b0c571908..71f1c361ebccbe83193c37ec3a90faa4
 +     * @deprecated use {@link #getBanList(io.papermc.paper.ban.BanListType)} to enforce the correct return value at compile time.
       */
      @NotNull
-+    @Deprecated // Paper - add BanListType (which has a generic)
++    @Deprecated(since = "1.20.4") // Paper - add BanListType (which has a generic)
      public static <T extends BanList<?>> T getBanList(@NotNull BanList.Type type) {
          return server.getBanList(type);
      }
@@ -100,7 +100,7 @@ index 2726ee0338cbcf4233588d0eb7dcce3b0c571908..71f1c361ebccbe83193c37ec3a90faa4
      /**
       * Gets a set containing all player operators.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index dc985b54e1582629dffeebc56152eedaedae56d3..c8595ffcfcbdd79794d464415287d46acef72b72 100644
+index f7e9b293484886e5d981ed44e223103b73d516fd..0614bd7e2d658172a7765925adf81b75b5620f11 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1410,10 +1410,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0457-Suspicious-Effect-Entry-API.patch
+++ b/patches/api/0457-Suspicious-Effect-Entry-API.patch
@@ -71,7 +71,7 @@ index 0000000000000000000000000000000000000000..e5002ccaef9ea7a9db94296ad0d66cda
 +record SuspiciousEffectEntryImpl(@NotNull PotionEffectType effect, int duration) implements SuspiciousEffectEntry {
 +}
 diff --git a/src/main/java/org/bukkit/entity/MushroomCow.java b/src/main/java/org/bukkit/entity/MushroomCow.java
-index 86c0043ef4e1288b6fe2f68a9b6d01c3de2c3454..21503b85e1e309e3e8b90517e98572fa6a29fc6f 100644
+index 86c0043ef4e1288b6fe2f68a9b6d01c3de2c3454..3677f19ef1c05b76d946b1b2b491a6c3cec76140 100644
 --- a/src/main/java/org/bukkit/entity/MushroomCow.java
 +++ b/src/main/java/org/bukkit/entity/MushroomCow.java
 @@ -34,14 +34,30 @@ public interface MushroomCow extends Cow, io.papermc.paper.entity.Shearable { //
@@ -85,7 +85,7 @@ index 86c0043ef4e1288b6fe2f68a9b6d01c3de2c3454..21503b85e1e309e3e8b90517e98572fa
       * @return true if the effects to be applied to the suspicious stew changed
       * as a result of this call
       */
-+    @Deprecated(forRemoval = true) // Paper - add overloads to use suspicious effect entry to mushroom cow and suspicious stew meta
++    @Deprecated(forRemoval = true, since = "1.20.2") // Paper - add overloads to use suspicious effect entry to mushroom cow and suspicious stew meta
      boolean addEffectToNextStew(@NotNull PotionEffect effect, boolean overwrite);
  
 +    // Paper start - add overloads to use suspicious effect entry to mushroom cow and suspicious stew meta
@@ -117,7 +117,7 @@ index 86c0043ef4e1288b6fe2f68a9b6d01c3de2c3454..21503b85e1e309e3e8b90517e98572fa
 +     * @return duration of the effect (in ticks)
 +     * @deprecated Mushroom cows can now hold multiple effects, use {@link #getStewEffects()}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.20.2")
 +    @org.jetbrains.annotations.Contract("-> fail")
 +    default int getStewEffectDuration() {
 +        throw new UnsupportedOperationException("Mushroom cows can now hold multiple effects. Use #getStewEffects");
@@ -130,7 +130,7 @@ index 86c0043ef4e1288b6fe2f68a9b6d01c3de2c3454..21503b85e1e309e3e8b90517e98572fa
 +     * @param duration duration of the effect (in ticks)
 +     * @deprecated Mushroom cows can now hold multiple effects, use {@link #setStewEffects(java.util.List)}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.20.2")
 +    @org.jetbrains.annotations.Contract("_ -> fail")
 +    default void setStewEffectDuration(int duration) {
 +        throw new UnsupportedOperationException("Mushroom cows can now hold multiple effects. Use #setStewEffects");
@@ -144,7 +144,7 @@ index 86c0043ef4e1288b6fe2f68a9b6d01c3de2c3454..21503b85e1e309e3e8b90517e98572fa
 +     * @deprecated Mushroom cows can now hold multiple effects, use {@link #getStewEffects()}
 +     * @throws UnsupportedOperationException
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.20.2")
 +    @org.jetbrains.annotations.Contract("-> fail")
 +    default org.bukkit.potion.PotionEffectType getStewEffectType() {
 +        throw new UnsupportedOperationException("Mushroom cows can now hold multiple effects. Use #getStewEffects");
@@ -159,7 +159,7 @@ index 86c0043ef4e1288b6fe2f68a9b6d01c3de2c3454..21503b85e1e309e3e8b90517e98572fa
 +     * @deprecated Mushroom cows can now hold multiple effects, use {@link #setStewEffects(java.util.List)}
 +     * @throws UnsupportedOperationException
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.20.2")
 +    @org.jetbrains.annotations.Contract("_ -> fail")
 +    default void setStewEffect(@org.jetbrains.annotations.Nullable org.bukkit.potion.PotionEffectType type) {
 +        throw new UnsupportedOperationException("Mushroom cows can now hold multiple effects. Use #setStewEffects");


### PR DESCRIPTION
I went back through a lot of the deprecations we've added to add the correct `since=` parts to the annotation. This will help when we decide what the next round of scheduled for removals should entail.