### PR TITLE
Fix base damage for trident

### DIFF
--- a/patches/server/0877-Allow-trident-custom-damage.patch
+++ b/patches/server/0877-Allow-trident-custom-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow trident custom damage
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownTrident.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownTrident.java
-index e45c3a9805d9fac1fabe6d891c817743acd9969e..cb71f468e90f076caf2c0dcc5f2ba2745c737c22 100644
+index e45c3a9805d9fac1fabe6d891c817743acd9969e..44c733c5b2c3e9942f28e882ad72306a24459c2c 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownTrident.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownTrident.java
-@@ -36,10 +36,12 @@ public class ThrownTrident extends AbstractArrow {
+@@ -36,16 +36,19 @@ public class ThrownTrident extends AbstractArrow {
  
      public ThrownTrident(EntityType<? extends ThrownTrident> type, Level world) {
          super(type, world);
@@ -21,7 +21,14 @@ index e45c3a9805d9fac1fabe6d891c817743acd9969e..cb71f468e90f076caf2c0dcc5f2ba274
          this.entityData.set(ThrownTrident.ID_LOYALTY, this.getLoyaltyFromItem(stack));
          this.entityData.set(ThrownTrident.ID_FOIL, stack.hasFoil());
      }
-@@ -129,7 +131,7 @@ public class ThrownTrident extends AbstractArrow {
+ 
+     public ThrownTrident(Level world, double x, double y, double z, ItemStack stack) {
+         super(EntityType.TRIDENT, x, y, z, world, stack, stack);
++        this.setBaseDamage(net.minecraft.world.item.TridentItem.BASE_DAMAGE); // Paper - Allow trident custom damage
+         this.entityData.set(ThrownTrident.ID_LOYALTY, this.getLoyaltyFromItem(stack));
+         this.entityData.set(ThrownTrident.ID_FOIL, stack.hasFoil());
+     }
+@@ -129,7 +132,7 @@ public class ThrownTrident extends AbstractArrow {
      @Override
      protected void onHitEntity(EntityHitResult entityHitResult) {
          Entity entity = entityHitResult.getEntity();


### PR DESCRIPTION
One constructor was missing the default base damage definition. The base damage was set to 2 instead of 8 points for this situation.
This is only used by the trial spawner via the ominous item spawner and can be reproduce easily with a custom loottable containing a single trident.