### PR TITLE
Update upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/paper-api-generator/src/main/java/io/papermc/generator/types/goal/MobGoalNames.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/types/goal/MobGoalNames.java
@@ -120,6 +120,7 @@ import org.bukkit.entity.ZombieVillager;
 import java.lang.reflect.Constructor;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -282,8 +283,8 @@ public class MobGoalNames {
         name = sb.toString();
         name = name.replaceFirst("_", "");
 
-        if (flag && !deobfuscationMap.containsKey(name.toLowerCase()) && !ignored.contains(name)) {
-            System.out.println("need to map " + original + " (" + name.toLowerCase() + ")");
+        if (flag && !deobfuscationMap.containsKey(name.toLowerCase(Locale.ROOT)) && !ignored.contains(name)) {
+            System.out.println("need to map " + original + " (" + name.toLowerCase(Locale.ROOT) + ")");
         }
 
         // did we rename this key?

--- a/paper-api-generator/src/main/java/io/papermc/generator/utils/Formatting.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/utils/Formatting.java
@@ -12,7 +12,7 @@ public final class Formatting {
     private static final Pattern ILLEGAL_FIELD_CHARACTERS = Pattern.compile("[.-/]");
 
     public static String formatKeyAsField(String path) {
-        return ILLEGAL_FIELD_CHARACTERS.matcher(path.toUpperCase(Locale.ENGLISH)).replaceAll("_");
+        return ILLEGAL_FIELD_CHARACTERS.matcher(path.toUpperCase(Locale.ROOT)).replaceAll("_");
     }
 
     public static Comparator<String> ALPHABETIC_KEY_ORDER = alphabeticKeyOrder(path -> path);

--- a/patches/api/0003-Test-changes.patch
+++ b/patches/api/0003-Test-changes.patch
@@ -233,10 +233,10 @@ index 89ca06ebecdaadd5dfc7bc74473ca15ad36f6eff..5974ceea58940e1799f3589eac0e39b9
  
      public static Stream<Arguments> data() {
 diff --git a/src/test/java/org/bukkit/support/TestServer.java b/src/test/java/org/bukkit/support/TestServer.java
-index 79173d6ed844f1e640e3aa745a9b560ec5e6a2bc..73ec679ac0d1f398b417bd174b47f9af93351e27 100644
+index 5709d52ed4ac4ce8dd8b0569281279f7305c5fb9..a47ee3ce660ec4467b5ed6a4b41fb2d19179a189 100644
 --- a/src/test/java/org/bukkit/support/TestServer.java
 +++ b/src/test/java/org/bukkit/support/TestServer.java
-@@ -61,6 +61,11 @@ public final class TestServer {
+@@ -72,6 +72,11 @@ public final class TestServer {
          UnsafeValues unsafeValues = mock(withSettings().stubOnly());
          when(instance.getUnsafe()).thenReturn(unsafeValues);
  

--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -1511,10 +1511,10 @@ index ce9bb54a6ef8a7d31804ec63aa1f6cbbd6ae2d54..baf49da3dd46039da2f24a4af8b1b861
      Material toLegacy(Material material);
  
 diff --git a/src/main/java/org/bukkit/Warning.java b/src/main/java/org/bukkit/Warning.java
-index efb97712cc9dc7c1e12a59f5b94e4f2ad7c6b7d8..3024468af4c073324e536c1cb26beffb1e09f3f4 100644
+index 0208fc2bcd5c99c60b37419b92248db76681fc1e..5c1dda6888561a7eba0fbf9ba6ca7d7fe856eb53 100644
 --- a/src/main/java/org/bukkit/Warning.java
 +++ b/src/main/java/org/bukkit/Warning.java
-@@ -67,6 +67,7 @@ public @interface Warning {
+@@ -68,6 +68,7 @@ public @interface Warning {
           *     </ul>
           */
          public boolean printFor(@Nullable Warning warning) {
@@ -1523,7 +1523,7 @@ index efb97712cc9dc7c1e12a59f5b94e4f2ad7c6b7d8..3024468af4c073324e536c1cb26beffb
                  return warning == null || warning.value();
              }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 3132e6754ab462eca0b7de1e7ad64c955316296d..a9858c2559f0921613b19710135cc6e060488e96 100644
+index c0479a8da773b2f8db29f190ddc0e4961fb9f107..9732929b666b0a5e1a2a41c8e8794cc4f2535e41 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -47,7 +47,7 @@ import org.jetbrains.annotations.Nullable;
@@ -1535,7 +1535,7 @@ index 3132e6754ab462eca0b7de1e7ad64c955316296d..a9858c2559f0921613b19710135cc6e0
  
      /**
       * Gets the {@link Block} at the given coordinates
-@@ -617,6 +617,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -644,6 +644,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public List<Player> getPlayers();
  
@@ -2182,10 +2182,10 @@ index b7d8dd30360a38dbdc7bbce40c8e6ced7261f833..0817f2395c2b18828565435568ce651f
      public void sendRawMessage(@Nullable UUID sender, @NotNull String message);
  }
 diff --git a/src/main/java/org/bukkit/enchantments/Enchantment.java b/src/main/java/org/bukkit/enchantments/Enchantment.java
-index 18983f405b2f6c4159dba5c99674ae7729905cc4..a82d6f469aca02fb28b1b3ad84dc40415f1f1ade 100644
+index f52cff3abcded891f6002a5fe4d5229ab551fe73..9db24da6836de45b7aff8d89782e6b0e1bc5391b 100644
 --- a/src/main/java/org/bukkit/enchantments/Enchantment.java
 +++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
-@@ -318,6 +318,19 @@ public abstract class Enchantment implements Keyed, Translatable {
+@@ -319,6 +319,19 @@ public abstract class Enchantment implements Keyed, Translatable {
       * @return True if the enchantment may be applied, otherwise False
       */
      public abstract boolean canEnchantItem(@NotNull ItemStack item);
@@ -2256,7 +2256,7 @@ index 558fe6e23f562ee873fc84112f930c6ea19a09f4..c78fb359bd28b8dc1ba242642ec612e8
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 712c0a8ae919ed9e7cb84cebd4b6a415ddaa63eb..4e9ba039669c7059180f5776ee2f7188f2dd01b5 100644
+index 3cec942c2fb46a8fa0b8bc63cbc353ebd23a93ba..c7d3d938534ac11fe420418655dae689c58fbe12 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -56,7 +56,41 @@ import org.jetbrains.annotations.Nullable;
@@ -2892,7 +2892,7 @@ index 712c0a8ae919ed9e7cb84cebd4b6a415ddaa63eb..4e9ba039669c7059180f5776ee2f7188
      public void sendTitle(@Nullable String title, @Nullable String subtitle, int fadeIn, int stay, int fadeOut);
  
      /**
-@@ -2117,6 +2491,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2165,6 +2539,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -2907,7 +2907,7 @@ index 712c0a8ae919ed9e7cb84cebd4b6a415ddaa63eb..4e9ba039669c7059180f5776ee2f7188
      /**
       * Gets the player's estimated ping in milliseconds.
       *
-@@ -2142,8 +2524,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2190,8 +2572,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -2918,7 +2918,7 @@ index 712c0a8ae919ed9e7cb84cebd4b6a415ddaa63eb..4e9ba039669c7059180f5776ee2f7188
      public String getLocale();
  
      /**
-@@ -2195,6 +2579,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2243,6 +2627,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public boolean isAllowingServerListings();
  
@@ -2933,7 +2933,7 @@ index 712c0a8ae919ed9e7cb84cebd4b6a415ddaa63eb..4e9ba039669c7059180f5776ee2f7188
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -2226,11 +2618,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2274,11 +2666,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -2947,7 +2947,7 @@ index 712c0a8ae919ed9e7cb84cebd4b6a415ddaa63eb..4e9ba039669c7059180f5776ee2f7188
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -2241,7 +2635,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2289,7 +2683,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -2957,7 +2957,7 @@ index 712c0a8ae919ed9e7cb84cebd4b6a415ddaa63eb..4e9ba039669c7059180f5776ee2f7188
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -2251,7 +2647,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2299,7 +2695,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -2967,7 +2967,7 @@ index 712c0a8ae919ed9e7cb84cebd4b6a415ddaa63eb..4e9ba039669c7059180f5776ee2f7188
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -2262,7 +2660,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2310,7 +2708,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -2977,7 +2977,7 @@ index 712c0a8ae919ed9e7cb84cebd4b6a415ddaa63eb..4e9ba039669c7059180f5776ee2f7188
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable java.util.UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -2273,7 +2673,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2321,7 +2721,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send
@@ -4294,10 +4294,10 @@ index e12996492c1558fed9fab30de9f8018e0ed7fac3..002acfbdce1db10f7ba1b6a013e678f5
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index b8bb11544bdfb5b9272c2c3c33c95a4c1c7fdf12..86fbc3902989a3baca851ab8c3866af445451787 100644
+index aa7fcae0de70aa5c10a331dfb076efd2f2c64065..d5342258086066d3b9ef404916bad8440f0cf0cd 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -215,4 +215,24 @@ public interface ItemFactory {
+@@ -200,4 +200,24 @@ public interface ItemFactory {
       */
      @NotNull
      ItemStack enchantItem(@NotNull final ItemStack item, final int level, final boolean allowTreasures);
@@ -4323,7 +4323,7 @@ index b8bb11544bdfb5b9272c2c3c33c95a4c1c7fdf12..86fbc3902989a3baca851ab8c3866af4
 +    // Paper end - Adventure
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 692f67c4e27cf62451130479510d06c89274ad23..22e883c8d737cf9f799c6160ff63d90f99250020 100644
+index eade62328895133c026e7e678e648e1fc846f5ee..730c42eddd38acec1cdbb19dfc8c675795d1e68d 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -26,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
@@ -4335,7 +4335,7 @@ index 692f67c4e27cf62451130479510d06c89274ad23..22e883c8d737cf9f799c6160ff63d90f
      private Material type = Material.AIR;
      private int amount = 0;
      private MaterialData data = null;
-@@ -624,4 +624,21 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -626,4 +626,21 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public String getTranslationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }
@@ -4596,10 +4596,10 @@ index 9bab73c3c2ca759b8e1c7d07d98cc593c961666a..f0c6943da3f783101ca647b75b3230fa
              throw new UnsupportedOperationException("Not supported yet.");
          }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 3a87089ba78f1e603ef582fcda3eb915d11f21a5..a23d030d2204098be17d8b18021fd0bb79b4431b 100644
+index 556df980d235e0ce09c227419e1c70fed68313bc..bc065cc78b69d26ac07941b8485fabe256d6286c 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -35,6 +35,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -36,6 +36,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       */
      boolean hasDisplayName();
  
@@ -4624,7 +4624,7 @@ index 3a87089ba78f1e603ef582fcda3eb915d11f21a5..a23d030d2204098be17d8b18021fd0bb
      /**
       * Gets the display name that is set.
       * <p>
-@@ -42,7 +60,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -43,7 +61,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * before calling this method.
       *
       * @return the display name that is set
@@ -4634,7 +4634,7 @@ index 3a87089ba78f1e603ef582fcda3eb915d11f21a5..a23d030d2204098be17d8b18021fd0bb
      @NotNull
      String getDisplayName();
  
-@@ -50,7 +70,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -51,7 +71,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * Sets the display name.
       *
       * @param name the name to set
@@ -4644,7 +4644,7 @@ index 3a87089ba78f1e603ef582fcda3eb915d11f21a5..a23d030d2204098be17d8b18021fd0bb
      void setDisplayName(@Nullable String name);
  
      /**
-@@ -63,6 +85,32 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -64,6 +86,32 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       */
      boolean hasItemName();
  
@@ -4677,7 +4677,7 @@ index 3a87089ba78f1e603ef582fcda3eb915d11f21a5..a23d030d2204098be17d8b18021fd0bb
      /**
       * Gets the item name that is set.
       * <br>
-@@ -73,7 +121,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -74,7 +122,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * calling this method.
       *
       * @return the item name that is set
@@ -4687,7 +4687,7 @@ index 3a87089ba78f1e603ef582fcda3eb915d11f21a5..a23d030d2204098be17d8b18021fd0bb
      @NotNull
      String getItemName();
  
-@@ -84,7 +134,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -85,7 +135,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * anvil, is not styled with italics, and does not show labels.
       *
       * @param name the name to set
@@ -4697,7 +4697,7 @@ index 3a87089ba78f1e603ef582fcda3eb915d11f21a5..a23d030d2204098be17d8b18021fd0bb
      void setItemName(@Nullable String name);
  
      /**
-@@ -125,6 +177,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -126,6 +178,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       */
      boolean hasLore();
  
@@ -4722,7 +4722,7 @@ index 3a87089ba78f1e603ef582fcda3eb915d11f21a5..a23d030d2204098be17d8b18021fd0bb
      /**
       * Gets the lore that is set.
       * <p>
-@@ -132,7 +202,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -133,7 +203,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * calling this method.
       *
       * @return a list of lore that is set
@@ -4732,7 +4732,7 @@ index 3a87089ba78f1e603ef582fcda3eb915d11f21a5..a23d030d2204098be17d8b18021fd0bb
      @Nullable
      List<String> getLore();
  
-@@ -141,7 +213,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -142,7 +214,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * Removes lore when given null.
       *
       * @param lore the lore that will be set

--- a/patches/api/0009-Paper-Plugins.patch
+++ b/patches/api/0009-Paper-Plugins.patch
@@ -1379,10 +1379,10 @@ index 1dbbc244309043b18c1d71707c4fb066c0d0e02d..551c5af6a7bfa2268cbc63be8e70d129
          this.executor = owner;
          this.owningPlugin = owner;
 diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-index e195e74c48c69047aa825b75fad95419c505b41f..53f28c9e6843991486a576d41b6641c170589807 100644
+index fd5a7a55484deb3fdcced7ebd1f4f6c14d5b4f4f..9207ae900cb4cc8ce41dd4e63d7ad8b35b0ac048 100644
 --- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
 +++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-@@ -34,7 +34,7 @@ public class SimpleCommandMap implements CommandMap {
+@@ -35,7 +35,7 @@ public class SimpleCommandMap implements CommandMap {
      private void setDefaultCommands() {
          register("bukkit", new VersionCommand("version"));
          register("bukkit", new ReloadCommand("reload"));
@@ -1450,10 +1450,10 @@ index 94f8ceb965cecb5669a84a0ec61c0f706c2a2673..e773db6da357ad210eb24d4c389af2dc
      }
  }
 diff --git a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
-index f48bdeb628a82416d93f84a0a10141447482bf83..c0691a849831f99268fdcb7b0f471f80a1a2a70e 100644
+index 8e44f7eaf960884b09ac8413c4383fe17e54b584..c5465431ce35d264d8510af45e73d058b333c60b 100644
 --- a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
 +++ b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
-@@ -198,7 +198,7 @@ import org.yaml.snakeyaml.representer.Representer;
+@@ -199,7 +199,7 @@ import org.yaml.snakeyaml.representer.Representer;
   *      inferno.burningdeaths: true
   *</pre></blockquote>
   */
@@ -1462,7 +1462,7 @@ index f48bdeb628a82416d93f84a0a10141447482bf83..c0691a849831f99268fdcb7b0f471f80
      private static final Pattern VALID_NAME = Pattern.compile("^[A-Za-z0-9 _.-]+$");
      private static final ThreadLocal<Yaml> YAML = new ThreadLocal<Yaml>() {
          @Override
-@@ -259,6 +259,70 @@ public final class PluginDescriptionFile {
+@@ -260,6 +260,70 @@ public final class PluginDescriptionFile {
      private Set<PluginAwareness> awareness = ImmutableSet.of();
      private String apiVersion = null;
      private List<String> libraries = ImmutableList.of();
@@ -1585,10 +1585,10 @@ index ae3e68562c29992fab627428db3ff0006d8216f9..47153dee66782a00b980ecf15e8774ab
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd73ae9d675 100644
+index 839130f713e9a1862e1026590a76ac027c00cab8..46c7be5fa69f13900860b9944523beea16f2409b 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -43,6 +43,8 @@ import org.jetbrains.annotations.Nullable;
+@@ -44,6 +44,8 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Handles all plugin management from the Server
   */
@@ -1597,7 +1597,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
  public final class SimplePluginManager implements PluginManager {
      private final Server server;
      private final Map<Pattern, PluginLoader> fileAssociations = new HashMap<Pattern, PluginLoader>();
-@@ -51,10 +53,13 @@ public final class SimplePluginManager implements PluginManager {
+@@ -52,10 +54,13 @@ public final class SimplePluginManager implements PluginManager {
      private MutableGraph<String> dependencyGraph = GraphBuilder.directed().build();
      private File updateDirectory;
      private final SimpleCommandMap commandMap;
@@ -1615,7 +1615,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
      private boolean useTimings = false;
  
      public SimplePluginManager(@NotNull Server instance, @NotNull SimpleCommandMap commandMap) {
-@@ -111,6 +116,11 @@ public final class SimplePluginManager implements PluginManager {
+@@ -112,6 +117,11 @@ public final class SimplePluginManager implements PluginManager {
      @Override
      @NotNull
      public Plugin[] loadPlugins(@NotNull File directory) {
@@ -1627,7 +1627,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          Preconditions.checkArgument(directory != null, "Directory cannot be null");
          Preconditions.checkArgument(directory.isDirectory(), "Directory must be a directory");
  
-@@ -129,6 +139,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -130,6 +140,7 @@ public final class SimplePluginManager implements PluginManager {
       */
      @NotNull
      public Plugin[] loadPlugins(@NotNull File[] files) {
@@ -1635,7 +1635,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          Preconditions.checkArgument(files != null, "File list cannot be null");
  
          List<Plugin> result = new ArrayList<Plugin>();
-@@ -389,6 +400,15 @@ public final class SimplePluginManager implements PluginManager {
+@@ -390,6 +401,15 @@ public final class SimplePluginManager implements PluginManager {
      @Nullable
      public synchronized Plugin loadPlugin(@NotNull File file) throws InvalidPluginException, UnknownDependencyException {
          Preconditions.checkArgument(file != null, "File cannot be null");
@@ -1651,7 +1651,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
  
          checkUpdate(file);
  
-@@ -439,12 +459,14 @@ public final class SimplePluginManager implements PluginManager {
+@@ -440,12 +460,14 @@ public final class SimplePluginManager implements PluginManager {
      @Override
      @Nullable
      public synchronized Plugin getPlugin(@NotNull String name) {
@@ -1666,7 +1666,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          return plugins.toArray(new Plugin[plugins.size()]);
      }
  
-@@ -458,6 +480,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -459,6 +481,7 @@ public final class SimplePluginManager implements PluginManager {
       */
      @Override
      public boolean isPluginEnabled(@NotNull String name) {
@@ -1674,7 +1674,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          Plugin plugin = getPlugin(name);
  
          return isPluginEnabled(plugin);
-@@ -471,6 +494,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -472,6 +495,7 @@ public final class SimplePluginManager implements PluginManager {
       */
      @Override
      public boolean isPluginEnabled(@Nullable Plugin plugin) {
@@ -1682,7 +1682,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          if ((plugin != null) && (plugins.contains(plugin))) {
              return plugin.isEnabled();
          } else {
-@@ -480,6 +504,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -481,6 +505,7 @@ public final class SimplePluginManager implements PluginManager {
  
      @Override
      public void enablePlugin(@NotNull final Plugin plugin) {
@@ -1690,7 +1690,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          if (!plugin.isEnabled()) {
              List<Command> pluginCommands = PluginCommandYamlParser.parse(plugin);
  
-@@ -499,6 +524,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -500,6 +525,7 @@ public final class SimplePluginManager implements PluginManager {
  
      @Override
      public void disablePlugins() {
@@ -1698,7 +1698,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          Plugin[] plugins = getPlugins();
          for (int i = plugins.length - 1; i >= 0; i--) {
              disablePlugin(plugins[i]);
-@@ -507,6 +533,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -508,6 +534,7 @@ public final class SimplePluginManager implements PluginManager {
  
      @Override
      public void disablePlugin(@NotNull final Plugin plugin) {
@@ -1706,7 +1706,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          if (plugin.isEnabled()) {
              try {
                  plugin.getPluginLoader().disablePlugin(plugin);
-@@ -551,6 +578,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -552,6 +579,7 @@ public final class SimplePluginManager implements PluginManager {
  
      @Override
      public void clearPlugins() {
@@ -1714,7 +1714,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          synchronized (this) {
              disablePlugins();
              plugins.clear();
-@@ -571,6 +599,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -572,6 +600,7 @@ public final class SimplePluginManager implements PluginManager {
       */
      @Override
      public void callEvent(@NotNull Event event) {
@@ -1722,7 +1722,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          if (event.isAsynchronous()) {
              if (Thread.holdsLock(this)) {
                  throw new IllegalStateException(event.getEventName() + " cannot be triggered asynchronously from inside synchronized code.");
-@@ -619,6 +648,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -620,6 +649,7 @@ public final class SimplePluginManager implements PluginManager {
  
      @Override
      public void registerEvents(@NotNull Listener listener, @NotNull Plugin plugin) {
@@ -1730,7 +1730,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          if (!plugin.isEnabled()) {
              throw new IllegalPluginAccessException("Plugin attempted to register " + listener + " while not enabled");
          }
-@@ -652,6 +682,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -653,6 +683,7 @@ public final class SimplePluginManager implements PluginManager {
          Preconditions.checkArgument(priority != null, "Priority cannot be null");
          Preconditions.checkArgument(executor != null, "Executor cannot be null");
          Preconditions.checkArgument(plugin != null, "Plugin cannot be null");
@@ -1738,12 +1738,12 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
  
          if (!plugin.isEnabled()) {
              throw new IllegalPluginAccessException("Plugin attempted to register " + event + " while not enabled");
-@@ -699,16 +730,19 @@ public final class SimplePluginManager implements PluginManager {
+@@ -700,16 +731,19 @@ public final class SimplePluginManager implements PluginManager {
      @Override
      @Nullable
      public Permission getPermission(@NotNull String name) {
 +        if (true) {return this.paperPluginManager.getPermission(name);} // Paper
-         return permissions.get(name.toLowerCase(java.util.Locale.ENGLISH));
+         return permissions.get(name.toLowerCase(Locale.ROOT));
      }
  
      @Override
@@ -1755,10 +1755,10 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
      @Deprecated
      public void addPermission(@NotNull Permission perm, boolean dirty) {
 +        if (true) {this.paperPluginManager.addPermission(perm); return;} // Paper - This just has a performance implication, use the better api to avoid this.
-         String name = perm.getName().toLowerCase(java.util.Locale.ENGLISH);
+         String name = perm.getName().toLowerCase(Locale.ROOT);
  
          if (permissions.containsKey(name)) {
-@@ -722,21 +756,25 @@ public final class SimplePluginManager implements PluginManager {
+@@ -723,21 +757,25 @@ public final class SimplePluginManager implements PluginManager {
      @Override
      @NotNull
      public Set<Permission> getDefaultPermissions(boolean op) {
@@ -1775,40 +1775,40 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
      @Override
      public void removePermission(@NotNull String name) {
 +        if (true) {this.paperPluginManager.removePermission(name); return;} // Paper
-         permissions.remove(name.toLowerCase(java.util.Locale.ENGLISH));
+         permissions.remove(name.toLowerCase(Locale.ROOT));
      }
  
      @Override
      public void recalculatePermissionDefaults(@NotNull Permission perm) {
 +        if (true) {this.paperPluginManager.recalculatePermissionDefaults(perm); return;} // Paper
-         if (perm != null && permissions.containsKey(perm.getName().toLowerCase(java.util.Locale.ENGLISH))) {
+         if (perm != null && permissions.containsKey(perm.getName().toLowerCase(Locale.ROOT))) {
              defaultPerms.get(true).remove(perm);
              defaultPerms.get(false).remove(perm);
-@@ -776,6 +814,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -777,6 +815,7 @@ public final class SimplePluginManager implements PluginManager {
  
      @Override
      public void subscribeToPermission(@NotNull String permission, @NotNull Permissible permissible) {
 +        if (true) {this.paperPluginManager.subscribeToPermission(permission, permissible); return;} // Paper
-         String name = permission.toLowerCase(java.util.Locale.ENGLISH);
+         String name = permission.toLowerCase(Locale.ROOT);
          Map<Permissible, Boolean> map = permSubs.get(name);
  
-@@ -789,6 +828,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -790,6 +829,7 @@ public final class SimplePluginManager implements PluginManager {
  
      @Override
      public void unsubscribeFromPermission(@NotNull String permission, @NotNull Permissible permissible) {
 +        if (true) {this.paperPluginManager.unsubscribeFromPermission(permission, permissible); return;} // Paper
-         String name = permission.toLowerCase(java.util.Locale.ENGLISH);
+         String name = permission.toLowerCase(Locale.ROOT);
          Map<Permissible, Boolean> map = permSubs.get(name);
  
-@@ -804,6 +844,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -805,6 +845,7 @@ public final class SimplePluginManager implements PluginManager {
      @Override
      @NotNull
      public Set<Permissible> getPermissionSubscriptions(@NotNull String permission) {
 +        if (true) {return this.paperPluginManager.getPermissionSubscriptions(permission);} // Paper
-         String name = permission.toLowerCase(java.util.Locale.ENGLISH);
+         String name = permission.toLowerCase(Locale.ROOT);
          Map<Permissible, Boolean> map = permSubs.get(name);
  
-@@ -816,6 +857,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -817,6 +858,7 @@ public final class SimplePluginManager implements PluginManager {
  
      @Override
      public void subscribeToDefaultPerms(boolean op, @NotNull Permissible permissible) {
@@ -1816,7 +1816,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          Map<Permissible, Boolean> map = defSubs.get(op);
  
          if (map == null) {
-@@ -828,6 +870,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -829,6 +871,7 @@ public final class SimplePluginManager implements PluginManager {
  
      @Override
      public void unsubscribeFromDefaultPerms(boolean op, @NotNull Permissible permissible) {
@@ -1824,7 +1824,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          Map<Permissible, Boolean> map = defSubs.get(op);
  
          if (map != null) {
-@@ -842,6 +885,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -843,6 +886,7 @@ public final class SimplePluginManager implements PluginManager {
      @Override
      @NotNull
      public Set<Permissible> getDefaultPermSubscriptions(boolean op) {
@@ -1832,7 +1832,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          Map<Permissible, Boolean> map = defSubs.get(op);
  
          if (map == null) {
-@@ -854,6 +898,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -855,6 +899,7 @@ public final class SimplePluginManager implements PluginManager {
      @Override
      @NotNull
      public Set<Permission> getPermissions() {
@@ -1840,7 +1840,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          return new HashSet<Permission>(permissions.values());
      }
  
-@@ -877,6 +922,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -878,6 +923,7 @@ public final class SimplePluginManager implements PluginManager {
  
      @Override
      public boolean useTimings() {
@@ -1848,7 +1848,7 @@ index 34830d2815d331a1b611f22eca08f53d815ea08a..fb4cb36391e69fd997300b952b64fbd7
          return useTimings;
      }
  
-@@ -888,4 +934,28 @@ public final class SimplePluginManager implements PluginManager {
+@@ -889,4 +935,28 @@ public final class SimplePluginManager implements PluginManager {
      public void useTimings(boolean use) {
          useTimings = use;
      }
@@ -1899,10 +1899,10 @@ index a80251eff75430863b37db1c131e22593f3fcd5e..310c4041963a3f1e0a26e39a6da12a9b
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d8a25b6ff 100644
+index 7fca39df009308adad55a6e9dc10a4a0dead86f2..2a14522c484febcd880d00197df4359a0020dddd 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-@@ -40,6 +40,7 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -41,6 +41,7 @@ public abstract class JavaPlugin extends PluginBase {
      private Server server = null;
      private File file = null;
      private PluginDescriptionFile description = null;
@@ -1910,7 +1910,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
      private File dataFolder = null;
      private ClassLoader classLoader = null;
      private boolean naggable = true;
-@@ -48,13 +49,16 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -49,13 +50,16 @@ public abstract class JavaPlugin extends PluginBase {
      private PluginLogger logger = null;
  
      public JavaPlugin() {
@@ -1931,7 +1931,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
      protected JavaPlugin(@NotNull final JavaPluginLoader loader, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file) {
          final ClassLoader classLoader = this.getClass().getClassLoader();
          if (classLoader instanceof PluginClassLoader) {
-@@ -79,9 +83,12 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -80,9 +84,12 @@ public abstract class JavaPlugin extends PluginBase {
       * Gets the associated PluginLoader responsible for this plugin
       *
       * @return PluginLoader that controls this plugin
@@ -1944,7 +1944,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
      public final PluginLoader getPluginLoader() {
          return loader;
      }
-@@ -122,13 +129,20 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -123,13 +130,20 @@ public abstract class JavaPlugin extends PluginBase {
       * Returns the plugin.yaml file containing the details for this plugin
       *
       * @return Contents of the plugin.yaml file
@@ -1965,7 +1965,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
      @NotNull
      @Override
      public FileConfiguration getConfig() {
-@@ -258,7 +272,8 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -259,7 +273,8 @@ public abstract class JavaPlugin extends PluginBase {
       *
       * @param enabled true if enabled, otherwise false
       */
@@ -1975,7 +1975,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
          if (isEnabled != enabled) {
              isEnabled = enabled;
  
-@@ -270,9 +285,18 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -271,9 +286,18 @@ public abstract class JavaPlugin extends PluginBase {
          }
      }
  
@@ -1997,7 +1997,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
          this.server = server;
          this.file = file;
          this.description = description;
-@@ -280,6 +304,7 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -281,6 +305,7 @@ public abstract class JavaPlugin extends PluginBase {
          this.classLoader = classLoader;
          this.configFile = new File(dataFolder, "config.yml");
          this.logger = new PluginLogger(this);
@@ -2005,7 +2005,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
      }
  
      /**
-@@ -396,10 +421,10 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -397,10 +422,10 @@ public abstract class JavaPlugin extends PluginBase {
              throw new IllegalArgumentException(clazz + " does not extend " + JavaPlugin.class);
          }
          final ClassLoader cl = clazz.getClassLoader();
@@ -2019,7 +2019,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
          if (plugin == null) {
              throw new IllegalStateException("Cannot get plugin for " + clazz + " from a static initializer");
          }
-@@ -422,10 +447,10 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -423,10 +448,10 @@ public abstract class JavaPlugin extends PluginBase {
      public static JavaPlugin getProvidingPlugin(@NotNull Class<?> clazz) {
          Preconditions.checkArgument(clazz != null, "Null class cannot have a plugin");
          final ClassLoader cl = clazz.getClassLoader();
@@ -2557,10 +2557,10 @@ index a8be3e23e3e280ad301d9530de50028515612966..43b58e920e739bb949ac0673e9ef73ba
      @Override
      public FileConfiguration getConfig() {
 diff --git a/src/test/java/org/bukkit/support/TestServer.java b/src/test/java/org/bukkit/support/TestServer.java
-index 73ec679ac0d1f398b417bd174b47f9af93351e27..b208150297a23c0b4acb79135416809718f5650e 100644
+index a47ee3ce660ec4467b5ed6a4b41fb2d19179a189..c79faf4197f9c0a7256cefe2b001182102d2b796 100644
 --- a/src/test/java/org/bukkit/support/TestServer.java
 +++ b/src/test/java/org/bukkit/support/TestServer.java
-@@ -25,8 +25,7 @@ public final class TestServer {
+@@ -26,8 +26,7 @@ public final class TestServer {
          Thread creatingThread = Thread.currentThread();
          when(instance.isPrimaryThread()).then(mock -> Thread.currentThread().equals(creatingThread));
  

--- a/patches/api/0011-Timings-v2.patch
+++ b/patches/api/0011-Timings-v2.patch
@@ -717,10 +717,10 @@ index 0000000000000000000000000000000000000000..199789d56d22fcb1b77ebd56805cc28a
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingHistory.java b/src/main/java/co/aikar/timings/TimingHistory.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..eb9d58f8852e732a1284beeaf542989301d21b1c
+index 0000000000000000000000000000000000000000..065991e7a7f6119797ea315a56836ba17dd17d05
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingHistory.java
-@@ -0,0 +1,355 @@
+@@ -0,0 +1,352 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -874,17 +874,14 @@ index 0000000000000000000000000000000000000000..eb9d58f8852e732a1284beeaf5429893
 +                                        }
 +                                    }
 +                                ),
-+                                toObjectMapper(input.tileEntityCounts.entrySet(),
-+                                    new Function<Map.Entry<Material, Counter>, JSONPair>() {
-+                                        @NotNull
-+                                        @Override
-+                                        public JSONPair apply(Map.Entry<Material, Counter> entry) {
-+                                            tileEntityTypeSet.add(entry.getKey());
-+                                            return pair(
-+                                                    String.valueOf(entry.getKey().ordinal()),
-+                                                    entry.getValue().count()
-+                                            );
-+                                        }
++                                toObjectMapper(
++                                    input.tileEntityCounts.entrySet(),
++                                    entry -> {
++                                        tileEntityTypeSet.add(entry.getKey());
++                                        return pair(
++                                            String.valueOf(entry.getKey().ordinal()),
++                                            entry.getValue().count()
++                                        );
 +                                    }
 +                                )
 +                            );
@@ -3143,10 +3140,10 @@ index 0000000000000000000000000000000000000000..9d263ab3afb938c215c0b64d9171345f
 +
 +}
 diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-index 53f28c9e6843991486a576d41b6641c170589807..4205649948a9e2a72f64c3f007112245abac6d50 100644
+index 9207ae900cb4cc8ce41dd4e63d7ad8b35b0ac048..36fc2c35395c72f8b81a2a2f3265fd205384ce26 100644
 --- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
 +++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-@@ -15,7 +15,6 @@ import org.bukkit.command.defaults.BukkitCommand;
+@@ -16,7 +16,6 @@ import org.bukkit.command.defaults.BukkitCommand;
  import org.bukkit.command.defaults.HelpCommand;
  import org.bukkit.command.defaults.PluginsCommand;
  import org.bukkit.command.defaults.ReloadCommand;
@@ -3154,7 +3151,7 @@ index 53f28c9e6843991486a576d41b6641c170589807..4205649948a9e2a72f64c3f007112245
  import org.bukkit.command.defaults.VersionCommand;
  import org.bukkit.entity.Player;
  import org.bukkit.util.StringUtil;
-@@ -35,7 +34,7 @@ public class SimpleCommandMap implements CommandMap {
+@@ -36,7 +35,7 @@ public class SimpleCommandMap implements CommandMap {
          register("bukkit", new VersionCommand("version"));
          register("bukkit", new ReloadCommand("reload"));
          //register("bukkit", new PluginsCommand("plugins")); // Paper
@@ -3163,15 +3160,15 @@ index 53f28c9e6843991486a576d41b6641c170589807..4205649948a9e2a72f64c3f007112245
      }
  
      public void setFallbackCommands() {
-@@ -67,6 +66,7 @@ public class SimpleCommandMap implements CommandMap {
+@@ -68,6 +67,7 @@ public class SimpleCommandMap implements CommandMap {
       */
      @Override
      public boolean register(@NotNull String label, @NotNull String fallbackPrefix, @NotNull Command command) {
 +        command.timings = co.aikar.timings.TimingsManager.getCommandTiming(fallbackPrefix, command); // Paper
-         label = label.toLowerCase(java.util.Locale.ENGLISH).trim();
-         fallbackPrefix = fallbackPrefix.toLowerCase(java.util.Locale.ENGLISH).trim();
+         label = label.toLowerCase(Locale.ROOT).trim();
+         fallbackPrefix = fallbackPrefix.toLowerCase(Locale.ROOT).trim();
          boolean registered = register(label, command, false, fallbackPrefix);
-@@ -143,16 +143,22 @@ public class SimpleCommandMap implements CommandMap {
+@@ -144,16 +144,22 @@ public class SimpleCommandMap implements CommandMap {
              return false;
          }
  
@@ -3455,10 +3452,10 @@ index 516d7fc7812aac343782861d0d567f54aa578c2a..00000000000000000000000000000000
 -    // Spigot end
 -}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 4e9ba039669c7059180f5776ee2f7188f2dd01b5..5b526d602057ab70b4a058142e01a0195694c28f 100644
+index c7d3d938534ac11fe420418655dae689c58fbe12..776a3ce9a6c106fbe96cc6399b9ee2cd81b10c76 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2678,7 +2678,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2726,7 +2726,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          @Deprecated // Paper
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable java.util.UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
@@ -3479,10 +3476,10 @@ index 4e9ba039669c7059180f5776ee2f7188f2dd01b5..5b526d602057ab70b4a058142e01a019
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index fb4cb36391e69fd997300b952b64fbd73ae9d675..3465bd660999caa53582e9d56a4e93ec7701a1de 100644
+index 46c7be5fa69f13900860b9944523beea16f2409b..6018574cd15b802833613beefa88da15dc2730cb 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -380,7 +380,6 @@ public final class SimplePluginManager implements PluginManager {
+@@ -381,7 +381,6 @@ public final class SimplePluginManager implements PluginManager {
              }
          }
  
@@ -3490,7 +3487,7 @@ index fb4cb36391e69fd997300b952b64fbd73ae9d675..3465bd660999caa53582e9d56a4e93ec
          return result.toArray(new Plugin[result.size()]);
      }
  
-@@ -428,9 +427,9 @@ public final class SimplePluginManager implements PluginManager {
+@@ -429,9 +428,9 @@ public final class SimplePluginManager implements PluginManager {
  
          if (result != null) {
              plugins.add(result);
@@ -3502,7 +3499,7 @@ index fb4cb36391e69fd997300b952b64fbd73ae9d675..3465bd660999caa53582e9d56a4e93ec
              }
          }
  
-@@ -460,7 +459,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -461,7 +460,7 @@ public final class SimplePluginManager implements PluginManager {
      @Nullable
      public synchronized Plugin getPlugin(@NotNull String name) {
          if (true) {return this.paperPluginManager.getPlugin(name);} // Paper
@@ -3511,7 +3508,7 @@ index fb4cb36391e69fd997300b952b64fbd73ae9d675..3465bd660999caa53582e9d56a4e93ec
      }
  
      @Override
-@@ -688,7 +687,8 @@ public final class SimplePluginManager implements PluginManager {
+@@ -689,7 +688,8 @@ public final class SimplePluginManager implements PluginManager {
              throw new IllegalPluginAccessException("Plugin attempted to register " + event + " while not enabled");
          }
  
@@ -3521,7 +3518,7 @@ index fb4cb36391e69fd997300b952b64fbd73ae9d675..3465bd660999caa53582e9d56a4e93ec
              getEventListeners(event).register(new TimedRegisteredListener(listener, executor, priority, plugin, ignoreCancelled));
          } else {
              getEventListeners(event).register(new RegisteredListener(listener, executor, priority, plugin, ignoreCancelled));
-@@ -923,7 +923,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -924,7 +924,7 @@ public final class SimplePluginManager implements PluginManager {
      @Override
      public boolean useTimings() {
          if (true) {return this.paperPluginManager.useTimings();} // Paper
@@ -3530,7 +3527,7 @@ index fb4cb36391e69fd997300b952b64fbd73ae9d675..3465bd660999caa53582e9d56a4e93ec
      }
  
      /**
-@@ -932,7 +932,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -933,7 +933,7 @@ public final class SimplePluginManager implements PluginManager {
       * @param use True if per event timing code should be used
       */
      public void useTimings(boolean use) {

--- a/patches/api/0012-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/api/0012-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -55,10 +55,10 @@ index 77f8b0889cd7039bf041fc052fba33b60aa77e17..09012ce27344c60730b9c5fcde85712a
       * Used for all administrative messages, such as an operator using a
       * command.
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index 3465bd660999caa53582e9d56a4e93ec7701a1de..ca539930905531a4ce079529c4d456bcb6fc9e8c 100644
+index 6018574cd15b802833613beefa88da15dc2730cb..e7b1895d3918487d711afcbe41d76863d85c0a62 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -116,9 +116,22 @@ public final class SimplePluginManager implements PluginManager {
+@@ -117,9 +117,22 @@ public final class SimplePluginManager implements PluginManager {
      @Override
      @NotNull
      public Plugin[] loadPlugins(@NotNull File directory) {

--- a/patches/api/0013-Player-affects-spawning-API.patch
+++ b/patches/api/0013-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5b526d602057ab70b4a058142e01a0195694c28f..f868eb1609f7c905fe6ebcf088a0a3030af55e92 100644
+index 776a3ce9a6c106fbe96cc6399b9ee2cd81b10c76..966a5626eac9305c88b1fe35d12c5fc6e28348d4 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2530,6 +2530,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2578,6 +2578,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/patches/api/0015-Expose-server-build-information.patch
+++ b/patches/api/0015-Expose-server-build-information.patch
@@ -329,10 +329,10 @@ index 9082e67324f810857db26bb89ecea7e9f866f80d..da997507b96908027c49dabc6daf7c78
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/command/defaults/VersionCommand.java b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
-index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..fd5d9881abfd930bb883120f018f76dc78b62b14 100644
+index 263208d3cba36cb80c9ee4e3022ef702ea113df2..e64bb57f74e6d6f78927be228825b3e0bdf41f48 100644
 --- a/src/main/java/org/bukkit/command/defaults/VersionCommand.java
 +++ b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
-@@ -24,8 +24,25 @@ import org.bukkit.plugin.Plugin;
+@@ -25,8 +25,25 @@ import org.bukkit.plugin.Plugin;
  import org.bukkit.plugin.PluginDescriptionFile;
  import org.bukkit.util.StringUtil;
  import org.jetbrains.annotations.NotNull;
@@ -358,7 +358,7 @@ index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..fd5d9881abfd930bb883120f018f76dc
      public VersionCommand(@NotNull String name) {
          super(name);
  
-@@ -40,7 +57,7 @@ public class VersionCommand extends BukkitCommand {
+@@ -41,7 +58,7 @@ public class VersionCommand extends BukkitCommand {
          if (!testPermission(sender)) return true;
  
          if (args.length == 0) {
@@ -367,7 +367,7 @@ index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..fd5d9881abfd930bb883120f018f76dc
              sendVersion(sender);
          } else {
              StringBuilder name = new StringBuilder();
-@@ -79,8 +96,17 @@ public class VersionCommand extends BukkitCommand {
+@@ -80,8 +97,17 @@ public class VersionCommand extends BukkitCommand {
  
      private void describeToSender(@NotNull Plugin plugin, @NotNull CommandSender sender) {
          PluginDescriptionFile desc = plugin.getDescription();
@@ -387,7 +387,7 @@ index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..fd5d9881abfd930bb883120f018f76dc
          if (desc.getDescription() != null) {
              sender.sendMessage(desc.getDescription());
          }
-@@ -146,14 +172,14 @@ public class VersionCommand extends BukkitCommand {
+@@ -147,14 +173,14 @@ public class VersionCommand extends BukkitCommand {
  
      private final ReentrantLock versionLock = new ReentrantLock();
      private boolean hasVersion = false;
@@ -404,7 +404,7 @@ index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..fd5d9881abfd930bb883120f018f76dc
                  lastCheck = System.currentTimeMillis();
                  hasVersion = false;
              } else {
-@@ -168,7 +194,7 @@ public class VersionCommand extends BukkitCommand {
+@@ -169,7 +195,7 @@ public class VersionCommand extends BukkitCommand {
                  return;
              }
              versionWaiters.add(sender);
@@ -413,7 +413,7 @@ index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..fd5d9881abfd930bb883120f018f76dc
              if (!versionTaskStarted) {
                  versionTaskStarted = true;
                  new Thread(new Runnable() {
-@@ -186,6 +212,13 @@ public class VersionCommand extends BukkitCommand {
+@@ -187,6 +213,13 @@ public class VersionCommand extends BukkitCommand {
  
      private void obtainVersion() {
          String version = Bukkit.getVersion();
@@ -427,7 +427,7 @@ index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..fd5d9881abfd930bb883120f018f76dc
          if (version == null) version = "Custom";
          String[] parts = version.substring(0, version.indexOf(' ')).split("-");
          if (parts.length == 4) {
-@@ -215,11 +248,24 @@ public class VersionCommand extends BukkitCommand {
+@@ -216,11 +249,24 @@ public class VersionCommand extends BukkitCommand {
          } else {
              setVersionMessage("Unknown version, custom build?");
          }

--- a/patches/api/0018-Add-view-distance-API.patch
+++ b/patches/api/0018-Add-view-distance-API.patch
@@ -8,10 +8,10 @@ Add per player no-tick, tick, and send view distances.
 Also add send/no-tick view distance to World.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index a9858c2559f0921613b19710135cc6e060488e96..890ae536fdaff11055b72b1be0fbf3766a41812c 100644
+index 9732929b666b0a5e1a2a41c8e8794cc4f2535e41..0a3a66e04f8785874f10a76603bff46469543688 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2941,6 +2941,66 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2968,6 +2968,66 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Set<FeatureFlag> getFeatureFlags();
  
@@ -79,10 +79,10 @@ index a9858c2559f0921613b19710135cc6e060488e96..890ae536fdaff11055b72b1be0fbf376
       * Gets all generated structures that intersect the chunk at the given
       * coordinates. <br>
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f868eb1609f7c905fe6ebcf088a0a3030af55e92..5d5d37e2ebbbe4d2641177c7d174059ba29bb688 100644
+index 966a5626eac9305c88b1fe35d12c5fc6e28348d4..b5179b6f8f65d39198c0b80e4be9aca17ca866da 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2544,6 +2544,82 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2592,6 +2592,82 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/patches/api/0023-Add-exception-reporting-event.patch
+++ b/patches/api/0023-Add-exception-reporting-event.patch
@@ -465,10 +465,10 @@ index 0000000000000000000000000000000000000000..5582999fe94c7a3dac655044ccc6d078
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-index 4205649948a9e2a72f64c3f007112245abac6d50..b3b32ce429edbf1ed040354dbe28ab86f0d24201 100644
+index 36fc2c35395c72f8b81a2a2f3265fd205384ce26..c7fa1d235cea78bda4656ed66b8d42b119cc50fb 100644
 --- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
 +++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-@@ -155,11 +155,14 @@ public class SimpleCommandMap implements CommandMap {
+@@ -156,11 +156,14 @@ public class SimpleCommandMap implements CommandMap {
              target.execute(sender, sentCommandLabel, Arrays.copyOfRange(args, 1, args.length));
              } // target.timings.stopTiming(); // Spigot // Paper
          } catch (CommandException ex) {
@@ -484,7 +484,7 @@ index 4205649948a9e2a72f64c3f007112245abac6d50..b3b32ce429edbf1ed040354dbe28ab86
          }
  
          // return true as command was handled
-@@ -238,7 +241,9 @@ public class SimpleCommandMap implements CommandMap {
+@@ -239,7 +242,9 @@ public class SimpleCommandMap implements CommandMap {
          } catch (CommandException ex) {
              throw ex;
          } catch (Throwable ex) {
@@ -496,10 +496,10 @@ index 4205649948a9e2a72f64c3f007112245abac6d50..b3b32ce429edbf1ed040354dbe28ab86
      }
  
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index ca539930905531a4ce079529c4d456bcb6fc9e8c..07a9c9e254188c251165ca84c8e961fccda01175 100644
+index e7b1895d3918487d711afcbe41d76863d85c0a62..003bece642b682985625db93cad93026352bfc66 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -527,7 +527,8 @@ public final class SimplePluginManager implements PluginManager {
+@@ -528,7 +528,8 @@ public final class SimplePluginManager implements PluginManager {
              try {
                  plugin.getPluginLoader().enablePlugin(plugin);
              } catch (Throwable ex) {
@@ -509,7 +509,7 @@ index ca539930905531a4ce079529c4d456bcb6fc9e8c..07a9c9e254188c251165ca84c8e961fc
              }
  
              HandlerList.bakeAll();
-@@ -550,32 +551,37 @@ public final class SimplePluginManager implements PluginManager {
+@@ -551,32 +552,37 @@ public final class SimplePluginManager implements PluginManager {
              try {
                  plugin.getPluginLoader().disablePlugin(plugin);
              } catch (Throwable ex) {
@@ -552,7 +552,7 @@ index ca539930905531a4ce079529c4d456bcb6fc9e8c..07a9c9e254188c251165ca84c8e961fc
              }
  
              try {
-@@ -588,6 +594,13 @@ public final class SimplePluginManager implements PluginManager {
+@@ -589,6 +595,13 @@ public final class SimplePluginManager implements PluginManager {
          }
      }
  
@@ -566,7 +566,7 @@ index ca539930905531a4ce079529c4d456bcb6fc9e8c..07a9c9e254188c251165ca84c8e961fc
      @Override
      public void clearPlugins() {
          if (true) {this.paperPluginManager.clearPlugins(); return;} // Paper
-@@ -653,7 +666,13 @@ public final class SimplePluginManager implements PluginManager {
+@@ -654,7 +667,13 @@ public final class SimplePluginManager implements PluginManager {
                              ));
                  }
              } catch (Throwable ex) {

--- a/patches/api/0044-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/api/0044-Allow-Reloading-of-Command-Aliases.patch
@@ -56,10 +56,10 @@ index bd2c7a6964722412148fae39e1b4951fc0002b9b..864c263bbd4dd6dd7c37a74b39b1a40a
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-index b3b32ce429edbf1ed040354dbe28ab86f0d24201..1424060c0a162020d4a680e0a592224561067b16 100644
+index c7fa1d235cea78bda4656ed66b8d42b119cc50fb..27243a1214bc4d7dbb46f0b9b254c8e3f8128419 100644
 --- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
 +++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-@@ -293,4 +293,11 @@ public class SimpleCommandMap implements CommandMap {
+@@ -294,4 +294,11 @@ public class SimpleCommandMap implements CommandMap {
              }
          }
      }

--- a/patches/api/0056-Fix-upstream-javadocs.patch
+++ b/patches/api/0056-Fix-upstream-javadocs.patch
@@ -155,10 +155,10 @@ index 1f039a3609a5a1208af408b0565f07664558a23f..b0734f8253ed540916db7bc75cd7dd24
       * @return an array containing all previous players
       */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 4dc687f16a8181876fb7b3e56b39a55ea5507408..98e3c12801cc36c868f08b15d1188295ea4364e0 100644
+index 9885fd1adc1f93a80d650e6d42dfa3a0b084db9f..c4f2f03ec31998d486dad1d45ef83df3f77b5e28 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2739,7 +2739,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2766,7 +2766,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      /**
       * Find the closest nearby structure of a given {@link StructureType}.
       * Finding unexplored structures can, and will, block if the world is
@@ -167,7 +167,7 @@ index 4dc687f16a8181876fb7b3e56b39a55ea5507408..98e3c12801cc36c868f08b15d1188295
       * temporarily freezing while locating an unexplored structure.
       * <p>
       * The {@code radius} is not a rigid square radius. Each structure may alter
-@@ -2773,7 +2773,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2800,7 +2800,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      /**
       * Find the closest nearby structure of a given {@link StructureType}.
       * Finding unexplored structures can, and will, block if the world is
@@ -176,7 +176,7 @@ index 4dc687f16a8181876fb7b3e56b39a55ea5507408..98e3c12801cc36c868f08b15d1188295
       * temporarily freezing while locating an unexplored structure.
       * <p>
       * The {@code radius} is not a rigid square radius. Each structure may alter
-@@ -2806,7 +2806,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2833,7 +2833,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      /**
       * Find the closest nearby structure of a given {@link Structure}. Finding
       * unexplored structures can, and will, block if the world is looking in
@@ -459,7 +459,7 @@ index ae9eaaa8e38e1d9dfc459926c7fc51ddb89de84a..b2ec535bb1b0ce0c114ddd7638b90218
      @Override
      public int getConversionTime();
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 252390260f62ee945c21267cd8717b7725158a21..cd00d2a064ee4c86b394a7861182fba9cf79cfb3 100644
+index b520489370bc1bca926f01f807f6a6725679fb8f..7d8075d7b0aeb4d10ba6879f7e1bddcec951ba31 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -478,15 +478,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -869,10 +869,10 @@ index bc71bc2d3ace0d19d730c09f05f9e0655bcee8f5..24077da8e6a7937f66eafc6779206055
  public class FurnaceBurnEvent extends BlockEvent implements Cancellable {
      private static final HandlerList handlers = new HandlerList();
 diff --git a/src/main/java/org/bukkit/event/inventory/FurnaceExtractEvent.java b/src/main/java/org/bukkit/event/inventory/FurnaceExtractEvent.java
-index 020739697a0b535cad0b15b574f77cdabbdfa3eb..a965b6a78073c5da86ad671752eff4a270029420 100644
+index 65db4991bd4789991868c0d75fea4034fed487a8..5ffd28fd24b4477a07fc9f6a3f669a6f4da9fa26 100644
 --- a/src/main/java/org/bukkit/event/inventory/FurnaceExtractEvent.java
 +++ b/src/main/java/org/bukkit/event/inventory/FurnaceExtractEvent.java
-@@ -7,7 +7,9 @@ import org.bukkit.event.block.BlockExpEvent;
+@@ -9,7 +9,9 @@ import org.bukkit.material.MaterialData;
  import org.jetbrains.annotations.NotNull;
  
  /**
@@ -1558,10 +1558,10 @@ index cdbcc8dbab2456cc2bc1f3084cbb1ced1698b7f5..d528b066c2aaa3fb097931914ff2181f
      void setPower(int power) throws IllegalArgumentException;
  
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index a23d030d2204098be17d8b18021fd0bb79b4431b..f427334c6e875a13aa53052ac1b5a746186b4ffe 100644
+index bc065cc78b69d26ac07941b8485fabe256d6286c..fe0f8459a381c35e1e7a312a2f63d6e6eda088d6 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -514,7 +514,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -547,7 +547,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Return an immutable copy of all {@link Attribute}s and their
       * {@link AttributeModifier}s for a given {@link EquipmentSlot}.<br>

--- a/patches/api/0066-Add-getI18NDisplayName-API.patch
+++ b/patches/api/0066-Add-getI18NDisplayName-API.patch
@@ -8,10 +8,10 @@ Currently the server only supports the English language. To override this,
 You must replace the language file embedded in the server jar.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 86fbc3902989a3baca851ab8c3866af445451787..e08c8b15c126a4051aba0d6ef8a53ddabe69c5c1 100644
+index d5342258086066d3b9ef404916bad8440f0cf0cd..c92843d0adb438d7a64a5d00ce67b67efd65ca14 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -235,4 +235,20 @@ public interface ItemFactory {
+@@ -220,4 +220,20 @@ public interface ItemFactory {
      @NotNull
      net.kyori.adventure.text.Component displayName(@NotNull ItemStack itemStack);
      // Paper end - Adventure
@@ -33,10 +33,10 @@ index 86fbc3902989a3baca851ab8c3866af445451787..e08c8b15c126a4051aba0d6ef8a53dda
 +    // Paper end - add getI18NDisplayName
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 22e883c8d737cf9f799c6160ff63d90f99250020..551f31fc91b91702b3093bec20113bee9660a3ec 100644
+index 730c42eddd38acec1cdbb19dfc8c675795d1e68d..da706fd72367b26b919ce08a5e118582020d4fbc 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -640,5 +640,20 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -642,5 +642,20 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public net.kyori.adventure.text.@NotNull Component displayName() {
          return Bukkit.getServer().getItemFactory().displayName(this);
      }

--- a/patches/api/0067-ensureServerConversions-API.patch
+++ b/patches/api/0067-ensureServerConversions-API.patch
@@ -7,10 +7,10 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index e08c8b15c126a4051aba0d6ef8a53ddabe69c5c1..43376f16d02e7ac26bcb0236e684fee4195dd008 100644
+index c92843d0adb438d7a64a5d00ce67b67efd65ca14..3d08beee52f2247db6f6e679206ed6a965fbf9a8 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -251,4 +251,18 @@ public interface ItemFactory {
+@@ -236,4 +236,18 @@ public interface ItemFactory {
      @Deprecated(since = "1.18.1")
      String getI18NDisplayName(@Nullable ItemStack item);
      // Paper end - add getI18NDisplayName
@@ -30,10 +30,10 @@ index e08c8b15c126a4051aba0d6ef8a53ddabe69c5c1..43376f16d02e7ac26bcb0236e684fee4
 +    // Paper end - ensure server conversions API
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 551f31fc91b91702b3093bec20113bee9660a3ec..76b6c21c68bc55d28b77dd53c988b40c9ae41258 100644
+index da706fd72367b26b919ce08a5e118582020d4fbc..29bc12cb3095282a31f01f08ac66c15b24f42524 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -559,7 +559,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -566,7 +566,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
              }
          }
  
@@ -42,7 +42,7 @@ index 551f31fc91b91702b3093bec20113bee9660a3ec..76b6c21c68bc55d28b77dd53c988b40c
      }
  
      /**
-@@ -641,6 +641,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -643,6 +643,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
          return Bukkit.getServer().getItemFactory().displayName(this);
      }
  

--- a/patches/api/0071-Handle-plugin-prefixes-in-implementation-logging-con.patch
+++ b/patches/api/0071-Handle-plugin-prefixes-in-implementation-logging-con.patch
@@ -17,10 +17,10 @@ The implementation should handle plugin prefixes by displaying
 logger names when appropriate.
 
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-index f594913e6b94f77b26a4a758c447a42d8a25b6ff..7cd9f98c042dc2bb80876af35c755f81bef34651 100644
+index 2a14522c484febcd880d00197df4359a0020dddd..f81e335a4e533221529355bec2f5d588aa79e60c 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-@@ -46,7 +46,7 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -47,7 +47,7 @@ public abstract class JavaPlugin extends PluginBase {
      private boolean naggable = true;
      private FileConfiguration newConfig = null;
      private File configFile = null;
@@ -29,7 +29,7 @@ index f594913e6b94f77b26a4a758c447a42d8a25b6ff..7cd9f98c042dc2bb80876af35c755f81
  
      public JavaPlugin() {
          // Paper start
-@@ -303,8 +303,8 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -304,8 +304,8 @@ public abstract class JavaPlugin extends PluginBase {
          this.dataFolder = dataFolder;
          this.classLoader = classLoader;
          this.configFile = new File(dataFolder, "config.yml");

--- a/patches/api/0073-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
+++ b/patches/api/0073-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
@@ -67,10 +67,10 @@ index 0000000000000000000000000000000000000000..087ee57fe5485bc760fadd45a176d4d9
 +
 +}
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-index 7cd9f98c042dc2bb80876af35c755f81bef34651..5cd236965de12392d8c7aa81307c0ff1cc8673b1 100644
+index f81e335a4e533221529355bec2f5d588aa79e60c..d359ea9b02952f981b9cf9d778c56eb995454c60 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-@@ -291,10 +291,10 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -292,10 +292,10 @@ public abstract class JavaPlugin extends PluginBase {
              .orElseThrow();
      }
      public final void init(@NotNull PluginLoader loader, @NotNull Server server, @NotNull PluginDescriptionFile description, @NotNull File dataFolder, @NotNull File file, @NotNull ClassLoader classLoader) {
@@ -83,7 +83,7 @@ index 7cd9f98c042dc2bb80876af35c755f81bef34651..5cd236965de12392d8c7aa81307c0ff1
      // Paper end
          this.loader = DummyPluginLoaderImplHolder.INSTANCE; // Paper
          this.server = server;
-@@ -304,7 +304,7 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -305,7 +305,7 @@ public abstract class JavaPlugin extends PluginBase {
          this.classLoader = classLoader;
          this.configFile = new File(dataFolder, "config.yml");
          this.pluginMeta = configuration; // Paper

--- a/patches/api/0092-Player.setPlayerProfile-API.patch
+++ b/patches/api/0092-Player.setPlayerProfile-API.patch
@@ -93,10 +93,10 @@ index aeb5399b1c5e90079b199a591f7986acdf111cba..e7f618a8d7245494e178052c6a63e1b1
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3dcc0a7ff628711c1b8349c5b98496fccd061787..3173e047fa4c7b295546532cea9e10b016adaf98 100644
+index 03c1b7331bec5c52afb853477e857f62a10cb4b9..631db41f2b35d3ddc96f0c80979958922be01adf 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3061,6 +3061,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3109,6 +3109,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      }
      // Paper end
  

--- a/patches/api/0095-Add-openSign-method-to-HumanEntity.patch
+++ b/patches/api/0095-Add-openSign-method-to-HumanEntity.patch
@@ -36,10 +36,10 @@ index c426bdea5ef71a095cf2af9a8a83a162db3c05b7..2308fa3ca898bcb6c0ac2d4853f82a33
      /**
       * Make the entity drop the item in their hand.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 56eed06cd3dbb238330973c1428bffc6d5286019..d68a055ef2b309da6db2de385f27d841adca1f66 100644
+index 631db41f2b35d3ddc96f0c80979958922be01adf..9152d19adf8869ddac26490929088627c257bd4e 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3022,10 +3022,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3070,10 +3070,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Open a Sign for editing by the Player.
       *

--- a/patches/api/0099-Additional-world.getNearbyEntities-API-s.patch
+++ b/patches/api/0099-Additional-world.getNearbyEntities-API-s.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Additional world.getNearbyEntities API's
 Provides more methods to get nearby entities, and filter by types and predicates
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 98e3c12801cc36c868f08b15d1188295ea4364e0..c489140bffdfdfa1e34e71489d308ed10cf10b21 100644
+index c4f2f03ec31998d486dad1d45ef83df3f77b5e28..9cf4823ddf1b8291e8c11c39c02c1fed58c18936 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -1,6 +1,9 @@
@@ -19,7 +19,7 @@ index 98e3c12801cc36c868f08b15d1188295ea4364e0..c489140bffdfdfa1e34e71489d308ed1
  import java.util.Collection;
  import java.util.HashMap;
  import java.util.List;
-@@ -636,6 +639,238 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -663,6 +666,238 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Collection<Entity> getEntitiesByClasses(@NotNull Class<?>... classes);
  

--- a/patches/api/0101-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0101-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -621,10 +621,10 @@ index 4a06ed9c769acb2eb4c6f4b76c84dc2e63176010..c5e3a8143a166d426d87fa3d0f0b3d4f
       * Options which can be applied to dust particles - a particle
       * color and size.
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index c489140bffdfdfa1e34e71489d308ed10cf10b21..b6d08d50c26aa0e69d2479d188fc3c690e8ed357 100644
+index 9cf4823ddf1b8291e8c11c39c02c1fed58c18936..44a74f15bea60ecd8380520e8faaea41a6c261c5 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2921,7 +2921,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2948,7 +2948,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
       */

--- a/patches/api/0108-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/api/0108-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 76b6c21c68bc55d28b77dd53c988b40c9ae41258..8cf07089bc3c60262ff1c4c6740310b48aa4169d 100644
+index 29bc12cb3095282a31f01f08ac66c15b24f42524..a11cc672fa1116addab8b43b7a4360ea182a0584 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -668,5 +668,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -670,5 +670,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public String getI18NDisplayName() {
          return Bukkit.getServer().getItemFactory().getI18NDisplayName(this);
      }

--- a/patches/api/0115-Expand-Explosions-API.patch
+++ b/patches/api/0115-Expand-Explosions-API.patch
@@ -108,10 +108,10 @@ index 3161eae2fa5f03b7d3a5e9945ab659c15cf568c6..af737017ee397f80c44ee02c6cc60cef
      /**
       * Returns a list of entities within a bounding box centered around a Location.
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index b6d08d50c26aa0e69d2479d188fc3c690e8ed357..a735dcdb9a0684accf81674b4810928ff20eb7e6 100644
+index 44a74f15bea60ecd8380520e8faaea41a6c261c5..50c1e4957f66826feb0a2eb04293dbd6b5595700 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1397,6 +1397,88 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1424,6 +1424,88 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public boolean createExplosion(@NotNull Location loc, float power, boolean setFire);
  

--- a/patches/api/0116-ItemStack-API-additions-for-quantity-flags-lore.patch
+++ b/patches/api/0116-ItemStack-API-additions-for-quantity-flags-lore.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack API additions for quantity/flags/lore
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 8cf07089bc3c60262ff1c4c6740310b48aa4169d..bb77d65fd42f9b53ef88537e814bea652bb230de 100644
+index a11cc672fa1116addab8b43b7a4360ea182a0584..991448ce7d1455b02889cc8da345e8d7200a8215 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -676,5 +676,185 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -678,5 +678,185 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
          // Requires access to NMS
          return ensureServerConversions().getMaxItemUseDuration();
      }

--- a/patches/api/0119-Add-World.getEntity-UUID-API.patch
+++ b/patches/api/0119-Add-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index a735dcdb9a0684accf81674b4810928ff20eb7e6..b34eca520c34c70152860f5bad978cf3bed044fa 100644
+index 50c1e4957f66826feb0a2eb04293dbd6b5595700..fd61be5d75dadb91b5a4bb8dfe246c7ec7aa2f1f 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -905,6 +905,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -932,6 +932,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Collection<Entity> getNearbyEntities(@NotNull Location location, double x, double y, double z);
  

--- a/patches/api/0133-Provide-Chunk-Coordinates-as-a-Long-API.patch
+++ b/patches/api/0133-Provide-Chunk-Coordinates-as-a-Long-API.patch
@@ -7,10 +7,10 @@ Allows you to easily access the chunks X/z as a long, and a method
 to look up by the long key too.
 
 diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
-index a25f112f4d679946ddcb5ec9b4d0a0e2d1795bd3..57976bbe682d2309f7d15d5dcd3ad7f8049429ec 100644
+index 20ed1c40437cbf8449dd4d7876086ccb6407b470..8764441ec1bae67a029b13c4c98246574ba32ef5 100644
 --- a/src/main/java/org/bukkit/Chunk.java
 +++ b/src/main/java/org/bukkit/Chunk.java
-@@ -35,6 +35,32 @@ public interface Chunk extends PersistentDataHolder {
+@@ -36,6 +36,32 @@ public interface Chunk extends PersistentDataHolder {
       */
      int getZ();
  
@@ -44,7 +44,7 @@ index a25f112f4d679946ddcb5ec9b4d0a0e2d1795bd3..57976bbe682d2309f7d15d5dcd3ad7f8
       * Gets the world containing this chunk
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index b34eca520c34c70152860f5bad978cf3bed044fa..273c50b6e4f26457415779000cf09aeaffd21733 100644
+index fd61be5d75dadb91b5a4bb8dfe246c7ec7aa2f1f..4ecbfe4d28316527ff00e206941da9c0fc9235d0 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -182,6 +182,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient

--- a/patches/api/0134-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
+++ b/patches/api/0134-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ability to get Tile Entities from a chunk without snapshots
 
 
 diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
-index 57976bbe682d2309f7d15d5dcd3ad7f8049429ec..546888898d9d6827079fe041c7bc6eb4e1e4605c 100644
+index 8764441ec1bae67a029b13c4c98246574ba32ef5..c2eb2edd87b4087bfcdffd98f0f8904fbfd4e657 100644
 --- a/src/main/java/org/bukkit/Chunk.java
 +++ b/src/main/java/org/bukkit/Chunk.java
-@@ -124,7 +124,30 @@ public interface Chunk extends PersistentDataHolder {
+@@ -125,7 +125,30 @@ public interface Chunk extends PersistentDataHolder {
       * @return The tile entities.
       */
      @NotNull

--- a/patches/api/0143-Async-Chunks-API.patch
+++ b/patches/api/0143-Async-Chunks-API.patch
@@ -8,10 +8,10 @@ Adds API's to load or generate chunks asynchronously.
 Also adds utility methods to Entity to teleport asynchronously.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 94c91385810642dcd120e534b5a20e21fbcd963a..727aa59b9080d53b9e1f6c619d73afcd077b59da 100644
+index 1cc5bdd63a97a6bb62b1d29aca01658359bd15f1..6242b64416fdea1f3fd6378ba26ed7bb33ab4cc4 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -950,6 +950,472 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -977,6 +977,472 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      }
      // Paper end - additional getNearbyEntities API
  
@@ -485,7 +485,7 @@ index 94c91385810642dcd120e534b5a20e21fbcd963a..727aa59b9080d53b9e1f6c619d73afcd
       * Get a list of all players in this World
       *
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 1e43deadce5a1a0e97521b1f69fee3106f5a0b9e..f1fc42ad24648ee481b9a5d4c4cc58ae8c0a93c1 100644
+index 48177547ec93fb5a807897a6fb472582a78f3978..99e1f17fddf9cebe7057998d1635804c55f18312 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -168,6 +168,39 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent

--- a/patches/api/0145-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0145-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 9dcec906cea7d4eb6da99ef3100a98218a280594..92a83edc03fa8d11f026ac312b989329fa6a7e88 100644
+index 105c076bdb6396c0b630b341ff306214d5d61567..f5bd443d3ed2b9d822dcd24e648868b9e1f4f6d9 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3263,6 +3263,28 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3311,6 +3311,28 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void setPlayerProfile(com.destroystokyo.paper.profile.@NotNull PlayerProfile profile);
      // Paper end - Player Profile API
  

--- a/patches/api/0148-Performance-Concurrency-Improvements-to-Permissions.patch
+++ b/patches/api/0148-Performance-Concurrency-Improvements-to-Permissions.patch
@@ -18,12 +18,12 @@ Optimized it to simply be a single get call cutting permission map
 lookups in half.
 
 diff --git a/src/main/java/org/bukkit/permissions/PermissibleBase.java b/src/main/java/org/bukkit/permissions/PermissibleBase.java
-index 728fc46daf7a38f13906353bdd7362133853af92..cd3296fea01648592d2af89b3d80135acb6d0958 100644
+index d0fd41a0ddee550cf880bb212b15dfe79cb4e683..75b77cc4fe189b4b6baa1af3663dc492e992a266 100644
 --- a/src/main/java/org/bukkit/permissions/PermissibleBase.java
 +++ b/src/main/java/org/bukkit/permissions/PermissibleBase.java
-@@ -72,8 +72,11 @@ public class PermissibleBase implements Permissible {
+@@ -73,8 +73,11 @@ public class PermissibleBase implements Permissible {
  
-         String name = inName.toLowerCase(java.util.Locale.ENGLISH);
+         String name = inName.toLowerCase(Locale.ROOT);
  
 -        if (isPermissionSet(name)) {
 -            return permissions.get(name).getValue();
@@ -35,9 +35,9 @@ index 728fc46daf7a38f13906353bdd7362133853af92..cd3296fea01648592d2af89b3d80135a
          } else {
              Permission perm = Bukkit.getServer().getPluginManager().getPermission(name);
  
-@@ -93,15 +96,18 @@ public class PermissibleBase implements Permissible {
+@@ -94,15 +97,18 @@ public class PermissibleBase implements Permissible {
  
-         String name = perm.getName().toLowerCase(java.util.Locale.ENGLISH);
+         String name = perm.getName().toLowerCase(Locale.ROOT);
  
 -        if (isPermissionSet(name)) {
 -            return permissions.get(name).getValue();
@@ -57,7 +57,7 @@ index 728fc46daf7a38f13906353bdd7362133853af92..cd3296fea01648592d2af89b3d80135a
          if (name == null) {
              throw new IllegalArgumentException("Permission name cannot be null");
          } else if (plugin == null) {
-@@ -120,7 +126,7 @@ public class PermissibleBase implements Permissible {
+@@ -121,7 +127,7 @@ public class PermissibleBase implements Permissible {
  
      @Override
      @NotNull
@@ -66,7 +66,7 @@ index 728fc46daf7a38f13906353bdd7362133853af92..cd3296fea01648592d2af89b3d80135a
          if (plugin == null) {
              throw new IllegalArgumentException("Plugin cannot be null");
          } else if (!plugin.isEnabled()) {
-@@ -136,7 +142,7 @@ public class PermissibleBase implements Permissible {
+@@ -137,7 +143,7 @@ public class PermissibleBase implements Permissible {
      }
  
      @Override
@@ -75,7 +75,7 @@ index 728fc46daf7a38f13906353bdd7362133853af92..cd3296fea01648592d2af89b3d80135a
          if (attachment == null) {
              throw new IllegalArgumentException("Attachment cannot be null");
          }
-@@ -155,7 +161,7 @@ public class PermissibleBase implements Permissible {
+@@ -156,7 +162,7 @@ public class PermissibleBase implements Permissible {
      }
  
      @Override
@@ -84,7 +84,7 @@ index 728fc46daf7a38f13906353bdd7362133853af92..cd3296fea01648592d2af89b3d80135a
          clearPermissions();
          Set<Permission> defaults = Bukkit.getServer().getPluginManager().getDefaultPermissions(isOp());
          Bukkit.getServer().getPluginManager().subscribeToDefaultPerms(isOp(), parent);
-@@ -204,7 +210,7 @@ public class PermissibleBase implements Permissible {
+@@ -205,7 +211,7 @@ public class PermissibleBase implements Permissible {
  
      @Override
      @Nullable
@@ -93,7 +93,7 @@ index 728fc46daf7a38f13906353bdd7362133853af92..cd3296fea01648592d2af89b3d80135a
          if (name == null) {
              throw new IllegalArgumentException("Permission name cannot be null");
          } else if (plugin == null) {
-@@ -224,7 +230,7 @@ public class PermissibleBase implements Permissible {
+@@ -225,7 +231,7 @@ public class PermissibleBase implements Permissible {
  
      @Override
      @Nullable
@@ -102,7 +102,7 @@ index 728fc46daf7a38f13906353bdd7362133853af92..cd3296fea01648592d2af89b3d80135a
          if (plugin == null) {
              throw new IllegalArgumentException("Plugin cannot be null");
          } else if (!plugin.isEnabled()) {
-@@ -244,7 +250,7 @@ public class PermissibleBase implements Permissible {
+@@ -245,7 +251,7 @@ public class PermissibleBase implements Permissible {
  
      @Override
      @NotNull

--- a/patches/api/0152-Add-Material-Tags.patch
+++ b/patches/api/0152-Add-Material-Tags.patch
@@ -12,10 +12,10 @@ Co-authored-by: Layla Silbernberg <livsilbernberg@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/MaterialSetTag.java b/src/main/java/com/destroystokyo/paper/MaterialSetTag.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a02a02aa0c87e0f0ed9e509e4dcab01565b3d92a
+index 0000000000000000000000000000000000000000..28282090c8b3668c11faefa0523f9e4ad9e43c42
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/MaterialSetTag.java
-@@ -0,0 +1,97 @@
+@@ -0,0 +1,100 @@
 +/*
 + * Copyright (c) 2018 Daniel Ennis (Aikar) MIT License
 + */
@@ -36,6 +36,7 @@ index 0000000000000000000000000000000000000000..a02a02aa0c87e0f0ed9e509e4dcab015
 +import java.util.function.Predicate;
 +import java.util.stream.Collectors;
 +import java.util.stream.Stream;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -83,12 +84,14 @@ index 0000000000000000000000000000000000000000..a02a02aa0c87e0f0ed9e509e4dcab015
 +
 +    @NotNull
 +    @Override
++    @ApiStatus.Internal
 +    protected Set<Material> getAllPossibleValues() {
 +        return Stream.of(Material.values()).collect(Collectors.toSet());
 +    }
 +
 +    @Override
 +    @NotNull
++    @ApiStatus.Internal
 +    protected String getName(@NotNull Material value) {
 +        return value.name();
 +    }
@@ -838,10 +841,10 @@ index 0000000000000000000000000000000000000000..be212b4fbeabab32a4dab6ae554768c3
 +}
 diff --git a/src/main/java/io/papermc/paper/tag/BaseTag.java b/src/main/java/io/papermc/paper/tag/BaseTag.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..794787912325ae32b3cfc8217bc3fc2159ceabd5
+index 0000000000000000000000000000000000000000..262b7f7e2c3cf39006392dd5197d4595a0bfb507
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/tag/BaseTag.java
-@@ -0,0 +1,181 @@
+@@ -0,0 +1,184 @@
 +package io.papermc.paper.tag;
 +
 +import com.google.common.collect.Lists;
@@ -849,6 +852,7 @@ index 0000000000000000000000000000000000000000..794787912325ae32b3cfc8217bc3fc21
 +import org.bukkit.Keyed;
 +import org.bukkit.NamespacedKey;
 +import org.bukkit.Tag;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +import java.util.Collection;
@@ -1018,9 +1022,11 @@ index 0000000000000000000000000000000000000000..794787912325ae32b3cfc8217bc3fc21
 +    }
 +
 +    @NotNull
++    @ApiStatus.Internal
 +    protected abstract Set<T> getAllPossibleValues();
 +
 +    @NotNull
++    @ApiStatus.Internal
 +    protected abstract String getName(@NotNull T value);
 +}
 diff --git a/src/main/java/io/papermc/paper/tag/EntitySetTag.java b/src/main/java/io/papermc/paper/tag/EntitySetTag.java

--- a/patches/api/0155-Add-sun-related-API.patch
+++ b/patches/api/0155-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 5efe33cef4d9c153d760fc71606721ff8abafbfc..b6ca63afb74b345e381d35646cc8faf52a2c7cbc 100644
+index 6242b64416fdea1f3fd6378ba26ed7bb33ab4cc4..fcdc5d83621acff5f9210585455be1ea50abb77c 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1771,6 +1771,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1798,6 +1798,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public void setFullTime(long time);
  

--- a/patches/api/0165-Add-ItemStack-Recipe-API-helper-methods.patch
+++ b/patches/api/0165-Add-ItemStack-Recipe-API-helper-methods.patch
@@ -9,10 +9,10 @@ Redirects some of upstream's APIs to these new methods to avoid
 usage of magic values and the deprecated RecipeChoice#getItemStack
 
 diff --git a/src/main/java/org/bukkit/inventory/RecipeChoice.java b/src/main/java/org/bukkit/inventory/RecipeChoice.java
-index 6734bc9d7a6eee8ee40419ae3fe245b67eabaca6..db8bcc66bdc4bedfffb4705db6338eda4c0ad29a 100644
+index a98fc2ffdae1a2f8f3a312bed95268e105f7f791..91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32 100644
 --- a/src/main/java/org/bukkit/inventory/RecipeChoice.java
 +++ b/src/main/java/org/bukkit/inventory/RecipeChoice.java
-@@ -146,8 +146,6 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -157,8 +157,6 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
      /**
       * Represents a choice that will be valid only if one of the stacks is
       * exactly matched (aside from stack size).

--- a/patches/api/0171-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0171-Fix-Spigot-annotation-mistakes.patch
@@ -12,10 +12,10 @@ that continues to have use (internally).
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Art.java b/src/main/java/org/bukkit/Art.java
-index ac420f0059fc50d3e1294f85df7515c9e17ff78f..24daba85ce4129fb0babe67570059ca8119360c0 100644
+index 0c20c6bf442de6015d673f5e4e7695ec6d96895e..e6e1606a202a825a45d2f5256441668ced90d7fa 100644
 --- a/src/main/java/org/bukkit/Art.java
 +++ b/src/main/java/org/bukkit/Art.java
-@@ -75,9 +75,9 @@ public enum Art implements Keyed {
+@@ -76,9 +76,9 @@ public enum Art implements Keyed {
       * Get the ID of this painting.
       *
       * @return The ID of this painting
@@ -27,7 +27,7 @@ index ac420f0059fc50d3e1294f85df7515c9e17ff78f..24daba85ce4129fb0babe67570059ca8
      public int getId() {
          return id;
      }
-@@ -93,9 +93,9 @@ public enum Art implements Keyed {
+@@ -94,9 +94,9 @@ public enum Art implements Keyed {
       *
       * @param id The ID
       * @return The painting
@@ -40,7 +40,7 @@ index ac420f0059fc50d3e1294f85df7515c9e17ff78f..24daba85ce4129fb0babe67570059ca8
      public static Art getById(int id) {
          return BY_ID.get(id);
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f1a4e9a4b54757b9b73dd3a66ef6083a7119378d..2f023dcab9fe1ea220ba04e575bb5efe78adbd45 100644
+index c93b84b4928ea8690602d7904eb9de4418d9e20e..82e973a8d5700c97eac3592981560f134127f6a8 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -879,9 +879,8 @@ public final class Bukkit {
@@ -269,7 +269,7 @@ index f9c9ae463aacd593e3aa9caf037ea1e23d56c780..f8ae143acbf586d5279b44f7311ca97f
  
      /**
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 02b4ffa6b918269bd64f7c518fcceef1f6990737..f0878c7539696cc0676e6010e88914d3850acf20 100644
+index c30600666e7b32b8b4ba1e20ede04fd5ebd5a692..eec6c9cd7da6938351905129bb5a66f49a257d01 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -46,7 +46,7 @@ public class Location implements Cloneable, ConfigurationSerializable, io.paperm
@@ -300,7 +300,7 @@ index 02b4ffa6b918269bd64f7c518fcceef1f6990737..f0878c7539696cc0676e6010e88914d3
          if (this.world == null) {
              return null;
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index fb6e030af69b085946a029d89347b19b121f6a14..7458278ad620d534b205438062327463caaa9bfc 100644
+index f01f8a3cfb40ca7e7d6b6714b678b19779bc866c..5ccca18290ffc3d0933e579fbb31bd64c527488d 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4749,20 +4749,20 @@ public enum Material implements Keyed, Translatable {
@@ -453,10 +453,10 @@ index 48aecc9421c500137bbef1dfe3bec8de277c3ff9..aff858346776386f1288b648b221404f
          return note;
      }
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 57dfc408fcf9036808af26bd1255afe104d40286..62a7748b7509907ac8c8c0026f0cc5911f530eb7 100644
+index e723bafe37b917eff0e0795c3c8c2467fe4bb231..3e0d1026e2581b4a8d23d55b7c98b028a58d22dd 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -219,14 +219,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -220,14 +220,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @see TrimMaterial
       */
@@ -471,7 +471,7 @@ index 57dfc408fcf9036808af26bd1255afe104d40286..62a7748b7509907ac8c8c0026f0cc591
      Registry<TrimPattern> TRIM_PATTERN = Bukkit.getRegistry(TrimPattern.class);
      /**
       * Damage types.
-@@ -328,8 +326,11 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -329,8 +327,11 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @param input non-null input
       * @return registered object or null if does not exist
@@ -498,7 +498,7 @@ index 6277451c3c6c551078c237cd767b6d70c4f585ea..10f5cfb1885833a1d2c1027c03974da4
      CRACKED(0x0),
      GLYPHED(0x1),
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 82f4359bc93b97304fbcbf2406ae69cfb0d74a0b..6d72b50b12315caf29842b5cf52e67715de8877d 100644
+index fc2c2941d247a1592194f11fddc1dc547269dcc7..e11398ca751d4d8b043b73f78f56b837229f70af 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -740,9 +740,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -592,7 +592,7 @@ index e455eb21abf121dc6ff10ff8a13dd06f67096a8f..bbc01e7c192ae6689c301670047ff114
          return origin;
      }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index b6ca63afb74b345e381d35646cc8faf52a2c7cbc..a523d1725f175c924ab1a7d544d389ec81b68bcf 100644
+index fcdc5d83621acff5f9210585455be1ea50abb77c..216995288f6b8b407ef8240411b5ed4713379a7a 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -418,9 +418,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -606,7 +606,7 @@ index b6ca63afb74b345e381d35646cc8faf52a2c7cbc..a523d1725f175c924ab1a7d544d389ec
      public boolean refreshChunk(int x, int z);
  
      /**
-@@ -3770,6 +3769,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3797,6 +3796,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      StructureSearchResult locateNearestStructure(@NotNull Location origin, @NotNull Structure structure, int radius, boolean findUnexplored);
  
      // Spigot start
@@ -614,7 +614,7 @@ index b6ca63afb74b345e381d35646cc8faf52a2c7cbc..a523d1725f175c924ab1a7d544d389ec
      public class Spigot {
  
          /**
-@@ -3803,7 +3803,11 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3830,7 +3830,11 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
          }
      }
  
@@ -626,7 +626,7 @@ index b6ca63afb74b345e381d35646cc8faf52a2c7cbc..a523d1725f175c924ab1a7d544d389ec
      Spigot spigot();
      // Spigot end
  
-@@ -4021,9 +4025,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -4048,9 +4052,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
           * Gets the dimension ID of this environment
           *
           * @return dimension ID
@@ -638,7 +638,7 @@ index b6ca63afb74b345e381d35646cc8faf52a2c7cbc..a523d1725f175c924ab1a7d544d389ec
          public int getId() {
              return id;
          }
-@@ -4033,9 +4037,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -4060,9 +4064,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
           *
           * @param id The ID of the environment
           * @return The environment
@@ -651,7 +651,7 @@ index b6ca63afb74b345e381d35646cc8faf52a2c7cbc..a523d1725f175c924ab1a7d544d389ec
          public static Environment getEnvironment(int id) {
              return lookup.get(id);
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index a71001677e2b1b0b6225a7be63b8ea5ce4456862..c7ef0386a09a07a2317c56274ed41218dfd7153d 100644
+index bb3cf2c5e2acbcd7cf53ad8551a5b11fa6104ada..e4393f2bd71308a58305cb870271d6a647ffcd92 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -526,7 +526,7 @@ public interface Block extends Metadatable, Translatable {
@@ -730,10 +730,10 @@ index b90f5dc345ad2cdd3ae353dc57f42a14c231d18a..a7b915ded9154d53ac8ca599119c1699
      public static PistonMoveReaction getById(int id) {
          return byId.get(id);
 diff --git a/src/main/java/org/bukkit/enchantments/Enchantment.java b/src/main/java/org/bukkit/enchantments/Enchantment.java
-index a82d6f469aca02fb28b1b3ad84dc40415f1f1ade..f4ec7891bdcedc73bff6938e3eddb7ee43d23ec1 100644
+index 9db24da6836de45b7aff8d89782e6b0e1bc5391b..6a89c75d913ee1ef5b368064a4cdc1ec0c96ce2b 100644
 --- a/src/main/java/org/bukkit/enchantments/Enchantment.java
 +++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
-@@ -273,7 +273,7 @@ public abstract class Enchantment implements Keyed, Translatable {
+@@ -274,7 +274,7 @@ public abstract class Enchantment implements Keyed, Translatable {
       * @deprecated enchantment groupings are now managed by tags, not categories
       */
      @NotNull
@@ -767,10 +767,10 @@ index 3afe2787de576f7190d87c796bea0ab34dc30248..58191017244f3949f6174fb108e3a245
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/EntityType.java b/src/main/java/org/bukkit/entity/EntityType.java
-index c308f6a9f36ae8d108d583179464e078e09bf051..dd410ff2cad3dc34ef9d2a37d72417c7b213de63 100644
+index bd6f99128728d2607530802caee438ae1fe0d2a3..afbd43ef062efae32c112ca8299b05a3796ee4fc 100644
 --- a/src/main/java/org/bukkit/entity/EntityType.java
 +++ b/src/main/java/org/bukkit/entity/EntityType.java
-@@ -393,9 +393,9 @@ public enum EntityType implements Keyed, Translatable {
+@@ -394,9 +394,9 @@ public enum EntityType implements Keyed, Translatable {
       *
       * @param name the entity type's name
       * @return the matching entity type or null
@@ -826,7 +826,7 @@ index bafef53c1d449135f1300c8c8fbb06f482ba67e1..f50aaddf8582be55fd4860ad374d8f22
 +@Deprecated(forRemoval = true) // Paper
  public interface LingeringPotion extends ThrownPotion { }
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 8cd525dd8ded0ddbd405c66e9c0fbeb40f788521..2b791a093a1220be80eb6b9d7202f6596fcf2dd6 100644
+index b5ea7b60b47f056553a1cec766c57e0f75735633..ec35111df4b38fd55cc34f4baedebcf39c7fc92b 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
 @@ -716,7 +716,9 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
@@ -874,7 +874,7 @@ index 95c79c5fa0c4e30201f887da6467ce5f81c8a255..7f9c4d4b430a3f0276461346ff2621ba
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 92a83edc03fa8d11f026ac312b989329fa6a7e88..33547e9e3f8f7c906a5d91b75eb62327cc1f2a3a 100644
+index f5bd443d3ed2b9d822dcd24e648868b9e1f4f6d9..a0ea2ba0995a54fa12037d2a2ebe8ef9e2dd4bd0 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1635,11 +1635,8 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -1023,7 +1023,7 @@ index e1123295b9511a2c610a1baf7195638f7f3e64c4..273ae8e5da0a858d3b82d1b0f5992318
      public void setCancelled(boolean cancel) {
          this.cancel = cancel;
 diff --git a/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java b/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
-index 775e3223aa5054f1883403e50c8f2241d97b1285..5d4817d2a3b709f1a1a1162309a1c923bd09cc1d 100644
+index 56e6024f1fa64569481543dc076e575bb512eef0..7fccda2a48f7bac7da54862c5cb8f1b484cc9da9 100644
 --- a/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
 @@ -19,22 +19,27 @@ public class ProjectileHitEvent extends EntityEvent implements Cancellable {
@@ -1399,10 +1399,10 @@ index 002acfbdce1db10f7ba1b6a013e678f504ac6e69..8d14426eb1ebea27058d5f22ea652f22
          return getPlayer().getItemOnCursor();
      }
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index b6b90f2ef735407ac41efa21371cfd6b07c2c66e..4c4e52b2c200408c4e33a141e1eed78126ceaaee 100644
+index 3d08beee52f2247db6f6e679206ed6a965fbf9a8..1b4f9b93860e58762ac28715adad5a67298b06d7 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -30,7 +30,7 @@ public interface ItemFactory {
+@@ -29,7 +29,7 @@ public interface ItemFactory {
       * @return a new ItemMeta that could be applied to an item stack of the
       *     specified material
       */
@@ -1412,7 +1412,7 @@ index b6b90f2ef735407ac41efa21371cfd6b07c2c66e..4c4e52b2c200408c4e33a141e1eed781
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index bb77d65fd42f9b53ef88537e814bea652bb230de..d758cea1d8e88937678dbfd0ac72d49b6c160fe0 100644
+index 991448ce7d1455b02889cc8da345e8d7200a8215..8fba0996b371276b281c86570dff01d652915247 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -10,6 +10,7 @@ import org.bukkit.Material;
@@ -1423,7 +1423,7 @@ index bb77d65fd42f9b53ef88537e814bea652bb230de..d758cea1d8e88937678dbfd0ac72d49b
  import org.bukkit.Utility;
  import org.bukkit.configuration.serialization.ConfigurationSerializable;
  import org.bukkit.enchantments.Enchantment;
-@@ -172,8 +173,10 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -179,8 +180,10 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
       * Gets the MaterialData for this stack of items
       *
       * @return MaterialData for this item
@@ -1434,7 +1434,7 @@ index bb77d65fd42f9b53ef88537e814bea652bb230de..d758cea1d8e88937678dbfd0ac72d49b
      public MaterialData getData() {
          Material mat = Bukkit.getUnsafe().toLegacy(getType());
          if (data == null && mat != null && mat.getData() != null) {
-@@ -187,7 +190,9 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -194,7 +197,9 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
       * Sets the MaterialData for this stack of items
       *
       * @param data New MaterialData for this item
@@ -1444,7 +1444,7 @@ index bb77d65fd42f9b53ef88537e814bea652bb230de..d758cea1d8e88937678dbfd0ac72d49b
      public void setData(@Nullable MaterialData data) {
          if (data == null) {
              this.data = data;
-@@ -567,7 +572,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -574,7 +579,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
       *
       * @return a copy of the current ItemStack's ItemData
       */
@@ -1587,10 +1587,10 @@ index 597a18a767b68b47e81454b7d44613c7178c1366..bc3440eb72127824b3961fbdae583bb6
      public ItemStack getInput() {
          return this.ingredient.getItemStack();
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index f427334c6e875a13aa53052ac1b5a746186b4ffe..abe5c56c09a29cb3dcd35936045938c1b88c8500 100644
+index fe0f8459a381c35e1e7a312a2f63d6e6eda088d6..27dfb5704b190f469dbe3d8fccd3cf47999b7133 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -142,6 +142,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -143,6 +143,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Checks for existence of a localized name.
       *
@@ -1598,7 +1598,7 @@ index f427334c6e875a13aa53052ac1b5a746186b4ffe..abe5c56c09a29cb3dcd35936045938c1
       * @return true if this has a localized name
       * @deprecated meta no longer exists
       */
-@@ -154,6 +155,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -155,6 +156,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * Plugins should check that hasLocalizedName() returns <code>true</code>
       * before calling this method.
       *
@@ -1606,7 +1606,7 @@ index f427334c6e875a13aa53052ac1b5a746186b4ffe..abe5c56c09a29cb3dcd35936045938c1
       * @return the localized name that is set
       * @deprecated meta no longer exists
       */
-@@ -164,6 +166,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -165,6 +167,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Sets the localized name.
       *
@@ -1858,10 +1858,10 @@ index 0ea9c6b2420a0f990bd1fdf50fc015e37a7060d8..e99644eae1c662b117aa19060d2484ac
  
      /**
 diff --git a/src/main/java/org/bukkit/potion/PotionEffectType.java b/src/main/java/org/bukkit/potion/PotionEffectType.java
-index 7feeb33f8938be968b20c19437723d8c968690fa..e045e6a74821f291938cc6af86e313c1f1c4626c 100644
+index 6bbfebab2ee2b59b3f3213789ecb59e2e7f2680a..42d893ce75a75fe46a4e52b17dc405f5b609ab86 100644
 --- a/src/main/java/org/bukkit/potion/PotionEffectType.java
 +++ b/src/main/java/org/bukkit/potion/PotionEffectType.java
-@@ -270,9 +270,9 @@ public abstract class PotionEffectType implements Keyed, Translatable {
+@@ -279,9 +279,9 @@ public abstract class PotionEffectType implements Keyed, Translatable {
       * Returns the unique ID of this type.
       *
       * @return Unique ID
@@ -1873,7 +1873,7 @@ index 7feeb33f8938be968b20c19437723d8c968690fa..e045e6a74821f291938cc6af86e313c1
      public abstract int getId();
  
      /**
-@@ -308,9 +308,9 @@ public abstract class PotionEffectType implements Keyed, Translatable {
+@@ -317,9 +317,9 @@ public abstract class PotionEffectType implements Keyed, Translatable {
       *
       * @param id Unique ID to fetch
       * @return Resulting type, or null if not found.

--- a/patches/api/0187-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/api/0187-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -20,10 +20,10 @@ index da997507b96908027c49dabc6daf7c787dcad95d..cb7aef53cbffc76dea9fec28445ea8ae
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index d758cea1d8e88937678dbfd0ac72d49b6c160fe0..066f99a1f4cc42cf0e87d495f97a0685817dfa18 100644
+index 8fba0996b371276b281c86570dff01d652915247..adb6576ba60219c15bcfddae03cd90e24906b01a 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -659,6 +659,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -661,6 +661,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
          return Bukkit.getServer().getItemFactory().ensureServerConversions(this);
      }
  

--- a/patches/api/0188-Add-Player-Client-Options-API.patch
+++ b/patches/api/0188-Add-Player-Client-Options-API.patch
@@ -231,10 +231,10 @@ index 0000000000000000000000000000000000000000..1757055d821d9ec7c728aa6c1b52fa6a
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 33547e9e3f8f7c906a5d91b75eb62327cc1f2a3a..7429666fd1af4f4a924cf93572df5b826782af05 100644
+index a0ea2ba0995a54fa12037d2a2ebe8ef9e2dd4bd0..9a9d3b9f19ad96704172cc709f49c2a517f117c2 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3282,6 +3282,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3330,6 +3330,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void resetCooldown();
      // Paper end - attack cooldown API
  

--- a/patches/api/0198-Support-components-in-ItemMeta.patch
+++ b/patches/api/0198-Support-components-in-ItemMeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index abe5c56c09a29cb3dcd35936045938c1b88c8500..a317111df3b6cda00dc700c68f4c2b789c51885d 100644
+index 27dfb5704b190f469dbe3d8fccd3cf47999b7133..434535afdbab29a21cd5eea9f454d47887f21a4e 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 @@ -5,6 +5,7 @@ import java.util.Collection;
@@ -16,7 +16,7 @@ index abe5c56c09a29cb3dcd35936045938c1b88c8500..a317111df3b6cda00dc700c68f4c2b78
  import org.bukkit.attribute.Attribute;
  import org.bukkit.attribute.AttributeModifier;
  import org.bukkit.configuration.serialization.ConfigurationSerializable;
-@@ -66,6 +67,20 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -67,6 +68,20 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @NotNull
      String getDisplayName();
  
@@ -37,7 +37,7 @@ index abe5c56c09a29cb3dcd35936045938c1b88c8500..a317111df3b6cda00dc700c68f4c2b78
      /**
       * Sets the display name.
       *
-@@ -75,6 +90,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -76,6 +91,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Deprecated // Paper
      void setDisplayName(@Nullable String name);
  
@@ -54,7 +54,7 @@ index abe5c56c09a29cb3dcd35936045938c1b88c8500..a317111df3b6cda00dc700c68f4c2b78
      /**
       * Checks for existence of an item name.
       * <br>
-@@ -211,6 +236,19 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -212,6 +237,19 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Nullable
      List<String> getLore();
  
@@ -74,7 +74,7 @@ index abe5c56c09a29cb3dcd35936045938c1b88c8500..a317111df3b6cda00dc700c68f4c2b78
      /**
       * Sets the lore for this item.
       * Removes lore when given null.
-@@ -221,6 +259,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -222,6 +260,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Deprecated // Paper
      void setLore(@Nullable List<String> lore);
  

--- a/patches/api/0203-Brand-support.patch
+++ b/patches/api/0203-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7429666fd1af4f4a924cf93572df5b826782af05..b0c0fd6687af5676d85094304ced25c1c444bc90 100644
+index 9a9d3b9f19ad96704172cc709f49c2a517f117c2..fb86055ba15b677b0d8969995713ec7f950cb30a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3395,6 +3395,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3443,6 +3443,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0207-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0207-Add-methods-to-get-translation-keys.patch
@@ -144,7 +144,7 @@ index dc66bd69646ac949d1386ce8f6ff913e9475439d..4482e8f2c617c2f51b2b53762e775d11
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index feebabf946913263461e1d0f13a478cf4bfd0f68..ebf505bbdc1b44d1fcd3c30f4143f6e5b89d09e9 100644
+index 5ccca18290ffc3d0933e579fbb31bd64c527488d..ab5db87139a887ef26e46812e59998f4ea83f28c 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -129,7 +129,7 @@ import org.jetbrains.annotations.Nullable;
@@ -286,7 +286,7 @@ index d3087d60378822cdd7cea25fd63d3f496e3cd2fb..5d8fa5b39a5d50cca48ba63af3a84b80
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index bf29d9b733afc7c62725d259f4920c4f211cc6d0..1d3812db989a55b6f31bb30dffe70323eb592a15 100644
+index 745413357506fa7399f8ba44dfe222d1f0c919f1..25db31b2e9a6d75f0c59f75237842f9ad7d1c350 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -32,7 +32,7 @@ import org.jetbrains.annotations.Nullable;
@@ -312,7 +312,7 @@ index bf29d9b733afc7c62725d259f4920c4f211cc6d0..1d3812db989a55b6f31bb30dffe70323
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/BlockType.java b/src/main/java/org/bukkit/block/BlockType.java
-index 95cedd536fed5a195fb2dd76da1c451598250f53..d4e824ad18714b951cf161031a9566e6796ab507 100644
+index 2fd6f52ad69074f1a060b9a85c1a0f01ae2add2d..56bc4cbc9af40e7fa400293ddc2479c7d2754c55 100644
 --- a/src/main/java/org/bukkit/block/BlockType.java
 +++ b/src/main/java/org/bukkit/block/BlockType.java
 @@ -125,7 +125,7 @@ import org.jetbrains.annotations.Nullable;
@@ -324,7 +324,7 @@ index 95cedd536fed5a195fb2dd76da1c451598250f53..d4e824ad18714b951cf161031a9566e6
  
      /**
       * Typed represents a subtype of {@link BlockType}s that have a known block
-@@ -3602,4 +3602,13 @@ public interface BlockType extends Keyed, Translatable {
+@@ -3603,4 +3603,13 @@ public interface BlockType extends Keyed, Translatable {
      @Nullable
      @Deprecated
      Material asMaterial();
@@ -339,10 +339,10 @@ index 95cedd536fed5a195fb2dd76da1c451598250f53..d4e824ad18714b951cf161031a9566e6
 +    // Paper end - add Translatable
  }
 diff --git a/src/main/java/org/bukkit/enchantments/Enchantment.java b/src/main/java/org/bukkit/enchantments/Enchantment.java
-index f4ec7891bdcedc73bff6938e3eddb7ee43d23ec1..4e41980dfbb256356231bc9565f6a90ea66aab76 100644
+index 6a89c75d913ee1ef5b368064a4cdc1ec0c96ce2b..0d6b06e09f6682d04623d176fcfd350cfa6a702a 100644
 --- a/src/main/java/org/bukkit/enchantments/Enchantment.java
 +++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
-@@ -16,7 +16,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -17,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * The various type of enchantments that may be added to armour or weapons
   */
@@ -367,10 +367,10 @@ index c4f86ba1037f3f0e5d697a0962d71d6f8c7c1fbe..ac0371285370594d4de1554871b19bbc
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/EntityType.java b/src/main/java/org/bukkit/entity/EntityType.java
-index dd410ff2cad3dc34ef9d2a37d72417c7b213de63..b7a454ca11d484209d08d0003d4c19a431456687 100644
+index afbd43ef062efae32c112ca8299b05a3796ee4fc..54fbfa2bce8d73a66ca165ba7227c574b58f91cb 100644
 --- a/src/main/java/org/bukkit/entity/EntityType.java
 +++ b/src/main/java/org/bukkit/entity/EntityType.java
-@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Contract;
+@@ -26,7 +26,7 @@ import org.jetbrains.annotations.Contract;
  import org.jetbrains.annotations.NotNull;
  import org.jetbrains.annotations.Nullable;
  
@@ -379,7 +379,7 @@ index dd410ff2cad3dc34ef9d2a37d72417c7b213de63..b7a454ca11d484209d08d0003d4c19a4
  
      // These strings MUST match the strings in nms.EntityTypes and are case sensitive.
      /**
-@@ -439,10 +439,22 @@ public enum EntityType implements Keyed, Translatable {
+@@ -440,10 +440,22 @@ public enum EntityType implements Keyed, Translatable {
  
      @Override
      @NotNull
@@ -509,7 +509,7 @@ index 5bd252c0ae3b09fe141d131360c67bb9bfbf5422..78587d9fabe6371a23a7963917b054db
 +
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 066f99a1f4cc42cf0e87d495f97a0685817dfa18..23686519b8c1338dd6e9f1c5a0e73467c0b59a4f 100644
+index adb6576ba60219c15bcfddae03cd90e24906b01a..427e0012376effbd1b459da094ac8e4d6324e38e 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
@@ -521,7 +521,7 @@ index 066f99a1f4cc42cf0e87d495f97a0685817dfa18..23686519b8c1338dd6e9f1c5a0e73467
      private Material type = Material.AIR;
      private int amount = 0;
      private MaterialData data = null;
-@@ -626,6 +626,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -628,6 +628,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
  
      @Override
      @NotNull
@@ -529,7 +529,7 @@ index 066f99a1f4cc42cf0e87d495f97a0685817dfa18..23686519b8c1338dd6e9f1c5a0e73467
      public String getTranslationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }
-@@ -885,5 +886,16 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -887,5 +888,16 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
          ItemMeta itemMeta = getItemMeta();
          return itemMeta != null && itemMeta.hasItemFlag(flag);
      }
@@ -547,7 +547,7 @@ index 066f99a1f4cc42cf0e87d495f97a0685817dfa18..23686519b8c1338dd6e9f1c5a0e73467
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemType.java b/src/main/java/org/bukkit/inventory/ItemType.java
-index aa0f66b7187c800cd22905bfa43af3ffb53edb5f..3d30c4957a2950ac8d4635ed7bb9bf39ca8cd158 100644
+index cf855eaf2859566a7c5763f838ff3fbecb9e3124..006c5e6449ec21b96c9e5af2fa00ae240451eeca 100644
 --- a/src/main/java/org/bukkit/inventory/ItemType.java
 +++ b/src/main/java/org/bukkit/inventory/ItemType.java
 @@ -49,7 +49,7 @@ import org.jetbrains.annotations.Nullable;
@@ -559,7 +559,7 @@ index aa0f66b7187c800cd22905bfa43af3ffb53edb5f..3d30c4957a2950ac8d4635ed7bb9bf39
  
      /**
       * Typed represents a subtype of {@link ItemType}s that have a known item meta type
-@@ -2419,4 +2419,13 @@ public interface ItemType extends Keyed, Translatable {
+@@ -2445,4 +2445,13 @@ public interface ItemType extends Keyed, Translatable {
      @Nullable
      @Deprecated
      Material asMaterial();

--- a/patches/api/0208-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/patches/api/0208-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 4c4e52b2c200408c4e33a141e1eed78126ceaaee..53b8934cb829f37971cb3ecd5652c9974dec6ab0 100644
+index 1b4f9b93860e58762ac28715adad5a67298b06d7..96546712f788e091749a1b4eebc6b1d6c3db7814 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -265,4 +265,65 @@ public interface ItemFactory {
+@@ -250,4 +250,65 @@ public interface ItemFactory {
      @NotNull
      ItemStack ensureServerConversions(@NotNull ItemStack item);
      // Paper end - ensure server conversions API

--- a/patches/api/0213-Player-elytra-boost-API.patch
+++ b/patches/api/0213-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b0c0fd6687af5676d85094304ced25c1c444bc90..28a811be93b29f105dad1db91a8adccbdf9fcaf7 100644
+index fb86055ba15b677b0d8969995713ec7f950cb30a..d03c0abada5389311d4d88c69bfb3ce8f981ac8a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3289,6 +3289,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3337,6 +3337,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      <T> @NotNull T getClientOption(com.destroystokyo.paper.@NotNull ClientOption<T> option);
      // Paper end - client option API
  

--- a/patches/api/0240-Add-sendOpLevel-API.patch
+++ b/patches/api/0240-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 28a811be93b29f105dad1db91a8adccbdf9fcaf7..752b2bac47588c0f75a13a7e6ec2be3c2f5a149e 100644
+index d03c0abada5389311d4d88c69bfb3ce8f981ac8a..0ac6fd7207311d27a650f5811e39de05e8f5fa9b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3308,6 +3308,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3356,6 +3356,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      }
      // Paper end - elytra boost API
  

--- a/patches/api/0241-Add-RegistryAccess-for-managing-registries.patch
+++ b/patches/api/0241-Add-RegistryAccess-for-managing-registries.patch
@@ -190,7 +190,7 @@ index 791813220b2504214b1adecc69093cd600fb0f8c..47fe5b0d5d031110c27210a0a256c260
          final RegistryKey<T> registryKey = createInternal(key);
          REGISTRY_KEYS.add(registryKey);
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 3210587c341bc8d80ddc7f387ca4030dbd0074c9..f35e5cd82c04bce3ca24120ca6cb5260a789b2d7 100644
+index 607fe5038c2a1a579c6eba16a732a6b0c42cc9b7..be1e26f4d41e991d5ffcca95d600558771fc2f26 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -2395,8 +2395,11 @@ public final class Bukkit {
@@ -206,10 +206,10 @@ index 3210587c341bc8d80ddc7f387ca4030dbd0074c9..f35e5cd82c04bce3ca24120ca6cb5260
          return server.getRegistry(tClass);
      }
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 62a7748b7509907ac8c8c0026f0cc5911f530eb7..e5393d3204f4d04d8e9640a45c6b4ba6a912079b 100644
+index 3e0d1026e2581b4a8d23d55b7c98b028a58d22dd..4857262f95e635e17aeaee83052ffcdf5502b736 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -101,7 +101,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -102,7 +102,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * @apiNote BlockType is not ready for public usage yet
       */
      @ApiStatus.Internal
@@ -218,7 +218,7 @@ index 62a7748b7509907ac8c8c0026f0cc5911f530eb7..e5393d3204f4d04d8e9640a45c6b4ba6
      /**
       * Custom boss bars.
       *
-@@ -139,7 +139,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -140,7 +140,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @see Enchantment
       */
@@ -227,7 +227,7 @@ index 62a7748b7509907ac8c8c0026f0cc5911f530eb7..e5393d3204f4d04d8e9640a45c6b4ba6
      /**
       * Server entity types.
       *
-@@ -151,7 +151,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -152,7 +152,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @see MusicInstrument
       */
@@ -236,7 +236,7 @@ index 62a7748b7509907ac8c8c0026f0cc5911f530eb7..e5393d3204f4d04d8e9640a45c6b4ba6
      /**
       * Server item types.
       *
-@@ -159,7 +159,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -160,7 +160,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * @apiNote ItemType is not ready for public usage yet
       */
      @ApiStatus.Internal
@@ -245,7 +245,7 @@ index 62a7748b7509907ac8c8c0026f0cc5911f530eb7..e5393d3204f4d04d8e9640a45c6b4ba6
      /**
       * Default server loot tables.
       *
-@@ -177,7 +177,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -178,7 +178,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @see PotionEffectType
       */
@@ -254,7 +254,7 @@ index 62a7748b7509907ac8c8c0026f0cc5911f530eb7..e5393d3204f4d04d8e9640a45c6b4ba6
      /**
       * Server particles.
       *
-@@ -200,14 +200,16 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -201,14 +201,16 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * Server structures.
       *
       * @see Structure
@@ -273,7 +273,7 @@ index 62a7748b7509907ac8c8c0026f0cc5911f530eb7..e5393d3204f4d04d8e9640a45c6b4ba6
      /**
       * Sound keys.
       *
-@@ -218,21 +220,26 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -219,21 +221,26 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * Trim materials.
       *
       * @see TrimMaterial
@@ -304,7 +304,7 @@ index 62a7748b7509907ac8c8c0026f0cc5911f530eb7..e5393d3204f4d04d8e9640a45c6b4ba6
      /**
       * Villager profession.
       *
-@@ -286,8 +293,10 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -287,8 +294,10 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * Wolf variants.
       *
       * @see Wolf.Variant
@@ -316,7 +316,7 @@ index 62a7748b7509907ac8c8c0026f0cc5911f530eb7..e5393d3204f4d04d8e9640a45c6b4ba6
      /**
       * Map cursor types.
       *
-@@ -300,7 +309,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -301,7 +310,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @see GameEvent
       */
@@ -326,7 +326,7 @@ index 62a7748b7509907ac8c8c0026f0cc5911f530eb7..e5393d3204f4d04d8e9640a45c6b4ba6
       * Get the object by its key.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f0c1d16c6bee58826a3cde3c4988e02690207fce..c53268bc4c3ae275ad8765f0848e46e1d6c7372d 100644
+index faf7b1bba8baa869294b0542fc53fe5ba1f4147a..0035e279eee2a5af44b992ae464bed7661e74657 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -2046,8 +2046,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -368,20 +368,30 @@ index 0000000000000000000000000000000000000000..f5ece852f97017f71bc129e194cb2129
 +    }
 +}
 diff --git a/src/test/java/org/bukkit/support/TestServer.java b/src/test/java/org/bukkit/support/TestServer.java
-index b208150297a23c0b4acb79135416809718f5650e..f11c639f1dc3c5034678d80bde3127a2e81a4a93 100644
+index c79faf4197f9c0a7256cefe2b001182102d2b796..55f1bc7d01e5184172559c43b8327ac86d58041b 100644
 --- a/src/test/java/org/bukkit/support/TestServer.java
 +++ b/src/test/java/org/bukkit/support/TestServer.java
-@@ -36,26 +36,11 @@ public final class TestServer {
+@@ -37,36 +37,11 @@ public final class TestServer {
  
          when(instance.getBukkitVersion()).thenReturn("BukkitVersion_" + TestServer.class.getPackage().getImplementationVersion());
  
 -        Map<Class<? extends Keyed>, Registry<?>> registers = new HashMap<>();
--        when(instance.getRegistry(any())).then(invocationOnMock -> registers.computeIfAbsent(invocationOnMock.getArgument(0), aClass -> new Registry<Keyed>() {
+-        when(instance.getRegistry(any())).then(invocationOnMock -> registers.computeIfAbsent(invocationOnMock.getArgument(0), aClass -> new Registry<>() {
 -            private final Map<NamespacedKey, Keyed> cache = new HashMap<>();
 -
 -            @Override
 -            public Keyed get(NamespacedKey key) {
--                return cache.computeIfAbsent(key, key2 -> mock(aClass, withSettings().stubOnly()));
+-                Class<? extends Keyed> theClass;
+-                // Some registries have extra Typed classes such as BlockType and ItemType.
+-                // To avoid class cast exceptions during init mock the Typed class.
+-                // To get the correct class, we just use the field type.
+-                try {
+-                    theClass = (Class<? extends Keyed>) aClass.getField(key.getKey().toUpperCase(Locale.ROOT).replace('.', '_')).getType();
+-                } catch (ClassCastException | NoSuchFieldException e) {
+-                    throw new RuntimeException(e);
+-                }
+-
+-                return cache.computeIfAbsent(key, key2 -> mock(theClass, withSettings().stubOnly()));
 -            }
 -
 -            @NotNull

--- a/patches/api/0242-Add-StructuresLocateEvent.patch
+++ b/patches/api/0242-Add-StructuresLocateEvent.patch
@@ -513,10 +513,10 @@ index 0000000000000000000000000000000000000000..1e7b53f9bc13dcd5a0a4a40004591e4f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index e5393d3204f4d04d8e9640a45c6b4ba6a912079b..d573d8e36fbe6b7f5a298fb64910feba9cba0697 100644
+index 4857262f95e635e17aeaee83052ffcdf5502b736..9a819b179ce3040e842be58a8ddceee2a14ffa59 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -310,6 +310,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -311,6 +311,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * @see GameEvent
       */
      Registry<GameEvent> GAME_EVENT = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.GAME_EVENT); // Paper

--- a/patches/api/0259-Improve-Item-Rarity-API.patch
+++ b/patches/api/0259-Improve-Item-Rarity-API.patch
@@ -43,7 +43,7 @@ index 0000000000000000000000000000000000000000..f1cd5a4f37eee8975ac3d0421b524afc
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index ebf505bbdc1b44d1fcd3c30f4143f6e5b89d09e9..04cb8279f2296cc42405355c7c1f120e761202c4 100644
+index ab5db87139a887ef26e46812e59998f4ea83f28c..c96c927367d22e2651a553a5e6685bde9c8f8873 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4756,6 +4756,21 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
@@ -110,10 +110,10 @@ index e7931f73f10fe35ebd5fe4a04b036d53bb117ebd..cbce835ed6d44e5b8c9aaae4e36a77f8
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 23686519b8c1338dd6e9f1c5a0e73467c0b59a4f..f0221815cbd30f3ccaacc87a57403491b55de128 100644
+index 427e0012376effbd1b459da094ac8e4d6324e38e..decc49d86de34c43daa04316320288fa33f935e5 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -897,5 +897,17 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -899,5 +899,17 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public @NotNull String translationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }

--- a/patches/api/0265-More-World-API.patch
+++ b/patches/api/0265-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 77314fdbd99a5cc34e7a1df4692ba8a1685ef002..f4d31d9d0f4cbd2621adf97a20b65ae83e5fd064 100644
+index c1fd76e1b8d0f326f985662a2845f76c1cdf5d40..50d27a6096f0da98db80ce28eab21a004de8a20a 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3849,6 +3849,122 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3876,6 +3876,122 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      StructureSearchResult locateNearestStructure(@NotNull Location origin, @NotNull Structure structure, int radius, boolean findUnexplored);
  

--- a/patches/api/0277-ItemStack-repair-check-API.patch
+++ b/patches/api/0277-ItemStack-repair-check-API.patch
@@ -25,10 +25,10 @@ index 8635846c9f672e39f0929eec7bf83b22536ed284..51f1a09164d501de6d2561ed90175f2c
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index f0221815cbd30f3ccaacc87a57403491b55de128..ca2dac7b377ea098158ff3c84fd47f405b636869 100644
+index decc49d86de34c43daa04316320288fa33f935e5..b2a9cb36d3bd0ba604514457294e337364a67756 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -909,5 +909,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -911,5 +911,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public io.papermc.paper.inventory.ItemRarity getRarity() {
          return io.papermc.paper.inventory.ItemRarity.valueOf(this.getItemMeta().getRarity().name());
      }

--- a/patches/api/0278-More-Enchantment-API.patch
+++ b/patches/api/0278-More-Enchantment-API.patch
@@ -41,10 +41,10 @@ index 0000000000000000000000000000000000000000..aec3b41d7c3388e26fa203e3c062f1e6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/enchantments/Enchantment.java b/src/main/java/org/bukkit/enchantments/Enchantment.java
-index 4e41980dfbb256356231bc9565f6a90ea66aab76..73e367fdf405b926599f4a7d34d61c25bb6c6e81 100644
+index 0d6b06e09f6682d04623d176fcfd350cfa6a702a..f8d9fba8791303794ba3be6f42542c096222691d 100644
 --- a/src/main/java/org/bukkit/enchantments/Enchantment.java
 +++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
-@@ -292,11 +292,7 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
+@@ -293,11 +293,7 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
       * Cursed enchantments are found the same way treasure enchantments are
       *
       * @return true if the enchantment is cursed
@@ -56,7 +56,7 @@ index 4e41980dfbb256356231bc9565f6a90ea66aab76..73e367fdf405b926599f4a7d34d61c25
      public abstract boolean isCursed();
  
      /**
-@@ -330,6 +326,97 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
+@@ -331,6 +327,97 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
       * @return the name of the enchantment with {@code level} applied
       */
      public abstract net.kyori.adventure.text.@NotNull Component displayName(int level);

--- a/patches/api/0280-ItemStack-editMeta.patch
+++ b/patches/api/0280-ItemStack-editMeta.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack#editMeta
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index ca2dac7b377ea098158ff3c84fd47f405b636869..5fb8f7c1b79bd256925cb68cccfe0b974fb84043 100644
+index b2a9cb36d3bd0ba604514457294e337364a67756..95e11895856101013c4ac434546a229eab09586e 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -567,6 +567,50 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -574,6 +574,50 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
          return result.ensureServerConversions(); // Paper
      }
  

--- a/patches/api/0282-Improve-item-default-attribute-API.patch
+++ b/patches/api/0282-Improve-item-default-attribute-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Improve item default attribute API
 
 
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 04cb8279f2296cc42405355c7c1f120e761202c4..18862cce7e252e69153f0a5380aa07de26d9d2e7 100644
+index c96c927367d22e2651a553a5e6685bde9c8f8873..a011123035a96c05921f0a206b92bef15732b443 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4771,6 +4771,23 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
@@ -72,10 +72,10 @@ index 04cb8279f2296cc42405355c7c1f120e761202c4..18862cce7e252e69153f0a5380aa07de
       *
       * @param slot the {@link EquipmentSlot} to check
 diff --git a/src/main/java/org/bukkit/inventory/ItemType.java b/src/main/java/org/bukkit/inventory/ItemType.java
-index 3d30c4957a2950ac8d4635ed7bb9bf39ca8cd158..077bd4d4e50169780f27e8502104e9e4b2ecdae6 100644
+index 006c5e6449ec21b96c9e5af2fa00ae240451eeca..a0cd105daf93fa02f243ef5b708efe9f3718d7bb 100644
 --- a/src/main/java/org/bukkit/inventory/ItemType.java
 +++ b/src/main/java/org/bukkit/inventory/ItemType.java
-@@ -2378,6 +2378,21 @@ public interface ItemType extends Keyed, Translatable, net.kyori.adventure.trans
+@@ -2404,6 +2404,21 @@ public interface ItemType extends Keyed, Translatable, net.kyori.adventure.trans
  //    @NotNull
  //    EquipmentSlot getEquipmentSlot();
  

--- a/patches/api/0292-Missing-Entity-API.patch
+++ b/patches/api/0292-Missing-Entity-API.patch
@@ -493,55 +493,34 @@ index c7364a6c266aba9568f491fe0794fa593ada224d..827574b3eff9b912500b092ca081e716
       * Mark the entity's removal.
       *
 diff --git a/src/main/java/org/bukkit/entity/Fireball.java b/src/main/java/org/bukkit/entity/Fireball.java
-index ceaf263bc554a92a232bd3ed18ea67ce4e0b487a..fcb8a7c3e885a89191556bf4ee5edab2e926d4b1 100644
+index d7ebb33e946d7c5c5ee682f2dc9cf8e4e9f7049f..252e3d35c0478ff4132d33c5caf65aa27911b675 100644
 --- a/src/main/java/org/bukkit/entity/Fireball.java
 +++ b/src/main/java/org/bukkit/entity/Fireball.java
-@@ -12,11 +12,11 @@ public interface Fireball extends Projectile, Explosive {
-      * Sets the direction the fireball should be flying towards.
-      * The direction vector will be normalized and the default speed will be applied.
-      * <br>
--     * To also change the speed of the fireball, use {@link #setVelocity(Vector)}.
-+     * To also change the acceleration of the fireball, use {@link #setPower(Vector)}.
-      * <b>Note:</b> that the client may not respect non-default speeds and will therefore
-      * mispredict the location of the fireball, causing visual stutter.
-      * <br>
--     * <b>Also Note:</b> that this method and {@link #setVelocity(Vector)} will override each other.
-+     * <b>Also Note:</b> that this method and {@link #setPower(Vector)} will override each other.
-      *
-      * @param direction the direction this fireball should be flying towards
-      * @see #setVelocity(Vector)
-@@ -32,4 +32,32 @@ public interface Fireball extends Projectile, Explosive {
+@@ -62,4 +62,25 @@ public interface Fireball extends Projectile, Explosive {
+      */
      @NotNull
-     public Vector getDirection();
- 
-+    // Paper start - Expose power on fireball projectiles
-+    /**
-+     * {@inheritDoc}
-+     * <p>
-+     * Note: For fireball entities, their movement is also controlled by their power.
-+     *
-+     * @param velocity New velocity to travel with
-+     * @see #setPower(Vector)
-+     */
-+    @Override
-+    public void setVelocity(@NotNull Vector velocity);
+     Vector getAcceleration();
 +
++    // Paper start - Expose power on fireball projectiles
 +    /**
 +     * Sets the power of a fireball. The power determines the direction and magnitude of its acceleration.
 +     *
 +     * @param power the power
++     * @deprecated use #setAcceleration(Vector) instead.
 +     */
++    @Deprecated
 +    public void setPower(@NotNull Vector power);
 +
 +    /**
 +     * Gets the power of a fireball. The power determines the direction and magnitude of its acceleration.
 +     *
 +     * @return the power
++     * @deprecated Use #getAcceleration instead.
 +     */
++    @Deprecated
 +    @NotNull
 +    public Vector getPower();
 +    // Paper end - Expose power on fireball projectiles
-+
  }
 diff --git a/src/main/java/org/bukkit/entity/Fox.java b/src/main/java/org/bukkit/entity/Fox.java
 index c61a473453f33f9d10c330fc46cfa9d52251fe49..473a7e36ad64f866d1d2e09e2ecb2e9881668faf 100644

--- a/patches/api/0295-fix-empty-array-elements-in-command-arguments.patch
+++ b/patches/api/0295-fix-empty-array-elements-in-command-arguments.patch
@@ -9,10 +9,10 @@ Adjacent spaces sent by players are removed in PlayerConnection, so this change 
 But it does affect the console, command blocks, Bukkit.dispatchCommand, etc.
 
 diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-index 1424060c0a162020d4a680e0a592224561067b16..ac9a28922f8a556944a4c3649d74c32c622f0cb0 100644
+index 27243a1214bc4d7dbb46f0b9b254c8e3f8128419..b5f9cd2bd191f8b071c6c95706ddbef97d3c244e 100644
 --- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
 +++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-@@ -130,7 +130,7 @@ public class SimpleCommandMap implements CommandMap {
+@@ -131,7 +131,7 @@ public class SimpleCommandMap implements CommandMap {
       */
      @Override
      public boolean dispatch(@NotNull CommandSender sender, @NotNull String commandLine) throws CommandException {

--- a/patches/api/0308-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/api/0308-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index f4d31d9d0f4cbd2621adf97a20b65ae83e5fd064..6953851a5177e9df3746f7a743f27ef02845e522 100644
+index 50d27a6096f0da98db80ce28eab21a004de8a20a..d3c524bbfe08d2118b0e093b2340620644d60d19 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -746,6 +746,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -773,6 +773,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public LightningStrike strikeLightningEffect(@NotNull Location loc);
  

--- a/patches/api/0309-Get-entity-default-attributes.patch
+++ b/patches/api/0309-Get-entity-default-attributes.patch
@@ -32,10 +32,10 @@ index 51f1a09164d501de6d2561ed90175f2c24a668c1..cbc63144e5eb35799548209f8fbee70d
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/EntityType.java b/src/main/java/org/bukkit/entity/EntityType.java
-index b7a454ca11d484209d08d0003d4c19a431456687..1d1315262737d99bf9f5aabc0ae66eee4645cc65 100644
+index 54fbfa2bce8d73a66ca165ba7227c574b58f91cb..ea33003014adf2e25fd974c8ff5dfc0343b805f4 100644
 --- a/src/main/java/org/bukkit/entity/EntityType.java
 +++ b/src/main/java/org/bukkit/entity/EntityType.java
-@@ -453,6 +453,25 @@ public enum EntityType implements Keyed, Translatable, net.kyori.adventure.trans
+@@ -454,6 +454,25 @@ public enum EntityType implements Keyed, Translatable, net.kyori.adventure.trans
          Preconditions.checkArgument(this != UNKNOWN, "UNKNOWN entities do not have translation keys");
          return org.bukkit.Bukkit.getUnsafe().getTranslationKey(this);
      }

--- a/patches/api/0314-Add-hasCollision-methods-to-various-places.patch
+++ b/patches/api/0314-Add-hasCollision-methods-to-various-places.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add hasCollision methods to various places
 
 
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 1df815c2e430a308baea08c9a7f3ca43377dc16e..195bd298cfc2d43720550d5bf5a3347c064e9a7a 100644
+index a011123035a96c05921f0a206b92bef15732b443..889f760e0c8de3f567d86936e6fc317a43993b10 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4788,6 +4788,21 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
@@ -31,7 +31,7 @@ index 1df815c2e430a308baea08c9a7f3ca43377dc16e..195bd298cfc2d43720550d5bf5a3347c
       * Do not use for any reason.
       *
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index b5fe76a6353816a2d009dfa5921f8ada92984f34..42cc4f2ee960c0abf9c6688aeee4150754612c32 100644
+index 6ada8c036f1a112f11a9fbc3baf1f79b3f1bfc8e..02361d58ac723d02d93db80a721b27d37f7dc3c1 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -482,6 +482,13 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
@@ -67,10 +67,10 @@ index fd4a9bdcfb6775dfbdb7492e6c9eb90722d2ecdc..e573e70d9e74e444783a7363e6cdac12
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/BlockType.java b/src/main/java/org/bukkit/block/BlockType.java
-index d4e824ad18714b951cf161031a9566e6796ab507..61a73e813f7c14c61fac358e96aaaa64c41e560b 100644
+index 56bc4cbc9af40e7fa400293ddc2479c7d2754c55..8ba422ce7eecdfdfb4edbc0d56f99eeaa3f16e9b 100644
 --- a/src/main/java/org/bukkit/block/BlockType.java
 +++ b/src/main/java/org/bukkit/block/BlockType.java
-@@ -3611,4 +3611,13 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
+@@ -3612,4 +3612,13 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
      @Override
      @NotNull String getTranslationKey();
      // Paper end - add Translatable

--- a/patches/api/0335-More-PotionEffectType-API.patch
+++ b/patches/api/0335-More-PotionEffectType-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More PotionEffectType API
 
 
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index d573d8e36fbe6b7f5a298fb64910feba9cba0697..f301f81817409f0a6799885d4f0972ed9bf3e4df 100644
+index 9a819b179ce3040e842be58a8ddceee2a14ffa59..132d375de164e6d8df61234def650154c67fc0df 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -318,6 +318,31 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -319,6 +319,31 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       */
      @Deprecated(forRemoval = true)
      Registry<io.papermc.paper.world.structure.ConfiguredStructure> CONFIGURED_STRUCTURE = Objects.requireNonNull(io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.world.structure.ConfiguredStructure.class), "No registry present for ConfiguredStructure. This is a bug.");
@@ -41,10 +41,10 @@ index d573d8e36fbe6b7f5a298fb64910feba9cba0697..f301f81817409f0a6799885d4f0972ed
      /**
       * Get the object by its key.
 diff --git a/src/main/java/org/bukkit/potion/PotionEffectType.java b/src/main/java/org/bukkit/potion/PotionEffectType.java
-index e045e6a74821f291938cc6af86e313c1f1c4626c..e77cf365cefafbeba09123187e70fd5274f10d53 100644
+index 42d893ce75a75fe46a4e52b17dc405f5b609ab86..10fa51d116b40450b51af9110d5637f3505ebf65 100644
 --- a/src/main/java/org/bukkit/potion/PotionEffectType.java
 +++ b/src/main/java/org/bukkit/potion/PotionEffectType.java
-@@ -16,7 +16,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -17,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a type of potion and its effect on an entity.
   */
@@ -53,7 +53,7 @@ index e045e6a74821f291938cc6af86e313c1f1c4626c..e77cf365cefafbeba09123187e70fd52
      private static final BiMap<Integer, PotionEffectType> ID_MAP = HashBiMap.create();
  
      /**
-@@ -352,4 +352,57 @@ public abstract class PotionEffectType implements Keyed, Translatable {
+@@ -361,4 +361,57 @@ public abstract class PotionEffectType implements Keyed, Translatable {
      public static PotionEffectType[] values() {
          return Lists.newArrayList(Registry.EFFECT).toArray(new PotionEffectType[0]);
      }

--- a/patches/api/0346-Add-enchantWithLevels-API.patch
+++ b/patches/api/0346-Add-enchantWithLevels-API.patch
@@ -7,10 +7,10 @@ Deprecate upstream's newer and poorly implemented similar
 API.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index a9ed193bbb85a5d363fd315e198430809cdbddc5..229dbdcb9094508e02d7a5ea1761d5764e5e4702 100644
+index 96546712f788e091749a1b4eebc6b1d6c3db7814..bd0e55562f1cabef3078573182e0cf9fbc844585 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -185,8 +185,11 @@ public interface ItemFactory {
+@@ -170,8 +170,11 @@ public interface ItemFactory {
       * @param level the level to use, which is the level in the enchantment table
       * @param allowTreasures allows treasure enchants, e.g. mending, if true.
       * @return a new ItemStack containing the result of the Enchantment
@@ -22,7 +22,7 @@ index a9ed193bbb85a5d363fd315e198430809cdbddc5..229dbdcb9094508e02d7a5ea1761d576
      ItemStack enchantItem(@NotNull final Entity entity, @NotNull final ItemStack item, final int level, final boolean allowTreasures);
  
      /**
-@@ -199,8 +202,11 @@ public interface ItemFactory {
+@@ -184,8 +187,11 @@ public interface ItemFactory {
       * @param level the level to use, which is the level in the enchantment table
       * @param allowTreasures allow the treasure enchants, e.g. mending, if true.
       * @return a new ItemStack containing the result of the Enchantment
@@ -34,7 +34,7 @@ index a9ed193bbb85a5d363fd315e198430809cdbddc5..229dbdcb9094508e02d7a5ea1761d576
      ItemStack enchantItem(@NotNull final World world, @NotNull final ItemStack item, final int level, final boolean allowTreasures);
  
      /**
-@@ -212,8 +218,11 @@ public interface ItemFactory {
+@@ -197,8 +203,11 @@ public interface ItemFactory {
       * @param level the level to use, which is the level in the enchantment table
       * @param allowTreasures allow treasure enchantments, e.g. mending, if true.
       * @return a new ItemStack containing the result of the Enchantment
@@ -46,7 +46,7 @@ index a9ed193bbb85a5d363fd315e198430809cdbddc5..229dbdcb9094508e02d7a5ea1761d576
      ItemStack enchantItem(@NotNull final ItemStack item, final int level, final boolean allowTreasures);
  
      // Paper start - Adventure
-@@ -326,4 +335,22 @@ public interface ItemFactory {
+@@ -311,4 +320,22 @@ public interface ItemFactory {
      @Deprecated
      net.md_5.bungee.api.chat.hover.content.Content hoverContentOf(@NotNull org.bukkit.entity.Entity entity, @NotNull net.md_5.bungee.api.chat.BaseComponent[] customName);
      // Paper end - bungee hover events
@@ -70,10 +70,10 @@ index a9ed193bbb85a5d363fd315e198430809cdbddc5..229dbdcb9094508e02d7a5ea1761d576
 +    // Paper end - enchantWithLevels API
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 5fb8f7c1b79bd256925cb68cccfe0b974fb84043..105cf1bf6e8b44846cdd3a8881fed36007daaa22 100644
+index 95e11895856101013c4ac434546a229eab09586e..a46b9b0efcc7becaf86fd885da5b8104d4f12982 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -676,6 +676,24 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -678,6 +678,24 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      }
  
      // Paper start

--- a/patches/api/0354-Expand-FallingBlock-API.patch
+++ b/patches/api/0354-Expand-FallingBlock-API.patch
@@ -10,10 +10,10 @@ Subject: [PATCH] Expand FallingBlock API
 Co-authored-by: Lukas Planz <lukas.planz@web.de>
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 2272c52c28f5f14e1ea8891feec47b18733319d9..6eeb919f478dbe33c9994f2141e77216c7d7e174 100644
+index 36deaae317cd9ac0455bc1daef22b7f1e1b73c62..406c404adb999acfa0e8f118b23714803e40a4fb 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2282,8 +2282,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2309,8 +2309,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The spawned {@link FallingBlock} instance
       * @throws IllegalArgumentException if {@link Location} or {@link
       *     MaterialData} are null or {@link Material} of the {@link MaterialData} is not a block
@@ -24,7 +24,7 @@ index 2272c52c28f5f14e1ea8891feec47b18733319d9..6eeb919f478dbe33c9994f2141e77216
      public FallingBlock spawnFallingBlock(@NotNull Location location, @NotNull MaterialData data) throws IllegalArgumentException;
  
      /**
-@@ -2296,8 +2298,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2323,8 +2325,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The spawned {@link FallingBlock} instance
       * @throws IllegalArgumentException if {@link Location} or {@link
       *     BlockData} are null
@@ -35,7 +35,7 @@ index 2272c52c28f5f14e1ea8891feec47b18733319d9..6eeb919f478dbe33c9994f2141e77216
      public FallingBlock spawnFallingBlock(@NotNull Location location, @NotNull BlockData data) throws IllegalArgumentException;
  
      /**
-@@ -2314,7 +2318,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2341,7 +2345,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The spawned {@link FallingBlock} instance
       * @throws IllegalArgumentException if {@link Location} or {@link
       *     Material} are null or {@link Material} is not a block

--- a/patches/api/0359-More-Teleport-API.patch
+++ b/patches/api/0359-More-Teleport-API.patch
@@ -120,7 +120,7 @@ index 0000000000000000000000000000000000000000..c8b5b570d44da9524bfc59c7e11b2ae5
 +
 +}
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 0cbf946c4f0f47ddfb59b23905968313f25294b1..a2223907c6e6780ca25dae255f321f9add11c912 100644
+index f51f3f04ba9efe15f68620c5531b502710078b6e..8bada7f7f0200103edc415ad003132d96ae09607 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -126,10 +126,32 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
@@ -158,10 +158,10 @@ index 0cbf946c4f0f47ddfb59b23905968313f25294b1..a2223907c6e6780ca25dae255f321f9a
       * Teleports this entity to the given location. If this entity is riding a
       * vehicle, it will be dismounted prior to teleportation.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index cd2d59a8a098227ec7725d121a63cc90e2a139fa..25064aafd5871a7168e8a0ba3e87d6de89e2b083 100644
+index 2cbb3d14612777422aa01ac45b7cea63e519fbfe..a2d51e8a547c95db235a2e4fa6228c9248cfa88b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3468,6 +3468,45 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3516,6 +3516,45 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      String getClientBrandName();
      // Paper end
  

--- a/patches/api/0361-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/api/0361-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 25064aafd5871a7168e8a0ba3e87d6de89e2b083..ac9227472443ecb819cc7480a217cd78a98a9b35 100644
+index a2d51e8a547c95db235a2e4fa6228c9248cfa88b..2cd85236e548c7a9732705d1af78d41f81e9d0d1 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3352,6 +3352,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3400,6 +3400,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void sendOpLevel(byte level);
      // Paper end - sendOpLevel API
  

--- a/patches/api/0371-Elder-Guardian-appearance-API.patch
+++ b/patches/api/0371-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ac9227472443ecb819cc7480a217cd78a98a9b35..ad61c664af66a15e214c5db14a5c9e172f5309ae 100644
+index 2cd85236e548c7a9732705d1af78d41f81e9d0d1..0c9b6aa22aa0b869f80403fa4bbd8538520168f9 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3532,6 +3532,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3580,6 +3580,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
      // Paper end - Teleport API
  

--- a/patches/api/0379-Add-Player-Warden-Warning-API.patch
+++ b/patches/api/0379-Add-Player-Warden-Warning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Player Warden Warning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ad61c664af66a15e214c5db14a5c9e172f5309ae..537ebbad48191741f666aa2a30c8584562dfcb83 100644
+index 0c9b6aa22aa0b869f80403fa4bbd8538520168f9..f0897d3d689ebca050c80df67581b1e3bc35ed24 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3548,6 +3548,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3596,6 +3596,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param silent whether sound should be silenced
       */
      void showElderGuardian(boolean silent);

--- a/patches/api/0382-ItemStack-damage-API.patch
+++ b/patches/api/0382-ItemStack-damage-API.patch
@@ -8,7 +8,7 @@ to simulate damage done to an itemstack and all
 the logic associated with damaging them
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 6bfc8a2148f504370df938447f4f6b757f1a516b..208bab1f5a3200f54141c38ee4272629cfc66da5 100644
+index 8dd993ce32686431e1c759d446a3620cb52f7ec1..0d665a31152c9a667576f2e9d91ffec5304ce944 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
 @@ -1365,4 +1365,53 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
@@ -66,10 +66,10 @@ index 6bfc8a2148f504370df938447f4f6b757f1a516b..208bab1f5a3200f54141c38ee4272629
 +    // Paper end - ItemStack damage API
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 105cf1bf6e8b44846cdd3a8881fed36007daaa22..ee5d2a30f634ccbe6f2cc2f82f9e56783939f5dd 100644
+index a46b9b0efcc7becaf86fd885da5b8104d4f12982..19dd25964803ca1cc3c377e69b4ed2d0df58c824 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -993,5 +993,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -995,5 +995,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public boolean canRepair(@NotNull ItemStack toBeRepaired) {
          return Bukkit.getUnsafe().isValidRepairItemStack(toBeRepaired, this);
      }

--- a/patches/api/0428-Allow-proper-checking-of-empty-item-stacks.patch
+++ b/patches/api/0428-Allow-proper-checking-of-empty-item-stacks.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow proper checking of empty item stacks
 This adds a method to check if an item stack is empty or not. This mirrors vanilla's implementation of the same method.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index ee5d2a30f634ccbe6f2cc2f82f9e56783939f5dd..e4dc17ec23d48591ff5742af5d23aa62bd9bfdbc 100644
+index 19dd25964803ca1cc3c377e69b4ed2d0df58c824..a2deadbceaa74232a82daa5a3f42a81dc93ba670 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -1007,5 +1007,24 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -1009,5 +1009,24 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public @NotNull ItemStack damage(int amount, @NotNull org.bukkit.entity.LivingEntity livingEntity) {
          return livingEntity.damageItemStack(this, amount);
      }

--- a/patches/api/0430-Add-player-idle-duration-API.patch
+++ b/patches/api/0430-Add-player-idle-duration-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5753d6d6ae791e2b086c861ddeb6522e46f2571c..9261f06e332f8db94b2ef7bc01f5b0e61422bcb2 100644
+index ce541b674303695be999018eedcddf554a6ea329..b7df63c31c890b58cf32b02ab3e9d379f30f2065 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3689,6 +3689,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3737,6 +3737,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void increaseWardenWarningLevel();
      // Paper end
  

--- a/patches/api/0432-Add-predicate-for-blocks-when-raytracing.patch
+++ b/patches/api/0432-Add-predicate-for-blocks-when-raytracing.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add predicate for blocks when raytracing
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 00fbc02a1751902edda327236e51a6991f5366f8..3abd62dc08e1edaeec6773819c8726671221074a 100644
+index 406c404adb999acfa0e8f118b23714803e40a4fb..cda78bdc6e6a76dbb5c711ee16dcb470a7b839a6 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1703,6 +1703,27 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1730,6 +1730,27 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public RayTraceResult rayTraceEntities(@NotNull Location start, @NotNull Vector direction, double maxDistance, double raySize, @Nullable Predicate<? super Entity> filter);
  
@@ -36,7 +36,7 @@ index 00fbc02a1751902edda327236e51a6991f5366f8..3abd62dc08e1edaeec6773819c872667
      /**
       * Performs a ray trace that checks for block collisions using the blocks'
       * precise collision shapes.
-@@ -1766,6 +1787,34 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1793,6 +1814,34 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public RayTraceResult rayTraceBlocks(@NotNull Location start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks);
  
@@ -71,7 +71,7 @@ index 00fbc02a1751902edda327236e51a6991f5366f8..3abd62dc08e1edaeec6773819c872667
      /**
       * Performs a ray trace that checks for both block and entity collisions.
       * <p>
-@@ -1799,6 +1848,42 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1826,6 +1875,42 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public RayTraceResult rayTrace(@NotNull Location start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, @Nullable Predicate<? super Entity> filter);
  

--- a/patches/api/0436-Remove-unnecessary-durability-check-in-ItemStack-isS.patch
+++ b/patches/api/0436-Remove-unnecessary-durability-check-in-ItemStack-isS.patch
@@ -9,10 +9,10 @@ By removing this check we avoid unnecessarily allocating useless `ItemMeta` obje
 This is a leftover from when checking for the item's durability was "free" because the durability was stored in the `ItemStack` itself, this [was changed in Minecraft 1.13](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/f8b2086d60942eb2cd7ac25a2a1408cb790c222c#src/main/java/org/bukkit/inventory/ItemStack.java).
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index e4dc17ec23d48591ff5742af5d23aa62bd9bfdbc..8975f6e8004d2ed65e20bb5b71bdbfa45713f78a 100644
+index a2deadbceaa74232a82daa5a3f42a81dc93ba670..f8573571cd256b9bf68e0e8c6fa523be5b46b83e 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -300,7 +300,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -307,7 +307,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
              return true;
          }
          Material comparisonType = (this.type.isLegacy()) ? Bukkit.getUnsafe().fromLegacy(this.getData(), true) : this.type; // This may be called from legacy item stacks, try to get the right material

--- a/patches/api/0438-add-missing-Experimental-annotations.patch
+++ b/patches/api/0438-add-missing-Experimental-annotations.patch
@@ -27,7 +27,7 @@ index 6b68c92ec894451d99ded3e3df5965cb31d68ed2..fd5e433f930963c102c9c977523a0036
      public static final FeatureFlag UPDATE_121 = Bukkit.getUnsafe().getFeatureFlag(NamespacedKey.minecraft("update_1_21"));
  }
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index b9ba0f82814b61e7992526f0b5ce324ca69a0d71..7509b61dfdc0a6675256970cb850b08f9e814580 100644
+index 889f760e0c8de3f567d86936e6fc317a43993b10..762216a117145676d3df2b74036799b024461fb7 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -151,54 +151,67 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
@@ -936,10 +936,10 @@ index db7723e2907525850f8dbd2bd7150c1e47ebf1c8..9951cf6780ae47649625b8fe0ed72d87
  
      private final String identifier;
 diff --git a/src/main/java/org/bukkit/enchantments/Enchantment.java b/src/main/java/org/bukkit/enchantments/Enchantment.java
-index de616cecaeb45018d96685c916532188e369bdd4..48a01a1eb80475adf9b181e9bd81535e9faec233 100644
+index f8d9fba8791303794ba3be6f42542c096222691d..7145fce635e542d5898576d815921d0b7105fee1 100644
 --- a/src/main/java/org/bukkit/enchantments/Enchantment.java
 +++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
-@@ -198,18 +198,21 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
+@@ -199,18 +199,21 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
       * Increases fall damage of maces
       */
      @MinecraftExperimental(Requires.UPDATE_1_21)
@@ -1141,10 +1141,10 @@ index 1afa33ca0d900d9301d52ace3ddb0bd50b5ce4e8..c7100c2bc2be9e294957862d943e629a
          ;
  
 diff --git a/src/main/java/org/bukkit/potion/PotionEffectType.java b/src/main/java/org/bukkit/potion/PotionEffectType.java
-index e77cf365cefafbeba09123187e70fd5274f10d53..7a7b98d40a031b09d6bc62df32d2ddeb25a9d41e 100644
+index 10fa51d116b40450b51af9110d5637f3505ebf65..4716df59a46c2fb1d5108c7c2a11a3235d98db4e 100644
 --- a/src/main/java/org/bukkit/potion/PotionEffectType.java
 +++ b/src/main/java/org/bukkit/potion/PotionEffectType.java
-@@ -192,31 +192,43 @@ public abstract class PotionEffectType implements Keyed, Translatable, net.kyori
+@@ -193,31 +193,43 @@ public abstract class PotionEffectType implements Keyed, Translatable, net.kyori
      /**
       * Causes trial spawners to become ominous.
       */

--- a/patches/api/0440-Improve-Registry.patch
+++ b/patches/api/0440-Improve-Registry.patch
@@ -31,10 +31,10 @@ index 62d2b3f950860dee0898d77b0a29635c3f9a7e23..704dba92f9246ef398ed8d162ebee3cf
      @Override
      public @NotNull String translationKey() {
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index f301f81817409f0a6799885d4f0972ed9bf3e4df..88bb3b9ae99fae97ec21972b75ec43cb6b7b22b5 100644
+index 132d375de164e6d8df61234def650154c67fc0df..73edd472b62441670653eb7e3c90aa9667792df7 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -353,6 +353,49 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -354,6 +354,49 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      @Nullable
      T get(@NotNull NamespacedKey key);
  
@@ -84,7 +84,7 @@ index f301f81817409f0a6799885d4f0972ed9bf3e4df..88bb3b9ae99fae97ec21972b75ec43cb
      /**
       * Returns a new stream, which contains all registry items, which are registered to the registry.
       *
-@@ -427,5 +470,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -428,5 +471,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
          public Class<T> getType() {
              return this.type;
          }

--- a/patches/api/0451-Add-Lifecycle-Event-system.patch
+++ b/patches/api/0451-Add-Lifecycle-Event-system.patch
@@ -573,10 +573,10 @@ index 4eb639fbb46a0848be207149ea433455550fae1c..ef431219fd2bce48bad63b6b92c99d54
 +    // Paper end - lifecycle events
  }
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-index 5cd236965de12392d8c7aa81307c0ff1cc8673b1..34037d3da2c536bac088e0ff629ee8f1daccc65b 100644
+index d359ea9b02952f981b9cf9d778c56eb995454c60..d5a3c3dce76c4ed0f1184ab5ba21db9c5f1c01ec 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-@@ -47,6 +47,11 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -48,6 +48,11 @@ public abstract class JavaPlugin extends PluginBase {
      private FileConfiguration newConfig = null;
      private File configFile = null;
      private Logger logger = null; // Paper - PluginLogger -> Logger
@@ -588,7 +588,7 @@ index 5cd236965de12392d8c7aa81307c0ff1cc8673b1..34037d3da2c536bac088e0ff629ee8f1
  
      public JavaPlugin() {
          // Paper start
-@@ -278,7 +283,9 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -279,7 +284,9 @@ public abstract class JavaPlugin extends PluginBase {
              isEnabled = enabled;
  
              if (isEnabled) {
@@ -598,7 +598,7 @@ index 5cd236965de12392d8c7aa81307c0ff1cc8673b1..34037d3da2c536bac088e0ff629ee8f1
              } else {
                  onDisable();
              }
-@@ -456,4 +463,11 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -457,4 +464,11 @@ public abstract class JavaPlugin extends PluginBase {
          }
          return plugin;
      }

--- a/patches/api/0452-ItemStack-Tooltip-API.patch
+++ b/patches/api/0452-ItemStack-Tooltip-API.patch
@@ -119,10 +119,10 @@ index 3f1b48fd65df954e874e6dc6b9093cb12370e2c5..0e9ccfee7a03d341e7c4d271f53b4ed1
 +    @NotNull java.util.List<net.kyori.adventure.text.Component> computeTooltipLines(@NotNull ItemStack itemStack, @NotNull io.papermc.paper.inventory.tooltip.TooltipContext tooltipContext, @Nullable org.bukkit.entity.Player player); // Paper - expose itemstack tooltip lines
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 8975f6e8004d2ed65e20bb5b71bdbfa45713f78a..8db71bd075b8ece36c6f0dc0339841df9257038b 100644
+index f8573571cd256b9bf68e0e8c6fa523be5b46b83e..61de2daa17957079ccc3ae36d40745d6cb516d16 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -1027,4 +1027,21 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -1029,4 +1029,21 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
          return type.isAir() || amount <= 0;
      }
      // Paper end

--- a/patches/api/0453-Add-getChunkSnapshot-includeLightData-parameter.patch
+++ b/patches/api/0453-Add-getChunkSnapshot-includeLightData-parameter.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getChunkSnapshot includeLightData parameter
 
 
 diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
-index 546888898d9d6827079fe041c7bc6eb4e1e4605c..d547ae2b20c58bc703de4532b3b591dd34ddb1c6 100644
+index c2eb2edd87b4087bfcdffd98f0f8904fbfd4e657..bc8b5bc17706250b8535b1b309134843d2ce2bb1 100644
 --- a/src/main/java/org/bukkit/Chunk.java
 +++ b/src/main/java/org/bukkit/Chunk.java
-@@ -102,6 +102,23 @@ public interface Chunk extends PersistentDataHolder {
+@@ -103,6 +103,23 @@ public interface Chunk extends PersistentDataHolder {
      @NotNull
      ChunkSnapshot getChunkSnapshot(boolean includeMaxblocky, boolean includeBiome, boolean includeBiomeTempRain);
  

--- a/patches/api/0462-Deprecate-ItemStack-setType.patch
+++ b/patches/api/0462-Deprecate-ItemStack-setType.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deprecate ItemStack#setType
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 8db71bd075b8ece36c6f0dc0339841df9257038b..4818b4e6583414fa98194bb6f3c5dbd4bd95be3a 100644
+index 61de2daa17957079ccc3ae36d40745d6cb516d16..e0c5685356e4de53389e9cacad9514b58dceeaf2 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -136,8 +136,18 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -143,8 +143,18 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
       * {@link Material#isItem()} returns false.</b>
       *
       * @param type New type to set the items in this stack to
@@ -27,7 +27,7 @@ index 8db71bd075b8ece36c6f0dc0339841df9257038b..4818b4e6583414fa98194bb6f3c5dbd4
      public void setType(@NotNull Material type) {
          Preconditions.checkArgument(type != null, "Material cannot be null");
          this.type = type;
-@@ -150,6 +160,24 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -157,6 +167,24 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
              this.data = null;
          }
      }

--- a/patches/api/0464-API-for-checking-sent-chunks.patch
+++ b/patches/api/0464-API-for-checking-sent-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for checking sent chunks
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f08b1a2ec8815efcaaf1371e20eb1461a5f2d359..8a1e39474af88188f2e1765731b57d349f0ee645 100644
+index b824be639084e73d5150b35f29506bfed7af4642..c91dd7689e767a93946ec09f39731301d0e163cb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3751,6 +3751,47 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3799,6 +3799,47 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void resetIdleDuration();
      // Paper end
  

--- a/patches/api/0466-More-Raid-API.patch
+++ b/patches/api/0466-More-Raid-API.patch
@@ -39,10 +39,10 @@ index 983a8c20a06d2b509602b27f49c090598b8ecc42..fa98599e3eee37bf68f0e9813497c718
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 0e3c7de14be8dc01199fd68b6bf41783c5c43ec3..97f97ea5c6aa513c439f86a9c82821e0f7d9cd1e 100644
+index c1f1faebc0d33710eb17dd96fddb16c85b7868e5..fdb87adfb8d6eff2bfabe7a41398c53d15d4cd98 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -4215,6 +4215,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -4242,6 +4242,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public Raid locateNearestRaid(@NotNull Location location, int radius);
  

--- a/patches/api/0468-Fix-ItemFlags.patch
+++ b/patches/api/0468-Fix-ItemFlags.patch
@@ -9,7 +9,7 @@ this, adding the new flag if the itemstack is old and had the
 old flag.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFlag.java b/src/main/java/org/bukkit/inventory/ItemFlag.java
-index a435f6c8947e4ac50b8c04f37b107055970937dd..92e30c281eab4801298b280bd388a0399212a0c1 100644
+index 5b8dac777bb1640dc00bbe98feb6460c36eebb98..1af15fd327e0613cd1a179bd7fef1e83cbe31761 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFlag.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFlag.java
 @@ -2,6 +2,8 @@ package org.bukkit.inventory;
@@ -47,10 +47,10 @@ index a435f6c8947e4ac50b8c04f37b107055970937dd..92e30c281eab4801298b280bd388a039
      /**
       * Setting to show/hide item-specific information, including, but not limited to:
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 4818b4e6583414fa98194bb6f3c5dbd4bd95be3a..c64413a6740b604282984dea2a8430a6e7478d68 100644
+index e0c5685356e4de53389e9cacad9514b58dceeaf2..40cde68c7b73a0a92e2a96667a90138d67ce66ff 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -581,6 +581,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -588,6 +588,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
              Object raw = args.get("meta");
              if (raw instanceof ItemMeta) {
                  ((ItemMeta) raw).setVersion(version);

--- a/patches/api/0476-Brigadier-based-command-API.patch
+++ b/patches/api/0476-Brigadier-based-command-API.patch
@@ -1900,10 +1900,10 @@ index 9d4f553c04784cca63901a56a7aea62a5cae1d72..abe256e1e45ce28036da4aa1586715bc
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-index ac9a28922f8a556944a4c3649d74c32c622f0cb0..c3a9cf65db73ed534bf20996c7f05b5eb0aaebe1 100644
+index b5f9cd2bd191f8b071c6c95706ddbef97d3c244e..5df19bd701c67506689fc7f49d91f99ebfbc83f0 100644
 --- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
 +++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-@@ -22,10 +22,14 @@ import org.jetbrains.annotations.NotNull;
+@@ -23,10 +23,14 @@ import org.jetbrains.annotations.NotNull;
  import org.jetbrains.annotations.Nullable;
  
  public class SimpleCommandMap implements CommandMap {
@@ -1920,7 +1920,7 @@ index ac9a28922f8a556944a4c3649d74c32c622f0cb0..c3a9cf65db73ed534bf20996c7f05b5e
          this.server = server;
          setDefaultCommands();
      }
-@@ -102,7 +106,10 @@ public class SimpleCommandMap implements CommandMap {
+@@ -103,7 +107,10 @@ public class SimpleCommandMap implements CommandMap {
       */
      private synchronized boolean register(@NotNull String label, @NotNull Command command, boolean isAlias, @NotNull String fallbackPrefix) {
          knownCommands.put(fallbackPrefix + ":" + label, command);
@@ -1932,7 +1932,7 @@ index ac9a28922f8a556944a4c3649d74c32c622f0cb0..c3a9cf65db73ed534bf20996c7f05b5e
              // Request is for an alias/fallback command and it conflicts with
              // a existing command or previous alias ignore it
              // Note: This will mean it gets removed from the commands list of active aliases
-@@ -114,7 +121,9 @@ public class SimpleCommandMap implements CommandMap {
+@@ -115,7 +122,9 @@ public class SimpleCommandMap implements CommandMap {
          // If the command exists but is an alias we overwrite it, otherwise we return
          Command conflict = knownCommands.get(label);
          if (conflict != null && conflict.getLabel().equals(label)) {

--- a/patches/api/0477-Fix-issues-with-recipe-API.patch
+++ b/patches/api/0477-Fix-issues-with-recipe-API.patch
@@ -126,10 +126,10 @@ index 39f9766a03d420340d79841197f75c8b1dd49f4a..4e59f5176fd6cf92457ad750081c253a
          }
      }
 diff --git a/src/main/java/org/bukkit/inventory/RecipeChoice.java b/src/main/java/org/bukkit/inventory/RecipeChoice.java
-index db8bcc66bdc4bedfffb4705db6338eda4c0ad29a..1cd6601c9d2e86ef850011fcb9e59811207b4af7 100644
+index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..e7796054f3f65f5bea7f93c75320195f6c2f0561 100644
 --- a/src/main/java/org/bukkit/inventory/RecipeChoice.java
 +++ b/src/main/java/org/bukkit/inventory/RecipeChoice.java
-@@ -19,6 +19,19 @@ import org.jetbrains.annotations.NotNull;
+@@ -22,6 +22,19 @@ import org.jetbrains.annotations.NotNull;
   */
  public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
  
@@ -149,7 +149,7 @@ index db8bcc66bdc4bedfffb4705db6338eda4c0ad29a..1cd6601c9d2e86ef850011fcb9e59811
      /**
       * Gets a single item stack representative of this stack choice.
       *
-@@ -35,6 +48,13 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -38,6 +51,13 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
      @Override
      boolean test(@NotNull ItemStack itemStack);
  
@@ -163,7 +163,7 @@ index db8bcc66bdc4bedfffb4705db6338eda4c0ad29a..1cd6601c9d2e86ef850011fcb9e59811
      /**
       * Represents a choice of multiple matching Materials.
       */
-@@ -141,6 +161,16 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -152,6 +172,16 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public String toString() {
              return "MaterialChoice{" + "choices=" + choices + '}';
          }
@@ -180,7 +180,7 @@ index db8bcc66bdc4bedfffb4705db6338eda4c0ad29a..1cd6601c9d2e86ef850011fcb9e59811
      }
  
      /**
-@@ -185,7 +215,12 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -197,7 +227,12 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public ExactChoice clone() {
              try {
                  ExactChoice clone = (ExactChoice) super.clone();
@@ -194,7 +194,7 @@ index db8bcc66bdc4bedfffb4705db6338eda4c0ad29a..1cd6601c9d2e86ef850011fcb9e59811
                  return clone;
              } catch (CloneNotSupportedException ex) {
                  throw new AssertionError(ex);
-@@ -232,5 +267,15 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -244,5 +279,15 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public String toString() {
              return "ExactChoice{" + "choices=" + choices + '}';
          }

--- a/patches/api/0478-Fix-equipment-slot-and-group-API.patch
+++ b/patches/api/0478-Fix-equipment-slot-and-group-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix equipment slot and group API
 was missing the 'body' slot group
 
 diff --git a/src/main/java/org/bukkit/attribute/AttributeModifier.java b/src/main/java/org/bukkit/attribute/AttributeModifier.java
-index 8ba00f743b61cd33dd41ae7f1c272ee2b0c8546d..7cc1fd241e1f62a9fe9b5849110c0a3d05d08034 100644
+index 9b47cbb93399a22301ec643e4be8f173314c455e..097396166b94ec7c9581a7b2f4ef644f95708671 100644
 --- a/src/main/java/org/bukkit/attribute/AttributeModifier.java
 +++ b/src/main/java/org/bukkit/attribute/AttributeModifier.java
-@@ -95,6 +95,7 @@ public class AttributeModifier implements ConfigurationSerializable {
+@@ -96,6 +96,7 @@ public class AttributeModifier implements ConfigurationSerializable {
       */
      @Nullable
      @Deprecated
@@ -48,10 +48,10 @@ index 1b34286fb6cbedb3841c84c499eb626f61885126..0829418cc4b586ea9c800617f7184b1e
      @NotNull
      public ItemStack getItem(@NotNull EquipmentSlot slot);
 diff --git a/src/main/java/org/bukkit/inventory/EquipmentSlotGroup.java b/src/main/java/org/bukkit/inventory/EquipmentSlotGroup.java
-index 82416a078f697f627916c578e6c2dbc003519acf..f72aa9cfd2d1472cf26600ac0f2380660069407d 100644
+index 0019c8d91eefbfb44e76b9f929b25cd189295b79..5ce9da41ac4967f036e376fa270d4065b3d2e5d5 100644
 --- a/src/main/java/org/bukkit/inventory/EquipmentSlotGroup.java
 +++ b/src/main/java/org/bukkit/inventory/EquipmentSlotGroup.java
-@@ -25,6 +25,7 @@ public final class EquipmentSlotGroup implements Predicate<EquipmentSlot> {
+@@ -26,6 +26,7 @@ public final class EquipmentSlotGroup implements Predicate<EquipmentSlot> {
      public static final EquipmentSlotGroup CHEST = get("chest", EquipmentSlot.CHEST);
      public static final EquipmentSlotGroup HEAD = get("head", EquipmentSlot.HEAD);
      public static final EquipmentSlotGroup ARMOR = get("armor", (test) -> test == EquipmentSlot.FEET || test == EquipmentSlot.LEGS || test == EquipmentSlot.CHEST || test == EquipmentSlot.HEAD, EquipmentSlot.CHEST);

--- a/patches/api/0479-Allow-Bukkit-plugin-to-use-Paper-PluginLoader-API.patch
+++ b/patches/api/0479-Allow-Bukkit-plugin-to-use-Paper-PluginLoader-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow Bukkit plugin to use Paper PluginLoader API
 
 
 diff --git a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
-index c0691a849831f99268fdcb7b0f471f80a1a2a70e..8f45caade7357bc55c6a90cfe0c3a2feb2d877ff 100644
+index c5465431ce35d264d8510af45e73d058b333c60b..a857e46fa6f0c212db93193e1fdd8b0ea9c33c38 100644
 --- a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
 +++ b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
-@@ -259,6 +259,13 @@ public final class PluginDescriptionFile implements io.papermc.paper.plugin.conf
+@@ -260,6 +260,13 @@ public final class PluginDescriptionFile implements io.papermc.paper.plugin.conf
      private Set<PluginAwareness> awareness = ImmutableSet.of();
      private String apiVersion = null;
      private List<String> libraries = ImmutableList.of();
@@ -22,7 +22,7 @@ index c0691a849831f99268fdcb7b0f471f80a1a2a70e..8f45caade7357bc55c6a90cfe0c3a2fe
      // Paper start - oh my goddddd
      /**
       * Don't use this.
-@@ -1232,6 +1239,23 @@ public final class PluginDescriptionFile implements io.papermc.paper.plugin.conf
+@@ -1233,6 +1240,23 @@ public final class PluginDescriptionFile implements io.papermc.paper.plugin.conf
          } else {
              libraries = ImmutableList.<String>of();
          }

--- a/patches/server/0002-Remap-fixes.patch
+++ b/patches/server/0002-Remap-fixes.patch
@@ -172,10 +172,10 @@ index 5818bfa69a8573a2a8f350066f829d587cbc546b..8e421a1bee0c526e3024eab9ba4cc0b3
  
              assertNotNull(bukkit, "Bukkit gene null for " + gene);
 diff --git a/src/test/java/org/bukkit/registry/RegistryConstantsTest.java b/src/test/java/org/bukkit/registry/RegistryConstantsTest.java
-index f3de891458ea190e1d608511b5984ca25b06b74c..1b1e55f70b3c9f922bd1cc63209816f50d7d29d1 100644
+index 6c84f1289c84d0aca1935c473ffa63dae1b52598..ebcb65cb74acdb9d1bcf2b4b3551a2dc6d809bc9 100644
 --- a/src/test/java/org/bukkit/registry/RegistryConstantsTest.java
 +++ b/src/test/java/org/bukkit/registry/RegistryConstantsTest.java
-@@ -28,17 +28,17 @@ public class RegistryConstantsTest extends AbstractTestingBase {
+@@ -29,17 +29,17 @@ public class RegistryConstantsTest extends AbstractTestingBase {
  
      @Test
      public void testTrimMaterial() {
@@ -197,7 +197,7 @@ index f3de891458ea190e1d608511b5984ca25b06b74c..1b1e55f70b3c9f922bd1cc63209816f5
  
          for (Field field : clazz.getFields()) {
 diff --git a/src/test/java/org/bukkit/registry/RegistryLoadOrderTest.java b/src/test/java/org/bukkit/registry/RegistryLoadOrderTest.java
-index 7d332ecf7905f71de106fe0e5fb4cc3e16bd6035..d7ef3a9a545d5278832b864bca683796b1fd0d42 100644
+index 31062b6d9ad685ea3750c6b5ddc6b295bb263e0a..5842cb5a6f3da42b8c40e6cbd5c5366572bf7684 100644
 --- a/src/test/java/org/bukkit/registry/RegistryLoadOrderTest.java
 +++ b/src/test/java/org/bukkit/registry/RegistryLoadOrderTest.java
 @@ -24,7 +24,7 @@ public class RegistryLoadOrderTest extends AbstractTestingBase {

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -131,7 +131,7 @@ index a5e8713bc0fefae455b666ebf13c9529e7ba94e6..1a528e1aa7b12f8b8cffce6c7bc4b5d5
  
      public static PackRepository createPackRepository(Path dataPacksPath, DirectoryValidator symlinkFinder) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 5595eb892fa868508c45448942da65d7c11d49fd..4b8602b168f9dd386aa72b4e5d189c441c93542e 100644
+index 029783f07da0a8d91c2e443f76359b89869bc4cc..bebc3bcffa6dc12d4caf613f05b1e2a28a26f316 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -210,7 +210,7 @@ public class Main {
@@ -142,7 +142,7 @@ index 5595eb892fa868508c45448942da65d7c11d49fd..4b8602b168f9dd386aa72b4e5d189c44
 +                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
  
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -3);
+                     deadline.add(Calendar.DAY_OF_YEAR, -21);
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 index 93046379d0cefd5d3236fc59e698809acdc18f80..774556a62eb240da42e84db4502e2ed43495be17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java

--- a/patches/server/0004-Test-changes.patch
+++ b/patches/server/0004-Test-changes.patch
@@ -338,10 +338,10 @@ index 0000000000000000000000000000000000000000..6cbf11c898439834cffb99ef84e5df14
 +    String[] value() default {};
 +}
 diff --git a/src/test/java/org/bukkit/registry/RegistryConstantsTest.java b/src/test/java/org/bukkit/registry/RegistryConstantsTest.java
-index 1b1e55f70b3c9f922bd1cc63209816f50d7d29d1..c75cfdfc3dc07b922d8943b67a59cfffbbb9a214 100644
+index ebcb65cb74acdb9d1bcf2b4b3551a2dc6d809bc9..7d9dbed7281099b78d7f898885b37cdcfe8b099f 100644
 --- a/src/test/java/org/bukkit/registry/RegistryConstantsTest.java
 +++ b/src/test/java/org/bukkit/registry/RegistryConstantsTest.java
-@@ -23,7 +23,7 @@ public class RegistryConstantsTest extends AbstractTestingBase {
+@@ -24,7 +24,7 @@ public class RegistryConstantsTest extends AbstractTestingBase {
      @Test
      public void testDamageType() {
          this.testExcessConstants(DamageType.class, Registry.DAMAGE_TYPE);
@@ -351,7 +351,7 @@ index 1b1e55f70b3c9f922bd1cc63209816f50d7d29d1..c75cfdfc3dc07b922d8943b67a59cfff
  
      @Test
 diff --git a/src/test/java/org/bukkit/support/DummyServer.java b/src/test/java/org/bukkit/support/DummyServer.java
-index ee0cff84379bc0539b2c611a4904aff9f5843814..02a8e6b45bf304b6e0f88043a25188aa16b3d6bf 100644
+index 4153866f3e630e54a23dc085aaac5e804344aa43..b8fe92fc75c611ee1efb82a8ab7089f28bf338ea 100644
 --- a/src/test/java/org/bukkit/support/DummyServer.java
 +++ b/src/test/java/org/bukkit/support/DummyServer.java
 @@ -50,6 +50,15 @@ public final class DummyServer {

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -3641,7 +3641,7 @@ index 0000000000000000000000000000000000000000..6cdc40cb4a5f94654c874f9dbdb106fa
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/transformation/world/LegacyPaperWorldConfig.java b/src/main/java/io/papermc/paper/configuration/transformation/world/LegacyPaperWorldConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..edaa6ef28c1f9a2239439698708897008fea2f7e
+index 0000000000000000000000000000000000000000..f7520ba86c1a650d3bd9b902d2a59ec8eb6cde5d
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/transformation/world/LegacyPaperWorldConfig.java
 @@ -0,0 +1,322 @@
@@ -3752,7 +3752,7 @@ index 0000000000000000000000000000000000000000..edaa6ef28c1f9a223943969870889700
 +            )
 +            .addVersion(26, ConfigurationTransformation.builder().addAction(path("alt-item-despawn-rate", "items", ConfigurationTransformation.WILDCARD_OBJECT), (path, value) -> {
 +                String itemName = path.get(path.size() - 1).toString();
-+                final Optional<Holder.Reference<Item>> item = BuiltInRegistries.ITEM.getHolder(ResourceKey.create(Registries.ITEM, new ResourceLocation(itemName.toLowerCase(Locale.ENGLISH))));
++                final Optional<Holder.Reference<Item>> item = BuiltInRegistries.ITEM.getHolder(ResourceKey.create(Registries.ITEM, new ResourceLocation(itemName.toLowerCase(Locale.ROOT))));
 +                if (item.isEmpty()) {
 +                    itemName = Material.valueOf(itemName).getKey().getKey();
 +                }
@@ -3784,7 +3784,7 @@ index 0000000000000000000000000000000000000000..edaa6ef28c1f9a223943969870889700
 +                    Map<String, Integer> rebuild = new HashMap<>();
 +                    value.childrenMap().forEach((key, node) -> {
 +                        String itemName = key.toString();
-+                        final Optional<Holder.Reference<Item>> itemHolder = BuiltInRegistries.ITEM.getHolder(ResourceKey.create(Registries.ITEM, new ResourceLocation(itemName.toLowerCase(Locale.ENGLISH))));
++                        final Optional<Holder.Reference<Item>> itemHolder = BuiltInRegistries.ITEM.getHolder(ResourceKey.create(Registries.ITEM, new ResourceLocation(itemName.toLowerCase(Locale.ROOT))));
 +                        final @Nullable String item;
 +                        if (itemHolder.isEmpty()) {
 +                            final @Nullable Material bukkitMat = Material.matchMaterial(itemName);
@@ -4116,7 +4116,7 @@ index 0000000000000000000000000000000000000000..d872b1948df52759fed9c3d892aed6ab
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/type/BooleanOrDefault.java b/src/main/java/io/papermc/paper/configuration/type/BooleanOrDefault.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5f03dcdff99bcd33bf789b0dd5521e39afbe09bf
+index 0000000000000000000000000000000000000000..a3eaa47cfcfc4fd2a607f9b375230fada35620d3
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/type/BooleanOrDefault.java
 @@ -0,0 +1,53 @@
@@ -4152,7 +4152,7 @@ index 0000000000000000000000000000000000000000..5f03dcdff99bcd33bf789b0dd5521e39
 +                    return USE_DEFAULT;
 +                }
 +                try {
-+                    return new BooleanOrDefault(BooleanUtils.toBoolean(string.toLowerCase(Locale.ENGLISH), "true", "false"));
++                    return new BooleanOrDefault(BooleanUtils.toBoolean(string.toLowerCase(Locale.ROOT), "true", "false"));
 +                } catch (IllegalArgumentException ex) {
 +                    throw new SerializationException(BooleanOrDefault.class, obj + "(" + type + ") is not a boolean or '" + DEFAULT_VALUE + "'", ex);
 +                }
@@ -4911,7 +4911,7 @@ index b334265d4015fec13d7fedbffba2b6c22f4c8bc8..5b4ac7b4fd0077e900e9f788963f1613
              String s = (String) Optional.ofNullable((String) optionset.valueOf("world")).orElse(dedicatedserversettings.getProperties().levelName);
              LevelStorageSource convertable = LevelStorageSource.createDefault(file.toPath());
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a6d495371a35195d6f841124329188107af1736f..1d241972e6f93a88c31f1276e15bae0912db5c9e 100644
+index 4506669b1e970daa78974d22349e5dc38cf31c5e..c2c20eb7fedbadc56b1f8ee8bf4b03092e62a26b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -302,6 +302,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -5039,10 +5039,10 @@ index ecbb926986bbc0ad6fe108b782cdc17ee8a9f035..b06ffa8d5953c8f0a47daf056495cd42
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3d80f58524861ad808caa35964676f0561b25547..e51e40910c51ab5cdc599e614d2b3fa813691f10 100644
+index 5b40c1198f4bbe84c5e1b45b32cce5c451fc28aa..4a4f7af9c7377e79a20398310ef7cf719d3cc0b5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -928,6 +928,7 @@ public final class CraftServer implements Server {
+@@ -951,6 +951,7 @@ public final class CraftServer implements Server {
          }
  
          org.spigotmc.SpigotConfig.init((File) this.console.options.valueOf("spigot-settings")); // Spigot
@@ -5051,7 +5051,7 @@ index 3d80f58524861ad808caa35964676f0561b25547..e51e40910c51ab5cdc599e614d2b3fa8
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 4b8602b168f9dd386aa72b4e5d189c441c93542e..1e3ca7ca98abfd5be233a7eeb6dad201776d2d6a 100644
+index bebc3bcffa6dc12d4caf613f05b1e2a28a26f316..bbc880e136c8fba9634fd4fee9e3e6838ef3f377 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -142,6 +142,19 @@ public class Main {
@@ -5088,7 +5088,7 @@ index 9658f2961d9b5632ad1abdba26a2443642624f69..38219af7d0ba2d871711102b6a29139a
          for ( Method method : clazz.getDeclaredMethods() )
          {
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 974e679ff20193f85fccb6e779a7ba791d0c5db4..8491ff48051224204b58d273c4971d16ab8867c1 100644
+index a6d2ce801b236b046b94913bccf7eccfc561f35a..b244b65799d9c082b8b1639bad15727442e63168 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -58,8 +58,14 @@ public class SpigotWorldConfig

--- a/patches/server/0008-CB-fixes.patch
+++ b/patches/server/0008-CB-fixes.patch
@@ -68,10 +68,10 @@ index 9b90649f71849b3830ca9b6a3c5a722c66b02f1f..209c6b64e79c29ea3bb84ddbe89a8bff
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e51e40910c51ab5cdc599e614d2b3fa813691f10..ca10f5f6fa70b2e3f4f09a132c91df331a1de559 100644
+index 4a4f7af9c7377e79a20398310ef7cf719d3cc0b5..10549f2f4d6ae01c080cdba16c71656b764314c3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2483,7 +2483,13 @@ public final class CraftServer implements Server {
+@@ -2506,7 +2506,13 @@ public final class CraftServer implements Server {
          Preconditions.checkArgument(key != null, "NamespacedKey key cannot be null");
  
          ReloadableServerRegistries.Holder registry = this.getServer().reloadableRegistries();
@@ -87,7 +87,7 @@ index e51e40910c51ab5cdc599e614d2b3fa813691f10..ca10f5f6fa70b2e3f4f09a132c91df33
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 1e3ca7ca98abfd5be233a7eeb6dad201776d2d6a..9ec50bbb262b25fea157ae48e8395f5cd38f8906 100644
+index bbc880e136c8fba9634fd4fee9e3e6838ef3f377..e5f070de12b63487b71c54d8020a895e5eda862c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -123,6 +123,7 @@ public class Main {
@@ -119,10 +119,10 @@ index 905adf97c0d1f0d1c774a6835a5dffcfea884e58..c017ce2ca1bc535795c958a2e509af2a
  public class CraftScheduler implements BukkitScheduler {
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 2166c420c47778caadf8f3140bbe3aebe06e130f..3b010825028f142c58fad40802c40df62486e903 100644
+index 8021fa01542a5dd203a834e88e286903093690cd..3879f1f69e13f4e90bd66c533bf76b257f041394 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -243,7 +243,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -244,7 +244,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
          try {
              nmsStack.applyComponents(new ItemParser(Commands.createValidationContext(MinecraftServer.getDefaultRegistryAccess())).parse(new StringReader(arguments)).components());
          } catch (CommandSyntaxException ex) {

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -6074,7 +6074,7 @@ index 3e5a85a7ad6149b04622c254fbc2e174896a4128..3f662692ed4846e026a9d48595e7b3b2
 +
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 9efd8dc1c35dc0a13f5ff3f097386e6e768b3bc0..977275f767c374a1be9055e4aa9e124025d55828 100644
+index 925c2c83191bdb70b0d14a6177183e4d9a190a97..da3cc749b3b1f3738e7e7cd77fb0b0fd6eea0b0b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -303,6 +303,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -6673,7 +6673,7 @@ index 7a604df2cec802f7da78935647990fe8b575307b..e8640bcbc1d4e2965049974385585f50
  
          while (objectiterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 8661ed9962d07fb40390faf7f186b9cd8ce6bc62..23c39b78486b018e222af489c8edbf4e749abff6 100644
+index 87e76f3c9f5185ee15a80eed37f72b0f376b00e5..712670230b6b881101b4128c1d275f2559fa705a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -47,6 +47,7 @@ import net.minecraft.world.level.storage.LevelStorageSource;
@@ -7061,7 +7061,7 @@ index b64ec67ebd3b30d29cca36086a7aa70a6dd1fac3..cc3304e2ea7f58b4649da09b68ac3749
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index d5c3ebe351803c3dd24f0667aa87e13c6b420080..d2f75ced3ad4ccb9d1d44307bfc98e69e5fc8c6f 100644
+index 20ad73994af8e4a25a60662a7ccb549d5704fab3..a3ebdbb231fb7bc6ed24747105ef02bb0ea9770e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -270,6 +270,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -7073,7 +7073,7 @@ index d5c3ebe351803c3dd24f0667aa87e13c6b420080..d2f75ced3ad4ccb9d1d44307bfc98e69
      @Override
      public float getBukkitYaw() {
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 04d9e3aced11c54b8f464ae7faba1b4aaf81e093..39e71ff8528622f640950d1a9b33483a7eb68957 100644
+index 1e599ab9c9576a42b32533abbd021f32223e53a2..d615649c67b54cfd1cb083e3ddb9719255e90bc7 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -287,6 +287,8 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Targeti
@@ -7111,7 +7111,7 @@ index f73604d762efbac400d40f536ec1782fca584efa..4701bf9ee203f2f15b0b68e84bbfa2c4
          super(type, world);
          this.xpReward = 5;
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 7442e2b880f6410d3ca57a563f3ad77158a4c8ba..bf19e8e8aa96d646f057b8727f2f01ad2e2497cd 100644
+index 12516ac7c18a90d12e0d9ec90448ebb64a468766..d7f427bf5c84d1bb405e4aaf16e3a8f1fed5ad79 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -952,6 +952,25 @@ public final class ItemStack implements DataComponentHolder {
@@ -7751,10 +7751,10 @@ index 34933c5324126f9afdc5cba9dea997ace8f01806..219062cff8a05c765b092f1525043d9d
              return false;
          } else {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ca10f5f6fa70b2e3f4f09a132c91df331a1de559..4cc75d39dd1104805e96c1d442400f2c18a7af2a 100644
+index 10549f2f4d6ae01c080cdba16c71656b764314c3..69d27337f13ca85ba74d611a0ca635c8af1d694e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2562,4 +2562,9 @@ public final class CraftServer implements Server {
+@@ -2585,4 +2585,9 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end
@@ -7765,7 +7765,7 @@ index ca10f5f6fa70b2e3f4f09a132c91df331a1de559..4cc75d39dd1104805e96c1d442400f2c
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index fb8243b6202374b5a1b5197a6b7984e1cfb60500..6ce2b09c4bb7153c960a7eed865296a9c93dd1cb 100644
+index 25787af664c6bb0c28a53265e308e3bf7a78ec8d..bd32f4e6ab8c41404ebcc8ef3b448c71db7b0650 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -252,8 +252,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -7788,7 +7788,7 @@ index fb8243b6202374b5a1b5197a6b7984e1cfb60500..6ce2b09c4bb7153c960a7eed865296a9
          if (playerChunk == null) return false;
  
          playerChunk.getTickingChunkFuture().thenAccept(either -> {
-@@ -2075,4 +2075,55 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2100,4 +2100,55 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.spigot;
      }
      // Spigot end
@@ -7845,10 +7845,10 @@ index fb8243b6202374b5a1b5197a6b7984e1cfb60500..6ce2b09c4bb7153c960a7eed865296a9
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b6072ff647cf9d823924afb02759ab39f37b3e4f..654d4994bb2e65c5ca6b7190c15d2113eede9e5b 100644
+index 99a16850b1cb0d66092524e04727874524b7ec03..1c0b19a8d7ce31802436bd5f0910f4fba8a391b7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2397,4 +2397,34 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2406,4 +2406,34 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.spigot;
      }
      // Spigot end
@@ -7884,7 +7884,7 @@ index b6072ff647cf9d823924afb02759ab39f37b3e4f..654d4994bb2e65c5ca6b7190c15d2113
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 39803e02ff5fcca8c9ce07aae890ab7095656370..b6521462d193bff83ace1dc694c6d957a7173969 100644
+index 93dc507732395332adc462cb133f2ba5053edf8f..f44502a51c9fb393746e866e1a93ae9cedc2b656 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -22,6 +22,20 @@ import org.bukkit.material.MaterialData;
@@ -8131,10 +8131,10 @@ index 0000000000000000000000000000000000000000..909b2c98e7a9117d2f737245e4661792
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 2166c420c47778caadf8f3140bbe3aebe06e130f..8a13d8ae4325854acb3be7083d022c08ba094df1 100644
+index 3879f1f69e13f4e90bd66c533bf76b257f041394..8a5d5d3bccc974feea09119eb90732934c8ae6a1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -109,8 +109,17 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -110,8 +110,17 @@ public final class CraftMagicNumbers implements UnsafeValues {
      private static final Map<Item, Material> ITEM_MATERIAL = new HashMap<>();
      private static final Map<Material, Item> MATERIAL_ITEM = new HashMap<>();
      private static final Map<Material, Block> MATERIAL_BLOCK = new HashMap<>();
@@ -8152,7 +8152,7 @@ index 2166c420c47778caadf8f3140bbe3aebe06e130f..8a13d8ae4325854acb3be7083d022c08
          for (Block block : BuiltInRegistries.BLOCK) {
              BLOCK_MATERIAL.put(block, Material.getMaterial(BuiltInRegistries.BLOCK.getKey(block).getPath().toUpperCase(Locale.ROOT)));
          }
-@@ -161,6 +170,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -162,6 +171,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public static ResourceLocation key(Material mat) {
          return CraftNamespacedKey.toMinecraft(mat.getKey());
      }

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2596,7 +2596,7 @@ index bb97fdb9aa6167083442a928276ebe4225a586ef..5d1758086ed4fce5b36a5b31df44ccea
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 977275f767c374a1be9055e4aa9e124025d55828..953e28f0cf60412a4ec9e311daa98f9d3cadea85 100644
+index da3cc749b3b1f3738e7e7cd77fb0b0fd6eea0b0b..84ad6aae39b5fe4c4ad5ec08890d4383829cbe50 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -195,6 +195,7 @@ import org.bukkit.craftbukkit.SpigotTimings; // Spigot
@@ -3249,7 +3249,7 @@ index ed54c81a3269360acce674aa4e1d54ccb2461841..c9c849534c3998cfcab7ddcb12a71ccb
      }
  
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index bf19e8e8aa96d646f057b8727f2f01ad2e2497cd..d6b02a946bd18ea71278a5026468ec49fabd3a3b 100644
+index d7f427bf5c84d1bb405e4aaf16e3a8f1fed5ad79..e65a5abfaac1f68bbefe0b7f3877823a548d56cc 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -186,7 +186,15 @@ public final class ItemStack implements DataComponentHolder {
@@ -3322,10 +3322,10 @@ index 3db3c6858d98d2eaf7c9bd8d395b83b22c447bb9..d42d39dff5aeb91c5b1e6a7fb967ce70
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4cc75d39dd1104805e96c1d442400f2c18a7af2a..a5c420721cd1905bb0d00f9e1e40e4fbdf98cce6 100644
+index 69d27337f13ca85ba74d611a0ca635c8af1d694e..beff0bfe2502a17fd297524c51f96b33f889db93 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -611,8 +611,10 @@ public final class CraftServer implements Server {
+@@ -633,8 +633,10 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -3336,7 +3336,7 @@ index 4cc75d39dd1104805e96c1d442400f2c18a7af2a..a5c420721cd1905bb0d00f9e1e40e4fb
      }
  
      @Override
-@@ -1587,7 +1589,15 @@ public final class CraftServer implements Server {
+@@ -1610,7 +1612,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -3352,7 +3352,7 @@ index 4cc75d39dd1104805e96c1d442400f2c18a7af2a..a5c420721cd1905bb0d00f9e1e40e4fb
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1761,7 +1771,20 @@ public final class CraftServer implements Server {
+@@ -1784,7 +1794,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -3373,7 +3373,7 @@ index 4cc75d39dd1104805e96c1d442400f2c18a7af2a..a5c420721cd1905bb0d00f9e1e40e4fb
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1769,14 +1792,14 @@ public final class CraftServer implements Server {
+@@ -1792,14 +1815,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -3390,7 +3390,7 @@ index 4cc75d39dd1104805e96c1d442400f2c18a7af2a..a5c420721cd1905bb0d00f9e1e40e4fb
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -2038,6 +2061,14 @@ public final class CraftServer implements Server {
+@@ -2061,6 +2084,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -3405,7 +3405,7 @@ index 4cc75d39dd1104805e96c1d442400f2c18a7af2a..a5c420721cd1905bb0d00f9e1e40e4fb
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Preconditions.checkArgument(type != null, "InventoryType cannot be null");
-@@ -2052,13 +2083,28 @@ public final class CraftServer implements Server {
+@@ -2075,13 +2106,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -3434,7 +3434,7 @@ index 4cc75d39dd1104805e96c1d442400f2c18a7af2a..a5c420721cd1905bb0d00f9e1e40e4fb
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -2123,6 +2169,17 @@ public final class CraftServer implements Server {
+@@ -2146,6 +2192,17 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(this.console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -3452,7 +3452,7 @@ index 4cc75d39dd1104805e96c1d442400f2c18a7af2a..a5c420721cd1905bb0d00f9e1e40e4fb
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2567,4 +2624,57 @@ public final class CraftServer implements Server {
+@@ -2590,4 +2647,57 @@ public final class CraftServer implements Server {
      public double[] getTPS() {
          return new double[]{0, 0, 0}; // TODO
      }
@@ -3511,7 +3511,7 @@ index 4cc75d39dd1104805e96c1d442400f2c18a7af2a..a5c420721cd1905bb0d00f9e1e40e4fb
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6ce2b09c4bb7153c960a7eed865296a9c93dd1cb..5bbbb9ee266879291e4ff56ad2ee39aa6151bfff 100644
+index bd32f4e6ab8c41404ebcc8ef3b448c71db7b0650..ee5b61c476abc1f9a2babf350ac9dfa45b2c3253 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -162,6 +162,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -3522,7 +3522,7 @@ index 6ce2b09c4bb7153c960a7eed865296a9c93dd1cb..5bbbb9ee266879291e4ff56ad2ee39aa
  
      private static final Random rand = new Random();
  
-@@ -1684,6 +1685,42 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1709,6 +1710,42 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              entityTracker.broadcastAndSend(packet);
          }
      }
@@ -3565,7 +3565,7 @@ index 6ce2b09c4bb7153c960a7eed865296a9c93dd1cb..5bbbb9ee266879291e4ff56ad2ee39aa
  
      private static Map<String, GameRules.Key<?>> gamerules;
      public static synchronized Map<String, GameRules.Key<?>> getGameRulesNMS() {
-@@ -2125,5 +2162,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2150,5 +2187,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public void setSendViewDistance(final int viewDistance) {
          throw new UnsupportedOperationException("Not implemented yet");
      }
@@ -3585,7 +3585,7 @@ index 6ce2b09c4bb7153c960a7eed865296a9c93dd1cb..5bbbb9ee266879291e4ff56ad2ee39aa
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 9ec50bbb262b25fea157ae48e8395f5cd38f8906..985b77911d03bc60a0210b796e901f31e2676268 100644
+index e5f070de12b63487b71c54d8020a895e5eda862c..73c44f94aac069fa3ea9e82be6b95e77a2421c63 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -20,6 +20,12 @@ public class Main {
@@ -4105,7 +4105,7 @@ index 55945b83a5426b352bad9507cc9e94afb1278032..9ea1537408ff2d790747b6e5a681d917
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 654d4994bb2e65c5ca6b7190c15d2113eede9e5b..4d1e8a9211462444543b4a16cefe369245e71b2f 100644
+index 1c0b19a8d7ce31802436bd5f0910f4fba8a391b7..e59f2ae85126061ee35812eaa02a35ddb4a9eb66 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -386,14 +386,40 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -4349,7 +4349,7 @@ index 654d4994bb2e65c5ca6b7190c15d2113eede9e5b..4d1e8a9211462444543b4a16cefe3692
      @Override
      public void removeResourcePack(UUID id) {
          Preconditions.checkArgument(id != null, "Resource pack id cannot be null");
-@@ -2265,6 +2386,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2274,6 +2395,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().requestedViewDistance() == 0) ? Bukkit.getViewDistance() : this.getHandle().requestedViewDistance();
      }
  
@@ -4362,7 +4362,7 @@ index 654d4994bb2e65c5ca6b7190c15d2113eede9e5b..4d1e8a9211462444543b4a16cefe3692
      @Override
      public int getPing() {
          return this.getHandle().connection.latency();
-@@ -2315,6 +2442,248 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2324,6 +2451,248 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().allowsListing();
      }
  
@@ -4778,10 +4778,10 @@ index 4dd9a80af9901287ab6740b072f2b89678c3d0cb..b2586684295b295a3196a2a9cf724cec
      public String getTitle() {
          return this.title;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 01963ef944da9251c038208c20012939afc77830..319ad3342740657175ad78a1c1cc383046fe2fb5 100644
+index efbef9a72e1ee7c4928ffc9e3a818dbbca6aa002..e8dd4ba93c09c514f3594f0d4b5f1167b719a17d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -501,4 +501,21 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -499,4 +499,21 @@ public final class CraftItemFactory implements ItemFactory {
          CraftItemStack craft = (CraftItemStack) itemStack;
          return CraftItemStack.asCraftMirror(EnchantmentHelper.enchantItem(MinecraftServer.getServer().getWorldData().enabledFeatures(), source, craft.handle, level, allowTreasures));
      }
@@ -5135,11 +5135,11 @@ index 2e6f0a0f4bbe4ae3c7c85e679f6187e89d1298ff..c7360e2b2d6e50abc371c21b09cdadd6
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 78653e2b669bee1f46fc9e8c4485ae4936244db7..8be2184fc6d04a722fd9fb27549ec8df906a12ee 100644
+index c33161090f6f746c04a87ca5b71f4df80f4fd246..41ba64593bd548131d1cdbecc79b2f38406aa78b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -862,6 +862,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
-         return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasDamage() || this.hasMaxDamage() || this.hasAttributeModifiers() || this.customTag != null);
+@@ -883,6 +883,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+         return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasTool() || this.hasDamage() || this.hasMaxDamage() || this.hasAttributeModifiers() || this.customTag != null);
      }
  
 +    // Paper start
@@ -5157,7 +5157,7 @@ index 78653e2b669bee1f46fc9e8c4485ae4936244db7..8be2184fc6d04a722fd9fb27549ec8df
      @Override
      public String getDisplayName() {
          return CraftChatMessage.fromComponent(this.displayName);
-@@ -892,6 +904,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -913,6 +925,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.itemName != null;
      }
  
@@ -5176,7 +5176,7 @@ index 78653e2b669bee1f46fc9e8c4485ae4936244db7..8be2184fc6d04a722fd9fb27549ec8df
      @Override
      public String getLocalizedName() {
          return this.getDisplayName();
-@@ -911,6 +935,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -932,6 +956,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.lore != null && !this.lore.isEmpty();
      }
  
@@ -5547,10 +5547,10 @@ index 4d586e1375ed8782939c9d480479e0dd981f8cbc..7900adb0b158bc17dd792dd082c33854
 +
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
-index 64191fb2f238c6dacf894d88a703ced6e75a6054..cb6cc3896e862291a058d21fa9704dd1519ff5e1 100644
+index 28038c3a531680201dcc8f2716b8f46f3886e769..5a9ddf71dc186c537a23083ac59434fb446a2140 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
-@@ -307,6 +307,7 @@ public final class CraftChatMessage {
+@@ -308,6 +308,7 @@ public final class CraftChatMessage {
  
      public static String fromComponent(Component component) {
          if (component == null) return "";
@@ -5559,10 +5559,10 @@ index 64191fb2f238c6dacf894d88a703ced6e75a6054..cb6cc3896e862291a058d21fa9704dd1
  
          boolean hadFormat = false;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 951f76eff07e53af20105b29a4e3c81b78ef8b65..cac2bfc711daba11a640e4e776b10c86041b0670 100644
+index 8a5d5d3bccc974feea09119eb90732934c8ae6a1..8727d09566cba3b7223e4c72f960e568a9d8bb62 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -80,6 +80,43 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -81,6 +81,43 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
      private CraftMagicNumbers() {}
  

--- a/patches/server/0011-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0011-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -216,7 +216,7 @@ index 0000000000000000000000000000000000000000..8f07539a82f449ad217e316a7513a170
 +
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
-index fc6e13e4f2408ccbfa645eae2d7ebf4dcfc21908..badd85a92f38caae257181f67a322fc79599d1ce 100644
+index 7397918cf747bc2352bf5bb112a71e7f6844e0e0..0f9b744a977ec7ab8f138989b2336117b3de1412 100644
 --- a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 +++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 @@ -31,6 +31,7 @@ import net.kyori.adventure.text.flattener.ComponentFlattener;
@@ -260,7 +260,7 @@ index 8323f135d6bf2e1f12525e05094ffa3f2420e7e1..a143ea1e58464a3122fbd8ccafe417bd
      }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 953e28f0cf60412a4ec9e311daa98f9d3cadea85..c25d80a1d5aa0f3cc2cbf1e9b94154c759aab36e 100644
+index 84ad6aae39b5fe4c4ad5ec08890d4383829cbe50..8dfa0fae4d5129688b7e2897da1fc51683aed6c3 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -148,7 +148,7 @@ import org.slf4j.Logger;
@@ -396,10 +396,10 @@ index 0ff094a90bf471ce57a3054c7701dc3d67742d9d..50f4b77c83854932050cc543c7c2deea
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a5c420721cd1905bb0d00f9e1e40e4fbdf98cce6..7d850ef45093ab5ca0dd29b29ed36f663f3fa2e2 100644
+index beff0bfe2502a17fd297524c51f96b33f889db93..749a4f1e8e46e0b072832056186d709a93df4b58 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -42,7 +42,7 @@ import java.util.logging.Level;
+@@ -43,7 +43,7 @@ import java.util.logging.Level;
  import java.util.logging.Logger;
  import java.util.stream.Collectors;
  import javax.imageio.ImageIO;
@@ -408,7 +408,7 @@ index a5c420721cd1905bb0d00f9e1e40e4fbdf98cce6..7d850ef45093ab5ca0dd29b29ed36f66
  import net.minecraft.advancements.AdvancementHolder;
  import net.minecraft.commands.CommandSourceStack;
  import net.minecraft.commands.Commands;
-@@ -1320,9 +1320,13 @@ public final class CraftServer implements Server {
+@@ -1343,9 +1343,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  
@@ -423,7 +423,7 @@ index a5c420721cd1905bb0d00f9e1e40e4fbdf98cce6..7d850ef45093ab5ca0dd29b29ed36f66
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 985b77911d03bc60a0210b796e901f31e2676268..9de87edb75947382fda114df883fb4b31c1a7141 100644
+index 73c44f94aac069fa3ea9e82be6b95e77a2421c63..2ef6386ea4b95211e26c8759cae849cbe68e3f40 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -13,7 +13,6 @@ import java.util.logging.Logger;

--- a/patches/server/0017-Paper-command.patch
+++ b/patches/server/0017-Paper-command.patch
@@ -123,7 +123,7 @@ index 0000000000000000000000000000000000000000..953c30500892e5f0c55b8597bc708ea8
 +}
 diff --git a/src/main/java/io/papermc/paper/command/PaperCommand.java b/src/main/java/io/papermc/paper/command/PaperCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8ccc59473bac983ced6b9e4a57e0ec4ebd2b0f32
+index 0000000000000000000000000000000000000000..95d3320c865d24609252063be07cddfd07d0d6d8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/PaperCommand.java
 @@ -0,0 +1,143 @@
@@ -253,7 +253,7 @@ index 0000000000000000000000000000000000000000..8ccc59473bac983ced6b9e4a57e0ec4e
 +    }
 +
 +    private static @Nullable Pair<String, PaperSubcommand> resolveCommand(String label) {
-+        label = label.toLowerCase(Locale.ENGLISH);
++        label = label.toLowerCase(Locale.ROOT);
 +        @Nullable PaperSubcommand subCommand = SUBCOMMANDS.get(label);
 +        if (subCommand == null) {
 +            final @Nullable String command = ALIASES.get(label);
@@ -332,7 +332,7 @@ index 0000000000000000000000000000000000000000..7e9e0ff8639be135bf8575e375cbada5
 +}
 diff --git a/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ff99336e0b8131ae161cfa5c4fc83c6905e3dbc8
+index 0000000000000000000000000000000000000000..67fcba634f8183bb33834ac3b2c3dcfb8d87129e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 @@ -0,0 +1,158 @@
@@ -396,15 +396,15 @@ index 0000000000000000000000000000000000000000..ff99336e0b8131ae161cfa5c4fc83c69
 +     */
 +    private void listEntities(final CommandSender sender, final String[] args) {
 +        // help
-+        if (args.length < 1 || !args[0].toLowerCase(Locale.ENGLISH).equals("list")) {
++        if (args.length < 1 || !args[0].toLowerCase(Locale.ROOT).equals("list")) {
 +            sender.sendMessage(text("Use /paper entity [list] help for more information on a specific command", RED));
 +            return;
 +        }
 +
-+        if ("list".equals(args[0].toLowerCase(Locale.ENGLISH))) {
++        if ("list".equals(args[0].toLowerCase(Locale.ROOT))) {
 +            String filter = "*";
 +            if (args.length > 1) {
-+                if (args[1].toLowerCase(Locale.ENGLISH).equals("help")) {
++                if (args[1].toLowerCase(Locale.ROOT).equals("help")) {
 +                    sender.sendMessage(text("Use /paper entity list [filter] [worldName] to get entity info that matches the optional filter.", RED));
 +                    return;
 +                }
@@ -617,10 +617,10 @@ index 21b8f1913ff54d2b1553826269355da8bdb7f702..b9c22f725f5aeaee469fe5b7d8c3a57d
          this.setPvpAllowed(dedicatedserverproperties.pvp);
          this.setFlightAllowed(dedicatedserverproperties.allowFlight);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7d850ef45093ab5ca0dd29b29ed36f663f3fa2e2..4c177faf5eda2cb5a34f84586a4bf45be942e0d6 100644
+index 749a4f1e8e46e0b072832056186d709a93df4b58..af1bca27eb2445218f7daeab3912e561085c9c00 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -952,6 +952,7 @@ public final class CraftServer implements Server {
+@@ -975,6 +975,7 @@ public final class CraftServer implements Server {
          this.commandMap.clearCommands();
          this.reloadData();
          org.spigotmc.SpigotConfig.registerCommands(); // Spigot
@@ -628,7 +628,7 @@ index 7d850ef45093ab5ca0dd29b29ed36f663f3fa2e2..4c177faf5eda2cb5a34f84586a4bf45b
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2672,6 +2673,34 @@ public final class CraftServer implements Server {
+@@ -2695,6 +2696,34 @@ public final class CraftServer implements Server {
      // Paper end
  
      // Paper start

--- a/patches/server/0019-Paper-Plugins.patch
+++ b/patches/server/0019-Paper-Plugins.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Paper Plugins
 Co-authored-by: Micah Rao <micah.s.rao@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/command/PaperCommand.java b/src/main/java/io/papermc/paper/command/PaperCommand.java
-index 8ccc59473bac983ced6b9e4a57e0ec4ebd2b0f32..6d06b772ffb9d47d6a717462a4b2b494544e80ae 100644
+index 95d3320c865d24609252063be07cddfd07d0d6d8..5b070d158760789bbcaa984426a55d20767abe4a 100644
 --- a/src/main/java/io/papermc/paper/command/PaperCommand.java
 +++ b/src/main/java/io/papermc/paper/command/PaperCommand.java
 @@ -37,6 +37,7 @@ public final class PaperCommand extends Command {
@@ -3567,7 +3567,7 @@ index 0000000000000000000000000000000000000000..7ce9ebba8ce304d1f3f21d4f15ee5f35
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/manager/PaperPermissionManager.java b/src/main/java/io/papermc/paper/plugin/manager/PaperPermissionManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..92a69677f21b2c1c035119d8e5a6af63fa19b801
+index 0000000000000000000000000000000000000000..afe793c35f05a80058e80bcaee76ac45a40b04a2
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/manager/PaperPermissionManager.java
 @@ -0,0 +1,201 @@
@@ -3654,7 +3654,7 @@ index 0000000000000000000000000000000000000000..92a69677f21b2c1c035119d8e5a6af63
 +    @Override
 +    public void recalculatePermissionDefaults(@NotNull Permission perm) {
 +        // we need a null check here because some plugins for some unknown reason pass null into this?
-+        if (perm != null && this.permissions().containsKey(perm.getName().toLowerCase(Locale.ENGLISH))) {
++        if (perm != null && this.permissions().containsKey(perm.getName().toLowerCase(Locale.ROOT))) {
 +            this.defaultPerms().get(true).remove(perm);
 +            this.defaultPerms().get(false).remove(perm);
 +
@@ -7248,10 +7248,10 @@ index 5b4ac7b4fd0077e900e9f788963f1613bbc9a5d0..6afede80c10503a261d0f735c351d943
              Bootstrap.validate();
              Util.startTimerHackThread();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4c177faf5eda2cb5a34f84586a4bf45be942e0d6..5f0638e2dd945371b311f8364294adc80bde3186 100644
+index af1bca27eb2445218f7daeab3912e561085c9c00..709712a9e5cadca181ef74302ca9e90703d74ca8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -275,7 +275,8 @@ public final class CraftServer implements Server {
+@@ -276,7 +276,8 @@ public final class CraftServer implements Server {
      private final CraftCommandMap commandMap = new CraftCommandMap(this);
      private final SimpleHelpMap helpMap = new SimpleHelpMap(this);
      private final StandardMessenger messenger = new StandardMessenger();
@@ -7261,7 +7261,7 @@ index 4c177faf5eda2cb5a34f84586a4bf45be942e0d6..5f0638e2dd945371b311f8364294adc8
      private final StructureManager structureManager;
      protected final DedicatedServer console;
      protected final DedicatedPlayerList playerList;
-@@ -421,24 +422,7 @@ public final class CraftServer implements Server {
+@@ -443,24 +444,7 @@ public final class CraftServer implements Server {
      }
  
      public void loadPlugins() {
@@ -7287,7 +7287,7 @@ index 4c177faf5eda2cb5a34f84586a4bf45be942e0d6..5f0638e2dd945371b311f8364294adc8
      }
  
      public void enablePlugins(PluginLoadOrder type) {
-@@ -527,15 +511,17 @@ public final class CraftServer implements Server {
+@@ -549,15 +533,17 @@ public final class CraftServer implements Server {
      private void enablePlugin(Plugin plugin) {
          try {
              List<Permission> perms = plugin.getDescription().getPermissions();
@@ -7311,7 +7311,7 @@ index 4c177faf5eda2cb5a34f84586a4bf45be942e0d6..5f0638e2dd945371b311f8364294adc8
  
              this.pluginManager.enablePlugin(plugin);
          } catch (Throwable ex) {
-@@ -976,6 +962,7 @@ public final class CraftServer implements Server {
+@@ -999,6 +985,7 @@ public final class CraftServer implements Server {
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));
          }
@@ -7337,10 +7337,10 @@ index 909b2c98e7a9117d2f737245e4661792ffafb744..d96399e9bf1a58db5a4a22e58abb99e7
      @Override
      public FileConfiguration getConfig() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index cac2bfc711daba11a640e4e776b10c86041b0670..e62b93ce958633a1b6c55a8768332d61289d6556 100644
+index 8727d09566cba3b7223e4c72f960e568a9d8bb62..66c75a4baa35970254027d42e017fa62b791590b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -425,6 +425,16 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -426,6 +426,16 @@ public final class CraftMagicNumbers implements UnsafeValues {
          net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
          return nmsItemStack.getItem().getDescriptionId(nmsItemStack);
      }

--- a/patches/server/0020-Plugin-remapping.patch
+++ b/patches/server/0020-Plugin-remapping.patch
@@ -1317,7 +1317,7 @@ index 0000000000000000000000000000000000000000..944250d2b8e1969f221b2f24cce7b101
 +}
 diff --git a/src/main/java/io/papermc/paper/util/Hashing.java b/src/main/java/io/papermc/paper/util/Hashing.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..49e235e0035d7f063c8544ec10bd8f9ef4e613c3
+index 0000000000000000000000000000000000000000..54c1324faa190a06bfa2b3b8f86928b4c51a57f8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/Hashing.java
 @@ -0,0 +1,50 @@
@@ -1346,7 +1346,7 @@ index 0000000000000000000000000000000000000000..49e235e0035d7f063c8544ec10bd8f9e
 +     */
 +    public static String sha256(final InputStream stream) {
 +        try (stream) {
-+            return com.google.common.hash.Hashing.sha256().hashBytes(IOUtils.toByteArray(stream)).toString().toUpperCase(Locale.ENGLISH);
++            return com.google.common.hash.Hashing.sha256().hashBytes(IOUtils.toByteArray(stream)).toString().toUpperCase(Locale.ROOT);
 +        } catch (final IOException ex) {
 +            throw new RuntimeException("Failed to take hash of InputStream", ex);
 +        }
@@ -1368,7 +1368,7 @@ index 0000000000000000000000000000000000000000..49e235e0035d7f063c8544ec10bd8f9e
 +        } catch (final IOException ex) {
 +            throw new RuntimeException("Failed to take hash of file '" + file + "'", ex);
 +        }
-+        return hash.toString().toUpperCase(Locale.ENGLISH);
++        return hash.toString().toUpperCase(Locale.ROOT);
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/util/MappingEnvironment.java b/src/main/java/io/papermc/paper/util/MappingEnvironment.java
@@ -1553,7 +1553,7 @@ index 0000000000000000000000000000000000000000..badff5d6ae6dd8d209c82bc7e8afe370
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c25d80a1d5aa0f3cc2cbf1e9b94154c759aab36e..cbbd9aaeb0d87aae72edc7fb5aa10920834de8bf 100644
+index 8dfa0fae4d5129688b7e2897da1fc51683aed6c3..5c0d2cb215e334b32332e322e931d72c46027190 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -636,6 +636,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -1904,10 +1904,10 @@ index 0000000000000000000000000000000000000000..73b20a92f330311e3fef8f03b51a0985
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5f0638e2dd945371b311f8364294adc80bde3186..950ad0a46cadc11554b9cde84e633df7cc447dcd 100644
+index 709712a9e5cadca181ef74302ca9e90703d74ca8..a348ddb7ca863da0b2d5eea1bb30bb356a6a751f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -966,6 +966,7 @@ public final class CraftServer implements Server {
+@@ -989,6 +989,7 @@ public final class CraftServer implements Server {
          this.loadPlugins();
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);

--- a/patches/server/0021-Hook-into-CB-plugin-rewrites.patch
+++ b/patches/server/0021-Hook-into-CB-plugin-rewrites.patch
@@ -8,18 +8,18 @@ our own relocation. Also lets us rewrite NMS calls for when we're
 debugging in an IDE pre-relocate.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 6f89eebc326c0dec6d18b0ca4ced3a1bb70ada55..3d3d77d66588aaf709a9f7688400ee661e181b4b 100644
+index beccd928d151164db8c29f5b7addefbe9a195311..dedcdac1c6b2ba056761d5bd02212c1fb76348c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -7,6 +7,7 @@ import java.io.InputStream;
- import java.util.ArrayList;
+@@ -8,6 +8,7 @@ import java.util.ArrayList;
  import java.util.Arrays;
+ import java.util.Collections;
  import java.util.Enumeration;
 +import java.util.HashMap;
  import java.util.HashSet;
  import java.util.List;
  import java.util.Map;
-@@ -16,6 +17,7 @@ import java.util.jar.JarEntry;
+@@ -17,6 +18,7 @@ import java.util.jar.JarEntry;
  import java.util.jar.JarFile;
  import java.util.jar.JarOutputStream;
  import java.util.zip.ZipEntry;
@@ -27,9 +27,9 @@ index 6f89eebc326c0dec6d18b0ca4ced3a1bb70ada55..3d3d77d66588aaf709a9f7688400ee66
  import joptsimple.OptionParser;
  import joptsimple.OptionSet;
  import joptsimple.OptionSpec;
-@@ -73,6 +75,40 @@ public class Commodore {
-     public static final List<Map<String, RerouteMethodData>> REROUTES = new ArrayList<>(); // Only used for testing
+@@ -77,6 +79,40 @@ public class Commodore {
      private static final Map<String, RerouteMethodData> FIELD_RENAME_METHOD_REROUTE = Commodore.createReroutes(FieldRename.class);
+     private static final Map<String, RerouteMethodData> MATERIAL_METHOD_REROUTE = Commodore.createReroutes(MaterialRerouting.class);
  
 +    // Paper start - Plugin rewrites
 +    private static final Map<String, String> SEARCH_AND_REMOVE = initReplacementsMap();
@@ -68,7 +68,7 @@ index 6f89eebc326c0dec6d18b0ca4ced3a1bb70ada55..3d3d77d66588aaf709a9f7688400ee66
      public static void main(String[] args) {
          OptionParser parser = new OptionParser();
          OptionSpec<File> inputFlag = parser.acceptsAll(Arrays.asList("i", "input")).withRequiredArg().ofType(File.class).required();
-@@ -199,9 +235,49 @@ public class Commodore {
+@@ -203,9 +239,49 @@ public class Commodore {
              @Override
              public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
                  return new MethodVisitor(this.api, super.visitMethod(access, name, desc, signature, exceptions)) {
@@ -118,7 +118,7 @@ index 6f89eebc326c0dec6d18b0ca4ced3a1bb70ada55..3d3d77d66588aaf709a9f7688400ee66
                          name = FieldRename.rename(pluginVersion, owner, name);
  
                          if (modern) {
-@@ -297,6 +373,13 @@ public class Commodore {
+@@ -301,6 +377,13 @@ public class Commodore {
                              return;
                          }
  
@@ -132,7 +132,7 @@ index 6f89eebc326c0dec6d18b0ca4ced3a1bb70ada55..3d3d77d66588aaf709a9f7688400ee66
                          if (modern) {
                              if (owner.equals("org/bukkit/Material") || (instantiatedMethodType != null && instantiatedMethodType.getDescriptor().startsWith("(Lorg/bukkit/Material;)"))) {
                                  switch (name) {
-@@ -400,6 +483,13 @@ public class Commodore {
+@@ -397,6 +480,13 @@ public class Commodore {
  
                      @Override
                      public void visitLdcInsn(Object value) {
@@ -146,7 +146,7 @@ index 6f89eebc326c0dec6d18b0ca4ced3a1bb70ada55..3d3d77d66588aaf709a9f7688400ee66
                          if (value instanceof String && ((String) value).equals("com.mysql.jdbc.Driver")) {
                              super.visitLdcInsn("com.mysql.cj.jdbc.Driver");
                              return;
-@@ -410,6 +500,14 @@ public class Commodore {
+@@ -407,6 +497,14 @@ public class Commodore {
  
                      @Override
                      public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
@@ -161,7 +161,7 @@ index 6f89eebc326c0dec6d18b0ca4ced3a1bb70ada55..3d3d77d66588aaf709a9f7688400ee66
                          if (bootstrapMethodHandle.getOwner().equals("java/lang/invoke/LambdaMetafactory")
                                  && bootstrapMethodHandle.getName().equals("metafactory") && bootstrapMethodArguments.length == 3) {
                              Type samMethodType = (Type) bootstrapMethodArguments[0];
-@@ -426,7 +524,7 @@ public class Commodore {
+@@ -423,7 +521,7 @@ public class Commodore {
                                  methodArgs.add(new Handle(newOpcode, newOwner, newName, newDescription, newItf));
                                  methodArgs.add(newInstantiated);
  
@@ -170,7 +170,7 @@ index 6f89eebc326c0dec6d18b0ca4ced3a1bb70ada55..3d3d77d66588aaf709a9f7688400ee66
                              }, implMethod.getTag(), implMethod.getOwner(), implMethod.getName(), implMethod.getDesc(), implMethod.isInterface(), samMethodType, instantiatedMethodType);
                              return;
                          }
-@@ -477,6 +575,12 @@ public class Commodore {
+@@ -474,6 +572,12 @@ public class Commodore {
  
              @Override
              public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {

--- a/patches/server/0022-Remap-reflection-calls-in-plugins-using-internals.patch
+++ b/patches/server/0022-Remap-reflection-calls-in-plugins-using-internals.patch
@@ -645,11 +645,11 @@ index 242811578a786e3807a1a7019d472d5a68f87116..0b65fdf53124f3dd042b2363b1b8df8e
              return traceElements;
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 3d3d77d66588aaf709a9f7688400ee661e181b4b..c6956b9241634e455a520f4fd3bd8c4b5a58eb9d 100644
+index dedcdac1c6b2ba056761d5bd02212c1fb76348c4..f45498bf9841c31338b83270c1badc6d7a792d25 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -76,36 +76,26 @@ public class Commodore {
-     private static final Map<String, RerouteMethodData> FIELD_RENAME_METHOD_REROUTE = Commodore.createReroutes(FieldRename.class);
+@@ -80,36 +80,26 @@ public class Commodore {
+     private static final Map<String, RerouteMethodData> MATERIAL_METHOD_REROUTE = Commodore.createReroutes(MaterialRerouting.class);
  
      // Paper start - Plugin rewrites
 -    private static final Map<String, String> SEARCH_AND_REMOVE = initReplacementsMap();
@@ -696,7 +696,7 @@ index 3d3d77d66588aaf709a9f7688400ee661e181b4b..c6956b9241634e455a520f4fd3bd8c4b
      }
      // Paper end - Plugin rewrites
  
-@@ -176,7 +166,7 @@ public class Commodore {
+@@ -180,7 +170,7 @@ public class Commodore {
          ClassReader cr = new ClassReader(b);
          ClassWriter cw = new ClassWriter(cr, 0);
  
@@ -706,10 +706,10 @@ index 3d3d77d66588aaf709a9f7688400ee661e181b4b..c6956b9241634e455a520f4fd3bd8c4b
              String className;
              boolean isInterface;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 81a11402fda54ff40039fa23c53abb3572dccadf..73616ac642c67d4591775fdef08e720c1ab612a4 100644
+index 66c75a4baa35970254027d42e017fa62b791590b..2de7ee6afa7eb404d7aeaa5ef7c7190d8287de1d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -360,7 +360,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -361,7 +361,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
              throw new InvalidPluginException("Plugin API version " + pdf.getAPIVersion() + " is lower than the minimum allowed version. Please update or replace it.");
          }
  
@@ -718,11 +718,11 @@ index 81a11402fda54ff40039fa23c53abb3572dccadf..73616ac642c67d4591775fdef08e720c
              CraftLegacy.init();
          }
  
-@@ -375,6 +375,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -376,6 +376,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
      @Override
      public byte[] processClass(PluginDescriptionFile pdf, String path, byte[] clazz) {
 +        if (io.papermc.paper.util.MappingEnvironment.DISABLE_PLUGIN_REWRITING) return clazz; // Paper
          try {
-             clazz = Commodore.convert(clazz, pdf.getName(), ApiVersion.getOrCreateVersion(pdf.getAPIVersion()));
+             clazz = Commodore.convert(clazz, pdf.getName(), ApiVersion.getOrCreateVersion(pdf.getAPIVersion()), ((CraftServer) Bukkit.getServer()).activeCompatibilities);
          } catch (Exception ex) {

--- a/patches/server/0023-Timings-v2.patch
+++ b/patches/server/0023-Timings-v2.patch
@@ -714,7 +714,7 @@ index 73e7bb59596600df1b1953175f6da17bee54a65c..e161ad0f53a21a68e8c78575ba5d3cdb
                      } catch (Exception exception) {
                          if (exception instanceof ReportedException) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c836204a04ca050988057dcc92c7a1fbcc02ef34..c91eb69bbab3ca563d77de7165d5ef39f0a6b532 100644
+index 5c0d2cb215e334b32332e322e931d72c46027190..e419ccaf2378d4736b8162092e537006aa3e1288 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -190,7 +190,7 @@ import org.bukkit.craftbukkit.Main;
@@ -893,7 +893,7 @@ index c836204a04ca050988057dcc92c7a1fbcc02ef34..c91eb69bbab3ca563d77de7165d5ef39
          this.profiler.popPush("send chunks");
          iterator = this.playerList.getPlayers().iterator();
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 98cba55466d6798e5de33d8dcbf03e205e5199d8..bbe2fabc9251838f232480a04f0a2cf2b49f2812 100644
+index 98cba55466d6798e5de33d8dcbf03e205e5199d8..8dcfcce4ccf0320b5d5b9eda2d1b5ebe04e26a13 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -63,10 +63,11 @@ import org.apache.logging.log4j.Level;
@@ -943,7 +943,7 @@ index 98cba55466d6798e5de33d8dcbf03e205e5199d8..bbe2fabc9251838f232480a04f0a2cf2
              }
 +            // Paper start
 +            command.set(event.getCommand());
-+            if (event.getCommand().toLowerCase().startsWith("timings") && event.getCommand().toLowerCase().matches("timings (report|paste|get|merged|seperate)")) {
++            if (event.getCommand().toLowerCase(java.util.Locale.ROOT).startsWith("timings") && event.getCommand().toLowerCase(java.util.Locale.ROOT).matches("timings (report|paste|get|merged|seperate)")) {
 +                org.bukkit.command.BufferedCommandSender sender = new org.bukkit.command.BufferedCommandSender();
 +                Waitable<String> waitable = new Waitable<>() {
 +                    @Override
@@ -1019,7 +1019,7 @@ index e53b68f91183c8abcc9a0f7d97adfc212aec02c6..15c9f4822d1d11d05de6c2d6797ee3e8
  
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 23c39b78486b018e222af489c8edbf4e749abff6..3f60a3289ec58d5eb3c0c5634ca62ef2fa287ce7 100644
+index 712670230b6b881101b4128c1d275f2559fa705a..c4c85ba56c52a00e10e61fe0954d7fb8de471bdd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -268,13 +268,15 @@ public class ServerChunkCache extends ChunkSource {
@@ -1379,7 +1379,7 @@ index 1099a85ab7e98d8652cdd1c318f269ca31f4d783..606dbc398745b689f957e62ebd9eaa56
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index d2f75ced3ad4ccb9d1d44307bfc98e69e5fc8c6f..856fb1a15279efc1e24a93fa289ca1ca8effd43e 100644
+index a3ebdbb231fb7bc6ed24747105ef02bb0ea9770e..ddf4a7bc19ba358364ea4517ce941e63ec4d26a0 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -149,7 +149,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -1391,7 +1391,7 @@ index d2f75ced3ad4ccb9d1d44307bfc98e69e5fc8c6f..856fb1a15279efc1e24a93fa289ca1ca
  
  public abstract class LivingEntity extends Entity implements Attackable {
  
-@@ -2951,7 +2951,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2945,7 +2945,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      @Override
      public void tick() {
@@ -1399,7 +1399,7 @@ index d2f75ced3ad4ccb9d1d44307bfc98e69e5fc8c6f..856fb1a15279efc1e24a93fa289ca1ca
          super.tick();
          this.updatingUsingItem();
          this.updateSwimAmount();
-@@ -2993,9 +2992,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2987,9 +2986,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          }
  
          if (!this.isRemoved()) {
@@ -1409,7 +1409,7 @@ index d2f75ced3ad4ccb9d1d44307bfc98e69e5fc8c6f..856fb1a15279efc1e24a93fa289ca1ca
          }
  
          double d0 = this.getX() - this.xo;
-@@ -3086,7 +3083,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3080,7 +3077,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.refreshDimensions();
          }
  
@@ -1417,7 +1417,7 @@ index d2f75ced3ad4ccb9d1d44307bfc98e69e5fc8c6f..856fb1a15279efc1e24a93fa289ca1ca
      }
  
      public void detectEquipmentUpdatesPublic() { // CraftBukkit
-@@ -3285,7 +3281,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3279,7 +3275,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
          this.setDeltaMovement(d0, d1, d2);
          this.level().getProfiler().push("ai");
@@ -1425,7 +1425,7 @@ index d2f75ced3ad4ccb9d1d44307bfc98e69e5fc8c6f..856fb1a15279efc1e24a93fa289ca1ca
          if (this.isImmobile()) {
              this.jumping = false;
              this.xxa = 0.0F;
-@@ -3295,7 +3290,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3289,7 +3284,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.serverAiStep();
              this.level().getProfiler().pop();
          }
@@ -1433,7 +1433,7 @@ index d2f75ced3ad4ccb9d1d44307bfc98e69e5fc8c6f..856fb1a15279efc1e24a93fa289ca1ca
  
          this.level().getProfiler().pop();
          this.level().getProfiler().push("jump");
-@@ -3335,7 +3329,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3329,7 +3323,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.resetFallDistance();
          }
  
@@ -1441,7 +1441,7 @@ index d2f75ced3ad4ccb9d1d44307bfc98e69e5fc8c6f..856fb1a15279efc1e24a93fa289ca1ca
          label104:
          {
              LivingEntity entityliving = this.getControllingPassenger();
-@@ -3349,7 +3342,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3343,7 +3336,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
              this.travel(vec3d1);
          }
@@ -1449,7 +1449,7 @@ index d2f75ced3ad4ccb9d1d44307bfc98e69e5fc8c6f..856fb1a15279efc1e24a93fa289ca1ca
  
          this.level().getProfiler().pop();
          this.level().getProfiler().push("freezing");
-@@ -3376,9 +3368,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3370,9 +3362,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.checkAutoSpinAttack(axisalignedbb, this.getBoundingBox());
          }
  
@@ -1527,7 +1527,7 @@ index 991ebf07bc0608df0a12f1f26e581cc93255ae01..946001c57c326f2d2f0677bca954e855
      private String descriptionId;
      @Nullable
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-index f0b4b9828ec237e93d5a6bdf5cbea8b469ebff02..7fa49fcf5469276e25c40af4cd27943f665d8721 100644
+index e6c586eb85c6c477a3c130e1e1a37b41f17c30c8..6e35709f2a7c32050908e7e5af5529c9f342b787 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 @@ -34,10 +34,12 @@ import org.bukkit.inventory.InventoryHolder;
@@ -1591,10 +1591,10 @@ index 8199fd0a50e0f7d2e1f2a14ac525bc6bd9feeac4..b0518725a2e145d29bd5bc0aa7e6998a
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b34b3008b4330103b3ed835e962d7c05cbe5b688..b1605bcb0379f4b274db4c7aac50e1dae5bdc831 100644
+index a348ddb7ca863da0b2d5eea1bb30bb356a6a751f..f42af8073569b4153858c2762d1553e89fe85a16 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -371,7 +371,7 @@ public final class CraftServer implements Server {
+@@ -373,7 +373,7 @@ public final class CraftServer implements Server {
          this.saveCommandsConfig();
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
@@ -1603,7 +1603,7 @@ index b34b3008b4330103b3ed835e962d7c05cbe5b688..b1605bcb0379f4b274db4c7aac50e1da
          this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
-@@ -2581,12 +2581,31 @@ public final class CraftServer implements Server {
+@@ -2604,12 +2604,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  
@@ -1805,10 +1805,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1c1f1db8cb8beff850103d998561d333823fe611..34fe109e3ab1e72b278218fad93c2de6b809020c 100644
+index e59f2ae85126061ee35812eaa02a35ddb4a9eb66..b64cabaee5adc3fc9e2b704c2959a7a4b3051ed2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2759,6 +2759,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2768,6 +2768,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
              CraftPlayer.this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSystemChatPacket(components, position == net.md_5.bungee.api.ChatMessageType.ACTION_BAR));
          }
@@ -2005,10 +2005,10 @@ index f97eccb6a17c7876e1e002d798eb67bbe80571a0..76effc345d362047e64d064eb64a5222
 +    } // Paper
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 73616ac642c67d4591775fdef08e720c1ab612a4..e7b98cefde1e0ecfbd151ef968062a774a6ebf55 100644
+index 2de7ee6afa7eb404d7aeaa5ef7c7190d8287de1d..233abe27ff9b11eb88c073d8d6bc7211a10ba5df 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -216,6 +216,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -217,6 +217,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
      }
      // Paper end
      // ========================================================================
@@ -2021,7 +2021,7 @@ index 73616ac642c67d4591775fdef08e720c1ab612a4..e7b98cefde1e0ecfbd151ef968062a77
  
      public static byte toLegacyData(BlockState data) {
          return CraftLegacy.toLegacyData(data);
-@@ -466,6 +472,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -467,6 +473,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public DamageSource.Builder createDamageSourceBuilder(DamageType damageType) {
          return new CraftDamageSourceBuilder(damageType);
      }

--- a/patches/server/0025-Further-improve-server-tick-loop.patch
+++ b/patches/server/0025-Further-improve-server-tick-loop.patch
@@ -12,7 +12,7 @@ Previous implementation did not calculate TPS correctly.
 Switch to a realistic rolling average and factor in std deviation as an extra reporting variable
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c91eb69bbab3ca563d77de7165d5ef39f0a6b532..8ead44e27598c01249f710e10a765dd1796ed249 100644
+index e419ccaf2378d4736b8162092e537006aa3e1288..93c7648106b18ef2982f476c3200839bb5e2ea0c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -289,7 +289,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -146,10 +146,10 @@ index c91eb69bbab3ca563d77de7165d5ef39f0a6b532..8ead44e27598c01249f710e10a765dd1
                  this.startMetricsRecordingTick();
                  this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b1605bcb0379f4b274db4c7aac50e1dae5bdc831..85e2293efd3f02234372f4ad3a07ffdf774bd13c 100644
+index f42af8073569b4153858c2762d1553e89fe85a16..c9767da51134fc5576f4d9f994f8b9fc05c57b9e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2634,7 +2634,11 @@ public final class CraftServer implements Server {
+@@ -2657,7 +2657,11 @@ public final class CraftServer implements Server {
  
      @Override
      public double[] getTPS() {

--- a/patches/server/0026-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0026-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 85e2293efd3f02234372f4ad3a07ffdf774bd13c..035c541290e5ff67d0db65fc0d68c612bba19840 100644
+index c9767da51134fc5576f4d9f994f8b9fc05c57b9e..0030794a3e125f2493a84ddac86430db625c626e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -425,6 +425,35 @@ public final class CraftServer implements Server {
+@@ -447,6 +447,35 @@ public final class CraftServer implements Server {
          io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.INSTANCE.enter(io.papermc.paper.plugin.entrypoint.Entrypoint.PLUGIN); // Paper - replace implementation
      }
  
@@ -47,7 +47,7 @@ index 85e2293efd3f02234372f4ad3a07ffdf774bd13c..035c541290e5ff67d0db65fc0d68c612
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 9de87edb75947382fda114df883fb4b31c1a7141..bc664b090e16ed27ba795c204dc5639679e6eee8 100644
+index 2ef6386ea4b95211e26c8759cae849cbe68e3f40..efedc5c8474c548781c943ddfdf2de121c7c09b7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -160,6 +160,12 @@ public class Main {

--- a/patches/server/0027-Support-components-in-ItemMeta.patch
+++ b/patches/server/0027-Support-components-in-ItemMeta.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 8be2184fc6d04a722fd9fb27549ec8df906a12ee..9e23cdef8bd166937093452009f50b86e683cc57 100644
+index 41ba64593bd548131d1cdbecc79b2f38406aa78b..c7eed6b642c69fb08bc6e50d4890ea61666cde01 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -879,11 +879,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -900,11 +900,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return CraftChatMessage.fromComponent(this.displayName);
      }
  
@@ -32,7 +32,7 @@ index 8be2184fc6d04a722fd9fb27549ec8df906a12ee..9e23cdef8bd166937093452009f50b86
      @Override
      public boolean hasDisplayName() {
          return this.displayName != null;
-@@ -1057,6 +1069,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1078,6 +1090,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.lore == null ? null : new ArrayList<String>(Lists.transform(this.lore, CraftChatMessage::fromComponent));
      }
  
@@ -47,7 +47,7 @@ index 8be2184fc6d04a722fd9fb27549ec8df906a12ee..9e23cdef8bd166937093452009f50b86
      @Override
      public void setLore(List<String> lore) {
          if (lore == null || lore.isEmpty()) {
-@@ -1071,6 +1091,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1092,6 +1112,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -69,7 +69,7 @@ index 8be2184fc6d04a722fd9fb27549ec8df906a12ee..9e23cdef8bd166937093452009f50b86
      @Override
      public boolean hasCustomModelData() {
          return this.customModelData != null;
-@@ -1722,6 +1757,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1763,6 +1798,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
  
          for (Object object : addFrom) {

--- a/patches/server/0034-Expose-server-build-information.patch
+++ b/patches/server/0034-Expose-server-build-information.patch
@@ -472,7 +472,7 @@ index 0000000000000000000000000000000000000000..790bad0494454ca12ee152e3de6da3da
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index dee319882d7d51a0e03e0f5f31ab6312048e189d..80a20dce63658842a0fa04004b8eaa8af7685fb4 100644
+index 93c7648106b18ef2982f476c3200839bb5e2ea0c..8b5a630a67b058f014478b033e6b1299f99afccc 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -43,7 +43,6 @@ import java.util.Set;
@@ -529,10 +529,10 @@ index f077b8ff0bf0d96628db3569132696b68fd79921..5f11f5b16766f9d1d5640ae037e259be
              value.append("\n   Plugins: {");
              for (Plugin plugin : Bukkit.getPluginManager().getPlugins()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b32ae5b9c232e5d9b3bd89303db3d2cc6258ea29..4d31fb8bc8bf285720a9d5828325d7124cf41c6e 100644
+index 0030794a3e125f2493a84ddac86430db625c626e..c052ec6b028613fb27c0cfead8da5a1793ecadd3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -10,8 +10,6 @@ import com.google.common.collect.MapMaker;
+@@ -11,8 +11,6 @@ import com.google.common.collect.MapMaker;
  import com.mojang.authlib.GameProfile;
  import com.mojang.brigadier.StringReader;
  import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -541,7 +541,7 @@ index b32ae5b9c232e5d9b3bd89303db3d2cc6258ea29..4d31fb8bc8bf285720a9d5828325d712
  import com.mojang.serialization.Dynamic;
  import com.mojang.serialization.Lifecycle;
  import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-@@ -26,7 +24,6 @@ import java.net.InetAddress;
+@@ -27,7 +25,6 @@ import java.net.InetAddress;
  import java.util.ArrayList;
  import java.util.Collections;
  import java.util.Date;
@@ -549,7 +549,7 @@ index b32ae5b9c232e5d9b3bd89303db3d2cc6258ea29..4d31fb8bc8bf285720a9d5828325d712
  import java.util.HashSet;
  import java.util.Iterator;
  import java.util.LinkedHashMap;
-@@ -153,7 +150,6 @@ import org.bukkit.craftbukkit.ban.CraftProfileBanList;
+@@ -154,7 +151,6 @@ import org.bukkit.craftbukkit.ban.CraftProfileBanList;
  import org.bukkit.craftbukkit.block.data.CraftBlockData;
  import org.bukkit.craftbukkit.boss.CraftBossBar;
  import org.bukkit.craftbukkit.boss.CraftKeyedBossbar;
@@ -557,7 +557,7 @@ index b32ae5b9c232e5d9b3bd89303db3d2cc6258ea29..4d31fb8bc8bf285720a9d5828325d712
  import org.bukkit.craftbukkit.command.CraftCommandMap;
  import org.bukkit.craftbukkit.command.VanillaCommandWrapper;
  import org.bukkit.craftbukkit.entity.CraftEntityFactory;
-@@ -249,7 +245,6 @@ import org.bukkit.plugin.PluginManager;
+@@ -250,7 +246,6 @@ import org.bukkit.plugin.PluginManager;
  import org.bukkit.plugin.ServicesManager;
  import org.bukkit.plugin.SimplePluginManager;
  import org.bukkit.plugin.SimpleServicesManager;
@@ -565,7 +565,7 @@ index b32ae5b9c232e5d9b3bd89303db3d2cc6258ea29..4d31fb8bc8bf285720a9d5828325d712
  import org.bukkit.plugin.messaging.Messenger;
  import org.bukkit.plugin.messaging.StandardMessenger;
  import org.bukkit.profile.PlayerProfile;
-@@ -266,7 +261,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -267,7 +262,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
  public final class CraftServer implements Server {
@@ -574,7 +574,7 @@ index b32ae5b9c232e5d9b3bd89303db3d2cc6258ea29..4d31fb8bc8bf285720a9d5828325d712
      private final String serverVersion;
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
-@@ -320,7 +315,7 @@ public final class CraftServer implements Server {
+@@ -322,7 +317,7 @@ public final class CraftServer implements Server {
                  return player.getBukkitEntity();
              }
          }));
@@ -583,7 +583,7 @@ index b32ae5b9c232e5d9b3bd89303db3d2cc6258ea29..4d31fb8bc8bf285720a9d5828325d712
          this.structureManager = new CraftStructureManager(console.getStructureManager(), console.registryAccess());
          this.dataPackManager = new CraftDataPackManager(this.getServer().getPackRepository());
          this.serverTickManager = new CraftServerTickManager(console.tickRateManager());
-@@ -573,6 +568,13 @@ public final class CraftServer implements Server {
+@@ -595,6 +590,13 @@ public final class CraftServer implements Server {
          return this.bukkitVersion;
      }
  
@@ -598,7 +598,7 @@ index b32ae5b9c232e5d9b3bd89303db3d2cc6258ea29..4d31fb8bc8bf285720a9d5828325d712
      public List<CraftPlayer> getOnlinePlayers() {
          return this.playerView;
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index bc664b090e16ed27ba795c204dc5639679e6eee8..9dc72b01092783c436bc1fa8ce29ff7cdaa39b19 100644
+index efedc5c8474c548781c943ddfdf2de121c7c09b7..ce4671b24c7471efb3f6a1ae87d96c67881642f6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -15,6 +15,7 @@ import joptsimple.OptionSet;
@@ -610,7 +610,7 @@ index bc664b090e16ed27ba795c204dc5639679e6eee8..9dc72b01092783c436bc1fa8ce29ff7c
      public static boolean useConsole = true;
  
 @@ -252,13 +253,26 @@ public class Main {
-                     deadline.add(Calendar.DAY_OF_YEAR, -3);
+                     deadline.add(Calendar.DAY_OF_YEAR, -21);
                      if (buildDate.before(deadline.getTime())) {
                          System.err.println("*** Error, this build is outdated ***");
 -                        System.err.println("*** Please download a new build as per instructions from https://www.spigotmc.org/go/outdated-spigot ***");
@@ -638,10 +638,10 @@ index bc664b090e16ed27ba795c204dc5639679e6eee8..9dc72b01092783c436bc1fa8ce29ff7c
                  net.minecraft.server.Main.main(options);
              } catch (Throwable t) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 983660c1cc4df5ec6f08ab7363a1bb5d47af9f19..f541ca7cb3328a9366e08a9933b24ed5c76059c0 100644
+index 233abe27ff9b11eb88c073d8d6bc7211a10ba5df..9730a3fe6b1e2734d897936dc8bff7c06edb3687 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -477,6 +477,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -478,6 +478,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public String getTimingsServerName() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().timings.serverName;
      }

--- a/patches/server/0035-Player-affects-spawning-API.patch
+++ b/patches/server/0035-Player-affects-spawning-API.patch
@@ -21,7 +21,7 @@ index 3126e8cab3c40e3af47f4c8925e1c6a9523309ba..3207166061bf9c4d7bf3f38e5a9f7aff
      public static Predicate<Entity> withinDistance(double x, double y, double z, double max) {
          double d4 = max * max;
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index c8ff4b01186f924473b9ffde948d7f0573e8d56f..426fa1798087ab1fb4198bd036f498606dce7c3f 100644
+index 577e7504064b97fa1115210f209bb40a3d94a60f..d4559aea807e3ee76f9dd1ecde72f77644636923 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -907,7 +907,7 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Targeti
@@ -135,10 +135,10 @@ index f38f62e777d88a783e1e3b7e1a48da921cc67cf4..77ae7882a08441d9a80b50492be5e484
          for (Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 34fe109e3ab1e72b278218fad93c2de6b809020c..a078655ad4d51075953c0f0f46ee41d1d76ba1d3 100644
+index b64cabaee5adc3fc9e2b704c2959a7a4b3051ed2..7cdd44a936c0a2ada4f0c5013ee2b05c5758c751 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2402,6 +2402,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2411,6 +2411,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().language;
      }
  

--- a/patches/server/0049-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0049-Implement-PlayerLocaleChangeEvent.patch
@@ -39,10 +39,10 @@ index 5b33cc5c54ab38b32f232dae00684d8b1e276acf..29020296e4f3bbddc0faabb1eeaa07a9
          // CraftBukkit end
          this.language = clientOptions.language();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8c98655a4d888e8511d094074e3e35bbba078b26..d76a6d003cdcc1d7489ee359a09e93db96061515 100644
+index de712c7b3711d2d36d5702b323946541f105e674..6d3171e90f3ab83df3a0888eff3a1abadd4bde8a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2400,7 +2400,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2409,7 +2409,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0056-Improve-Player-chat-API-handling.patch
+++ b/patches/server/0056-Improve-Player-chat-API-handling.patch
@@ -40,10 +40,10 @@ index b700cd5ccf37f3592f7cb931101397fbc59dc60f..ad598e57feb2d9db1b71cb3a432df222
          if ( org.spigotmc.SpigotConfig.logCommands ) // Spigot
          this.LOGGER.info(this.player.getScoreboardName() + " issued server command: " + s);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4d31fb8bc8bf285720a9d5828325d7124cf41c6e..2ca22c4d3f15ec3d7c2f8abf68ce7d810fe7c3ea 100644
+index c052ec6b028613fb27c0cfead8da5a1793ecadd3..255848f770427d59d466cb382dd20d4dd213c08b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -900,7 +900,7 @@ public final class CraftServer implements Server {
+@@ -922,7 +922,7 @@ public final class CraftServer implements Server {
      public boolean dispatchCommand(CommandSender sender, String commandLine) {
          Preconditions.checkArgument(sender != null, "sender cannot be null");
          Preconditions.checkArgument(commandLine != null, "commandLine cannot be null");
@@ -53,7 +53,7 @@ index 4d31fb8bc8bf285720a9d5828325d7124cf41c6e..2ca22c4d3f15ec3d7c2f8abf68ce7d81
          if (this.commandMap.dispatch(sender, commandLine)) {
              return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d76a6d003cdcc1d7489ee359a09e93db96061515..e4be5445045c28e0bf6c84f4b6695ff47f8df72e 100644
+index 6d3171e90f3ab83df3a0888eff3a1abadd4bde8a..facd720eaf61f408d6867f416ea793f63605565e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -544,7 +544,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0057-All-chunks-are-slime-spawn-chunks-toggle.patch
+++ b/patches/server/0057-All-chunks-are-slime-spawn-chunks-toggle.patch
@@ -18,10 +18,10 @@ index 172be1f03f77dcc6d57dd9a9316b303c6f9c7175..136ec2413b6fe4680d7f2e903d04c998
                  if (random.nextInt(10) == 0 && flag && pos.getY() < 40) {
                      return checkMobSpawnRules(type, world, spawnReason, pos, random);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index ce05946e4fcff7c8151aa1213b18365dab9060f5..1d4587a97e86251982a9df832949a7093b216862 100644
+index 1401ba66c98a3e0732ff449a7491a090e46887d5..110bdba382c361228c52c1c1f807fef25f127ab5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -217,7 +217,7 @@ public class CraftChunk implements Chunk {
+@@ -218,7 +218,7 @@ public class CraftChunk implements Chunk {
      @Override
      public boolean isSlimeChunk() {
          // 987234911L is deterimined in EntitySlime when seeing if a slime can spawn in a chunk

--- a/patches/server/0058-Expose-server-CommandMap.patch
+++ b/patches/server/0058-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2ca22c4d3f15ec3d7c2f8abf68ce7d810fe7c3ea..61f2e7faa5c5497eb5c45e127166b933c532036a 100644
+index 255848f770427d59d466cb382dd20d4dd213c08b..0cff3f1864f8bc0e731a7275842908c056332212 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2143,6 +2143,7 @@ public final class CraftServer implements Server {
+@@ -2166,6 +2166,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0062-Add-velocity-warnings.patch
+++ b/patches/server/0062-Add-velocity-warnings.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Add velocity warnings
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 61f2e7faa5c5497eb5c45e127166b933c532036a..8ebd605a35b16a07ed1d927ebc9308a56a497c40 100644
+index 0cff3f1864f8bc0e731a7275842908c056332212..65502d719c5e87dc6e24662fcc8ba1d0bde0b78d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -298,6 +298,7 @@ public final class CraftServer implements Server {
-     public boolean ignoreVanillaPermissions = false;
+@@ -300,6 +300,7 @@ public final class CraftServer implements Server {
      private final List<CraftPlayer> playerView;
      public int reloadCount;
+     public Set<String> activeCompatibilities = Collections.emptySet();
 +    public static Exception excessiveVelEx; // Paper - Velocity warnings
  
      static {

--- a/patches/server/0069-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0069-Default-loading-permissions.yml-before-plugins.patch
@@ -16,10 +16,10 @@ modify that. Under the previous logic, plugins were unable (cleanly) override pe
 A config option has been added for those who depend on the previous behavior, but I don't expect that.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8ebd605a35b16a07ed1d927ebc9308a56a497c40..a4fffd20b0617563a67d5b9980814a7dc6fda997 100644
+index 65502d719c5e87dc6e24662fcc8ba1d0bde0b78d..df0b643e9665d967d1fcd4556a3a23135b4c577f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -454,6 +454,7 @@ public final class CraftServer implements Server {
+@@ -476,6 +476,7 @@ public final class CraftServer implements Server {
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
              this.helpMap.initializeGeneralTopics();
@@ -27,7 +27,7 @@ index 8ebd605a35b16a07ed1d927ebc9308a56a497c40..a4fffd20b0617563a67d5b9980814a7d
          }
  
          Plugin[] plugins = this.pluginManager.getPlugins();
-@@ -473,7 +474,7 @@ public final class CraftServer implements Server {
+@@ -495,7 +496,7 @@ public final class CraftServer implements Server {
              this.commandMap.registerServerAliases();
              DefaultPermissions.registerCorePermissions();
              CraftDefaultPermissions.registerCorePermissions();

--- a/patches/server/0070-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0070-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a4fffd20b0617563a67d5b9980814a7dc6fda997..363a56ab9e1debb075ae8d441c9e2d31fa4fd5bb 100644
+index df0b643e9665d967d1fcd4556a3a23135b4c577f..f8818be7a36cfd0066f6ffebf493ff8ccab4112e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2754,5 +2754,23 @@ public final class CraftServer implements Server {
+@@ -2777,5 +2777,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0071-Remove-Metadata-on-reload.patch
+++ b/patches/server/0071-Remove-Metadata-on-reload.patch
@@ -7,10 +7,10 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 363a56ab9e1debb075ae8d441c9e2d31fa4fd5bb..9eb00817b757fea2d2400aac7a33f72866ab8796 100644
+index f8818be7a36cfd0066f6ffebf493ff8ccab4112e..3683d2e692a092afba12b12e6e70f6b104aa89f0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -967,8 +967,16 @@ public final class CraftServer implements Server {
+@@ -990,8 +990,16 @@ public final class CraftServer implements Server {
              world.spigotConfig.init(); // Spigot
          }
  

--- a/patches/server/0072-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0072-Handle-Item-Meta-Inconsistencies.patch
@@ -82,7 +82,7 @@ index b49eb019cce58049c2b3a0e80e3d08998b16f7ea..af18de11dd55938b6091f5ab183bd3fe
  
          public Mutable(ItemEnchantments enchantmentsComponent) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index b6521462d193bff83ace1dc694c6d957a7173969..6ad6181a6f2c7e2a3de61bec68f1ca1ef5dc494d 100644
+index f44502a51c9fb393746e866e1a93ae9cedc2b656..dac1ff1387462b0125140a37d134d51c5e023bf5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -191,16 +191,13 @@ public final class CraftItemStack extends ItemStack {
@@ -151,7 +151,7 @@ index b6521462d193bff83ace1dc694c6d957a7173969..6ad6181a6f2c7e2a3de61bec68f1ca1e
  
      static Map<Enchantment, Integer> getEnchantments(net.minecraft.world.item.ItemStack item) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 9e23cdef8bd166937093452009f50b86e683cc57..a052c2dab5af99355737a88f75cb0b2e42a60177 100644
+index c7eed6b642c69fb08bc6e50d4890ea61666cde01..f5689a447bb990d5e2acbb35ce3d02419f4a00e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
@@ -170,7 +170,7 @@ index 9e23cdef8bd166937093452009f50b86e683cc57..a052c2dab5af99355737a88f75cb0b2e
  import java.util.EnumSet;
  import java.util.HashMap;
  import java.util.Iterator;
-@@ -236,7 +238,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -241,7 +243,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      private List<Component> lore; // null and empty are two different states internally
      private Integer customModelData;
      private Map<String, String> blockData;
@@ -179,7 +179,7 @@ index 9e23cdef8bd166937093452009f50b86e683cc57..a052c2dab5af99355737a88f75cb0b2e
      private Multimap<Attribute, AttributeModifier> attributeModifiers;
      private int repairCost;
      private int hideFlag;
-@@ -275,7 +277,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -281,7 +283,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.blockData = meta.blockData;
  
          if (meta.enchantments != null) {
@@ -188,7 +188,7 @@ index 9e23cdef8bd166937093452009f50b86e683cc57..a052c2dab5af99355737a88f75cb0b2e
          }
  
          if (meta.hasAttributeModifiers()) {
-@@ -406,8 +408,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -418,8 +420,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -199,7 +199,7 @@ index 9e23cdef8bd166937093452009f50b86e683cc57..a052c2dab5af99355737a88f75cb0b2e
  
          tag.entrySet().forEach((entry) -> {
              Holder<net.minecraft.world.item.enchantment.Enchantment> id = entry.getKey();
-@@ -661,13 +663,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -678,13 +680,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return modifiers;
      }
  
@@ -215,7 +215,7 @@ index 9e23cdef8bd166937093452009f50b86e683cc57..a052c2dab5af99355737a88f75cb0b2e
          for (Map.Entry<?, ?> entry : ench.entrySet()) {
              Enchantment enchantment = CraftEnchantment.stringToBukkit(entry.getKey().toString());
              if ((enchantment != null) && (entry.getValue() instanceof Integer)) {
-@@ -982,14 +984,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1003,14 +1005,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public Map<Enchantment, Integer> getEnchants() {
@@ -232,7 +232,7 @@ index 9e23cdef8bd166937093452009f50b86e683cc57..a052c2dab5af99355737a88f75cb0b2e
          }
  
          if (ignoreRestrictions || level >= ench.getStartLevel() && level <= ench.getMaxLevel()) {
-@@ -1553,7 +1555,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1591,7 +1593,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.customModelData = this.customModelData;
              clone.blockData = this.blockData;
              if (this.enchantments != null) {
@@ -241,7 +241,7 @@ index 9e23cdef8bd166937093452009f50b86e683cc57..a052c2dab5af99355737a88f75cb0b2e
              }
              if (this.hasAttributeModifiers()) {
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
-@@ -1875,4 +1877,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1918,4 +1920,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
          return (result != null) ? result : Optional.empty();
      }

--- a/patches/server/0075-Custom-replacement-for-eaten-items.patch
+++ b/patches/server/0075-Custom-replacement-for-eaten-items.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom replacement for eaten items
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e0ad0e242181261adccdec9c006a9937ac4a24e6..d710e20447df4767e10f9250ce91dcd3141eaab0 100644
+index 878a8b7e1b0551d7b749cacce7ae63bc5349b5f3..1a8316cb8cfb5efe19b68eb93fef317c6774325d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3808,10 +3808,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3802,10 +3802,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      this.triggerItemUseEffects(this.useItem, 16);
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
@@ -21,7 +21,7 @@ index e0ad0e242181261adccdec9c006a9937ac4a24e6..d710e20447df4767e10f9250ce91dcd3
                          this.level().getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {
-@@ -3825,6 +3826,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3819,6 +3820,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      } else {
                          itemstack = this.useItem.finishUsingItem(this.level(), this);
                      }
@@ -34,7 +34,7 @@ index e0ad0e242181261adccdec9c006a9937ac4a24e6..d710e20447df4767e10f9250ce91dcd3
                      // CraftBukkit end
  
                      if (itemstack != this.useItem) {
-@@ -3832,6 +3839,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3826,6 +3833,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0076-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0076-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] handle NaN health/absorb values and repair bad data
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index d710e20447df4767e10f9250ce91dcd3141eaab0..e1d34c666f88bdbead59aff0d349a49608a7b8cd 100644
+index 1a8316cb8cfb5efe19b68eb93fef317c6774325d..b59f48771aaad9429bd7078c6ecddf4f46d08cef 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -833,7 +833,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -34,7 +34,7 @@ index d710e20447df4767e10f9250ce91dcd3141eaab0..e1d34c666f88bdbead59aff0d349a496
          // CraftBukkit start - Handle scaled health
          if (this instanceof ServerPlayer) {
              org.bukkit.craftbukkit.entity.CraftPlayer player = ((ServerPlayer) this).getBukkitEntity();
-@@ -3643,7 +3653,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3637,7 +3647,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public final void setAbsorptionAmount(float absorptionAmount) {
@@ -44,7 +44,7 @@ index d710e20447df4767e10f9250ce91dcd3141eaab0..e1d34c666f88bdbead59aff0d349a496
  
      protected void internalSetAbsorptionAmount(float absorptionAmount) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 155f7053504874758d8d25a21f0ac613f81ca7d1..4923e6bba9eb95c3e7f6fafef63961cec091e1f8 100644
+index 03dc8bced6c54b7a5e7e2be0102f6dd3225fd1d7..00a76f70440887a0398e172657bf29c15e6d3bc9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2324,6 +2324,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0106-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0106-Add-setting-for-proxy-online-mode-status.patch
@@ -60,10 +60,10 @@ index a0b0614ac7d2009db5c6c10ab4a5f09dd447c635..653856d0b8dcf2baf4cc77a276f17c8c
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9eb00817b757fea2d2400aac7a33f72866ab8796..762c9b039cb4591745d341ae0988dafae38d1aed 100644
+index 3683d2e692a092afba12b12e6e70f6b104aa89f0..3c4a90d1936fe2331564dfb4eda8459499230c0c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1852,7 +1852,7 @@ public final class CraftServer implements Server {
+@@ -1875,7 +1875,7 @@ public final class CraftServer implements Server {
          if (result == null) {
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 762c9b039cb4591745d341ae0988dafae38d1aed..26dc95f14efbe293c0a8548e050a213206aeb582 100644
+index 3c4a90d1936fe2331564dfb4eda8459499230c0c..52dc0049d596287a089bd5397cdfd2c99c711f2a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2780,5 +2780,24 @@ public final class CraftServer implements Server {
+@@ -2803,5 +2803,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0127-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0127-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -127,10 +127,10 @@ index 1f29ed95ef3d1904a014715028d9d591fe39231f..1a829f79e6f9e03ead745e13ece4d1b5
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 19dbfbef6d008ba858ab37fb6d5139b0846ef95f..1379f0ba7cf99e7829aaaca62ac4c56c359f6bf0 100644
+index 51f6b7be6b8e65dbd8700ba2d7a40760b229f512..3cb452003cffd02a1ef88b0cb512a5c66d4e078b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1819,7 +1819,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1813,7 +1813,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
      protected void dropExperience() {
          // CraftBukkit start - Update getExpReward() above if the removed if() changes!
          if (true && !(this instanceof net.minecraft.world.entity.boss.enderdragon.EnderDragon)) { // CraftBukkit - SPIGOT-2420: Special case ender dragon will drop the xp over time

--- a/patches/server/0128-Cap-Entity-Collisions.patch
+++ b/patches/server/0128-Cap-Entity-Collisions.patch
@@ -24,10 +24,10 @@ index 2fcdd61e9669904756aa33b1ff8ab7160ea5e371..660a210c363fcb42145b273ea6b977ce
      @javax.annotation.Nullable
      private org.bukkit.util.Vector origin;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 1379f0ba7cf99e7829aaaca62ac4c56c359f6bf0..894772009bd3ca2615297b6ca856a9ffe23f3c42 100644
+index 3cb452003cffd02a1ef88b0cb512a5c66d4e078b..eafbe6fd829c2067b1e81ea8aad77fe3ba3df82f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3460,10 +3460,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3454,10 +3454,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  }
  
                  Iterator iterator1 = list.iterator();

--- a/patches/server/0132-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0132-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 26dc95f14efbe293c0a8548e050a213206aeb582..02308021712a2e947bd389e625b5d93e62f5024b 100644
+index 52dc0049d596287a089bd5397cdfd2c99c711f2a..e9aa21a1ca5a3406f8ab40e1ce75f9e0ab6ddf5a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2799,5 +2799,10 @@ public final class CraftServer implements Server {
+@@ -2822,5 +2822,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0138-Basic-PlayerProfile-API.patch
+++ b/patches/server/0138-Basic-PlayerProfile-API.patch
@@ -625,10 +625,10 @@ index 416b26c2ab62b29d640169166980e398d5824b14..774d81c702edb76a2f6184d4dc53687d
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 02308021712a2e947bd389e625b5d93e62f5024b..f7c258b6f0f4eb6094828da20e4a5af2388a04ac 100644
+index e9aa21a1ca5a3406f8ab40e1ce75f9e0ab6ddf5a..1182f5582b59a07a53a5b76b446326c05fe24411 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -260,6 +260,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -261,6 +261,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
@@ -638,7 +638,7 @@ index 02308021712a2e947bd389e625b5d93e62f5024b..f7c258b6f0f4eb6094828da20e4a5af2
  public final class CraftServer implements Server {
      private final String serverName = io.papermc.paper.ServerBuildInfo.buildInfo().brandName(); // Paper
      private final String serverVersion;
-@@ -303,6 +306,7 @@ public final class CraftServer implements Server {
+@@ -305,6 +308,7 @@ public final class CraftServer implements Server {
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
          ConfigurationSerialization.registerClass(CraftPlayerProfile.class);
@@ -646,7 +646,7 @@ index 02308021712a2e947bd389e625b5d93e62f5024b..f7c258b6f0f4eb6094828da20e4a5af2
          CraftItemFactory.instance();
          CraftEntityFactory.instance();
      }
-@@ -2804,5 +2808,39 @@ public final class CraftServer implements Server {
+@@ -2827,5 +2831,39 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }

--- a/patches/server/0139-Add-UnknownCommandEvent.patch
+++ b/patches/server/0139-Add-UnknownCommandEvent.patch
@@ -78,10 +78,10 @@ index b81a4204a85e5b431cd6137fd8b80e43779c97b7..eec5279ac4386132fa053c57889e32e6
  
              return null;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f7c258b6f0f4eb6094828da20e4a5af2388a04ac..ea8e5b4775944fc2bf4e30c311b281363bd21049 100644
+index 1182f5582b59a07a53a5b76b446326c05fe24411..3c3f1b8b0885a1db6859718ee0ce0637153f012a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -914,7 +914,13 @@ public final class CraftServer implements Server {
+@@ -936,7 +936,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
          if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {

--- a/patches/server/0145-ensureServerConversions-API.patch
+++ b/patches/server/0145-ensureServerConversions-API.patch
@@ -7,10 +7,10 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 319ad3342740657175ad78a1c1cc383046fe2fb5..3868c1fbfed3a6bc1cea760834a96a1df66b184c 100644
+index e8dd4ba93c09c514f3594f0d4b5f1167b719a17d..aa1d144dfffc780284fc0a955ff18b711dc8c7bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -518,4 +518,12 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -516,4 +516,12 @@ public final class CraftItemFactory implements ItemFactory {
          return io.papermc.paper.adventure.PaperAdventure.asAdventure(CraftItemStack.asNMSCopy(itemStack).getDisplayName());
      }
      // Paper end - Adventure

--- a/patches/server/0146-Implement-getI18NDisplayName.patch
+++ b/patches/server/0146-Implement-getI18NDisplayName.patch
@@ -8,10 +8,10 @@ Currently the server only supports the English language. To override this,
 You must replace the language file embedded in the server jar.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 3868c1fbfed3a6bc1cea760834a96a1df66b184c..2c5037f04f79564306d3319e6489dfcf3d244d80 100644
+index aa1d144dfffc780284fc0a955ff18b711dc8c7bf..fa4de12ba4fdce7a632923af8007e888141904c8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -526,4 +526,19 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -524,4 +524,19 @@ public final class CraftItemFactory implements ItemFactory {
          return CraftItemStack.asCraftMirror(CraftItemStack.asNMSCopy(item));
      }
      // Paper end - ensure server conversions API

--- a/patches/server/0148-Fix-this-stupid-bullshit.patch
+++ b/patches/server/0148-Fix-this-stupid-bullshit.patch
@@ -31,12 +31,12 @@ index 26892378d27dadce25c178333188ba093dc1617b..a3a2097716430b30c9bac2581b9f67fe
              Bootstrap.isBootstrapped = true;
              Instant instant = Instant.now();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 9515a6f72b54bc8926f10182143b2aa9b684a341..faa228698c7dd60bde0f3767cc27957ece04b8be 100644
+index 04a12fc412693c689c2048e4d568225b10ccf17b..1f62158072d7503f0148a9af4e9fbebab30e6fd7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -260,10 +260,12 @@ public class Main {
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -3);
+                     deadline.add(Calendar.DAY_OF_YEAR, -21);
                      if (buildDate.before(deadline.getTime())) {
 -                        System.err.println("*** Error, this build is outdated ***");
 +                        // Paper start - This is some stupid bullshit

--- a/patches/server/0158-Add-PlayerArmorChangeEvent.patch
+++ b/patches/server/0158-Add-PlayerArmorChangeEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 894772009bd3ca2615297b6ca856a9ffe23f3c42..72c5da58cc13ff7dc33159073b92c8e8fbb5bb28 100644
+index eafbe6fd829c2067b1e81ea8aad77fe3ba3df82f..2bb22c70c52a98abc0f4839ae67e9d27c320251a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3143,6 +3143,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3137,6 +3137,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
              ItemStack itemstack2 = this.getItemBySlot(enumitemslot);
  
              if (this.equipmentHasChanged(itemstack1, itemstack2)) {

--- a/patches/server/0163-AsyncTabCompleteEvent.patch
+++ b/patches/server/0163-AsyncTabCompleteEvent.patch
@@ -80,10 +80,10 @@ index 196682a91c47ed2c4d2a8e1b71728200cc22191c..fffd671feb7a4e9805eafc473632b232
  
          this.server.getCommands().getDispatcher().getCompletionSuggestions(parseresults).thenAccept((suggestions) -> {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ea8e5b4775944fc2bf4e30c311b281363bd21049..9126d9409d1df900790db05c4c30a224460c36cd 100644
+index 3c3f1b8b0885a1db6859718ee0ce0637153f012a..4dc7631babd1b433555fefbf33917af53868dec9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2253,7 +2253,7 @@ public final class CraftServer implements Server {
+@@ -2276,7 +2276,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0167-Add-setPlayerProfile-API-for-Skulls.patch
+++ b/patches/server/0167-Add-setPlayerProfile-API-for-Skulls.patch
@@ -48,7 +48,7 @@ index aa965ea05fb364e9cfc4bbf4241a47c3400355b0..45ac1d9193c3a0dc397d6e7ccfccec89
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index d20ae5345d85dee1bcc83a45837d2288a6da49be..0f725408691384800abb2cc7a43d9e1c75c9a17e 100644
+index b5a287349a3a200cc030ef6c2e76c24727ccfb5b..a08c57770c658bb289c96b69b966d98af72eef67 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 @@ -178,6 +178,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
@@ -93,12 +93,12 @@ index d20ae5345d85dee1bcc83a45837d2288a6da49be..0f725408691384800abb2cc7a43d9e1c
          }
      }
  
-@@ -295,7 +310,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
-     Builder<String, Object> serialize(Builder<String, Object> builder) {
+@@ -296,7 +311,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          super.serialize(builder);
+ 
          if (this.profile != null) {
--            return builder.put(CraftMetaSkull.SKULL_OWNER.BUKKIT, new CraftPlayerProfile(this.profile));
-+            return builder.put(CraftMetaSkull.SKULL_OWNER.BUKKIT, new com.destroystokyo.paper.profile.CraftPlayerProfile(this.profile)); // Paper
+-            builder.put(CraftMetaSkull.SKULL_OWNER.BUKKIT, new CraftPlayerProfile(this.profile));
++            builder.put(CraftMetaSkull.SKULL_OWNER.BUKKIT, new com.destroystokyo.paper.profile.CraftPlayerProfile(this.profile)); // Paper
          }
+ 
          NamespacedKey namespacedKeyNB = this.getNoteBlockSound();
-         if (namespacedKeyNB != null) {

--- a/patches/server/0171-Add-ArmorStand-Item-Meta.patch
+++ b/patches/server/0171-Add-ArmorStand-Item-Meta.patch
@@ -13,10 +13,10 @@ starting point for future additions in this area.
 Fixes GH-559
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
-index 662cf08d1cb2b41da5b17dae3585333cdf605c0b..f5bb5802aae64773252c9399df0fbe9de3d1d121 100644
+index 7c7b85972d6a97cc325bf86a836ef208f00dbb37..8d484ba6ed0f7917cf281ff67b1f2b0c2c5c81d8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
-@@ -66,7 +66,7 @@ public class CraftItemType<M extends ItemMeta> implements ItemType.Typed<M>, Han
+@@ -67,7 +67,7 @@ public class CraftItemType<M extends ItemMeta> implements ItemType.Typed<M>, Han
      private Class<M> getItemMetaClass(Item item) {
          ItemMeta meta = new ItemStack(this.asMaterial()).getItemMeta();
          if (meta != null) {

--- a/patches/server/0178-Player.setPlayerProfile-API.patch
+++ b/patches/server/0178-Player.setPlayerProfile-API.patch
@@ -77,7 +77,7 @@ index 818df09e9245b5d89b4180b1eaa51470b7539341..461656e1cb095243bfe7a9ee2906e5b0
  
      public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2928c835d2f99ea82db2bb06761cd273e1427caf..a1e7fe7fb36e8ee9a76a50d6508c0d8150b6ddd3 100644
+index 8b3e3d85ec11406143e7a9f447007615afecae2a..627b957388bb52a779796b618fe8158a76be093e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -247,11 +247,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -220,10 +220,10 @@ index 2928c835d2f99ea82db2bb06761cd273e1427caf..a1e7fe7fb36e8ee9a76a50d6508c0d81
      public void onEntityRemove(Entity entity) {
          this.invertedVisibilityEntities.remove(entity.getUUID());
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index c6956b9241634e455a520f4fd3bd8c4b5a58eb9d..e8e5ec73f5197249e9ebdec2bf055043d9f04c54 100644
+index f45498bf9841c31338b83270c1badc6d7a792d25..5b71ef6231c6c44ebeabfb1fb39941806cb22b5c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -370,6 +370,13 @@ public class Commodore {
+@@ -374,6 +374,13 @@ public class Commodore {
                          }
                          // Paper end - Rewrite plugins
  

--- a/patches/server/0179-getPlayerUniqueId-API.patch
+++ b/patches/server/0179-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9126d9409d1df900790db05c4c30a224460c36cd..cd249a21120f7d24fe224c2bcbeae26cf07c6298 100644
+index 4dc7631babd1b433555fefbf33917af53868dec9..c02ebe1a8fbae4cd01f5ad355b3a5530494fab73 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1852,6 +1852,25 @@ public final class CraftServer implements Server {
+@@ -1875,6 +1875,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0189-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0189-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -34,10 +34,10 @@ index f31d403420294f479e116013b200ea7e87ac901e..82947c9743433df9c03732e0a3229563
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 705cfb8ac38ee49adfb36a93b6939c975bbe95e9..8faebe25c0242eaf15a6b67fb1ade71cc46d263e 100644
+index 8fea8bc0117b5b9ebff1979a73783446b7afe228..6bca713e3cc3d63ec69b06cb7ec1820dd61cd88f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1957,8 +1957,19 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1982,8 +1982,19 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0201-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0201-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 72c5da58cc13ff7dc33159073b92c8e8fbb5bb28..b10d532d81efa8330f363f86d5a19e8847b90ba0 100644
+index 2bb22c70c52a98abc0f4839ae67e9d27c320251a..249b73a3d794a7bb84e3fdd85ef6c8725d7adae1 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3917,12 +3917,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3911,12 +3911,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (this.isUsingItem() && !this.useItem.isEmpty()) {
              Item item = this.useItem.getItem();
  

--- a/patches/server/0204-Add-entity-knockback-events.patch
+++ b/patches/server/0204-Add-entity-knockback-events.patch
@@ -40,10 +40,10 @@ index 655ce0b58cc327a8dac1b006bec7dcb34964da0a..afc2e4a3eda78a47209581307c100663
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index b10d532d81efa8330f363f86d5a19e8847b90ba0..6cc1a7ea24ebd32b898d440abf5c1f6121239ec8 100644
+index 249b73a3d794a7bb84e3fdd85ef6c8725d7adae1..a2fd82e4ff315d462f2da8cf572825c7b4058186 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1540,7 +1540,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1534,7 +1534,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                          d0 = (Math.random() - Math.random()) * 0.01D;
                      }
  
@@ -52,7 +52,7 @@ index b10d532d81efa8330f363f86d5a19e8847b90ba0..6cc1a7ea24ebd32b898d440abf5c1f61
                      if (!flag) {
                          this.indicateDamage(d0, d1);
                      }
-@@ -1593,7 +1593,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1587,7 +1587,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      protected void blockedByShield(LivingEntity target) {
@@ -61,7 +61,7 @@ index b10d532d81efa8330f363f86d5a19e8847b90ba0..6cc1a7ea24ebd32b898d440abf5c1f61
      }
  
      private boolean checkTotemDeathProtection(DamageSource source) {
-@@ -1853,23 +1853,27 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1847,23 +1847,27 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      public void knockback(double strength, double x, double z) {
          // CraftBukkit start - EntityKnockbackEvent

--- a/patches/server/0205-Expand-Explosions-API.patch
+++ b/patches/server/0205-Expand-Explosions-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 8faebe25c0242eaf15a6b67fb1ade71cc46d263e..f2e67748d2970207907b3120b0d0fb50744eb7c2 100644
+index 6bca713e3cc3d63ec69b06cb7ec1820dd61cd88f..5ed7c2edeca2a2126f2beb8a5dcf4587a4400ddf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -764,6 +764,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -789,6 +789,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return !this.world.explode(source == null ? null : ((CraftEntity) source).getHandle(), x, y, z, power, setFire, explosionType).wasCanceled;
      }

--- a/patches/server/0209-Implement-World.getEntity-UUID-API.patch
+++ b/patches/server/0209-Implement-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f2e67748d2970207907b3120b0d0fb50744eb7c2..2abd68c5a8c53dfc503b732f64b3ba3195244fbf 100644
+index 5ed7c2edeca2a2126f2beb8a5dcf4587a4400ddf..ead66f549576034ef32ee4d74c0e2f5ac79e944e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1100,6 +1100,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1125,6 +1125,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return list;
      }
  

--- a/patches/server/0229-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0229-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -9,7 +9,7 @@ thread dumps at an interval until the point of crash.
 This will help diagnose what was going on in that time before the crash.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 2ae6eb3a05bd0574143699e1286f63f5fd699f30..6d871dd9bc4a954046f03f0911003e3fb2d4dfd6 100644
+index b6c5656665e492a7fdec0ae15545ecbabf585336..a8a53b0aad6cda7fa1cd0565b5a4249a228f87f7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1101,6 +1101,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -33,10 +33,10 @@ index 0ffa25a6e41cc56e78c79e0cee45e3b811794129..1b47e228ad7365b31d6ddd8c572d3bc5
          com.destroystokyo.paper.Metrics.PaperMetrics.startMetrics(); // Paper - start metrics
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // Paper - load version history now
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cd249a21120f7d24fe224c2bcbeae26cf07c6298..6144d3c422fe5cac93e4468a5879cbfba018d1a0 100644
+index c02ebe1a8fbae4cd01f5ad355b3a5530494fab73..d9a283591efa1adad5107dd517382bb655768190 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -929,6 +929,7 @@ public final class CraftServer implements Server {
+@@ -951,6 +951,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -44,7 +44,7 @@ index cd249a21120f7d24fe224c2bcbeae26cf07c6298..6144d3c422fe5cac93e4468a5879cbfb
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -1019,6 +1020,7 @@ public final class CraftServer implements Server {
+@@ -1042,6 +1043,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.pluginsEnabled(); // Paper - Remap plugins
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));

--- a/patches/server/0232-Ability-to-get-block-entities-from-a-chunk-without-s.patch
+++ b/patches/server/0232-Ability-to-get-block-entities-from-a-chunk-without-s.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ability to get block entities from a chunk without snapshots
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 1d4587a97e86251982a9df832949a7093b216862..fc335e4e80553e8c6c915e7813e9610ac10649c2 100644
+index 110bdba382c361228c52c1c1f807fef25f127ab5..01596f87ee078fceeb3f2f29bbb2500e63e9efb8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -173,6 +173,13 @@ public class CraftChunk implements Chunk {
+@@ -174,6 +174,13 @@ public class CraftChunk implements Chunk {
  
      @Override
      public BlockState[] getTileEntities() {
@@ -22,7 +22,7 @@ index 1d4587a97e86251982a9df832949a7093b216862..fc335e4e80553e8c6c915e7813e9610a
          if (!this.isLoaded()) {
              this.getWorld().getChunkAt(this.x, this.z); // Transient load for this tick
          }
-@@ -182,7 +189,29 @@ public class CraftChunk implements Chunk {
+@@ -183,7 +190,29 @@ public class CraftChunk implements Chunk {
          BlockState[] entities = new BlockState[chunk.blockEntities.size()];
  
          for (BlockPos position : chunk.blockEntities.keySet()) {

--- a/patches/server/0242-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/patches/server/0242-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2abd68c5a8c53dfc503b732f64b3ba3195244fbf..932e71656f587678c02766fc8cfb685034368016 100644
+index ead66f549576034ef32ee4d74c0e2f5ac79e944e..8aac52d6a31c36ce7fd173972ab4709c1dc95f9f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -407,7 +407,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -432,7 +432,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0243-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/patches/server/0243-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ray tracing methods to LivingEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 6cc1a7ea24ebd32b898d440abf5c1f6121239ec8..7fffb8ee4474a4a39e77350e5b49feb8dac08cc6 100644
+index a2fd82e4ff315d462f2da8cf572825c7b4058186..1a64ea5e875fe0d362d3e76cf9d112b238b67bbe 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3928,6 +3928,19 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3922,6 +3922,19 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      // Paper start - Make shield blocking delay configurable

--- a/patches/server/0244-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0244-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 59d19212487770304a9b273f1546a2cc199764ab..a787be4cc43a01c7a6d66fe507df2ab2b63019a0 100644
+index bbd7d5a10a7792994314141ead60b41a7a21f965..44faaf75631a00caaa659fc44c35779b7dee510d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2953,6 +2953,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2962,6 +2962,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0245-Improve-death-events.patch
+++ b/patches/server/0245-Improve-death-events.patch
@@ -80,7 +80,7 @@ index c96e761dd29dbad42d590a88f1742c9a494eebfc..a0801437d631b148d435b3700e60f97f
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 12e205a01366a5825fd1b99097f1cef75dc0408e..3b9bd1e1043d7388c03936d5b131e9e288fb8fec 100644
+index 5583c67f093a68cc6727cf03ce3e98559bbf3b49..69ffb72df34454b601d58af624594f410e5ea8df 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -271,6 +271,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -91,7 +91,7 @@ index 12e205a01366a5825fd1b99097f1cef75dc0408e..3b9bd1e1043d7388c03936d5b131e9e2
  
      @Override
      public float getBukkitYaw() {
-@@ -1549,11 +1550,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1543,11 +1544,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
              if (this.isDeadOrDying()) {
                  if (!this.checkTotemDeathProtection(source)) {
@@ -107,7 +107,7 @@ index 12e205a01366a5825fd1b99097f1cef75dc0408e..3b9bd1e1043d7388c03936d5b131e9e2
                  }
              } else if (flag1) {
                  this.playHurtSound(source);
-@@ -1712,6 +1714,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1706,6 +1708,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              Entity entity = damageSource.getEntity();
              LivingEntity entityliving = this.getKillCredit();
  
@@ -115,7 +115,7 @@ index 12e205a01366a5825fd1b99097f1cef75dc0408e..3b9bd1e1043d7388c03936d5b131e9e2
              if (this.deathScore >= 0 && entityliving != null) {
                  entityliving.awardKillScore(this, this.deathScore, damageSource);
              }
-@@ -1723,24 +1726,59 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1717,24 +1720,59 @@ public abstract class LivingEntity extends Entity implements Attackable {
              if (!this.level().isClientSide && this.hasCustomName()) {
                  if (org.spigotmc.SpigotConfig.logNamedDeaths) LivingEntity.LOGGER.info("Named entity {} died: {}", this, this.getCombatTracker().getDeathMessage().getString()); // Spigot
              }
@@ -180,7 +180,7 @@ index 12e205a01366a5825fd1b99097f1cef75dc0408e..3b9bd1e1043d7388c03936d5b131e9e2
          }
      }
  
-@@ -1748,7 +1786,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1742,7 +1780,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (!this.level().isClientSide) {
              boolean flag = false;
  
@@ -189,7 +189,7 @@ index 12e205a01366a5825fd1b99097f1cef75dc0408e..3b9bd1e1043d7388c03936d5b131e9e2
                  if (this.level().getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
                      BlockPos blockposition = this.blockPosition();
                      BlockState iblockdata = Blocks.WITHER_ROSE.defaultBlockState();
-@@ -1777,7 +1815,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1771,7 +1809,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
          }
      }
  
@@ -202,7 +202,7 @@ index 12e205a01366a5825fd1b99097f1cef75dc0408e..3b9bd1e1043d7388c03936d5b131e9e2
          Entity entity = source.getEntity();
          int i;
  
-@@ -1792,18 +1834,27 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1786,18 +1828,27 @@ public abstract class LivingEntity extends Entity implements Attackable {
          this.dropEquipment(); // CraftBukkit - from below
          if (this.shouldDropLoot() && this.level().getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
              this.dropFromLootTable(source, flag);
@@ -426,7 +426,7 @@ index b1867bb5c07b70b1cc8e5d3065a78b37c235a11e..029d5756f424dba57b4a974b09453c2f
          // CraftBukkit end
          this.gameEvent(GameEvent.ENTITY_DIE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a787be4cc43a01c7a6d66fe507df2ab2b63019a0..3f8135387474c7fb2a7ceefff8dc213ea841a57d 100644
+index bd151c63a957b0540051aeb60be63c234c6d27bb..f113add7e0ff9301b8ca1feeef1cc4e2899f7c04 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2499,7 +2499,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0255-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0255-Add-LivingEntity-getTargetEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a4118a6109154b7d9c21023ac6bb10e521fe368d..4f63352f9f96b104e3a01929d96ee33dcd01ab7d 100644
+index 59a1cdbfdde5bc167d46eeb86cf2f54f9d0d8404..7217cf55beb26823ca9c2eb97dc0af4ff456da08 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -121,6 +121,7 @@ import net.minecraft.world.level.storage.loot.LootTable;
@@ -16,7 +16,7 @@ index a4118a6109154b7d9c21023ac6bb10e521fe368d..4f63352f9f96b104e3a01929d96ee33d
  import net.minecraft.world.phys.HitResult;
  import net.minecraft.world.phys.Vec3;
  import net.minecraft.world.scores.PlayerTeam;
-@@ -3992,6 +3993,38 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3986,6 +3987,38 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return this.level().clip(raytrace);
      }
  

--- a/patches/server/0256-Add-sun-related-API.patch
+++ b/patches/server/0256-Add-sun-related-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add sun related API
 public net.minecraft.world.entity.Mob isSunBurnTick()Z
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 932e71656f587678c02766fc8cfb685034368016..cbb7ffab637e640eb2cedfac63c13392147f7e12 100644
+index 8aac52d6a31c36ce7fd173972ab4709c1dc95f9f..f3d52650e9dd338396d325c9fb7a46e3927d3b36 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -731,6 +731,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -756,6 +756,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
      }
  

--- a/patches/server/0270-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0270-Make-the-default-permission-message-configurable.patch
@@ -18,10 +18,10 @@ index 6d06b772ffb9d47d6a717462a4b2b494544e80ae..69ffd6ea2ce7c6d4f211c6081fcea79a
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6144d3c422fe5cac93e4468a5879cbfba018d1a0..32765f19f6cd4973b4d2d8085637124f8192373c 100644
+index d9a283591efa1adad5107dd517382bb655768190..eb1b151560ef77cd8208f44880c860626caf8d3b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2836,6 +2836,16 @@ public final class CraftServer implements Server {
+@@ -2859,6 +2859,16 @@ public final class CraftServer implements Server {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }
  

--- a/patches/server/0271-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0271-force-entity-dismount-during-teleportation.patch
@@ -106,10 +106,10 @@ index 1f28f466aab3d829fe719878faee40f35320163b..ea8abc813809360b51cd67072d12efa0
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4f63352f9f96b104e3a01929d96ee33dcd01ab7d..cc5cafa8388d96e18494d3c89f36d1654ea44f7d 100644
+index 7217cf55beb26823ca9c2eb97dc0af4ff456da08..7a9e6671ac38a3473d5562b0eb1de9eecc95c6c5 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3575,9 +3575,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3569,9 +3569,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      @Override
      public void stopRiding() {

--- a/patches/server/0296-Expose-the-internal-current-tick.patch
+++ b/patches/server/0296-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index eb178edff9fa0d2be549e2fa62a8ddfd7fd73f83..383f38cd8436fa8efaff53d235b0ad9f757c5c0b 100644
+index eb1b151560ef77cd8208f44880c860626caf8d3b..10b638183a06702ce97159e634b18a9c8b55d049 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2879,5 +2879,10 @@ public final class CraftServer implements Server {
+@@ -2902,5 +2902,10 @@ public final class CraftServer implements Server {
          profile.getGameProfile().getProperties().putAll(((CraftPlayer) player).getHandle().getGameProfile().getProperties());
          return profile;
      }

--- a/patches/server/0301-Prevent-consuming-the-wrong-itemstack.patch
+++ b/patches/server/0301-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cc5cafa8388d96e18494d3c89f36d1654ea44f7d..58dacb52494972698b2d3740ed1cbe53e5264771 100644
+index 7a9e6671ac38a3473d5562b0eb1de9eecc95c6c5..73738ef71f2698a6116cd5371f80c26a97c0a77c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3811,9 +3811,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3805,9 +3805,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public void startUsingItem(InteractionHand hand) {
@@ -24,7 +24,7 @@ index cc5cafa8388d96e18494d3c89f36d1654ea44f7d..58dacb52494972698b2d3740ed1cbe53
              this.useItem = itemstack;
              this.useItemRemaining = itemstack.getUseDuration();
              if (!this.level().isClientSide) {
-@@ -3893,6 +3898,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3887,6 +3892,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  this.releaseUsingItem();
              } else {
                  if (!this.useItem.isEmpty() && this.isUsingItem()) {
@@ -32,7 +32,7 @@ index cc5cafa8388d96e18494d3c89f36d1654ea44f7d..58dacb52494972698b2d3740ed1cbe53
                      this.triggerItemUseEffects(this.useItem, 16);
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
-@@ -3927,8 +3933,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3921,8 +3927,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0322-Entity-Jump-API.patch
+++ b/patches/server/0322-Entity-Jump-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Entity Jump API
 public net.minecraft.world.entity.LivingEntity jumping
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 58dacb52494972698b2d3740ed1cbe53e5264771..575f6b542a7c5c9a3f96a0e4e78f75f7dc060cd7 100644
+index 73738ef71f2698a6116cd5371f80c26a97c0a77c..639357aa6335b96da3723973a754db763ecbc0f8 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3391,8 +3391,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3385,8 +3385,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
              } else if (this.isInLava() && (!this.onGround() || d3 > d4)) {
                  this.jumpInLiquid(FluidTags.LAVA);
              } else if ((this.onGround() || flag && d3 <= d4) && this.noJumpDelay == 0) {

--- a/patches/server/0331-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0331-Add-tick-times-API-and-mspt-command.patch
@@ -125,7 +125,7 @@ index 72f2e81b9905a0d57ed8e2a88578f62d5235c456..7b58b2d6297800c2dcdbf7539e5ab8e7
  
      public static void registerCommands(final MinecraftServer server) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 5d8fb0a781b2f86ab15c7045cd09c58563848848..3788057fa995d11c23f189c39d0554e9ccac0a68 100644
+index 3b6517cb569a6c702dabb60e8f98cd5f9c367e5b..6e31678d1b49584208b7c0ed1f6cfd394f597362 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -252,6 +252,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -184,10 +184,10 @@ index 5d8fb0a781b2f86ab15c7045cd09c58563848848..3788057fa995d11c23f189c39d0554e9
 +    // Paper end - Add tick times API and /mspt command
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 11ef05f685b040f90988436bd07b1e747777dbb8..6e10244fe14d6271c0215c09a6df3f55a3ca6ade 100644
+index 10b638183a06702ce97159e634b18a9c8b55d049..428a2738008c14f7e0179c15026494eda44fa14f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2650,6 +2650,16 @@ public final class CraftServer implements Server {
+@@ -2673,6 +2673,16 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0332-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0332-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 69c10ac5f54141fe8afeef79df287ab694f2b033..2b096d8594b71261fe7166664574532fe7009a2a 100644
+index 428a2738008c14f7e0179c15026494eda44fa14f..af99292c4461819c4c7d304134f3f3ffb88c175d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2894,5 +2894,10 @@ public final class CraftServer implements Server {
+@@ -2917,5 +2917,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0333-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/server/0333-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Raw Byte ItemStack Serialization
 Serializes using NBT which is safer for server data migrations than bukkits format.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index f541ca7cb3328a9366e08a9933b24ed5c76059c0..3547edda0db53ec6c59f30f478f1614bd932be02 100644
+index 9730a3fe6b1e2734d897936dc8bff7c06edb3687..3fc189cd1e54f91c1713315214da9b6af2923074 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -482,6 +482,53 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -483,6 +483,53 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {
          return new com.destroystokyo.paper.PaperVersionFetcher();
      }

--- a/patches/server/0345-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0345-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -12,10 +12,10 @@ The entity's current team collision rule causes them to NEVER collide.
 Co-authored-by: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 575f6b542a7c5c9a3f96a0e4e78f75f7dc060cd7..8c95f08302439c7bd36ae9834ea991b29c435cfa 100644
+index 639357aa6335b96da3723973a754db763ecbc0f8..2b38a9d88b459674b1b8d667c4e02b93ad7290b4 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3502,10 +3502,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3496,10 +3496,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (this.level().isClientSide()) {
              this.level().getEntities(EntityTypeTest.forClass(net.minecraft.world.entity.player.Player.class), this.getBoundingBox(), EntitySelector.pushableBy(this)).forEach(this::doPush);
          } else {

--- a/patches/server/0350-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/patches/server/0350-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8c95f08302439c7bd36ae9834ea991b29c435cfa..166502bdeb4e20a122c023935f48047debc69bbd 100644
+index 2b38a9d88b459674b1b8d667c4e02b93ad7290b4..accb574f961114f225596a633b36a91e3009ed87 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2254,7 +2254,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2248,7 +2248,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
              EntityDamageEvent event = CraftEventFactory.handleLivingEntityDamageEvent(this, damagesource, originalDamage, hardHatModifier, blockingModifier, armorModifier, resistanceModifier, magicModifier, absorptionModifier, hardHat, blocking, armor, resistance, magic, absorption);
              if (damagesource.getEntity() instanceof net.minecraft.world.entity.player.Player) {

--- a/patches/server/0353-Fix-item-duplication-and-teleport-issues.patch
+++ b/patches/server/0353-Fix-item-duplication-and-teleport-issues.patch
@@ -80,10 +80,10 @@ index b93185f50bd87d070ef08b9c6a714a065dd714d8..996ca6762fe45ee1c2fa2392ed6a050b
  
      public float getBlockExplosionResistance(Explosion explosion, BlockGetter world, BlockPos pos, BlockState blockState, FluidState fluidState, float max) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index dfe327a17ec97d9317e451303721c7fea5268d2f..5280bae3ad8f9c137e58add8a8d056df81de9928 100644
+index bff839920bdac3e5d31fe411bda6ec6cbfc1303a..26affae253104122531ebac4358412c992db3a76 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1740,9 +1740,9 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1734,9 +1734,9 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  // Paper start
                  org.bukkit.event.entity.EntityDeathEvent deathEvent = this.dropAllDeathLoot(damageSource);
                  if (deathEvent == null || !deathEvent.isCancelled()) {
@@ -96,7 +96,7 @@ index dfe327a17ec97d9317e451303721c7fea5268d2f..5280bae3ad8f9c137e58add8a8d056df
                      // Paper start - clear equipment if event is not cancelled
                      if (this instanceof Mob) {
                          for (EquipmentSlot slot : this.clearedEquipmentSlots) {
-@@ -1843,8 +1843,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1837,8 +1837,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.dropCustomDeathLoot(source, i, flag);
              this.clearEquipmentSlots = prev; // Paper
          }

--- a/patches/server/0357-misc-debugging-dumps.patch
+++ b/patches/server/0357-misc-debugging-dumps.patch
@@ -49,7 +49,7 @@ index f15c388434a0a501f86868de35cc138756975027..5044a7dc120c8b040ee23365d2bf97e6
                  StackTraceElement[] astacktraceelement = exception.getStackTrace();
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 3788057fa995d11c23f189c39d0554e9ccac0a68..386f8b825dac6dda253b0c55a3a0eeef5bdca271 100644
+index 6e31678d1b49584208b7c0ed1f6cfd394f597362..92cb9a0a479f3dc1c78eda42191d020106d059dd 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -909,6 +909,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -105,10 +105,10 @@ index 970d1ddf0a014b47b0ac97440489706137324991..e4086bea596e5f5d71491e0b7ad650d7
              this.connection.disconnect(ServerConfigurationPacketListenerImpl.DISCONNECT_REASON_INVALID_DATA);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8e082ec92c437e27d71e70a91a0bf65153de29a3..26bebc3ddd15e963e818011556f216f275bd7415 100644
+index af99292c4461819c4c7d304134f3f3ffb88c175d..9cc6f2ae2f0ae71d550f0da5f81412a434b0bdf7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1013,6 +1013,7 @@ public final class CraftServer implements Server {
+@@ -1036,6 +1036,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getFullName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/patches/server/0359-Implement-Mob-Goal-API.patch
+++ b/patches/server/0359-Implement-Mob-Goal-API.patch
@@ -18,7 +18,7 @@ index 2caa4c8e250a7925e7d6f9ba00a95956b5328568..69b5d39f57a63130c0b83f6238898bdf
      testImplementation("org.mockito:mockito-core:5.11.0")
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java b/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..55e85267c7cbd8be5d2da212e33c43fb353f2e12
+index 0000000000000000000000000000000000000000..3f8cca8027051694cb0440373e75f418f73edf87
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java
 @@ -0,0 +1,378 @@
@@ -305,8 +305,8 @@ index 0000000000000000000000000000000000000000..55e85267c7cbd8be5d2da212e33c43fb
 +        name = sb.toString();
 +        name = name.replaceFirst("_", "");
 +
-+        if (flag && !deobfuscationMap.containsKey(name.toLowerCase()) && !ignored.contains(name)) {
-+            System.out.println("need to map " + clazz.getName() + " (" + name.toLowerCase() + ")");
++        if (flag && !deobfuscationMap.containsKey(name.toLowerCase(java.util.Locale.ROOT)) && !ignored.contains(name)) {
++            System.out.println("need to map " + clazz.getName() + " (" + name.toLowerCase(java.util.Locale.ROOT) + ")");
 +        }
 +
 +        // did we rename this key?
@@ -781,10 +781,10 @@ index 6667ecc4b7eded4e20a415cef1e1b1179e6710b8..16f9a98b8a939e5ca7e2dc04f87134a7
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cd6fb7eb121c527e798219177781c13097fd9ef6..c6a96664ef914d0da1e24b93da93bad1b4a17716 100644
+index 9cc6f2ae2f0ae71d550f0da5f81412a434b0bdf7..13ef7ed49526b9f0d1ec376ec3242e14f66f0a23 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2900,5 +2900,11 @@ public final class CraftServer implements Server {
+@@ -2923,5 +2923,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0364-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0364-Wait-for-Async-Tasks-during-shutdown.patch
@@ -10,7 +10,7 @@ Adds a 5 second grace period for any async tasks to finish and warns
 if any are still running after that delay just as reload does.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 386f8b825dac6dda253b0c55a3a0eeef5bdca271..0087e8037e2d30d940e6efa886226e59e8daa98f 100644
+index 92cb9a0a479f3dc1c78eda42191d020106d059dd..2575129d1647eda4acb1ce4f19619f42257cb6f8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -936,6 +936,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -22,10 +22,10 @@ index 386f8b825dac6dda253b0c55a3a0eeef5bdca271..0087e8037e2d30d940e6efa886226e59
          // CraftBukkit end
          if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.shutdown(); // Paper - Plugin remapping
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c6a96664ef914d0da1e24b93da93bad1b4a17716..45799f96978a68a79b4c89e17e9b543dec99a8b1 100644
+index 13ef7ed49526b9f0d1ec376ec3242e14f66f0a23..91b8fefc2c97c1f487bde1559d4ccf76795ca954 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1024,6 +1024,32 @@ public final class CraftServer implements Server {
+@@ -1047,6 +1047,32 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0380-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0380-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -8,7 +8,7 @@ makes it so that the server keeps the last difficulty used instead
 of restoring the server.properties every single load.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 0087e8037e2d30d940e6efa886226e59e8daa98f..a7de512a019a51d3133d4304b9ef80a6b6b6b80d 100644
+index 2575129d1647eda4acb1ce4f19619f42257cb6f8..f5a2645afc64f3ba9ee21e6442697d6eb2fabb13 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -830,7 +830,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -102,10 +102,10 @@ index 299a2e78f4a83d224038c80287636a5d6b9b7450..95d20facdc43a356fd2e82f5d597f52e
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 45799f96978a68a79b4c89e17e9b543dec99a8b1..72f64528092f92adf60dadb7d1b5dc38c7a8d4ee 100644
+index 91b8fefc2c97c1f487bde1559d4ccf76795ca954..3e4cde7825634c4949312e44f19b03cc96c4aaa3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -962,8 +962,8 @@ public final class CraftServer implements Server {
+@@ -985,8 +985,8 @@ public final class CraftServer implements Server {
          org.spigotmc.SpigotConfig.init((File) this.console.options.valueOf("spigot-settings")); // Spigot
          this.console.paperConfigurations.reloadConfigs(this.console);
          for (ServerLevel world : this.console.getAllLevels()) {
@@ -117,10 +117,10 @@ index 45799f96978a68a79b4c89e17e9b543dec99a8b1..72f64528092f92adf60dadb7d1b5dc38
              for (SpawnCategory spawnCategory : SpawnCategory.values()) {
                  if (CraftSpawnCategory.isValidForLimits(spawnCategory)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c3cf58e297ca56d31bd4b1bcbef201afbcee0cb6..29eed790684d03890d73d9692028d65fde143765 100644
+index 77395861f528b0443db84bf882351c7f5ccfd3ba..680733c3ccf8ff27478d43b3dfab6028cec5c829 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1163,7 +1163,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1188,7 +1188,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setDifficulty(Difficulty difficulty) {

--- a/patches/server/0382-Improve-Legacy-Component-serialization-size.patch
+++ b/patches/server/0382-Improve-Legacy-Component-serialization-size.patch
@@ -7,10 +7,10 @@ Don't constantly send format: false for all formatting options when parent alrea
 has it false
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
-index cb6cc3896e862291a058d21fa9704dd1519ff5e1..10aad9c05aa8f35d8f2952315a896bed7775c4bc 100644
+index 5a9ddf71dc186c537a23083ac59434fb446a2140..70f207f016959402ff3cba9de924f906fea28110 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
-@@ -47,6 +47,7 @@ public final class CraftChatMessage {
+@@ -48,6 +48,7 @@ public final class CraftChatMessage {
          // Separate pattern with no group 3, new lines are part of previous string
          private static final Pattern INCREMENTAL_PATTERN_KEEP_NEWLINES = Pattern.compile("(" + String.valueOf(org.bukkit.ChatColor.COLOR_CHAR) + "[0-9a-fk-orx])|((?:(?:https?):\\/\\/)?(?:[-\\w_\\.]{2,}\\.[a-z]{2,4}.*?(?=[\\.\\?!,;:]?(?:[" + String.valueOf(org.bukkit.ChatColor.COLOR_CHAR) + " ]|$))))", Pattern.CASE_INSENSITIVE);
          // ChatColor.b does not explicitly reset, its more of empty
@@ -18,7 +18,7 @@ index cb6cc3896e862291a058d21fa9704dd1519ff5e1..10aad9c05aa8f35d8f2952315a896bed
          private static final Style RESET = Style.EMPTY.withBold(false).withItalic(false).withUnderlined(false).withStrikethrough(false).withObfuscated(false);
  
          private final List<Component> list = new ArrayList<Component>();
-@@ -68,6 +69,7 @@ public final class CraftChatMessage {
+@@ -69,6 +70,7 @@ public final class CraftChatMessage {
              Matcher matcher = (keepNewlines ? StringMessage.INCREMENTAL_PATTERN_KEEP_NEWLINES : StringMessage.INCREMENTAL_PATTERN).matcher(message);
              String match = null;
              boolean needsAdd = false;
@@ -26,7 +26,7 @@ index cb6cc3896e862291a058d21fa9704dd1519ff5e1..10aad9c05aa8f35d8f2952315a896bed
              while (matcher.find()) {
                  int groupId = 0;
                  while ((match = matcher.group(++groupId)) == null) {
-@@ -113,7 +115,26 @@ public final class CraftChatMessage {
+@@ -114,7 +116,26 @@ public final class CraftChatMessage {
                              throw new AssertionError("Unexpected message format");
                          }
                      } else { // Color resets formatting

--- a/patches/server/0383-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0383-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,10 +22,10 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 72f64528092f92adf60dadb7d1b5dc38c7a8d4ee..38da9a19546c979c4bfd4ab23a34b77266911a24 100644
+index 3e4cde7825634c4949312e44f19b03cc96c4aaa3..f5079f1bb3f66392e663cac495f555edb6a08a09 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -375,7 +375,7 @@ public final class CraftServer implements Server {
+@@ -377,7 +377,7 @@ public final class CraftServer implements Server {
          this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -33,8 +33,8 @@ index 72f64528092f92adf60dadb7d1b5dc38c7a8d4ee..38da9a19546c979c4bfd4ab23a34b772
 +        TicketType.PLUGIN.timeout = Math.min(20, this.configuration.getInt("chunk-gc.period-in-ticks")); // Paper - cap plugin loads to 1 second
          this.minimumAPI = ApiVersion.getOrCreateVersion(this.configuration.getString("settings.minimum-api"));
          this.loadIcon();
- 
-@@ -942,7 +942,7 @@ public final class CraftServer implements Server {
+         this.loadCompatibilities();
+@@ -964,7 +964,7 @@ public final class CraftServer implements Server {
          this.console.setMotd(config.motd);
          this.overrideSpawnLimits();
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -44,7 +44,7 @@ index 72f64528092f92adf60dadb7d1b5dc38c7a8d4ee..38da9a19546c979c4bfd4ab23a34b772
          this.printSaveWarning = false;
          this.console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 29eed790684d03890d73d9692028d65fde143765..630b3e9a9a89016846dba1b18ff68c11f1815685 100644
+index 680733c3ccf8ff27478d43b3dfab6028cec5c829..8db6209b22c838d01b0b8032ad0608713cc8a54c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -289,7 +289,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -84,7 +84,7 @@ index 29eed790684d03890d73d9692028d65fde143765..630b3e9a9a89016846dba1b18ff68c11
          }
  
          return true;
-@@ -439,7 +451,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -464,7 +476,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
  
          if (chunk instanceof net.minecraft.world.level.chunk.LevelChunk) {
@@ -93,7 +93,7 @@ index 29eed790684d03890d73d9692028d65fde143765..630b3e9a9a89016846dba1b18ff68c11
              return true;
          }
  
-@@ -2239,6 +2251,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2264,6 +2276,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          io.papermc.paper.chunk.system.ChunkSystem.scheduleChunkLoad(this.getHandle(), x, z, gen, ChunkStatus.FULL, true, priority, (c) -> {
              net.minecraft.server.MinecraftServer.getServer().scheduleOnMain(() -> {
                  net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk)c;

--- a/patches/server/0385-Convert-legacy-attributes-in-Item-Meta.patch
+++ b/patches/server/0385-Convert-legacy-attributes-in-Item-Meta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Convert legacy attributes in Item Meta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/attribute/CraftAttributeMap.java b/src/main/java/org/bukkit/craftbukkit/attribute/CraftAttributeMap.java
-index de40e522960469b98f987bd688489740446d9f85..a0a34f680e21007ebf2c2497d2e6505eedae6481 100644
+index de40e522960469b98f987bd688489740446d9f85..5678d2007d5adf45dec0638c5dd848b601801814 100644
 --- a/src/main/java/org/bukkit/craftbukkit/attribute/CraftAttributeMap.java
 +++ b/src/main/java/org/bukkit/craftbukkit/attribute/CraftAttributeMap.java
 @@ -9,6 +9,20 @@ import org.bukkit.attribute.AttributeInstance;
@@ -20,7 +20,7 @@ index de40e522960469b98f987bd688489740446d9f85..a0a34f680e21007ebf2c2497d2e6505e
 +            return null;
 +        }
 +        nms = legacyNMS.getOrDefault(nms, nms);
-+        if (!nms.toLowerCase().equals(nms) || nms.indexOf(' ') != -1) {
++        if (!nms.toLowerCase(java.util.Locale.ROOT).equals(nms) || nms.indexOf(' ') != -1) {
 +            return null;
 +        }
 +        return nms;
@@ -30,10 +30,10 @@ index de40e522960469b98f987bd688489740446d9f85..a0a34f680e21007ebf2c2497d2e6505e
      public CraftAttributeMap(AttributeMap handle) {
          this.handle = handle;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index a052c2dab5af99355737a88f75cb0b2e42a60177..43fad0ad01712da8d8bdcd54078aaa7b5fbc2720 100644
+index f5689a447bb990d5e2acbb35ce3d02419f4a00e8..ce6767537bd0f8eb5c28eef9d50e042c5a9b4b4b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -627,7 +627,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -644,7 +644,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
              AttributeModifier attribMod = CraftAttributeInstance.convert(nmsModifier);
  

--- a/patches/server/0390-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/patches/server/0390-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4b64e3575302fb7238bd647af409b85d69f4798a..34e89959a1ec8d391709373e02e7da928ca69770 100644
+index a4d5e0ffbdade4e1b15d30de6e60feddda697c24..dd5a32360f4b49e9544009d3874da3f4af7b386a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3614,7 +3614,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3608,7 +3608,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          Entity entity = this.getVehicle();
  
          super.stopRiding(suppressCancellation); // Paper - Force entity dismount during teleportation

--- a/patches/server/0400-Brand-support.patch
+++ b/patches/server/0400-Brand-support.patch
@@ -57,10 +57,10 @@ index 289a74e35836717bd20c777e9fc8c17722e90411..a5dce1e83e63292054b21ec693ec3006
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 776532b4818d15a5f4cfd35d0c076d4774615681..9a9c6e43c96689171a2767f93aea8856db1b7287 100644
+index 61b9dabaa74ee9e2b357316382ecbdf6c822b916..b623d3242c5166ee16cf5e334f7c04f801ac5e9d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3112,6 +3112,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3121,6 +3121,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0404-Add-moon-phase-API.patch
+++ b/patches/server/0404-Add-moon-phase-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add moon phase API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-index 089b8351168d7b4f55e75b3cfd4c2b72e829bd1c..9801f78f1d44fd5a72fbdb319681b683e8fb85c4 100644
+index 3cae8eba83fdf7f99d0c0d9dc96f4b3ebc29a4ca..f129fa38d079dc57ca2cf3b6738dd9dc0fa95991 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-@@ -505,4 +505,11 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+@@ -508,4 +508,11 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
  
          throw new IllegalArgumentException("Cannot spawn an entity for " + clazz.getName());
      }

--- a/patches/server/0413-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0413-Add-methods-to-get-translation-keys.patch
@@ -58,10 +58,10 @@ index 5ed90ed0461165da02c7a1acae805c12466e38d6..faf0f726453aa957d17b75dfd8de5b40
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
-index f5bb5802aae64773252c9399df0fbe9de3d1d121..1aa8010e872686f392430ce47214a324d431cada 100644
+index 8d484ba6ed0f7917cf281ff67b1f2b0c2c5c81d8..1218163a4d803288aeb1c9254f8cd03013a9fbcc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
-@@ -226,4 +226,11 @@ public class CraftItemType<M extends ItemMeta> implements ItemType.Typed<M>, Han
+@@ -238,4 +238,11 @@ public class CraftItemType<M extends ItemMeta> implements ItemType.Typed<M>, Han
      public Material asMaterial() {
          return Registry.MATERIAL.get(this.key);
      }
@@ -87,13 +87,14 @@ index ebdb19d7ee0460d50c082b0a41b3a6a57a3534ee..b444bd26d6c3def3494d3cc0520e4624
              case BALL:
                  return FireworkExplosion.Shape.SMALL_BALL;
 diff --git a/src/test/java/io/papermc/paper/world/TranslationKeyTest.java b/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
-index 7f8b6462d2a1bbd39a870d2543bebc135f7eb45b..441e8fbd548e425ca9b0dfd69d08f7b83081888c 100644
+index 7f8b6462d2a1bbd39a870d2543bebc135f7eb45b..b61b8b8e4fe1b5d905f218bf3b406b1e1af3f6b3 100644
 --- a/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
 +++ b/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
-@@ -1,12 +1,27 @@
+@@ -1,12 +1,28 @@
  package io.papermc.paper.world;
  
  import com.destroystokyo.paper.ClientOption;
++import java.util.Locale;
 +import java.util.Map;
 +import net.minecraft.core.registries.BuiltInRegistries;
 +import net.minecraft.network.chat.contents.TranslatableContents;
@@ -119,7 +120,7 @@ index 7f8b6462d2a1bbd39a870d2543bebc135f7eb45b..441e8fbd548e425ca9b0dfd69d08f7b8
  
      @Test
      public void testChatVisibilityKeys() {
-@@ -15,4 +30,69 @@ public class TranslationKeyTest {
+@@ -15,4 +31,69 @@ public class TranslationKeyTest {
              Assertions.assertEquals(ChatVisiblity.valueOf(chatVisibility.name()).getKey(), chatVisibility.translationKey(), chatVisibility + "'s translation key doesn't match");
          }
      }
@@ -175,7 +176,7 @@ index 7f8b6462d2a1bbd39a870d2543bebc135f7eb45b..441e8fbd548e425ca9b0dfd69d08f7b8
 +    @Test
 +    public void testBiome() {
 +        for (Map.Entry<ResourceKey<Biome>, Biome> nms : AbstractTestingBase.BIOMES.entrySet()) {
-+            org.bukkit.block.Biome bukkit = org.bukkit.block.Biome.valueOf(nms.getKey().location().getPath().toUpperCase());
++            org.bukkit.block.Biome bukkit = org.bukkit.block.Biome.valueOf(nms.getKey().location().getPath().toUpperCase(Locale.ROOT));
 +            Assertions.assertEquals(nms.getKey().location().toLanguageKey("biome"), bukkit.translationKey(), "translation key mismatch for " + bukkit);
 +        }
 +    }

--- a/patches/server/0414-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/patches/server/0414-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 2c5037f04f79564306d3319e6489dfcf3d244d80..46a4518e25a0eaaa99b13e4fb522060974ce4ec2 100644
+index fa4de12ba4fdce7a632923af8007e888141904c8..7c32802947fd5318009a02724c85206b250e7143 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -541,4 +541,44 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -539,4 +539,44 @@ public final class CraftItemFactory implements ItemFactory {
          return nms != null ? net.minecraft.locale.Language.getInstance().getOrDefault(nms.getItem().getDescriptionId(nms)) : null;
      }
      // Paper end - add getI18NDisplayName

--- a/patches/server/0420-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0420-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0b98618cb0b0e9c4b13415ab0e535cdfbd55b224..240f322b1ae99a73f6b4720d2a03d1a1440cf930 100644
+index f66c382a1365f559c833cbfd70f8b6db34e8133a..90a4eaeccedc588ac7131757421e5230e1c43e4a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -4444,4 +4444,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -21,10 +21,10 @@ index 0b98618cb0b0e9c4b13415ab0e535cdfbd55b224..240f322b1ae99a73f6b4720d2a03d1a1
 +    // Paper end - Expose entity id counter
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 3547edda0db53ec6c59f30f478f1614bd932be02..390e8ebbc3d96cd6eaaae616d4366bfe52d6d62e 100644
+index 3fc189cd1e54f91c1713315214da9b6af2923074..b4df6f9b25da2b772b099e8cb46a50c3d006734f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -529,6 +529,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -530,6 +530,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
          Preconditions.checkArgument(dataVersion <= getDataVersion(), "Newer version! Server downgrades are not supported!");
          return compound;
      }

--- a/patches/server/0433-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0433-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 38da9a19546c979c4bfd4ab23a34b77266911a24..756fb2613c2cca9ff937a770b1e35c499fcb97a1 100644
+index f5079f1bb3f66392e663cac495f555edb6a08a09..aee62eef2a67be2ca0d1c19143cc7f42e5e32390 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1929,6 +1929,28 @@ public final class CraftServer implements Server {
+@@ -1952,6 +1952,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0436-Fix-client-lag-on-advancement-loading.patch
+++ b/patches/server/0436-Fix-client-lag-on-advancement-loading.patch
@@ -15,10 +15,10 @@ manually reload the advancement data for all players, which
 normally takes place as a part of the datapack reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 390e8ebbc3d96cd6eaaae616d4366bfe52d6d62e..d3723fa5f64d0c12867d57c44513db08f6eed599 100644
+index b4df6f9b25da2b772b099e8cb46a50c3d006734f..176557c1910eff297cfedc11ae95f0f03c73812d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -336,7 +336,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -337,7 +337,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
                      Bukkit.getLogger().log(Level.SEVERE, "Error saving advancement " + key, ex);
                  }
  

--- a/patches/server/0443-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0443-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,15 +5,15 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9a9c6e43c96689171a2767f93aea8856db1b7287..c47681e2192cc498abb6b47c82f29ec298decd4e 100644
+index b623d3242c5166ee16cf5e334f7c04f801ac5e9d..37d6be0ae176569971659b4a83895f386eeef863 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2679,7 +2679,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2689,7 +2689,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
-     public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data) {
--        ClientboundLevelParticlesPacket packetplayoutworldparticles = new ClientboundLevelParticlesPacket(CraftParticle.createParticleParam(particle, data), true, (float) x, (float) y, (float) z, (float) offsetX, (float) offsetY, (float) offsetZ, (float) extra, count);
-+        ClientboundLevelParticlesPacket packetplayoutworldparticles = new ClientboundLevelParticlesPacket(CraftParticle.createParticleParam(particle, data), true, x, y, z, (float) offsetX, (float) offsetY, (float) offsetZ, (float) extra, count); // Paper - fix x/y/z precision loss
+     public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {
+-        ClientboundLevelParticlesPacket packetplayoutworldparticles = new ClientboundLevelParticlesPacket(CraftParticle.createParticleParam(particle, data), force, (float) x, (float) y, (float) z, (float) offsetX, (float) offsetY, (float) offsetZ, (float) extra, count);
++        ClientboundLevelParticlesPacket packetplayoutworldparticles = new ClientboundLevelParticlesPacket(CraftParticle.createParticleParam(particle, data), force, x, y, z, (float) offsetX, (float) offsetY, (float) offsetZ, (float) extra, count); // Paper - fix x/y/z precision loss
          this.getHandle().connection.send(packetplayoutworldparticles);
- 
      }
+ 

--- a/patches/server/0448-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0448-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -44,10 +44,10 @@ index ee4495b67c46cf1282cdd6ad15b224b0b7b10bfb..e382a29b441b656f35bc24cb90f95cb4
              } else if (entity.level().isClientSide && (!(entity1 instanceof Player) || !((Player) entity1).isLocalPlayer())) {
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 34e89959a1ec8d391709373e02e7da928ca69770..784aea6bddd4f8c71733549d0d7b7643becde9de 100644
+index dd5a32360f4b49e9544009d3874da3f4af7b386a..e2cd1097756832a2bb60cdd73fdd05d1c64e38d0 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3530,7 +3530,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3524,7 +3524,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  return;
              }
              // Paper end - don't run getEntities if we're not going to use its result
@@ -56,7 +56,7 @@ index 34e89959a1ec8d391709373e02e7da928ca69770..784aea6bddd4f8c71733549d0d7b7643
  
              if (!list.isEmpty()) {
                  // Paper - don't run getEntities if we're not going to use its result; moved up
-@@ -3720,9 +3720,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3714,9 +3714,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return !this.isRemoved() && this.collides; // CraftBukkit
      }
  

--- a/patches/server/0470-Add-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0470-Add-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 0b46ad360be919e4aeb0ffc0eebae9fe712fb861..51e560d7856f230c5aa2dc32706c3a49
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2436d66fb3be1611885bf05b793975dc2aa1a2e8..10ef342b9648699d140968376894f4cd6feca028 100644
+index a493c8d12935336bb3049aa6d00eb1a4f2194c25..a78922dc4a1f0719753d7349fc6abd473fd96eed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1883,8 +1883,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1908,8 +1908,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index 2436d66fb3be1611885bf05b793975dc2aa1a2e8..10ef342b9648699d140968376894f4cd
          handle.onChanged(this.getHandle());
          return true;
      }
-@@ -1920,8 +1925,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1945,8 +1950,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0481-Add-RegistryAccess-for-managing-Registries.patch
+++ b/patches/server/0481-Add-RegistryAccess-for-managing-Registries.patch
@@ -706,10 +706,10 @@ index cf08819dd7ef6db807053a52aaf66a7fdea18ab6..69682d7be64a2163d574de939f5146f5
                  SimpleJsonResourceReloadListener.scanDirectory(resourceManager, type.directory(), GSON, map);
                  map.forEach(
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-index 7c1304b42c6692cf66613fb2cf851b9df17f21e5..0b19ddf411933240f3cdc6b4e9ce3817c8d45af1 100644
+index 107734d32d8bb6384b96e11d99d36cb9a203750f..a644309edb612d97da290f86a1ef6fe597c7d85d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-@@ -111,57 +111,12 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -110,57 +110,12 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
                  + ", this can happen if a plugin creates its own registry entry with out properly registering it.");
      }
  
@@ -725,37 +725,37 @@ index 7c1304b42c6692cf66613fb2cf851b9df17f21e5..0b19ddf411933240f3cdc6b4e9ce3817
 -            return new CraftRegistry<>(Enchantment.class, registryHolder.registryOrThrow(Registries.ENCHANTMENT), CraftEnchantment::new, FieldRename.ENCHANTMENT_RENAME);
 -        }
 -        if (bukkitClass == GameEvent.class) {
--            return new CraftRegistry<>(GameEvent.class, registryHolder.registryOrThrow(Registries.GAME_EVENT), CraftGameEvent::new, CraftRegistry.NONE);
+-            return new CraftRegistry<>(GameEvent.class, registryHolder.registryOrThrow(Registries.GAME_EVENT), CraftGameEvent::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == MusicInstrument.class) {
--            return new CraftRegistry<>(MusicInstrument.class, registryHolder.registryOrThrow(Registries.INSTRUMENT), CraftMusicInstrument::new, CraftRegistry.NONE);
+-            return new CraftRegistry<>(MusicInstrument.class, registryHolder.registryOrThrow(Registries.INSTRUMENT), CraftMusicInstrument::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == PotionEffectType.class) {
--            return new CraftRegistry<>(PotionEffectType.class, registryHolder.registryOrThrow(Registries.MOB_EFFECT), CraftPotionEffectType::new, CraftRegistry.NONE);
+-            return new CraftRegistry<>(PotionEffectType.class, registryHolder.registryOrThrow(Registries.MOB_EFFECT), CraftPotionEffectType::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == Structure.class) {
--            return new CraftRegistry<>(Structure.class, registryHolder.registryOrThrow(Registries.STRUCTURE), CraftStructure::new, CraftRegistry.NONE);
+-            return new CraftRegistry<>(Structure.class, registryHolder.registryOrThrow(Registries.STRUCTURE), CraftStructure::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == StructureType.class) {
--            return new CraftRegistry<>(StructureType.class, BuiltInRegistries.STRUCTURE_TYPE, CraftStructureType::new, CraftRegistry.NONE);
+-            return new CraftRegistry<>(StructureType.class, BuiltInRegistries.STRUCTURE_TYPE, CraftStructureType::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == TrimMaterial.class) {
--            return new CraftRegistry<>(TrimMaterial.class, registryHolder.registryOrThrow(Registries.TRIM_MATERIAL), CraftTrimMaterial::new, CraftRegistry.NONE);
+-            return new CraftRegistry<>(TrimMaterial.class, registryHolder.registryOrThrow(Registries.TRIM_MATERIAL), CraftTrimMaterial::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == TrimPattern.class) {
--            return new CraftRegistry<>(TrimPattern.class, registryHolder.registryOrThrow(Registries.TRIM_PATTERN), CraftTrimPattern::new, CraftRegistry.NONE);
+-            return new CraftRegistry<>(TrimPattern.class, registryHolder.registryOrThrow(Registries.TRIM_PATTERN), CraftTrimPattern::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == DamageType.class) {
--            return new CraftRegistry<>(DamageType.class, registryHolder.registryOrThrow(Registries.DAMAGE_TYPE), CraftDamageType::new, CraftRegistry.NONE);
+-            return new CraftRegistry<>(DamageType.class, registryHolder.registryOrThrow(Registries.DAMAGE_TYPE), CraftDamageType::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == Wolf.Variant.class) {
--            return new CraftRegistry<>(Wolf.Variant.class, registryHolder.registryOrThrow(Registries.WOLF_VARIANT), CraftWolf.CraftVariant::new, CraftRegistry.NONE);
+-            return new CraftRegistry<>(Wolf.Variant.class, registryHolder.registryOrThrow(Registries.WOLF_VARIANT), CraftWolf.CraftVariant::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == BlockType.class) {
--            return new CraftRegistry<>(BlockType.class, registryHolder.registryOrThrow(Registries.BLOCK), CraftBlockType::new, CraftRegistry.NONE);
+-            return new CraftRegistry<>(BlockType.class, registryHolder.registryOrThrow(Registries.BLOCK), CraftBlockType::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == ItemType.class) {
--            return new CraftRegistry<>(ItemType.class, registryHolder.registryOrThrow(Registries.ITEM), CraftItemType::new, CraftRegistry.NONE);
+-            return new CraftRegistry<>(ItemType.class, registryHolder.registryOrThrow(Registries.ITEM), CraftItemType::new, FieldRename.NONE);
 -        }
 -
 -        return null;
@@ -770,7 +770,7 @@ index 7c1304b42c6692cf66613fb2cf851b9df17f21e5..0b19ddf411933240f3cdc6b4e9ce3817
          }
  
          if (bukkit instanceof Registry.SimpleRegistry<?> simple) {
-@@ -187,23 +142,21 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -186,23 +141,21 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
          return bukkit.get(namespacedKey);
      }
  
@@ -800,10 +800,10 @@ index 7c1304b42c6692cf66613fb2cf851b9df17f21e5..0b19ddf411933240f3cdc6b4e9ce3817
      @Override
      public B get(NamespacedKey namespacedKey) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 756fb2613c2cca9ff937a770b1e35c499fcb97a1..c18515e56a8ac010897e3e2f65b2b28566f4ef71 100644
+index aee62eef2a67be2ca0d1c19143cc7f42e5e32390..740b34322aeb566248abfe0e34b8919078982217 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -279,7 +279,7 @@ public final class CraftServer implements Server {
+@@ -280,7 +280,7 @@ public final class CraftServer implements Server {
      protected final DedicatedServer console;
      protected final DedicatedPlayerList playerList;
      private final Map<String, World> worlds = new LinkedHashMap<String, World>();
@@ -812,7 +812,7 @@ index 756fb2613c2cca9ff937a770b1e35c499fcb97a1..c18515e56a8ac010897e3e2f65b2b285
      private YamlConfiguration configuration;
      private YamlConfiguration commandsConfiguration;
      private final Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
-@@ -2690,7 +2690,7 @@ public final class CraftServer implements Server {
+@@ -2713,7 +2713,7 @@ public final class CraftServer implements Server {
  
      @Override
      public <T extends Keyed> Registry<T> getRegistry(Class<T> aClass) {
@@ -822,19 +822,21 @@ index 756fb2613c2cca9ff937a770b1e35c499fcb97a1..c18515e56a8ac010897e3e2f65b2b285
  
      @Deprecated
 diff --git a/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java b/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
-index d3c9b5b6651be7474f91c99fd31140f9641e579b..43d9f70769be4be6c07b0a3d689e43e9f6805a19 100644
+index d2eef51fb508a2cfc45ce8e11bb0fe0e89a24b0e..4ce818047911922857a5d5b377aa34ae0dfecba4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
 +++ b/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
-@@ -53,10 +53,13 @@ public class FieldRename {
+@@ -56,11 +56,14 @@ public class FieldRename {
          return Enum.valueOf(enumClass, FieldRename.rename(apiVersion, enumClass.getName().replace('.', '/'), name));
      }
  
+-    @RequireCompatibility("allow-old-keys-in-registry")
 -    public static <T extends Keyed> T get(Registry<T> registry, NamespacedKey namespacedKey) {
 -        // We don't have version-specific changes, so just use current, and don't inject a version
 -        return CraftRegistry.get(registry, namespacedKey, ApiVersion.CURRENT);
 -    }
 +    // Paper start - absolutely not, having this as an expectation for plugin developers opens a huge
 +    // can of worms in the future, especially if mojang comes back and reuses some old key
++    // @RequireCompatibility("allow-old-keys-in-registry")
 +    // public static <T extends Keyed> T get(Registry<T> registry, NamespacedKey namespacedKey) {
 +    //     // We don't have version-specific changes, so just use current, and don't inject a version
 +    //     return CraftRegistry.get(registry, namespacedKey, ApiVersion.CURRENT);
@@ -850,6 +852,19 @@ index 0000000000000000000000000000000000000000..8a083d45004f82fc9c51c219fb20f346
 +++ b/src/main/resources/META-INF/services/io.papermc.paper.registry.RegistryAccess
 @@ -0,0 +1 @@
 +io.papermc.paper.registry.PaperRegistryAccess
+diff --git a/src/main/resources/configurations/bukkit.yml b/src/main/resources/configurations/bukkit.yml
+index 6615fffc4cbeee971f2b0f918cb8a9fd1fac2430..eef7c125b2689f29cae5464659eacdf33f5695b2 100644
+--- a/src/main/resources/configurations/bukkit.yml
++++ b/src/main/resources/configurations/bukkit.yml
+@@ -23,8 +23,6 @@ settings:
+     shutdown-message: Server closed
+     minimum-api: none
+     use-map-color-cache: true
+-    compatibility:
+-        allow-old-keys-in-registry: false
+ spawn-limits:
+     monsters: 70
+     animals: 10
 diff --git a/src/test/java/io/papermc/paper/registry/LegacyRegistryIdentifierTest.java b/src/test/java/io/papermc/paper/registry/LegacyRegistryIdentifierTest.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..b9d00e65639521eecd44bd2be3e012264c3785f5

--- a/patches/server/0495-Add-EntityMoveEvent.patch
+++ b/patches/server/0495-Add-EntityMoveEvent.patch
@@ -29,10 +29,10 @@ index a9a39c99874001f1024f71bfc97130e8c9a507e7..19333b61bcb50f2171ac2c75d7f4ca4f
      public LevelChunk getChunkIfLoaded(int x, int z) {
          return this.chunkSource.getChunk(x, z, false);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 784aea6bddd4f8c71733549d0d7b7643becde9de..cff15c86d693835eb85272efcdeeef778cbd6c8d 100644
+index e2cd1097756832a2bb60cdd73fdd05d1c64e38d0..ab220fcc5301e91e76671c5a11ddbbc9ac604bf9 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3467,6 +3467,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3461,6 +3461,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
          this.pushEntities();
          this.level().getProfiler().pop();

--- a/patches/server/0511-Expand-world-key-API.patch
+++ b/patches/server/0511-Expand-world-key-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expand world key API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-index 9801f78f1d44fd5a72fbdb319681b683e8fb85c4..1e720b96f0367652db6924b8654deaa9467e3d2c 100644
+index f129fa38d079dc57ca2cf3b6738dd9dc0fa95991..9bf4d9eaa961196873b3be89c2ca05e701025871 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-@@ -511,5 +511,10 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+@@ -514,5 +514,10 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
      public io.papermc.paper.world.MoonPhase getMoonPhase() {
          return io.papermc.paper.world.MoonPhase.getPhase(this.getHandle().dayTime() / 24000L);
      }
@@ -20,10 +20,10 @@ index 9801f78f1d44fd5a72fbdb319681b683e8fb85c4..1e720b96f0367652db6924b8654deaa9
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c18515e56a8ac010897e3e2f65b2b28566f4ef71..db230f2d1254ef34233324b638a33445df1a9ee1 100644
+index 740b34322aeb566248abfe0e34b8919078982217..144d09f65aca6456b060c5874b61f55a1cd5ae59 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1146,9 +1146,15 @@ public final class CraftServer implements Server {
+@@ -1169,9 +1169,15 @@ public final class CraftServer implements Server {
          File folder = new File(this.getWorldContainer(), name);
          World world = this.getWorld(name);
  
@@ -41,16 +41,16 @@ index c18515e56a8ac010897e3e2f65b2b28566f4ef71..db230f2d1254ef34233324b638a33445
  
          if (folder.exists()) {
              Preconditions.checkArgument(folder.isDirectory(), "File (%s) exists and isn't a folder", name);
-@@ -1274,7 +1280,7 @@ public final class CraftServer implements Server {
+@@ -1297,7 +1303,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
--            worldKey = ResourceKey.create(Registries.DIMENSION, new ResourceLocation(name.toLowerCase(java.util.Locale.ENGLISH)));
-+            worldKey = ResourceKey.create(Registries.DIMENSION, new net.minecraft.resources.ResourceLocation(creator.key().getNamespace().toLowerCase(java.util.Locale.ENGLISH), creator.key().getKey().toLowerCase(java.util.Locale.ENGLISH))); // Paper
+-            worldKey = ResourceKey.create(Registries.DIMENSION, new ResourceLocation(name.toLowerCase(Locale.ROOT)));
++            worldKey = ResourceKey.create(Registries.DIMENSION, new net.minecraft.resources.ResourceLocation(creator.key().getNamespace().toLowerCase(java.util.Locale.ROOT), creator.key().getKey().toLowerCase(java.util.Locale.ROOT))); // Paper
          }
  
          // If set to not keep spawn in memory (changed from default) then adjust rule accordingly
-@@ -1370,6 +1376,15 @@ public final class CraftServer implements Server {
+@@ -1393,6 +1399,15 @@ public final class CraftServer implements Server {
          return null;
      }
  
@@ -67,10 +67,10 @@ index c18515e56a8ac010897e3e2f65b2b28566f4ef71..db230f2d1254ef34233324b638a33445
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index d3723fa5f64d0c12867d57c44513db08f6eed599..7e8bd8204dcdc64897464331c99eae25b127d30c 100644
+index 176557c1910eff297cfedc11ae95f0f03c73812d..6898e89b19f028736b5eb736746000bf7023145a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -540,6 +540,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -541,6 +541,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public int nextEntityId() {
          return net.minecraft.world.entity.Entity.nextEntityId();
      }

--- a/patches/server/0516-Expose-protocol-version.patch
+++ b/patches/server/0516-Expose-protocol-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose protocol version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 7e8bd8204dcdc64897464331c99eae25b127d30c..28f8a85c35c9c160bb223b8cd4245949b259dd5c 100644
+index 6898e89b19f028736b5eb736746000bf7023145a..b89dcdf4b303042024dec1bf07f92fb08327f061 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -545,6 +545,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -546,6 +546,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public String getMainLevelName() {
          return ((net.minecraft.server.dedicated.DedicatedServer) net.minecraft.server.MinecraftServer.getServer()).getProperties().levelName;
      }

--- a/patches/server/0518-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0518-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,10 +9,10 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cff15c86d693835eb85272efcdeeef778cbd6c8d..9c8e7dfef41f2559de77b79a93fbb3da827ec4fa 100644
+index ab220fcc5301e91e76671c5a11ddbbc9ac604bf9..5b03665a04a68dc49fb0100b58148ffa2d8f6000 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3961,6 +3961,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3955,6 +3955,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                          this.level().getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {

--- a/patches/server/0527-More-World-API.patch
+++ b/patches/server/0527-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 10ef342b9648699d140968376894f4cd6feca028..5dbc079309933af548e5bec036475d6e621deb8e 100644
+index a78922dc4a1f0719753d7349fc6abd473fd96eed..0f1f5e4cbe476f45f9473cc9ce4e50f837eba652 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2128,6 +2128,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2153,6 +2153,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return new CraftStructureSearchResult(CraftStructure.minecraftToBukkit(found.getSecond().value()), CraftLocation.toBukkit(found.getFirst(), this));
      }
  

--- a/patches/server/0540-Add-basic-Datapack-API.patch
+++ b/patches/server/0540-Add-basic-Datapack-API.patch
@@ -92,18 +92,18 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index db230f2d1254ef34233324b638a33445df1a9ee1..ec9f392d92d96a6b4f3a513361282085a95769b5 100644
+index 144d09f65aca6456b060c5874b61f55a1cd5ae59..14616e4be1cfd4961fdb0d990310bf625cc821a9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -301,6 +301,7 @@ public final class CraftServer implements Server {
-     public boolean ignoreVanillaPermissions = false;
+@@ -303,6 +303,7 @@ public final class CraftServer implements Server {
      private final List<CraftPlayer> playerView;
      public int reloadCount;
+     public Set<String> activeCompatibilities = Collections.emptySet();
 +    private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings
  
      static {
-@@ -383,6 +384,7 @@ public final class CraftServer implements Server {
+@@ -386,6 +387,7 @@ public final class CraftServer implements Server {
          if (this.configuration.getBoolean("settings.use-map-color-cache")) {
              MapPalette.setMapColorCache(new CraftMapColorCache(this.logger));
          }
@@ -111,7 +111,7 @@ index db230f2d1254ef34233324b638a33445df1a9ee1..ec9f392d92d96a6b4f3a513361282085
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2969,5 +2971,11 @@ public final class CraftServer implements Server {
+@@ -2992,5 +2994,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0543-ItemStack-repair-check-API.patch
+++ b/patches/server/0543-ItemStack-repair-check-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack repair check API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 28f8a85c35c9c160bb223b8cd4245949b259dd5c..952a8147947fa0e2a960628fc760212d3d206ce6 100644
+index b89dcdf4b303042024dec1bf07f92fb08327f061..206f7fff1be676bebef086a0c1b5350cfd175e33 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -550,6 +550,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -551,6 +551,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public int getProtocolVersion() {
          return net.minecraft.SharedConstants.getCurrentVersion().getProtocolVersion();
      }

--- a/patches/server/0550-Improve-item-default-attribute-API.patch
+++ b/patches/server/0550-Improve-item-default-attribute-API.patch
@@ -21,10 +21,10 @@ index 8afbb8e0cb368e95f23bb78c1261f9aa9b8abd86..0a18983151d17b8e1460b82326b03800
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
-index 1aa8010e872686f392430ce47214a324d431cada..6bcc3192097dfbf378592fd2437a80dcd0825f13 100644
+index 1218163a4d803288aeb1c9254f8cd03013a9fbcc..5fcf64a30a798a516cd3b30123d16cc5c420e45f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
-@@ -187,15 +187,34 @@ public class CraftItemType<M extends ItemMeta> implements ItemType.Typed<M>, Han
+@@ -199,15 +199,34 @@ public class CraftItemType<M extends ItemMeta> implements ItemType.Typed<M>, Han
  //        return CraftEquipmentSlot.getSlot(EntityInsentient.getEquipmentSlotForItem(CraftItemStack.asNMSCopy(ItemStack.of(this))));
  //    }
  
@@ -66,10 +66,10 @@ index 1aa8010e872686f392430ce47214a324d431cada..6bcc3192097dfbf378592fd2437a80dc
          return defaultAttributes.build();
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 952a8147947fa0e2a960628fc760212d3d206ce6..f0577689f4c57ce6254aad32ccf5d8eac961c9bd 100644
+index 206f7fff1be676bebef086a0c1b5350cfd175e33..44e3e4c8326dc93292f482c136fe2d6e6b8eb0b6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -399,15 +399,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -400,15 +400,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
      @Override
      public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(Material material, EquipmentSlot slot) {

--- a/patches/server/0551-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0551-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -95,10 +95,10 @@ index e50ad48658193f889d65d37c57b1e30ce46758b7..efd0bcfebb3b4f63018d4e20a6a89f79
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5dbc079309933af548e5bec036475d6e621deb8e..26457cb201b84547875b2989f55f4f4d2c8c03ce 100644
+index 0f1f5e4cbe476f45f9473cc9ce4e50f837eba652..e75d2970329dd92263bc57c7452d0c46afa3da16 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1206,7 +1206,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1231,7 +1231,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -107,7 +107,7 @@ index 5dbc079309933af548e5bec036475d6e621deb8e..26457cb201b84547875b2989f55f4f4d
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1228,7 +1228,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1253,7 +1253,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0564-Line-Of-Sight-Changes.patch
+++ b/patches/server/0564-Line-Of-Sight-Changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Line Of Sight Changes
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9c8e7dfef41f2559de77b79a93fbb3da827ec4fa..6fbfa08afc40e51af1110b5c7357a0c6089ff9a5 100644
+index 5b03665a04a68dc49fb0100b58148ffa2d8f6000..f6febeb8f24b227520cda80efac7e43c023f1b10 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3710,7 +3710,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3704,7 +3704,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
              Vec3 vec3d = new Vec3(this.getX(), this.getEyeY(), this.getZ());
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  
@@ -19,10 +19,10 @@ index 9c8e7dfef41f2559de77b79a93fbb3da827ec4fa..6fbfa08afc40e51af1110b5c7357a0c6
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-index 1e720b96f0367652db6924b8654deaa9467e3d2c..4932ba59a6b70b405f7dd05358f6bb00b629d34c 100644
+index 9bf4d9eaa961196873b3be89c2ca05e701025871..54a79d802806d5354db74d27c04458e8baedfa0c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-@@ -516,5 +516,21 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+@@ -519,5 +519,21 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
      public org.bukkit.NamespacedKey getKey() {
          return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(this.getHandle().getLevel().dimension().location());
      }

--- a/patches/server/0569-Missing-Entity-API.patch
+++ b/patches/server/0569-Missing-Entity-API.patch
@@ -737,48 +737,28 @@ index d30e1dd1b4525674c8a52da9b677c09a251b2467..9edcdc71b28cf08e42fbe44723ba540e
 +    // Paper end - missing entity api
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
-index 114e84b485a6f05eac66083d8fd71028018d57ea..e4e23a7b6d308ee476b5b8c2ad80efe4608b8346 100644
+index 763cfa6cfc8447c5a963e79f128e734efe542f89..b0a02c9ca4349ab56ceceae8b78559e20a9b0af5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
-@@ -56,23 +56,29 @@ public class CraftFireball extends AbstractProjectile implements Fireball {
-     public void setDirection(Vector direction) {
-         Preconditions.checkArgument(direction != null, "Vector direction cannot be null");
-         if (direction.isZero()) {
--            this.setVelocity(direction);
-+            this.setPower(direction); // Paper
-             return;
-         }
-         this.getHandle().assignPower(direction.getX(), direction.getY(), direction.getZ());
-         this.update(); // SPIGOT-6579
+@@ -84,6 +84,18 @@ public class CraftFireball extends AbstractProjectile implements Fireball {
+         return new Vector(this.getHandle().xPower, this.getHandle().yPower, this.getHandle().zPower);
      }
  
-+    // Paper - fix upstream bug where they thought x/y/zPower was velocity
-+
 +    // Paper start - Expose power on fireball projectiles
-     @Override
--    public void setVelocity(Vector velocity) {
--        Preconditions.checkArgument(velocity != null, "Vector velocity cannot be null");
--        // SPIGOT-6993: Allow power to be higher / lower than the normalized direction enforced by #setDirection(Vector)
--        // Note: Because of MC-80142 the fireball will stutter on the client when setting the velocity to something other than 0 or the normalized vector * 0.1
--        this.getHandle().xPower = velocity.getX();
--        this.getHandle().yPower = velocity.getY();
--        this.getHandle().zPower = velocity.getZ();
--        this.update(); // SPIGOT-6579
++    @Override
 +    public void setPower(final Vector power) {
-+        this.getHandle().xPower = power.getX();
-+        this.getHandle().yPower = power.getY();
-+        this.getHandle().zPower = power.getZ();
-+        this.update();
++        this.setAcceleration(power);
 +    }
 +
 +    @Override
 +    public Vector getPower() {
-+        return new Vector(this.getHandle().xPower, this.getHandle().yPower, this.getHandle().zPower);
-     }
++        return this.getAcceleration();
++    }
 +    // Paper end - Expose power on fireball projectiles
- 
++
      @Override
      public AbstractHurtingProjectile getHandle() {
+         return (AbstractHurtingProjectile) this.entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftFox.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftFox.java
 index 17164811bbcf983bef62c47bc99330074762267b..c455deb4fd2a7684bcc01a8212c362a2375c190b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftFox.java

--- a/patches/server/0580-Add-System.out-err-catcher.patch
+++ b/patches/server/0580-Add-System.out-err-catcher.patch
@@ -105,11 +105,11 @@ index 0000000000000000000000000000000000000000..a8e813ca89b033f061e695288b3383bd
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ec9f392d92d96a6b4f3a513361282085a95769b5..bb157f5a9d0dca8d108411a6ce09cc0297026334 100644
+index 14616e4be1cfd4961fdb0d990310bf625cc821a9..54820a8d11bb12c516d4138fb0bf77c16f053f3f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -303,6 +303,7 @@ public final class CraftServer implements Server {
-     public int reloadCount;
+@@ -305,6 +305,7 @@ public final class CraftServer implements Server {
+     public Set<String> activeCompatibilities = Collections.emptySet();
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings
 +    private final io.papermc.paper.logging.SysoutCatcher sysoutCatcher = new io.papermc.paper.logging.SysoutCatcher(); // Paper

--- a/patches/server/0595-Add-missing-team-sidebar-display-slots.patch
+++ b/patches/server/0595-Add-missing-team-sidebar-display-slots.patch
@@ -9,10 +9,10 @@ public org.bukkit.craftbukkit.scoreboard.CraftScoreboardTranslations toBukkitSlo
 public org.bukkit.craftbukkit.scoreboard.CraftScoreboardTranslations fromBukkitSlot(Lorg/bukkit/scoreboard/DisplaySlot;)Lnet/minecraft/world/scores/DisplaySlot;
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java b/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
-index 43d9f70769be4be6c07b0a3d689e43e9f6805a19..e809d2506d27b62d74f2f255a75a923aaf590d9c 100644
+index 4ce818047911922857a5d5b377aa34ae0dfecba4..d0ca716aba5706afdd93900d62d95b7ab5073ca6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
 +++ b/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
-@@ -32,6 +32,7 @@ public class FieldRename {
+@@ -35,6 +35,7 @@ public class FieldRename {
          }
  
          return switch (owner) {
@@ -20,7 +20,7 @@ index 43d9f70769be4be6c07b0a3d689e43e9f6805a19..e809d2506d27b62d74f2f255a75a923a
              case "org/bukkit/block/banner/PatternType" -> FieldRename.convertPatternTypeName(apiVersion, from);
              case "org/bukkit/enchantments/Enchantment" -> FieldRename.convertEnchantmentName(apiVersion, from);
              case "org/bukkit/block/Biome" -> FieldRename.convertBiomeName(apiVersion, from);
-@@ -61,6 +62,16 @@ public class FieldRename {
+@@ -65,6 +66,16 @@ public class FieldRename {
      // }
      // Paper end
  

--- a/patches/server/0597-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0597-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -31,10 +31,10 @@ index eecc5704582ce7c9a45adee8057d8297eae03a86..5cb0281ea110a1ce3444f4392bccbb19
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3e448a40aaf4c2ae61de685d060495d4cedea031..5f6cec79745aa8e5ae3aa8139c93bbdd1c36c6d5 100644
+index e10043db80ee5dc6468c8caa16d55ad418fa3670..d83321ba1de5445b4a060fd11c5bb8b237bc8b3f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -687,6 +687,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -712,6 +712,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  

--- a/patches/server/0598-Get-entity-default-attributes.patch
+++ b/patches/server/0598-Get-entity-default-attributes.patch
@@ -81,10 +81,10 @@ index 0000000000000000000000000000000000000000..ec9ebd2d539333293c51b7edfa18f18b
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index f0577689f4c57ce6254aad32ccf5d8eac961c9bd..6a1f645595a579036b64ec05f24c967892d14376 100644
+index 44e3e4c8326dc93292f482c136fe2d6e6b8eb0b6..68e805cb5085aa0413bb733c58690878fb670cf3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -554,6 +554,18 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -555,6 +555,18 @@ public final class CraftMagicNumbers implements UnsafeValues {
          }
          return CraftMagicNumbers.getItem(itemToBeRepaired.getType()).isValidRepairItem(CraftItemStack.asNMSCopy(itemToBeRepaired), CraftItemStack.asNMSCopy(repairMaterial));
      }

--- a/patches/server/0600-Add-more-advancement-API.patch
+++ b/patches/server/0600-Add-more-advancement-API.patch
@@ -164,10 +164,10 @@ index 8ca86852319d7463f60832bc98b825b0b4325995..62ada73302c6b3ce3fb2dcc8c31a1d9c
  
      private final DisplayInfo handle;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index e8e5ec73f5197249e9ebdec2bf055043d9f04c54..cdd0463b31a8d2766eaa15881b3b6f0dcf6e3e4a 100644
+index 5b71ef6231c6c44ebeabfb1fb39941806cb22b5c..7d7abae8e2978d78b97cf22c5eecf47878818f52 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -375,6 +375,11 @@ public class Commodore {
+@@ -379,6 +379,11 @@ public class Commodore {
                              super.visitMethodInsn(opcode, owner, name, "()Lcom/destroystokyo/paper/profile/PlayerProfile;", itf);
                              return;
                          }

--- a/patches/server/0601-Add-ItemFactory-getSpawnEgg-API.patch
+++ b/patches/server/0601-Add-ItemFactory-getSpawnEgg-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ItemFactory#getSpawnEgg API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 46a4518e25a0eaaa99b13e4fb522060974ce4ec2..6b2d2b8397bb95ce6ffd87dc1a2f3292f81dd422 100644
+index 7c32802947fd5318009a02724c85206b250e7143..be31b8a286794508a1c1bfcf3da0ac64c0383c60 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -581,4 +581,19 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -579,4 +579,19 @@ public final class CraftItemFactory implements ItemFactory {
              new net.md_5.bungee.api.chat.TextComponent(customName));
      }
      // Paper end - bungee hover events
@@ -29,10 +29,10 @@ index 46a4518e25a0eaaa99b13e4fb522060974ce4ec2..6b2d2b8397bb95ce6ffd87dc1a2f3292
 +    // Paper end - old getSpawnEgg API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index cdd0463b31a8d2766eaa15881b3b6f0dcf6e3e4a..5c05258ce502a9ff7d6f182f61e3722ec42e9e69 100644
+index 7d7abae8e2978d78b97cf22c5eecf47878818f52..8ae3b6bb5daf4d0a4a429868d1dea700c3ee129c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -382,6 +382,15 @@ public class Commodore {
+@@ -386,6 +386,15 @@ public class Commodore {
                          }
                          // Paper end
  

--- a/patches/server/0607-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0607-Add-Raw-Byte-Entity-Serialization.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 public net.minecraft.world.entity.Entity setLevel(Lnet/minecraft/world/level/Level;)V
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2d98bdae7e8686d8a15e8938a16d8d63f0575bef..96c9feb545c02014c324852344a1d86156c32237 100644
+index 5d4fa3823a6dbb6150e4b97cf3973eb254018e38..ebacae6f39fea052f4fb7c60f7164763b49f8148 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2105,6 +2105,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -50,10 +50,10 @@ index 9edcdc71b28cf08e42fbe44723ba540e8d4f7808..a61638bc8200f6aa25d9c3254aea6c0c
      @Override
      public boolean isInvisible() {  // Paper - moved up from LivingEntity
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 6a1f645595a579036b64ec05f24c967892d14376..0bf7e2b73bbde4ac23a2f52a145de464f0851396 100644
+index 68e805cb5085aa0413bb733c58690878fb670cf3..83730eac9887bbf9bd5284676ec9a0509ec14a04 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -504,7 +504,33 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -505,7 +505,33 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.parse(MinecraftServer.getServer().registryAccess(), compound).orElseThrow());
      }
  

--- a/patches/server/0611-Improve-and-expand-AsyncCatcher.patch
+++ b/patches/server/0611-Improve-and-expand-AsyncCatcher.patch
@@ -29,7 +29,7 @@ index 40d2c7bfc8ba8b8b366f23e53cf37f331e19ccf7..795e65c7c98d50ff67953ccb1ff68dac
          if (player.isRemoved()) {
              LOGGER.info("Attempt to teleport removed player {} restricted", player.getScoreboardName());
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 5dc4deca24f966bd4cb0b7f296f74487964e4c95..a1edb9465872f762e1bc3daf1a3121bc3654e847 100644
+index f6febeb8f24b227520cda80efac7e43c023f1b10..a44b48bbb736e7efb04061f302bbb61015284bcb 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1147,7 +1147,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -166,10 +166,10 @@ index 219062cff8a05c765b092f1525043d9d9a1153ae..1c6e8438219f355274db4e0fa849cdd9
                  PersistentEntitySectionManager.LOGGER.warn("Entity {} wasn't found in section {} (destroying due to {})", new Object[]{this.entity, SectionPos.of(this.currentSectionKey), reason});
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5f6cec79745aa8e5ae3aa8139c93bbdd1c36c6d5..1bf9fbc8f39ec4b0dd1369cace6bbd347c81541a 100644
+index d83321ba1de5445b4a060fd11c5bb8b237bc8b3f..7b1a4925e40550432c2e7c599c85303b173843d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1756,6 +1756,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1781,6 +1781,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void playSound(Location loc, Sound sound, org.bukkit.SoundCategory category, float volume, float pitch, long seed) {
@@ -177,7 +177,7 @@ index 5f6cec79745aa8e5ae3aa8139c93bbdd1c36c6d5..1bf9fbc8f39ec4b0dd1369cace6bbd34
          if (loc == null || sound == null || category == null) return;
  
          double x = loc.getX();
-@@ -1767,6 +1768,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1792,6 +1793,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void playSound(Location loc, String sound, org.bukkit.SoundCategory category, float volume, float pitch, long seed) {
@@ -185,7 +185,7 @@ index 5f6cec79745aa8e5ae3aa8139c93bbdd1c36c6d5..1bf9fbc8f39ec4b0dd1369cace6bbd34
          if (loc == null || sound == null || category == null) return;
  
          double x = loc.getX();
-@@ -1799,6 +1801,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1824,6 +1826,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void playSound(Entity entity, Sound sound, org.bukkit.SoundCategory category, float volume, float pitch, long seed) {
@@ -193,7 +193,7 @@ index 5f6cec79745aa8e5ae3aa8139c93bbdd1c36c6d5..1bf9fbc8f39ec4b0dd1369cace6bbd34
          if (!(entity instanceof CraftEntity craftEntity) || entity.getWorld() != this || sound == null || category == null) return;
  
          ClientboundSoundEntityPacket packet = new ClientboundSoundEntityPacket(CraftSound.bukkitToMinecraftHolder(sound), net.minecraft.sounds.SoundSource.valueOf(category.name()), craftEntity.getHandle(), volume, pitch, seed);
-@@ -1810,6 +1813,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1835,6 +1838,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void playSound(Entity entity, String sound, org.bukkit.SoundCategory category, float volume, float pitch, long seed) {

--- a/patches/server/0612-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0612-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -278,10 +278,10 @@ index 58ea6a1f95a09c22125a8262b1b221004ebce0e4..ea6533c1ac218aa075da3401807a06fc
          BlockPos blockposition = NaturalSpawner.getRandomPosWithin(world, chunk);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bb157f5a9d0dca8d108411a6ce09cc0297026334..ff6efc68070218e9ae23f1ec358955ff84f75439 100644
+index 54820a8d11bb12c516d4138fb0bf77c16f053f3f..659d8ad2e0232934a3009f79283924e4363f7f32 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2294,6 +2294,11 @@ public final class CraftServer implements Server {
+@@ -2317,6 +2317,11 @@ public final class CraftServer implements Server {
  
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
@@ -294,10 +294,10 @@ index bb157f5a9d0dca8d108411a6ce09cc0297026334..ff6efc68070218e9ae23f1ec358955ff
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1bf9fbc8f39ec4b0dd1369cace6bbd347c81541a..f88614e0e83a0b6df379816a532c621108c5ae9d 100644
+index 7b1a4925e40550432c2e7c599c85303b173843d4..fbd5df61e5cfd67991dedb7bbba4a16ff16fa49b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1714,9 +1714,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1739,9 +1739,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Preconditions.checkArgument(spawnCategory != null, "SpawnCategory cannot be null");
          Preconditions.checkArgument(CraftSpawnCategory.isValidForLimits(spawnCategory), "SpawnCategory.%s are not supported", spawnCategory);
  

--- a/patches/server/0641-Prevent-excessive-velocity-through-repeated-crits.patch
+++ b/patches/server/0641-Prevent-excessive-velocity-through-repeated-crits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent excessive velocity through repeated crits
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e75da895d4e050a775d77966c5007487c2617fdc..cd0c949eb76814829e8554977358f8f818f33b20 100644
+index a44b48bbb736e7efb04061f302bbb61015284bcb..0fe6b9f4376d2b852f6f23e31848cd9236577bdf 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2744,16 +2744,28 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2738,16 +2738,28 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return this.hasEffect(MobEffects.JUMP) ? 0.1F * ((float) this.getEffect(MobEffects.JUMP).getAmplifier() + 1.0F) : 0.0F;
      }
  

--- a/patches/server/0647-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0647-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ff6efc68070218e9ae23f1ec358955ff84f75439..95d6d4483fbfc0c0aa18b551f84694aa02f59a20 100644
+index 659d8ad2e0232934a3009f79283924e4363f7f32..a1c108bd8a11f63c0973e2d26186e18f5c3ba69e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2479,6 +2479,90 @@ public final class CraftServer implements Server {
+@@ -2502,6 +2502,90 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registries.BIOME));
      }
  

--- a/patches/server/0648-Fix-ChunkSnapshot-isSectionEmpty-int-and-optimize-Pa.patch
+++ b/patches/server/0648-Fix-ChunkSnapshot-isSectionEmpty-int-and-optimize-Pa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix ChunkSnapshot#isSectionEmpty(int) and optimize
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index fc335e4e80553e8c6c915e7813e9610ac10649c2..5b59b19a6d913ebdfc28a755e3a1a8b8384a3116 100644
+index 01596f87ee078fceeb3f2f29bbb2500e63e9efb8..f8c2d91958d6e4a1452fcf32c16fa8b97ea271a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -337,13 +337,17 @@ public class CraftChunk implements Chunk {
+@@ -338,14 +338,17 @@ public class CraftChunk implements Chunk {
          PalettedContainerRO<Holder<net.minecraft.world.level.biome.Biome>>[] biome = (includeBiome || includeBiomeTempRain) ? new PalettedContainer[cs.length] : null;
  
          Registry<net.minecraft.world.level.biome.Biome> iregistry = this.worldServer.registryAccess().registryOrThrow(Registries.BIOME);
@@ -20,6 +20,7 @@ index fc335e4e80553e8c6c915e7813e9610ac10649c2..5b59b19a6d913ebdfc28a755e3a1a8b8
  
 -            data.put("block_states", ChunkSerializer.BLOCK_STATE_CODEC.encodeStart(NbtOps.INSTANCE, cs[i].getStates()).getOrThrow());
 -            sectionBlockIDs[i] = ChunkSerializer.BLOCK_STATE_CODEC.parse(NbtOps.INSTANCE, data.getCompound("block_states")).getOrThrow(ChunkSerializer.ChunkReadException::new);
+-            sectionEmpty[i] = cs[i].hasOnlyAir();
 +            // Paper start - Fix ChunkSnapshot#isSectionEmpty(int); and remove codec usage
 +            sectionEmpty[i] = cs[i].hasOnlyAir(); // fix sectionEmpty array not being filled
 +            if (!sectionEmpty[i]) {
@@ -31,7 +32,7 @@ index fc335e4e80553e8c6c915e7813e9610ac10649c2..5b59b19a6d913ebdfc28a755e3a1a8b8
  
              LevelLightEngine lightengine = this.worldServer.getLightEngine();
              DataLayer skyLightArray = lightengine.getLayerListener(LightLayer.SKY).getDataLayerData(SectionPos.of(this.x, chunk.getSectionYFromSectionIndex(i), this.z)); // SPIGOT-7498: Convert section index
-@@ -362,8 +366,7 @@ public class CraftChunk implements Chunk {
+@@ -364,8 +367,7 @@ public class CraftChunk implements Chunk {
              }
  
              if (biome != null) {

--- a/patches/server/0661-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0661-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose vanilla BiomeProvider from WorldInfo
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 2986dc458ddbd642669c6c2c104df2a2446e5b11..533e1225b863ef314b7defebc4787304fd19f5a1 100644
+index cdbdacee826c424177096ee78427eaf80131b5fd..f295eaf2dced5bf294eb094f6d6110da826f053f 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -605,7 +605,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -18,10 +18,10 @@ index 2986dc458ddbd642669c6c2c104df2a2446e5b11..533e1225b863ef314b7defebc4787304
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 95d6d4483fbfc0c0aa18b551f84694aa02f59a20..f9b4f47553e7180c315052a2af3340043d140be1 100644
+index a1c108bd8a11f63c0973e2d26186e18f5c3ba69e..f61ea45fd39b2641dbab5e4a7e35c46c1639367d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1271,7 +1271,7 @@ public final class CraftServer implements Server {
+@@ -1294,7 +1294,7 @@ public final class CraftServer implements Server {
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
          LevelStem worlddimension = iregistry.get(actualDimension);
  
@@ -31,7 +31,7 @@ index 95d6d4483fbfc0c0aa18b551f84694aa02f59a20..f9b4f47553e7180c315052a2af334004
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f88614e0e83a0b6df379816a532c621108c5ae9d..43b3af7bba4551d98c7ffb53fbee9413ed5b8dd3 100644
+index fbd5df61e5cfd67991dedb7bbba4a16ff16fa49b..a5121eb7fa8fccf7e742beea285c2f741ece513d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -212,6 +212,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0670-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0670-Freeze-Tick-Lock-API.patch
@@ -46,10 +46,10 @@ index 1632b2231e20901ce8498f3a0442e9ea54fcc068..6025b45d1c247941d83cd9c2d516c14a
  
          } catch (Throwable throwable) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cd0c949eb76814829e8554977358f8f818f33b20..81017788a4b08c9cb0fe7a1a9a99e13d903a55d8 100644
+index 0fe6b9f4376d2b852f6f23e31848cd9236577bdf..8aae4dacb85f67ea5f67e1143f2094851d40e85e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3454,7 +3454,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3448,7 +3448,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
          this.level().getProfiler().pop();
          this.level().getProfiler().push("freezing");

--- a/patches/server/0671-More-PotionEffectType-API.patch
+++ b/patches/server/0671-More-PotionEffectType-API.patch
@@ -8,10 +8,10 @@ public net.minecraft.world.effect.MobEffect attributeModifiers
 public net.minecraft.world.effect.MobEffect$AttributeTemplate
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionEffectType.java b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionEffectType.java
-index 8dffef71c8b193c0fc84b65a592c93827e341bf7..e15d83ac2668ebb0da9e22c15b9fd902689d5522 100644
+index 21d4224c8993f521d6004d708ecbf71fa6d09306..956b3eb1478b32399e507aead1551b51d6876695 100644
 --- a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionEffectType.java
 +++ b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionEffectType.java
-@@ -123,6 +123,48 @@ public class CraftPotionEffectType extends PotionEffectType implements Handleabl
+@@ -129,6 +129,48 @@ public class CraftPotionEffectType extends PotionEffectType implements Handleabl
          return this.handle.getDescriptionId();
      }
  

--- a/patches/server/0673-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0673-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -122,10 +122,10 @@ index 0000000000000000000000000000000000000000..e3a5f1ec376319bdfda87fa27ae217bf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f9b4f47553e7180c315052a2af3340043d140be1..29471efb47878244352195f012cac3ed3ed15122 100644
+index f61ea45fd39b2641dbab5e4a7e35c46c1639367d..4e6a3cb16a7f42e30ee210235f686f416d4c916d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2125,6 +2125,13 @@ public final class CraftServer implements Server {
+@@ -2148,6 +2148,13 @@ public final class CraftServer implements Server {
          return this.console.console;
      }
  

--- a/patches/server/0677-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0677-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 29471efb47878244352195f012cac3ed3ed15122..a7de5a300ab2c6f2feecc92d34785763e53282cc 100644
+index 4e6a3cb16a7f42e30ee210235f686f416d4c916d..84760f00681e5493106daeec21aeef260dc11fb2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2302,6 +2302,8 @@ public final class CraftServer implements Server {
+@@ -2325,6 +2325,8 @@ public final class CraftServer implements Server {
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
          // Paper start - Add mobcaps commands

--- a/patches/server/0678-Add-GameEvent-tags.patch
+++ b/patches/server/0678-Add-GameEvent-tags.patch
@@ -46,10 +46,10 @@ index 0000000000000000000000000000000000000000..e7d9fd2702a1ce96596580fff8f5ee4f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a7de5a300ab2c6f2feecc92d34785763e53282cc..826124355e809f9865e00fd2743d8a7e48ddb074 100644
+index 84760f00681e5493106daeec21aeef260dc11fb2..b6281c7dfe455b19d1016ea1d60de981228fb325 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2730,6 +2730,15 @@ public final class CraftServer implements Server {
+@@ -2753,6 +2753,15 @@ public final class CraftServer implements Server {
                      return (org.bukkit.Tag<T>) new CraftEntityTag(BuiltInRegistries.ENTITY_TYPE, entityTagKey);
                  }
              }
@@ -65,7 +65,7 @@ index a7de5a300ab2c6f2feecc92d34785763e53282cc..826124355e809f9865e00fd2743d8a7e
              default -> throw new IllegalArgumentException();
          }
  
-@@ -2762,6 +2771,13 @@ public final class CraftServer implements Server {
+@@ -2785,6 +2794,13 @@ public final class CraftServer implements Server {
                  net.minecraft.core.Registry<EntityType<?>> entityTags = BuiltInRegistries.ENTITY_TYPE;
                  return entityTags.getTags().map(pair -> (org.bukkit.Tag<T>) new CraftEntityTag(entityTags, pair.getFirst())).collect(ImmutableList.toImmutableList());
              }

--- a/patches/server/0684-Put-world-into-worldlist-before-initing-the-world.patch
+++ b/patches/server/0684-Put-world-into-worldlist-before-initing-the-world.patch
@@ -7,7 +7,7 @@ Some parts of legacy conversion will need the overworld
 to get the legacy structure data storage
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b72b5fb2fa1d372f914ad1084e43b21b14f4fffb..f9a4b5558bacff9c478f407c2656cb08588f421f 100644
+index 235886ef53d259622ee920fc70d089279d933f29..4fcd06f188ae23d1bb6f6ee1840c0103e018f4c2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -637,9 +637,10 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -23,10 +23,10 @@ index b72b5fb2fa1d372f914ad1084e43b21b14f4fffb..f9a4b5558bacff9c478f407c2656cb08
  
              if (worlddata.getCustomBossEvents() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 826124355e809f9865e00fd2743d8a7e48ddb074..5bfa93a55e486a9d26fc174db87f0f6705522363 100644
+index b6281c7dfe455b19d1016ea1d60de981228fb325..4534e1398cf90ef0f697fc327e9fa010313d9cb7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1297,10 +1297,11 @@ public final class CraftServer implements Server {
+@@ -1320,10 +1320,11 @@ public final class CraftServer implements Server {
              return null;
          }
  

--- a/patches/server/0686-Custom-Potion-Mixes.patch
+++ b/patches/server/0686-Custom-Potion-Mixes.patch
@@ -96,7 +96,7 @@ index 0000000000000000000000000000000000000000..7ea357ac2f3a93db4ebdf24b5072be7d
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f9a4b5558bacff9c478f407c2656cb08588f421f..6f72020fab6e4e175a265f85ec9efc31811bdbfd 100644
+index 4fcd06f188ae23d1bb6f6ee1840c0103e018f4c2..0420e92207a8b106d9b70f92774b21bb1dc19b25 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2138,6 +2138,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -282,10 +282,10 @@ index 3ebfd564d4bbf00da5919e966f3d047285845640..887957ce1ddc2f32569405642f35df46
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5bfa93a55e486a9d26fc174db87f0f6705522363..9ef7950eefea0693e51622cd55258fa1a884e961 100644
+index 4534e1398cf90ef0f697fc327e9fa010313d9cb7..0990c02fb8826f47a1f12617042f71790248e7b1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -304,6 +304,7 @@ public final class CraftServer implements Server {
+@@ -306,6 +306,7 @@ public final class CraftServer implements Server {
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings
      private final io.papermc.paper.logging.SysoutCatcher sysoutCatcher = new io.papermc.paper.logging.SysoutCatcher(); // Paper
@@ -293,7 +293,7 @@ index 5bfa93a55e486a9d26fc174db87f0f6705522363..9ef7950eefea0693e51622cd55258fa1
  
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
-@@ -385,6 +386,7 @@ public final class CraftServer implements Server {
+@@ -388,6 +389,7 @@ public final class CraftServer implements Server {
          if (this.configuration.getBoolean("settings.use-map-color-cache")) {
              MapPalette.setMapColorCache(new CraftMapColorCache(this.logger));
          }
@@ -301,7 +301,7 @@ index 5bfa93a55e486a9d26fc174db87f0f6705522363..9ef7950eefea0693e51622cd55258fa1
          datapackManager = new io.papermc.paper.datapack.PaperDatapackManager(console.getPackRepository()); // Paper
      }
  
-@@ -3093,5 +3095,9 @@ public final class CraftServer implements Server {
+@@ -3116,5 +3118,9 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0688-Fix-falling-block-spawn-methods.patch
+++ b/patches/server/0688-Fix-falling-block-spawn-methods.patch
@@ -11,10 +11,10 @@ Restores the API behavior from previous versions of the server
 public net.minecraft.world.entity.item.FallingBlockEntity <init>(Lnet/minecraft/world/level/Level;DDDLnet/minecraft/world/level/block/state/BlockState;)V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e31794510cb204fa1360803050d25d0e226785e2..193b544d1fea692d9948e00c72aa566836c2a4d2 100644
+index 7e9344fdafb01030061458c55ccf6836bf643da3..a9106f4777d05928d432e14e4998fd06df5a0786 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1425,7 +1425,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1450,7 +1450,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Preconditions.checkArgument(material != null, "Material cannot be null");
          Preconditions.checkArgument(material.isBlock(), "Material.%s must be a block", material);
  
@@ -28,7 +28,7 @@ index e31794510cb204fa1360803050d25d0e226785e2..193b544d1fea692d9948e00c72aa5668
          return (FallingBlock) entity.getBukkitEntity();
      }
  
-@@ -1434,7 +1439,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1459,7 +1464,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Preconditions.checkArgument(location != null, "Location cannot be null");
          Preconditions.checkArgument(data != null, "BlockData cannot be null");
  

--- a/patches/server/0691-More-Projectile-API.patch
+++ b/patches/server/0691-More-Projectile-API.patch
@@ -320,10 +320,10 @@ index 7ba6302ecb72fa6e523054e7e3223d79eedf6589..907904da7f89e8e5e5cfab80977f04af
          register(new EntityTypeData<>(EntityType.COMMAND_BLOCK_MINECART, CommandMinecart.class, CraftMinecartCommand::new, spawnData -> new MinecartCommandBlock(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z())));
          register(new EntityTypeData<>(EntityType.MINECART, RideableMinecart.class, CraftMinecartRideable::new, spawnData -> new Minecart(spawnData.minecraftWorld(), spawnData.x(), spawnData.y(), spawnData.z())));
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
-index e4e23a7b6d308ee476b5b8c2ad80efe4608b8346..241914415f74e0559fef59aa3f87f3e303f6c2c4 100644
+index b0a02c9ca4349ab56ceceae8b78559e20a9b0af5..297b7e592caa2a05e1fb18a3ad22a91ae7621f5d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
-@@ -32,20 +32,7 @@ public class CraftFireball extends AbstractProjectile implements Fireball {
+@@ -33,20 +33,7 @@ public class CraftFireball extends AbstractProjectile implements Fireball {
          this.getHandle().bukkitYield = yield;
      }
  
@@ -682,7 +682,7 @@ index e374b9f40eddca13b30855d25a2030f8df98138f..4fc893378fb0568ddcffc7593d66df6b
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 59d444a79b5852dabc082b56bafe71d79e42541f..fa50860c8bb34c914096a2af17be62277b698c1a 100644
+index efc3808dde268f8325304f4bce8fb3bf399adafd..9588c191ccb5665be2ff90ae2ded5bbff12faacb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -832,19 +832,19 @@ public class CraftEventFactory {
@@ -733,7 +733,7 @@ index 59d444a79b5852dabc082b56bafe71d79e42541f..fa50860c8bb34c914096a2af17be6227
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 3d226c03dbecf876bb5a50d493aceeb0f8f69d28..6352e56fa3e69690846842d474a1ae51ad4059c6 100644
+index 92faa15f79f0541048e29254dcf3560616d3c0e7..2a7996f5cfb1eacf098e73f35bafc4327b041c51 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -295,12 +295,22 @@ public final class CraftItemStack extends ItemStack {

--- a/patches/server/0696-Implement-enchantWithLevels-API.patch
+++ b/patches/server/0696-Implement-enchantWithLevels-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement enchantWithLevels API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 6b2d2b8397bb95ce6ffd87dc1a2f3292f81dd422..c13944058e26895a03f0013b6ca49ac7580ee9bf 100644
+index be31b8a286794508a1c1bfcf3da0ac64c0383c60..b0d73a9412421d86bd244757806d58fd99687163 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -596,4 +596,26 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -594,4 +594,26 @@ public final class CraftItemFactory implements ItemFactory {
          return eggItem == null ? null : new net.minecraft.world.item.ItemStack(eggItem).asBukkitMirror();
      }
      // Paper end - old getSpawnEgg API

--- a/patches/server/0697-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0697-Fix-saving-in-unloadWorld.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix saving in unloadWorld
 Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9ef7950eefea0693e51622cd55258fa1a884e961..ba56431ca9c8a29b8e2470858135d185e96dac62 100644
+index 0990c02fb8826f47a1f12617042f71790248e7b1..60441fbe87fed55d76967b7e709a21f462f4f511 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1346,7 +1346,7 @@ public final class CraftServer implements Server {
+@@ -1369,7 +1369,7 @@ public final class CraftServer implements Server {
  
          try {
              if (save) {

--- a/patches/server/0709-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/server/0709-WorldCreator-keepSpawnLoaded.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ba56431ca9c8a29b8e2470858135d185e96dac62..519dc5dedeac097f4cfc8104b00a22de369aa07f 100644
+index 60441fbe87fed55d76967b7e709a21f462f4f511..fbfc9e45e7740c0560affb2f1c135032fa5aecc9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1289,7 +1289,7 @@ public final class CraftServer implements Server {
+@@ -1312,7 +1312,7 @@ public final class CraftServer implements Server {
          }
  
          // If set to not keep spawn in memory (changed from default) then adjust rule accordingly

--- a/patches/server/0715-Add-PlayerStopUsingItemEvent.patch
+++ b/patches/server/0715-Add-PlayerStopUsingItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerStopUsingItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 81017788a4b08c9cb0fe7a1a9a99e13d903a55d8..4e25c8b48425777474fb22483f9e5e03a9d42178 100644
+index 8aae4dacb85f67ea5f67e1143f2094851d40e85e..e98ece3b5af0d1ffe6dddce4e342cd2858166ba3 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4023,6 +4023,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4017,6 +4017,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      public void releaseUsingItem() {
          if (!this.useItem.isEmpty()) {

--- a/patches/server/0724-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0724-Throw-exception-on-world-create-while-being-ticked.patch
@@ -7,7 +7,7 @@ There are no plans to support creating worlds while worlds are
 being ticked themselvess.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 6f72020fab6e4e175a265f85ec9efc31811bdbfd..803c234ec23147ed317ae4639438141462dfbd80 100644
+index 0420e92207a8b106d9b70f92774b21bb1dc19b25..91771afb413b56ff84697f4d1264e2e97ee5c132 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -311,6 +311,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -45,10 +45,10 @@ index 6f72020fab6e4e175a265f85ec9efc31811bdbfd..803c234ec23147ed317ae46394381414
          this.profiler.popPush("connection");
          MinecraftTimings.connectionTimer.startTiming(); // Spigot // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 519dc5dedeac097f4cfc8104b00a22de369aa07f..f2b75588265739c9b0876d8953184be43139e104 100644
+index fbfc9e45e7740c0560affb2f1c135032fa5aecc9..6a4ade9e6d741fbc5ca878047df6a35cf24a8461 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -882,6 +882,11 @@ public final class CraftServer implements Server {
+@@ -904,6 +904,11 @@ public final class CraftServer implements Server {
          return new ArrayList<World>(this.worlds.values());
      }
  
@@ -60,7 +60,7 @@ index 519dc5dedeac097f4cfc8104b00a22de369aa07f..f2b75588265739c9b0876d8953184be4
      public DedicatedPlayerList getHandle() {
          return this.playerList;
      }
-@@ -1143,6 +1148,7 @@ public final class CraftServer implements Server {
+@@ -1166,6 +1171,7 @@ public final class CraftServer implements Server {
      @Override
      public World createWorld(WorldCreator creator) {
          Preconditions.checkState(this.console.getAllLevels().iterator().hasNext(), "Cannot create additional worlds on STARTUP");
@@ -68,7 +68,7 @@ index 519dc5dedeac097f4cfc8104b00a22de369aa07f..f2b75588265739c9b0876d8953184be4
          Preconditions.checkArgument(creator != null, "WorldCreator cannot be null");
  
          String name = creator.name();
-@@ -1319,6 +1325,7 @@ public final class CraftServer implements Server {
+@@ -1342,6 +1348,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean unloadWorld(World world, boolean save) {

--- a/patches/server/0730-Don-t-broadcast-messages-to-command-blocks.patch
+++ b/patches/server/0730-Don-t-broadcast-messages-to-command-blocks.patch
@@ -20,10 +20,10 @@ index 8c2dcc4134d96351cee75773214f3f47e71533e9..e6bfcc50cdf728216084bc00a5bb8b6b
              Date date = new Date();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f2b75588265739c9b0876d8953184be43139e104..291e444e75d4155a0bcb2335a54436a4ddf69f7c 100644
+index 6a4ade9e6d741fbc5ca878047df6a35cf24a8461..8b629647c15721207f14081832bea6a702359b77 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1888,7 +1888,7 @@ public final class CraftServer implements Server {
+@@ -1911,7 +1911,7 @@ public final class CraftServer implements Server {
          // Paper end
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {

--- a/patches/server/0742-Warn-on-plugins-accessing-faraway-chunks.patch
+++ b/patches/server/0742-Warn-on-plugins-accessing-faraway-chunks.patch
@@ -18,7 +18,7 @@ index 1408faa8754b2492879f2dbb525aba3bfc8f0421..0fb975d74b8e91617de91dacb206699f
  
      private static boolean isOutsideSpawnableHeight(int y) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 193b544d1fea692d9948e00c72aa566836c2a4d2..0c5c67480e16333641f4ebc89d892f7a0e2387fd 100644
+index a9106f4777d05928d432e14e4998fd06df5a0786..606797b07bb5eb0ce8fa9d01eaa74e0d6c10b56b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -319,9 +319,24 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -54,7 +54,7 @@ index 193b544d1fea692d9948e00c72aa566836c2a4d2..0c5c67480e16333641f4ebc89d892f7a
          // Paper start - implement regenerateChunk method
          final ServerLevel serverLevel = this.world;
          final net.minecraft.server.level.ServerChunkCache serverChunkCache = serverLevel.getChunkSource();
-@@ -518,6 +534,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -543,6 +559,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
@@ -62,7 +62,7 @@ index 193b544d1fea692d9948e00c72aa566836c2a4d2..0c5c67480e16333641f4ebc89d892f7a
          ChunkAccess chunk = this.world.getChunkSource().getChunk(x, z, generate || isChunkGenerated(x, z) ? ChunkStatus.FULL : ChunkStatus.EMPTY, true); // Paper
  
          // If generate = false, but the chunk already exists, we will get this back.
-@@ -550,6 +567,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -575,6 +592,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean addPluginChunkTicket(int x, int z, Plugin plugin) {
@@ -70,7 +70,7 @@ index 193b544d1fea692d9948e00c72aa566836c2a4d2..0c5c67480e16333641f4ebc89d892f7a
          Preconditions.checkArgument(plugin != null, "null plugin");
          Preconditions.checkArgument(plugin.isEnabled(), "plugin is not enabled");
  
-@@ -650,6 +668,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -675,6 +693,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setChunkForceLoaded(int x, int z, boolean forced) {
@@ -78,7 +78,7 @@ index 193b544d1fea692d9948e00c72aa566836c2a4d2..0c5c67480e16333641f4ebc89d892f7a
          this.getHandle().setChunkForced(x, z, forced);
      }
  
-@@ -978,6 +997,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1003,6 +1022,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public int getHighestBlockYAt(int x, int z, org.bukkit.HeightMap heightMap) {
@@ -86,7 +86,7 @@ index 193b544d1fea692d9948e00c72aa566836c2a4d2..0c5c67480e16333641f4ebc89d892f7a
          // Transient load for this tick
          return this.world.getChunk(x >> 4, z >> 4).getHeight(CraftHeightMap.toNMS(heightMap), x, z);
      }
-@@ -2400,6 +2420,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2425,6 +2445,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot end
      // Paper start
      public java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent) {

--- a/patches/server/0745-Collision-API.patch
+++ b/patches/server/0745-Collision-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Collision API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-index d1c265733941874002f6dfc7543917af88600659..72c275d7da798ee10a224bbd3f4c92abd82601e1 100644
+index 4cacc8a8f5d04ea0e1f087194481fa749efa1797..fce1e4bc4898f10c7e8ae788630a55e42e99dd20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-@@ -539,5 +539,12 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+@@ -542,5 +542,12 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
  
          return this.getHandle().clip(new net.minecraft.world.level.ClipContext(start, end, net.minecraft.world.level.ClipContext.Block.COLLIDER, net.minecraft.world.level.ClipContext.Fluid.NONE, net.minecraft.world.phys.shapes.CollisionContext.empty())).getType() == net.minecraft.world.phys.HitResult.Type.MISS;
      }

--- a/patches/server/0748-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0748-Add-Velocity-IP-Forwarding-Support.patch
@@ -228,10 +228,10 @@ index 9bcded0466f3b10fafd709edc44c60f85cb48b7f..cb006ae0e5be2f1d31261bdd36964229
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 291e444e75d4155a0bcb2335a54436a4ddf69f7c..c26e50d9f50e96135a7729070c1e71d82751a990 100644
+index 8b629647c15721207f14081832bea6a702359b77..e135d634f4336a23e90fd94b4e4c261bfc0cffe9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -811,7 +811,7 @@ public final class CraftServer implements Server {
+@@ -833,7 +833,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0749-Add-NamespacedKey-biome-methods.patch
+++ b/patches/server/0749-Add-NamespacedKey-biome-methods.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add NamespacedKey biome methods
 Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 0bf7e2b73bbde4ac23a2f52a145de464f0851396..144118d50b0cae226480788fc9e74c178475369f 100644
+index 83730eac9887bbf9bd5284676ec9a0509ec14a04..ff2c6a7b4b8ae2f7e9e1c84e1a3bd04e0484d075 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -594,6 +594,21 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -595,6 +595,21 @@ public final class CraftMagicNumbers implements UnsafeValues {
      }
      // Paper end
  

--- a/patches/server/0751-Stop-large-look-changes-from-crashing-the-server.patch
+++ b/patches/server/0751-Stop-large-look-changes-from-crashing-the-server.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Stop large look changes from crashing the server
 Co-authored-by: Jaren Knodel <Jaren@Knodel.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4e25c8b48425777474fb22483f9e5e03a9d42178..0a0a3e4c03e86a11430811c4934742122391687e 100644
+index e98ece3b5af0d1ffe6dddce4e342cd2858166ba3..160347d036d6c8eaf48082c1155234e1a8df54c3 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3132,37 +3132,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3126,37 +3126,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
          this.level().getProfiler().pop();
          this.level().getProfiler().push("rangeChecks");
  

--- a/patches/server/0759-Mitigate-effects-of-WorldCreator-keepSpawnLoaded-ret.patch
+++ b/patches/server/0759-Mitigate-effects-of-WorldCreator-keepSpawnLoaded-ret.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Mitigate effects of WorldCreator#keepSpawnLoaded ret type
 TODO: Remove in 1.21?
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 5c05258ce502a9ff7d6f182f61e3722ec42e9e69..b2f58a57906eeea52be1aa9408c5748c8c64213a 100644
+index 8ae3b6bb5daf4d0a4a429868d1dea700c3ee129c..6fdea5b2f82c40c03091b7bd18ebcae20a3458ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -380,6 +380,12 @@ public class Commodore {
+@@ -384,6 +384,12 @@ public class Commodore {
                              super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, runtimeCbPkgPrefix() + "advancement/CraftAdvancement", "getDisplay0", desc, false);
                              return;
                          }

--- a/patches/server/0769-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0769-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9fd66c351dc74ed9a62db1efd58df2c5bfddfad8..d3fb8dfa57b83bcdca34909269a09787c2b5ae7b 100644
+index 7e6ae084118e36eb1be9b5598eeb7e8885179eae..da2a2a2f2c0145e3342ab42f7fd1382c8def432c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3271,6 +3271,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3280,6 +3280,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0783-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0783-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d3fb8dfa57b83bcdca34909269a09787c2b5ae7b..47c4255348fc8aca404d8fcce72d1b54a833413a 100644
+index da2a2a2f2c0145e3342ab42f7fd1382c8def432c..503367692e50e32375923f6a6e1a892920785fa4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3276,6 +3276,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3285,6 +3285,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }

--- a/patches/server/0786-check-global-player-list-where-appropriate.patch
+++ b/patches/server/0786-check-global-player-list-where-appropriate.patch
@@ -24,10 +24,10 @@ index 9f7088691c3ab848c5095b6109d14eae947ace99..1e122d5b49aa7f6a626e781e53de53be
 +    // Paper end - check global player list where appropriate
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 0a0a3e4c03e86a11430811c4934742122391687e..d736a53a6ea2a20a950096cd89df178864e644f4 100644
+index 160347d036d6c8eaf48082c1155234e1a8df54c3..947bccb93f2a5baa6236e1da1a7ec0b27c072a14 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3678,7 +3678,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3672,7 +3672,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public void onItemPickup(ItemEntity item) {

--- a/patches/server/0787-Fix-async-entity-add-due-to-fungus-trees.patch
+++ b/patches/server/0787-Fix-async-entity-add-due-to-fungus-trees.patch
@@ -17,10 +17,10 @@ index 68a6572da2acf2ea2e6996e653a0ffe405846575..a59eece9c7a8c33cb8ce963906e993c3
                  BlockEntity tileentity = iblockdata.hasBlockEntity() ? this.getBlockEntity(pos) : null;
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-index 72c275d7da798ee10a224bbd3f4c92abd82601e1..0e307c2bb788c1ec856613b0203f5fc7aca7e85d 100644
+index fce1e4bc4898f10c7e8ae788630a55e42e99dd20..5cdc44c73b536f2ed2dcd49dbeccf0f69f614dba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-@@ -257,10 +257,10 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+@@ -260,10 +260,10 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
                  ((ChorusFlowerBlock) Blocks.CHORUS_FLOWER).generatePlant(access, pos, random, 8);
                  return true;
              case CRIMSON_FUNGUS:

--- a/patches/server/0801-Improve-logging-and-errors.patch
+++ b/patches/server/0801-Improve-logging-and-errors.patch
@@ -28,10 +28,10 @@ index 2665170b8391a77d6b3fb7ae7b5ccfc0be65acd7..e00d4e0896c0163c43d79af63338de67
  
      private boolean tryInsert(AdvancementHolder advancement) {
 diff --git a/src/main/java/net/minecraft/server/ServerAdvancementManager.java b/src/main/java/net/minecraft/server/ServerAdvancementManager.java
-index 4fa6abfe79ab7ff0e7643975351ab1a10efdc278..b4f15c51faae544bc0a4fcc33760df66e1397f87 100644
+index 294172ea6f61a7951793e34518f74ef56b57e37d..de8c8b408e5921ecb98c97333657b614635cff06 100644
 --- a/src/main/java/net/minecraft/server/ServerAdvancementManager.java
 +++ b/src/main/java/net/minecraft/server/ServerAdvancementManager.java
-@@ -67,6 +67,7 @@ public class ServerAdvancementManager extends SimpleJsonResourceReloadListener {
+@@ -70,6 +70,7 @@ public class ServerAdvancementManager extends SimpleJsonResourceReloadListener {
          AdvancementTree advancementtree = new AdvancementTree();
  
          advancementtree.addAll(this.advancements.values());
@@ -95,7 +95,7 @@ index 9ae23dbf076e977c9d9b98a02c5925e9a8f68f7f..0126b88f60904dfbf1e29eb3b89a9850
  
      // CraftBukkit start
 diff --git a/src/main/java/org/bukkit/craftbukkit/legacy/CraftLegacy.java b/src/main/java/org/bukkit/craftbukkit/legacy/CraftLegacy.java
-index 8e42a91587353271820d58c30ac84c708c00b989..ae6d9453cbfb708ed00a61a221bd425110b291a4 100644
+index 427363452b5f7623360e7aad8af534f077d0d77f..62f4835309df2b2deeb799609f9b1b325bf58af3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/legacy/CraftLegacy.java
 +++ b/src/main/java/org/bukkit/craftbukkit/legacy/CraftLegacy.java
 @@ -44,6 +44,7 @@ import org.bukkit.material.MaterialData;
@@ -106,7 +106,7 @@ index 8e42a91587353271820d58c30ac84c708c00b989..ae6d9453cbfb708ed00a61a221bd4251
  
      private static final Map<Byte, Material> SPAWN_EGGS = new HashMap<>();
      private static final Set<String> whitelistedStates = new HashSet<>(Arrays.asList("explode", "check_decay", "decayable", "facing"));
-@@ -255,7 +256,7 @@ public final class CraftLegacy {
+@@ -264,7 +265,7 @@ public final class CraftLegacy {
      }
  
      static {

--- a/patches/server/0810-Correctly-shrink-items-during-EntityResurrectEvent.patch
+++ b/patches/server/0810-Correctly-shrink-items-during-EntityResurrectEvent.patch
@@ -25,7 +25,7 @@ diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/ma
 index 8a4977bf4d5b87ca30e048d749b6a878b1a17911..6c502f67234eee9c1446d490acde1dbe6f34119e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1644,7 +1644,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1638,7 +1638,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.level().getCraftServer().getPluginManager().callEvent(event);
  
              if (!event.isCancelled()) {

--- a/patches/server/0820-Fix-advancement-triggers-for-entity-damage.patch
+++ b/patches/server/0820-Fix-advancement-triggers-for-entity-damage.patch
@@ -23,10 +23,10 @@ index 2ebbf7954dc5e0d6c9d53327d05b725eec310086..c5bd2e90ad74ba08910f65a2e07b6f76
  
              return !this.getResponse();
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 1a891485933c81e0b80c8a193db5eca9208cbb18..e69a71595abbbf963e91995e5bbc91d1e509748b 100644
+index ca5dd07e74d1ecf303091faeb4d7796bbc7a57c8..d314d5f9f66a86376d66cd607e3545c5d95fd12e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2365,7 +2365,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2359,7 +2359,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  // Duplicate triggers if blocking
                  if (event.getDamage(DamageModifier.BLOCKING) < 0) {
                      if (this instanceof ServerPlayer) {
@@ -35,7 +35,7 @@ index 1a891485933c81e0b80c8a193db5eca9208cbb18..e69a71595abbbf963e91995e5bbc91d1
                          f2 = (float) -event.getDamage(DamageModifier.BLOCKING);
                          if (f2 > 0.0F && f2 < 3.4028235E37F) {
                              ((ServerPlayer) this).awardStat(Stats.DAMAGE_BLOCKED_BY_SHIELD, Math.round(originalDamage * 10.0F));
-@@ -2373,7 +2373,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2367,7 +2367,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      }
  
                      if (damagesource.getEntity() instanceof ServerPlayer) {

--- a/patches/server/0824-Fix-SpawnEggMeta-get-setSpawnedType.patch
+++ b/patches/server/0824-Fix-SpawnEggMeta-get-setSpawnedType.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SpawnEggMeta#get/setSpawnedType
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
-index 163b1712ce4a1c8f91028dc7c2cd56ba7ad8981f..726438237093abc85d9239f9c84be3df6d8318c4 100644
+index 686816a1fb9f918b13c0a589c5c5c95a1c7ffe3a..1c2b0407b51906a255e6d240fab969578743938e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
-@@ -224,6 +224,30 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
+@@ -185,6 +185,30 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
      public void setSpawnedType(EntityType type) {
          throw new UnsupportedOperationException("Must change item type to set spawned type");
      }

--- a/patches/server/0843-Don-t-enforce-icanhasbukkit-default-if-alias-block-e.patch
+++ b/patches/server/0843-Don-t-enforce-icanhasbukkit-default-if-alias-block-e.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't enforce icanhasbukkit default if alias block exists
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c26e50d9f50e96135a7729070c1e71d82751a990..1c0361f1533f5bff7eac650ca933c962e56437a6 100644
+index e135d634f4336a23e90fd94b4e4c261bfc0cffe9..c2dc4a7194c83cb01724fc04ea4971b34b2f8235 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -350,7 +350,11 @@ public final class CraftServer implements Server {
+@@ -352,7 +352,11 @@ public final class CraftServer implements Server {
          }
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
          this.commandsConfiguration.options().copyDefaults(true);

--- a/patches/server/0856-fix-item-meta-for-tadpole-buckets.patch
+++ b/patches/server/0856-fix-item-meta-for-tadpole-buckets.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] fix item meta for tadpole buckets
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index c13944058e26895a03f0013b6ca49ac7580ee9bf..6e2a6ce5cf456bd9f6c8c18a58f08e2285dc77ed 100644
+index b0d73a9412421d86bd244757806d58fd99687163..a83f726bd10cc25565098e485c337783ba6dbd69 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -364,6 +364,7 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -367,6 +367,7 @@ public final class CraftItemFactory implements ItemFactory {
          case COD_BUCKET:
          case PUFFERFISH_BUCKET:
          case SALMON_BUCKET:
@@ -17,7 +17,7 @@ index c13944058e26895a03f0013b6ca49ac7580ee9bf..6e2a6ce5cf456bd9f6c8c18a58f08e22
          case GLOW_ITEM_FRAME:
          case PAINTING:
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index a1173823b3a95b973ae742f886b0555b3203288c..55ae50f99a891a26dcdc0ec6266e3c05b3d12a5e 100644
+index fa223d2381986cb260c79f074fb7b123396f1f86..7c510d673253e53c1cebbe7af2aacbcaa59cb9de 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -604,6 +604,7 @@ public final class CraftItemStack extends ItemStack {

--- a/patches/server/0865-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/server/0865-Folia-scheduler-and-owned-region-API.patch
@@ -1148,7 +1148,7 @@ index 0000000000000000000000000000000000000000..d306f911757a4d556c82c0070d4837db
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e463727cccc6931de822f62309090241c7abada4..187421d19a6d3422612edad650ef15b40ba8c9b9 100644
+index 9ba2a71e5bedbf8e65f9dd1652639afd397439c7..2a92268dfc8ee264e4ee6ffc56b40a87e334acc8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1551,6 +1551,20 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -1185,7 +1185,7 @@ index 942af999a4a3aa03cb7ef5f0b9d377c78677fd0e..0246db4a1f6eb168fa88260282311fee
          this.players.remove(entityplayer);
          this.playersByName.remove(entityplayer.getScoreboardName().toLowerCase(java.util.Locale.ROOT)); // Spigot
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9541fbd06bc000023d6119eff03787ef068178ce..3aeb24963ce0415e97168196cbf53e8f26334013 100644
+index 9119bf1eac38f9b40d035f702150a7939095266c..27d736d34c91c08782fa8fd60742e296580e08f2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -249,11 +249,23 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -1251,10 +1251,10 @@ index 9541fbd06bc000023d6119eff03787ef068178ce..3aeb24963ce0415e97168196cbf53e8f
      public void setLevelCallback(EntityInLevelCallback changeListener) {
          this.levelCallback = changeListener;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1c0361f1533f5bff7eac650ca933c962e56437a6..24bded5c7c2c64b359348929ee94cbef8899a121 100644
+index c2dc4a7194c83cb01724fc04ea4971b34b2f8235..e61e1f4621ca29cab1afdf26b013b7b89b1ac358 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -306,6 +306,76 @@ public final class CraftServer implements Server {
+@@ -308,6 +308,76 @@ public final class CraftServer implements Server {
      private final io.papermc.paper.logging.SysoutCatcher sysoutCatcher = new io.papermc.paper.logging.SysoutCatcher(); // Paper
      private final io.papermc.paper.potion.PaperPotionBrewer potionBrewer; // Paper - Custom Potion Mixes
  

--- a/patches/server/0867-API-for-updating-recipes-on-clients.patch
+++ b/patches/server/0867-API-for-updating-recipes-on-clients.patch
@@ -39,10 +39,10 @@ index 0246db4a1f6eb168fa88260282311fee2ebb6014..ea04eb049e16d1027d15f9863d1fcd16
          Iterator iterator1 = this.players.iterator();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 24bded5c7c2c64b359348929ee94cbef8899a121..8d8142d80a552f43c89a94ea4180ef9320b346f6 100644
+index e61e1f4621ca29cab1afdf26b013b7b89b1ac358..f5a4ddf217fc114daf7faf345dd6c2e9294cba52 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1139,6 +1139,18 @@ public final class CraftServer implements Server {
+@@ -1162,6 +1162,18 @@ public final class CraftServer implements Server {
          ReloadCommand.reload(this.console);
      }
  
@@ -61,7 +61,7 @@ index 24bded5c7c2c64b359348929ee94cbef8899a121..8d8142d80a552f43c89a94ea4180ef93
      private void loadIcon() {
          this.icon = new CraftIconCache(null);
          try {
-@@ -1518,6 +1530,13 @@ public final class CraftServer implements Server {
+@@ -1541,6 +1553,13 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean addRecipe(Recipe recipe) {
@@ -75,7 +75,7 @@ index 24bded5c7c2c64b359348929ee94cbef8899a121..8d8142d80a552f43c89a94ea4180ef93
          CraftRecipe toAdd;
          if (recipe instanceof CraftRecipe) {
              toAdd = (CraftRecipe) recipe;
-@@ -1547,6 +1566,11 @@ public final class CraftServer implements Server {
+@@ -1570,6 +1589,11 @@ public final class CraftServer implements Server {
              }
          }
          toAdd.addToCraftingManager();
@@ -87,7 +87,7 @@ index 24bded5c7c2c64b359348929ee94cbef8899a121..8d8142d80a552f43c89a94ea4180ef93
          return true;
      }
  
-@@ -1727,10 +1751,23 @@ public final class CraftServer implements Server {
+@@ -1750,10 +1774,23 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean removeRecipe(NamespacedKey recipeKey) {

--- a/patches/server/0872-Use-correct-seed-on-api-world-load.patch
+++ b/patches/server/0872-Use-correct-seed-on-api-world-load.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use correct seed on api world load
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8d8142d80a552f43c89a94ea4180ef9320b346f6..57a869806f51845eafeabd34a0937d398721e301 100644
+index f5a4ddf217fc114daf7faf345dd6c2e9294cba52..79aa2d308c079205b50abae38fa88d69b51063e3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1361,7 +1361,7 @@ public final class CraftServer implements Server {
+@@ -1384,7 +1384,7 @@ public final class CraftServer implements Server {
              net.minecraft.server.Main.forceUpgrade(worldSession, DataFixers.getDataFixer(), this.console.options.has("eraseCache"), () -> true, iregistrycustom_dimension, this.console.options.has("recreateRegionFiles"));
          }
  

--- a/patches/server/0875-Fix-custom-statistic-criteria-creation.patch
+++ b/patches/server/0875-Fix-custom-statistic-criteria-creation.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix custom statistic criteria creation
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 144118d50b0cae226480788fc9e74c178475369f..ac42442b64b1b2ba29997d0720970e7f677a2702 100644
+index ff2c6a7b4b8ae2f7e9e1c84e1a3bd04e0484d075..256fdd08a7653d1dc93cd13a976cd114253aa945 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -609,6 +609,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -610,6 +610,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
      }
      // Paper end - namespaced key biome methods
  

--- a/patches/server/0876-Bandaid-fix-for-Effect.patch
+++ b/patches/server/0876-Bandaid-fix-for-Effect.patch
@@ -68,10 +68,10 @@ index 71733f918ed84b9879ac1b142ef6205c5e768a9c..c856384019eff2f2d0bb831ebe1ccb0f
              break;
          case BONE_MEAL_USE:
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0c5c67480e16333641f4ebc89d892f7a0e2387fd..18c1cceb9e8b2873b24134a9e012633616634aae 100644
+index 606797b07bb5eb0ce8fa9d01eaa74e0d6c10b56b..f371e76215a789f84eb5086a3d08bcf6e4e02dd8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1402,7 +1402,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1427,7 +1427,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public <T> void playEffect(Location loc, Effect effect, T data, int radius) {
          if (data != null) {
              Preconditions.checkArgument(effect.getData() != null, "Effect.%s does not have a valid Data", effect);
@@ -81,7 +81,7 @@ index 0c5c67480e16333641f4ebc89d892f7a0e2387fd..18c1cceb9e8b2873b24134a9e0126336
              // Special case: the axis is optional for ELECTRIC_SPARK
              Preconditions.checkArgument(effect.getData() == null || effect == Effect.ELECTRIC_SPARK, "Wrong kind of data for the %s effect", effect);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index abc9c4869994e97b0d6301dd58882f8f7e9383e1..1654c04c261f5591df4815423efb55751882de10 100644
+index b41646469bcbde02a1c2254247748bbcbbabddad..a06145c8ba3cd88c827bcc354e7dc2dafa3eda32 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -915,7 +915,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0879-Deprecate-and-replace-methods-with-old-StructureType.patch
+++ b/patches/server/0879-Deprecate-and-replace-methods-with-old-StructureType.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deprecate and replace methods with old StructureType
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 57a869806f51845eafeabd34a0937d398721e301..19934047295cb8ad3783bb73a03075916f1508ae 100644
+index 79aa2d308c079205b50abae38fa88d69b51063e3..cce628673b6173f17ac81bce5469a7dbd8a2c648 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1966,6 +1966,11 @@ public final class CraftServer implements Server {
+@@ -1989,6 +1989,11 @@ public final class CraftServer implements Server {
  
          ServerLevel worldServer = ((CraftWorld) world).getHandle();
          Location structureLocation = world.locateNearestStructure(location, structureType, radius, findUnexplored);
@@ -20,7 +20,7 @@ index 57a869806f51845eafeabd34a0937d398721e301..19934047295cb8ad3783bb73a0307591
          BlockPos structurePosition = CraftLocation.toBlockPosition(structureLocation);
  
          // Create map with trackPlayer = true, unlimitedTracking = true
-@@ -1976,6 +1981,31 @@ public final class CraftServer implements Server {
+@@ -1999,6 +2004,31 @@ public final class CraftServer implements Server {
  
          return CraftItemStack.asBukkitCopy(stack);
      }

--- a/patches/server/0913-Fix-UnsafeValues-loadAdvancement.patch
+++ b/patches/server/0913-Fix-UnsafeValues-loadAdvancement.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix UnsafeValues#loadAdvancement
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index ac42442b64b1b2ba29997d0720970e7f677a2702..cb72cc3e2b86b447e51236a70a4dd04a611ac81c 100644
+index 256fdd08a7653d1dc93cd13a976cd114253aa945..b5abf9c7e5e09c670ae2435c23587e0482fbe917 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -321,9 +321,30 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -322,9 +322,30 @@ public final class CraftMagicNumbers implements UnsafeValues {
          ResourceLocation minecraftkey = CraftNamespacedKey.toMinecraft(key);
  
          JsonElement jsonelement = ServerAdvancementManager.GSON.fromJson(advancement, JsonElement.class);

--- a/patches/server/0914-Add-player-idle-duration-API.patch
+++ b/patches/server/0914-Add-player-idle-duration-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5da5dc72a0ddb45515bce0ea81825f5368bbd997..027abbde974ff2c4844c3d815230d600140690a4 100644
+index 357255d58c2ec1e20828a544e5ae9f0927485cef..af14b09630af4a092491e6b9a7b3f418cc82c0de 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3391,6 +3391,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3400,6 +3400,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0920-Add-predicate-for-blocks-when-raytracing.patch
+++ b/patches/server/0920-Add-predicate-for-blocks-when-raytracing.patch
@@ -47,10 +47,10 @@ index c978f3b2d42f512e982f289e76c2422e41b7eec6..bb8e962e63c7a2d931f9bd7f7c002aa3
              Vec3 vec3d = raytrace1.getFrom().subtract(raytrace1.getTo());
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 18c1cceb9e8b2873b24134a9e012633616634aae..3abb776f546edb84307f374943427be02dc4c911 100644
+index f371e76215a789f84eb5086a3d08bcf6e4e02dd8..7732d838ef33936b6728042f8d6be49b500e6dd2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1136,9 +1136,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1161,9 +1161,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public RayTraceResult rayTraceEntities(Location start, Vector direction, double maxDistance, double raySize, Predicate<? super Entity> filter) {
@@ -68,7 +68,7 @@ index 18c1cceb9e8b2873b24134a9e012633616634aae..3abb776f546edb84307f374943427be0
  
          Preconditions.checkArgument(direction != null, "Vector direction cannot be null");
          direction.checkFinite();
-@@ -1188,9 +1194,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1213,9 +1219,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks) {
@@ -87,7 +87,7 @@ index 18c1cceb9e8b2873b24134a9e012633616634aae..3abb776f546edb84307f374943427be0
  
          Preconditions.checkArgument(direction != null, "Vector direction cannot be null");
          direction.checkFinite();
-@@ -1203,16 +1216,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1228,16 +1241,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
  
          Vector dir = direction.clone().normalize().multiply(maxDistance);

--- a/patches/server/0921-Broadcast-take-item-packets-with-collector-as-source.patch
+++ b/patches/server/0921-Broadcast-take-item-packets-with-collector-as-source.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Broadcast take item packets with collector as source
 This fixes players (which can't view the collector) seeing item pickups with themselves as the target.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e69a71595abbbf963e91995e5bbc91d1e509748b..33c3c6ac66842735b06c078821930767386c7fd7 100644
+index d314d5f9f66a86376d66cd607e3545c5d95fd12e..844da8d55e43607239b54c7cb823cf26f2b04ed1 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3704,7 +3704,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3698,7 +3698,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      public void take(Entity item, int count) {
          if (!item.isRemoved() && !this.level().isClientSide && (item instanceof ItemEntity || item instanceof AbstractArrow || item instanceof ExperienceOrb)) {

--- a/patches/server/0923-Fix-strikeLightningEffect-powers-lightning-rods-and-.patch
+++ b/patches/server/0923-Fix-strikeLightningEffect-powers-lightning-rods-and-.patch
@@ -45,10 +45,10 @@ index 0471d9c85af02133f99cca4e181b83b58a3f1abc..4f701788bd21b61cad251a3a88f9bc41
              BlockState iblockdata = BaseFireBlock.getState(this.level(), blockposition);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3abb776f546edb84307f374943427be02dc4c911..039efd0b8eb141de044668a5633f26eee238c2b0 100644
+index 7732d838ef33936b6728042f8d6be49b500e6dd2..8b4b4017f9874a153c27a96a7df1a966c5bdf4f3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -768,7 +768,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -793,7 +793,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          LightningBolt lightning = EntityType.LIGHTNING_BOLT.create(this.world);
          lightning.moveTo(loc.getX(), loc.getY(), loc.getZ());

--- a/patches/server/0931-Fix-CraftMetaItem-getAttributeModifier-duplication-c.patch
+++ b/patches/server/0931-Fix-CraftMetaItem-getAttributeModifier-duplication-c.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix CraftMetaItem#getAttributeModifier duplication check
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 43fad0ad01712da8d8bdcd54078aaa7b5fbc2720..d90876888c2dedbdedd63cff932f48da286c8172 100644
+index ce6767537bd0f8eb5c28eef9d50e042c5a9b4b4b..e3ac829ae4f2b39c103e5626180ec9220c2b1f33 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1285,7 +1285,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1321,7 +1321,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          Preconditions.checkNotNull(modifier, "AttributeModifier cannot be null");
          this.checkAttributeList();
          for (Map.Entry<Attribute, AttributeModifier> entry : this.attributeModifiers.entries()) {

--- a/patches/server/0935-Improve-Registry.patch
+++ b/patches/server/0935-Improve-Registry.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Improve Registry
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-index 0b19ddf411933240f3cdc6b4e9ce3817c8d45af1..5c725faae98a126ee0e34eea53cfa484d2315709 100644
+index a644309edb612d97da290f86a1ef6fe597c7d85d..3adf18d5e736abff701a4866ee1f8403aeafca84 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-@@ -144,6 +144,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -143,6 +143,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
  
      private final Class<?> bukkitClass; // Paper - relax preload class
      private final Map<NamespacedKey, B> cache = new HashMap<>();
@@ -16,7 +16,7 @@ index 0b19ddf411933240f3cdc6b4e9ce3817c8d45af1..5c725faae98a126ee0e34eea53cfa484
      private final net.minecraft.core.Registry<M> minecraftRegistry;
      private final BiFunction<NamespacedKey, M, B> minecraftToBukkit;
      private final BiFunction<NamespacedKey, ApiVersion, NamespacedKey> serializationUpdater; // Paper - rename to make it *clear* what it is *only* for
-@@ -192,6 +193,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -191,6 +192,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
          }
  
          this.cache.put(namespacedKey, bukkit);
@@ -24,7 +24,7 @@ index 0b19ddf411933240f3cdc6b4e9ce3817c8d45af1..5c725faae98a126ee0e34eea53cfa484
  
          return bukkit;
      }
-@@ -214,4 +216,11 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -213,4 +215,11 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
  
          return this.minecraftToBukkit.apply(namespacedKey, minecraft);
      }

--- a/patches/server/0936-Fix-NPE-on-null-loc-for-EntityTeleportEvent.patch
+++ b/patches/server/0936-Fix-NPE-on-null-loc-for-EntityTeleportEvent.patch
@@ -26,10 +26,10 @@ index a306b30af19277386a2f3e560b4902a8b5796f2a..54851f6cc0d5fddb32a9a1e84a4f5ae4
                  x = to.getX();
                  y = to.getY();
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index c2a4c4607ccbbcabde66d7a92fe6c9010263225d..9b72443d98525b860e1ceae9f9c20b4ef7d8dd90 100644
+index cb07999629ba2d56602b3ae06ef06e350a8d1fb1..b7af45eac986097ef53fa90bb4edd67f8829f13c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4179,7 +4179,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4173,7 +4173,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      if (!(this instanceof ServerPlayer)) {
                          EntityTeleportEvent teleport = new EntityTeleportEvent(this.getBukkitEntity(), new Location(this.level().getWorld(), d3, d4, d5), new Location(this.level().getWorld(), d0, d6, d2));
                          this.level().getCraftServer().getPluginManager().callEvent(teleport);

--- a/patches/server/0942-Fixup-NamespacedKey-handling.patch
+++ b/patches/server/0942-Fixup-NamespacedKey-handling.patch
@@ -52,10 +52,10 @@ index 209c6b64e79c29ea3bb84ddbe89a8bff66f81d0f..1f90f4b3f310b8cf5750c3a581be178f
  
      public static NamespacedKey minecraftToBukkitKey(ResourceKey<LootTable> minecraft) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-index 5c725faae98a126ee0e34eea53cfa484d2315709..d41b502eb451ec11dade2b987aee621511312ac6 100644
+index 3adf18d5e736abff701a4866ee1f8403aeafca84..4a5778d1751b774c825bbce0e870e2998278afe3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-@@ -111,6 +111,16 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -110,6 +110,16 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
                  + ", this can happen if a plugin creates its own registry entry with out properly registering it.");
      }
  

--- a/patches/server/0947-Add-api-for-spawn-egg-texture-colors.patch
+++ b/patches/server/0947-Add-api-for-spawn-egg-texture-colors.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add api for spawn egg texture colors
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index cb72cc3e2b86b447e51236a70a4dd04a611ac81c..00cf4a0daa227e6b24ed052873290ff3fdae3119 100644
+index b5abf9c7e5e09c670ae2435c23587e0482fbe917..b485a14a11f468e16d1da672f981e678c7a1522e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -653,6 +653,15 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -654,6 +654,15 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return CraftRegistry.get(registry, namespacedKey, ApiVersion.CURRENT);
      }
  

--- a/patches/server/0948-Add-Lifecycle-Event-system.patch
+++ b/patches/server/0948-Add-Lifecycle-Event-system.patch
@@ -707,10 +707,10 @@ index 2e96308696e131f3f013469a395e5ddda2c5d529..65a66e484c1c39c5f41d97db52f31c67
                  } catch (Throwable e) {
                      LOGGER.error("Failed to run bootstrapper for %s. This plugin will not be loaded.".formatted(provider.getSource()), e);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 19934047295cb8ad3783bb73a03075916f1508ae..17a50b11da960a24bfea0ec780faf1718ca992d4 100644
+index cce628673b6173f17ac81bce5469a7dbd8a2c648..fd4417e2863fb028a1b22b4f5c00d585dd127ad1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1013,6 +1013,11 @@ public final class CraftServer implements Server {
+@@ -1035,6 +1035,11 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -739,10 +739,10 @@ index d96399e9bf1a58db5a4a22e58abb99e7660e0694..66bdac50130f523f9dc4379b103b7a46
 +    // Paper end - lifecycle events
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 00cf4a0daa227e6b24ed052873290ff3fdae3119..6fc7b20c0f8f14c1d6a47177f9ccf402e88153e6 100644
+index b485a14a11f468e16d1da672f981e678c7a1522e..5143b8f81ce31e5d88f5de6b2856c3b7e3676048 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -662,6 +662,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -663,6 +663,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
      }
      // Paper end - spawn egg color visibility
  

--- a/patches/server/0949-ItemStack-Tooltip-API.patch
+++ b/patches/server/0949-ItemStack-Tooltip-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack Tooltip API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 6fc7b20c0f8f14c1d6a47177f9ccf402e88153e6..1fabc9cf3bf7a05a2593f64eb3e41c21b5f4ee84 100644
+index 5143b8f81ce31e5d88f5de6b2856c3b7e3676048..f6c33a9e2900890e4f6cb19784e01ff438cce83d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -638,6 +638,21 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -639,6 +639,21 @@ public final class CraftMagicNumbers implements UnsafeValues {
      }
      // Paper end - fix custom stats criteria creation
  

--- a/patches/server/0950-Add-getChunkSnapshot-includeLightData-parameter.patch
+++ b/patches/server/0950-Add-getChunkSnapshot-includeLightData-parameter.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getChunkSnapshot includeLightData parameter
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 5b59b19a6d913ebdfc28a755e3a1a8b8384a3116..7dae8d91b74cc7df0745f0c121e3bea09b8d0b6d 100644
+index f8c2d91958d6e4a1452fcf32c16fa8b97ea271a2..36a611d06131be00197c915871b8323544bb4972 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -327,12 +327,21 @@ public class CraftChunk implements Chunk {
+@@ -328,12 +328,21 @@ public class CraftChunk implements Chunk {
  
      @Override
      public ChunkSnapshot getChunkSnapshot(boolean includeMaxBlockY, boolean includeBiome, boolean includeBiomeTempRain) {
@@ -32,7 +32,7 @@ index 5b59b19a6d913ebdfc28a755e3a1a8b8384a3116..7dae8d91b74cc7df0745f0c121e3bea0
          boolean[] sectionEmpty = new boolean[cs.length];
          PalettedContainerRO<Holder<net.minecraft.world.level.biome.Biome>>[] biome = (includeBiome || includeBiomeTempRain) ? new PalettedContainer[cs.length] : null;
  
-@@ -349,6 +358,7 @@ public class CraftChunk implements Chunk {
+@@ -350,6 +359,7 @@ public class CraftChunk implements Chunk {
              }
              // Paper end - Fix ChunkSnapshot#isSectionEmpty(int)
  
@@ -40,7 +40,7 @@ index 5b59b19a6d913ebdfc28a755e3a1a8b8384a3116..7dae8d91b74cc7df0745f0c121e3bea0
              LevelLightEngine lightengine = this.worldServer.getLightEngine();
              DataLayer skyLightArray = lightengine.getLayerListener(LightLayer.SKY).getDataLayerData(SectionPos.of(this.x, chunk.getSectionYFromSectionIndex(i), this.z)); // SPIGOT-7498: Convert section index
              if (skyLightArray == null) {
-@@ -364,6 +374,7 @@ public class CraftChunk implements Chunk {
+@@ -365,6 +375,7 @@ public class CraftChunk implements Chunk {
                  sectionEmitLights[i] = new byte[2048];
                  System.arraycopy(emitLightArray.getData(), 0, sectionEmitLights[i], 0, 2048);
              }

--- a/patches/server/0953-improve-BanList-types.patch
+++ b/patches/server/0953-improve-BanList-types.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] improve BanList types
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 17a50b11da960a24bfea0ec780faf1718ca992d4..542ad1746c3a933688fa8c2384beda48718a22e6 100644
+index fd4417e2863fb028a1b22b4f5c00d585dd127ad1..16a736e8327450712630b1659b156da879a57352 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2219,6 +2219,21 @@ public final class CraftServer implements Server {
+@@ -2242,6 +2242,21 @@ public final class CraftServer implements Server {
          };
      }
  

--- a/patches/server/0956-Deprecate-ItemStack-setType.patch
+++ b/patches/server/0956-Deprecate-ItemStack-setType.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deprecate ItemStack#setType
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index f53d6587b2bab3ed8428338950795a62b356c694..ce224087345f49aca84ee94c76dac96dcf9a630f 100644
+index 520b637e0f281d3d3018681ec7b48b06c47f621e..7249ff939dfa786395595f687338315b779e0931 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -717,4 +717,24 @@ public final class CraftItemStack extends ItemStack {
+@@ -711,4 +711,24 @@ public final class CraftItemStack extends ItemStack {
      static boolean hasItemMeta(net.minecraft.world.item.ItemStack item) {
          return !(item == null || item.getComponentsPatch().isEmpty());
      }

--- a/patches/server/0958-More-Raid-API.patch
+++ b/patches/server/0958-More-Raid-API.patch
@@ -86,10 +86,10 @@ index b8ce1c1c2447f9cff1717bfcfd6eb911ade0d4b3..51f21af9d75769abdcba713b9aa33392
 +    // Paper end - more Raid API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4a62482b7c73728de8a94542e8978e836540b328..34f03dd227181a03fa90845067424a26382bab9b 100644
+index 2536a37ab9e5a7aa7373b1880f55cdb8c32a6f53..44ed6bd76fb9e81f6c0d99fe46173685dbbfe2a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2373,6 +2373,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2398,6 +2398,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (raid == null) ? null : new CraftRaid(raid);
      }
  

--- a/patches/server/0971-Rewrite-dataconverter-system.patch
+++ b/patches/server/0971-Rewrite-dataconverter-system.patch
@@ -28981,10 +28981,10 @@ index 1d287dd7379e56f7fd4b425880b850cd843f5789..8ab7ca373a885fbe658013c9c6a2e38d
              return nbttagcompound;
          });
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 1fabc9cf3bf7a05a2593f64eb3e41c21b5f4ee84..4788a591f40f506d81b10fd9f6ab68f308a68e23 100644
+index f6c33a9e2900890e4f6cb19784e01ff438cce83d..f99353a60e3f236735ef6e2e6f13381b50ae9b7b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -521,7 +521,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -522,7 +522,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
          net.minecraft.nbt.CompoundTag compound = deserializeNbtFromBytes(data);
          final int dataVersion = compound.getInt("DataVersion");
@@ -28993,7 +28993,7 @@ index 1fabc9cf3bf7a05a2593f64eb3e41c21b5f4ee84..4788a591f40f506d81b10fd9f6ab68f3
          return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.parse(MinecraftServer.getServer().registryAccess(), compound).orElseThrow());
      }
  
-@@ -542,7 +542,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -543,7 +543,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
          net.minecraft.nbt.CompoundTag compound = deserializeNbtFromBytes(data);
          int dataVersion = compound.getInt("DataVersion");

--- a/patches/server/0976-Rewrite-chunk-system.patch
+++ b/patches/server/0976-Rewrite-chunk-system.patch
@@ -14268,7 +14268,7 @@ index 0000000000000000000000000000000000000000..f7b0e2564ac4bd2db1d2b2bdc230c9f5
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/command/PaperCommand.java b/src/main/java/io/papermc/paper/command/PaperCommand.java
-index e47fb2aa5e885162cae5cbfc9f33ff7864bf538e..b68b37274f22c2a89d723aec4d1c6be813eef73c 100644
+index a3f43dccb796f30f6e9389e1ae182f06e9024e96..92bf78112c1cc75173e4e735bdeec9695fe10df6 100644
 --- a/src/main/java/io/papermc/paper/command/PaperCommand.java
 +++ b/src/main/java/io/papermc/paper/command/PaperCommand.java
 @@ -43,6 +43,7 @@ public final class PaperCommand extends Command {
@@ -14281,7 +14281,7 @@ index e47fb2aa5e885162cae5cbfc9f33ff7864bf538e..b68b37274f22c2a89d723aec4d1c6be8
              .flatMap(entry -> entry.getKey().stream().map(s -> Map.entry(s, entry.getValue())))
 diff --git a/src/main/java/io/papermc/paper/command/subcommands/ChunkDebugCommand.java b/src/main/java/io/papermc/paper/command/subcommands/ChunkDebugCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..962d3cae6340fc11607b59355e291629618f289c
+index 0000000000000000000000000000000000000000..61fa1ab0f6550fec2b9d035ea45c72627eb990d4
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/subcommands/ChunkDebugCommand.java
 @@ -0,0 +1,265 @@
@@ -14526,10 +14526,10 @@ index 0000000000000000000000000000000000000000..962d3cae6340fc11607b59355e291629
 +            return;
 +        }
 +
-+        final String debugType = args[0].toLowerCase(Locale.ENGLISH);
++        final String debugType = args[0].toLowerCase(Locale.ROOT);
 +        switch (debugType) {
 +            case "chunks" -> {
-+                if (args.length >= 2 && args[1].toLowerCase(Locale.ENGLISH).equals("help")) {
++                if (args.length >= 2 && args[1].toLowerCase(Locale.ROOT).equals("help")) {
 +                    sender.sendMessage(text("Use /paper debug chunks [world] to dump loaded chunk information to a file", RED));
 +                    break;
 +                }
@@ -15630,7 +15630,7 @@ index c33f85b570f159ab465b5a10a8044a81f2797f43..244a19ecd0234fa1d7a6ecfea2075159
                  DedicatedServer dedicatedserver1 = new DedicatedServer(optionset, worldLoader.get(), thread, convertable_conversionsession, resourcepackrepository, worldstem, dedicatedserversettings, DataFixers.getDataFixer(), services, LoggerChunkProgressListener::createFromGameruleRadius);
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 093a5d49d1a001b3ad5b4a880c60c0cb18874531..99e5b663b7cded44164b7b4e2ccb0f7a063b8bf9 100644
+index 1a9e323659dcff12ce53919eb3d6d6f66f835292..2e4f20ba5f6f61b797f1eef267302fa3314f94a5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -315,7 +315,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -15792,7 +15792,7 @@ index 093a5d49d1a001b3ad5b4a880c60c0cb18874531..99e5b663b7cded44164b7b4e2ccb0f7a
      public boolean isDebugging() {
          return false;
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 00679b76715fde4b90a999fd11cca40d048b1349..89c2c26afc5f06c4f57716cadbebabb8854f3635 100644
+index ea5ef39a814522f0abffd570e216d899833f588d..e365ed1be9739f57d0e1851f0593229dc1286796 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -473,7 +473,34 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -18056,7 +18056,7 @@ index 7a48ae2ba962ff56d0abff581b51f28b48bd9aae..ed5154e41ca858f4d6b4d1c276c66831
 +    */ // Paper - rewrite chunk system
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 2d9d4d06b75873f888ef4d8f5779a52706f821a8..f74efe41cd0da2f9749fc96fb9e0f7cf237ad1c6 100644
+index 0e89cf0742b9443f5256081987242554de24d893..802e9d266c01eaf8a83e78fe8dbe881e22e8b4d6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -71,7 +71,7 @@ public class ServerChunkCache extends ChunkSource {
@@ -21487,10 +21487,10 @@ index 47c2b2da9799690291396effb9e1b06d71efc6fd..2cdd18f724296f10cd4a522d1e819672
  
              for (SavedTick<T> savedTick : this.pendingTicks) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 7dae8d91b74cc7df0745f0c121e3bea09b8d0b6d..1e2530c9e5212b6d2bdbc94817beddb4247dac73 100644
+index 36a611d06131be00197c915871b8323544bb4972..bb22473df13f68ac3b45a9c000d1de7260e07792 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -115,7 +115,7 @@ public class CraftChunk implements Chunk {
+@@ -116,7 +116,7 @@ public class CraftChunk implements Chunk {
  
      @Override
      public boolean isEntitiesLoaded() {
@@ -21499,7 +21499,7 @@ index 7dae8d91b74cc7df0745f0c121e3bea09b8d0b6d..1e2530c9e5212b6d2bdbc94817beddb4
      }
  
      @Override
-@@ -124,51 +124,7 @@ public class CraftChunk implements Chunk {
+@@ -125,51 +125,7 @@ public class CraftChunk implements Chunk {
              this.getWorld().getChunkAt(this.x, this.z); // Transient load for this tick
          }
  
@@ -21553,10 +21553,10 @@ index 7dae8d91b74cc7df0745f0c121e3bea09b8d0b6d..1e2530c9e5212b6d2bdbc94817beddb4
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 542ad1746c3a933688fa8c2384beda48718a22e6..678d7dc846dd48b0e7054f31b967ba3a9016dcd9 100644
+index 16a736e8327450712630b1659b156da879a57352..0e30a227948464979e12c991b10bd00cf7320399 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1403,7 +1403,6 @@ public final class CraftServer implements Server {
+@@ -1426,7 +1426,6 @@ public final class CraftServer implements Server {
          // Paper - Put world into worldlist before initing the world; move up
  
          this.getServer().prepareLevels(internal.getChunkSource().chunkMap.progressListener, internal);
@@ -21564,7 +21564,7 @@ index 542ad1746c3a933688fa8c2384beda48718a22e6..678d7dc846dd48b0e7054f31b967ba3a
  
          this.pluginManager.callEvent(new WorldLoadEvent(internal.getWorld()));
          return internal.getWorld();
-@@ -1448,7 +1447,7 @@ public final class CraftServer implements Server {
+@@ -1471,7 +1470,7 @@ public final class CraftServer implements Server {
              }
  
              handle.getChunkSource().close(save);
@@ -21573,7 +21573,7 @@ index 542ad1746c3a933688fa8c2384beda48718a22e6..678d7dc846dd48b0e7054f31b967ba3a
              handle.convertable.close();
          } catch (Exception ex) {
              this.getLogger().log(Level.SEVERE, null, ex);
-@@ -2484,7 +2483,7 @@ public final class CraftServer implements Server {
+@@ -2507,7 +2506,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {
@@ -21583,7 +21583,7 @@ index 542ad1746c3a933688fa8c2384beda48718a22e6..678d7dc846dd48b0e7054f31b967ba3a
  
      // Paper start - Adventure
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4b6a04e47f5d4c071607516519098fab317dcf12..01fc74e6cc8ea8808b821583afb26309587dc003 100644
+index 7aee9f6b143c89cf8d65ca55eeda808152b4dd26..9c06c3729b09726e1da6ff8fb975cef2aeba9643 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -518,10 +518,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -21614,7 +21614,7 @@ index 4b6a04e47f5d4c071607516519098fab317dcf12..01fc74e6cc8ea8808b821583afb26309
  
          return true;
      }
-@@ -609,20 +612,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -634,20 +637,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public Collection<Plugin> getPluginChunkTickets(int x, int z) {
          DistanceManager chunkDistanceManager = this.world.getChunkSource().chunkMap.distanceManager;
@@ -21636,7 +21636,7 @@ index 4b6a04e47f5d4c071607516519098fab317dcf12..01fc74e6cc8ea8808b821583afb26309
      }
  
      @Override
-@@ -630,7 +620,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -655,7 +645,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Map<Plugin, ImmutableList.Builder<Chunk>> ret = new HashMap<>();
          DistanceManager chunkDistanceManager = this.world.getChunkSource().chunkMap.distanceManager;
  
@@ -21645,7 +21645,7 @@ index 4b6a04e47f5d4c071607516519098fab317dcf12..01fc74e6cc8ea8808b821583afb26309
              long chunkKey = chunkTickets.getLongKey();
              SortedArraySet<Ticket<?>> tickets = chunkTickets.getValue();
  
-@@ -1327,12 +1317,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1352,12 +1342,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public int getViewDistance() {
@@ -21660,7 +21660,7 @@ index 4b6a04e47f5d4c071607516519098fab317dcf12..01fc74e6cc8ea8808b821583afb26309
      }
  
      public BlockMetadataStore getBlockMetadata() {
-@@ -2495,17 +2485,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2520,17 +2510,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setSimulationDistance(final int simulationDistance) {
@@ -21685,10 +21685,10 @@ index 4b6a04e47f5d4c071607516519098fab317dcf12..01fc74e6cc8ea8808b821583afb26309
  
      // Paper start - implement pointers
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8016976d226a421b3e16d281fa3c01be2f8d3eb0..2d373be107a610522db9b3ce8ae446b848d92580 100644
+index 68a0b6b8650e9e80e8e8c4037d92389cae899d72..9aec6efef4094bbdb920101df1a7a5a2a6070dde 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3454,31 +3454,31 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3463,31 +3463,31 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public int getViewDistance() {

--- a/patches/server/0980-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
+++ b/patches/server/0980-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
@@ -26,10 +26,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 6c2e9654f853cb821f77e67dacf225ddb7f22271..5bc16477729412e6252384e0ea58699ee08f7313 100644
+index 958b25e62b040943c346114ef19d56104ae0a844..56351d5c2b4ea2c1b335253153cedafdf058d9ae 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3726,7 +3726,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3720,7 +3720,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  
              // Paper - diff on change - used in CraftLivingEntity#hasLineOfSight(Location) and CraftWorld#lineOfSightExists

--- a/patches/server/0983-Fix-World-isChunkGenerated-calls.patch
+++ b/patches/server/0983-Fix-World-isChunkGenerated-calls.patch
@@ -152,7 +152,7 @@ index c2838ae91b7f078369b63503df57a1eb5d2b0df5..c33640859aab837c85f3e860fe2241a0
                  // Paper start - don't write garbage data to disk if writing serialization fails
                  dataoutputstream.close(); // Only write if successful
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 01fc74e6cc8ea8808b821583afb26309587dc003..0ce0589204a01051aa1251d6af752eed4ac69c0f 100644
+index 9c06c3729b09726e1da6ff8fb975cef2aeba9643..8f50d893f8f9dea306756b640abd2373ee028a86 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -391,9 +391,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -181,7 +181,7 @@ index 01fc74e6cc8ea8808b821583afb26309587dc003..0ce0589204a01051aa1251d6af752eed
              throw new RuntimeException(ex);
          }
      }
-@@ -547,20 +561,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -572,20 +586,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          warnUnsafeChunk("loading a faraway chunk", x, z); // Paper

--- a/patches/server/0987-Anti-Xray.patch
+++ b/patches/server/0987-Anti-Xray.patch
@@ -1560,10 +1560,10 @@ index 5f85d8d82212f9a8133304dc05bf2cd39da1f9e7..ace99d55c8343fa1907545f47a03f069
      // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 1e2530c9e5212b6d2bdbc94817beddb4247dac73..82b4bd669c57b18fb0b443bcd94495023cd5a528 100644
+index bb22473df13f68ac3b45a9c000d1de7260e07792..92f1ea81b5e90529905d9c508aca18c31443ff6a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -55,7 +55,7 @@ public class CraftChunk implements Chunk {
+@@ -56,7 +56,7 @@ public class CraftChunk implements Chunk {
      private final ServerLevel worldServer;
      private final int x;
      private final int z;
@@ -1573,10 +1573,10 @@ index 1e2530c9e5212b6d2bdbc94817beddb4247dac73..82b4bd669c57b18fb0b443bcd9449502
      private static final byte[] EMPTY_LIGHT = new byte[2048];
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 678d7dc846dd48b0e7054f31b967ba3a9016dcd9..10c22c67e8469c736d48a8729ce7765b41b331d8 100644
+index 0e30a227948464979e12c991b10bd00cf7320399..3eea023d24c8e1b991f548632564508bfc565d8a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2655,7 +2655,7 @@ public final class CraftServer implements Server {
+@@ -2678,7 +2678,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Preconditions.checkArgument(world != null, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();
@@ -1586,7 +1586,7 @@ index 678d7dc846dd48b0e7054f31b967ba3a9016dcd9..10c22c67e8469c736d48a8729ce7765b
  
      // Paper start - Allow delegation to vanilla chunk gen
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0ce0589204a01051aa1251d6af752eed4ac69c0f..f2b20ed5063a293f0b464548f590d652170cd1d8 100644
+index 8f50d893f8f9dea306756b640abd2373ee028a86..6303760f10af17f1da1d92d6c4dc7dd6f5778f94 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -541,11 +541,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/1000-Improve-boat-collision-performance.patch
+++ b/patches/server/1000-Improve-boat-collision-performance.patch
@@ -17,7 +17,7 @@ index 2cd0a4dc4f0baa08bd7f5a053303bb63733f0bab..0bd367235f80c1f0d319a6aa5130d82a
      };
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 5bc16477729412e6252384e0ea58699ee08f7313..5161fdef2f0ebeb1943f30df5452875f09a45f32 100644
+index 56351d5c2b4ea2c1b335253153cedafdf058d9ae..9601d3def5e4ac0650bae42a1da2a64ab1e5aef7 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1459,7 +1459,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -29,7 +29,7 @@ index 5bc16477729412e6252384e0ea58699ee08f7313..5161fdef2f0ebeb1943f30df5452875f
                          LivingEntity entityliving = (LivingEntity) entity;
  
                          this.blockUsingShield(entityliving);
-@@ -1559,11 +1559,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1553,11 +1553,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  }
  
                  if (entity1 != null && !source.is(DamageTypeTags.NO_KNOCKBACK)) {
@@ -44,7 +44,7 @@ index 5bc16477729412e6252384e0ea58699ee08f7313..5161fdef2f0ebeb1943f30df5452875f
                          d0 = (Math.random() - Math.random()) * 0.01D;
                      }
  
-@@ -2330,7 +2331,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2324,7 +2325,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  this.hurtCurrentlyUsedShield((float) -event.getDamage(DamageModifier.BLOCKING));
                  Entity entity = damagesource.getDirectEntity();
  

--- a/patches/server/1014-Properly-resend-entities.patch
+++ b/patches/server/1014-Properly-resend-entities.patch
@@ -166,10 +166,10 @@ index 9153c15cd2b8a3811d5f1c16ac2221aea7c3aacd..7ef9f67d27cc240191dd5d07e8dcf5fb
      public boolean equals(Object object) {
          return object instanceof Entity ? ((Entity) object).id == this.id : false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 5161fdef2f0ebeb1943f30df5452875f09a45f32..8ffbc96af09288d6a81ff597a205df0f2d59bf43 100644
+index 9601d3def5e4ac0650bae42a1da2a64ab1e5aef7..81a8296e25275639718e0839888ac6a900b54bf3 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3824,6 +3824,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3818,6 +3818,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 2) > 0 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
      }
  

--- a/patches/server/1019-Lag-compensation-ticks.patch
+++ b/patches/server/1019-Lag-compensation-ticks.patch
@@ -63,10 +63,10 @@ index c7efde4e2b87b14e768429748b01c1bce659682b..1047027610624c9ba4bb5afd5d7f0714
  
          if (this.hasDelayedDestroy) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8ffbc96af09288d6a81ff597a205df0f2d59bf43..f26f05f8ab0d60c3a3668db63a01cc16a947a4b2 100644
+index 81a8296e25275639718e0839888ac6a900b54bf3..4928dc3c879ddad0fe8c377b1b26e543a1c40cca 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3829,6 +3829,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3823,6 +3823,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
          this.resendPossiblyDesyncedDataValues(java.util.List.of(DATA_LIVING_ENTITY_FLAGS), serverPlayer);
      }
      // Paper end - Properly cancel usable items
@@ -77,7 +77,7 @@ index 8ffbc96af09288d6a81ff597a205df0f2d59bf43..f26f05f8ab0d60c3a3668db63a01cc16
      private void updatingUsingItem() {
          if (this.isUsingItem()) {
              if (ItemStack.isSameItem(this.getItemInHand(this.getUsedItemHand()), this.useItem)) {
-@@ -3847,7 +3851,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3841,7 +3845,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.triggerItemUseEffects(stack, 5);
          }
  
@@ -91,7 +91,7 @@ index 8ffbc96af09288d6a81ff597a205df0f2d59bf43..f26f05f8ab0d60c3a3668db63a01cc16
              this.completeUsingItem();
          }
  
-@@ -3893,7 +3902,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3887,7 +3896,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
          if (!itemstack.isEmpty() && !this.isUsingItem() || forceUpdate) { // Paper - Prevent consuming the wrong itemstack
              this.useItem = itemstack;
@@ -103,7 +103,7 @@ index 8ffbc96af09288d6a81ff597a205df0f2d59bf43..f26f05f8ab0d60c3a3668db63a01cc16
              if (!this.level().isClientSide) {
                  this.setLivingEntityFlag(1, true);
                  this.setLivingEntityFlag(2, hand == InteractionHand.OFF_HAND);
-@@ -3918,7 +3930,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3912,7 +3924,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  }
              } else if (!this.isUsingItem() && !this.useItem.isEmpty()) {
                  this.useItem = ItemStack.EMPTY;
@@ -115,7 +115,7 @@ index 8ffbc96af09288d6a81ff597a205df0f2d59bf43..f26f05f8ab0d60c3a3668db63a01cc16
              }
          }
  
-@@ -4053,7 +4068,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4047,7 +4062,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
          }
  
          this.useItem = ItemStack.EMPTY;

--- a/patches/server/1024-API-for-checking-sent-chunks.patch
+++ b/patches/server/1024-API-for-checking-sent-chunks.patch
@@ -21,10 +21,10 @@ index ee58c67cb2bd78159cce19ec75f13dc6168a0e7a..149cfb0587299f72fcfddf395fb71b70
  
      // TODO rebase into util patch
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2d373be107a610522db9b3ce8ae446b848d92580..84ed5dc8c82e28aa93fa0440d90ddb44dc5f3d40 100644
+index 9aec6efef4094bbdb920101df1a7a5a2a6070dde..815bcfd90218b932ca004c0f18db8b4de5d35c19 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3446,6 +3446,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3455,6 +3455,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/1026-Deep-clone-nbt-tags-in-PDC.patch
+++ b/patches/server/1026-Deep-clone-nbt-tags-in-PDC.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deep clone nbt tags in PDC
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index d90876888c2dedbdedd63cff932f48da286c8172..eba1c67abc2ace5913ab3ae8d732f8c68fd0f683 100644
+index e3ac829ae4f2b39c103e5626180ec9220c2b1f33..2b131cc6f511416d4c8964848caff373a9c6325d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -298,7 +298,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -307,7 +307,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.damage = meta.damage;
          this.maxDamage = meta.maxDamage;
          this.unhandledTags = meta.unhandledTags;
@@ -17,7 +17,7 @@ index d90876888c2dedbdedd63cff932f48da286c8172..eba1c67abc2ace5913ab3ae8d732f8c6
  
          this.customTag = meta.customTag;
  
-@@ -1563,7 +1563,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1601,7 +1601,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              if (this.customTag != null) {
                  clone.customTag = this.customTag.copy();
              }

--- a/patches/server/1028-Fix-shield-disable-inconsistency.patch
+++ b/patches/server/1028-Fix-shield-disable-inconsistency.patch
@@ -8,10 +8,10 @@ it will not disable the shield if the attacker is holding
 an axe item.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f26f05f8ab0d60c3a3668db63a01cc16a947a4b2..3276ea59999e76c2a2b0c82b96e0e91865e96a98 100644
+index 4928dc3c879ddad0fe8c377b1b26e543a1c40cca..6118de380a95b0c927a239ac3e288780f114289e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2331,7 +2331,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2325,7 +2325,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  this.hurtCurrentlyUsedShield((float) -event.getDamage(DamageModifier.BLOCKING));
                  Entity entity = damagesource.getDirectEntity();
  

--- a/patches/server/1030-Don-t-lose-removed-data-components-in-ItemMeta.patch
+++ b/patches/server/1030-Don-t-lose-removed-data-components-in-ItemMeta.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't lose removed data components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index eba1c67abc2ace5913ab3ae8d732f8c68fd0f683..eb9ba1a161f4feade220507a602086bc9d6ce03f 100644
+index 2b131cc6f511416d4c8964848caff373a9c6325d..b525bfbab2c4a5ea408981287f477a8b35d699ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -188,6 +188,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -191,6 +191,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              return this;
          }
  
@@ -22,7 +22,7 @@ index eba1c67abc2ace5913ab3ae8d732f8c68fd0f683..eb9ba1a161f4feade220507a602086bc
          DataComponentPatch build() {
              return this.builder.build();
          }
-@@ -398,7 +405,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -410,7 +417,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
          Set<Map.Entry<DataComponentType<?>, Optional<?>>> keys = tag.entrySet();
          for (Map.Entry<DataComponentType<?>, Optional<?>> key : keys) {
@@ -33,7 +33,7 @@ index eba1c67abc2ace5913ab3ae8d732f8c68fd0f683..eb9ba1a161f4feade220507a602086bc
                  key.getValue().ifPresentOrElse((value) -> {
                      this.unhandledTags.set((DataComponentType) key.getKey(), value);
                  }, () -> {
-@@ -788,9 +797,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -809,9 +818,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
  
          for (Map.Entry<DataComponentType<?>, Optional<?>> e : this.unhandledTags.build().entrySet()) {

--- a/patches/server/1033-Fix-ItemFlags.patch
+++ b/patches/server/1033-Fix-ItemFlags.patch
@@ -33,10 +33,10 @@ index fca0cfba14dd2cc6f24b56eaf269594b2d87fd04..8734f0b777432cd8639094b75a3da1b9
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index eb9ba1a161f4feade220507a602086bc9d6ce03f..2caa968b3fea322d1cb3210d2dfa7bc844961189 100644
+index b525bfbab2c4a5ea408981287f477a8b35d699ca..43a4a76d3829fb2ed7b5635d804fd826484c16db 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -238,6 +238,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -243,6 +243,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      static final ItemMetaKeyType<Unit> HIDE_ADDITIONAL_TOOLTIP = new ItemMetaKeyType(DataComponents.HIDE_ADDITIONAL_TOOLTIP);
      @Specific(Specific.To.NBT)
      static final ItemMetaKeyType<CustomData> CUSTOM_DATA = new ItemMetaKeyType<>(DataComponents.CUSTOM_DATA);
@@ -49,7 +49,7 @@ index eb9ba1a161f4feade220507a602086bc9d6ce03f..2caa968b3fea322d1cb3210d2dfa7bc8
  
      // We store the raw original JSON representation of all text data. See SPIGOT-5063, SPIGOT-5656, SPIGOT-5304
      private Component displayName;
-@@ -310,6 +316,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -319,6 +325,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.customTag = meta.customTag;
  
          this.version = meta.version;
@@ -60,7 +60,7 @@ index eb9ba1a161f4feade220507a602086bc9d6ce03f..2caa968b3fea322d1cb3210d2dfa7bc8
      }
  
      CraftMetaItem(DataComponentPatch tag) {
-@@ -402,6 +412,20 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -414,6 +424,20 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  this.customTag = null;
              }
          });
@@ -81,12 +81,8 @@ index eb9ba1a161f4feade220507a602086bc9d6ce03f..2caa968b3fea322d1cb3210d2dfa7bc8
  
          Set<Map.Entry<DataComponentType<?>, Optional<?>>> keys = tag.entrySet();
          for (Map.Entry<DataComponentType<?>, Optional<?>> key : keys) {
-@@ -583,10 +607,19 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
- 
-         String unhandled = SerializableMeta.getString(map, "unhandled", true);
-         if (unhandled != null) {
--            ByteArrayInputStream buf = new ByteArrayInputStream(Base64.getDecoder().decode(internal));
-+            ByteArrayInputStream buf = new ByteArrayInputStream(Base64.getDecoder().decode(unhandled)); // Paper - fix deserializing unhandled tags
+@@ -603,7 +627,16 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+             ByteArrayInputStream buf = new ByteArrayInputStream(Base64.getDecoder().decode(unhandled));
              try {
                  CompoundTag unhandledTag = NbtIo.readCompressed(buf, NbtAccounter.unlimitedHeap());
 -                this.unhandledTags.copy(DataComponentPatch.CODEC.parse(MinecraftServer.getDefaultRegistryAccess().createSerializationContext(NbtOps.INSTANCE), unhandledTag).result().get());
@@ -103,7 +99,7 @@ index eb9ba1a161f4feade220507a602086bc9d6ce03f..2caa968b3fea322d1cb3210d2dfa7bc8
              } catch (IOException ex) {
                  Logger.getLogger(CraftMetaItem.class.getName()).log(Level.SEVERE, null, ex);
              }
-@@ -796,6 +829,15 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -817,6 +850,15 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              itemTag.put(CraftMetaItem.MAX_DAMAGE, this.maxDamage);
          }
  
@@ -119,17 +115,17 @@ index eb9ba1a161f4feade220507a602086bc9d6ce03f..2caa968b3fea322d1cb3210d2dfa7bc8
          for (Map.Entry<DataComponentType<?>, Optional<?>> e : this.unhandledTags.build().entrySet()) {
              e.getValue().ifPresentOrElse((value) -> {
                  itemTag.builder.set((DataComponentType) e.getKey(), value);
-@@ -870,7 +912,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -891,7 +933,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Overridden
      boolean isEmpty() {
--        return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasDamage() || this.hasMaxDamage() || this.hasAttributeModifiers() || this.customTag != null);
-+        return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasDamage() || this.hasMaxDamage() || this.hasAttributeModifiers() || this.customTag != null || this.canPlaceOnPredicates != null || this.canBreakPredicates != null); // Paper
+-        return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasTool() || this.hasDamage() || this.hasMaxDamage() || this.hasAttributeModifiers() || this.customTag != null);
++        return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasTool() || this.hasDamage() || this.hasMaxDamage() || this.hasAttributeModifiers() || this.customTag != null || this.canPlaceOnPredicates != null || this.canBreakPredicates != null); // Paper
      }
  
      // Paper start
-@@ -1507,6 +1549,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
-                 && (this.hasFood() ? that.hasFood() && this.food.equals(that.food) : !that.hasFood())
+@@ -1544,6 +1586,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+                 && (this.hasTool() ? that.hasTool() && this.tool.equals(that.tool) : !that.hasTool())
                  && (this.hasDamage() ? that.hasDamage() && this.damage == that.damage : !that.hasDamage())
                  && (this.hasMaxDamage() ? that.hasMaxDamage() && this.maxDamage.equals(that.maxDamage) : !that.hasMaxDamage())
 +                && (this.canPlaceOnPredicates != null ? that.canPlaceOnPredicates != null && this.canPlaceOnPredicates.equals(that.canPlaceOnPredicates) : that.canPlaceOnPredicates == null) // Paper
@@ -137,7 +133,7 @@ index eb9ba1a161f4feade220507a602086bc9d6ce03f..2caa968b3fea322d1cb3210d2dfa7bc8
                  && (this.version == that.version);
      }
  
-@@ -1549,6 +1593,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1587,6 +1631,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          hash = 61 * hash + (this.hasDamage() ? this.damage : 0);
          hash = 61 * hash + (this.hasMaxDamage() ? 1231 : 1237);
          hash = 61 * hash + (this.hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
@@ -146,7 +142,7 @@ index eb9ba1a161f4feade220507a602086bc9d6ce03f..2caa968b3fea322d1cb3210d2dfa7bc8
          hash = 61 * hash + this.version;
          return hash;
      }
-@@ -1586,6 +1632,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1627,6 +1673,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.damage = this.damage;
              clone.maxDamage = this.maxDamage;
              clone.version = this.version;
@@ -161,7 +157,7 @@ index eb9ba1a161f4feade220507a602086bc9d6ce03f..2caa968b3fea322d1cb3210d2dfa7bc8
              return clone;
          } catch (CloneNotSupportedException e) {
              throw new Error(e);
-@@ -1695,6 +1749,16 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1740,6 +1794,16 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              }
          }
  
@@ -178,7 +174,7 @@ index eb9ba1a161f4feade220507a602086bc9d6ce03f..2caa968b3fea322d1cb3210d2dfa7bc8
          if (!this.unhandledTags.isEmpty()) {
              Tag unhandled = DataComponentPatch.CODEC.encodeStart(MinecraftServer.getDefaultRegistryAccess().createSerializationContext(NbtOps.INSTANCE), this.unhandledTags.build()).getOrThrow(IllegalStateException::new);
              try {
-@@ -1705,6 +1769,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1750,6 +1814,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  Logger.getLogger(CraftMetaItem.class.getName()).log(Level.SEVERE, null, ex);
              }
          }
@@ -193,7 +189,7 @@ index eb9ba1a161f4feade220507a602086bc9d6ce03f..2caa968b3fea322d1cb3210d2dfa7bc8
  
          if (!this.persistentDataContainer.isEmpty()) { // Store custom tags, wrapped in their compound
              builder.put(CraftMetaItem.BUKKIT_CUSTOM_TAG.BUKKIT, this.persistentDataContainer.serialize());
-@@ -1846,6 +1918,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1888,6 +1960,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaItem.MAX_DAMAGE.TYPE,
                          CraftMetaItem.CUSTOM_DATA.TYPE,
                          CraftMetaItem.ATTRIBUTES.TYPE,

--- a/patches/server/1035-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
+++ b/patches/server/1035-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Revert to vanilla handling of LivingEntity#actuallyHurt
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3276ea59999e76c2a2b0c82b96e0e91865e96a98..6b447cdf5b14deb26e0454f9f731724c89f2d498 100644
+index 6118de380a95b0c927a239ac3e288780f114289e..d0b6ade676d94e768c92432dc6cee9f200acf5f2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2216,7 +2216,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2210,7 +2210,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      // CraftBukkit start
@@ -17,11 +17,11 @@ index 3276ea59999e76c2a2b0c82b96e0e91865e96a98..6b447cdf5b14deb26e0454f9f731724c
         if (!this.isInvulnerableTo(damagesource)) {
              final boolean human = this instanceof net.minecraft.world.entity.player.Player;
              float originalDamage = f;
-@@ -2388,12 +2388,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2382,12 +2382,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
                      return true;
                  } else {
--                    return originalDamage >= 0;
+-                    return originalDamage > 0;
 +                    return true; // Paper - return false ONLY if event was cancelled
                  }
                  // CraftBukkit end

--- a/patches/server/1036-improve-checking-handled-tags-in-itemmeta.patch
+++ b/patches/server/1036-improve-checking-handled-tags-in-itemmeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] improve checking handled tags in itemmeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index ce224087345f49aca84ee94c76dac96dcf9a630f..3e552a859846d206ba79c3ee740ae76a37ee7606 100644
+index 7249ff939dfa786395595f687338315b779e0931..c0bf7efac56e558052992d2ce2455fccff4d9897 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -156,10 +156,11 @@ public final class CraftItemStack extends ItemStack {
@@ -404,10 +404,10 @@ index b444bd26d6c3def3494d3cc0520e462408272be3..8e0dd4b7a7a25a8beb27b507047bc48d
          getOrEmpty(tag, CraftMetaFirework.FIREWORKS).ifPresent((fireworks) -> {
              this.power = fireworks.flightDuration();
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 2caa968b3fea322d1cb3210d2dfa7bc844961189..12a193db7475870e5107c86c7611bb4b92feacb8 100644
+index 43a4a76d3829fb2ed7b5635d804fd826484c16db..5d86861a0df7308ae9b8440e5d9136fa7c8f1835 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -322,7 +322,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -331,7 +331,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          // Paper end
      }
  
@@ -416,7 +416,7 @@ index 2caa968b3fea322d1cb3210d2dfa7bc844961189..12a193db7475870e5107c86c7611bb4b
          CraftMetaItem.getOrEmpty(tag, CraftMetaItem.NAME).ifPresent((component) -> {
              this.displayName = component;
          });
-@@ -427,11 +427,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -439,11 +439,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          });
          // Paper end - fix ItemFlags
  
@@ -436,7 +436,7 @@ index 2caa968b3fea322d1cb3210d2dfa7bc844961189..12a193db7475870e5107c86c7611bb4b
                  key.getValue().ifPresentOrElse((value) -> {
                      this.unhandledTags.set((DataComponentType) key.getKey(), value);
                  }, () -> {
-@@ -1895,65 +1902,73 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1936,67 +1943,74 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.version = version;
      }
  
@@ -459,6 +459,7 @@ index 2caa968b3fea322d1cb3210d2dfa7bc844961189..12a193db7475870e5107c86c7611bb4b
 -                        CraftMetaItem.MAX_STACK_SIZE.TYPE,
 -                        CraftMetaItem.RARITY.TYPE,
 -                        CraftMetaItem.FOOD.TYPE,
+-                        CraftMetaItem.TOOL.TYPE,
 -                        CraftMetaItem.DAMAGE.TYPE,
 -                        CraftMetaItem.MAX_DAMAGE.TYPE,
 -                        CraftMetaItem.CUSTOM_DATA.TYPE,
@@ -475,6 +476,7 @@ index 2caa968b3fea322d1cb3210d2dfa7bc844961189..12a193db7475870e5107c86c7611bb4b
 -                        CraftMetaMap.MAP_ID.TYPE,
 -                        CraftMetaPotion.POTION_CONTENTS.TYPE,
 -                        CraftMetaSkull.SKULL_PROFILE.TYPE,
+-                        CraftMetaSkull.NOTE_BLOCK_SOUND.TYPE,
 -                        CraftMetaSpawnEgg.ENTITY_TAG.TYPE,
 -                        CraftMetaBlockState.BLOCK_ENTITY_TAG.TYPE,
 -                        CraftMetaBook.BOOK_CONTENT.TYPE,
@@ -516,6 +518,7 @@ index 2caa968b3fea322d1cb3210d2dfa7bc844961189..12a193db7475870e5107c86c7611bb4b
 +        CraftMetaItem.MAX_STACK_SIZE.TYPE,
 +        CraftMetaItem.RARITY.TYPE,
 +        CraftMetaItem.FOOD.TYPE,
++        CraftMetaItem.TOOL.TYPE,
 +        CraftMetaItem.DAMAGE.TYPE,
 +        CraftMetaItem.MAX_DAMAGE.TYPE,
 +        CraftMetaItem.CUSTOM_DATA.TYPE,
@@ -658,7 +661,7 @@ index e2aa305dcaf94d76fa3b74fc33b4d8bbc6d92b2b..db7f71af22d904de08d4badaa7f66d12
              potionContents.potion().ifPresent((potion) -> {
                  this.type = CraftPotionType.minecraftHolderToBukkit(potion);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index 0f725408691384800abb2cc7a43d9e1c75c9a17e..c769d2a210060f6829a6cbe739d6d9ab2f602644 100644
+index a08c57770c658bb289c96b69b966d98af72eef67..7bdc94c3ba7d8a0d74c2d88edbb32112a90c5980 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 @@ -69,8 +69,8 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
@@ -673,11 +676,11 @@ index 0f725408691384800abb2cc7a43d9e1c75c9a17e..c769d2a210060f6829a6cbe739d6d9ab
          getOrEmpty(tag, CraftMetaSkull.SKULL_PROFILE).ifPresent((resolvableProfile) -> {
              this.setProfile(resolvableProfile.gameProfile());
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
-index 726438237093abc85d9239f9c84be3df6d8318c4..a3c1a8c469630464ac80b7786731462046134998 100644
+index 1c2b0407b51906a255e6d240fab969578743938e..b98e656c0bb382667bd186a500c5505f1ed3f7cd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
-@@ -125,8 +125,8 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
-         this.updateMaterial(null); // Trigger type population
+@@ -119,8 +119,8 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
+         this.entityTag = egg.entityTag;
      }
  
 -    CraftMetaSpawnEgg(DataComponentPatch tag) {
@@ -718,10 +721,10 @@ index 911bdce0795a6b11cd1d5ad5211202456e5225d4..b5392a3a6f6f3d0a54549e6bb93f2859
          getOrEmpty(tag, CraftMetaTropicalFishBucket.ENTITY_TAG).ifPresent((nbt) -> {
              this.entityTag = nbt.copyTag();
 diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java
-index 100e9b72b1dac2deb956753b9a8097ba917236fa..0b11d5ea89539decd2f6c60c5b581bbd78ff1fd6 100644
+index 51e2acf125bdff2ba6d8fd8af9f22e233d7c74a7..6bed0a5c8d9f1ca72678cdf4699128e441a24541 100644
 --- a/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java
 +++ b/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java
-@@ -95,7 +95,7 @@ public class DeprecatedItemMetaCustomValueTest extends AbstractTestingBase {
+@@ -96,7 +96,7 @@ public class DeprecatedItemMetaCustomValueTest extends AbstractTestingBase {
          CraftMetaItem.Applicator compound = new CraftMetaItem.Applicator();
          itemMeta.applyToItem(compound);
  
@@ -769,10 +772,10 @@ index 0000000000000000000000000000000000000000..d9692972e3ad089885d43711b6a7fb3e
 +    }
 +}
 diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java
-index 217331448adfa11c1724fe2b54c318547aa30255..f3939074a886b20f17b00dd3c39833725f47d3f0 100644
+index 30da18cbc878fb1ac2a134f3bcbfcb8d7bec3938..6f94c7a19f2f598a836ec7db30332dd95f8675a6 100644
 --- a/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java
 +++ b/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java
-@@ -129,7 +129,7 @@ public class PersistentDataContainerTest extends AbstractTestingBase {
+@@ -130,7 +130,7 @@ public class PersistentDataContainerTest extends AbstractTestingBase {
          CraftMetaItem.Applicator compound = new CraftMetaItem.Applicator();
          itemMeta.applyToItem(compound);
  
@@ -781,7 +784,7 @@ index 217331448adfa11c1724fe2b54c318547aa30255..f3939074a886b20f17b00dd3c3983372
      }
  
      @Test
-@@ -462,7 +462,7 @@ public class PersistentDataContainerTest extends AbstractTestingBase {
+@@ -463,7 +463,7 @@ public class PersistentDataContainerTest extends AbstractTestingBase {
  
      @Test
      public void testEmptyListApplicationToAnyType() throws IOException {
@@ -790,7 +793,7 @@ index 217331448adfa11c1724fe2b54c318547aa30255..f3939074a886b20f17b00dd3c3983372
          final PersistentDataContainer container = craftItem.getPersistentDataContainer();
  
          container.set(PersistentDataContainerTest.requestKey("list"), PersistentDataType.LIST.strings(), List.of());
-@@ -475,7 +475,7 @@ public class PersistentDataContainerTest extends AbstractTestingBase {
+@@ -476,7 +476,7 @@ public class PersistentDataContainerTest extends AbstractTestingBase {
          final CraftMetaItem.Applicator storage = new CraftMetaItem.Applicator();
          craftItem.applyToItem(storage);
  

--- a/patches/server/1037-General-ItemMeta-fixes.patch
+++ b/patches/server/1037-General-ItemMeta-fixes.patch
@@ -10,18 +10,9 @@ public org/bukkit/craftbukkit/block/CraftBlockStates getBlockState(Lorg/bukkit/W
 public net/minecraft/world/level/block/entity/BlockEntity saveId(Lnet/minecraft/nbt/CompoundTag;)V
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 86dcad62f59f68d2eefe2d5df1cdaee0955dc6e3..1bd673336f13f12a875210acd23bd8496b5773ae 100644
+index 066feef97f92b3f788dd6d25d188f2cc36fc4c80..7c7b9b1e0b604b0164b431873e6753b60421f970 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -414,7 +414,7 @@ public final class ItemStack implements DataComponentHolder {
-             } finally {
-                 world.captureBlockStates = false;
-             }
--            DataComponentPatch newData = this.getComponentsPatch();
-+            DataComponentPatch newData = this.components.asPatch(); // Paper - Directly access components as patch instead of getComponentsPatch as said method yields EMPTY on items with count 0
-             int newCount = this.getCount();
-             this.setCount(oldCount);
-             this.restorePatch(oldData);
 @@ -1258,6 +1258,11 @@ public final class ItemStack implements DataComponentHolder {
      public void setItem(Item item) {
          this.bukkitStack = null; // Paper
@@ -75,7 +66,7 @@ index 397eb1a101bd60f49dbb2fa8eddf28f6f233167f..2c61e8d5bbab59c691f4cb003041e7e5
      protected void load(T tileEntity) {
          if (tileEntity != null && tileEntity != this.snapshot) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 3e552a859846d206ba79c3ee740ae76a37ee7606..f1e1953f2dc65dc615b7b7b648c37b195d3b4c25 100644
+index c0bf7efac56e558052992d2ce2455fccff4d9897..3eb650bcb60f23ce0ac0f856526b4bd131cb7a20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -328,7 +328,14 @@ public final class CraftItemStack extends ItemStack {
@@ -94,8 +85,8 @@ index 3e552a859846d206ba79c3ee740ae76a37ee7606..f1e1953f2dc65dc615b7b7b648c37b19
          ((CraftMetaItem) itemMeta).applyToItem(tag);
          itemStack.applyComponents(tag.build());
      }
-@@ -689,15 +696,20 @@ public final class CraftItemStack extends ItemStack {
-         }
+@@ -683,15 +690,20 @@ public final class CraftItemStack extends ItemStack {
+         if (itemMeta == null) return true;
  
          if (!((CraftMetaItem) itemMeta).isEmpty()) {
 -            CraftMetaItem.Applicator tag = new CraftMetaItem.Applicator();
@@ -839,10 +830,10 @@ index 8e0dd4b7a7a25a8beb27b507047bc48d8227627c..77489c3ffaa3a72d4cf105499a77150f
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd501ffd67c 100644
+index 705d7365a7bab9fe29b90a175040e6a1623e21a7..8ccb8d71ee489891e8d9128a5520675dd3a62786 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -172,9 +172,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -175,9 +175,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -855,7 +846,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
  
          <T> Applicator put(ItemMetaKeyType<T> key, T value) {
              this.builder.set(key.TYPE, value);
-@@ -293,7 +294,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -299,7 +300,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              this.enchantments = new EnchantmentMap(meta.enchantments); // Paper
          }
  
@@ -864,7 +855,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
              this.attributeModifiers = LinkedHashMultimap.create(meta.attributeModifiers);
          }
  
-@@ -323,6 +324,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -332,6 +333,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
  
      CraftMetaItem(DataComponentPatch tag, Set<DataComponentType<?>> extraHandledTags) { // Paper - improve handled tags on type changes
@@ -876,7 +867,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          CraftMetaItem.getOrEmpty(tag, CraftMetaItem.NAME).ifPresent((component) -> {
              this.displayName = component;
          });
-@@ -733,7 +739,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -750,7 +756,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          Map<?, ?> mods = SerializableMeta.getObject(Map.class, map, key.BUKKIT, true);
          Multimap<Attribute, AttributeModifier> result = LinkedHashMultimap.create();
          if (mods == null) {
@@ -885,7 +876,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          }
  
          for (Object obj : mods.keySet()) {
-@@ -887,10 +893,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -908,10 +914,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
  
      void applyModifiers(Multimap<Attribute, AttributeModifier> modifiers, CraftMetaItem.Applicator tag) {
@@ -898,16 +889,16 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
              return;
          }
  
-@@ -919,7 +923,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -940,7 +944,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Overridden
      boolean isEmpty() {
--        return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasDamage() || this.hasMaxDamage() || this.hasAttributeModifiers() || this.customTag != null || this.canPlaceOnPredicates != null || this.canBreakPredicates != null); // Paper
-+        return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasDamage() || this.hasMaxDamage() || this.attributeModifiers != null || this.customTag != null || this.canPlaceOnPredicates != null || this.canBreakPredicates != null); // Paper
+-        return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasTool() || this.hasDamage() || this.hasMaxDamage() || this.hasAttributeModifiers() || this.customTag != null || this.canPlaceOnPredicates != null || this.canBreakPredicates != null); // Paper
++        return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasTool() || this.hasDamage() || this.hasMaxDamage() || this.attributeModifiers != null || this.customTag != null || this.canPlaceOnPredicates != null || this.canBreakPredicates != null); // Paper
      }
  
      // Paper start
-@@ -1015,6 +1019,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1036,6 +1040,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public void lore(final List<? extends net.kyori.adventure.text.Component> lore) {
@@ -915,7 +906,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          this.lore = lore != null ? io.papermc.paper.adventure.PaperAdventure.asVanilla(lore) : null;
      }
      // Paper end
-@@ -1139,6 +1144,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1160,6 +1165,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      // Paper end
      @Override
      public void setLore(List<String> lore) {
@@ -923,7 +914,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          if (lore == null || lore.isEmpty()) {
              this.lore = null;
          } else {
-@@ -1154,6 +1160,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1175,6 +1181,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      // Paper start
      @Override
      public void setLoreComponents(List<net.md_5.bungee.api.chat.BaseComponent[]> lore) {
@@ -931,7 +922,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          if (lore == null) {
              this.lore = null;
          } else {
-@@ -1295,7 +1302,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1316,7 +1323,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public FoodComponent getFood() {
@@ -940,7 +931,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
      }
  
      @Override
-@@ -1321,7 +1328,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1357,7 +1364,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public Multimap<Attribute, AttributeModifier> getAttributeModifiers(@Nullable EquipmentSlot slot) {
@@ -949,7 +940,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          SetMultimap<Attribute, AttributeModifier> result = LinkedHashMultimap.create();
          for (Map.Entry<Attribute, AttributeModifier> entry : this.attributeModifiers.entries()) {
              if (entry.getValue().getSlot() == null || entry.getValue().getSlot() == slot) {
-@@ -1334,6 +1341,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1370,6 +1377,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      @Override
      public Collection<AttributeModifier> getAttributeModifiers(@Nonnull Attribute attribute) {
          Preconditions.checkNotNull(attribute, "Attribute cannot be null");
@@ -957,7 +948,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          return this.attributeModifiers.containsKey(attribute) ? ImmutableList.copyOf(this.attributeModifiers.get(attribute)) : null;
      }
  
-@@ -1341,10 +1349,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1377,10 +1385,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      public boolean addAttributeModifier(@Nonnull Attribute attribute, @Nonnull AttributeModifier modifier) {
          Preconditions.checkNotNull(attribute, "Attribute cannot be null");
          Preconditions.checkNotNull(modifier, "AttributeModifier cannot be null");
@@ -971,7 +962,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          return this.attributeModifiers.put(attribute, modifier);
      }
  
-@@ -1355,8 +1365,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1391,8 +1401,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              return;
          }
  
@@ -985,7 +976,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
  
          Iterator<Map.Entry<Attribute, AttributeModifier>> iterator = attributeModifiers.entries().iterator();
          while (iterator.hasNext()) {
-@@ -1366,6 +1379,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1402,6 +1415,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  iterator.remove();
                  continue;
              }
@@ -993,7 +984,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
              this.attributeModifiers.put(next.getKey(), next.getValue());
          }
      }
-@@ -1373,13 +1387,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1409,13 +1423,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      @Override
      public boolean removeAttributeModifier(@Nonnull Attribute attribute) {
          Preconditions.checkNotNull(attribute, "Attribute cannot be null");
@@ -1009,7 +1000,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          int removed = 0;
          Iterator<Map.Entry<Attribute, AttributeModifier>> iter = this.attributeModifiers.entries().iterator();
  
-@@ -1399,7 +1413,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1435,7 +1449,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      public boolean removeAttributeModifier(@Nonnull Attribute attribute, @Nonnull AttributeModifier modifier) {
          Preconditions.checkNotNull(attribute, "Attribute cannot be null");
          Preconditions.checkNotNull(modifier, "AttributeModifier cannot be null");
@@ -1018,7 +1009,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          int removed = 0;
          Iterator<Map.Entry<Attribute, AttributeModifier>> iter = this.attributeModifiers.entries().iterator();
  
-@@ -1421,7 +1435,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1457,7 +1471,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public String getAsString() {
@@ -1027,7 +1018,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          this.applyToItem(tag);
          DataComponentPatch patch = tag.build();
          Tag nbt = DataComponentPatch.CODEC.encodeStart(MinecraftServer.getDefaultRegistryAccess().createSerializationContext(NbtOps.INSTANCE), patch).getOrThrow();
-@@ -1430,7 +1444,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1466,7 +1480,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public String getAsComponentString() {
@@ -1036,7 +1027,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          this.applyToItem(tag);
          DataComponentPatch patch = tag.build();
  
-@@ -1470,6 +1484,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1506,6 +1520,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          if (first == null || second == null) {
              return false;
          }
@@ -1044,7 +1035,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          for (Map.Entry<Attribute, AttributeModifier> entry : first.entries()) {
              if (!second.containsEntry(entry.getKey(), entry.getValue())) {
                  return false;
-@@ -1495,6 +1510,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1531,6 +1546,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public void setDamage(int damage) {
@@ -1053,7 +1044,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          this.damage = damage;
      }
  
-@@ -1511,6 +1528,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1547,6 +1564,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public void setMaxDamage(Integer maxDamage) {
@@ -1061,7 +1052,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          this.maxDamage = maxDamage;
      }
  
-@@ -1542,7 +1560,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1578,7 +1596,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hasCustomModelData() ? that.hasCustomModelData() && this.customModelData.equals(that.customModelData) : !that.hasCustomModelData())
                  && (this.hasBlockData() ? that.hasBlockData() && this.blockData.equals(that.blockData) : !that.hasBlockData())
                  && (this.hasRepairCost() ? that.hasRepairCost() && this.repairCost == that.repairCost : !that.hasRepairCost())
@@ -1070,9 +1061,9 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
                  && (this.unhandledTags.equals(that.unhandledTags))
                  && (Objects.equals(this.customTag, that.customTag))
                  && (this.persistentDataContainer.equals(that.persistentDataContainer))
-@@ -1598,8 +1616,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
-         hash = 61 * hash + (this.hasRarity() ? this.rarity.hashCode() : 0);
+@@ -1636,8 +1654,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          hash = 61 * hash + (this.hasFood() ? this.food.hashCode() : 0);
+         hash = 61 * hash + (this.hasTool() ? this.tool.hashCode() : 0);
          hash = 61 * hash + (this.hasDamage() ? this.damage : 0);
 -        hash = 61 * hash + (this.hasMaxDamage() ? 1231 : 1237);
 -        hash = 61 * hash + (this.hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
@@ -1081,7 +1072,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          hash = 61 * hash + (this.canPlaceOnPredicates != null ? this.canPlaceOnPredicates.hashCode() : 0); // Paper
          hash = 61 * hash + (this.canBreakPredicates != null ? this.canBreakPredicates.hashCode() : 0); // Paper
          hash = 61 * hash + this.version;
-@@ -1619,7 +1637,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1657,7 +1675,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              if (this.enchantments != null) {
                  clone.enchantments = new EnchantmentMap(this.enchantments); // Paper
              }
@@ -1090,7 +1081,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
              }
              if (this.customTag != null) {
-@@ -1823,7 +1841,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1864,7 +1882,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
  
      static void serializeModifiers(Multimap<Attribute, AttributeModifier> modifiers, ImmutableMap.Builder<String, Object> builder, ItemMetaKey key) {
@@ -1099,7 +1090,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
              return;
          }
  
-@@ -1905,7 +1923,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1946,7 +1964,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      // Paper start - improve checking handled tags
      @org.jetbrains.annotations.VisibleForTesting
      public static final Map<Class<? extends CraftMetaItem>, Set<DataComponentType<?>>> HANDLED_DCTS_PER_TYPE = new HashMap<>();
@@ -1108,7 +1099,7 @@ index 12a193db7475870e5107c86c7611bb4b92feacb8..c235b80b94fdb6c77766016114713cd5
          CraftMetaItem.NAME.TYPE,
          CraftMetaItem.ITEM_NAME.TYPE,
          CraftMetaItem.LORE.TYPE,
-@@ -1971,7 +1989,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -2013,7 +2031,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      // Paper end - improve checking handled data component types
  
      protected static <T> Optional<? extends T> getOrEmpty(DataComponentPatch tag, ItemMetaKeyType<T> type) {
@@ -1341,7 +1332,7 @@ index db7f71af22d904de08d4badaa7f66d1286d5bf16..e32143e140db50a11cf602cf622d68b7
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index c769d2a210060f6829a6cbe739d6d9ab2f602644..1feffe289a1e714084bd37b5c5ad23a37dd58325 100644
+index 7bdc94c3ba7d8a0d74c2d88edbb32112a90c5980..ab9b3279db914fb4d6666a4dacbf5e401d2bcb87 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 @@ -137,10 +137,10 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
@@ -1359,10 +1350,10 @@ index c769d2a210060f6829a6cbe739d6d9ab2f602644..1feffe289a1e714084bd37b5c5ad23a3
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
-index a3c1a8c469630464ac80b7786731462046134998..4bc0aa160e5ed90be622932ff735a9ed98830f33 100644
+index b98e656c0bb382667bd186a500c5505f1ed3f7cd..63088d50c1ec69d1a829fd0783cf109f7981f43f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
-@@ -251,6 +251,7 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
+@@ -212,6 +212,7 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
  
      @Override
      public EntitySnapshot getSpawnedEntity() {
@@ -1370,14 +1361,12 @@ index a3c1a8c469630464ac80b7786731462046134998..4bc0aa160e5ed90be622932ff735a9ed
          return CraftEntitySnapshot.create(this.entityTag);
      }
  
-@@ -268,8 +269,8 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
+@@ -229,7 +230,7 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
          if (meta instanceof CraftMetaSpawnEgg) {
              CraftMetaSpawnEgg that = (CraftMetaSpawnEgg) meta;
  
--            return this.hasSpawnedType() ? that.hasSpawnedType() && this.spawnedType.equals(that.spawnedType) : !that.hasSpawnedType()
--                    && this.entityTag != null ? that.entityTag != null && this.entityTag.equals(that.entityTag) : this.entityTag == null;
-+            return (this.hasSpawnedType() ? that.hasSpawnedType() && this.spawnedType.equals(that.spawnedType) : !that.hasSpawnedType()) // Paper
-+                    && (this.entityTag != null ? that.entityTag != null && this.entityTag.equals(that.entityTag) : that.entityTag == null); // Paper
+-            return this.entityTag != null ? that.entityTag != null && this.entityTag.equals(that.entityTag) : this.entityTag == null;
++            return this.entityTag != null ? that.entityTag != null && this.entityTag.equals(that.entityTag) : that.entityTag == null; // Paper
          }
          return true;
      }
@@ -1410,10 +1399,10 @@ index b5392a3a6f6f3d0a54549e6bb93f28590ee048f0..7514aa6f206c4b82fecd112783f96bb9
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/SerializableMeta.java b/src/main/java/org/bukkit/craftbukkit/inventory/SerializableMeta.java
-index 05a4a06c0def28fc97e61b4712c45c8730fec60c..a86eb660d8f523cb99a0b668ef1130535d50ce1c 100644
+index 8b407a33b04af6ae396ada0b8aca7dc246d314ef..d204845cf0b9de00589593469755cb8e42e0aa67 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/SerializableMeta.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/SerializableMeta.java
-@@ -110,4 +110,21 @@ public final class SerializableMeta implements ConfigurationSerializable {
+@@ -123,4 +123,21 @@ public final class SerializableMeta implements ConfigurationSerializable {
          }
          throw new IllegalArgumentException(field + "(" + object + ") is not a valid " + clazz);
      }
@@ -1456,10 +1445,10 @@ index c68e85cca0f532a94545c0b7f6ed54451ce5a47e..b647b5205b9c54ccb83e09a9410c722e
  
          FoodProperties.PossibleEffect newEffect = new net.minecraft.world.food.FoodProperties.PossibleEffect(CraftPotionUtil.fromBukkit(effect), probability);
 diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java
-index 0b11d5ea89539decd2f6c60c5b581bbd78ff1fd6..74ebadacbbd11b5a0d8f8c6cd6409cce17cfa37d 100644
+index 6bed0a5c8d9f1ca72678cdf4699128e441a24541..8e03e14d0e65bfdf2196a08220d1408b1297aa0d 100644
 --- a/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java
 +++ b/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java
-@@ -92,7 +92,7 @@ public class DeprecatedItemMetaCustomValueTest extends AbstractTestingBase {
+@@ -93,7 +93,7 @@ public class DeprecatedItemMetaCustomValueTest extends AbstractTestingBase {
      public void testNBTTagStoring() {
          CraftMetaItem itemMeta = this.createComplexItemMeta();
  
@@ -1482,10 +1471,10 @@ index d6018439015583fa0344c7c01b2e60a13de29795..aabe3730fa582f442ee0544dd1a9f312
      @Test
      public void testPowerLimitExact() {
 diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java
-index f3939074a886b20f17b00dd3c39833725f47d3f0..1123cc60671c1a48bba9b2baa1f10c6d5a6855fe 100644
+index 6f94c7a19f2f598a836ec7db30332dd95f8675a6..54ffbfd91a03efa2d0d271ed10db4209a2309638 100644
 --- a/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java
 +++ b/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java
-@@ -126,7 +126,7 @@ public class PersistentDataContainerTest extends AbstractTestingBase {
+@@ -127,7 +127,7 @@ public class PersistentDataContainerTest extends AbstractTestingBase {
      public void testNBTTagStoring() {
          CraftMetaItem itemMeta = this.createComplexItemMeta();
  
@@ -1494,7 +1483,7 @@ index f3939074a886b20f17b00dd3c39833725f47d3f0..1123cc60671c1a48bba9b2baa1f10c6d
          itemMeta.applyToItem(compound);
  
          assertEquals(itemMeta, new CraftMetaItem(compound.build(), null)); // Paper
-@@ -472,7 +472,7 @@ public class PersistentDataContainerTest extends AbstractTestingBase {
+@@ -473,7 +473,7 @@ public class PersistentDataContainerTest extends AbstractTestingBase {
          assertEquals(List.of(), container.get(PersistentDataContainerTest.requestKey("list"), PersistentDataType.LIST.strings()));
  
          // Write and read the entire container to NBT

--- a/patches/server/1043-Brigadier-based-command-API.patch
+++ b/patches/server/1043-Brigadier-based-command-API.patch
@@ -2213,7 +2213,7 @@ index 982b2bab27e3d55d0ba07060862c0c3183ad91b0..5fa8a3343ffc11e82c20b78a73205fd8
          Component component = message.resolveComponent(commandSourceStack);
          CommandSigningContext commandSigningContext = commandSourceStack.getSigningContext();
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 0408d5d54fef7767ecf70e70686ad520d890ff26..0ed42fa899721f83b598db05be1b5f321af3614a 100644
+index 5df535aae94bbba940da5d21eb72afc945915f4c..3751c2a077bd13bac330b93c6efc2a640a17f4f2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -299,7 +299,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -2377,10 +2377,10 @@ index 3faf80fca51d66480265eaf3cc89149e53ceb215..b9b3277c8ed94e0cd30b20b9c00a33ea
      // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 10c22c67e8469c736d48a8729ce7765b41b331d8..94a31c8f903eb61eb6d203e8e6fe8fb0beca28b1 100644
+index 3eea023d24c8e1b991f548632564508bfc565d8a..5db08432b6afd3639688830e717f40ceaf599248 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -270,11 +270,11 @@ public final class CraftServer implements Server {
+@@ -271,11 +271,11 @@ public final class CraftServer implements Server {
      private final Logger logger = Logger.getLogger("Minecraft");
      private final ServicesManager servicesManager = new SimpleServicesManager();
      private final CraftScheduler scheduler = new CraftScheduler();
@@ -2395,7 +2395,7 @@ index 10c22c67e8469c736d48a8729ce7765b41b331d8..94a31c8f903eb61eb6d203e8e6fe8fb0
      private final StructureManager structureManager;
      protected final DedicatedServer console;
      protected final DedicatedPlayerList playerList;
-@@ -399,6 +399,12 @@ public final class CraftServer implements Server {
+@@ -401,6 +401,12 @@ public final class CraftServer implements Server {
          this.serverTickManager = new CraftServerTickManager(console.tickRateManager());
  
          Bukkit.setServer(this);
@@ -2408,7 +2408,7 @@ index 10c22c67e8469c736d48a8729ce7765b41b331d8..94a31c8f903eb61eb6d203e8e6fe8fb0
  
          CraftRegistry.setMinecraftRegistry(console.registryAccess());
  
-@@ -568,48 +574,11 @@ public final class CraftServer implements Server {
+@@ -590,48 +596,11 @@ public final class CraftServer implements Server {
      }
  
      private void setVanillaCommands(boolean first) { // Spigot
@@ -2459,7 +2459,7 @@ index 10c22c67e8469c736d48a8729ce7765b41b331d8..94a31c8f903eb61eb6d203e8e6fe8fb0
  
          // Refresh commands
          for (ServerPlayer player : this.getHandle().players) {
-@@ -996,17 +965,31 @@ public final class CraftServer implements Server {
+@@ -1018,17 +987,31 @@ public final class CraftServer implements Server {
              return true;
          }
  
@@ -2501,7 +2501,7 @@ index 10c22c67e8469c736d48a8729ce7765b41b331d8..94a31c8f903eb61eb6d203e8e6fe8fb0
  
          return false;
      }
-@@ -1015,7 +998,7 @@ public final class CraftServer implements Server {
+@@ -1037,7 +1020,7 @@ public final class CraftServer implements Server {
      public void reload() {
          // Paper start - lifecycle events
          if (io.papermc.paper.plugin.lifecycle.event.LifecycleEventRunner.INSTANCE.blocksPluginReloading()) {
@@ -2510,7 +2510,7 @@ index 10c22c67e8469c736d48a8729ce7765b41b331d8..94a31c8f903eb61eb6d203e8e6fe8fb0
          }
          // Paper end - lifecycle events
          org.spigotmc.WatchdogThread.hasStarted = false; // Paper - Disable watchdog early timeout on reload
-@@ -1068,8 +1051,9 @@ public final class CraftServer implements Server {
+@@ -1091,8 +1074,9 @@ public final class CraftServer implements Server {
          }
  
          Plugin[] pluginClone = pluginManager.getPlugins().clone(); // Paper
@@ -2521,7 +2521,7 @@ index 10c22c67e8469c736d48a8729ce7765b41b331d8..94a31c8f903eb61eb6d203e8e6fe8fb0
          // Paper start
          for (Plugin plugin : pluginClone) {
              entityMetadata.removeAll(plugin);
-@@ -1109,6 +1093,12 @@ public final class CraftServer implements Server {
+@@ -1132,6 +1116,12 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.pluginsEnabled(); // Paper - Remap plugins

--- a/patches/server/1045-Fix-equipment-slot-and-group-API.patch
+++ b/patches/server/1045-Fix-equipment-slot-and-group-API.patch
@@ -32,10 +32,10 @@ index 9d74577af071954e1e37201a96368c1360076209..eafa54c870c3e2aef30c3f9f96f51660
                  throw new IllegalArgumentException("Not implemented. This is a bug");
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index c235b80b94fdb6c77766016114713cd501ffd67c..d5789326d70bb8b029c5448270bbaa6faf52e6e1 100644
+index 8ccb8d71ee489891e8d9128a5520675dd3a62786..ad51c62b80bfd8f09c57e9ed1e73aad12341293a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1331,7 +1331,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1367,7 +1367,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          if (this.attributeModifiers == null) return LinkedHashMultimap.create(); // Paper - don't change the components
          SetMultimap<Attribute, AttributeModifier> result = LinkedHashMultimap.create();
          for (Map.Entry<Attribute, AttributeModifier> entry : this.attributeModifiers.entries()) {
@@ -44,7 +44,7 @@ index c235b80b94fdb6c77766016114713cd501ffd67c..d5789326d70bb8b029c5448270bbaa6f
                  result.put(entry.getKey(), entry.getValue());
              }
          }
-@@ -1399,9 +1399,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1435,9 +1435,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
          while (iter.hasNext()) {
              Map.Entry<Attribute, AttributeModifier> entry = iter.next();

--- a/patches/server/1047-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/1047-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -214,10 +214,10 @@ index b9b3277c8ed94e0cd30b20b9c00a33eaad48e5ac..c450447585af4c8cdc87abe871c229ff
                                  }
                              }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 6b447cdf5b14deb26e0454f9f731724c89f2d498..ce01fe82dc1eaaf06ca317ddbc62b7d1b87a48b2 100644
+index d0b6ade676d94e768c92432dc6cee9f200acf5f2..21e61bb75ac7ce468bc757633ce678b21bcb9deb 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3308,7 +3308,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3302,7 +3302,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              }
  
          });

--- a/patches/server/1053-Adopt-MaterialRerouting.patch
+++ b/patches/server/1053-Adopt-MaterialRerouting.patch
@@ -1,0 +1,134 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <lynxplay101@gmail.com>
+Date: Thu, 13 Jun 2024 11:02:36 +0200
+Subject: [PATCH] Adopt MaterialRerouting
+
+Adopts the paper-api to the material rerouting infrastructure introduced
+by upstream.
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/legacy/MaterialRerouting.java b/src/main/java/org/bukkit/craftbukkit/legacy/MaterialRerouting.java
+index 3ff0f0e34356cee4c510fdd60af723b1c5df156a..9c004e7cb46841d874ab997bf2e3b63ae763aec7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/legacy/MaterialRerouting.java
++++ b/src/main/java/org/bukkit/craftbukkit/legacy/MaterialRerouting.java
+@@ -600,4 +600,82 @@ public class MaterialRerouting {
+     public static void setBlocks(ToolComponent.ToolRule toolRule, Collection<Material> blocks) {
+         toolRule.setBlocks(blocks.stream().map(MaterialRerouting::transformToBlockType).toList());
+     }
++
++    // Paper start - register paper API specific material consumers in rerouting
++    // A lot of these methods do *not* run through MaterialRerouting to avoid the overhead of a system that
++    // currently is an effective noop.
++    // The only downside is that upstream moved the handling of legacy materials into transformFromXType methods.
++    // As such, methods introduced prior to 1.13 need to run through the transformation to make sure legacy material
++    // constants still work.
++
++    // Utility method for constructing a set from an existing one after mapping each element.
++    private static <I, O> Set<O> mapSet(final Set<I> input, final java.util.function.Function<I,O> mapper) {
++        final Set<O> output = new it.unimi.dsi.fastutil.objects.ObjectOpenHashSet<>(input.size());
++        for (final I i : input) {
++            output.add(mapper.apply(i));
++        }
++        return output;
++    }
++
++    // Method added post-1.13, noop (https://github.com/PaperMC/Paper/pull/4965)
++    public static org.bukkit.Material getMinecartMaterial(org.bukkit.entity.Minecart minecart, @InjectPluginVersion ApiVersion version) {
++        return minecart.getMinecartMaterial();
++    }
++
++    // Method added post-1.13, noop (https://github.com/PaperMC/Paper/pull/4965)
++    public static Material getBoatMaterial(Boat boat, @InjectPluginVersion ApiVersion version) {
++        return boat.getBoatMaterial();
++    }
++
++    // Method added post-1.13, noop (https://github.com/PaperMC/Paper/pull/3807)
++    public static Material getType(io.papermc.paper.event.player.PlayerItemCooldownEvent event, @InjectPluginVersion ApiVersion version) {
++        return event.getType();
++    }
++
++    // Method added post-1.13, noop (https://github.com/PaperMC/Paper/pull/3850)
++    public static Collection<Material> getInfiniburn(World world, @InjectPluginVersion ApiVersion version) {
++        return world.getInfiniburn();
++    }
++
++    // Method added pre-1.13, needs legacy rerouting (https://github.com/PaperMC/Paper/commit/3438e96192)
++    public static Set<Material> getTypes(
++        final com.destroystokyo.paper.event.player.PlayerArmorChangeEvent.SlotType slotType,
++        @InjectPluginVersion final ApiVersion apiVersion
++    ) {
++        if (apiVersion.isNewerThanOrSameAs(ApiVersion.FLATTENING)) return slotType.getTypes();
++        else return mapSet(slotType.getTypes(), MaterialRerouting::transformToItemType); // Needed as pre-flattening is hanled by transformToItemType
++    }
++
++    // Method added pre-1.13, needs legacy rerouting (https://github.com/PaperMC/Paper/commit/3438e96192)
++    @RerouteStatic("com/destroystokyo/paper/event/player/PlayerArmorChangeEvent$SlotType")
++    public static com.destroystokyo.paper.event.player.PlayerArmorChangeEvent.SlotType getByMaterial(
++        final Material material
++    ) {
++        return com.destroystokyo.paper.event.player.PlayerArmorChangeEvent.SlotType.getByMaterial(MaterialRerouting.transformToItemType(material));
++    }
++
++    // Method added pre-1.13, needs legacy rerouting (https://github.com/PaperMC/Paper/commit/3438e96192)
++    @RerouteStatic("com/destroystokyo/paper/event/player/PlayerArmorChangeEvent$SlotType")
++    public static boolean isEquipable(final Material material) {
++        return com.destroystokyo.paper.event.player.PlayerArmorChangeEvent.SlotType.isEquipable(MaterialRerouting.transformToItemType(material));
++    }
++
++    // Method added post 1.13, no-op (https://github.com/PaperMC/Paper/pull/1244)1
++    public static Material getMaterial(final com.destroystokyo.paper.event.block.AnvilDamagedEvent.DamageState damageState) {
++        return damageState.getMaterial();
++    }
++
++    // Method added post 1.13, no-op (https://github.com/PaperMC/Paper/pull/1244)1
++    @RerouteStatic("com/destroystokyo/paper/event/block/AnvilDamagedEvent$DamageState")
++    public static com.destroystokyo.paper.event.block.AnvilDamagedEvent.DamageState getState(
++        final Material material
++    ) {
++        return com.destroystokyo.paper.event.block.AnvilDamagedEvent.DamageState.getState(material);
++    }
++
++    // Method added post 1.13, no-op (https://github.com/PaperMC/Paper/pull/10290)
++    public static ItemStack withType(final ItemStack itemStack, final Material material) {
++        return itemStack.withType(material);
++    }
++    // Paper end - register paper API specific material consumers in rerouting
+ }
+diff --git a/src/test/java/org/bukkit/craftbukkit/legacy/MaterialReroutingTest.java b/src/test/java/org/bukkit/craftbukkit/legacy/MaterialReroutingTest.java
+index 26208ca74688be062584824de5d074321b33f1b1..946cd46f3389a4d4ceda86e0115c59c5725a8a0a 100644
+--- a/src/test/java/org/bukkit/craftbukkit/legacy/MaterialReroutingTest.java
++++ b/src/test/java/org/bukkit/craftbukkit/legacy/MaterialReroutingTest.java
+@@ -55,6 +55,9 @@ public class MaterialReroutingTest extends AbstractTestingBase {
+                 .filter(entry -> !entry.getName().endsWith("ItemType.class"))
+                 .filter(entry -> !entry.getName().endsWith("Registry.class"))
+                 .filter(entry -> !entry.getName().startsWith("org/bukkit/material"))
++                // Paper start - types that cannot be translated to ItemType/BlockType
++                .filter(entry -> !entry.getName().equals("com/destroystokyo/paper/MaterialSetTag.class"))
++                // Paper end - types that cannot be translated to ItemType/BlockType
+                 .map(entry -> {
+                     try {
+                         return MaterialReroutingTest.jarFile.getInputStream(entry);
+@@ -92,6 +95,10 @@ public class MaterialReroutingTest extends AbstractTestingBase {
+                             continue;
+                         }
+                     }
++                    // Paper start - filter out more methods from rerouting test
++                    if (methodNode.name.startsWith("lambda$")) continue;
++                    if (isInternal(methodNode.invisibleAnnotations)) continue;
++                    // Paper end - filter out more methods from rerouting test
+ 
+                     if (!Commodore.rerouteMethods(Collections.emptySet(), MaterialReroutingTest.MATERIAL_METHOD_REROUTE, (methodNode.access & Opcodes.ACC_STATIC) != 0, classNode.name, methodNode.name, methodNode.desc, a -> { })) {
+                         missingReroute.add(methodNode.name + " " + methodNode.desc + " " + methodNode.signature);
+@@ -108,6 +115,13 @@ public class MaterialReroutingTest extends AbstractTestingBase {
+         }
+     }
+ 
++    // Paper start - filter out more methods from rerouting test
++    private static boolean isInternal(final List<org.objectweb.asm.tree.AnnotationNode> annotationNodes) {
++        return annotationNodes != null
++            && annotationNodes.stream().anyMatch(a -> a.desc.equals("Lorg/jetbrains/annotations/ApiStatus$Internal;"));
++    }
++    // Paper end - filter out more methods from rerouting test
++
+     @AfterAll
+     public static void clear() throws IOException {
+         if (MaterialReroutingTest.jarFile != null) {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
376e37db SPIGOT-7677: Update which entities are marked as spawnable
06c4add3 SPIGOT-7737: Add separate TreeType.MEGA_PINE
19b7caaa SPIGOT-7731: Spawn eggs cannot have damage
e585297e PR-1022: Add force option to Player#spawnParticle
d26e0094 PR-1018: Add methods to get players seeing specific chunks
8df1ed18 PR-978: Add Material#isCompostable and Material#getCompostChance
4b9b59c7 SPIGOT-7676: Enforce locale parameter in toLowerCase and toUpperCase method calls and always use root locale
8d1e700a PR-1020: Cast instead of using #typed when getting BlockType and ItemType to better work with testing / mocks
fa28607a PR-1016: Fix incorrect assumption of Fireball having constant speed
4c6c8586 PR-1015: Add a tool component to ItemMeta
6f6b2123 PR-1014: Add PotionEffectTypeCategory to distinguish between beneficial and harmful effects
f511cfe1 PR-1013, SPIGOT-4288, SPIGOT-6202: Add material rerouting in preparation for the switch to ItemType and BlockType
def44cbf SPIGOT-7669: Fix typo in ProjectileHitEvent#getHitBlockFace documentation
53fa4f72 PR-1011: Throw an exception if a RecipeChoice is ever supplied air

CraftBukkit Changes:
ee95e171a SPIGOT-7737: Add separate TreeType.MEGA_PINE
0dae4c62c Fix spawn egg equality check and copy constructor
ab59e847c Fix spawn eggs with no entity creating invalid stacks and disconnect creative clients
3b6093b28 SPIGOT-7736: Creative spawn egg use loses components
c6b4d5a87 SPIGOT-7731: Spawn eggs cannot have damage
340ccd57f SPIGOT-7735: Fix serialization of player heads with note block sound
fd2f41834 SPIGOT-7734: Can't register a custom advancement using unsafe()
02456e2a5 PR-1413: Add force option to Player#spawnParticle
6a61f38b2 SPIGOT-7680: Per-world weather command
58c41cebb PR-1409: Add methods to get players seeing specific chunks
16c976797 PR-1412: Fix shipwreck loot tables not being set for BlockTransformers
7189ba636 PR-1360: Add Material#isCompostable and Material#getCompostChance
900384556 SPIGOT-7676: Enforce locale parameter in toLowerCase and toUpperCase method calls and always use root locale
bdb40c5f1 Increase outdated build delay
d6607c7dd SPIGOT-7675: Fix FoodComponent config deserialization
b148ed332 PR-1406: Fix incorrect assumption of Fireball having constant speed
3ec31ca75 PR-1405: Add a tool component to ItemMeta
5d7d675b9 PR-1404: Add PotionEffectTypeCategory to distinguish between beneficial and harmful effects
960827981 PR-1403, SPIGOT-4288, SPIGOT-6202: Add material rerouting in preparation for the switch to ItemType and BlockType
94e44ec93 PR-1401: Add a config option to accept old keys in registry get calls
a43701920 PR-1402: Fix ChunkSnapshot#isSectionEmpty() is always false
87d0a3368 SPIGOT-7668: Move NONE Registry updater to FieldRename to avoid some class loader issues
2ea1e7ac2 PR-1399: Fix regression preventing positive .setDamage value from causing knockback for 0 damage events
ba2d49d21 Increase outdated build delay

Spigot Changes:
fcd94e21 Rebuild patches
342f4939 SPIGOT-7661: Add experimental unload-frozen-chunks option