### PR TITLE
Fix inventory desync when placing blocks with spawn protection

### DIFF
--- a/patches/server/0748-Fix-a-bunch-of-vanilla-bugs.patch
+++ b/patches/server/0748-Fix-a-bunch-of-vanilla-bugs.patch
@@ -52,6 +52,9 @@ https://bugs.mojang.com/browse/MC-200092
 https://bugs.mojang.com/browse/MC-158900
   Fix error when joining after tempban expired
 
+https://bugs.mojang.com/browse/MC-99075
+  Fix inventory desync within spawn protected area
+
 == AT ==
 public net/minecraft/world/entity/Mob leashInfoTag
 
@@ -123,6 +126,19 @@ index 6abecaac8407b992d208a9108e11fd4954a4106f..03d89f326d320c5d778c3d1e2db7d6b8
              this.player.onUpdateAbilities();
              this.player.server.getPlayerList().broadcastAll(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE, this.player), this.player); // CraftBukkit
              this.level.updateSleepingPlayerList();
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index ca32e5aa6e77ca1bab886e7b6a778ec931ac4e4c..28808ffc6e486f7dc01be370c9eb249dc1f7ea46 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1814,7 +1814,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+                             } else if (enuminteractionresult.shouldSwing() && !this.player.gameMode.interactResult) { // Paper - Call interact event
+                                 this.player.swing(enumhand, true);
+                             }
+-                        }
++                        } else { this.player.containerMenu.sendAllDataToRemote(); } // Paper - Fix inventory desync; MC-99075
+                     } else {
+                         MutableComponent ichatmutablecomponent1 = Component.translatable("build.tooHigh", i - 1).withStyle(ChatFormatting.RED);
+ 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
 index be842c81ae6c6ec64a233f126d7221a37d66439c..b54e8da2209d99696e12c65a23323a68b7da272b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java

--- a/patches/server/0877-Fix-slot-desync.patch
+++ b/patches/server/0877-Fix-slot-desync.patch
@@ -22,17 +22,9 @@ index 7270b6fa96bae937663c0fea77887e21fbd0eb57..530728cd4b258444f6efe064903b521f
          this.containerMenu.findSlot(this.getInventory(), this.getInventory().selected).ifPresent(s -> {
              this.containerSynchronizer.sendSlotChange(this.containerMenu, s, this.getMainHandItem());
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d14cb295fa3a3a2aa14efd58cccdaa9471955548..80a8449424e0549fcca4c075a260fd3d2319c070 100644
+index be0ce72bb493593a3d2eb7d7c37e3a650b7cc34b..0ffa95542a0ed49a3f83700841f7c76c0717ae22 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1866,7 +1866,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
-                             } else if (enuminteractionresult.shouldSwing() && !this.player.gameMode.interactResult) { // Paper - Call interact event
-                                 this.player.swing(enumhand, true);
-                             }
--                        }
-+                        } else { this.player.containerMenu.sendAllDataToRemote(); } // Paper - Fix inventory desync; MC-99075
-                     } else {
-                         MutableComponent ichatmutablecomponent1 = Component.translatable("build.tooHigh", i - 1).withStyle(ChatFormatting.RED);
 @@ -2729,10 +2729,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  // Refresh the current entity metadata
                                  entity.refreshEntityData(ServerGamePacketListenerImpl.this.player);

--- a/patches/server/0877-Fix-slot-desync.patch
+++ b/patches/server/0877-Fix-slot-desync.patch
@@ -25,6 +25,14 @@ diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListener
 index adf9357363465fd7a8c9e0d51b80b9f61d531a01..5541de6364b9982ae95e0a952167ae09084f65cf 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1867,7 +1867,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+                             } else if (enuminteractionresult.shouldSwing() && !this.player.gameMode.interactResult) { // Paper - Call interact event
+                                 this.player.swing(enumhand, true);
+                             }
+-                        }
++                        } else { this.player.containerMenu.sendAllDataToRemote(); } // Paper - Fix inventory desync
+                     } else {
+                         MutableComponent ichatmutablecomponent1 = Component.translatable("build.tooHigh", i - 1).withStyle(ChatFormatting.RED);
 @@ -2729,10 +2729,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  // Refresh the current entity metadata
                                  entity.refreshEntityData(ServerGamePacketListenerImpl.this.player);

--- a/patches/server/0877-Fix-slot-desync.patch
+++ b/patches/server/0877-Fix-slot-desync.patch
@@ -22,15 +22,15 @@ index 7270b6fa96bae937663c0fea77887e21fbd0eb57..530728cd4b258444f6efe064903b521f
          this.containerMenu.findSlot(this.getInventory(), this.getInventory().selected).ifPresent(s -> {
              this.containerSynchronizer.sendSlotChange(this.containerMenu, s, this.getMainHandItem());
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index adf9357363465fd7a8c9e0d51b80b9f61d531a01..5541de6364b9982ae95e0a952167ae09084f65cf 100644
+index d14cb295fa3a3a2aa14efd58cccdaa9471955548..80a8449424e0549fcca4c075a260fd3d2319c070 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1867,7 +1867,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1866,7 +1866,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              } else if (enuminteractionresult.shouldSwing() && !this.player.gameMode.interactResult) { // Paper - Call interact event
                                  this.player.swing(enumhand, true);
                              }
 -                        }
-+                        } else { this.player.containerMenu.sendAllDataToRemote(); } // Paper - Fix inventory desync
++                        } else { this.player.containerMenu.sendAllDataToRemote(); } // Paper - Fix inventory desync; MC-99075
                      } else {
                          MutableComponent ichatmutablecomponent1 = Component.translatable("build.tooHigh", i - 1).withStyle(ChatFormatting.RED);
 @@ -2729,10 +2729,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl


### PR DESCRIPTION
fixes #11012 

Should we maybe call BlockPlaceEvent in a cancelled state when a player tries placing blocks with spawn protection on? This could allow plugins to pick which blocks should be placeable at spawn.