### PR TITLE
Fix to issue 10873: Corrected removing all enchantments from ItemStack

### DIFF
--- a/patches/server/1054-fixup-SPIGOT-6921-1330-Add-methods-to-remove-all-enc.patch
+++ b/patches/server/1054-fixup-SPIGOT-6921-1330-Add-methods-to-remove-all-enc.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Julius=20Gr=C3=BCnberg=28GhastCraftHD=29?=
+ <julius.gruenberg@troense.de>
+Date: Fri, 14 Jun 2024 19:40:30 +0200
+Subject: [PATCH] fixup! SPIGOT-6921, #1330: Add methods to remove all
+ enchantments on an ItemStack
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+index b6cd6897844aa9c8b9a94e41c56c4cfe4ac78780..3bb8a6a200b0256c981547bc91cf7e5bb1e2d4dd 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+@@ -1099,7 +1099,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+     @Override
+     public void removeEnchantments() {
+         if (this.hasEnchants()) {
+-            this.enchantments.clear();
++            this.enchantments = null;
+         }
+     }
+ 


### PR DESCRIPTION
Fixed issue [10873](https://github.com/PaperMC/Paper/issues/10873)
Set the enchantment map to null rather just clearing it