### PR TITLE
Update AbstractArrow item method implementations for 1.20.6

### DIFF
--- a/patches/api/0344-More-Projectile-API.patch
+++ b/patches/api/0344-More-Projectile-API.patch
@@ -7,7 +7,7 @@ Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/entity/AbstractArrow.java b/src/main/java/org/bukkit/entity/AbstractArrow.java
-index 839e5b7df49f42b5fec7729997bef3370ba36d80..b36298679d6d52d09fe4bb8e52e19e18f6df742a 100644
+index 839e5b7df49f42b5fec7729997bef3370ba36d80..07b7d3ddd6c8400c39578f8c09df13dc2411be1d 100644
 --- a/src/main/java/org/bukkit/entity/AbstractArrow.java
 +++ b/src/main/java/org/bukkit/entity/AbstractArrow.java
 @@ -130,17 +130,21 @@ public interface AbstractArrow extends Projectile {
@@ -25,26 +25,34 @@ index 839e5b7df49f42b5fec7729997bef3370ba36d80..b36298679d6d52d09fe4bb8e52e19e18
       * Sets the ItemStack which will be picked up from this arrow.
       *
       * @param item ItemStack set to be picked up
-+     * @deprecated until 1.20.5 when the behavior is more defined
++     * @deprecated use {@link #getItemStack()}
       */
      @ApiStatus.Experimental
-+    @Deprecated // Paper - remove in 1.20.5
++    @Deprecated(forRemoval = true, since = "1.20.4") // Paper
      public void setItem(@NotNull ItemStack item);
  
      /**
-@@ -194,4 +198,44 @@ public interface AbstractArrow extends Projectile {
+@@ -194,4 +198,52 @@ public interface AbstractArrow extends Projectile {
          CREATIVE_ONLY;
      }
      // Paper end
 +
 +    // Paper start - more projectile API
 +    /**
-+     * Gets the ItemStack for this arrow.
++     * Gets the {@link ItemStack} for this arrow. This stack is used
++     * for both visuals on the arrow and the stack that could be picked up.
 +     *
 +     * @return The ItemStack, as if a player picked up the arrow
 +     */
-+    @NotNull
-+    org.bukkit.inventory.ItemStack getItemStack();
++    @NotNull ItemStack getItemStack();
++
++    /**
++     * Sets the {@link ItemStack} for this arrow. This stack is used for both
++     * visuals on the arrow and the stack that could be picked up.
++     *
++     * @param stack the arrow stack
++     */
++    void setItemStack(@NotNull ItemStack stack);
 +
 +    /**
 +     * Sets the amount of ticks this arrow has been alive in the world

--- a/patches/server/0691-More-Projectile-API.patch
+++ b/patches/server/0691-More-Projectile-API.patch
@@ -12,6 +12,7 @@ public net.minecraft.world.entity.projectile.ShulkerBullet targetDeltaZ
 public net.minecraft.world.entity.projectile.ShulkerBullet currentMoveDirection
 public net.minecraft.world.entity.projectile.ShulkerBullet flightSteps
 public net.minecraft.world.entity.projectile.AbstractArrow soundEvent
+public net/minecraft/world/entity/projectile/AbstractArrow setPickupItemStack(Lnet/minecraft/world/item/ItemStack;)V
 public net.minecraft.world.entity.projectile.ThrownTrident dealtDamage
 public net.minecraft.world.entity.projectile.Projectile hasBeenShot
 public net.minecraft.world.entity.projectile.Projectile leftOwner
@@ -174,7 +175,7 @@ index 91c2d0b40d3fca86938cd454e1415a4eea3df7c7..de4fb2654c7895cfd83ad694455ee56c
 +    // Paper end - More projectile API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractArrow.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractArrow.java
-index 98f46fadd60ea688fefa8d83dbd6fe9b61b6a96f..0cc1cdf91deb07ebb437ef5e61d149b2c109877f 100644
+index 98f46fadd60ea688fefa8d83dbd6fe9b61b6a96f..656e1fc4321a804aa79a08bca8974637d4ffdb1b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractArrow.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractArrow.java
 @@ -60,20 +60,7 @@ public class CraftAbstractArrow extends AbstractProjectile implements AbstractAr
@@ -199,15 +200,21 @@ index 98f46fadd60ea688fefa8d83dbd6fe9b61b6a96f..0cc1cdf91deb07ebb437ef5e61d149b2
  
      @Override
      public boolean isInBlock() {
-@@ -140,4 +127,31 @@ public class CraftAbstractArrow extends AbstractProjectile implements AbstractAr
+@@ -140,4 +127,37 @@ public class CraftAbstractArrow extends AbstractProjectile implements AbstractAr
      public String toString() {
          return "CraftArrow";
      }
 +
 +    // Paper start
 +    @Override
-+    public org.bukkit.craftbukkit.inventory.CraftItemStack getItemStack() {
-+        return org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(this.getHandle().getPickupItem());
++    public CraftItemStack getItemStack() {
++        return CraftItemStack.asCraftMirror(this.getHandle().getPickupItem());
++    }
++
++    @Override
++    public void setItemStack(final ItemStack stack) {
++        Preconditions.checkArgument(stack != null, "ItemStack cannot be null");
++        this.getHandle().setPickupItemStack(CraftItemStack.asNMSCopy(stack));
 +    }
 +
 +    @Override
@@ -607,7 +614,7 @@ index e374b9f40eddca13b30855d25a2030f8df98138f..4fc893378fb0568ddcffc7593d66df6b
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 59d444a79b5852dabc082b56bafe71d79e42541f..fa50860c8bb34c914096a2af17be62277b698c1a 100644
+index efc3808dde268f8325304f4bce8fb3bf399adafd..9588c191ccb5665be2ff90ae2ded5bbff12faacb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -832,19 +832,19 @@ public class CraftEventFactory {


### PR DESCRIPTION
One question is... right now we just use the internal setPickupItemStack method when the stack changes, however that doesn't accept empty stacks. If you pass an empty stack, it reverts back to the default pickup itemstack for that projectile. Unsure if we want to bypass that.