### PR TITLE
Item stack name tooltip API

### DIFF
--- a/patches/api/0480-Item-stack-name-tooltip-API.patch
+++ b/patches/api/0480-Item-stack-name-tooltip-API.patch
@@ -5,21 +5,30 @@ Subject: [PATCH] Item stack name tooltip API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7c56182acaf827f4b1a986a61cea8e9960604c98..f7d0d7937e86a4a1b51fc2105f072f40ae623396 100644
+index 7c56182acaf827f4b1a986a61cea8e9960604c98..9da64bc368b1eac55fad336f58619509542dd5e1 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3855,6 +3855,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3855,6 +3855,23 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      boolean isChunkSent(long chunkKey);
      // Paper end
  
++    // Paper start - Item stack name tooltip API
 +    /**
-+     * Checks whether the currently held item is displaying the item name tooltip on the client.
++     * Checks whether the currently held item is assumed to be displaying the item name tooltip on the client.
 +     * However, this behavior can be changed via the Accessibility Settings, which can lead to inaccuracies.
 +     * Keep in mind that this assumes default settings and is prone to break.
 +     * @return true if it is showing with default settings, false if not.
 +     */
-+    boolean isItemNameTooltipShown(); // Paper - Item stack name tooltip API
++    boolean isItemNameTooltipEstimatedToBeVisible();
 +
++    /**
++     * Gets the last timestamp when the player has changed their selected item stack in their hotbar.
++     * This time is measured using {@link net.minecraft.Util#getMillis}.
++     * @return The last timestamp, or zero, if the player hasn't changed selected item stacks.
++     */
++    long getLastItemStackChangeTime();
++
++    // Paper end - Item stack name tooltip API
      @NotNull
      @Override
      Spigot spigot();

--- a/patches/api/0480-Item-stack-name-tooltip-API.patch
+++ b/patches/api/0480-Item-stack-name-tooltip-API.patch
@@ -5,27 +5,20 @@ Subject: [PATCH] Item stack name tooltip API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7c56182acaf827f4b1a986a61cea8e9960604c98..5899dcdcbb95c2d3da3869ca202270ce7b106336 100644
+index 7c56182acaf827f4b1a986a61cea8e9960604c98..f7d0d7937e86a4a1b51fc2105f072f40ae623396 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3855,6 +3855,21 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3855,6 +3855,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      boolean isChunkSent(long chunkKey);
      // Paper end
  
-+    // Paper start - Item stack name tooltip API
 +    /**
 +     * Checks whether the currently held item is displaying the item name tooltip on the client.
-+     * However this behavior can be changed via the Accessibility Settings, which can lead to inaccuracies.
-+     * @return true if it is showing with default settings, false if not
++     * However, this behavior can be changed via the Accessibility Settings, which can lead to inaccuracies.
++     * Keep in mind that this assumes default settings and is prone to break.
++     * @return true if it is showing with default settings, false if not.
 +     */
-+    boolean isItemNameTooltipShown();
-+
-+    /**
-+     * Gets the last time where the selected item stack in the hotbar has been changed.
-+     * @return The last time, in milliseconds, if it exists.
-+     */
-+    long getLastItemStackChangeTime();
-+    // Paper end - Item stack name tooltip API
++    boolean isItemNameTooltipShown(); // Paper - Item stack name tooltip API
 +
      @NotNull
      @Override

--- a/patches/api/0480-Item-stack-name-tooltip-API.patch
+++ b/patches/api/0480-Item-stack-name-tooltip-API.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: radsteve <radsteve@radsteve.net>
+Date: Sun, 7 Jul 2024 10:51:46 +0200
+Subject: [PATCH] Item stack name tooltip API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 7c56182acaf827f4b1a986a61cea8e9960604c98..5899dcdcbb95c2d3da3869ca202270ce7b106336 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -3855,6 +3855,21 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+     boolean isChunkSent(long chunkKey);
+     // Paper end
+ 
++    // Paper start - Item stack name tooltip API
++    /**
++     * Checks whether the currently held item is displaying the item name tooltip on the client.
++     * However this behavior can be changed via the Accessibility Settings, which can lead to inaccuracies.
++     * @return true if it is showing with default settings, false if not
++     */
++    boolean isItemNameTooltipShown();
++
++    /**
++     * Gets the last time where the selected item stack in the hotbar has been changed.
++     * @return The last time, in milliseconds, if it exists.
++     */
++    long getLastItemStackChangeTime();
++    // Paper end - Item stack name tooltip API
++
+     @NotNull
+     @Override
+     Spigot spigot();

