### PR TITLE
Bundle spark

### DIFF
--- a/patches/api/0011-Timings-v2.patch
+++ b/patches/api/0011-Timings-v2.patch
@@ -1261,10 +1261,10 @@ index 0000000000000000000000000000000000000000..df142a89b8c43acb81eb383eac0ef048
 +}
 diff --git a/src/main/java/co/aikar/timings/Timings.java b/src/main/java/co/aikar/timings/Timings.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9812d668ad945aba486fbf6d5bf83c4292cb5d03
+index 0000000000000000000000000000000000000000..445b5d3b61f31cf263475d0155a7b0252c54a3f8
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/Timings.java
-@@ -0,0 +1,337 @@
+@@ -0,0 +1,331 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -1426,23 +1426,17 @@ index 0000000000000000000000000000000000000000..9812d668ad945aba486fbf6d5bf83c42
 +
 +    public static Component deprecationMessage() {
 +        return Component.text()
-+            .color(TextColor.color(0xf3ef91))
++            .color(TextColor.color(0xffc93a))
 +            .append(Component.text("[!] The timings profiler has been enabled but has been scheduled for removal from Paper in the future."))
 +            .append(Component.newline())
-+            .append(
-+                Component.text("    We recommend installing the spark profiler as a replacement: ")
-+                    .append(
-+                        Component.text()
-+                            .content("https://spark.lucko.me/")
-+                            .clickEvent(ClickEvent.openUrl("https://spark.lucko.me/")))
-+            )
++            .append(Component.text("    We recommend migrating to the spark profiler."))
 +            .append(Component.newline())
 +            .append(
 +                Component.text("    For more information please visit: ")
 +                    .append(
 +                        Component.text()
-+                            .content("https://github.com/PaperMC/Paper/issues/8948")
-+                            .clickEvent(ClickEvent.openUrl("https://github.com/PaperMC/Paper/issues/8948")))
++                            .content("https://github.com/PaperMC/Paper/discussions/10565")
++                            .clickEvent(ClickEvent.openUrl("https://github.com/PaperMC/Paper/discussions/10565")))
 +            )
 +            .build();
 +    }

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -487,10 +487,10 @@ index 0000000000000000000000000000000000000000..d9502ba028a96f9cc846f9ed428bd806
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a4f91ef8d5c4a8263961c4f00c0ce8cc937497d9
+index 0000000000000000000000000000000000000000..9bf81a47b03769a46c995019c3d8016cd161c15d
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,313 @@
+@@ -0,0 +1,321 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -542,6 +542,14 @@ index 0000000000000000000000000000000000000000..a4f91ef8d5c4a8263961c4f00c0ce8cc
 +
 +        public Component noPermission = Component.text("I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error.", NamedTextColor.RED);
 +        public boolean useDisplayNameInQuitMessage = false;
++    }
++
++    public Spark spark;
++
++    public class Spark extends ConfigurationPart {
++        public boolean enabled = true;
++        public boolean enableImmediately = false;
++        public boolean preferSparkPlugin = false;
 +    }
 +
 +    @Deprecated(forRemoval = true)

