### PR TITLE
Expose LivingEntity#canUseSlot

### DIFF
--- a/patches/api/0471-Fix-equipment-slot-and-group-API.patch
+++ b/patches/api/0471-Fix-equipment-slot-and-group-API.patch
@@ -3,7 +3,11 @@ From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Wed, 22 May 2024 10:00:19 -0700
 Subject: [PATCH] Fix equipment slot and group API
 
-was missing the 'body' slot group
+Adds the following:
+- Add missing 'body' slot group
+- Expose LivingEntity#canUseSlot
+
+Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/attribute/AttributeModifier.java b/src/main/java/org/bukkit/attribute/AttributeModifier.java
 index 90f18f355a6a236a7e4273cc1258e7c8034b8276..a0750d457a9cd7cf3ab9c45bb28ce5a2aef35298 100644
@@ -17,33 +21,55 @@ index 90f18f355a6a236a7e4273cc1258e7c8034b8276..a0750d457a9cd7cf3ab9c45bb28ce5a2
      public EquipmentSlot getSlot() {
          return slot == EquipmentSlotGroup.ANY ? null : slot.getExample();
      }
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 5c29956c6db53440322330ff723c7087193641f1..a3e9360168a999fb08797285ecaec6578687676c 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -1447,4 +1447,14 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+      */
+     void setBodyYaw(float bodyYaw);
+     // Paper end - body yaw API
++
++    // Paper start - Expose canUseSlot
++    /**
++     * Checks whether this entity can use the equipment slot
++     *
++     * @param slot equipment slot
++     * @return whether this entity can use the equipment slot
++     */
++    boolean canUseEquipmentSlot(org.bukkit.inventory.@NotNull EquipmentSlot slot);
++    // Paper end - Expose canUseSlot
+ }
 diff --git a/src/main/java/org/bukkit/inventory/EntityEquipment.java b/src/main/java/org/bukkit/inventory/EntityEquipment.java
-index 1b34286fb6cbedb3841c84c499eb626f61885126..0829418cc4b586ea9c800617f7184b1e60f756a6 100644
+index 1b34286fb6cbedb3841c84c499eb626f61885126..91cd0a918b640df7e75f6e40f3c6bd3689d4ff40 100644
 --- a/src/main/java/org/bukkit/inventory/EntityEquipment.java
 +++ b/src/main/java/org/bukkit/inventory/EntityEquipment.java
