### PR TITLE
Properly apply damage tick after absorption

### DIFF
--- a/patches/server/0968-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
+++ b/patches/server/0968-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Revert to vanilla handling of LivingEntity#actuallyHurt
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8072d31525d9c7890804bb879893f1a69820e32d..651c965cb92a91af7b346416f9e4f2e407b3ba18 100644
+index 8072d31525d9c7890804bb879893f1a69820e32d..c54cb799730353ba1d44c110c85455eb1da6b1d1 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1479,6 +1479,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  if (!this.actuallyHurt(source, (float) event.getFinalDamage() - this.lastHurt, event)) {
                      return false;
                  }
-+                if (this instanceof ServerPlayer && event.getDamage() == 0) return false; // Paper - revert to vanilla damage - players are not affected by damage that is 0 - use base damage here, as it is just amount but post plugin modifiers.
++                if (this instanceof ServerPlayer && event.getDamage() == 0) return false; // Paper - revert to vanilla damage - players are not affected by damage that is 0 - use raw damage here, as it is just the original amount but post plugin changes to it.
                  // CraftBukkit end
                  this.lastHurt = amount;
                  flag1 = false;
@@ -20,7 +20,7 @@ index 8072d31525d9c7890804bb879893f1a69820e32d..651c965cb92a91af7b346416f9e4f2e4
                  if (!this.actuallyHurt(source, (float) event.getFinalDamage(), event)) {
                      return false;
                  }
-+                if (this instanceof ServerPlayer && event.getDamage() == 0) return false; // Paper - revert to vanilla damage - players are not affected by damage that is 0 - use base damage here, as it is just amount but post plugin modifiers.
++                if (this instanceof ServerPlayer && event.getDamage() == 0) return false; // Paper - revert to vanilla damage - players are not affected by damage that is 0 - use raw damage here, as it is just the original amount but post plugin changes to it.
                  this.lastHurt = amount;
                  this.invulnerableTime = this.invulnerableDuration; // CraftBukkit - restore use of maxNoDamageTicks
                  // this.actuallyHurt(damagesource, f);

--- a/patches/server/0968-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
+++ b/patches/server/0968-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
@@ -5,31 +5,26 @@ Subject: [PATCH] Revert to vanilla handling of LivingEntity#actuallyHurt
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8072d31525d9c7890804bb879893f1a69820e32d..d41e22ff113231923d95567244fd33dcc4f320d4 100644
+index 8072d31525d9c7890804bb879893f1a69820e32d..651c965cb92a91af7b346416f9e4f2e407b3ba18 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1476,9 +1476,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
-                 }
- 
-                 // CraftBukkit start
--                if (!this.actuallyHurt(source, (float) event.getFinalDamage() - this.lastHurt, event)) {
-+                final float actualDamage = (float) event.getFinalDamage() - this.lastHurt; // Paper - revert to vanilla damage - move out for diff on change
-+                if (!this.actuallyHurt(source, actualDamage, event)) { // Paper - revert to vanilla damage - move out for diff on change
+@@ -1479,6 +1479,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+                 if (!this.actuallyHurt(source, (float) event.getFinalDamage() - this.lastHurt, event)) {
                      return false;
                  }
-+                if (this instanceof ServerPlayer && actualDamage == 0.0F) return false; // Paper - revert to vanilla damage - players are not affected by damage that is 0.
++                if (this instanceof ServerPlayer && event.getDamage() == 0) return false; // Paper - revert to vanilla damage - players are not affected by damage that is 0 - use base damage here, as it is just amount but post plugin modifiers.
                  // CraftBukkit end
                  this.lastHurt = amount;
                  flag1 = false;
-@@ -1487,6 +1489,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1487,6 +1488,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  if (!this.actuallyHurt(source, (float) event.getFinalDamage(), event)) {
                      return false;
                  }
-+                if (this instanceof ServerPlayer && event.getFinalDamage() == 0.0F) return false; // Paper - revert to vanilla damage - players are not affected by damage that is 0.
++                if (this instanceof ServerPlayer && event.getDamage() == 0) return false; // Paper - revert to vanilla damage - players are not affected by damage that is 0 - use base damage here, as it is just amount but post plugin modifiers.
                  this.lastHurt = amount;
                  this.invulnerableTime = this.invulnerableDuration; // CraftBukkit - restore use of maxNoDamageTicks
                  // this.actuallyHurt(damagesource, f);
-@@ -2411,12 +2414,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2411,12 +2413,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
                      return true;
                  } else {

--- a/patches/server/0979-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0979-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -214,10 +214,10 @@ index 60c65af218d533d53b765ba2175fed163c32c126..a0f5839719ca0ce6ed048229f074041b
                                  }
                              }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index d41e22ff113231923d95567244fd33dcc4f320d4..ea983f83bb8d511e5a978cd4168888b705f94bbb 100644
