### PR TITLE
Copy forward when registering alias (fixes #10827)

### DIFF
--- a/patches/server/0975-Brigadier-based-command-API.patch
+++ b/patches/server/0975-Brigadier-based-command-API.patch
@@ -686,10 +686,10 @@ index 0000000000000000000000000000000000000000..1b1642f306771f029e6214a2e2ebebb6
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java b/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..27509813a90980be1dfc7bde27d0eba60adfc820
+index 0000000000000000000000000000000000000000..972aa60e73921904c49233c57cc789b62a50246d
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
-@@ -0,0 +1,193 @@
+@@ -0,0 +1,194 @@
 +package io.papermc.paper.command.brigadier;
 +
 +import com.google.common.base.Preconditions;
@@ -822,6 +822,7 @@ index 0000000000000000000000000000000000000000..27509813a90980be1dfc7bde27d0eba6
 +        if (redirectTo.getChildren().isEmpty() || hasFlattenRedirectFlag) {
 +            redirect = Commands.literal(aliasLiteral)
 +                .executes(redirectTo.getCommand())
++                .forward(redirectTo.getRedirect(), redirectTo.getRedirectModifier(), redirectTo.isFork())
 +                .requires(redirectTo.getRequirement())
 +                .build();
 +


### PR DESCRIPTION
When flattening any command or registering an alias to a node with no direct children (such as a redirect), the code now takes into account any potential redirect/fork/forward on the target node. This fixes the issue where, when registering a command that was simply a redirect, only the namespaced literal would work, and not any aliases of the command.

This fixes #10827