--- a/patches/server/1036-Item-stack-name-tooltip-API.patch
+++ b/patches/server/1036-Item-stack-name-tooltip-API.patch
@@ -5,15 +5,16 @@ Subject: [PATCH] Item stack name tooltip API
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..3b74464b2c0300a252bac22897f61050500b2189 100644
+index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..4384869b79539c9e424b20bd656b67160a475b77 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -805,6 +805,18 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+@@ -805,6 +805,19 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
          this.trackEnteredOrExitedLavaOnVehicle();
          this.updatePlayerAttributes();
          this.advancements.flushDirty(this);
 +
 +        // Paper start - Item stack name tooltip API
++        // This is taken from net.minecraft.client.gui.Gui#tick and adapted to a non-tick behaviour.
 +        ItemStack selectedStack = this.getInventory().getSelected();
 +        if(selectedStack.isEmpty()) {
 +            lastItemStackChangeTime = 0;
@@ -27,7 +28,7 @@ index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..3b74464b2c0300a252bac22897f61050
      }
  
      private void updatePlayerAttributes() {
-@@ -2944,4 +2956,12 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+@@ -2944,4 +2957,12 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
          return (CraftPlayer) super.getBukkitEntity();
      }
      // CraftBukkit end

--- a/patches/server/1036-Item-stack-name-tooltip-API.patch
+++ b/patches/server/1036-Item-stack-name-tooltip-API.patch
@@ -1,0 +1,83 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: radsteve <radsteve@radsteve.net>
+Date: Sun, 7 Jul 2024 10:51:55 +0200
+Subject: [PATCH] Item stack name tooltip API
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..5392ce22ec1da5566e069438345bc26966741f20 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -301,6 +301,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+     public com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper - PlayerNaturallySpawnCreaturesEvent
+     public @Nullable String clientBrandName = null; // Paper - Brand support
+     public org.bukkit.event.player.PlayerQuitEvent.QuitReason quitReason = null; // Paper - Add API for quit reason; there are a lot of changes to do if we change all methods leading to the event
++    private ItemStack currentlySelectedItemStack = ItemStack.EMPTY; // Paper - Item stack name tooltip API
+ 
+     // Paper start - rewrite chunk system
+     private ca.spottedleaf.moonrise.patches.chunk_system.player.RegionizedPlayerChunkLoader.PlayerChunkLoaderData chunkLoader;
+@@ -805,6 +806,19 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+         this.trackEnteredOrExitedLavaOnVehicle();
+         this.updatePlayerAttributes();
+         this.advancements.flushDirty(this);
++
++        // Paper start - Item stack name tooltip API
++        CraftPlayer craftPlayer = this.getBukkitEntity();
++        ItemStack selectedStack = this.getInventory().getSelected();
++        if(selectedStack.isEmpty()) {
++            craftPlayer.setLastItemStackChange(0);
++        } else {
++            if(!selectedStack.is(this.currentlySelectedItemStack.getItem()) || !selectedStack.getDisplayName().equals(this.currentlySelectedItemStack.getDisplayName())) {
++                craftPlayer.setLastItemStackChange(Util.getMillis());
++            }
++        }
++        this.currentlySelectedItemStack = selectedStack;
++        // Paper end - Item stack name tooltip API
+     }
+ 
+     private void updatePlayerAttributes() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index d01b45a48d412e3cb591acee101730704574448a..360c1f814c8024e7a4082ea0cce249044d907730 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -35,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
+ import java.util.logging.Level;
+ import java.util.logging.Logger;
+ import javax.annotation.Nullable;
++import net.minecraft.Util;
+ import net.minecraft.advancements.AdvancementProgress;
+ import net.minecraft.core.BlockPos;
+ import net.minecraft.core.Holder;
+@@ -212,6 +213,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     public org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus; // Paper - more resource pack API
+     private static final boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
+     private long lastSaveTime; // Paper - getLastPlayed replacement API
++    private long lastItemStackChange = 0; // Paper - Item stack name tooltip API
+ 
+     public CraftPlayer(CraftServer server, ServerPlayer entity) {
+         super(server, entity);
+@@ -3554,4 +3556,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         ((ca.spottedleaf.moonrise.patches.chunk_system.player.ChunkSystemServerPlayer)this.getHandle())
+             .moonrise$getViewDistanceHolder().setSendViewDistance(viewDistance);
+     }
++
++    // Paper start - Item stack name tooltip API
++    private static final long ITEM_TOOLTIP_DURATION_MS = 40 * 50;
++
++    @Override
++    public boolean isItemNameTooltipShown() {
++        long currentTime = Util.getMillis();
++        long lastItemStackChange = this.getLastItemStackChangeTime();
++        return currentTime - lastItemStackChange < ITEM_TOOLTIP_DURATION_MS;
++    }
++
++    @Override
++    public long getLastItemStackChangeTime() {
++        return this.lastItemStackChange;
++    }
++
++    public void setLastItemStackChange(long itemStackChange) {
++        this.lastItemStackChange = itemStackChange;
++    }
++    // Paper end - Item stack name tooltip API
+ }

