### PR TITLE
Fix jukebox playable component being not applied using item meta

### DIFF
--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -1006,6 +1006,25 @@ index e3f185dc982d1c38195a4e01ddd485c13ffa58c0..918a045165cdcde264bc24082b7afebb
  public enum ChatColor {
      /**
       * Represents black
+diff --git a/src/main/java/org/bukkit/JukeboxSong.java b/src/main/java/org/bukkit/JukeboxSong.java
+index 3bf2743fbf123af981d03f0eee6fafd68786ace5..bf487bd9a9fb627c15c7f5e0c623441d367e7c80 100644
+--- a/src/main/java/org/bukkit/JukeboxSong.java
++++ b/src/main/java/org/bukkit/JukeboxSong.java
+@@ -34,4 +34,14 @@ public interface JukeboxSong extends Keyed, Translatable {
+     private static JukeboxSong get(@NotNull String s) {
+         return Objects.requireNonNull(Registry.JUKEBOX_SONG.get(NamespacedKey.minecraft(s)), "Missing song " + s);
+     }
++
++    // Paper start - adventure
++    /**
++     * @deprecated this method assumes that jukebox song description will
++     * always be a translatable component which is not guaranteed.
++     */
++    @Override
++    @Deprecated(forRemoval = true)
++    @org.jetbrains.annotations.NotNull String getTranslationKey();
++    // Paper end - adventure
+ }
 diff --git a/src/main/java/org/bukkit/Keyed.java b/src/main/java/org/bukkit/Keyed.java
 index 32c92621c2c15eec14c50965f5ecda00c46e6c80..e076d447da62445764a9776ee2554c077637d270 100644
 --- a/src/main/java/org/bukkit/Keyed.java

