### PR TITLE
Add Event to control who hears the dragon death sound

### DIFF
--- a/patches/api/0480-Add-event-so-you-can-modify-what-players-will-hear-t.patch
+++ b/patches/api/0480-Add-event-so-you-can-modify-what-players-will-hear-t.patch
@@ -27,65 +27,11 @@ index 0000000000000000000000000000000000000000..c9f821dd291c486c56597cc32135f481
 +public class DragonPrepareDeathSoundTargetsEvent extends EntityEvent {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
-+    private Set<Player> playerList;
++    public Set<Player> playerList;
 +
 +    public DragonPrepareDeathSoundTargetsEvent(final @NotNull EnderDragon enderDragon, Collection<? extends Player> players) {
 +        super(enderDragon);
 +        playerList = new HashSet<>(players);
-+    }
-+
-+    /**
-+     * Gets the list of {@link Player}s that are going to hear the sound.
-+     *
-+     * @return Collection of Players
-+     */
-+    public Set<Player> getPlayerList() {
-+        return playerList;
-+    }
-+
-+    /**
-+     * Sets the player list to a Collection of defined {@link Player}s
-+     *
-+     * @param newPlayerList The new collection of players to hear the sound.
-+     */
-+    public void setPlayerList(Set<Player> newPlayerList) {
-+        playerList = newPlayerList;
-+    }
-+
-+    /**
-+     * Add another {@link Player} to the list of that will hear the death sound if not already present.
-+     *
-+     * @param player The player to be added
-+     */
-+    public void addPlayer(Player player) {
-+        playerList.add(player);
-+    }
-+
-+    /**
-+     * Will remove a {@link Player} from the list that will hear the death sound if present.
-+     *
-+     * @param player The player to be removed
-+     */
-+    public void removePlayer(Player player) {
-+        playerList.remove(player);
-+    }
-+
-+    /**
-+     * Will add a collection of {@link Player}s to the list that will hear the death sound if not already present.
-+     *
-+     * @param playersToAdd Collection of players to be added
-+     */
-+    public void addPlayers(Set<Player> playersToAdd) {
-+        playerList.addAll(playersToAdd);
-+    }
-+
-+    /**
-+     * Will remove a collection of {@link Player}s from the list that will hear the death sound if present.
-+     *
-+     * @param playersToRemove Collection of players to be removed.
-+     */
-+    public void removePlayers(Set<Player> playersToRemove) {
-+        playerList.removeAll(playersToRemove);
 +    }
 +
 +    /**

--- a/patches/api/0480-Add-event-so-you-can-modify-what-players-will-hear-t.patch
+++ b/patches/api/0480-Add-event-so-you-can-modify-what-players-will-hear-t.patch
@@ -1,0 +1,111 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lurkrul <44719592+Lurkrul@users.noreply.github.com>
+Date: Wed, 19 Jun 2024 17:57:27 +0800
+Subject: [PATCH] Add event so you can modify what players will hear the event
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/DragonPrepareDeathSoundTargetsEvent.java b/src/main/java/io/papermc/paper/event/entity/DragonPrepareDeathSoundTargetsEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..c9f821dd291c486c56597cc32135f481592daeff
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/DragonPrepareDeathSoundTargetsEvent.java
+@@ -0,0 +1,99 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.entity.Player;
++import org.bukkit.entity.EnderDragon;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.NotNull;
++import java.util.Collection;
++import java.util.HashSet;
++import java.util.Set;
++
++/**
++ * Is called when an {@link EnderDragon} dies to determine what {@link Player}s hear it.
++ */
++public class DragonPrepareDeathSoundTargetsEvent extends EntityEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++    private Set<Player> playerList;
++
++    public DragonPrepareDeathSoundTargetsEvent(final @NotNull EnderDragon enderDragon, Collection<? extends Player> players) {
++        super(enderDragon);
++        playerList = new HashSet<>(players);
++    }
++
++    /**
++     * Gets the list of {@link Player}s that are going to hear the sound.
++     *
++     * @return Collection of Players
++     */
++    public Set<Player> getPlayerList() {
++        return playerList;
++    }
++
++    /**
++     * Sets the player list to a Collection of defined {@link Player}s
++     *
++     * @param newPlayerList The new collection of players to hear the sound.
++     */
++    public void setPlayerList(Set<Player> newPlayerList) {
++        playerList = newPlayerList;
++    }
++
++    /**
++     * Add another {@link Player} to the list of that will hear the death sound if not already present.
++     *
++     * @param player The player to be added
++     */
++    public void addPlayer(Player player) {
++        playerList.add(player);
++    }
++
++    /**
++     * Will remove a {@link Player} from the list that will hear the death sound if present.
++     *
++     * @param player The player to be removed
++     */
++    public void removePlayer(Player player) {
++        playerList.remove(player);
++    }
++
++    /**
++     * Will add a collection of {@link Player}s to the list that will hear the death sound if not already present.
++     *
++     * @param playersToAdd Collection of players to be added
++     */
++    public void addPlayers(Set<Player> playersToAdd) {
++        playerList.addAll(playersToAdd);
++    }
++
++    /**
++     * Will remove a collection of {@link Player}s from the list that will hear the death sound if present.
++     *
++     * @param playersToRemove Collection of players to be removed.
++     */
++    public void removePlayers(Set<Player> playersToRemove) {
++        playerList.removeAll(playersToRemove);
++    }
++
++    /**
++     * The {@link EnderDragon} that fired this event when it died.
++     *
++     * @return the dragon
++     */
++    public EnderDragon getDragon() {
++        return (EnderDragon) super.getEntity();
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++}

--- a/patches/server/1028-add-event-so-you-can-modify-what-players-hear-the-dr.patch
+++ b/patches/server/1028-add-event-so-you-can-modify-what-players-hear-the-dr.patch
@@ -35,7 +35,6 @@ index bd6fee3e3ad9116802ff8bb57bfa741b881c4057..f225942db664b8ce6f97dd907f39daca
      // Paper end - add EntityFertilizeEggEvent
 +
 +    // Paper start - add DragonPrepareDeathSoundTargetsEvent
-+
 +    /**
 +     * Calls {@link io.papermc.paper.event.entity.DragonPrepareDeathSoundTargetsEvent}
 +     * Listeners can add and remove players from the list of players that will hear the dragon death sound.

--- a/patches/server/1028-add-event-so-you-can-modify-what-players-hear-the-dr.patch
+++ b/patches/server/1028-add-event-so-you-can-modify-what-players-hear-the-dr.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lurkrul <44719592+Lurkrul@users.noreply.github.com>
+Date: Wed, 19 Jun 2024 17:59:03 +0800
+Subject: [PATCH] add event so you can modify what players hear the dragon
+ death sound
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+index 4d2fbade3a01ca26ff107f1323ae23db6dad8ef8..43788f3ea1a752e74c1a0be905bc0d1df5fa14c8 100644
+--- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
++++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+@@ -727,7 +727,11 @@ public class EnderDragon extends Mob implements Enemy {
+                 // CraftBukkit start - Use relative location for far away sounds
+                 // this.level().globalLevelEvent(1028, this.blockPosition(), 0);
+                 int viewDistance = ((ServerLevel) this.level()).getCraftServer().getViewDistance() * 16;
++                 
++                 //paper start - adding control event to determine who hears death sounds
+-                for (net.minecraft.server.level.ServerPlayer player : this.level().getPlayersForGlobalSoundGamerule()) { // Paper - respect global sound events gamerule
++                io.papermc.paper.event.entity.DragonPrepareDeathSoundTargetsEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callDragonPrepareDeathSoundEvent((org.bukkit.entity.EnderDragon) this.getBukkitEntity(), this.level().getPlayersForGlobalSoundGamerule());
++                // change the for loop to loop through the players collected in the event. It still respects the global sound events
++                //for (net.minecraft.server.level.ServerPlayer player : this.level().getPlayersForGlobalSoundGamerule()) { // Paper - respect global sound events gamerule
++                for(org.bukkit.entity.Player bukkitPlayer: event.getPlayerList()) {
++                    net.minecraft.server.level.ServerPlayer player = ((org.bukkit.craftbukkit.entity.CraftPlayer)bukkitPlayer).getHandle();
++                     //paper end - adding control event to determine who hears death sounds
+                     double deltaX = this.getX() - player.getX();
+                     double deltaZ = this.getZ() - player.getZ();
+                     double distanceSquared = deltaX * deltaX + deltaZ * deltaZ;
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index bd6fee3e3ad9116802ff8bb57bfa741b881c4057..f225942db664b8ce6f97dd907f39daca5b85fc9b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -2204,4 +2200,21 @@ public class CraftEventFactory {
+         return event;
+     }
+     // Paper end - add EntityFertilizeEggEvent
++
++    // Paper start - add DragonPrepareDeathSoundTargetsEvent
++
++    /**
++     * Calls {@link io.papermc.paper.event.entity.DragonPrepareDeathSoundTargetsEvent}
++     * Listeners can add and remove players from the list of players that will hear the dragon death sound.
++     *
++     * @param dragon the EnderDragon that has died
++     * @param players the players that are origionally intended to hear the death sound.
++     * @return the event after it was called. This will be used to retrieve the list of players that will hear the death sound
++     */
++    public static io.papermc.paper.event.entity.DragonPrepareDeathSoundTargetsEvent callDragonPrepareDeathSoundEvent(org.bukkit.entity.EnderDragon dragon, List<net.minecraft.server.level.ServerPlayer> players) {
++        io.papermc.paper.event.entity.DragonPrepareDeathSoundTargetsEvent event = new io.papermc.paper.event.entity.DragonPrepareDeathSoundTargetsEvent(dragon, players.stream().map(element->element.getBukkitEntity().getPlayer()).collect(Collectors.toCollection(java.util.HashSet::new)));
++        event.callEvent();
++        return event;
++    }
++    // Paper end - add DragonPrepareDeathSoundTargetsEvent
+ }


### PR DESCRIPTION
Allows plugins to add/remove players from who will hear the dragon death sound.

While this has a niche use case, it will be helpful in those cases.

Servers that have their own customized enderdragon can use the event to change it to where all damage dealers will hear the noise.
This can also be used in the case where a server wants to allow players to ignore the dragon death sound.