### PR TITLE
Add PlayerLandEvent

### DIFF
--- a/patches/api/0484-Add-PlayerLandEvent.patch
+++ b/patches/api/0484-Add-PlayerLandEvent.patch
@@ -1,0 +1,99 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: StillLutto <iameinsteinhe@gmail.com>
+Date: Sat, 8 Jun 2024 19:44:50 +0200
+Subject: [PATCH] Add PlayerLandEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/player/PlayerLandEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerLandEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..0a26286eb9d807ee202df60923166525a5f3af62
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/player/PlayerLandEvent.java
+@@ -0,0 +1,87 @@
++package io.papermc.paper.event.player;
++
++import com.google.common.base.Preconditions;
++import org.bukkit.Location;
++import org.bukkit.block.Block;
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.event.player.PlayerMoveEvent;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when the server detects the player lands on the ground.
++ * <p>
++ * Added to avoid the overhead and special case logic that many plugins use
++ * when checking for player landing via {@link PlayerMoveEvent}, this event is fired whenever
++ * the server detects that the player lands on the ground.
++ */
++public class PlayerLandEvent extends PlayerEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @NotNull private final Location to;
++    @NotNull private Location from;
++    @NotNull private Block mainSupportingBlock;
++
++    @ApiStatus.Internal
++    public PlayerLandEvent(@NotNull final Player player, @NotNull final Location from, @NotNull final Location to, final Block mainSupportingBlock) {
++        super(player);
++        this.from = from;
++        this.to = to;
++        this.mainSupportingBlock = mainSupportingBlock;
++    }
++
++    /**
++     * Gets the location where the player lands from
++     *
++     * @return Location where the player lands from
++     */
++    @NotNull
++    public Location getFrom() {
++        return this.from;
++    }
++
++    /**
++     * Sets the location to mark as where the player lands from
++     *
++     * @param from New location to mark as the players previous location
++     */
++    public void setFrom(@NotNull Location from) {
++        Preconditions.checkArgument(from != null, "Cannot use null from location!");
++        Preconditions.checkArgument(from.getWorld() != null, "Cannot use from location with null world!");
++        this.from = from;
++    }
++
++    /**
++     * Gets the location where the player lands
++     *
++     * @return Location where the player lands
++     */
++    @NotNull
++    public Location getTo() {
++        return this.to.clone();
++    }
++
++    /**
++     * Gets the location this player jumped to
++     *
++     * @return Location the player jumped to
++     */
++    @NotNull
++    public Block getMainSupportingBlock() {
++        return this.mainSupportingBlock;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}

--- a/patches/server/1053-Add-PlayerLandEvent.patch
+++ b/patches/server/1053-Add-PlayerLandEvent.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: StillLutto <iameinsteinhe@gmail.com>
+Date: Sat, 8 Jun 2024 19:44:50 +0200
+Subject: [PATCH] Add PlayerLandEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 4ae88bfcead40cd05f9514a48a922a37767cb3cf..8e6d05933857764ef582a31088f7a97eed8c4cc9 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -193,6 +193,7 @@ import net.minecraft.world.phys.Vec3;
+ import net.minecraft.world.phys.shapes.BooleanOp;
+ import net.minecraft.world.phys.shapes.Shapes;
+ import net.minecraft.world.phys.shapes.VoxelShape;
++import org.bukkit.craftbukkit.block.CraftBlock;
+ import org.slf4j.Logger;
+ 
+ // CraftBukkit start
+@@ -1591,6 +1592,15 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+                                 this.player.absMoveTo(d0, d1, d2, f, f1);
+                                 boolean flag4 = this.player.isAutoSpinAttack();
+ 
++                                // Paper start - Add PlayerLandEvent
++                                if (flag2 && !(this.player.getY() - d4 >= 0.0)) {
++                                    this.player.setOnGround(true);
++                                    final org.bukkit.block.Block mainSupportingBlock = CraftBlock.at(this.player.level(), this.player.mainSupportingBlockPos.get());
++                                    io.papermc.paper.event.player.PlayerLandEvent event = new io.papermc.paper.event.player.PlayerLandEvent(player, from, to, mainSupportingBlock);
++                                    event.callEvent();
++                                }
++                                // Paper end - Add PlayerLandEvent
++
+                                 this.clientIsFloating = d11 >= -0.03125D && !flag2 && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR && !this.server.isFlightAllowed() && !this.player.getAbilities().mayfly && !this.player.hasEffect(MobEffects.LEVITATION) && !flag && !flag4 && this.noBlocksAround(this.player);
+                                 this.player.serverLevel().getChunkSource().move(this.player);
+                                 this.player.doCheckFallDamage(this.player.getX() - d3, this.player.getY() - d4, this.player.getZ() - d5, packet.isOnGround());

