### PR TITLE
Fixed typo in Registration.java

### DIFF
--- a/test-plugin/src/main/java/io/papermc/testplugin/brigtests/Registration.java
+++ b/test-plugin/src/main/java/io/papermc/testplugin/brigtests/Registration.java
@@ -62,7 +62,7 @@ public final class Registration {
             // ensure plugin commands override
             commands.register(Commands.literal("tag")
                     .executes(ctx -> {
-                        ctx.getSource().getSender().sendPlainMessage("overriden command");
+                        ctx.getSource().getSender().sendPlainMessage("overridden command");
                         return Command.SINGLE_SUCCESS;
                     })
                     .build(),


### PR DESCRIPTION
line 65 in Registration.java contained "overriden" instead of  "overridden".