### PR TITLE
Copy forward when registering alias (fixes #10827)

### DIFF
--- a/patches/server/0950-Brigadier-based-command-API.patch
+++ b/patches/server/0950-Brigadier-based-command-API.patch
@@ -687,10 +687,10 @@ index 0000000000000000000000000000000000000000..1b1642f306771f029e6214a2e2ebebb6
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java b/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..95d3b42cbe2184b0a04d941f27f7a6e643ef59be
+index 0000000000000000000000000000000000000000..27509813a90980be1dfc7bde27d0eba60adfc820
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
-@@ -0,0 +1,204 @@
+@@ -0,0 +1,205 @@
 +package io.papermc.paper.command.brigadier;
 +
 +import com.google.common.base.Preconditions;
@@ -825,6 +825,7 @@ index 0000000000000000000000000000000000000000..95d3b42cbe2184b0a04d941f27f7a6e6
 +        if (redirectTo.getChildren().isEmpty() || hasFlattenRedirectFlag) {
 +            redirect = Commands.literal(aliasLiteral)
 +                .executes(redirectTo.getCommand())
++                .forward(redirectTo.getRedirect(), redirectTo.getRedirectModifier(), redirectTo.isFork())
 +                .requires(redirectTo.getRequirement())
 +                .build();
 +


### PR DESCRIPTION
When flattening any command or registering an alias to a node with no direct children (such as a redirect), the code now takes into account any potential redirect/fork/forward on the target node. This fixes the issue where, when registering a command that was simply a redirect, only the namespaced literal would work, and not any aliases of the command.

This fixes #10827, and is now correctly based on a non-`master` branch :)