-@@ -15,6 +15,7 @@ public interface EntityEquipment {
+@@ -15,6 +15,8 @@ public interface EntityEquipment {
       *
       * @param slot the slot to put the ItemStack
       * @param item the ItemStack to set
 +     * @throws IllegalArgumentException if the slot is invalid for the entity
++     * @see org.bukkit.entity.LivingEntity#canUseEquipmentSlot(EquipmentSlot)
       */
      public void setItem(@NotNull EquipmentSlot slot, @Nullable ItemStack item);
  
-@@ -23,7 +24,8 @@ public interface EntityEquipment {
+@@ -23,7 +25,9 @@ public interface EntityEquipment {
       *
       * @param slot the slot to put the ItemStack
       * @param item the ItemStack to set
 -     * @param silent whether or not the equip sound should be silenced
 +     * @param silent whether the equip sound should be silenced
 +     * @throws IllegalArgumentException if the slot is invalid for the entity
++     * @see org.bukkit.entity.LivingEntity#canUseEquipmentSlot(EquipmentSlot)
       */
      public void setItem(@NotNull EquipmentSlot slot, @Nullable ItemStack item, boolean silent);
  
-@@ -32,6 +34,7 @@ public interface EntityEquipment {
+@@ -32,6 +36,8 @@ public interface EntityEquipment {
       *
       * @param slot the slot to get the ItemStack
       * @return the ItemStack in the given slot
 +     * @throws IllegalArgumentException if the slot is invalid for the entity
++     * @see org.bukkit.entity.LivingEntity#canUseEquipmentSlot(EquipmentSlot)
       */
      @NotNull
      public ItemStack getItem(@NotNull EquipmentSlot slot);
@@ -74,3 +100,25 @@ index 0019c8d91eefbfb44e76b9f929b25cd189295b79..2ba475ee5e976a6f5451021be1769734
      //
      private final String key;
      private final Predicate<EquipmentSlot> predicate;
+diff --git a/src/main/java/org/bukkit/inventory/PlayerInventory.java b/src/main/java/org/bukkit/inventory/PlayerInventory.java
+index 2c54660dc1fbc7c1232096797a23cae1262888e9..bcfcf963063e7c0fdc711febef2df2d0ff12776d 100644
+--- a/src/main/java/org/bukkit/inventory/PlayerInventory.java
++++ b/src/main/java/org/bukkit/inventory/PlayerInventory.java
+@@ -95,6 +95,8 @@ public interface PlayerInventory extends Inventory {
+      * @param slot the slot to put the ItemStack
+      * @param item the ItemStack to set
+      *
++     * @throws IllegalArgumentException if the slot is invalid for the player
++     * @see org.bukkit.entity.LivingEntity#canUseEquipmentSlot(EquipmentSlot)
+      * @see #setItem(int, ItemStack)
+      */
+     public void setItem(@NotNull EquipmentSlot slot, @Nullable ItemStack item);
+@@ -105,6 +107,8 @@ public interface PlayerInventory extends Inventory {
+      * @param slot the slot to get the ItemStack
+      *
+      * @return the ItemStack in the given slot
++     * @throws IllegalArgumentException if the slot is invalid for the player
++     * @see org.bukkit.entity.LivingEntity#canUseEquipmentSlot(EquipmentSlot)
+      */
+     @NotNull // Paper
+     public ItemStack getItem(@NotNull EquipmentSlot slot);

--- a/patches/api/0471-Fix-equipment-slot-and-group-API.patch
+++ b/patches/api/0471-Fix-equipment-slot-and-group-API.patch
@@ -22,17 +22,18 @@ index 90f18f355a6a236a7e4273cc1258e7c8034b8276..a0750d457a9cd7cf3ab9c45bb28ce5a2
          return slot == EquipmentSlotGroup.ANY ? null : slot.getExample();
      }
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 5c29956c6db53440322330ff723c7087193641f1..a3e9360168a999fb08797285ecaec6578687676c 100644
+index 5c29956c6db53440322330ff723c7087193641f1..a1e54e9d14393a6c0ea57cca854071c5396d9717 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1447,4 +1447,14 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1447,4 +1447,15 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      void setBodyYaw(float bodyYaw);
      // Paper end - body yaw API
 +
 +    // Paper start - Expose canUseSlot
 +    /**
-+     * Checks whether this entity can use the equipment slot
++     * Checks whether this entity can use the equipment slot.
++     * <br>For example, not all entities may have {@link org.bukkit.inventory.EquipmentSlot#BODY}.
 +     *
 +     * @param slot equipment slot
 +     * @return whether this entity can use the equipment slot

--- a/patches/server/0977-Fix-equipment-slot-and-group-API.patch
+++ b/patches/server/0977-Fix-equipment-slot-and-group-API.patch
@@ -3,8 +3,28 @@ From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Wed, 22 May 2024 10:01:19 -0700
 Subject: [PATCH] Fix equipment slot and group API
 
-Add test for EquipmentSlotGroup
+Adds the following:
+- Add test for EquipmentSlotGroup
+- Expose LivingEntity#canUseSlot
 
+Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index a1e715629313346f670bce92483996122b0f1d7b..a51b965cafa30e76cc8b4bca188b548c7837b098 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -1181,4 +1181,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+         this.getHandle().setYBodyRot(bodyYaw);
+     }
+     // Paper end - body yaw API
++
++    // Paper start - Expose canUseSlot
++    @Override
++    public boolean canUseEquipmentSlot(org.bukkit.inventory.EquipmentSlot slot) {
++        return this.getHandle().canUseSlot(org.bukkit.craftbukkit.CraftEquipmentSlot.getNMS(slot));
++    }
++    // Paper end - Expose canUseSlot
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
 index 9d74577af071954e1e37201a96368c1360076209..eafa54c870c3e2aef30c3f9f96f516607a7cae24 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java


### PR DESCRIPTION
- Adds `LivingEntity#canUseEquipmentSlot(EquipmentSlot)` to check whether an entity can use that slot.
- Adds missing `@throws` annotations to PlayerInventory.

Follow-up/related to https://github.com/PaperMC/Paper/pull/10822.