### PR TITLE
[ci skip] Fix javadoc mistake in EnchantmentRegistryEntry.Builder

### DIFF
--- a/patches/api/0477-Introduce-registry-entry-and-builders.patch
+++ b/patches/api/0477-Introduce-registry-entry-and-builders.patch
@@ -23,7 +23,7 @@ index 76daccf4ea502e1747a6f9176dc16fd20c561286..2945dde566682f977e84fde5d473a6c6
  
 diff --git a/src/main/java/io/papermc/paper/registry/data/EnchantmentRegistryEntry.java b/src/main/java/io/papermc/paper/registry/data/EnchantmentRegistryEntry.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..15fcdbba6da2defb8849450ec4e19e6da301362a
+index 0000000000000000000000000000000000000000..4e010d213c165abbdbf784431bf0b78179d079be
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/data/EnchantmentRegistryEntry.java
 @@ -0,0 +1,332 @@
@@ -153,7 +153,7 @@ index 0000000000000000000000000000000000000000..15fcdbba6da2defb8849450ec4e19e6d
 +    @NonNull RegistryKeySet<Enchantment> exclusiveWith();
 +
 +    /**
-+     * A mutable builder for the {@link GameEventRegistryEntry} plugins may change in applicable registry events.
++     * A mutable builder for the {@link EnchantmentRegistryEntry} plugins may change in applicable registry events.
 +     * <p>
 +     * The following values are required for each builder:
 +     * <ul>


### PR DESCRIPTION
The javadoc for EnchantmentRegistryEntry.Builder accidentally refers to GameEventRegistryEntry, which is a different buildable registry entry.