### PR TITLE
Fix Color Particle API

### DIFF
--- a/patches/api/0098-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0098-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -10,10 +10,10 @@ This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/com/destroystokyo/paper/ParticleBuilder.java b/src/main/java/com/destroystokyo/paper/ParticleBuilder.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..52f639b838e8b49952c560f20bacbad0337f279c
+index 0000000000000000000000000000000000000000..3b3e46dc420712f26f911f12d1b0403ae3903f53
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/ParticleBuilder.java
-@@ -0,0 +1,583 @@
+@@ -0,0 +1,587 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.base.Preconditions;
@@ -455,7 +455,7 @@ index 0000000000000000000000000000000000000000..52f639b838e8b49952c560f20bacbad0
 +
 +    /**
 +     * Sets the particle Color.
-+     * Only valid for {@link Particle#DUST}.
++     * Only valid for particles with a data type of {@link Color} or {@link Particle.DustOptions}.
 +     *
 +     * @param color the new particle color
 +     * @return a reference to this object.
@@ -467,7 +467,7 @@ index 0000000000000000000000000000000000000000..52f639b838e8b49952c560f20bacbad0
 +
 +    /**
 +     * Sets the particle Color and size.
-+     * Only valid for {@link Particle#DUST}.
++     * Only valid for particles with a data type of {@link Color} or {@link Particle.DustOptions}.
 +     *
 +     * @param color the new particle color
 +     * @param size the size of the particle
@@ -475,17 +475,21 @@ index 0000000000000000000000000000000000000000..52f639b838e8b49952c560f20bacbad0
 +     */
 +    @NotNull
 +    public ParticleBuilder color(@Nullable Color color, float size) {
-+        if (particle != Particle.DUST && color != null) {
-+            throw new IllegalStateException("Color may only be set on particle DUST.");
++        if (particle.getDataType() != Color.class && particle.getDataType() != Particle.DustOptions.class && color != null) {
++            throw new IllegalStateException("Color cannot be set on this particle type.");
 +        }
 +
 +        // We don't officially support reusing these objects, but here we go
 +        if (color == null) {
-+            if (data instanceof Particle.DustOptions) {
++            if (data instanceof Particle.DustOptions || data instanceof Color) {
 +                return data(null);
 +            } else {
 +                return this;
 +            }
++        }
++
++        if (particle.getDataType() == Color.class) {
++            return data(color);
 +        }
 +
 +        return data(new Particle.DustOptions(color, size));
@@ -493,7 +497,7 @@ index 0000000000000000000000000000000000000000..52f639b838e8b49952c560f20bacbad0
 +
 +    /**
 +     * Sets the particle Color.
-+     * Only valid for {@link Particle#DUST}.
++     * Only valid for particles with a data type of {@link Color} or {@link Particle.DustOptions}.
 +     *
 +     * @param r red color component
 +     * @param g green color component
@@ -507,7 +511,7 @@ index 0000000000000000000000000000000000000000..52f639b838e8b49952c560f20bacbad0
 +
 +    /**
 +     * Sets the particle Color.
-+     * Only valid for {@link Particle#DUST}.
++     * Only valid for particles with a data type of {@link Color} or {@link Particle.DustOptions}.
 +     *
 +     * @param rgb an integer representing the red, green, and blue color components
 +     * @return a reference to this object.

--- a/patches/api/0098-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0098-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -10,10 +10,10 @@ This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/com/destroystokyo/paper/ParticleBuilder.java b/src/main/java/com/destroystokyo/paper/ParticleBuilder.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3b3e46dc420712f26f911f12d1b0403ae3903f53
+index 0000000000000000000000000000000000000000..aa02a08da205b670408b2102af0d1151d677d89f
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/ParticleBuilder.java
-@@ -0,0 +1,587 @@
+@@ -0,0 +1,611 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.base.Preconditions;
@@ -512,13 +512,37 @@ index 0000000000000000000000000000000000000000..3b3e46dc420712f26f911f12d1b0403a
 +    /**
 +     * Sets the particle Color.
 +     * Only valid for particles with a data type of {@link Color} or {@link Particle.DustOptions}.
++     * <p>
++     * This method detects if the provided color integer is in RGB or ARGB format.
++     * If the alpha channel is zero, it treats the color as RGB. Otherwise, it treats it as ARGB.
++     * <\p>
 +     *
-+     * @param rgb an integer representing the red, green, and blue color components
++     * @param color an integer representing the color components. If the highest byte (alpha channel) is zero,
++     *              the color is treated as RGB. Otherwise, it is treated as ARGB.
 +     * @return a reference to this object.
 +     */
 +    @NotNull
-+    public ParticleBuilder color(final int rgb) {
-+        return color(Color.fromRGB(rgb));
++    public ParticleBuilder color(final int color) {
++        int alpha = (color >> 24) & 0xFF;
++        if (alpha == 0) {
++            return color(Color.fromRGB(color));
++        }
++        return color(Color.fromARGB(color));
++    }
++
++    /**
++     * Sets the particle Color.
++     * Only valid for particles with a data type of {@link Color} or {@link Particle.DustOptions}.
++     *
++     * @param r red color component
++     * @param g green color component
++     * @param b blue color component
++     * @param a alpha color component
++     * @return a reference to this object.
++     */
++    @NotNull
++    public ParticleBuilder color(final int a, final int r, final int g, final int b) {
++        return color(Color.fromARGB(a, r, g, b));
 +    }
 +
 +    /**

--- a/patches/api/0098-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0098-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -534,10 +534,10 @@ index 0000000000000000000000000000000000000000..aa02a08da205b670408b2102af0d1151
 +     * Sets the particle Color.
 +     * Only valid for particles with a data type of {@link Color} or {@link Particle.DustOptions}.
 +     *
++     * @param a alpha color component
 +     * @param r red color component
 +     * @param g green color component
 +     * @param b blue color component
-+     * @param a alpha color component
 +     * @return a reference to this object.
 +     */
 +    @NotNull

--- a/patches/api/0098-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0098-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -10,10 +10,10 @@ This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/com/destroystokyo/paper/ParticleBuilder.java b/src/main/java/com/destroystokyo/paper/ParticleBuilder.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..aa02a08da205b670408b2102af0d1151d677d89f
+index 0000000000000000000000000000000000000000..970084a788ab5547d16a5e08d4e9d9c769aca67e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/ParticleBuilder.java
-@@ -0,0 +1,611 @@
+@@ -0,0 +1,609 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.base.Preconditions;
@@ -462,12 +462,15 @@ index 0000000000000000000000000000000000000000..aa02a08da205b670408b2102af0d1151
 +     */
 +    @NotNull
 +    public ParticleBuilder color(@Nullable Color color) {
++        if (particle.getDataType() == Color.class) {
++            return data(color);
++        }
 +        return color(color, 1);
 +    }
 +
 +    /**
 +     * Sets the particle Color and size.
-+     * Only valid for particles with a data type of {@link Color} or {@link Particle.DustOptions}.
++     * Only valid for particles with a data type of {@link Particle.DustOptions}.
 +     *
 +     * @param color the new particle color
 +     * @param size the size of the particle
@@ -475,21 +478,17 @@ index 0000000000000000000000000000000000000000..aa02a08da205b670408b2102af0d1151
 +     */
 +    @NotNull
 +    public ParticleBuilder color(@Nullable Color color, float size) {
-+        if (particle.getDataType() != Color.class && particle.getDataType() != Particle.DustOptions.class && color != null) {
-+            throw new IllegalStateException("Color cannot be set on this particle type.");
++        if (particle.getDataType() != Particle.DustOptions.class && color != null) {
++            throw new IllegalStateException("The combination of Color and size cannot be set on this particle type.");
 +        }
 +
 +        // We don't officially support reusing these objects, but here we go
 +        if (color == null) {
-+            if (data instanceof Particle.DustOptions || data instanceof Color) {
++            if (data instanceof Particle.DustOptions) {
 +                return data(null);
 +            } else {
 +                return this;
 +            }
-+        }
-+
-+        if (particle.getDataType() == Color.class) {
-+            return data(color);
 +        }
 +
 +        return data(new Particle.DustOptions(color, size));
@@ -515,7 +514,6 @@ index 0000000000000000000000000000000000000000..aa02a08da205b670408b2102af0d1151
 +     * <p>
 +     * This method detects if the provided color integer is in RGB or ARGB format.
 +     * If the alpha channel is zero, it treats the color as RGB. Otherwise, it treats it as ARGB.
-+     * <\p>
 +     *
 +     * @param color an integer representing the color components. If the highest byte (alpha channel) is zero,
 +     *              the color is treated as RGB. Otherwise, it is treated as ARGB.


### PR DESCRIPTION
Checks particle datatype instead of particle type.

Fixes #10872 