--- a/patches/server/1036-Item-stack-name-tooltip-API.patch
+++ b/patches/server/1036-Item-stack-name-tooltip-API.patch
@@ -42,10 +42,10 @@ index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..4384869b79539c9e424b20bd656b6716
 +    // Paper end - Item stack name tooltip API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d01b45a48d412e3cb591acee101730704574448a..61d9885d87d8a8662b7bde787598db54d0522c14 100644
+index d01b45a48d412e3cb591acee101730704574448a..52a985b95d8c6a35f7df52979b7fab84ad673e98 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3554,4 +3554,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3554,4 +3554,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          ((ca.spottedleaf.moonrise.patches.chunk_system.player.ChunkSystemServerPlayer)this.getHandle())
              .moonrise$getViewDistanceHolder().setSendViewDistance(viewDistance);
      }
@@ -54,9 +54,14 @@ index d01b45a48d412e3cb591acee101730704574448a..61d9885d87d8a8662b7bde787598db54
 +    private static final long DEFAULT_ITEM_TOOLTIP_DURATION_MS = 40 * 50;
 +
 +    @Override
-+    public boolean isItemNameTooltipShown() {
++    public long getLastItemStackChangeTime() {
++        return this.getHandle().getLastItemStackChangeTime();
++    }
++
++    @Override
++    public boolean isItemNameTooltipEstimatedToBeVisible() {
 +        long currentTime = net.minecraft.Util.getMillis();
-+        long lastItemStackChange = this.getHandle().getLastItemStackChangeTime();
++        long lastItemStackChange = this.getLastItemStackChangeTime();
 +        return currentTime - lastItemStackChange < DEFAULT_ITEM_TOOLTIP_DURATION_MS;
 +    }
 +    // Paper end - Item stack name tooltip API

--- a/patches/server/1036-Item-stack-name-tooltip-API.patch
+++ b/patches/server/1036-Item-stack-name-tooltip-API.patch
@@ -5,30 +5,29 @@ Subject: [PATCH] Item stack name tooltip API
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..5392ce22ec1da5566e069438345bc26966741f20 100644
+index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..1ec6599676de973d10c297c9082cb4dece1a34cd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -301,6 +301,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
-     public com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper - PlayerNaturallySpawnCreaturesEvent
-     public @Nullable String clientBrandName = null; // Paper - Brand support
-     public org.bukkit.event.player.PlayerQuitEvent.QuitReason quitReason = null; // Paper - Add API for quit reason; there are a lot of changes to do if we change all methods leading to the event
-+    private ItemStack currentlySelectedItemStack = ItemStack.EMPTY; // Paper - Item stack name tooltip API
- 
-     // Paper start - rewrite chunk system
-     private ca.spottedleaf.moonrise.patches.chunk_system.player.RegionizedPlayerChunkLoader.PlayerChunkLoaderData chunkLoader;
-@@ -805,6 +806,19 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+@@ -95,7 +95,6 @@ import net.minecraft.util.Mth;
+ import net.minecraft.util.RandomSource;
+ import net.minecraft.util.Unit;
+ import net.minecraft.world.damagesource.DamageSource;
+-import net.minecraft.world.damagesource.DamageSources;
+ import net.minecraft.world.effect.MobEffectInstance;
+ import net.minecraft.world.effect.MobEffects;
+ import net.minecraft.world.entity.Entity;
+@@ -805,6 +804,18 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
          this.trackEnteredOrExitedLavaOnVehicle();
          this.updatePlayerAttributes();
          this.advancements.flushDirty(this);
 +
 +        // Paper start - Item stack name tooltip API
-+        CraftPlayer craftPlayer = this.getBukkitEntity();
 +        ItemStack selectedStack = this.getInventory().getSelected();
 +        if(selectedStack.isEmpty()) {
-+            craftPlayer.setLastItemStackChange(0);
++            lastItemStackChangeTime = 0;
 +        } else {
 +            if(!selectedStack.is(this.currentlySelectedItemStack.getItem()) || !selectedStack.getDisplayName().equals(this.currentlySelectedItemStack.getDisplayName())) {
-+                craftPlayer.setLastItemStackChange(Util.getMillis());
++                lastItemStackChangeTime = net.minecraft.Util.getMillis();
 +            }
 +        }
 +        this.currentlySelectedItemStack = selectedStack;
@@ -36,33 +35,60 @@ index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..5392ce22ec1da5566e069438345bc269
      }
  
      private void updatePlayerAttributes() {
+@@ -2944,4 +2955,12 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+         return (CraftPlayer) super.getBukkitEntity();
+     }
+     // CraftBukkit end
++
++    // Paper start - Item stack name tooltip API
++    private ItemStack currentlySelectedItemStack = ItemStack.EMPTY;
++    private long lastItemStackChangeTime = 0;
++    public long getLastItemStackChangeTime() {
++        return lastItemStackChangeTime;
++    }
++    // Paper end - Item stack name tooltip API
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d01b45a48d412e3cb591acee101730704574448a..846c8d8577515e7641b264c2c0790d6d4b770971 100644
+index d01b45a48d412e3cb591acee101730704574448a..156f64452a766f235c8a3d7c75e1129fbc260aef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3554,4 +3554,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -161,7 +161,6 @@ import org.bukkit.craftbukkit.map.CraftMapView;
+ import org.bukkit.craftbukkit.map.RenderData;
+ import org.bukkit.craftbukkit.potion.CraftPotionEffectType;
+ import org.bukkit.craftbukkit.potion.CraftPotionUtil;
+-import org.bukkit.craftbukkit.profile.CraftPlayerProfile;
+ import org.bukkit.craftbukkit.scoreboard.CraftScoreboard;
+ import org.bukkit.craftbukkit.util.CraftChatMessage;
+ import org.bukkit.craftbukkit.util.CraftLocation;
+@@ -174,7 +173,6 @@ import org.bukkit.event.player.PlayerExpCooldownChangeEvent;
+ import org.bukkit.event.player.PlayerHideEntityEvent;
+ import org.bukkit.event.player.PlayerRegisterChannelEvent;
+ import org.bukkit.event.player.PlayerShowEntityEvent;
+-import org.bukkit.event.player.PlayerSpawnChangeEvent;
+ import org.bukkit.event.player.PlayerTeleportEvent;
+ import org.bukkit.event.player.PlayerUnregisterChannelEvent;
+ import org.bukkit.inventory.EquipmentSlot;
+@@ -187,7 +185,6 @@ import org.bukkit.plugin.Plugin;
+ import org.bukkit.plugin.messaging.StandardMessenger;
+ import org.bukkit.potion.PotionEffect;
+ import org.bukkit.potion.PotionEffectType;
+-import org.bukkit.profile.PlayerProfile;
+ import org.bukkit.scoreboard.Scoreboard;
+ import org.jetbrains.annotations.NotNull;
+ 
+@@ -3554,4 +3551,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          ((ca.spottedleaf.moonrise.patches.chunk_system.player.ChunkSystemServerPlayer)this.getHandle())
              .moonrise$getViewDistanceHolder().setSendViewDistance(viewDistance);
      }
 +
 +    // Paper start - Item stack name tooltip API
