### PR TITLE
Don't require author and title to be set on signed book meta

### DIFF
--- a/patches/server/0970-General-ItemMeta-fixes.patch
+++ b/patches/server/0970-General-ItemMeta-fixes.patch
@@ -12,7 +12,7 @@ public net/minecraft/world/level/block/entity/BlockEntity saveId(Lnet/minecraft/
 Co-authored-by: GhastCraftHD <julius.gruenberg@leghast.de>
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 486c3769a0e6a1ecb5530a35e2591f78776619b9..b800b03ae034b276740c3b41555a52b778ad9aad 100644
+index fa4bdf8bdbd6eaeb854e62a2acb45d7998e4aa2b..8309d2f7872ccdbc9d76f0fbf481411f74080148 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -1275,6 +1275,11 @@ public final class ItemStack implements DataComponentHolder {
@@ -68,7 +68,7 @@ index e28bc898786542f695017ff0a036676840eb79fe..cee3fe00cc662f095e7d726b5f1a913c
      protected void load(T tileEntity) {
          if (tileEntity != null && tileEntity != this.snapshot) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 7672128ecca3052f2dc422349a863484c301310e..be36336a3c7d1ae88277f4ee1be70075001de7a7 100644
+index 25096ca7b30483fc9549502caf8b989506405457..369d43f911289b670dcef3b7af3dce73273d95ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -339,7 +339,14 @@ public final class CraftItemStack extends ItemStack {
@@ -457,6 +457,26 @@ index e064af399dcae40b4f35aa993d356b1462f91d6c..27a275f324891e395bf3fd3038c0b9a7
      static final int MAX_PAGE_LENGTH = WritableBookContent.PAGE_EDIT_LENGTH; // SPIGOT-6911: Use Minecraft limits
  
      // We store the pages in their raw original text representation. See SPIGOT-5063, SPIGOT-5350, SPIGOT-3206
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
+index 806c1cbee7c4e23eee38c8f400ec2d924c9a360c..d357c8ddf06aea99bac6b43c1e20d2e99f98d034 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
+@@ -124,13 +124,13 @@ public class CraftMetaBookSigned extends CraftMetaItem implements BookMeta {
+     void applyToItem(CraftMetaItem.Applicator itemData) {
+         super.applyToItem(itemData);
+ 
++        List<Filterable<Component>> list = new ArrayList<>(); // Paper - General ItemMeta Fixes
+         if (this.pages != null) {
+-            List<Filterable<Component>> list = new ArrayList<>();
+             for (Component page : this.pages) {
+                 list.add(Filterable.passThrough(page));
+             }
+-            itemData.put(CraftMetaBookSigned.BOOK_CONTENT, new WrittenBookContent(Filterable.from(FilteredText.passThrough(this.title)), this.author, this.generation, list, this.resolved));
+         }
++        itemData.put(CraftMetaBookSigned.BOOK_CONTENT, new WrittenBookContent(Filterable.from(this.title == null ? FilteredText.EMPTY : FilteredText.passThrough(this.title)), this.author == null ? "" : this.author, this.generation, list, this.resolved)); // Paper - General ItemMeta Fixes
+     }
+ 
+     @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBundle.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBundle.java
 index 2736a87a6c481da0575e6e29ea08faa539c24378..51da0db4da3549efd69f367e28450408968fa8d0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBundle.java


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/11067

Fix a regression in https://github.com/PaperMC/Paper/commit/4d20922b79f5b3976e240932d087357a3808fde4 and make pages optional too while still keeping the author and title.