### PR TITLE
Add option to throttle spawn attempts after several failures

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1403,10 +1403,10 @@ index 0000000000000000000000000000000000000000..990d1bb46e0f9719f4e9af928d80ac6f
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7509b17414f836e8b53fc62b02b386ba4e8c5ca9
+index 0000000000000000000000000000000000000000..f9a2bbd0aa64bd3a77f1dc80cbdc5ef52da89b5b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,551 @@
+@@ -0,0 +1,560 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1594,6 +1594,15 @@ index 0000000000000000000000000000000000000000..7509b17414f836e8b53fc62b02b386ba
 +            public Map<MobCategory, DespawnRange> despawnRanges = Arrays.stream(MobCategory.values()).collect(Collectors.toMap(Function.identity(), category -> new DespawnRange(category.getNoDespawnDistance(), category.getDespawnDistance())));
 +            @MergeMap
 +            public Reference2IntMap<MobCategory> ticksPerSpawn = Util.make(new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length), map -> Arrays.stream(NaturalSpawner.SPAWNING_CATEGORIES).forEach(mobCategory -> map.put(mobCategory, -1)));
++
++            public SpawningThrottle spawningThrottle;
++
++            public class SpawningThrottle extends ConfigurationPart {
++                public IntOr.Disabled failedAttemptsThreshold = IntOr.Disabled.DISABLED;
++
++                @MergeMap
++                public Reference2IntMap<MobCategory> throttledTicksPerSpawn = Util.make(new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length), map -> Arrays.stream(NaturalSpawner.SPAWNING_CATEGORIES).forEach(mobCategory -> map.put(mobCategory, -1)));
++            }
 +
 +            @ConfigSerializable
 +            public record DespawnRange(@Required int soft, @Required int hard) {

--- a/patches/server/1042-Throttle-failed-spawn-attempts.patch
+++ b/patches/server/1042-Throttle-failed-spawn-attempts.patch
@@ -1,0 +1,117 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: froobynooby <froobynooby@froobworld.com>
+Date: Wed, 17 Jul 2024 18:46:11 +0930
+Subject: [PATCH] Throttle failed spawn attempts
+
+This patch adds the option to use longer ticks-per-spawn for a given
+mob type in chunks where spawn attempts are consecutively failing.
+
+This behaviour is particularly useful on servers where players build
+mob farms. Mob farm designs often require making surrounding chunks
+spawnproof, which causes the server to waste CPU cycles trying to spawn mobs in
+vain. Throttling spawn attempts in suspected spawnproof chunks improves
+performance without noticeably advantaging or disadvantaging the mob farm.
+
+diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+index 7509b17414f836e8b53fc62b02b386ba4e8c5ca9..fe202580ce199417bab4cf458a6445a23c3fd4cb 100644
+--- a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
++++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+@@ -186,6 +186,15 @@ public class WorldConfiguration extends ConfigurationPart {
+             @MergeMap
+             public Reference2IntMap<MobCategory> ticksPerSpawn = Util.make(new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length), map -> Arrays.stream(NaturalSpawner.SPAWNING_CATEGORIES).forEach(mobCategory -> map.put(mobCategory, -1)));
+ 
++            public SpawningThrottle spawningThrottle;
++
++            public class SpawningThrottle extends ConfigurationPart {
++                public int failedAttemptsThreshold = 1200;
++
++                @MergeMap
++                public Reference2IntMap<MobCategory> throttledTicksPerSpawn = Util.make(new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length), map -> Arrays.stream(NaturalSpawner.SPAWNING_CATEGORIES).forEach(mobCategory -> map.put(mobCategory, -1)));
++            }
++
+             @ConfigSerializable
+             public record DespawnRange(@Required int soft, @Required int hard) {
+             }
+diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
+index ed8032495af9ce9c23419224814b8d27e4a97c17..7eece3f7d7b2ea732502b03697ac3d843ee5e2b4 100644
+--- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
++++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
+@@ -140,8 +140,14 @@ public final class NaturalSpawner {
+             boolean spawnThisTick = true;
+             int limit = enumcreaturetype.getMaxInstancesPerChunk();
+             SpawnCategory spawnCategory = CraftSpawnCategory.toBukkit(enumcreaturetype);
++            // Paper start - throttle failed spawn attempts
++            long ticksPerSpawn = world.ticksPerSpawnCategory.getLong(spawnCategory);
++            if (chunk.failedSpawnAttempts.getOrDefault(enumcreaturetype, 0L) > world.paperConfig().entities.spawning.spawningThrottle.failedAttemptsThreshold) {
++                ticksPerSpawn = Math.max(ticksPerSpawn, world.paperConfig().entities.spawning.spawningThrottle.throttledTicksPerSpawn.getOrDefault(enumcreaturetype, -1));
++            }
++            // Paper end - throttle failed spawn attempts
+             if (CraftSpawnCategory.isValidForLimits(spawnCategory)) {
+-                spawnThisTick = world.ticksPerSpawnCategory.getLong(spawnCategory) != 0 && worlddata.getGameTime() % world.ticksPerSpawnCategory.getLong(spawnCategory) == 0;
++                spawnThisTick = world.ticksPerSpawnCategory.getLong(spawnCategory) != 0 && worlddata.getGameTime() % ticksPerSpawn == 0; // Paper - throttle failed spawn attempts
+                 limit = world.getWorld().getSpawnLimit(spawnCategory);
+             }
+ 
+@@ -178,6 +184,13 @@ public final class NaturalSpawner {
+                     difference, world.paperConfig().entities.spawning.perPlayerMobSpawns ? world.getChunkSource().chunkMap::updatePlayerMobTypeMap : null);
+                 info.mobCategoryCounts.mergeInt(enumcreaturetype, spawnCount, Integer::sum);
+                 // Paper end - Optional per player mob spawns
++                // Paper start - throttle failed spawn attempts
++                if (spawnCount == 0) {
++                    chunk.failedSpawnAttempts.compute(enumcreaturetype, (k, v) -> (v == null ? 0 : v) + 1);
++                } else {
++                    chunk.failedSpawnAttempts.put(enumcreaturetype, 0L);
++                }
++                // Paper end - throttle failed spawn attempts
+             }
+         }
+ 
+diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java b/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
+index 75c8125e20b70433fe9d143a3193d821043327c3..03463c0aa67773d1a8800662d1e72fe6c428a633 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
++++ b/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
+@@ -84,6 +84,7 @@ public abstract class ChunkAccess implements BlockGetter, BiomeManager.NoiseBiom
+     public final Map<BlockPos, BlockEntity> blockEntities = new Object2ObjectOpenHashMap();
+     protected final LevelHeightAccessor levelHeightAccessor;
+     protected final LevelChunkSection[] sections;
++    public final Map<net.minecraft.world.entity.MobCategory, Long> failedSpawnAttempts = new java.util.EnumMap<>(net.minecraft.world.entity.MobCategory.class); // Paper - throttle failed spawn attempts
+ 
+     // CraftBukkit start - SPIGOT-6814: move to IChunkAccess to account for 1.17 to 1.18 chunk upgrading.
+     private static final org.bukkit.craftbukkit.persistence.CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new org.bukkit.craftbukkit.persistence.CraftPersistentDataTypeRegistry();
+diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
+index ecf7ba97d397e15e4fcaf4c1e1f48bb7972e60dc..0cc8985da7c1463f8e42d9b57880b44b50483bce 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
++++ b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
+@@ -302,6 +302,16 @@ public class ChunkSerializer {
+                 ((ChunkAccess) object1).addPackedPostProcess(nbttaglist2.getShort(i1), j1);
+             }
+         }
++        // Paper start - throttle failed spawn attempts
++        if (nbt.contains("Paper.FailedSpawnAttempts", Tag.TAG_COMPOUND)) {
++            CompoundTag failedSpawnAttemptsTag = nbt.getCompound("Paper.FailedSpawnAttempts");
++            for (net.minecraft.world.entity.MobCategory mobCategory : net.minecraft.world.level.NaturalSpawner.SPAWNING_CATEGORIES) {
++                if (failedSpawnAttemptsTag.contains(mobCategory.getSerializedName(), Tag.TAG_LONG)) {
++                    ((ChunkAccess) object1).failedSpawnAttempts.put(mobCategory, failedSpawnAttemptsTag.getLong(mobCategory.getSerializedName()));
++                }
++            }
++        }
++        // Paper end - throttle failed spawn attempts
+ 
+         ca.spottedleaf.moonrise.patches.starlight.util.SaveUtil.loadLightHook(world, chunkPos, nbt, (ChunkAccess)object1); // Paper - rewrite chunk system - note: it's ok to pass the raw value instead of wrapped
+ 
+@@ -545,6 +555,15 @@ public class ChunkSerializer {
+             nbttagcompound.put("ChunkBukkitValues", chunk.persistentDataContainer.toTagCompound());
+         }
+         // CraftBukkit end
++        // Paper start - throttle failed spawn attempts
++        if (!chunk.failedSpawnAttempts.isEmpty()) {
++            CompoundTag failedSpawnAttemptsTag = new CompoundTag();
++            for (final Entry<net.minecraft.world.entity.MobCategory, Long> entry : chunk.failedSpawnAttempts.entrySet()) {
++                failedSpawnAttemptsTag.putLong(entry.getKey().getSerializedName(), entry.getValue());
++            }
++            nbttagcompound.put("Paper.FailedSpawnAttempts", failedSpawnAttemptsTag);
++        }
++        // Paper end
+         ca.spottedleaf.moonrise.patches.starlight.util.SaveUtil.saveLightHook(world, chunk, nbttagcompound); // Paper - rewrite chunk system
+         return nbttagcompound;
+     }

