### PR TITLE
[ci skip] add adventure-key javadoc

### DIFF
--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -8,7 +8,7 @@ Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 Co-authored-by: Yannick Lamprecht <yannicklamprecht@live.de>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 2f266350a787a4cfdfda1b0e760bfb7604cac43c..bae542d05c059d53199b9171bee505de818df349 100644
+index 2f266350a787a4cfdfda1b0e760bfb7604cac43c..af3514113abdf3f42c41f1e7ff0f930cc1a417f5 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -11,12 +11,28 @@ java {
@@ -55,7 +55,7 @@ index 2f266350a787a4cfdfda1b0e760bfb7604cac43c..bae542d05c059d53199b9171bee505de
      // Paper end
  
      compileOnly("org.apache.maven:maven-resolver-provider:3.9.6")
-@@ -99,14 +122,30 @@ tasks.withType<Javadoc> {
+@@ -99,14 +122,31 @@ tasks.withType<Javadoc> {
          "https://guava.dev/releases/32.1.2-jre/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/2.2/",
          "https://javadoc.io/doc/org.jetbrains/annotations/$annotationsVersion/", // Paper - we don't want Java 5 annotations
@@ -67,6 +67,7 @@ index 2f266350a787a4cfdfda1b0e760bfb7604cac43c..bae542d05c059d53199b9171bee505de
          // Paper end
 +        // Paper start
 +        "https://jd.advntr.dev/api/$adventureVersion/",
++        "https://jd.advntr.dev/key/$adventureVersion/",
 +        "https://jd.advntr.dev/text-minimessage/$adventureVersion/",
 +        "https://jd.advntr.dev/text-serializer-gson/$adventureVersion/",
 +        "https://jd.advntr.dev/text-serializer-legacy/$adventureVersion/",

--- a/patches/api/0008-Use-ASM-for-event-executors.patch
+++ b/patches/api/0008-Use-ASM-for-event-executors.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use ASM for event executors.
 Uses method handles for private or static methods.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index bae542d05c059d53199b9171bee505de818df349..a0c6f2c36fa4c16787616a79b5d996523c274fe0 100644
+index af3514113abdf3f42c41f1e7ff0f930cc1a417f5..ed0b67ac322aa22b191cd35502ae5b4f20af19f8 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -47,6 +47,9 @@ dependencies {

--- a/patches/api/0009-Paper-Plugins.patch
+++ b/patches/api/0009-Paper-Plugins.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Paper Plugins
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index a0c6f2c36fa4c16787616a79b5d996523c274fe0..effad8017bff46e2651af01f1789cb8dd08a49d5 100644
+index ed0b67ac322aa22b191cd35502ae5b4f20af19f8..258d7010d24c529c9bbc76cc26adf226c641ee58 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -52,7 +52,7 @@ dependencies {
@@ -17,7 +17,7 @@ index a0c6f2c36fa4c16787616a79b5d996523c274fe0..effad8017bff46e2651af01f1789cb8d
      compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.9.18")
      compileOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.9.18")
  
-@@ -138,6 +138,7 @@ tasks.withType<Javadoc> {
+@@ -139,6 +139,7 @@ tasks.withType<Javadoc> {
          "https://jd.advntr.dev/text-serializer-plain/$adventureVersion/",
          "https://jd.advntr.dev/text-logger-slf4j/$adventureVersion/",
          // Paper end

--- a/patches/api/0067-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0067-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,7 +14,7 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index effad8017bff46e2651af01f1789cb8dd08a49d5..eecf458e1250ee9968630cf5c3c3287a1693e52e 100644
+index 258d7010d24c529c9bbc76cc26adf226c641ee58..4da053d427f3f9c5e7fc144408836ebef80026c6 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -12,6 +12,8 @@ java {
@@ -35,7 +35,7 @@ index effad8017bff46e2651af01f1789cb8dd08a49d5..eecf458e1250ee9968630cf5c3c3287a
  
      implementation("org.ow2.asm:asm:9.7")
      implementation("org.ow2.asm:asm-commons:9.7")
-@@ -137,6 +141,8 @@ tasks.withType<Javadoc> {
+@@ -138,6 +142,8 @@ tasks.withType<Javadoc> {
          "https://jd.advntr.dev/text-serializer-legacy/$adventureVersion/",
          "https://jd.advntr.dev/text-serializer-plain/$adventureVersion/",
          "https://jd.advntr.dev/text-logger-slf4j/$adventureVersion/",

--- a/patches/api/0469-Brigadier-based-command-API.patch
+++ b/patches/api/0469-Brigadier-based-command-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Brigadier based command API
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index eecf458e1250ee9968630cf5c3c3287a1693e52e..fd39ed209b20c927054b8482c400beeeeab460a3 100644
+index 4da053d427f3f9c5e7fc144408836ebef80026c6..540fe7e2c110e79c3742f229b3ed8c54b101d260 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -27,6 +27,7 @@ configurations.api {


### PR DESCRIPTION
Continuation of https://github.com/PaperMC/Paper/pull/9355

May also be an idea to add Brigadier but I don't think Mojang publishes the javadoc jars.