### PR TITLE
Add default requires and permission methods to BasicCommand

### DIFF
--- a/patches/api/0469-Brigadier-based-command-API.patch
+++ b/patches/api/0469-Brigadier-based-command-API.patch
@@ -502,7 +502,7 @@ index 0000000000000000000000000000000000000000..9df87708206e26167a2c4934deff7fc6
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/BasicCommand.java b/src/main/java/io/papermc/paper/command/brigadier/BasicCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..712db7acae2f9818a3b112f770ee77029c6c4e04
+index 0000000000000000000000000000000000000000..99a9a5ecc5010bcd30351f8844cb5d824c252523
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/BasicCommand.java
 @@ -0,0 +1,60 @@
@@ -548,18 +548,18 @@ index 0000000000000000000000000000000000000000..712db7acae2f9818a3b112f770ee7702
 +     * Checks whether a command sender can receive and run the root command.
 +     *
 +     * @param sender the command sender trying to execute the command
-+     * @return whether the command sender fulfill the root command requirement
++     * @return whether the command sender fulfills the root command requirement
 +     * @see #permission()
 +     */
 +    @ApiStatus.OverrideOnly
-+    default boolean requires(final @NotNull CommandSender sender) {
++    default boolean canUse(final @NotNull CommandSender sender) {
 +        return this.permission() == null || sender.hasPermission(this.permission());
 +    }
 +
 +    /**
-+     * Returns the permission for the root command used in {@link #requires(CommandSender)} by default.
++     * Returns the permission for the root command used in {@link #canUse(CommandSender)} by default.
 +     *
-+     * @return the permission for the root command used in {@link #requires(CommandSender)}
++     * @return the permission for the root command used in {@link #canUse(CommandSender)}
 +     */
 +    @ApiStatus.OverrideOnly
 +    default @Nullable String permission() {

--- a/patches/api/0469-Brigadier-based-command-API.patch
+++ b/patches/api/0469-Brigadier-based-command-API.patch
@@ -502,16 +502,18 @@ index 0000000000000000000000000000000000000000..9df87708206e26167a2c4934deff7fc6
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/BasicCommand.java b/src/main/java/io/papermc/paper/command/brigadier/BasicCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0f6b921b4bcf983cf25188823f78a061eec5263d
+index 0000000000000000000000000000000000000000..712db7acae2f9818a3b112f770ee77029c6c4e04
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/BasicCommand.java
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,60 @@
 +package io.papermc.paper.command.brigadier;
 +
 +import java.util.Collection;
 +import java.util.Collections;
++import org.bukkit.command.CommandSender;
 +import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
 +
 +/**
 + * Implementing this interface allows for easily creating "Bukkit-style" {@code String[] args} commands.
@@ -540,6 +542,28 @@ index 0000000000000000000000000000000000000000..0f6b921b4bcf983cf25188823f78a061
 +    @ApiStatus.OverrideOnly
 +    default @NotNull Collection<String> suggest(final @NotNull CommandSourceStack commandSourceStack, final @NotNull String[] args) {
 +        return Collections.emptyList();
++    }
++
++    /**
++     * Checks whether a command sender can receive and run the root command.
++     *
++     * @param sender the command sender trying to execute the command
++     * @return whether the command sender fulfill the root command requirement
++     * @see #permission()
++     */
++    @ApiStatus.OverrideOnly
++    default boolean requires(final @NotNull CommandSender sender) {
++        return this.permission() == null || sender.hasPermission(this.permission());
++    }
++
++    /**
++     * Returns the permission for the root command used in {@link #requires(CommandSender)} by default.
++     *
++     * @return the permission for the root command used in {@link #requires(CommandSender)}
++     */
++    @ApiStatus.OverrideOnly
++    default @Nullable String permission() {
++        return null;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/CommandRegistrationFlag.java b/src/main/java/io/papermc/paper/command/brigadier/CommandRegistrationFlag.java

--- a/patches/server/0975-Brigadier-based-command-API.patch
+++ b/patches/server/0975-Brigadier-based-command-API.patch
@@ -686,10 +686,10 @@ index 0000000000000000000000000000000000000000..1b1642f306771f029e6214a2e2ebebb6
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java b/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..27509813a90980be1dfc7bde27d0eba60adfc820
+index 0000000000000000000000000000000000000000..ac83eefcea3f22b7980bf7b4f1f22a5ae18d82c1
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
-@@ -0,0 +1,193 @@
+@@ -0,0 +1,194 @@
 +package io.papermc.paper.command.brigadier;
 +
 +import com.google.common.base.Preconditions;
@@ -860,11 +860,12 @@ index 0000000000000000000000000000000000000000..27509813a90980be1dfc7bde27d0eba6
 +    @Override
 +    public @Unmodifiable Set<String> register(final PluginMeta pluginMeta, final String label, final @Nullable String description, final Collection<String> aliases, final BasicCommand basicCommand) {
 +        final LiteralArgumentBuilder<CommandSourceStack> builder = Commands.literal(label)
++            .requires(stack -> basicCommand.requires(stack.getSender()))
 +            .then(
 +                Commands.argument("args", StringArgumentType.greedyString())
 +                    .suggests((context, suggestionsBuilder) -> {
 +                        final String[] args = StringUtils.split(suggestionsBuilder.getRemaining());
-+                        final SuggestionsBuilder offsetSuggestionsBuilder = suggestionsBuilder.createOffset(suggestionsBuilder.getInput().lastIndexOf(' ') + 1);;
++                        final SuggestionsBuilder offsetSuggestionsBuilder = suggestionsBuilder.createOffset(suggestionsBuilder.getInput().lastIndexOf(' ') + 1);
 +
 +                        final Collection<String> suggestions = basicCommand.suggest(context.getSource(), args);
 +                        suggestions.forEach(offsetSuggestionsBuilder::suggest);

--- a/patches/server/0975-Brigadier-based-command-API.patch
+++ b/patches/server/0975-Brigadier-based-command-API.patch
@@ -686,7 +686,7 @@ index 0000000000000000000000000000000000000000..1b1642f306771f029e6214a2e2ebebb6
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java b/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ac83eefcea3f22b7980bf7b4f1f22a5ae18d82c1
+index 0000000000000000000000000000000000000000..a3e128bde0fa4ab0ecab4172f02288a29b9fddc7
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
 @@ -0,0 +1,194 @@
@@ -860,7 +860,7 @@ index 0000000000000000000000000000000000000000..ac83eefcea3f22b7980bf7b4f1f22a5a
 +    @Override
 +    public @Unmodifiable Set<String> register(final PluginMeta pluginMeta, final String label, final @Nullable String description, final Collection<String> aliases, final BasicCommand basicCommand) {
 +        final LiteralArgumentBuilder<CommandSourceStack> builder = Commands.literal(label)
-+            .requires(stack -> basicCommand.requires(stack.getSender()))
++            .requires(stack -> basicCommand.canUse(stack.getSender()))
 +            .then(
 +                Commands.argument("args", StringArgumentType.greedyString())
 +                    .suggests((context, suggestionsBuilder) -> {


### PR DESCRIPTION
Alternative to https://github.com/PaperMC/Paper/pull/11046; does not deprecate the existing methods and instead opts for a simpler solution