### PR TITLE
Backport `LivingEntity#canUseEquipmentSlot` API

### DIFF
--- a/patches/api/0478-Fix-equipment-slot-and-group-API.patch
+++ b/patches/api/0478-Fix-equipment-slot-and-group-API.patch
@@ -3,7 +3,11 @@ From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Wed, 22 May 2024 10:00:19 -0700
 Subject: [PATCH] Fix equipment slot and group API
 
-was missing the 'body' slot group
+Adds the following:
+- Add missing 'body' slot group
+- Expose LivingEntity#canUseSlot
+
+Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/attribute/AttributeModifier.java b/src/main/java/org/bukkit/attribute/AttributeModifier.java
 index 9b47cbb93399a22301ec643e4be8f173314c455e..097396166b94ec7c9581a7b2f4ef644f95708671 100644
@@ -17,33 +21,56 @@ index 9b47cbb93399a22301ec643e4be8f173314c455e..097396166b94ec7c9581a7b2f4ef644f
      public EquipmentSlot getSlot() {
          return slot == EquipmentSlotGroup.ANY ? null : slot.getExample();
      }
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 5c29956c6db53440322330ff723c7087193641f1..a1e54e9d14393a6c0ea57cca854071c5396d9717 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -1447,4 +1447,15 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+      */
+     void setBodyYaw(float bodyYaw);
+     // Paper end - body yaw API
++
++    // Paper start - Expose canUseSlot
++    /**
++     * Checks whether this entity can use the equipment slot.
++     * <br>For example, not all entities may have {@link org.bukkit.inventory.EquipmentSlot#BODY}.
++     *
++     * @param slot equipment slot
++     * @return whether this entity can use the equipment slot
++     */
++    boolean canUseEquipmentSlot(org.bukkit.inventory.@NotNull EquipmentSlot slot);
++    // Paper end - Expose canUseSlot
+ }
 diff --git a/src/main/java/org/bukkit/inventory/EntityEquipment.java b/src/main/java/org/bukkit/inventory/EntityEquipment.java
-index 1b34286fb6cbedb3841c84c499eb626f61885126..0829418cc4b586ea9c800617f7184b1e60f756a6 100644
+index 1b34286fb6cbedb3841c84c499eb626f61885126..91cd0a918b640df7e75f6e40f3c6bd3689d4ff40 100644
 --- a/src/main/java/org/bukkit/inventory/EntityEquipment.java
 +++ b/src/main/java/org/bukkit/inventory/EntityEquipment.java
-@@ -15,6 +15,7 @@ public interface EntityEquipment {
+@@ -15,6 +15,8 @@ public interface EntityEquipment {
       *
       * @param slot the slot to put the ItemStack
       * @param item the ItemStack to set
 +     * @throws IllegalArgumentException if the slot is invalid for the entity
++     * @see org.bukkit.entity.LivingEntity#canUseEquipmentSlot(EquipmentSlot)
       */
      public void setItem(@NotNull EquipmentSlot slot, @Nullable ItemStack item);
  
-@@ -23,7 +24,8 @@ public interface EntityEquipment {
+@@ -23,7 +25,9 @@ public interface EntityEquipment {
       *
       * @param slot the slot to put the ItemStack
       * @param item the ItemStack to set
 -     * @param silent whether or not the equip sound should be silenced
 +     * @param silent whether the equip sound should be silenced
 +     * @throws IllegalArgumentException if the slot is invalid for the entity
++     * @see org.bukkit.entity.LivingEntity#canUseEquipmentSlot(EquipmentSlot)
       */
      public void setItem(@NotNull EquipmentSlot slot, @Nullable ItemStack item, boolean silent);
  
-@@ -32,6 +34,7 @@ public interface EntityEquipment {
+@@ -32,6 +36,8 @@ public interface EntityEquipment {
       *
       * @param slot the slot to get the ItemStack
       * @return the ItemStack in the given slot
 +     * @throws IllegalArgumentException if the slot is invalid for the entity
++     * @see org.bukkit.entity.LivingEntity#canUseEquipmentSlot(EquipmentSlot)
       */
      @NotNull
      public ItemStack getItem(@NotNull EquipmentSlot slot);
@@ -59,3 +86,25 @@ index 0019c8d91eefbfb44e76b9f929b25cd189295b79..5ce9da41ac4967f036e376fa270d4065
      //
      private final String key;
      private final Predicate<EquipmentSlot> predicate;
+diff --git a/src/main/java/org/bukkit/inventory/PlayerInventory.java b/src/main/java/org/bukkit/inventory/PlayerInventory.java
+index 2c54660dc1fbc7c1232096797a23cae1262888e9..bcfcf963063e7c0fdc711febef2df2d0ff12776d 100644
+--- a/src/main/java/org/bukkit/inventory/PlayerInventory.java
++++ b/src/main/java/org/bukkit/inventory/PlayerInventory.java
+@@ -95,6 +95,8 @@ public interface PlayerInventory extends Inventory {
+      * @param slot the slot to put the ItemStack
+      * @param item the ItemStack to set
+      *
++     * @throws IllegalArgumentException if the slot is invalid for the player
++     * @see org.bukkit.entity.LivingEntity#canUseEquipmentSlot(EquipmentSlot)
+      * @see #setItem(int, ItemStack)
+      */
+     public void setItem(@NotNull EquipmentSlot slot, @Nullable ItemStack item);
+@@ -105,6 +107,8 @@ public interface PlayerInventory extends Inventory {
+      * @param slot the slot to get the ItemStack
+      *
+      * @return the ItemStack in the given slot
++     * @throws IllegalArgumentException if the slot is invalid for the player
++     * @see org.bukkit.entity.LivingEntity#canUseEquipmentSlot(EquipmentSlot)
+      */
+     @NotNull // Paper
+     public ItemStack getItem(@NotNull EquipmentSlot slot);

--- a/patches/server/1045-Fix-equipment-slot-and-group-API.patch
+++ b/patches/server/1045-Fix-equipment-slot-and-group-API.patch
@@ -3,8 +3,28 @@ From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Wed, 22 May 2024 10:01:19 -0700
 Subject: [PATCH] Fix equipment slot and group API
 
-Add test for EquipmentSlotGroup
+Adds the following:
+- Add test for EquipmentSlotGroup
+- Expose LivingEntity#canUseSlot
 
+Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index 0196a49a5822e257b0e065e2383ec92b1bc27bba..541c256e4e834da3915023db20235587a0d2259f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -1180,4 +1180,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+         this.getHandle().setYBodyRot(bodyYaw);
+     }
+     // Paper end - body yaw API
++
++    // Paper start - Expose canUseSlot
++    @Override
++    public boolean canUseEquipmentSlot(org.bukkit.inventory.EquipmentSlot slot) {
++        return this.getHandle().canUseSlot(org.bukkit.craftbukkit.CraftEquipmentSlot.getNMS(slot));
++    }
++    // Paper end - Expose canUseSlot
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
 index 9d74577af071954e1e37201a96368c1360076209..eafa54c870c3e2aef30c3f9f96f516607a7cae24 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java


### PR DESCRIPTION
Closes #10974 
See reasoning & explanation in linked discussion ^