--- a/patches/api/0053-Fix-upstream-javadocs.patch
+++ b/patches/api/0053-Fix-upstream-javadocs.patch
@@ -1558,9 +1558,27 @@ index cdbcc8dbab2456cc2bc1f3084cbb1ced1698b7f5..d528b066c2aaa3fb097931914ff2181f
      void setPower(int power) throws IllegalArgumentException;
  
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 014c1a0379e532a5c924694a8e0715eb0ba50ec2..707d6138f4b27370ee68c8396204f89fa0fb65f2 100644
+index 014c1a0379e532a5c924694a8e0715eb0ba50ec2..10ca843e57c74dfa32d539acd174c8867dfd56ec 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+@@ -540,7 +540,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+      * The returned component is a snapshot of its current state and does not
+      * reflect a live view of what is on an item. After changing any value on
+      * this component, it must be set with
+-     * {@link #setJukeboxPlayable(org.bukkit.inventory.meta.components.JukeboxComponent)}
++     * {@link #setJukeboxPlayable(org.bukkit.inventory.meta.components.JukeboxPlayableComponent)}
+      * to apply the changes.
+      *
+      * @return component
+@@ -549,7 +549,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+     JukeboxPlayableComponent getJukeboxPlayable();
+ 
+     /**
+-     * Sets the item tool.
++     * Sets the jukebox playable component.
+      *
+      * @param jukeboxPlayable new component
+      */
 @@ -576,7 +576,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Return an immutable copy of all {@link Attribute}s and their

--- a/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
@@ -1600,7 +1600,7 @@ index 597a18a767b68b47e81454b7d44613c7178c1366..bc3440eb72127824b3961fbdae583bb6
      public ItemStack getInput() {
          return this.ingredient.getItemStack();
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 707d6138f4b27370ee68c8396204f89fa0fb65f2..bdb8b666ded9837382093e6353c8d60ed8d77033 100644
+index 10ca843e57c74dfa32d539acd174c8867dfd56ec..e7ee3c9ac835a6eaf7faae44e6b2a811e8f8a703 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 @@ -144,6 +144,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
@@ -1627,6 +1627,15 @@ index 707d6138f4b27370ee68c8396204f89fa0fb65f2..bdb8b666ded9837382093e6353c8d60e
       * @param name the name to set
       * @deprecated meta no longer exists
       */
+@@ -545,7 +548,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+      *
+      * @return component
+      */
+-    @Nullable
++    @NotNull // Paper
+     JukeboxPlayableComponent getJukeboxPlayable();
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/inventory/meta/MapMeta.java b/src/main/java/org/bukkit/inventory/meta/MapMeta.java
 index 32055a8890425e0b819930f3059da5ea9dfca553..26a336dade83baee97d20eb39a058925659f5777 100644
 --- a/src/main/java/org/bukkit/inventory/meta/MapMeta.java

--- a/patches/api/0193-Support-components-in-ItemMeta.patch
+++ b/patches/api/0193-Support-components-in-ItemMeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index bdb8b666ded9837382093e6353c8d60ed8d77033..3029c9a8db501d37ffd5f52ce482c8a608e328ea 100644
+index e7ee3c9ac835a6eaf7faae44e6b2a811e8f8a703..1a4260b00b193b94ce4b1b2954644f4e41baff4c 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 @@ -5,6 +5,7 @@ import java.util.Collection;

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -3313,6 +3313,18 @@ index 6acee03278c8005a06d9cd2577761f2f5355a7ec..5e469bd4d9ca428abdd9d75899316463
                      }
                  }
                  collection = icons;
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftJukeboxSong.java b/src/main/java/org/bukkit/craftbukkit/CraftJukeboxSong.java
+index 49c037e961c5ca5ba8d6a870cb32ffe8719adc91..2772c19f58a35713d61aab24f6f0d6f5070153c6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftJukeboxSong.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftJukeboxSong.java
+@@ -59,6 +59,7 @@ public class CraftJukeboxSong implements JukeboxSong, Handleable<net.minecraft.w
+     @NotNull
+     @Override
+     public String getTranslationKey() {
++        if (!(this.handle.description().getContents() instanceof TranslatableContents)) throw new UnsupportedOperationException("Description isn't translatable!"); // Paper
+         return ((TranslatableContents) this.handle.description().getContents()).getKey();
+     }
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 index 9babfd8e6c847ea26863be6243f17fc252dc9e1d..0e3ff653211b0210f8679b475d5f62eecbdfd946 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java

--- a/patches/server/0970-General-ItemMeta-fixes.patch
+++ b/patches/server/0970-General-ItemMeta-fixes.patch
@@ -830,7 +830,7 @@ index 97b7085250d749c5e46352b372068b51de89bc7f..7277e7ee566aabf6e01937072d949ed6
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..b62496dee2551a3485fc0f70cfd7ef99c8c6718d 100644
+index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfacefbe682e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -182,9 +182,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -912,7 +912,7 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..b62496dee2551a3485fc0f70cfd7ef99
      @Overridden
      boolean isEmpty() {
 -        return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.removedTags.isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasTool() || this.hasDamage() || this.hasMaxDamage() || this.hasAttributeModifiers() || this.customTag != null || this.canPlaceOnPredicates != null || this.canBreakPredicates != null); // Paper
-+        return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.removedTags.isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasTool() || this.hasDamageValue() || this.hasMaxDamage() || this.hasAttributeModifiers() || this.customTag != null || this.canPlaceOnPredicates != null || this.canBreakPredicates != null); // Paper
++        return !(this.hasDisplayName() || this.hasItemName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.build().isEmpty() || !this.removedTags.isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isHideTooltip() || this.isUnbreakable() || this.hasEnchantmentGlintOverride() || this.isFireResistant() || this.hasMaxStackSize() || this.hasRarity() || this.hasFood() || this.hasTool() || this.hasJukeboxPlayable() || this.hasDamageValue() || this.hasMaxDamage() || this.hasAttributeModifiers() || this.customTag != null || this.canPlaceOnPredicates != null || this.canBreakPredicates != null); // Paper
      }
  
      // Paper start

--- a/patches/server/0977-Fix-equipment-slot-and-group-API.patch
+++ b/patches/server/0977-Fix-equipment-slot-and-group-API.patch
@@ -32,7 +32,7 @@ index 9d74577af071954e1e37201a96368c1360076209..eafa54c870c3e2aef30c3f9f96f51660
                  throw new IllegalArgumentException("Not implemented. This is a bug");
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index b62496dee2551a3485fc0f70cfd7ef99c8c6718d..1f52bfccc0bebf3f59af88f0cdab58015e115af0 100644
+index 776f4dcc0b61a5b8ee4020a283cfcfacefbe682e..9aef0223cd790d9f4a74dfe22e7926027c08dca5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -1452,7 +1452,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {


### PR DESCRIPTION
The itemmeta was considered as empty even with valid data in the component (so previously the conversion would always clear the component).
Also fixed the javadoc and annotation of ItemMeta#getJukeboxPlayable. And for some reason spigot considered the jukebox song as always translatable which might be not the case for data pack ones.