### PR TITLE
Change item/xp merge and entity tracking range defaults

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -5091,7 +5091,7 @@ index 192b6fbd34b9b90112f869ae6e367ab9ba5a5906..08b0ca7b68bf238366f4d6904478852e
          for ( Method method : clazz.getDeclaredMethods() )
          {
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index a6d2ce801b236b046b94913bccf7eccfc561f35a..b244b65799d9c082b8b1639bad15727442e63168 100644
+index a6d2ce801b236b046b94913bccf7eccfc561f35a..0149d9014d0c6eab772297e7caeb9e7272574306 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -58,8 +58,14 @@ public class SpigotWorldConfig
@@ -5111,6 +5111,47 @@ index a6d2ce801b236b046b94913bccf7eccfc561f35a..b244b65799d9c082b8b1639bad157274
      }
  
      public <T> List getList(String path, T def)
+@@ -138,14 +144,14 @@ public class SpigotWorldConfig
+     public double itemMerge;
+     private void itemMerge()
+     {
+-        this.itemMerge = this.getDouble("merge-radius.item", 2.5 );
++        this.itemMerge = this.getDouble("merge-radius.item", 0.5 );
+         this.log( "Item Merge Radius: " + this.itemMerge );
+     }
+ 
+     public double expMerge;
+     private void expMerge()
+     {
+-        this.expMerge = this.getDouble("merge-radius.exp", 3.0 );
++        this.expMerge = this.getDouble("merge-radius.exp", 0.5 );
+         this.log( "Experience Merge Radius: " + this.expMerge );
+     }
+ 
+@@ -197,7 +203,7 @@ public class SpigotWorldConfig
+ 
+     public int animalActivationRange = 32;
+     public int monsterActivationRange = 32;
+-    public int raiderActivationRange = 48;
++    public int raiderActivationRange = 64;
+     public int miscActivationRange = 16;
+     public boolean tickInactiveVillagers = true;
+     public boolean ignoreSpectatorActivation = false;
+@@ -212,10 +218,10 @@ public class SpigotWorldConfig
+         this.log( "Entity Activation Range: An " + this.animalActivationRange + " / Mo " + this.monsterActivationRange + " / Ra " + this.raiderActivationRange + " / Mi " + this.miscActivationRange + " / Tiv " + this.tickInactiveVillagers + " / Isa " + this.ignoreSpectatorActivation );
+     }
+ 
+-    public int playerTrackingRange = 48;
+-    public int animalTrackingRange = 48;
+-    public int monsterTrackingRange = 48;
+-    public int miscTrackingRange = 32;
++    public int playerTrackingRange = 128;
++    public int animalTrackingRange = 96;
++    public int monsterTrackingRange = 96;
++    public int miscTrackingRange = 96;
+     public int displayTrackingRange = 128;
+     public int otherTrackingRange = 64;
+     private void trackingRange()
 diff --git a/src/test/java/io/papermc/paper/configuration/GlobalConfigTestingBase.java b/src/test/java/io/papermc/paper/configuration/GlobalConfigTestingBase.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..0396589795da1f83ddf62426236dde9a3afa1376

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -5091,7 +5091,7 @@ index 192b6fbd34b9b90112f869ae6e367ab9ba5a5906..08b0ca7b68bf238366f4d6904478852e
          for ( Method method : clazz.getDeclaredMethods() )
          {
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index a6d2ce801b236b046b94913bccf7eccfc561f35a..0149d9014d0c6eab772297e7caeb9e7272574306 100644
+index a6d2ce801b236b046b94913bccf7eccfc561f35a..8bc7a9da0eb345e65f42461e2fb22731eb80790a 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -58,8 +58,14 @@ public class SpigotWorldConfig
@@ -5124,7 +5124,7 @@ index a6d2ce801b236b046b94913bccf7eccfc561f35a..0149d9014d0c6eab772297e7caeb9e72
      private void expMerge()
      {
 -        this.expMerge = this.getDouble("merge-radius.exp", 3.0 );
-+        this.expMerge = this.getDouble("merge-radius.exp", 0.5 );
++        this.expMerge = this.getDouble("merge-radius.exp", -1 );
          this.log( "Experience Merge Radius: " + this.expMerge );
      }
  

--- a/patches/server/0233-Restore-vanilla-default-mob-spawn-range-and-water-an.patch
+++ b/patches/server/0233-Restore-vanilla-default-mob-spawn-range-and-water-an.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Restore vanilla default mob-spawn-range and water animals
 
 
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index b244b65799d9c082b8b1639bad15727442e63168..da91101f250a828a88b0511f7fd34879956db8dd 100644
+index 0149d9014d0c6eab772297e7caeb9e7272574306..631b9f02ae04acd1e21a5ee01ac53ecb81594990 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -190,7 +190,7 @@ public class SpigotWorldConfig

--- a/patches/server/0233-Restore-vanilla-default-mob-spawn-range-and-water-an.patch
+++ b/patches/server/0233-Restore-vanilla-default-mob-spawn-range-and-water-an.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Restore vanilla default mob-spawn-range and water animals
 
 
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 0149d9014d0c6eab772297e7caeb9e7272574306..631b9f02ae04acd1e21a5ee01ac53ecb81594990 100644
+index 8bc7a9da0eb345e65f42461e2fb22731eb80790a..c4acaec8d331b4600c7b8b28fa969de9645938da 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -190,7 +190,7 @@ public class SpigotWorldConfig

--- a/patches/server/0327-Set-spigots-verbose-world-setting-to-false-by-def.patch
+++ b/patches/server/0327-Set-spigots-verbose-world-setting-to-false-by-def.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Set spigots verbose world setting to false by def
 
 
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 631b9f02ae04acd1e21a5ee01ac53ecb81594990..222312d176e0844419fe13b0da756a27a1b9c79c 100644
+index c4acaec8d331b4600c7b8b28fa969de9645938da..491dd55b2870093184a606efabd251c68cc24719 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -20,7 +20,7 @@ public class SpigotWorldConfig

--- a/patches/server/0327-Set-spigots-verbose-world-setting-to-false-by-def.patch
+++ b/patches/server/0327-Set-spigots-verbose-world-setting-to-false-by-def.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Set spigots verbose world setting to false by def
 
 
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index da91101f250a828a88b0511f7fd34879956db8dd..c15c60fb88c9d6e370e2100c57ccb59d5441c96f 100644
+index 631b9f02ae04acd1e21a5ee01ac53ecb81594990..222312d176e0844419fe13b0da756a27a1b9c79c 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -20,7 +20,7 @@ public class SpigotWorldConfig

--- a/patches/server/0634-Fix-Spigot-growth-modifiers.patch
+++ b/patches/server/0634-Fix-Spigot-growth-modifiers.patch
@@ -102,7 +102,7 @@ index c9ed129db2cadd0a33d69993961f43088725c3cb..d06e3892cf42723f8e3f621b5497c534
              this.grow(world, state, pos, 1);
          }
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 222312d176e0844419fe13b0da756a27a1b9c79c..3d151140338df551768965b1673e8dd11fbc4116 100644
+index 491dd55b2870093184a606efabd251c68cc24719..e76f96a5c48d1eda2f9bbb3e11dd79f23f9ab75c 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -96,6 +96,7 @@ public class SpigotWorldConfig

