### PR TITLE
Fix fetching biomes during world generation

### DIFF
--- a/patches/server/1042-Fix-fetching-biomes-during-world-gen.patch
+++ b/patches/server/1042-Fix-fetching-biomes-during-world-gen.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Newwind <support@newwindserver.com>
+Date: Sat, 13 Jul 2024 18:00:37 +0200
+Subject: [PATCH] Fix fetching biomes during world generation
+
+getNoiseBiome() on LevelReader first attempts to getChunk() to get its cached noise biome,
+however, calling getChunk() on WorldGenRegion will cause a crash if the chunk isn't found
+"Requested chunk unavailable during world generation"
+This means features which attempt to fetch biomes during generation, such as LakeFeature,
+can cause the server to crash. This patch simply removes chunk lookups from getNoiseBiome()
+for WorldGenRegion by overriding the method.
+
+diff --git a/src/main/java/net/minecraft/server/level/WorldGenRegion.java b/src/main/java/net/minecraft/server/level/WorldGenRegion.java
+index 5a8a33638..dfbdf0c62 100644
+--- a/src/main/java/net/minecraft/server/level/WorldGenRegion.java
++++ b/src/main/java/net/minecraft/server/level/WorldGenRegion.java
+@@ -145,6 +145,13 @@ public class WorldGenRegion implements WorldGenLevel {
+         return this.getChunk(chunkX, chunkZ, ChunkStatus.EMPTY);
+     }
+ 
++    // Paper start - Always use uncached noise to get biomes in WorldGenRegion
++    @Override
++    public Holder<Biome> getNoiseBiome(int biomeX, int biomeY, int biomeZ) {
++        return this.getUncachedNoiseBiome(biomeX, biomeY, biomeZ);
++    }
++    // Paper end
++
+     @Nullable
+     @Override
+     public ChunkAccess getChunk(int chunkX, int chunkZ, ChunkStatus leastStatus, boolean create) {


### PR DESCRIPTION
Fixes #11084

getNoiseBiome() on LevelReader first attempts to getChunk() to get its cached noise biome, however, calling getChunk() on WorldGenRegion will cause a crash if the chunk isn't found "Requested chunk unavailable during world generation"

This means features which attempt to fetch biomes during generation, such as LakeFeature, can cause the server to crash.
This PR simply removes chunk lookups from getNoiseBiome() for WorldGenRegion by overriding the method.