### PR TITLE
Fix NPE of AbstractArrow#getWeapon

### DIFF
--- a/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
@@ -742,6 +742,19 @@ index c7a901707048e9dc82b8f17f3285727460173c72..64675a3641acb50676ca0122f8473ce9
      public abstract EnchantmentTarget getItemTarget();
  
      /**
+diff --git a/src/main/java/org/bukkit/entity/AbstractArrow.java b/src/main/java/org/bukkit/entity/AbstractArrow.java
+index 493f81ba879d1eb29a32722da27e4ff7ce4c68a8..8bf9bf7940d2911486e9d3a4f688cfae3f6173f2 100644
+--- a/src/main/java/org/bukkit/entity/AbstractArrow.java
++++ b/src/main/java/org/bukkit/entity/AbstractArrow.java
+@@ -157,7 +157,7 @@ public interface AbstractArrow extends Projectile {
+      *
+      * @return The firing ItemStack
+      */
+-    @NotNull
++    @Nullable // Paper
+     @ApiStatus.Experimental
+     public ItemStack getWeapon();
+ 
 diff --git a/src/main/java/org/bukkit/entity/Enderman.java b/src/main/java/org/bukkit/entity/Enderman.java
 index 3afe2787de576f7190d87c796bea0ab34dc30248..58191017244f3949f6174fb108e3a245738a53c4 100644
 --- a/src/main/java/org/bukkit/entity/Enderman.java

--- a/patches/api/0338-More-Projectile-API.patch
+++ b/patches/api/0338-More-Projectile-API.patch
@@ -7,7 +7,7 @@ Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/entity/AbstractArrow.java b/src/main/java/org/bukkit/entity/AbstractArrow.java
-index 493f81ba879d1eb29a32722da27e4ff7ce4c68a8..15c7149cf9f6a0b1d99134122bb36672de72c7ca 100644
+index 8bf9bf7940d2911486e9d3a4f688cfae3f6173f2..9bf4b86e730f3d066f6ebfd4e516caf78145479e 100644
 --- a/src/main/java/org/bukkit/entity/AbstractArrow.java
 +++ b/src/main/java/org/bukkit/entity/AbstractArrow.java
 @@ -139,17 +139,21 @@ public interface AbstractArrow extends Projectile {

--- a/patches/server/0679-More-Projectile-API.patch
+++ b/patches/server/0679-More-Projectile-API.patch
@@ -176,7 +176,7 @@ index 91c2d0b40d3fca86938cd454e1415a4eea3df7c7..de4fb2654c7895cfd83ad694455ee56c
 +    // Paper end - More projectile API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractArrow.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractArrow.java
-index 329ca9c743a7f2feeabbfb769ff9a71f60165006..a574161c8ff6b94bb8fda68fbc72d4b109dea593 100644
+index 329ca9c743a7f2feeabbfb769ff9a71f60165006..faa08ad912fa43e7a6c5a2359e23c04c059c5edf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractArrow.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractArrow.java
 @@ -58,20 +58,7 @@ public class CraftAbstractArrow extends AbstractProjectile implements AbstractAr
@@ -201,7 +201,15 @@ index 329ca9c743a7f2feeabbfb769ff9a71f60165006..a574161c8ff6b94bb8fda68fbc72d4b1
  
      @Override
      public boolean isInBlock() {
-@@ -149,4 +136,37 @@ public class CraftAbstractArrow extends AbstractProjectile implements AbstractAr
+@@ -130,6 +117,7 @@ public class CraftAbstractArrow extends AbstractProjectile implements AbstractAr
+ 
+     @Override
+     public ItemStack getWeapon() {
++        if (this.getHandle().getWeaponItem() == null) return null; // Paper - fix NPE
+         return CraftItemStack.asBukkitCopy(this.getHandle().getWeaponItem());
+     }
+ 
+@@ -149,4 +137,37 @@ public class CraftAbstractArrow extends AbstractProjectile implements AbstractAr
      public String toString() {
          return "CraftArrow";
      }


### PR DESCRIPTION
getWeaponItem() is nullable and CraftItemStack#asBukkitCopy doesn't allow null input even before the itemstack delegate commit.