--- a/patches/server/0634-Fix-Spigot-growth-modifiers.patch
+++ b/patches/server/0634-Fix-Spigot-growth-modifiers.patch
@@ -102,7 +102,7 @@ index c9ed129db2cadd0a33d69993961f43088725c3cb..d06e3892cf42723f8e3f621b5497c534
              this.grow(world, state, pos, 1);
          }
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index c15c60fb88c9d6e370e2100c57ccb59d5441c96f..44bdd0e6cdcabcb4deedd9aa3340330db2370615 100644
+index 222312d176e0844419fe13b0da756a27a1b9c79c..3d151140338df551768965b1673e8dd11fbc4116 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -96,6 +96,7 @@ public class SpigotWorldConfig

--- a/patches/server/0664-Add-missing-structure-set-seed-configs.patch
+++ b/patches/server/0664-Add-missing-structure-set-seed-configs.patch
@@ -277,7 +277,7 @@ index a4c34e9415632354d33668a38d06453ada4d3c77..cbf13e4f2da6a27619e9bc9a7cd73bb6
  
          @Override
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 3d151140338df551768965b1673e8dd11fbc4116..f19da33110d8690c3824d9cdcd9f1e6f98d051a4 100644
+index e76f96a5c48d1eda2f9bbb3e11dd79f23f9ab75c..2b263246135c85aa225120519e9702a628773935 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -322,6 +322,18 @@ public class SpigotWorldConfig

--- a/patches/server/0664-Add-missing-structure-set-seed-configs.patch
+++ b/patches/server/0664-Add-missing-structure-set-seed-configs.patch
@@ -277,7 +277,7 @@ index a4c34e9415632354d33668a38d06453ada4d3c77..cbf13e4f2da6a27619e9bc9a7cd73bb6
  
          @Override
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 44bdd0e6cdcabcb4deedd9aa3340330db2370615..37bbda040bd6f8a92295d2f32affbb53ea2d369b 100644
+index 3d151140338df551768965b1673e8dd11fbc4116..f19da33110d8690c3824d9cdcd9f1e6f98d051a4 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -322,6 +322,18 @@ public class SpigotWorldConfig

--- a/patches/server/1000-Entity-Activation-Range-2.0.patch
+++ b/patches/server/1000-Entity-Activation-Range-2.0.patch
@@ -746,7 +746,7 @@ index 9fb9fa62c32445ac3c3883a6433759c86dcfc428..bf2d18f74b0f0da7c3c30310c74224a1
              isActive = false;
          }
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index f19da33110d8690c3824d9cdcd9f1e6f98d051a4..50569f24a678f993dc8feeb74585bca0c7cf544f 100644
+index 2b263246135c85aa225120519e9702a628773935..2c408fa4abcbe1171c58aee8799c8cf7867d0f0a 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -211,14 +211,60 @@ public class SpigotWorldConfig

--- a/patches/server/1000-Entity-Activation-Range-2.0.patch
+++ b/patches/server/1000-Entity-Activation-Range-2.0.patch
@@ -746,12 +746,12 @@ index 9fb9fa62c32445ac3c3883a6433759c86dcfc428..bf2d18f74b0f0da7c3c30310c74224a1
              isActive = false;
          }
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 37bbda040bd6f8a92295d2f32affbb53ea2d369b..dbfe355221fb2ee66b79442a749412d9288afc0d 100644
+index f19da33110d8690c3824d9cdcd9f1e6f98d051a4..50569f24a678f993dc8feeb74585bca0c7cf544f 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -211,14 +211,60 @@ public class SpigotWorldConfig
      public int monsterActivationRange = 32;
-     public int raiderActivationRange = 48;
+     public int raiderActivationRange = 64;
      public int miscActivationRange = 16;
 +    // Paper start
 +    public int flyingMonsterActivationRange = 32;


### PR DESCRIPTION
Restore vanilla defaults for the merge radius, increase the tracking range values as the current ones are absolute ass. I also increased `raiderActivationRange`, as raiders like to get stuck just out of reach and become unfindable.

Waiting on feedback on possibly changing other config values. No Paper comments because it's just a Spigot file and Paper go zoom