### PR TITLE
Validate speed for tool component rule

### DIFF
--- a/patches/server/0970-General-ItemMeta-fixes.patch
+++ b/patches/server/0970-General-ItemMeta-fixes.patch
@@ -1518,6 +1518,42 @@ index 63fc9138dc3388ceb9acf672b3f75ba0976e8e54..cad52601583c1f304f94de954c4d18a6
          List<FoodProperties.PossibleEffect> effects = new ArrayList<>(this.handle.effects());
  
          FoodProperties.PossibleEffect newEffect = new net.minecraft.world.food.FoodProperties.PossibleEffect(CraftPotionUtil.fromBukkit(effect), probability);
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/components/CraftToolComponent.java b/src/main/java/org/bukkit/craftbukkit/inventory/components/CraftToolComponent.java
+index 4d7889ccd1c70db537402a9bbab42e40c3bb0d65..73be17186c87019868fdd7f9e0fdcdadeef79570 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/components/CraftToolComponent.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/components/CraftToolComponent.java
+@@ -108,6 +108,7 @@ public final class CraftToolComponent implements ToolComponent {
+     public ToolRule addRule(Material block, Float speed, Boolean correctForDrops) {
+         Preconditions.checkArgument(block != null, "block must not be null");
+         Preconditions.checkArgument(block.isBlock(), "block must be a block type, given %s", block.getKey());
++        Preconditions.checkArgument(speed == null || speed > 0, "speed must be positive"); // Paper - validate speed
+ 
+         Holder.Reference<Block> nmsBlock = CraftBlockType.bukkitToMinecraft(block).builtInRegistryHolder();
+         return this.addRule(HolderSet.direct(nmsBlock), speed, correctForDrops);
+@@ -115,6 +116,7 @@ public final class CraftToolComponent implements ToolComponent {
+ 
+     @Override
+     public ToolRule addRule(Collection<Material> blocks, Float speed, Boolean correctForDrops) {
++        Preconditions.checkArgument(speed == null || speed > 0, "speed must be positive"); // Paper - validate speed
+         List<Holder.Reference<Block>> nmsBlocks = new ArrayList<>(blocks.size());
+ 
+         for (Material material : blocks) {
+@@ -128,6 +130,7 @@ public final class CraftToolComponent implements ToolComponent {
+     @Override
+     public ToolRule addRule(Tag<Material> tag, Float speed, Boolean correctForDrops) {
+         Preconditions.checkArgument(tag instanceof CraftBlockTag, "tag must be a block tag");
++        Preconditions.checkArgument(speed == null || speed > 0, "speed must be positive"); // Paper - validate speed
+         return this.addRule(((CraftBlockTag) tag).getHandle(), speed, correctForDrops);
+     }
+ 
+@@ -290,6 +293,7 @@ public final class CraftToolComponent implements ToolComponent {
+ 
+         @Override
+         public void setSpeed(Float speed) {
++            Preconditions.checkArgument(speed == null || speed > 0, "speed must be positive"); // Paper - validate speed
+             this.handle = new Tool.Rule(this.handle.blocks(), Optional.ofNullable(speed), this.handle.correctForDrops());
+         }
+ 
 diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java
 index 6bed0a5c8d9f1ca72678cdf4699128e441a24541..8e03e14d0e65bfdf2196a08220d1408b1297aa0d 100644
 --- a/src/test/java/org/bukkit/craftbukkit/inventory/DeprecatedItemMetaCustomValueTest.java


### PR DESCRIPTION
Make it easier for plugin to diagnose issue down the line and prevent being in an unstable state in the server.
Player save and dump item will fail for player holding this bad item.