-+    private long lastItemStackChange = 0;
-+    private static final long ITEM_TOOLTIP_DURATION_MS = 40 * 50;
++    private static final long DEFAULT_ITEM_TOOLTIP_DURATION_MS = 40 * 50;
 +
 +    @Override
 +    public boolean isItemNameTooltipShown() {
 +        long currentTime = net.minecraft.Util.getMillis();
-+        long lastItemStackChange = this.getLastItemStackChangeTime();
-+        return currentTime - lastItemStackChange < ITEM_TOOLTIP_DURATION_MS;
-+    }
-+
-+    @Override
-+    public long getLastItemStackChangeTime() {
-+        return this.lastItemStackChange;
-+    }
-+
-+    public void setLastItemStackChange(long itemStackChange) {
-+        this.lastItemStackChange = itemStackChange;
++        long lastItemStackChange = this.getHandle().getLastItemStackChangeTime();
++        return currentTime - lastItemStackChange < DEFAULT_ITEM_TOOLTIP_DURATION_MS;
 +    }
 +    // Paper end - Item stack name tooltip API
  }

--- a/patches/server/1036-Item-stack-name-tooltip-API.patch
+++ b/patches/server/1036-Item-stack-name-tooltip-API.patch
@@ -5,18 +5,10 @@ Subject: [PATCH] Item stack name tooltip API
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..1ec6599676de973d10c297c9082cb4dece1a34cd 100644
+index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..3b74464b2c0300a252bac22897f61050500b2189 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -95,7 +95,6 @@ import net.minecraft.util.Mth;
- import net.minecraft.util.RandomSource;
- import net.minecraft.util.Unit;
- import net.minecraft.world.damagesource.DamageSource;
--import net.minecraft.world.damagesource.DamageSources;
- import net.minecraft.world.effect.MobEffectInstance;
- import net.minecraft.world.effect.MobEffects;
- import net.minecraft.world.entity.Entity;
-@@ -805,6 +804,18 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+@@ -805,6 +805,18 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
          this.trackEnteredOrExitedLavaOnVehicle();
          this.updatePlayerAttributes();
          this.advancements.flushDirty(this);