--- a/patches/server/1042-Throttle-failed-spawn-attempts.patch
+++ b/patches/server/1042-Throttle-failed-spawn-attempts.patch
@@ -13,7 +13,7 @@ vain. Throttling spawn attempts in suspected spawnproof chunks improves
 performance without noticeably advantaging or disadvantaging the mob farm.
 
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index ed8032495af9ce9c23419224814b8d27e4a97c17..f0fb8d3d28615374df813fcebfb1ef1be3934777 100644
+index ed8032495af9ce9c23419224814b8d27e4a97c17..a5b4fca33df8cfffbe7000f77e4f999b0256edc5 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -140,8 +140,14 @@ public final class NaturalSpawner {
@@ -22,7 +22,7 @@ index ed8032495af9ce9c23419224814b8d27e4a97c17..f0fb8d3d28615374df813fcebfb1ef1b
              SpawnCategory spawnCategory = CraftSpawnCategory.toBukkit(enumcreaturetype);
 +            // Paper start - throttle failed spawn attempts
 +            long ticksPerSpawn = world.ticksPerSpawnCategory.getLong(spawnCategory);
-+            if (world.paperConfig().entities.spawning.spawningThrottle.failedAttemptsThreshold.test(threshold -> chunk.failedSpawnAttempts.getOrDefault(enumcreaturetype, 0L) > threshold)) {
++            if (world.paperConfig().entities.spawning.spawningThrottle.failedAttemptsThreshold.test(threshold -> chunk.failedSpawnAttempts[enumcreaturetype.ordinal()] > threshold)) {
 +                ticksPerSpawn = Math.max(ticksPerSpawn, world.paperConfig().entities.spawning.spawningThrottle.throttledTicksPerSpawn.getOrDefault(enumcreaturetype, -1));
 +            }
 +            // Paper end - throttle failed spawn attempts
@@ -38,28 +38,28 @@ index ed8032495af9ce9c23419224814b8d27e4a97c17..f0fb8d3d28615374df813fcebfb1ef1b
                  // Paper end - Optional per player mob spawns
 +                // Paper start - throttle failed spawn attempts
 +                if (spawnCount == 0) {
-+                    chunk.failedSpawnAttempts.compute(enumcreaturetype, (k, v) -> (v == null ? 0 : v) + 1);
++                    chunk.failedSpawnAttempts[enumcreaturetype.ordinal()]++;
 +                } else {
-+                    chunk.failedSpawnAttempts.put(enumcreaturetype, 0L);
++                    chunk.failedSpawnAttempts[enumcreaturetype.ordinal()] = 0;
 +                }
 +                // Paper end - throttle failed spawn attempts
              }
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java b/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
-index 75c8125e20b70433fe9d143a3193d821043327c3..03463c0aa67773d1a8800662d1e72fe6c428a633 100644
+index 75c8125e20b70433fe9d143a3193d821043327c3..fdc5fbb5d713a170741c3e1b7d1980bbf80b5985 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
 @@ -84,6 +84,7 @@ public abstract class ChunkAccess implements BlockGetter, BiomeManager.NoiseBiom
      public final Map<BlockPos, BlockEntity> blockEntities = new Object2ObjectOpenHashMap();
      protected final LevelHeightAccessor levelHeightAccessor;
      protected final LevelChunkSection[] sections;
-+    public final Map<net.minecraft.world.entity.MobCategory, Long> failedSpawnAttempts = new java.util.EnumMap<>(net.minecraft.world.entity.MobCategory.class); // Paper - throttle failed spawn attempts
++    public final long[] failedSpawnAttempts = new long[net.minecraft.world.entity.MobCategory.values().length]; // Paper - throttle failed spawn attempts
  
      // CraftBukkit start - SPIGOT-6814: move to IChunkAccess to account for 1.17 to 1.18 chunk upgrading.
      private static final org.bukkit.craftbukkit.persistence.CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new org.bukkit.craftbukkit.persistence.CraftPersistentDataTypeRegistry();
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
-index ecf7ba97d397e15e4fcaf4c1e1f48bb7972e60dc..0cc8985da7c1463f8e42d9b57880b44b50483bce 100644
+index ecf7ba97d397e15e4fcaf4c1e1f48bb7972e60dc..3727bad0fb880f5e8501fea7d85cccf3174def3f 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 @@ -302,6 +302,16 @@ public class ChunkSerializer {
@@ -71,7 +71,7 @@ index ecf7ba97d397e15e4fcaf4c1e1f48bb7972e60dc..0cc8985da7c1463f8e42d9b57880b44b
 +            CompoundTag failedSpawnAttemptsTag = nbt.getCompound("Paper.FailedSpawnAttempts");
 +            for (net.minecraft.world.entity.MobCategory mobCategory : net.minecraft.world.level.NaturalSpawner.SPAWNING_CATEGORIES) {
 +                if (failedSpawnAttemptsTag.contains(mobCategory.getSerializedName(), Tag.TAG_LONG)) {
-+                    ((ChunkAccess) object1).failedSpawnAttempts.put(mobCategory, failedSpawnAttemptsTag.getLong(mobCategory.getSerializedName()));
++                    ((ChunkAccess) object1).failedSpawnAttempts[mobCategory.ordinal()] = failedSpawnAttemptsTag.getLong(mobCategory.getSerializedName());
 +                }
 +            }
 +        }
@@ -79,19 +79,22 @@ index ecf7ba97d397e15e4fcaf4c1e1f48bb7972e60dc..0cc8985da7c1463f8e42d9b57880b44b
  
          ca.spottedleaf.moonrise.patches.starlight.util.SaveUtil.loadLightHook(world, chunkPos, nbt, (ChunkAccess)object1); // Paper - rewrite chunk system - note: it's ok to pass the raw value instead of wrapped
  
-@@ -545,6 +555,15 @@ public class ChunkSerializer {
+@@ -545,6 +555,18 @@ public class ChunkSerializer {
              nbttagcompound.put("ChunkBukkitValues", chunk.persistentDataContainer.toTagCompound());
          }
          // CraftBukkit end
 +        // Paper start - throttle failed spawn attempts
-+        if (!chunk.failedSpawnAttempts.isEmpty()) {
-+            CompoundTag failedSpawnAttemptsTag = new CompoundTag();
-+            for (final Entry<net.minecraft.world.entity.MobCategory, Long> entry : chunk.failedSpawnAttempts.entrySet()) {
-+                failedSpawnAttemptsTag.putLong(entry.getKey().getSerializedName(), entry.getValue());
++        CompoundTag failedSpawnAttemptsTag = new CompoundTag();
++        for (net.minecraft.world.entity.MobCategory mobCategory : net.minecraft.world.entity.MobCategory.values()) {
++            long failedSpawnAttempts = chunk.failedSpawnAttempts[mobCategory.ordinal()];
++            if (failedSpawnAttempts > 0) {
++                failedSpawnAttemptsTag.putLong(mobCategory.getSerializedName(), failedSpawnAttempts);
 +            }
++        }
++        if (!failedSpawnAttemptsTag.isEmpty()) {
 +            nbttagcompound.put("Paper.FailedSpawnAttempts", failedSpawnAttemptsTag);
 +        }
-+        // Paper end
++        // Paper end - throttle failed spawn attempts
          ca.spottedleaf.moonrise.patches.starlight.util.SaveUtil.saveLightHook(world, chunk, nbttagcompound); // Paper - rewrite chunk system
          return nbttagcompound;
      }

--- a/patches/server/1042-Throttle-failed-spawn-attempts.patch
+++ b/patches/server/1042-Throttle-failed-spawn-attempts.patch
@@ -12,28 +12,8 @@ spawnproof, which causes the server to waste CPU cycles trying to spawn mobs in
 vain. Throttling spawn attempts in suspected spawnproof chunks improves
 performance without noticeably advantaging or disadvantaging the mob farm.
 
-diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-index 7509b17414f836e8b53fc62b02b386ba4e8c5ca9..fe202580ce199417bab4cf458a6445a23c3fd4cb 100644
---- a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-+++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -186,6 +186,15 @@ public class WorldConfiguration extends ConfigurationPart {
-             @MergeMap
-             public Reference2IntMap<MobCategory> ticksPerSpawn = Util.make(new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length), map -> Arrays.stream(NaturalSpawner.SPAWNING_CATEGORIES).forEach(mobCategory -> map.put(mobCategory, -1)));
- 
-+            public SpawningThrottle spawningThrottle;
-+
-+            public class SpawningThrottle extends ConfigurationPart {
-+                public int failedAttemptsThreshold = 1200;
-+
-+                @MergeMap
-+                public Reference2IntMap<MobCategory> throttledTicksPerSpawn = Util.make(new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length), map -> Arrays.stream(NaturalSpawner.SPAWNING_CATEGORIES).forEach(mobCategory -> map.put(mobCategory, -1)));
-+            }
-+
-             @ConfigSerializable
-             public record DespawnRange(@Required int soft, @Required int hard) {
-             }
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index ed8032495af9ce9c23419224814b8d27e4a97c17..7eece3f7d7b2ea732502b03697ac3d843ee5e2b4 100644
+index ed8032495af9ce9c23419224814b8d27e4a97c17..f0fb8d3d28615374df813fcebfb1ef1be3934777 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -140,8 +140,14 @@ public final class NaturalSpawner {
@@ -42,7 +22,7 @@ index ed8032495af9ce9c23419224814b8d27e4a97c17..7eece3f7d7b2ea732502b03697ac3d84
              SpawnCategory spawnCategory = CraftSpawnCategory.toBukkit(enumcreaturetype);
 +            // Paper start - throttle failed spawn attempts
 +            long ticksPerSpawn = world.ticksPerSpawnCategory.getLong(spawnCategory);
-+            if (chunk.failedSpawnAttempts.getOrDefault(enumcreaturetype, 0L) > world.paperConfig().entities.spawning.spawningThrottle.failedAttemptsThreshold) {
++            if (world.paperConfig().entities.spawning.spawningThrottle.failedAttemptsThreshold.test(threshold -> chunk.failedSpawnAttempts.getOrDefault(enumcreaturetype, 0L) > threshold)) {
 +                ticksPerSpawn = Math.max(ticksPerSpawn, world.paperConfig().entities.spawning.spawningThrottle.throttledTicksPerSpawn.getOrDefault(enumcreaturetype, -1));
 +            }
 +            // Paper end - throttle failed spawn attempts


### PR DESCRIPTION
This patch adds an option to use a longer ticks-per-spawn for given mob types in chunks where previous spawn attempts have consecutively failed (e.g. spawnproofed chunks). The ticks-per-spawn and the number of failed attempts before they kick in are both configurable (the setting is disabled by default). The number of failed spawn attempts is stored with the chunk so it persists across unloads. As soon as a mob is able to spawn in a chunk, the failed spawn attempt counter resets and the chunk starts using the default ticks-per-spawn again.

This behaviour is useful on servers where players use mob farms. Mob farms typically require spawnproofing the surrounding chunks to improve rates, which causes the server to waste CPU cycles trying to find suitable spawn locations. By identifying suspected spawnproof chunks and throttling attempts at spawning mobs in them, it is possible to improve performance without noticeably affecting overall mob spawning behaviour.

I've been using a [similar patch](https://github.com/FroobWorld/Nabulus/commit/edd916abed9fbf921a023fccbbedd77bc7475858) on my reasonably busy survival server for nearly a year without any complaints from players.

For illustrative purposes I ran a simple test spending 5 minutes AFK at standard spawning-tower mob farm which had been properly spawnproofed.

Without patch (default ticks-per-spawn):
![image](https://github.com/user-attachments/assets/f037acaa-8d35-4466-be24-ac44e343c412)
With patch (multiplying default ticks-per-spawn by 10 after 1200 failed attempts):
![Screenshot from 2024-07-17 22-08-00](https://github.com/user-attachments/assets/284d3602-cb92-4cd1-9482-4ad4883e32f4)
