### PR TITLE
Only call EntityDamageEvents before actuallyHurt

### DIFF
--- a/patches/server/1036-Only-call-EntityDamageEvents-before-actuallyHurt.patch
+++ b/patches/server/1036-Only-call-EntityDamageEvents-before-actuallyHurt.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <lynxplay101@gmail.com>
+Date: Mon, 8 Jul 2024 22:01:08 +0200
+Subject: [PATCH] Only call EntityDamageEvents before actuallyHurt
+
+The recent upstream update moved around the event logic for
+EntiyDamageEvent and its derivatives.
+However, the event was called on every call to #hurt as it was moved out
+of actuallyHurt.
+
+This patch moves the invocation directly before the #actuallyHurt calls,
+respective invulnerable timings.
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 945da6b82653f05625f054d64bbf605a4ec1cd05..909accac7538e1c0c0c51deb2ee0605697c059d0 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -1459,12 +1459,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+             }
+ 
+             // CraftBukkit start
+-            EntityDamageEvent event = this.handleEntityDamage(source, amount);
+-            amount = 0;
+-            amount += (float) event.getDamage(DamageModifier.BASE);
+-            amount += (float) event.getDamage(DamageModifier.BLOCKING);
+-            amount += (float) event.getDamage(DamageModifier.FREEZING);
+-            amount += (float) event.getDamage(DamageModifier.HARD_HAT);
++            EntityDamageEvent event; // Paper - move this into the actual invuln check....
+             // CraftBukkit end
+ 
+             this.walkAnimation.setSpeed(1.5F);
+@@ -1475,6 +1470,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+                     return false;
+                 }
+ 
++                // Paper start - only call damage event when actuallyHurt will be called - move call logic down
++                event = this.handleEntityDamage(source, amount);
++                amount = computeAmountFromEntityDamageEvent(event);
++                // Paper end - only call damage event when actuallyHurt will be called - move call logic down
++
+                 // CraftBukkit start
+                 if (!this.actuallyHurt(source, (float) event.getFinalDamage() - this.lastHurt, event)) {
+                     return false;
+@@ -1484,6 +1484,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+                 this.lastHurt = amount;
+                 flag1 = false;
+             } else {
++                // Paper start - only call damage event when actuallyHurt will be called - move call logic down
++                event = this.handleEntityDamage(source, amount);
++                amount = computeAmountFromEntityDamageEvent(event);
++                // Paper end - only call damage event when actuallyHurt will be called - move call logic down
+                 // CraftBukkit start
+                 if (!this.actuallyHurt(source, (float) event.getFinalDamage(), event)) {
+                     return false;
+@@ -1615,6 +1619,18 @@ public abstract class LivingEntity extends Entity implements Attackable {
+         }
+     }
+ 
++    // Paper start - only call damage event when actuallyHurt will be called - move out amount computation logic
++    private float computeAmountFromEntityDamageEvent(final EntityDamageEvent event) {
++        // Taken from hurt()'s craftbukkit diff.
++        float amount = 0;
++        amount += (float) event.getDamage(DamageModifier.BASE);
++        amount += (float) event.getDamage(DamageModifier.BLOCKING);
++        amount += (float) event.getDamage(DamageModifier.FREEZING);
++        amount += (float) event.getDamage(DamageModifier.HARD_HAT);
++        return amount;
++    }
++    // Paper end - only call damage event when actuallyHurt will be called - move out amount computation logic
++
+     protected void blockUsingShield(LivingEntity attacker) {
+         attacker.blockedByShield(this);
+     }


### PR DESCRIPTION
The recent upstream update moved around the event logic for EntiyDamageEvent and its derivatives.
However, the event was called on every call to #hurt as it was moved out of actuallyHurt.

This patch moves the invocation directly before the #actuallyHurt calls, respective invulnerable timings.

Resolves: #11044
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-11045.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1679358382.zip)