@@ -35,7 +27,7 @@ index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..1ec6599676de973d10c297c9082cb4de
      }
  
      private void updatePlayerAttributes() {
-@@ -2944,4 +2955,12 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+@@ -2944,4 +2956,12 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
          return (CraftPlayer) super.getBukkitEntity();
      }
      // CraftBukkit end
@@ -49,34 +41,10 @@ index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..1ec6599676de973d10c297c9082cb4de
 +    // Paper end - Item stack name tooltip API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d01b45a48d412e3cb591acee101730704574448a..156f64452a766f235c8a3d7c75e1129fbc260aef 100644
+index d01b45a48d412e3cb591acee101730704574448a..61d9885d87d8a8662b7bde787598db54d0522c14 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -161,7 +161,6 @@ import org.bukkit.craftbukkit.map.CraftMapView;
- import org.bukkit.craftbukkit.map.RenderData;
- import org.bukkit.craftbukkit.potion.CraftPotionEffectType;
- import org.bukkit.craftbukkit.potion.CraftPotionUtil;
--import org.bukkit.craftbukkit.profile.CraftPlayerProfile;
- import org.bukkit.craftbukkit.scoreboard.CraftScoreboard;
- import org.bukkit.craftbukkit.util.CraftChatMessage;
- import org.bukkit.craftbukkit.util.CraftLocation;
-@@ -174,7 +173,6 @@ import org.bukkit.event.player.PlayerExpCooldownChangeEvent;
- import org.bukkit.event.player.PlayerHideEntityEvent;
- import org.bukkit.event.player.PlayerRegisterChannelEvent;
- import org.bukkit.event.player.PlayerShowEntityEvent;
--import org.bukkit.event.player.PlayerSpawnChangeEvent;
- import org.bukkit.event.player.PlayerTeleportEvent;
- import org.bukkit.event.player.PlayerUnregisterChannelEvent;
- import org.bukkit.inventory.EquipmentSlot;
-@@ -187,7 +185,6 @@ import org.bukkit.plugin.Plugin;
- import org.bukkit.plugin.messaging.StandardMessenger;
- import org.bukkit.potion.PotionEffect;
- import org.bukkit.potion.PotionEffectType;
--import org.bukkit.profile.PlayerProfile;
- import org.bukkit.scoreboard.Scoreboard;
- import org.jetbrains.annotations.NotNull;
- 
-@@ -3554,4 +3551,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3554,4 +3554,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          ((ca.spottedleaf.moonrise.patches.chunk_system.player.ChunkSystemServerPlayer)this.getHandle())
              .moonrise$getViewDistanceHolder().setSendViewDistance(viewDistance);
      }

