### PR TITLE
Configurable damage tick when blocking with shield

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -487,10 +487,10 @@ index 0000000000000000000000000000000000000000..7684e71f802f3d19e5340713b45cc848
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..892351c3b6397b3cde6a31a6594c0e16bbe1252b
+index 0000000000000000000000000000000000000000..7045040681e639f36fefcf2735f67367d5e3cbc4
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,311 @@
+@@ -0,0 +1,313 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -651,6 +651,8 @@ index 0000000000000000000000000000000000000000..892351c3b6397b3cde6a31a6594c0e16
 +        public boolean performUsernameValidation = true;
 +        @Comment("This setting controls if players should be able to create headless pistons.")
 +        public boolean allowHeadlessPistons = false;
++        @Comment("This setting controls if the vanilla damage tick should be skipped if damage was blocked via a shield.")
++        public boolean skipVanillaDamageTickWhenShieldBlocked = false;
 +        @Comment("This setting controls what compression format is used for region files.")
 +        public CompressionFormat compressionFormat = CompressionFormat.ZLIB;
 +

--- a/patches/server/0758-Configurable-chat-thread-limit.patch
+++ b/patches/server/0758-Configurable-chat-thread-limit.patch
@@ -22,10 +22,10 @@ is actually processed, this is honestly really just exposed for the misnomers or
 who just wanna ensure that this won't grow over a specific size if chat gets stupidly active
 
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 892351c3b6397b3cde6a31a6594c0e16bbe1252b..ab5089781b8866cd6ad1b9570634ba84d936cfe7 100644
+index 7045040681e639f36fefcf2735f67367d5e3cbc4..cc847dce0116b8260790b890b1d5452c280e186c 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -285,7 +285,18 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -287,7 +287,18 @@ public class GlobalConfiguration extends ConfigurationPart {
  
              @PostProcess
              private void postProcess() {

--- a/patches/server/0976-Rewrite-chunk-system.patch
+++ b/patches/server/0976-Rewrite-chunk-system.patch
@@ -14551,7 +14551,7 @@ index 0000000000000000000000000000000000000000..61fa1ab0f6550fec2b9d035ea45c7262
 +
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 4de88f74182bb596c6b5ad0351cc0dacefd0ce96..2874bc3001c4e7d9191e47ba512c5a68369c21f1 100644
+index 2a5453707bc172d8d0efe3f11959cb0b5f830984..0467ad99b144aa81a04baa45d4c8bbb2b70185a2 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 @@ -29,6 +29,45 @@ public class GlobalConfiguration extends ConfigurationPart {
@@ -14622,7 +14622,7 @@ index 4de88f74182bb596c6b5ad0351cc0dacefd0ce96..2874bc3001c4e7d9191e47ba512c5a68
      public UnsupportedSettings unsupportedSettings;
  
      public class UnsupportedSettings extends ConfigurationPart {
-@@ -201,7 +225,7 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -203,7 +227,7 @@ public class GlobalConfiguration extends ConfigurationPart {
  
          @PostProcess
          private void postProcess() {

--- a/patches/server/1056-Configurable-damage-tick-when-blocking-with-shield.patch
+++ b/patches/server/1056-Configurable-damage-tick-when-blocking-with-shield.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <lynxplay101@gmail.com>
+Date: Thu, 13 Jun 2024 17:16:01 +0200
+Subject: [PATCH] Configurable damage tick when blocking with shield
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 21e61bb75ac7ce468bc757633ce678b21bcb9deb..015134a614a44b610aac1a4c6a1eb6b7b5bb96b5 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -2380,7 +2380,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+                         CriteriaTriggers.PLAYER_HURT_ENTITY.trigger((ServerPlayer) damagesource.getEntity(), this, damagesource, originalDamage, f, true); // Paper - fix taken/dealt param order
+                     }
+ 
+-                    return true;
++                    return !io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.skipVanillaDamageTickWhenShieldBlocked; // Paper - this should always return true, however expose an unsupported setting to flip this to false to enable "shield stunning".
+                 } else {
+                     return true; // Paper - return false ONLY if event was cancelled
+                 }


### PR DESCRIPTION
A long standing bug in spigot and its derivatives was the fact that players taking damage while blocking with a shield would not receive invulnerability, while they do in vanilla.

This enabled the pvp technique of disabling a shield and immediately attacking again to knock a player into the air.
While upstream fixed this and properly aligned itself with vanilla damage logic (in this specific case) changing such long standing behaviour has some downsides.

To allow players used to this specific bug to still use it, this patch introduces a configuration option to re-introduce said bug. As there is no easy way to *only* re-add this bug, the option is found in the unsupported section as it may introduce other damage related disparity from vanilla.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-10877.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1605148982.zip)