### PR TITLE
Only skip damage tick if damage is unmodified zero

### DIFF
--- a/patches/server/0968-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
+++ b/patches/server/0968-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
@@ -5,14 +5,23 @@ Subject: [PATCH] Revert to vanilla handling of LivingEntity#actuallyHurt
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8072d31525d9c7890804bb879893f1a69820e32d..c54cb799730353ba1d44c110c85455eb1da6b1d1 100644
+index 8072d31525d9c7890804bb879893f1a69820e32d..7b019553d88a4294fad1107c5f28ba3fff985d63 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -1425,7 +1425,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+             }
+ 
+             this.noActionTime = 0;
+-            float f1 = amount;
++            float f1 = amount; final float originalAmount = f1; // Paper - revert to vanilla #hurt - OBFHELPER
+             boolean flag = amount > 0.0F && this.isDamageSourceBlocked(source); // Copied from below
+             float f2 = 0.0F;
+ 
 @@ -1479,6 +1479,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  if (!this.actuallyHurt(source, (float) event.getFinalDamage() - this.lastHurt, event)) {
                      return false;
                  }
-+                if (this instanceof ServerPlayer && event.getDamage() == 0) return false; // Paper - revert to vanilla damage - players are not affected by damage that is 0 - use raw damage here, as it is just the original amount but post plugin changes to it.
++                if (this instanceof ServerPlayer && event.getDamage() == 0 && originalAmount == 0) return false; // Paper - revert to vanilla damage - players are not affected by damage that is 0 - skip damage if the vanilla damage is 0 and was not modified by plugins in the event.
                  // CraftBukkit end
                  this.lastHurt = amount;
                  flag1 = false;
@@ -20,7 +29,7 @@ index 8072d31525d9c7890804bb879893f1a69820e32d..c54cb799730353ba1d44c110c85455eb
                  if (!this.actuallyHurt(source, (float) event.getFinalDamage(), event)) {
                      return false;
                  }
-+                if (this instanceof ServerPlayer && event.getDamage() == 0) return false; // Paper - revert to vanilla damage - players are not affected by damage that is 0 - use raw damage here, as it is just the original amount but post plugin changes to it.
++                if (this instanceof ServerPlayer && event.getDamage() == 0 && originalAmount == 0) return false; // Paper - revert to vanilla damage - players are not affected by damage that is 0 - skip damage if the vanilla damage is 0 and was not modified by plugins in the event.
                  this.lastHurt = amount;
                  this.invulnerableTime = this.invulnerableDuration; // CraftBukkit - restore use of maxNoDamageTicks
                  // this.actuallyHurt(damagesource, f);


### PR DESCRIPTION
Only skip the damage tick logic on player entities if the original damage was zero and was not modified by plugins down the line.

This way all the following three scenarios trigger the damage tick

  a) vanilla damage was 0, plugin set it to non zero
  b) vanilla damage was non zero, plugin did not modify it
  c) vanilla damage was non zero, plugin set it to zero.

Regarding case c, the argument here is that EntityDamageEvent#setDamage should not modify the damage tick logic.

Resolves: #11055
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-11058.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1691608530.zip)