### PR TITLE
Fix HIDE_ATTRIBUTES flag not working for items without attributes set

### DIFF
--- a/patches/server/0970-General-ItemMeta-fixes.patch
+++ b/patches/server/0970-General-ItemMeta-fixes.patch
@@ -859,19 +859,6 @@ index 58da8cb19a8444c634cbc1f39e93503ca8e2ecab..776f4dcc0b61a5b8ee4020a283cfcfac
              itemTag.put(CraftMetaItem.DAMAGE, this.damage);
          }
  
-@@ -970,10 +976,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
-     }
- 
-     void applyModifiers(Multimap<Attribute, AttributeModifier> modifiers, CraftMetaItem.Applicator tag) {
--        if (modifiers == null || modifiers.isEmpty()) {
--            if (this.hasItemFlag(ItemFlag.HIDE_ATTRIBUTES)) {
--                tag.put(CraftMetaItem.ATTRIBUTES, new ItemAttributeModifiers(Collections.emptyList(), false));
--            }
-+        if (modifiers == null/* || modifiers.isEmpty()*/) { // Paper - empty modifiers has a specific meaning, they should still be saved
-+            // Paper - don't save ItemFlag if the underlying data isn't present
-             return;
-         }
- 
 @@ -1010,7 +1014,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Overridden


### PR DESCRIPTION
Fixes #10744

Currently, on paper, when you add HIDE_ATTRIBUTES flag to an item, e.g. a diamond sword, it incorrectly still shows the "When in main hand 7 attack damage..." default attributes, which are supposed to be hidden.

On spigot, however, these default attributes are correctly hidden, upon investigation, the general-itemmeta-fixes patch [breaks this functionality](https://github.com/PaperMC/Paper/commit/9d8d38d13714433271fa9ed17485bc1578629b9e#diff-22b14b0a6e7f7cb65eacc9eb15cb1664dbc8d48dc20813dabf7cbce9b7b70573R268), This PR fixes the functionality and brings it back in line with spigot/pre 1.20.5 behaviour.

Note, on #10744 there is a comment stating that having empty attributes defined on the item overrides the default attributes, but from my testing this does not appear to be the case.