--- a/patches/server/1036-Item-stack-name-tooltip-API.patch
+++ b/patches/server/1036-Item-stack-name-tooltip-API.patch
@@ -37,36 +37,21 @@ index 9d1e68c09fa7093cf0f6fa636f90cb15a44cbb38..5392ce22ec1da5566e069438345bc269
  
      private void updatePlayerAttributes() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d01b45a48d412e3cb591acee101730704574448a..360c1f814c8024e7a4082ea0cce249044d907730 100644
+index d01b45a48d412e3cb591acee101730704574448a..846c8d8577515e7641b264c2c0790d6d4b770971 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -35,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
- import java.util.logging.Level;
- import java.util.logging.Logger;
- import javax.annotation.Nullable;
-+import net.minecraft.Util;
- import net.minecraft.advancements.AdvancementProgress;
- import net.minecraft.core.BlockPos;
- import net.minecraft.core.Holder;
-@@ -212,6 +213,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
-     public org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus; // Paper - more resource pack API
-     private static final boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
-     private long lastSaveTime; // Paper - getLastPlayed replacement API
-+    private long lastItemStackChange = 0; // Paper - Item stack name tooltip API
- 
-     public CraftPlayer(CraftServer server, ServerPlayer entity) {
-         super(server, entity);
-@@ -3554,4 +3556,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3554,4 +3554,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          ((ca.spottedleaf.moonrise.patches.chunk_system.player.ChunkSystemServerPlayer)this.getHandle())
              .moonrise$getViewDistanceHolder().setSendViewDistance(viewDistance);
      }
 +
 +    // Paper start - Item stack name tooltip API
++    private long lastItemStackChange = 0;
 +    private static final long ITEM_TOOLTIP_DURATION_MS = 40 * 50;
 +
 +    @Override
 +    public boolean isItemNameTooltipShown() {
-+        long currentTime = Util.getMillis();
++        long currentTime = net.minecraft.Util.getMillis();
 +        long lastItemStackChange = this.getLastItemStackChangeTime();
 +        return currentTime - lastItemStackChange < ITEM_TOOLTIP_DURATION_MS;
 +    }


### PR DESCRIPTION
This adds an API for getting whether the current item stack that the player is holding is showing its name as a tooltip. It's important to note that this behavior can be configured via the accessbility settings, under notification time. This is still very useful for server owners, e.g. when you have a UI Overlay in your action bar, which is slightly shifted downwards using fonts, this can collide with the item's name tooltip. But instead, with this API, you can detect if it's shown and then raise the overlay a bit. Here is an example of this in action (not made by me):

https://github.com/PaperMC/Paper/assets/96977790/eaf40378-9e7f-494c-b96a-48596840c462

