### PR TITLE
Fix speed for launched trident using api

### DIFF
--- a/patches/server/0679-More-Projectile-API.patch
+++ b/patches/server/0679-More-Projectile-API.patch
@@ -515,9 +515,18 @@ index 6e2f91423371ead9890095cf4b1e2299c4dcba28..9d8f4b7176e60180565e3134a14ecf19
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 464d67075e052f13e86b51f3e71d05a6536ef540..cc33f39dc31692e9309e62c09463e1cc621e2534 100644
+index 464d67075e052f13e86b51f3e71d05a6536ef540..34276233751a41b41ee6af99afa97ef7d4bca836 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -596,7 +596,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+             } else {
+                 launch = new net.minecraft.world.entity.projectile.Arrow(world, this.getHandle(), new net.minecraft.world.item.ItemStack(net.minecraft.world.item.Items.ARROW), null);
+             }
+-            ((net.minecraft.world.entity.projectile.AbstractArrow) launch).shootFromRotation(this.getHandle(), this.getHandle().getXRot(), this.getHandle().getYRot(), 0.0F, 3.0F, 1.0F); // ItemBow
++            ((net.minecraft.world.entity.projectile.AbstractArrow) launch).shootFromRotation(this.getHandle(), this.getHandle().getXRot(), this.getHandle().getYRot(), 0.0F, Trident.class.isAssignableFrom(projectile) ? net.minecraft.world.item.TridentItem.SHOOT_POWER : 3.0F, 1.0F); // ItemBow // Paper - see TridentItem
+         } else if (ThrownPotion.class.isAssignableFrom(projectile)) {
+             if (LingeringPotion.class.isAssignableFrom(projectile)) {
+                 launch = new net.minecraft.world.entity.projectile.ThrownPotion(world, this.getHandle());
 @@ -650,7 +650,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          } else if (Firework.class.isAssignableFrom(projectile)) {
              Location location = this.getEyeLocation();

--- a/patches/server/0744-Add-a-consumer-parameter-to-ProjectileSource-launchP.patch
+++ b/patches/server/0744-Add-a-consumer-parameter-to-ProjectileSource-launchP.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add a consumer parameter to ProjectileSource#launchProjectile
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index cc33f39dc31692e9309e62c09463e1cc621e2534..d0601fa54f804059b86cf8d5d459b756308e360b 100644
+index 34276233751a41b41ee6af99afa97ef7d4bca836..f278346bb5fe816f3c559a02692b125dde0446f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -569,8 +569,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {

--- a/patches/server/0759-Add-entity-knockback-API.patch
+++ b/patches/server/0759-Add-entity-knockback-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add entity knockback API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index d0601fa54f804059b86cf8d5d459b756308e360b..766052686d2b7ba479c503b675e7a8cc49590bbe 100644
+index f278346bb5fe816f3c559a02692b125dde0446f4..3cc29107c018848a364e0fca689acf16cdd0ddb0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -1098,4 +1098,12 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {

--- a/patches/server/0775-ItemStack-damage-API.patch
+++ b/patches/server/0775-ItemStack-damage-API.patch
@@ -51,7 +51,7 @@ index d825c2e3808e44db9935dab4e7b528146c6d83c2..96a7e80e3efab1bf626fb7aff61e095c
  
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 766052686d2b7ba479c503b675e7a8cc49590bbe..30c3abfdc9280a1ec21a28bd9aef25dd7f509916 100644
+index 3cc29107c018848a364e0fca689acf16cdd0ddb0..6d3183c2bfe9b28070a72cb5c3c05dda2a9d8b11 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -1106,4 +1106,48 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {

--- a/patches/server/0776-Friction-API.patch
+++ b/patches/server/0776-Friction-API.patch
@@ -133,7 +133,7 @@ index 1a291dd8a287db30e71dcb315599fc4b038764c4..30d62ee4d5cd2ddacb8783b5bbbf475d
      public int getHealth() {
          return this.getHandle().health;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 30c3abfdc9280a1ec21a28bd9aef25dd7f509916..66611d26cbb7b70003e1a3fec375da0782e113bb 100644
+index 6d3183c2bfe9b28070a72cb5c3c05dda2a9d8b11..89af84b8ff3aac5269dfb2b069a6e23742b82b4e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -1150,4 +1150,17 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {

--- a/patches/server/0801-Add-Entity-Body-Yaw-API.patch
+++ b/patches/server/0801-Add-Entity-Body-Yaw-API.patch
@@ -43,7 +43,7 @@ index 3c1e199316ae283210529d4d27b4f9d70b4d9404..d8b1cdc78eb234023a42d74059900973
      @Override
      public boolean isInvisible() {  // Paper - moved up from LivingEntity
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 66611d26cbb7b70003e1a3fec375da0782e113bb..c64a2efd3c66ac9f4d4fcfb684b8406be22c8f81 100644
+index 89af84b8ff3aac5269dfb2b069a6e23742b82b4e..413a58d025cc7baf794e1f2866c3582504df4daf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -1163,4 +1163,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {

--- a/patches/server/0832-Add-method-to-remove-all-active-potion-effects.patch
+++ b/patches/server/0832-Add-method-to-remove-all-active-potion-effects.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add method to remove all active potion effects
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index c64a2efd3c66ac9f4d4fcfb684b8406be22c8f81..b3970222ed979dda5296ce472739c112b70d0e89 100644
+index 413a58d025cc7baf794e1f2866c3582504df4daf..de1c0c610931471c580266f0d0e0fd881b1e7d3d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -563,6 +563,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {

--- a/patches/server/0977-Fix-equipment-slot-and-group-API.patch
+++ b/patches/server/0977-Fix-equipment-slot-and-group-API.patch
@@ -10,10 +10,10 @@ Adds the following:
 Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index a1e715629313346f670bce92483996122b0f1d7b..a51b965cafa30e76cc8b4bca188b548c7837b098 100644
+index de1c0c610931471c580266f0d0e0fd881b1e7d3d..d2bb0831394c03b620b2cbd8306cb82b621f34f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1181,4 +1181,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1182,4 +1182,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          this.getHandle().setYBodyRot(bodyYaw);
      }
      // Paper end - body yaw API


### PR DESCRIPTION
The trident launch speed when a player launch it by hand is set to 2.5 however the api always set it to 3 which change the outcome.