### PR TITLE
Fix rails, redstone and diodes not firing BlockDestroyEvent (fixes #10869)

### DIFF
--- a/patches/api/0161-BlockDestroyEvent.patch
+++ b/patches/api/0161-BlockDestroyEvent.patch
@@ -12,10 +12,10 @@ This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java b/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c0742b58ca2c098c27394915b624889ece1a9168
+index 0000000000000000000000000000000000000000..258efc10319e89b9967fd8b1fc6c75489d273b9d
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java
-@@ -0,0 +1,122 @@
+@@ -0,0 +1,123 @@
 +package com.destroystokyo.paper.event.block;
 +
 +import org.bukkit.block.Block;
@@ -31,7 +31,7 @@ index 0000000000000000000000000000000000000000..c0742b58ca2c098c27394915b624889e
 + * This does not fire anytime a block is set to air, but only with more direct triggers such
 + * as physics updates, pistons, Entities changing blocks, commands set to "Destroy".
 + * <p>
-+ * This event is associated with the game playing a sound effect at the block in question, when
++ * This event is mostly associated with the game playing a sound effect at the block in question, when
 + * something can be described as "intend to destroy what is there",
 + * <p>
 + * Events such as leaves decaying, pistons retracting (where the block is moving), does NOT fire this event.
@@ -42,17 +42,18 @@ index 0000000000000000000000000000000000000000..c0742b58ca2c098c27394915b624889e
 +
 +    @NotNull private final BlockData newState;
 +    private boolean willDrop;
-+    private boolean playEffect = true;
++    private boolean playEffect;
 +    private BlockData effectBlock;
 +
 +    private boolean cancelled;
 +
 +    @ApiStatus.Internal
-+    public BlockDestroyEvent(@NotNull Block block, @NotNull BlockData newState, @NotNull BlockData effectBlock, int xp, boolean willDrop) {
++    public BlockDestroyEvent(@NotNull Block block, @NotNull BlockData newState, @NotNull BlockData effectBlock, int xp, boolean willDrop, boolean playEffect) {
 +        super(block, xp);
 +        this.newState = newState;
 +        this.effectBlock = effectBlock;
 +        this.willDrop = willDrop;
++        this.playEffect = playEffect;
 +    }
 +
 +    /**

--- a/patches/server/0276-BlockDestroyEvent.patch
+++ b/patches/server/0276-BlockDestroyEvent.patch
@@ -11,7 +11,7 @@ floating in the air.
 This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index c0b0a9328faf93b85ceaf6cc9989f1a59520c7f4..8e2acb3c6f815b5b1d3237a2f4e0b5f3683d2c60 100644
+index c0b0a9328faf93b85ceaf6cc9989f1a59520c7f4..ed387fddc8e6870ed00979291a89faff94f8629a 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -25,6 +25,7 @@ import net.minecraft.core.registries.Registries;
@@ -22,18 +22,29 @@ index c0b0a9328faf93b85ceaf6cc9989f1a59520c7f4..8e2acb3c6f815b5b1d3237a2f4e0b5f3
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.FullChunkStatus;
  import net.minecraft.server.level.ServerLevel;
-@@ -576,9 +577,26 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -570,15 +571,37 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+ 
+     @Override
+     public boolean destroyBlock(BlockPos pos, boolean drop, @Nullable Entity breakingEntity, int maxUpdateDepth) {
++        // Paper start - create new override since sometimes we don't want to play the effect
++        return destroyBlock(pos, drop, breakingEntity, maxUpdateDepth, true);
++    }
++
++    public boolean destroyBlock(BlockPos pos, boolean drop, @Nullable Entity breakingEntity, int maxUpdateDepth, boolean playEffect) {
++        // Paper end
+         BlockState iblockdata = this.getBlockState(pos);
+ 
+         if (iblockdata.isAir()) {
              return false;
          } else {
              FluidState fluid = this.getFluidState(pos);
 +            // Paper start - BlockDestroyEvent; while the above setAir method is named same and looks very similar
 +            // they are NOT used with same intent and the above should not fire this event. The above method is more of a BlockSetToAirEvent,
 +            // it doesn't imply destruction of a block that plays a sound effect / drops an item.
-+            boolean playEffect = true;
 +            BlockState effectType = iblockdata;
 +            int xp = iblockdata.getBlock().getExpDrop(iblockdata, (ServerLevel) this, pos, ItemStack.EMPTY, true);
 +            if (com.destroystokyo.paper.event.block.BlockDestroyEvent.getHandlerList().getRegisteredListeners().length > 0) {
-+                com.destroystokyo.paper.event.block.BlockDestroyEvent event = new com.destroystokyo.paper.event.block.BlockDestroyEvent(org.bukkit.craftbukkit.block.CraftBlock.at(this, pos), fluid.createLegacyBlock().createCraftBlockData(), effectType.createCraftBlockData(), xp, drop);
++                com.destroystokyo.paper.event.block.BlockDestroyEvent event = new com.destroystokyo.paper.event.block.BlockDestroyEvent(org.bukkit.craftbukkit.block.CraftBlock.at(this, pos), fluid.createLegacyBlock().createCraftBlockData(), effectType.createCraftBlockData(), xp, drop, playEffect);
 +                if (!event.callEvent()) {
 +                    return false;
 +                }
@@ -51,3 +62,57 @@ index c0b0a9328faf93b85ceaf6cc9989f1a59520c7f4..8e2acb3c6f815b5b1d3237a2f4e0b5f3
              }
  
              if (drop) {
+diff --git a/src/main/java/net/minecraft/world/level/block/BaseRailBlock.java b/src/main/java/net/minecraft/world/level/block/BaseRailBlock.java
+index f9b6db516fa0788a6d4d40fa7ea2039cd3282b24..db43f834fd618cbdff28419163f6e176bfca6210 100644
+--- a/src/main/java/net/minecraft/world/level/block/BaseRailBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/BaseRailBlock.java
+@@ -78,8 +78,11 @@ public abstract class BaseRailBlock extends Block implements SimpleWaterloggedBl
+         if (!world.isClientSide && world.getBlockState(pos).is(this)) {
+             RailShape railShape = state.getValue(this.getShapeProperty());
+             if (shouldBeRemoved(pos, world, railShape)) {
+-                dropResources(state, world, pos);
+-                world.removeBlock(pos, notify);
++                //dropResources(state, world, pos); Paper - change call so that BlockDestroyEvent is called
++                //world.removeBlock(pos, notify); Paper - change call so that BlockDestroyEvent is called
++                // Paper - change call so that BlockDestroyEvent is called
++                world.destroyBlock(pos, true, null, 512, false);
++                // Paper end
+             } else {
+                 this.updateState(state, world, pos, sourceBlock);
+             }
+diff --git a/src/main/java/net/minecraft/world/level/block/DiodeBlock.java b/src/main/java/net/minecraft/world/level/block/DiodeBlock.java
+index b9f605db2b0de1c18c615f0f6485da7eaaf09b65..f596001dc3eec0408630ee8ce56e6fbcb596dea5 100644
+--- a/src/main/java/net/minecraft/world/level/block/DiodeBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/DiodeBlock.java
+@@ -95,8 +95,11 @@ public abstract class DiodeBlock extends HorizontalDirectionalBlock {
+         } else {
+             BlockEntity tileentity = state.hasBlockEntity() ? world.getBlockEntity(pos) : null;
+ 
+-            dropResources(state, world, pos, tileentity);
+-            world.removeBlock(pos, false);
++            //dropResources(state, world, pos, tileentity); Paper - change call so that BlockDestroyEvent is called
++            //world.removeBlock(pos, false); Paper - change call so that BlockDestroyEvent is called
++            // Paper start - change call so that BlockDestroyEvent is called
++            world.destroyBlock(pos, true, null, 512, false);
++            // Paper end
+             Direction[] aenumdirection = Direction.values();
+             int i = aenumdirection.length;
+ 
+diff --git a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
+index c73bf0b36252796ca93c500affa2be568e3f6c9e..c63db09c4a838fef026f3afd7c00c17262961362 100644
+--- a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
+@@ -413,8 +413,11 @@ public class RedStoneWireBlock extends Block {
+             if (state.canSurvive(world, pos)) {
+                 this.updatePowerStrength(world, pos, state);
+             } else {
+-                dropResources(state, world, pos);
+-                world.removeBlock(pos, false);
++                //dropResources(state, world, pos); Paper - change call so that BlockDestroyEvent is called
++                //world.removeBlock(pos, false); Paper - change call so that BlockDestroyEvent is called
++                // Paper start - change call so that BlockDestroyEvent is called
++                world.destroyBlock(pos, true, null, 512, false);
++                // Paper end
+             }
+ 
+         }

--- a/patches/server/0288-Optimize-Captured-BlockEntity-Lookup.patch
+++ b/patches/server/0288-Optimize-Captured-BlockEntity-Lookup.patch
@@ -10,10 +10,10 @@ Optimize to check if the captured list even has values in it, and also to
 just do a get call since the value can never be null.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 8e2acb3c6f815b5b1d3237a2f4e0b5f3683d2c60..5a3a89c568d42a2adbc2b6e2631fd4b70e54f0bf 100644
+index ed387fddc8e6870ed00979291a89faff94f8629a..17226087adf11dea8c98c55aaa1b9581a5aa1fa5 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -912,9 +912,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -917,9 +917,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      @Nullable
      public BlockEntity getBlockEntity(BlockPos blockposition, boolean validate) {

--- a/patches/server/0393-Fix-some-rails-connecting-improperly.patch
+++ b/patches/server/0393-Fix-some-rails-connecting-improperly.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix some rails connecting improperly
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/BaseRailBlock.java b/src/main/java/net/minecraft/world/level/block/BaseRailBlock.java
-index f9b6db516fa0788a6d4d40fa7ea2039cd3282b24..0961f6f5e627debe0bf02670d922e6d3388ba631 100644
+index db43f834fd618cbdff28419163f6e176bfca6210..b9997372155e0d3d15c3914237e9a00a3526824b 100644
 --- a/src/main/java/net/minecraft/world/level/block/BaseRailBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/BaseRailBlock.java
 @@ -68,6 +68,7 @@ public abstract class BaseRailBlock extends Block implements SimpleWaterloggedBl

--- a/patches/server/0424-Retain-block-place-order-when-capturing-blockstates.patch
+++ b/patches/server/0424-Retain-block-place-order-when-capturing-blockstates.patch
@@ -10,7 +10,7 @@ In general, look at making this logic more robust (i.e properly handling
 cases where a captured entry is overriden) - but for now this will do.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 5a3a89c568d42a2adbc2b6e2631fd4b70e54f0bf..cfd5d3e50197b38d0ffef6debbb7f5b4b208382a 100644
+index 17226087adf11dea8c98c55aaa1b9581a5aa1fa5..84b7e04d597110ea31e6de138fb7542189057251 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -152,7 +152,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0564-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/patches/server/0564-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -21,7 +21,7 @@ index 9a09946b6b178837c44daae894555000668aeb72..8c268f57d44d70df3210510abf783293
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index cfd5d3e50197b38d0ffef6debbb7f5b4b208382a..ed1fc466151ebebf7c3ac135c6893f4ea9a55a52 100644
+index 84b7e04d597110ea31e6de138fb7542189057251..50dc4f17c307a3e93c9aca39dd8a4b6adc4cb982 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -180,6 +180,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0607-Make-sure-inlined-getChunkAt-has-inlined-logic-for-l.patch
+++ b/patches/server/0607-Make-sure-inlined-getChunkAt-has-inlined-logic-for-l.patch
@@ -10,7 +10,7 @@ chunks did get inlined, but the standard CPS.getChunkAt
 method was not inlined.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index ed1fc466151ebebf7c3ac135c6893f4ea9a55a52..38bcf9f410e8a9d47c7d486c28dbc16a6225b650 100644
+index 50dc4f17c307a3e93c9aca39dd8a4b6adc4cb982..b2fbfb5bfc56a9f86a7133295900594b36c78dcc 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -352,7 +352,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0730-Warn-on-plugins-accessing-faraway-chunks.patch
+++ b/patches/server/0730-Warn-on-plugins-accessing-faraway-chunks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Warn on plugins accessing faraway chunks
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 38bcf9f410e8a9d47c7d486c28dbc16a6225b650..210c3b6167dac93e550fe849e34b5aa404ab6dce 100644
+index b2fbfb5bfc56a9f86a7133295900594b36c78dcc..2a0d02a3a9bd34c3cf57c00ba6daba3ac9bbf5db 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -339,7 +339,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0826-Fix-block-place-logic.patch
+++ b/patches/server/0826-Fix-block-place-logic.patch
@@ -22,7 +22,7 @@ index 7d76cdc59984b156628273c8357485eb10046007..7180996027f70aef7afe32fb2adfce64
                      itemstack.consume(1, entityhuman);
                      return InteractionResult.sidedSuccess(world.isClientSide);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 210c3b6167dac93e550fe849e34b5aa404ab6dce..ed1c50d31fc077e4e009719fa622a44edefcdf2c 100644
+index 2a0d02a3a9bd34c3cf57c00ba6daba3ac9bbf5db..b175a2d6dc889ea8acada98cc027b27f24a386e2 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -552,17 +552,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0855-Only-capture-actual-tree-growth.patch
+++ b/patches/server/0855-Only-capture-actual-tree-growth.patch
@@ -29,10 +29,10 @@ index 92be749721f26e9385e592a985db58cf05c67801..1f2e6f57ffb827ef9bf3623bfdde07db
                      entityhuman.awardStat(Stats.ITEM_USED.get(item)); // SPIGOT-7236 - award stat
                  }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index ed1c50d31fc077e4e009719fa622a44edefcdf2c..8337f2f1d650fc7efb830a7034e3676dc0695ee4 100644
+index b175a2d6dc889ea8acada98cc027b27f24a386e2..b33c678e2a4fb24ee8c33b157f694bb5bb61aef7 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1378,4 +1378,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1383,4 +1383,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return range <= 0 ? 64.0 * 64.0 : range * range; // 64 is taken from default in ServerLevel#levelEvent
      }
      // Paper end - respect global sound events gamerule

--- a/patches/server/0927-Properly-handle-experience-dropping-on-block-break.patch
+++ b/patches/server/0927-Properly-handle-experience-dropping-on-block-break.patch
@@ -7,10 +7,10 @@ This causes spawnAfterBreak to spawn xp by default, removing the need to manuall
 For classes that use custom xp amounts, they can drop the resources with disabling
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 8337f2f1d650fc7efb830a7034e3676dc0695ee4..2f1acea765d1b6726863cdc89707ca6148548493 100644
+index b33c678e2a4fb24ee8c33b157f694bb5bb61aef7..8b58855790883b9cb5fe2d2865659e278d6de4f5 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -617,7 +617,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -622,7 +622,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              if (drop) {
                  BlockEntity tileentity = iblockdata.hasBlockEntity() ? this.getBlockEntity(pos) : null;
  

--- a/patches/server/0955-Per-world-ticks-per-spawn-settings.patch
+++ b/patches/server/0955-Per-world-ticks-per-spawn-settings.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Per world ticks per spawn settings
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 2f1acea765d1b6726863cdc89707ca6148548493..81bdb6e64e04641f741c2c3350236685b097ec7a 100644
+index 8b58855790883b9cb5fe2d2865659e278d6de4f5..235b4c1f102c573bcc540dfad47756aa7baf062d 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -186,6 +186,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0957-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/0957-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -25,7 +25,7 @@ index 69914a048987c21ee2ed2c489aab269862fda8f2..bff83fe413c7baef4ba56a3270ea4463
  
                              if (!this.level.isInWorldBounds(blockposition)) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 81bdb6e64e04641f741c2c3350236685b097ec7a..c6c9400fa155831ab11d0f059971d0123617e622 100644
+index 235b4c1f102c573bcc540dfad47756aa7baf062d..05c7976c1d50f94967292349903a44673132bbe9 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -447,6 +447,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0981-Fix-cancelling-BlockPlaceEvent-calling-onRemove.patch
+++ b/patches/server/0981-Fix-cancelling-BlockPlaceEvent-calling-onRemove.patch
@@ -21,7 +21,7 @@ index b800b03ae034b276740c3b41555a52b778ad9aad..86197725f0f2ac1e650297ae7a799075
  
                      // Brute force all possible updates
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index c6c9400fa155831ab11d0f059971d0123617e622..e27d3547d1e19c137e05e6b8d075127a8bafb237 100644
+index 05c7976c1d50f94967292349903a44673132bbe9..386b768a352953b302c85595f70abadbaa02e75d 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -151,6 +151,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0991-Chunk-System-Starlight-from-Moonrise.patch
+++ b/patches/server/0991-Chunk-System-Starlight-from-Moonrise.patch
@@ -27249,7 +27249,7 @@ index bd20bea7f76a7307f1698fb2dfef37125032d166..70c2017400168d4fef3c14462798edcf
          if (shape.isEmpty()) {
              return true;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index e27d3547d1e19c137e05e6b8d075127a8bafb237..557273061fa03ebaa4b9de01ad12ed4ac859c292 100644
+index 386b768a352953b302c85595f70abadbaa02e75d..a803e809914dde01e4d05ce6cf140e56be98a531 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -102,7 +102,7 @@ import org.bukkit.entity.SpawnCategory;
@@ -27337,7 +27337,7 @@ index e27d3547d1e19c137e05e6b8d075127a8bafb237..557273061fa03ebaa4b9de01ad12ed4a
                  this.sendBlockUpdated(blockposition, iblockdata1, iblockdata, i);
              }
  
-@@ -949,7 +1002,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -954,7 +1007,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          }
          // Paper end - Perf: Optimize capturedTileEntities lookup
          // CraftBukkit end
@@ -27346,7 +27346,7 @@ index e27d3547d1e19c137e05e6b8d075127a8bafb237..557273061fa03ebaa4b9de01ad12ed4a
      }
  
      public void setBlockEntity(BlockEntity blockEntity) {
-@@ -1039,28 +1092,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1044,28 +1097,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      @Override
      public List<Entity> getEntities(@Nullable Entity except, AABB box, Predicate<? super Entity> predicate) {
          this.getProfiler().incrementCounter("getEntities");
@@ -27380,7 +27380,7 @@ index e27d3547d1e19c137e05e6b8d075127a8bafb237..557273061fa03ebaa4b9de01ad12ed4a
      }
  
      @Override
-@@ -1075,36 +1113,77 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1080,36 +1118,77 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.getEntities(filter, box, predicate, result, Integer.MAX_VALUE);
      }
  

--- a/patches/server/0994-Optimize-isInWorldBounds-and-getBlockState-for-inlin.patch
+++ b/patches/server/0994-Optimize-isInWorldBounds-and-getBlockState-for-inlin.patch
@@ -29,7 +29,7 @@ index 02367ef1371dde94ff6c4cd40bd32e800d6ccaaf..7b0fc7135bc107103dcaed6dc0707b18
          this.x = x;
          this.y = y;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 557273061fa03ebaa4b9de01ad12ed4ac859c292..316a72f5019d4ad65237b41ccb4ef3be729246ad 100644
+index a803e809914dde01e4d05ce6cf140e56be98a531..95c4fa41283e3815d4907d6dd22416b60ce39003 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -394,7 +394,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl

--- a/patches/server/0996-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
+++ b/patches/server/0996-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
@@ -62,7 +62,7 @@ index bb8e962e63c7a2d931f9bd7f7c002aa35cfa5fd3..0fa131a6c98adb498fc8d534e0e39647
      default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition) {
          // Paper start - Add predicate for blocks when raytracing
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 316a72f5019d4ad65237b41ccb4ef3be729246ad..5ea8f51accdda2387b640d2cff1d6a8baa673bee 100644
+index 95c4fa41283e3815d4907d6dd22416b60ce39003..87ee6f8f21031474bd5bf76a9874f9dcd842b88a 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -386,10 +386,87 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl

--- a/patches/server/1000-Entity-Activation-Range-2.0.patch
+++ b/patches/server/1000-Entity-Activation-Range-2.0.patch
@@ -340,7 +340,7 @@ index 0b7f52021441d633c37543e8ae485e81c292b747..d7f8464bf3eed0e42a5fc7f14a5b243d
 +
  }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 5ea8f51accdda2387b640d2cff1d6a8baa673bee..3fa8ae3a9afd81bf757ee1e183684442444376f4 100644
+index 87ee6f8f21031474bd5bf76a9874f9dcd842b88a..42bfcab86da297435db4d5e9cdac3f1b4f06fd02 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -156,6 +156,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl

--- a/patches/server/1002-Anti-Xray.patch
+++ b/patches/server/1002-Anti-Xray.patch
@@ -1168,7 +1168,7 @@ index 9b1a6d8351fb473eec75a2fd08fb892b770e3586..0d0b07c9199be9ca0d5ac3feb1d44f14
          }
          // Paper end - Send empty chunk
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 3fa8ae3a9afd81bf757ee1e183684442444376f4..392032d749b8a9077b61f4e1c5e413de048c7067 100644
+index 42bfcab86da297435db4d5e9cdac3f1b4f06fd02..5419c94dc4c1d2d5c37979d988df763899fef80d 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -171,6 +171,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl

--- a/patches/server/1003-Eigencraft-redstone-implementation.patch
+++ b/patches/server/1003-Eigencraft-redstone-implementation.patch
@@ -988,7 +988,7 @@ index 0000000000000000000000000000000000000000..9f17170179cc99d84ad25a1e838aff3d
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
-index c73bf0b36252796ca93c500affa2be568e3f6c9e..18ed178223cca85dbba65b1e07741622e266d318 100644
+index c63db09c4a838fef026f3afd7c00c17262961362..d0129353f8a02f508b53778d3089bcd3a8ed7a03 100644
 --- a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 @@ -258,6 +258,116 @@ public class RedStoneWireBlock extends Block {
@@ -1141,5 +1141,5 @@ index c73bf0b36252796ca93c500affa2be568e3f6c9e..18ed178223cca85dbba65b1e07741622
 -                this.updatePowerStrength(world, pos, state);
 +                this.updateSurroundingRedstone(world, pos, state, sourcePos); // Paper - Optimize redstone
              } else {
-                 dropResources(state, world, pos);
-                 world.removeBlock(pos, false);
+                 //dropResources(state, world, pos); Paper - change call so that BlockDestroyEvent is called
+                 //world.removeBlock(pos, false); Paper - change call so that BlockDestroyEvent is called

--- a/patches/server/1004-Add-Alternate-Current-redstone-implementation.patch
+++ b/patches/server/1004-Add-Alternate-Current-redstone-implementation.patch
@@ -2035,10 +2035,10 @@ index a463cdd3b9dbda64d52c86223e1f2e1164deac80..798016774df02c3f7ebf909c9cc125f8
  
          EntityCallbacks() {}
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 392032d749b8a9077b61f4e1c5e413de048c7067..55e841269585feb6a083b48ffeecea30cc65f6d6 100644
+index 5419c94dc4c1d2d5c37979d988df763899fef80d..40538dd68a1876956cb226ab05f95dffb35a4127 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1568,4 +1568,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
+@@ -1573,4 +1573,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
          }
      }
      // Paper end - notify observers even if grow failed
@@ -2054,7 +2054,7 @@ index 392032d749b8a9077b61f4e1c5e413de048c7067..55e841269585feb6a083b48ffeecea30
 +    // Paper end - optimize redstone (Alternate Current)
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
-index 18ed178223cca85dbba65b1e07741622e266d318..c131734cad123a35456d18f8a161f77a4ac9ac99 100644
+index d0129353f8a02f508b53778d3089bcd3a8ed7a03..463f3d2113ad7f8e551bb5042fa845d633e1574d 100644
 --- a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 @@ -258,7 +258,7 @@ public class RedStoneWireBlock extends Block {
@@ -2110,5 +2110,5 @@ index 18ed178223cca85dbba65b1e07741622e266d318..c131734cad123a35456d18f8a161f77a
 -                this.updateSurroundingRedstone(world, pos, state, sourcePos); // Paper - Optimize redstone
 +                this.updateSurroundingRedstone(world, pos, state, sourcePos); // Paper - Optimize redstone (Eigencraft)
              } else {
-                 dropResources(state, world, pos);
-                 world.removeBlock(pos, false);
+                 //dropResources(state, world, pos); Paper - change call so that BlockDestroyEvent is called
+                 //world.removeBlock(pos, false); Paper - change call so that BlockDestroyEvent is called

--- a/patches/server/1023-Improved-Watchdog-Support.patch
+++ b/patches/server/1023-Improved-Watchdog-Support.patch
@@ -287,10 +287,10 @@ index 2510589400b3012b827efcab477c6483d9d55901..43487a9ee202c5b0e5a416519939111f
          }
      }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 55e841269585feb6a083b48ffeecea30cc65f6d6..fee155c81df385faa474e3aec777a30375ecb07d 100644
+index 40538dd68a1876956cb226ab05f95dffb35a4127..e788ac058d48867c662514e988336b0d2f0f7085 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -982,6 +982,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
+@@ -987,6 +987,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
          try {
              tickConsumer.accept(entity);
          } catch (Throwable throwable) {


### PR DESCRIPTION
As the titles states.

Only remaining question is with ignoring the notify parameter of neighborChanged in BaseRailBlock. Does this have any impact?