### PR TITLE
Correct duplicate attribute check

### DIFF
--- a/patches/server/0917-Fix-CraftMetaItem-getAttributeModifier-duplication-c.patch
+++ b/patches/server/0917-Fix-CraftMetaItem-getAttributeModifier-duplication-c.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix CraftMetaItem#getAttributeModifier duplication check
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 24ebc5841ed16129c0e9305da6cf1d8fb67d42ec..529e20fcbf0e7ba22a3f0e7a60ae540c21fed424 100644
+index 24ebc5841ed16129c0e9305da6cf1d8fb67d42ec..995ef97b833a0b6e83a27620b1291e984527f09d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -1405,7 +1405,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -13,7 +13,7 @@ index 24ebc5841ed16129c0e9305da6cf1d8fb67d42ec..529e20fcbf0e7ba22a3f0e7a60ae540c
          this.checkAttributeList();
          for (Map.Entry<Attribute, AttributeModifier> entry : this.attributeModifiers.entries()) {
 -            Preconditions.checkArgument(!entry.getValue().getKey().equals(modifier.getKey()), "Cannot register AttributeModifier. Modifier is already applied! %s", modifier);
-+            Preconditions.checkArgument(!entry.getValue().getKey().equals(modifier.getKey()) && entry.getKey() == attribute, "Cannot register AttributeModifier. Modifier is already applied! %s", modifier); // Paper - attribute modifiers with same namespaced key but on different attributes are fine
++            Preconditions.checkArgument(!(entry.getValue().getKey().equals(modifier.getKey()) && entry.getKey() == attribute), "Cannot register AttributeModifier. Modifier is already applied! %s", modifier); // Paper - attribute modifiers with same namespaced key but on different attributes are fine
          }
          return this.attributeModifiers.put(attribute, modifier);
      }

--- a/patches/server/0960-Deep-clone-nbt-tags-in-PDC.patch
+++ b/patches/server/0960-Deep-clone-nbt-tags-in-PDC.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Deep clone nbt tags in PDC
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 529e20fcbf0e7ba22a3f0e7a60ae540c21fed424..64457318250c8ab1dcefdbd1f3373b891d859a7a 100644
+index 995ef97b833a0b6e83a27620b1291e984527f09d..9874406f42531699538ba46f261016394f1c4b04 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -322,7 +322,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {

--- a/patches/server/0963-Don-t-lose-removed-data-components-in-ItemMeta.patch
+++ b/patches/server/0963-Don-t-lose-removed-data-components-in-ItemMeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Don't lose removed data components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 64457318250c8ab1dcefdbd1f3373b891d859a7a..b5103f318b685145d10337c833f0026d4785f05f 100644
+index 9874406f42531699538ba46f261016394f1c4b04..5dd726c50b0a174dfd2715683e56cd9744c7a28e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -198,6 +198,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {

--- a/patches/server/0965-Fix-ItemFlags.patch
+++ b/patches/server/0965-Fix-ItemFlags.patch
@@ -33,7 +33,7 @@ index 73fe41322e0349ad1d46a760f621b6c91112e90e..19af55ec2bf62b70bd3be44f499b32f5
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index b5103f318b685145d10337c833f0026d4785f05f..1b7d4bea50730f97804f1b9a4ac8896a365bae26 100644
+index 5dd726c50b0a174dfd2715683e56cd9744c7a28e..044713d5b2661405200590914f73b07e73aeb48f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -252,6 +252,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {

--- a/patches/server/0969-improve-checking-handled-tags-in-itemmeta.patch
+++ b/patches/server/0969-improve-checking-handled-tags-in-itemmeta.patch
@@ -451,7 +451,7 @@ index f2cecd01f7f214a023e1bdeecc14359f696fb9d4..97b7085250d749c5e46352b372068b51
          getOrEmpty(tag, CraftMetaFirework.FIREWORKS).ifPresent((fireworks) -> {
              this.power = fireworks.flightDuration();
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 1b7d4bea50730f97804f1b9a4ac8896a365bae26..8cfce9c557c4411914adffd10872bf3129435423 100644
+index 044713d5b2661405200590914f73b07e73aeb48f..58da8cb19a8444c634cbc1f39e93503ca8e2ecab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -346,7 +346,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {

--- a/patches/server/0970-General-ItemMeta-fixes.patch
+++ b/patches/server/0970-General-ItemMeta-fixes.patch
@@ -830,7 +830,7 @@ index 97b7085250d749c5e46352b372068b51de89bc7f..7277e7ee566aabf6e01937072d949ed6
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 8cfce9c557c4411914adffd10872bf3129435423..62d615a4c7acfbd970278531e1bbceb71591f7b1 100644
+index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..b62496dee2551a3485fc0f70cfd7ef99c8c6718d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -182,9 +182,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -982,7 +982,7 @@ index 8cfce9c557c4411914adffd10872bf3129435423..62d615a4c7acfbd970278531e1bbceb7
 -        this.checkAttributeList();
 +        if (this.attributeModifiers != null) { // Paper
          for (Map.Entry<Attribute, AttributeModifier> entry : this.attributeModifiers.entries()) {
-             Preconditions.checkArgument(!entry.getValue().getKey().equals(modifier.getKey()) && entry.getKey() == attribute, "Cannot register AttributeModifier. Modifier is already applied! %s", modifier); // Paper - attribute modifiers with same namespaced key but on different attributes are fine
+             Preconditions.checkArgument(!(entry.getValue().getKey().equals(modifier.getKey()) && entry.getKey() == attribute), "Cannot register AttributeModifier. Modifier is already applied! %s", modifier); // Paper - attribute modifiers with same namespaced key but on different attributes are fine
          }
 +        } // Paper
 +        this.checkAttributeList(); // Paper - moved down

--- a/patches/server/0977-Fix-equipment-slot-and-group-API.patch
+++ b/patches/server/0977-Fix-equipment-slot-and-group-API.patch
@@ -32,7 +32,7 @@ index 9d74577af071954e1e37201a96368c1360076209..eafa54c870c3e2aef30c3f9f96f51660
                  throw new IllegalArgumentException("Not implemented. This is a bug");
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 62d615a4c7acfbd970278531e1bbceb71591f7b1..4d97024bb05ab815409fc25c5924903868cc3945 100644
+index b62496dee2551a3485fc0f70cfd7ef99c8c6718d..1f52bfccc0bebf3f59af88f0cdab58015e115af0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -1452,7 +1452,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {


### PR DESCRIPTION
Brackets got lost during the update, leading to an incorrect precondition call.