+index 651c965cb92a91af7b346416f9e4f2e407b3ba18..882e3b6a58951f33a71f862bfa49a5b32d8e8f98 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3354,7 +3354,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3353,7 +3353,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              }
  
          });

--- a/patches/server/0989-Configurable-damage-tick-when-blocking-with-shield.patch
+++ b/patches/server/0989-Configurable-damage-tick-when-blocking-with-shield.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable damage tick when blocking with shield
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ea983f83bb8d511e5a978cd4168888b705f94bbb..70f42996f722edc0435a75d22985940ffba9b409 100644
+index 882e3b6a58951f33a71f862bfa49a5b32d8e8f98..4827998c3b5ad72578de1310ab1c67671c21c5a2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2412,7 +2412,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2411,7 +2411,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                          CriteriaTriggers.PLAYER_HURT_ENTITY.trigger((ServerPlayer) damagesource.getEntity(), this, damagesource, originalDamage, f, true); // Paper - fix taken/dealt param order
                      }
  

--- a/patches/server/0996-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
+++ b/patches/server/0996-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
@@ -26,10 +26,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 70f42996f722edc0435a75d22985940ffba9b409..eedbf5e73dcf4019f408a9098e020488d32ccf4c 100644
+index 4827998c3b5ad72578de1310ab1c67671c21c5a2..42ff2150543108c393f108767963cde49d08efa8 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3775,7 +3775,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3774,7 +3774,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  
              // Paper - diff on change - used in CraftLivingEntity#hasLineOfSight(Location) and CraftWorld#lineOfSightExists

--- a/patches/server/1019-Check-distance-in-entity-interactions.patch
+++ b/patches/server/1019-Check-distance-in-entity-interactions.patch
@@ -17,7 +17,7 @@ index 42d7ecfab6f72517904451d9df3f0404b176fdb2..0e38a641d8e537750166b56c57aca4a9
      };
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index eedbf5e73dcf4019f408a9098e020488d32ccf4c..226148e763a9d63ac340a0b4dc07db3e3c5663b6 100644
+index 42ff2150543108c393f108767963cde49d08efa8..6e5af47f5d2775c1afc4914342c3d0ea6569c792 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1437,7 +1437,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -29,7 +29,7 @@ index eedbf5e73dcf4019f408a9098e020488d32ccf4c..226148e763a9d63ac340a0b4dc07db3e
                          LivingEntity entityliving = (LivingEntity) entity;
  
                          this.blockUsingShield(entityliving);
-@@ -1558,6 +1558,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1557,6 +1557,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
                          d0 = source.getSourcePosition().x() - this.getX();
                          d1 = source.getSourcePosition().z() - this.getZ();
                      }
@@ -44,7 +44,7 @@ index eedbf5e73dcf4019f408a9098e020488d32ccf4c..226148e763a9d63ac340a0b4dc07db3e
  
                      this.knockback(0.4000000059604645D, d0, d1, entity1, entity1 == null ? io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.DAMAGE : io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.ENTITY_ATTACK); // CraftBukkit // Paper - knockback events
                      if (!flag) {
-@@ -2352,7 +2360,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2351,7 +2359,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  this.hurtCurrentlyUsedShield((float) -event.getDamage(DamageModifier.BLOCKING));
                  Entity entity = damagesource.getDirectEntity();
  

--- a/patches/server/1023-Properly-resend-entities.patch
+++ b/patches/server/1023-Properly-resend-entities.patch
@@ -166,10 +166,10 @@ index f1fb4e830c6720d09b22056e3d0b9a08fe2bd472..83f3ffdd8fa901b3de580d2359cdb5ea
      public boolean equals(Object object) {
          return object instanceof Entity ? ((Entity) object).id == this.id : false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 226148e763a9d63ac340a0b4dc07db3e3c5663b6..77d2d93966b99f3dfa2b47a505db74dd2dacfb1e 100644
+index 6e5af47f5d2775c1afc4914342c3d0ea6569c792..c5ca9fa86b940c6b5a54b05ff1bb3d0a300d60b2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3880,6 +3880,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3879,6 +3879,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 2) > 0 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
      }
  


### PR DESCRIPTION
The logic in place to prevent players from processing a damage tick/knockback/etc when hit with 0 damage incorrectly used the damage events final damage value, which is reduced by absorption.

Instead, use the event's "raw damage", e.g. the amount passed to hurt, in order to determine if the damage tick should be skipped. This still allows plugins to change the damage to a non-zero value and properly damage ticks the player in such a case, but correctly processes the damage tick in cases where the original damage is non zero but the actual damage is.

Closes: #11042