--- a/patches/server/0745-Configurable-chat-thread-limit.patch
+++ b/patches/server/0745-Configurable-chat-thread-limit.patch
@@ -22,10 +22,10 @@ is actually processed, this is honestly really just exposed for the misnomers or
 who just wanna ensure that this won't grow over a specific size if chat gets stupidly active
 
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index a4f91ef8d5c4a8263961c4f00c0ce8cc937497d9..701196635f9c08d62d785fa1b448313937259c76 100644
+index 9bf81a47b03769a46c995019c3d8016cd161c15d..0ab240d1b1d872dffb78f424b388b2b802326832 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -287,7 +287,18 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -295,7 +295,18 @@ public class GlobalConfiguration extends ConfigurationPart {
  
              @PostProcess
              private void postProcess() {

--- a/patches/server/0988-Moonrise-optimisation-patches.patch
+++ b/patches/server/0988-Moonrise-optimisation-patches.patch
@@ -22226,7 +22226,7 @@ index 0000000000000000000000000000000000000000..85950a1aa732ab8c01ad28bec9e0de14
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 5160dc617cc5037cd3f10479454159f2a9984169..379452394679c466a09441d4c12882d0d00d9ef3 100644
+index ae6089f34e2420c0d745165ea0f754f4a9f1880f..c01fda50d9faba2ec373ac14b4a5992f516fac3a 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 @@ -29,6 +29,45 @@ public class GlobalConfiguration extends ConfigurationPart {
@@ -22275,7 +22275,7 @@ index 5160dc617cc5037cd3f10479454159f2a9984169..379452394679c466a09441d4c12882d0
      static void set(GlobalConfiguration instance) {
          GlobalConfiguration.instance = instance;
      }
-@@ -130,21 +169,6 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -138,21 +177,6 @@ public class GlobalConfiguration extends ConfigurationPart {
          public int incomingPacketThreshold = 300;
      }
  
@@ -22297,7 +22297,7 @@ index 5160dc617cc5037cd3f10479454159f2a9984169..379452394679c466a09441d4c12882d0
      public UnsupportedSettings unsupportedSettings;
  
      public class UnsupportedSettings extends ConfigurationPart {
-@@ -203,7 +227,7 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -211,7 +235,7 @@ public class GlobalConfiguration extends ConfigurationPart {
  
          @PostProcess
          private void postProcess() {

--- a/patches/server/1043-Bundle-spark.patch
+++ b/patches/server/1043-Bundle-spark.patch
@@ -1,0 +1,347 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Riley Park <rileysebastianpark@gmail.com>
+Date: Tue, 16 Jul 2024 14:55:23 -0700
+Subject: [PATCH] Bundle spark
+
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index 1a734293c9416f13324bb0edf8f950c9029f8bc4..568d0b65bb5010e0ab365cb47b624720807a1f63 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -61,6 +61,10 @@ dependencies {
+     implementation("io.papermc:reflection-rewriter-runtime:$reflectionRewriterVersion")
+     implementation("io.papermc:reflection-rewriter-proxy-generator:$reflectionRewriterVersion")
+     // Paper end - Remap reflection
++    // Paper start - spark
++    implementation("me.lucko:spark-api:0.1-SNAPSHOT")
++    implementation("me.lucko:spark-paper:1.10.83-SNAPSHOT")
++    // Paper end - spark
+ }
+ 
+ paperweight {
+diff --git a/src/main/java/io/papermc/paper/SparksFly.java b/src/main/java/io/papermc/paper/SparksFly.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..e4cb01a1a50311eae503b568f6e3e599d48302c8
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/SparksFly.java
+@@ -0,0 +1,177 @@
++package io.papermc.paper;
++
++import io.papermc.paper.configuration.GlobalConfiguration;
++import io.papermc.paper.util.MCUtil;
++import java.util.List;
++import java.util.logging.Level;
++import java.util.logging.Logger;
++import me.lucko.spark.paper.api.Compatibility;
++import me.lucko.spark.paper.api.PaperClassLookup;
++import me.lucko.spark.paper.api.PaperScheduler;
++import me.lucko.spark.paper.api.PaperSparkModule;
++import net.kyori.adventure.text.Component;
++import net.kyori.adventure.text.format.TextColor;
++import org.bukkit.Server;
++import org.bukkit.command.Command;
++import org.bukkit.command.CommandSender;
++import org.bukkit.craftbukkit.CraftServer;
++
++// It's like electricity.
++public final class SparksFly {
++    public static final String ID = "spark";
++    public static final String COMMAND_NAME = "spark";
++
++    private static final int SPARK_YELLOW = 0xffc93a;
++
++    private final Logger logger;
++    private final PaperSparkModule spark;
++
++    private boolean enabled;
++    private boolean disabledInConfigurationWarningLogged;
++
++    public SparksFly(final Server server) {
++        this.logger = Logger.getLogger(ID);
++        this.logger.log(Level.INFO, "This server bundles the spark profiler. For more information please visit https://docs.papermc.io/paper/profiling");
++        this.spark = PaperSparkModule.create(Compatibility.VERSION_1_0, server, this.logger, new PaperScheduler() {
++            @Override
++            public void executeAsync(final Runnable runnable) {
++                MCUtil.scheduleAsyncTask(this.catching(runnable, "asynchronous"));
++            }
++
++            @Override
++            public void executeSync(final Runnable runnable) {
++                MCUtil.ensureMain(this.catching(runnable, "synchronous"));
++            }
++
++            private Runnable catching(final Runnable runnable, final String type) {
++                return () -> {
++                    try {
++                        runnable.run();
++                    } catch (final Throwable t) {
++                        SparksFly.this.logger.log(Level.SEVERE, "An exception was encountered while executing a " + type + " spark task", t);
++                    }
++                };
++            }
++        }, new PaperClassLookup() {
++            @Override
++            public Class<?> lookup(final String className) throws Exception {
++                return Class.forName(className);
++            }
++        });
++    }
++
++    public void enableEarlyIfRequested() {
++        if (!isPluginPreferred() && shouldEnableImmediately()) {
++            this.enable();
++        }
++    }
++
++    public void enableBeforePlugins() {
++        if (!isPluginPreferred()) {
++            this.enable();
++        }
++    }
++
++    public void enableAfterPlugins(final Server server) {
++        final boolean isPluginPreferred = isPluginPreferred();
++        final boolean isPluginEnabled = isPluginEnabled(server);
++        if (!isPluginPreferred || !isPluginEnabled) {
++            if (isPluginPreferred && !this.enabled) {
++                this.logger.log(Level.INFO, "The spark plugin has been preferred but was not loaded. The bundled spark profiler will enabled instead.");
++            }
++            this.enable();
++        }
++    }
++
++    private void enable() {
++        if (!this.enabled) {
++            if (GlobalConfiguration.get().spark.enabled) {
++                this.enabled = true;
++                this.spark.enable();
++            } else {
++                if (!this.disabledInConfigurationWarningLogged) {
++                    this.logger.log(Level.INFO, "The spark profiler will not be enabled because it is currently disabled in the configuration.");
++                    this.disabledInConfigurationWarningLogged = true;
++                }
++            }
++        }
++    }
++
++    public void disable() {
++        if (this.enabled) {
++            this.spark.disable();
++            this.enabled = false;
++        }
++    }
++
++    public void registerCommandBeforePlugins(final Server server) {
++        if (!isPluginPreferred()) {
++            this.registerCommand(server);
++        }
++    }
++
++    public void registerCommandAfterPlugins(final Server server) {
++        if ((!isPluginPreferred() || !isPluginEnabled(server)) && server.getCommandMap().getCommand(COMMAND_NAME) == null) {
++            this.registerCommand(server);
++        }
++    }
++
++    private void registerCommand(final Server server) {
++        server.getCommandMap().register(COMMAND_NAME, "paper", new CommandImpl(COMMAND_NAME));
++    }
++
++    public void tickStart() {
++        this.spark.onServerTickStart();
++    }
++
++    public void tickEnd(final double duration) {
++        this.spark.onServerTickEnd(duration);
++    }
++
++    void executeCommand(final CommandSender sender, final String[] args) {
++        this.spark.executeCommand(sender, args);
++    }
++
++    List<String> tabComplete(final CommandSender sender, final String[] args) {
++        return this.spark.tabComplete(sender, args);
++    }
++
++    public static boolean isPluginPreferred() {
++        return GlobalConfiguration.get().spark.preferSparkPlugin;
++    }
++
++    private static boolean isPluginEnabled(final Server server) {
++        return server.getPluginManager().isPluginEnabled(ID);
++    }
++
++    private static boolean shouldEnableImmediately() {
++        return GlobalConfiguration.get().spark.enableImmediately;
++    }
++
++    public static final class CommandImpl extends Command {
++        CommandImpl(final String name) {
++            super(name);
++            this.setPermission("spark");
++        }
++
++        @Override
++        public boolean execute(final CommandSender sender, final String commandLabel, final String[] args) {
++            final SparksFly spark = ((CraftServer) sender.getServer()).spark;
++            if (spark.enabled) {
++                spark.executeCommand(sender, args);
++            } else {
++                sender.sendMessage(Component.text("The spark profiler is currently disabled.", TextColor.color(SPARK_YELLOW)));
++            }
++            return true;
++        }
++
++        @Override
++        public List<String> tabComplete(final CommandSender sender, final String alias, final String[] args) throws IllegalArgumentException {
++            final SparksFly spark = ((CraftServer) sender.getServer()).spark;
++            if (spark.enabled) {
++                return spark.tabComplete(sender, args);
++            }
++            return List.of();
++        }
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java b/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
+index 6b8ed8a0baaf4a57d20e57cec3400af5561ddd79..48604e7f96adc9e226e034054c5e2bad0b024eb5 100644
+--- a/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
++++ b/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
+@@ -1,6 +1,9 @@
+ package io.papermc.paper.plugin.provider.source;
+ 
++import com.mojang.logging.LogUtils;
++import io.papermc.paper.SparksFly;
+ import io.papermc.paper.plugin.PluginInitializerManager;
++import io.papermc.paper.plugin.configuration.PluginMeta;
+ import io.papermc.paper.plugin.entrypoint.EntrypointHandler;
+ import io.papermc.paper.plugin.provider.type.PluginFileType;
+ import org.bukkit.plugin.InvalidPluginException;
+@@ -17,12 +20,14 @@ import java.nio.file.attribute.BasicFileAttributes;
+ import java.util.Set;
+ import java.util.function.Function;
+ import java.util.jar.JarFile;
++import org.slf4j.Logger;
+ 
+ /**
+  * Loads a plugin provider at the given plugin jar file path.
+  */
+ public class FileProviderSource implements ProviderSource<Path, Path> {
+ 
++    private static final Logger LOGGER = LogUtils.getClassLogger();
+     private final Function<Path, String> contextChecker;
+     private final boolean applyRemap;
+ 
+@@ -82,6 +87,12 @@ public class FileProviderSource implements ProviderSource<Path, Path> {
+             );
+         }
+ 
++        final PluginMeta config = type.getConfig(file);
++        if ((config.getName().equals("spark") && config.getMainClass().equals("me.lucko.spark.bukkit.BukkitSparkPlugin")) && !SparksFly.isPluginPreferred()) {
++            LOGGER.info("The spark plugin will not be loaded as this server bundles the spark profiler.");
++            return;
++        }
++
+         type.register(entrypointHandler, file, context);
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 8160c35368fc2c52d6f4a42df27adb2ef6eb87f3..9325d6f95165a7cee00d7de736af723681cc16b4 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -751,6 +751,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         // Paper end - Configurable player collision
+ 
+         this.server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.POSTWORLD);
++        this.server.spark.registerCommandBeforePlugins(this.server); // Paper - spark
++        this.server.spark.enableAfterPlugins(this.server); // Paper - spark
+         if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.pluginsEnabled(); // Paper - Remap plugins
+         io.papermc.paper.command.brigadier.PaperCommands.INSTANCE.setValid(); // Paper - reset invalid state for event fire below
+         io.papermc.paper.plugin.lifecycle.event.LifecycleEventRunner.INSTANCE.callReloadableRegistrarEvent(io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents.COMMANDS, io.papermc.paper.command.brigadier.PaperCommands.INSTANCE, org.bukkit.plugin.Plugin.class, io.papermc.paper.plugin.lifecycle.event.registrar.ReloadableRegistrarEvent.Cause.INITIAL); // Paper - call commands event for regular plugins
+@@ -1037,6 +1039,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         MinecraftServer.LOGGER.info("Stopping server");
+         Commands.COMMAND_SENDING_POOL.shutdownNow(); // Paper - Perf: Async command map building; Shutdown and don't bother finishing
+         MinecraftTimings.stopServer(); // Paper
++        this.server.spark.disable(); // Paper - spark
+         // CraftBukkit start
+         if (this.server != null) {
+             this.server.disablePlugins();
+@@ -1226,6 +1229,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+             // tasks are default scheduled at -1 + delay, and first tick will tick at 1
+             final long actualDoneTimeMs = System.currentTimeMillis() - org.bukkit.craftbukkit.Main.BOOT_TIME.toEpochMilli(); // Paper - Add total time
+             LOGGER.info("Done ({})! For help, type \"help\"", String.format(java.util.Locale.ROOT, "%.3fs", actualDoneTimeMs / 1000.00D)); // Paper - Add total time
++            this.server.spark.enableBeforePlugins(); // Paper - spark
+             org.spigotmc.WatchdogThread.tick();
+             // Paper end - Improved Watchdog Support
+             org.spigotmc.WatchdogThread.hasStarted = true; // Paper
+@@ -1585,6 +1589,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         });
+         isOversleep = false;MinecraftTimings.serverOversleep.stopTiming();
+         // Paper end
++        this.server.spark.tickStart(); // Paper - spark
+         new com.destroystokyo.paper.event.server.ServerTickStartEvent(this.tickCount+1).callEvent(); // Paper - Server Tick Events
+ 
+         ++this.tickCount;
+@@ -1627,6 +1632,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         long endTime = System.nanoTime();
+         long remaining = (TICK_TIME - (endTime - lastTick)) - catchupTime;
+         new com.destroystokyo.paper.event.server.ServerTickEndEvent(this.tickCount, ((double)(endTime - lastTick) / 1000000D), remaining).callEvent();
++        this.server.spark.tickEnd(((double)(endTime - lastTick) / 1000000D)); // Paper - spark
+         // Paper end - Server Tick Events
+         this.profiler.push("tallying");
+         long j = Util.getNanos() - i;
+diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+index d43b98bdfcb00603737a309c0fb7793d42289b8c..dd56c8e041116ef3602a9f89c998c8208ab89b51 100644
+--- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -226,6 +226,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         this.paperConfigurations.initializeGlobalConfiguration(this.registryAccess());
+         this.paperConfigurations.initializeWorldDefaultsConfiguration(this.registryAccess());
+         // Paper end - initialize global and world-defaults configuration
++        this.server.spark.enableEarlyIfRequested(); // Paper - spark
+         // Paper start - fix converting txt to json file; convert old users earlier after PlayerList creation but before file load/save
+         if (this.convertOldUsers()) {
+             this.getProfileCache().save(false); // Paper
+@@ -235,6 +236,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         org.spigotmc.WatchdogThread.doStart(org.spigotmc.SpigotConfig.timeoutTime, org.spigotmc.SpigotConfig.restartOnCrash); // Paper - start watchdog thread
+         thread.start(); // Paper - Enhance console tab completions for brigadier commands; start console thread after MinecraftServer.console & PaperConfig are initialized
+         io.papermc.paper.command.PaperCommands.registerCommands(this); // Paper - setup /paper command
++        this.server.spark.registerCommandBeforePlugins(this.server); // Paper - spark
+         com.destroystokyo.paper.Metrics.PaperMetrics.startMetrics(); // Paper - start metrics
+         com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // Paper - load version history now
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 3a91faeb6957e4e783b1de3e1145e7d1d164a857..c8b82bc41f2042bb4b067f06265a3a22e51f7629 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -309,6 +309,7 @@ public final class CraftServer implements Server {
+     public static Exception excessiveVelEx; // Paper - Velocity warnings
+     private final io.papermc.paper.logging.SysoutCatcher sysoutCatcher = new io.papermc.paper.logging.SysoutCatcher(); // Paper
+     private final io.papermc.paper.potion.PaperPotionBrewer potionBrewer; // Paper - Custom Potion Mixes
++    public final io.papermc.paper.SparksFly spark; // Paper - spark
+ 
+     // Paper start - Folia region threading API
+     private final io.papermc.paper.threadedregions.scheduler.FallbackRegionScheduler regionizedScheduler = new io.papermc.paper.threadedregions.scheduler.FallbackRegionScheduler();
+@@ -474,6 +475,7 @@ public final class CraftServer implements Server {
+         }
+         this.potionBrewer = new io.papermc.paper.potion.PaperPotionBrewer(console); // Paper - custom potion mixes
+         datapackManager = new io.papermc.paper.datapack.PaperDatapackManager(console.getPackRepository()); // Paper
++        this.spark = new io.papermc.paper.SparksFly(this); // Paper - spark
+     }
+ 
+     public boolean getCommandBlockOverride(String command) {
+@@ -1099,6 +1101,7 @@ public final class CraftServer implements Server {
+         this.reloadData();
+         org.spigotmc.SpigotConfig.registerCommands(); // Spigot
+         io.papermc.paper.command.PaperCommands.registerCommands(this.console); // Paper
++        this.spark.registerCommandBeforePlugins(this); // Paper - spark
+         this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
+         this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
+ 
+@@ -1127,6 +1130,7 @@ public final class CraftServer implements Server {
+         this.loadPlugins();
+         this.enablePlugins(PluginLoadOrder.STARTUP);
+         this.enablePlugins(PluginLoadOrder.POSTWORLD);
++        this.spark.registerCommandAfterPlugins(this); // Paper - spark
+         if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.pluginsEnabled(); // Paper - Remap plugins
+         // Paper start - brigadier command API
+         io.papermc.paper.command.brigadier.PaperCommands.INSTANCE.setValid(); // to clear invalid state for event fire below


### PR DESCRIPTION
discussion: https://github.com/PaperMC/Paper/discussions/10565
docs: https://github.com/PaperMC/docs/pull/447

New configuration options (global configuration):
```yaml
spark:
  # If the bundled spark profiler should be enabled at all.
  enabled: true
  # If the bundled spark profiler should be enabled as soon as possible.
  # If true, spark enables as early as possible. This can be useful for profiling the server during startup.
  # If false, spark enables once the server has finished starting up (when the `Done (4.720s)! For help, type "help"` message is sent in console).
  enable-immediately: false
  # Prefers the spark plugin over the bundled spark profiler.
  # If enabled and the spark plugin is found in the plugins directory, it will be loaded and the bundled spark profiler will not be loaded.
  # If enabled and the spark plugin is not found in the plugins directory, the bundled profiler will be enabled.
  prefer-spark-plugin: false
```