--- a/patches/server/1054-Add-PlayerLandEvent.patch
+++ b/patches/server/1054-Add-PlayerLandEvent.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: StillLutto <iameinsteinhe@gmail.com>
+Date: Sun, 9 Jun 2024 12:34:52 +0200
+Subject: [PATCH] Add PlayerLandEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 8e6d05933857764ef582a31088f7a97eed8c4cc9..eea852d36ec9ce8703f5c4474646e3fa56fc6f2d 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -193,7 +193,6 @@ import net.minecraft.world.phys.Vec3;
+ import net.minecraft.world.phys.shapes.BooleanOp;
+ import net.minecraft.world.phys.shapes.Shapes;
+ import net.minecraft.world.phys.shapes.VoxelShape;
+-import org.bukkit.craftbukkit.block.CraftBlock;
+ import org.slf4j.Logger;
+ 
+ // CraftBukkit start
+@@ -1592,19 +1591,18 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+                                 this.player.absMoveTo(d0, d1, d2, f, f1);
+                                 boolean flag4 = this.player.isAutoSpinAttack();
+ 
++                                this.clientIsFloating = d11 >= -0.03125D && !flag2 && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR && !this.server.isFlightAllowed() && !this.player.getAbilities().mayfly && !this.player.hasEffect(MobEffects.LEVITATION) && !flag && !flag4 && this.noBlocksAround(this.player);
++                                this.player.serverLevel().getChunkSource().move(this.player);
++                                this.player.doCheckFallDamage(this.player.getX() - d3, this.player.getY() - d4, this.player.getZ() - d5, packet.isOnGround());
++                                this.player.setOnGroundWithKnownMovement(packet.isOnGround(), new Vec3(this.player.getX() - d3, this.player.getY() - d4, this.player.getZ() - d5));
+                                 // Paper start - Add PlayerLandEvent
+-                                if (flag2 && !(this.player.getY() - d4 >= 0.0)) {
++                                if (flag2 && (this.player.getY() - d4 >= 0.0)) {
+                                     this.player.setOnGround(true);
+-                                    final org.bukkit.block.Block mainSupportingBlock = CraftBlock.at(this.player.level(), this.player.mainSupportingBlockPos.get());
++                                    final org.bukkit.block.Block mainSupportingBlock = org.bukkit.craftbukkit.block.CraftBlock.at(this.player.level(), this.player.mainSupportingBlockPos.get());
+                                     io.papermc.paper.event.player.PlayerLandEvent event = new io.papermc.paper.event.player.PlayerLandEvent(player, from, to, mainSupportingBlock);
+                                     event.callEvent();
+                                 }
+                                 // Paper end - Add PlayerLandEvent
+-
+-                                this.clientIsFloating = d11 >= -0.03125D && !flag2 && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR && !this.server.isFlightAllowed() && !this.player.getAbilities().mayfly && !this.player.hasEffect(MobEffects.LEVITATION) && !flag && !flag4 && this.noBlocksAround(this.player);
+-                                this.player.serverLevel().getChunkSource().move(this.player);
+-                                this.player.doCheckFallDamage(this.player.getX() - d3, this.player.getY() - d4, this.player.getZ() - d5, packet.isOnGround());
+-                                this.player.setOnGroundWithKnownMovement(packet.isOnGround(), new Vec3(this.player.getX() - d3, this.player.getY() - d4, this.player.getZ() - d5));
+                                 if (flag1) {
+                                     this.player.resetFallDistance();
+                                 }


### PR DESCRIPTION
## Description

This is a very simple event. This event is triggered whenever a player lands on a block. The event is mostly useful for when you want to do a specific action whenever a player lands on a specific block/location.

## Event Details

    Event Name: PlayerLandEvent
    Trigger: When a player lands on the ground
    Purpose: To allow players to do specific actions when a player lands on a specific block

## Key Components

    Player: The player that landed.
    From: The location the player landed from.
    To: The location the player landed to.
    Main Supporting Block: The main block supporting the player, the block that the player landed on.