### PR TITLE
Item stack name tooltip API

### DIFF
--- a/patches/api/0480-Item-stack-name-tooltip-API.patch
+++ b/patches/api/0480-Item-stack-name-tooltip-API.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: radsteve <radsteve@radsteve.net>
+Date: Sun, 7 Jul 2024 10:51:46 +0200
+Subject: [PATCH] Item stack name tooltip API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 7c56182acaf827f4b1a986a61cea8e9960604c98..5899dcdcbb95c2d3da3869ca202270ce7b106336 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -3855,6 +3855,21 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+     boolean isChunkSent(long chunkKey);
+     // Paper end
+ 
++    // Paper start - Item stack name tooltip API
++    /**
++     * Checks whether the currently held item is displaying the item name tooltip on the client.
++     * However this behavior can be changed via the Accessibility Settings, which can lead to inaccuracies.
++     * @return true if it is showing with default settings, false if not
++     */
++    boolean isItemNameTooltipShown();
++
++    /**
++     * Gets the last time where the selected item stack in the hotbar has been changed.
++     * @return The last time, in milliseconds, if it exists.
++     */
++    long getLastItemStackChangeTime();
++    // Paper end - Item stack name tooltip API
++
+     @NotNull
+     @Override
+     Spigot spigot();

--- a/patches/server/1036-Item-stack-name-tooltip-API.patch
+++ b/patches/server/1036-Item-stack-name-tooltip-API.patch
@@ -1,0 +1,83 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: radsteve <radsteve@radsteve.net>
+Date: Sun, 7 Jul 2024 10:51:55 +0200
+Subject: [PATCH] Item stack name tooltip API
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..5392ce22ec1da5566e069438345bc26966741f20 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -301,6 +301,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+     public com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper - PlayerNaturallySpawnCreaturesEvent
+     public @Nullable String clientBrandName = null; // Paper - Brand support
+     public org.bukkit.event.player.PlayerQuitEvent.QuitReason quitReason = null; // Paper - Add API for quit reason; there are a lot of changes to do if we change all methods leading to the event
++    private ItemStack currentlySelectedItemStack = ItemStack.EMPTY; // Paper - Item stack name tooltip API
+ 
+     // Paper start - rewrite chunk system
+     private ca.spottedleaf.moonrise.patches.chunk_system.player.RegionizedPlayerChunkLoader.PlayerChunkLoaderData chunkLoader;
+@@ -805,6 +806,19 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+         this.trackEnteredOrExitedLavaOnVehicle();
+         this.updatePlayerAttributes();
+         this.advancements.flushDirty(this);
++
++        // Paper start - Item stack name tooltip API
++        CraftPlayer craftPlayer = this.getBukkitEntity();
++        ItemStack selectedStack = this.getInventory().getSelected();
++        if(selectedStack.isEmpty()) {
++            craftPlayer.setLastItemStackChange(0);
++        } else {
++            if(!selectedStack.is(this.currentlySelectedItemStack.getItem()) || !selectedStack.getDisplayName().equals(this.currentlySelectedItemStack.getDisplayName())) {
++                craftPlayer.setLastItemStackChange(Util.getMillis());
++            }
++        }
++        this.currentlySelectedItemStack = selectedStack;
++        // Paper end - Item stack name tooltip API
+     }
+ 
+     private void updatePlayerAttributes() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index d01b45a48d412e3cb591acee101730704574448a..360c1f814c8024e7a4082ea0cce249044d907730 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -35,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
+ import java.util.logging.Level;
+ import java.util.logging.Logger;
+ import javax.annotation.Nullable;
++import net.minecraft.Util;
+ import net.minecraft.advancements.AdvancementProgress;
+ import net.minecraft.core.BlockPos;
+ import net.minecraft.core.Holder;
+@@ -212,6 +213,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     public org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus; // Paper - more resource pack API
+     private static final boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
+     private long lastSaveTime; // Paper - getLastPlayed replacement API
++    private long lastItemStackChange = 0; // Paper - Item stack name tooltip API
+ 
+     public CraftPlayer(CraftServer server, ServerPlayer entity) {
+         super(server, entity);
+@@ -3554,4 +3556,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         ((ca.spottedleaf.moonrise.patches.chunk_system.player.ChunkSystemServerPlayer)this.getHandle())
+             .moonrise$getViewDistanceHolder().setSendViewDistance(viewDistance);
+     }
++
++    // Paper start - Item stack name tooltip API
++    private static final long ITEM_TOOLTIP_DURATION_MS = 40 * 50;
++
++    @Override
++    public boolean isItemNameTooltipShown() {
++        long currentTime = Util.getMillis();
++        long lastItemStackChange = this.getLastItemStackChangeTime();
++        return currentTime - lastItemStackChange < ITEM_TOOLTIP_DURATION_MS;
++    }
++
++    @Override
++    public long getLastItemStackChangeTime() {
++        return this.lastItemStackChange;
++    }
++
++    public void setLastItemStackChange(long itemStackChange) {
++        this.lastItemStackChange = itemStackChange;
++    }
++    // Paper end - Item stack name tooltip API
+ }


### PR DESCRIPTION
This adds an API for getting whether the current item stack that the player is holding is showing its name as a tooltip. It's important to note that this behavior can be configured via the accessbility settings, under notification time. This is still very useful for server owners, e.g. when you have a UI Overlay in your action bar, which is slightly shifted downwards using fonts, this can collide with the item's name tooltip. But instead, with this API, you can detect if it's shown and then raise the overlay a bit. Here is an example of this in action (not made by me):

https://github.com/PaperMC/Paper/assets/96977790/eaf40378-9e7f-494c-b96a-48596840c462

