### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -4880,10 +4880,10 @@ index bd512a7840d4686759097ee4cbd8b375c530956b..f2242ddc4085f7e7cdd748d860857822
 +    // Paper end - adventure
  }
 diff --git a/src/main/java/org/bukkit/map/MapCursor.java b/src/main/java/org/bukkit/map/MapCursor.java
-index e645a65dbd3340a86f5325dbfd515e0a99f31ab0..940066ec529acc4cb9c8136f15345f100ea9467e 100644
+index 8250821fe7be7987c92edbc36911f88875c470fc..2aadb995ab512086ac41b48df4c724722697e166 100644
 --- a/src/main/java/org/bukkit/map/MapCursor.java
 +++ b/src/main/java/org/bukkit/map/MapCursor.java
-@@ -13,7 +13,7 @@ public final class MapCursor {
+@@ -17,7 +17,7 @@ public final class MapCursor {
      private byte x, y;
      private byte direction;
      private boolean visible;
@@ -4892,7 +4892,7 @@ index e645a65dbd3340a86f5325dbfd515e0a99f31ab0..940066ec529acc4cb9c8136f15345f10
      private Type type;
  
      /**
-@@ -28,7 +28,7 @@ public final class MapCursor {
+@@ -32,7 +32,7 @@ public final class MapCursor {
       */
      @Deprecated
      public MapCursor(byte x, byte y, byte direction, byte type, boolean visible) {
@@ -4901,7 +4901,7 @@ index e645a65dbd3340a86f5325dbfd515e0a99f31ab0..940066ec529acc4cb9c8136f15345f10
      }
  
      /**
-@@ -41,7 +41,7 @@ public final class MapCursor {
+@@ -45,7 +45,7 @@ public final class MapCursor {
       * @param visible Whether the cursor is visible by default.
       */
      public MapCursor(byte x, byte y, byte direction, @NotNull Type type, boolean visible) {
@@ -4910,7 +4910,7 @@ index e645a65dbd3340a86f5325dbfd515e0a99f31ab0..940066ec529acc4cb9c8136f15345f10
      }
  
      /**
-@@ -53,7 +53,7 @@ public final class MapCursor {
+@@ -57,7 +57,7 @@ public final class MapCursor {
       * @param type The type (color/style) of the map cursor.
       * @param visible Whether the cursor is visible by default.
       * @param caption cursor caption
@@ -4919,7 +4919,7 @@ index e645a65dbd3340a86f5325dbfd515e0a99f31ab0..940066ec529acc4cb9c8136f15345f10
       */
      @Deprecated
      public MapCursor(byte x, byte y, byte direction, byte type, boolean visible, @Nullable String caption) {
-@@ -62,8 +62,42 @@ public final class MapCursor {
+@@ -66,8 +66,42 @@ public final class MapCursor {
          setDirection(direction);
          setRawType(type);
          this.visible = visible;
@@ -4963,7 +4963,7 @@ index e645a65dbd3340a86f5325dbfd515e0a99f31ab0..940066ec529acc4cb9c8136f15345f10
  
      /**
       * Initialize the map cursor.
-@@ -81,7 +115,7 @@ public final class MapCursor {
+@@ -85,7 +119,7 @@ public final class MapCursor {
          setDirection(direction);
          this.type = type;
          this.visible = visible;
@@ -4972,7 +4972,7 @@ index e645a65dbd3340a86f5325dbfd515e0a99f31ab0..940066ec529acc4cb9c8136f15345f10
      }
  
      /**
-@@ -200,23 +234,45 @@ public final class MapCursor {
+@@ -204,23 +238,45 @@ public final class MapCursor {
          this.visible = visible;
      }
  

--- a/patches/api/0053-Fix-upstream-javadocs.patch
+++ b/patches/api/0053-Fix-upstream-javadocs.patch
@@ -607,18 +607,18 @@ index af5110b4160979c39cc1e5de6fa3bd7957b21403..15a0a733b0e5804655b5957cbf208312
       * @param location the location to remove
       * @see #getExploredLocations()
 diff --git a/src/main/java/org/bukkit/entity/Villager.java b/src/main/java/org/bukkit/entity/Villager.java
-index 6bf3af3ed81b66f61e53105d3591165ea74dba0e..a91400cd8bb4c72d1f3200a17f6de025540fe09d 100644
+index 45dd54afa6d6f3d9895ef52f13076d3351036e4b..cfa0d4809f9bb4ac150251efa85ba4d1808ab1b2 100644
 --- a/src/main/java/org/bukkit/entity/Villager.java
 +++ b/src/main/java/org/bukkit/entity/Villager.java
-@@ -202,7 +202,7 @@ public interface Villager extends AbstractVillager {
+@@ -228,7 +228,7 @@ public interface Villager extends AbstractVillager {
           */
-         NITWIT,
+         Profession NITWIT = getProfession("nitwit");
          /**
 -         * Sheperd profession. Wears a brown robe. Shepherds primarily trade for
 +         * Shepherd profession. Wears a brown robe. Shepherds primarily trade for
           * wool items, and shears.
           */
-         SHEPHERD,
+         Profession SHEPHERD = getProfession("shepherd");
 diff --git a/src/main/java/org/bukkit/event/block/BlockDropItemEvent.java b/src/main/java/org/bukkit/event/block/BlockDropItemEvent.java
 index a0f6f1af304190b4c5db4b284d460f625eeb7801..7e21548cac8515c281ec86853e9272ab7695b24f 100644
 --- a/src/main/java/org/bukkit/event/block/BlockDropItemEvent.java
@@ -647,10 +647,10 @@ index a0f6f1af304190b4c5db4b284d460f625eeb7801..7e21548cac8515c281ec86853e9272ab
   * The Block is already broken as this event is called, so #getBlock() will be
   * AIR in most cases. Use #getBlockState() for more Information about the broken
 diff --git a/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java b/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
-index e534954457a9961a26dbec7ac035bec07e1d6694..a7c297364805c58ae16895055d8eae0484384b7d 100644
+index 1df172c0bb48de3b143179a3f0c63d6ecc30649e..254d549f956053af4264ca3a52d34a97ede4273d 100644
 --- a/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
 +++ b/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
-@@ -13,6 +13,9 @@ import org.jetbrains.annotations.NotNull;
+@@ -14,6 +14,9 @@ import org.jetbrains.annotations.NotNull;
   * Note that due to the nature of explosions, {@link #getBlock()} will always be
   * an air block. {@link #getExplodedBlockState()} should be used to get
   * information about the block state that exploded.
@@ -660,14 +660,6 @@ index e534954457a9961a26dbec7ac035bec07e1d6694..a7c297364805c58ae16895055d8eae04
   */
  public class BlockExplodeEvent extends BlockEvent implements Cancellable {
      private static final HandlerList handlers = new HandlerList();
-@@ -29,6 +32,7 @@ public class BlockExplodeEvent extends BlockEvent implements Cancellable {
-         this.cancel = false;
-     }
- 
-+    @io.papermc.paper.annotation.DoNotUse // Paper
-     @Deprecated(forRemoval = true)
-     public BlockExplodeEvent(@NotNull final Block what, @NotNull final List<Block> blocks, final float yield) {
-         this(what, what.getState(), blocks, yield);
 diff --git a/src/main/java/org/bukkit/event/block/BlockPistonRetractEvent.java b/src/main/java/org/bukkit/event/block/BlockPistonRetractEvent.java
 index 340fa397e68c024df380a28db21545a0c83d9fa6..79ac8a5db689cf9f8e2ff4cb7c06df6989128d10 100644
 --- a/src/main/java/org/bukkit/event/block/BlockPistonRetractEvent.java
@@ -721,7 +713,7 @@ index a37febd0d4dd5b733e9ee72628fdf9395fec4367..9cee218b9ee14688356f16b1f5851218
   */
  public class AreaEffectCloudApplyEvent extends EntityEvent implements Cancellable {
 diff --git a/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java b/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
-index 90b287cd2cc6f05bb0c588d8be397cf52a7822de..15cb5ea4b68eca070f73d2b899543274415ad240 100644
+index d3f93163fb3108f42e542c22e437c9cb8289f0e8..1e2bb345d19ebe03589d85bdab13021b6fa2ed98 100644
 --- a/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
 @@ -158,11 +158,12 @@ public class CreatureSpawnEvent extends EntitySpawnEvent {
@@ -765,10 +757,10 @@ index 573165ddf3368a96e1ffc6476eb27c9e29a6f86e..148c4aad384ae8e3b8b22d264a84bddf
       * @return the block state
       */
 diff --git a/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java b/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
-index 10d0e18dfd423b108fe381e8142867eb10399359..099efafa14c10910e4ed04abb1823f0c1a96b6a6 100644
+index fc2158793aec67310bc8d06ac1f0bac39d2a5c3d..50161d313cfcc9e61441589685c3d0e1f057dd86 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
-@@ -9,7 +9,9 @@ import org.bukkit.event.HandlerList;
+@@ -10,7 +10,9 @@ import org.bukkit.event.HandlerList;
  import org.jetbrains.annotations.NotNull;
  
  /**

--- a/patches/api/0165-Fixes-and-additions-to-the-spawn-reason-API.patch
+++ b/patches/api/0165-Fixes-and-additions-to-the-spawn-reason-API.patch
@@ -30,7 +30,7 @@ index 99e1f17fddf9cebe7057998d1635804c55f18312..c3387a88a16cfd9157ade5d8a06eae25
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java b/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
-index 15cb5ea4b68eca070f73d2b899543274415ad240..2de81ee445824562aec7b52b7369b75280aab959 100644
+index 1e2bb345d19ebe03589d85bdab13021b6fa2ed98..6ff1988092de06f9d751cd40da521c2ed6e2e4bd 100644
 --- a/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
 @@ -206,6 +206,12 @@ public class CreatureSpawnEvent extends EntitySpawnEvent {
@@ -44,5 +44,5 @@ index 15cb5ea4b68eca070f73d2b899543274415ad240..2de81ee445824562aec7b52b7369b752
 +        OMINOUS_ITEM_SPAWNER,
 +        // Paper end - Fixes and additions to the SpawnReason API
          /**
-          * When a creature is spawned by plugins
-          */
+          * When a creature is spawned by a potion effect, for example:
+          * {@link org.bukkit.potion.PotionType#OOZING}, {@link org.bukkit.potion.PotionType#INFESTED}

--- a/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
@@ -453,7 +453,7 @@ index 48aecc9421c500137bbef1dfe3bec8de277c3ff9..aff858346776386f1288b648b221404f
          return note;
      }
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index f1a7f3b3e20963fa9d97bcc0686a35863de2b60f..3effaea369d9c7a6a22979fbfc270f55f9f25cf2 100644
+index 3bd96bbd35b657a6030d744e86622e616c2c3b08..5529e227781cd2411de9c6581a1cb1255ce9bb20 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
 @@ -220,14 +220,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
@@ -471,7 +471,7 @@ index f1a7f3b3e20963fa9d97bcc0686a35863de2b60f..3effaea369d9c7a6a22979fbfc270f55
      Registry<TrimPattern> TRIM_PATTERN = Bukkit.getRegistry(TrimPattern.class);
      /**
       * Damage types.
-@@ -336,8 +334,11 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -335,8 +333,11 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @param input non-null input
       * @return registered object or null if does not exist
@@ -1823,10 +1823,10 @@ index edef478786bb7456af29ca960009873095830050..e8ac449e6280827beb6d2699df75b1d5
  
      /**
 diff --git a/src/main/java/org/bukkit/map/MapCursor.java b/src/main/java/org/bukkit/map/MapCursor.java
-index 940066ec529acc4cb9c8136f15345f100ea9467e..82993302cb3cf62ad4a94a0ebaa7711cc4d8e550 100644
+index 2aadb995ab512086ac41b48df4c724722697e166..4d96cf385fa5c6d80097bdf6282be5f0eed73307 100644
 --- a/src/main/java/org/bukkit/map/MapCursor.java
 +++ b/src/main/java/org/bukkit/map/MapCursor.java
-@@ -159,9 +159,9 @@ public final class MapCursor {
+@@ -163,9 +163,9 @@ public final class MapCursor {
       * Get the type of this cursor.
       *
       * @return The type (color/style) of the map cursor.
@@ -1836,9 +1836,9 @@ index 940066ec529acc4cb9c8136f15345f100ea9467e..82993302cb3cf62ad4a94a0ebaa7711c
 -    @Deprecated
 +    @org.jetbrains.annotations.ApiStatus.Internal // Paper
      public byte getRawType() {
-         return type.value;
+         return type.getValue();
      }
-@@ -216,9 +216,9 @@ public final class MapCursor {
+@@ -220,9 +220,9 @@ public final class MapCursor {
       * Set the type of this cursor.
       *
       * @param type The type (color/style) of the map cursor.
@@ -1850,7 +1850,7 @@ index 940066ec529acc4cb9c8136f15345f100ea9467e..82993302cb3cf62ad4a94a0ebaa7711c
      public void setRawType(byte type) {
          Type enumType = Type.byValue(type);
          Preconditions.checkArgument(enumType != null, "Unknown type by id %s", type);
-@@ -337,9 +337,9 @@ public final class MapCursor {
+@@ -336,9 +336,9 @@ public final class MapCursor {
           * Gets the internal value of the cursor.
           *
           * @return the value
@@ -1859,10 +1859,10 @@ index 940066ec529acc4cb9c8136f15345f100ea9467e..82993302cb3cf62ad4a94a0ebaa7711c
           */
 -        @Deprecated
 +        @org.jetbrains.annotations.ApiStatus.Internal // Paper
-         public byte getValue() {
-             return value;
-         }
-@@ -349,9 +349,9 @@ public final class MapCursor {
+         byte getValue();
+ 
+         /**
+@@ -346,9 +346,9 @@ public final class MapCursor {
           *
           * @param value the value
           * @return the matching type
@@ -1872,7 +1872,7 @@ index 940066ec529acc4cb9c8136f15345f100ea9467e..82993302cb3cf62ad4a94a0ebaa7711c
 -        @Deprecated
 +        @org.jetbrains.annotations.ApiStatus.Internal // Paper
          @Nullable
-         public static Type byValue(byte value) {
+         static Type byValue(byte value) {
              for (Type t : values()) {
 diff --git a/src/main/java/org/bukkit/map/MapPalette.java b/src/main/java/org/bukkit/map/MapPalette.java
 index 3a9aaca2e76411a9c27f9f5e0f22d060d5a66d06..c80faa079eca1564847070f0338fc98024639829 100644

--- a/patches/api/0186-Villager-Restocks-API.patch
+++ b/patches/api/0186-Villager-Restocks-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Villager Restocks API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Villager.java b/src/main/java/org/bukkit/entity/Villager.java
-index a91400cd8bb4c72d1f3200a17f6de025540fe09d..4128b848ec739308694d54d9e859c28185f42a63 100644
+index cfa0d4809f9bb4ac150251efa85ba4d1808ab1b2..ecb0f32a4449f8000248c4bebf89a56df186899f 100644
 --- a/src/main/java/org/bukkit/entity/Villager.java
 +++ b/src/main/java/org/bukkit/entity/Villager.java
-@@ -78,6 +78,20 @@ public interface Villager extends AbstractVillager {
+@@ -82,6 +82,20 @@ public interface Villager extends AbstractVillager {
       */
      public void setVillagerExperience(int experience);
  

--- a/patches/api/0188-Add-villager-reputation-API.patch
+++ b/patches/api/0188-Add-villager-reputation-API.patch
@@ -110,20 +110,20 @@ index 0000000000000000000000000000000000000000..5600fcdc9795a9f49091db48d73bbd49
 +    TRADING,
 +}
 diff --git a/src/main/java/org/bukkit/entity/Villager.java b/src/main/java/org/bukkit/entity/Villager.java
-index 4128b848ec739308694d54d9e859c28185f42a63..49db82ceff5e2c5f6414045648d68bd384c857c8 100644
+index ecb0f32a4449f8000248c4bebf89a56df186899f..d839630d7b2e51629e52edf24e7c6dd86b5f58f6 100644
 --- a/src/main/java/org/bukkit/entity/Villager.java
 +++ b/src/main/java/org/bukkit/entity/Villager.java
-@@ -1,6 +1,8 @@
- package org.bukkit.entity;
- 
+@@ -3,6 +3,8 @@ package org.bukkit.entity;
+ import com.google.common.base.Preconditions;
+ import com.google.common.collect.Lists;
  import java.util.Locale;
 +import java.util.Map; // Paper
 +import java.util.UUID; // Paper
  import org.bukkit.Keyed;
  import org.bukkit.Location;
  import org.bukkit.NamespacedKey;
-@@ -242,4 +244,50 @@ public interface Villager extends AbstractVillager {
-             return key;
+@@ -289,4 +291,50 @@ public interface Villager extends AbstractVillager {
+             return Lists.newArrayList(Registry.VILLAGER_PROFESSION).toArray(new Profession[0]);
          }
      }
 +

--- a/patches/api/0202-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0202-Add-methods-to-get-translation-keys.patch
@@ -420,27 +420,27 @@ index d248069adfc67eb840951f7ab4a1fa5d30214dec..976f701ed9b9873945a5628173c580e2
       * Gets if this EntityType is enabled by feature in a world.
       *
 diff --git a/src/main/java/org/bukkit/entity/Villager.java b/src/main/java/org/bukkit/entity/Villager.java
-index 49db82ceff5e2c5f6414045648d68bd384c857c8..b3957b3ff64f35fdeb2daa2ed1fb34fd65e24693 100644
+index d839630d7b2e51629e52edf24e7c6dd86b5f58f6..0759f66986cec2c7e3f765aaa5b1654b5ed9f4b5 100644
 --- a/src/main/java/org/bukkit/entity/Villager.java
 +++ b/src/main/java/org/bukkit/entity/Villager.java
-@@ -160,7 +160,7 @@ public interface Villager extends AbstractVillager {
+@@ -185,7 +185,7 @@ public interface Villager extends AbstractVillager {
       * Represents the various different Villager professions there may be.
       * Villagers have different trading options depending on their profession,
       */
--    public enum Profession implements Keyed {
-+    public enum Profession implements Keyed, net.kyori.adventure.translation.Translatable { // Paper
-         NONE,
+-    interface Profession extends OldEnum<Profession>, Keyed {
++    interface Profession extends OldEnum<Profession>, Keyed, net.kyori.adventure.translation.Translatable {
+ 
+         Profession NONE = getProfession("none");
          /**
-          * Armorer profession. Wears a black apron. Armorers primarily trade for
-@@ -243,6 +243,13 @@ public interface Villager extends AbstractVillager {
-         public NamespacedKey getKey() {
-             return key;
+@@ -290,6 +290,13 @@ public interface Villager extends AbstractVillager {
+         static Profession[] values() {
+             return Lists.newArrayList(Registry.VILLAGER_PROFESSION).toArray(new Profession[0]);
          }
 +
 +        // Paper start
 +        @Override
-+        public @NotNull String translationKey() {
-+            return "entity.minecraft.villager." + this.key.getKey();
++        default @NotNull String translationKey() {
++            return "entity.minecraft.villager." + this.getKey().getKey();
 +        }
 +        // Paper end
      }

--- a/patches/api/0236-Add-RegistryAccess-for-managing-registries.patch
+++ b/patches/api/0236-Add-RegistryAccess-for-managing-registries.patch
@@ -206,7 +206,7 @@ index e0f652117e585882693736de8165ae9c689e1d68..fbe14c327ee9c1ac07893853ca7c699e
          return server.getRegistry(tClass);
      }
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 3effaea369d9c7a6a22979fbfc270f55f9f25cf2..93e898c14728491a59bb2d08aff0dd678feef26a 100644
+index 5529e227781cd2411de9c6581a1cb1255ce9bb20..f99e68f160deba42e2833fa0f81df4c17bf68ec7 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
 @@ -102,7 +102,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
@@ -218,7 +218,13 @@ index 3effaea369d9c7a6a22979fbfc270f55f9f25cf2..93e898c14728491a59bb2d08aff0dd67
      /**
       * Custom boss bars.
       *
-@@ -139,8 +139,10 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -134,13 +134,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      *
+      * @see Cat.Type
+      */
+-    Registry<Cat.Type> CAT_VARIANT = Objects.requireNonNull(Bukkit.getRegistry(Cat.Type.class), "No registry present for Cat Type. This is a bug.");
++    Registry<Cat.Type> CAT_VARIANT = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.CAT_VARIANT); // Paper
+     /**
       * Server enchantments.
       *
       * @see Enchantment
@@ -276,7 +282,7 @@ index 3effaea369d9c7a6a22979fbfc270f55f9f25cf2..93e898c14728491a59bb2d08aff0dd67
      /**
       * Sound keys.
       *
-@@ -219,28 +223,35 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -219,40 +223,47 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * Trim materials.
       *
       * @see TrimMaterial
@@ -317,7 +323,27 @@ index 3effaea369d9c7a6a22979fbfc270f55f9f25cf2..93e898c14728491a59bb2d08aff0dd67
      /**
       * Villager profession.
       *
-@@ -294,8 +305,10 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      * @see Villager.Profession
+      */
+-    Registry<Villager.Profession> VILLAGER_PROFESSION = Objects.requireNonNull(Bukkit.getRegistry(Villager.Profession.class), "No registry present for Villager Profession. This is a bug.");
++    Registry<Villager.Profession> VILLAGER_PROFESSION = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.VILLAGER_PROFESSION); // Paper
+     /**
+      * Villager type.
+      *
+      * @see Villager.Type
+      */
+-    Registry<Villager.Type> VILLAGER_TYPE = Objects.requireNonNull(Bukkit.getRegistry(Villager.Type.class), "No registry present for Villager Type. This is a bug.");
++    Registry<Villager.Type> VILLAGER_TYPE = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.VILLAGER_TYPE); // Paper
+     /**
+      * Memory Keys.
+      *
+@@ -289,25 +300,27 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      *
+      * @see Frog.Variant
+      */
+-    Registry<Frog.Variant> FROG_VARIANT = Objects.requireNonNull(Bukkit.getRegistry(Frog.Variant.class), "No registry present for Frog Variant. This is a bug.");
++    Registry<Frog.Variant> FROG_VARIANT = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.FROG_VARIANT); // Paper
+     /**
       * Wolf variants.
       *
       * @see Wolf.Variant
@@ -329,7 +355,12 @@ index 3effaea369d9c7a6a22979fbfc270f55f9f25cf2..93e898c14728491a59bb2d08aff0dd67
      /**
       * Map cursor types.
       *
-@@ -308,7 +321,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      * @see MapCursor.Type
+      */
+-    Registry<MapCursor.Type> MAP_DECORATION_TYPE = Objects.requireNonNull(Bukkit.getRegistry(MapCursor.Type.class), "No registry present for MapCursor Type. This is a bug.");
++    Registry<MapCursor.Type> MAP_DECORATION_TYPE = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.MAP_DECORATION_TYPE); // Paper
+     /**
+      * Game events.
       *
       * @see GameEvent
       */

--- a/patches/api/0287-Missing-Entity-API.patch
+++ b/patches/api/0287-Missing-Entity-API.patch
@@ -258,11 +258,11 @@ index adb20a9abba33c32d553f620fa82b27dff64ab5f..1f6702b0de00b87dbed7f6d93e911655
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Cat.java b/src/main/java/org/bukkit/entity/Cat.java
-index d1327761a4b95eba97877f1991fc19b298b48eaf..0534fbc228f64cf3b361ab097d9b88212bdb0f36 100644
+index 117e3e8c63e56247213b2a9cf9908915d4c65665..70cc76f0c1f4ba23bfa78591e8144bbf8d3f0868 100644
 --- a/src/main/java/org/bukkit/entity/Cat.java
 +++ b/src/main/java/org/bukkit/entity/Cat.java
-@@ -68,4 +68,36 @@ public interface Cat extends Tameable, Sittable {
-             return key;
+@@ -94,4 +94,36 @@ public interface Cat extends Tameable, Sittable {
+             return Lists.newArrayList(Registry.CAT_VARIANT).toArray(new Type[0]);
          }
      }
 +

--- a/patches/api/0329-More-PotionEffectType-API.patch
+++ b/patches/api/0329-More-PotionEffectType-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More PotionEffectType API
 
 
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 93e898c14728491a59bb2d08aff0dd678feef26a..17714f04fdd87ed4332ea62bcfab7063560bf1be 100644
+index a583d26883c8b7012203e128cd64113df94307c1..4d3e0b90579b33ff93fc565e8ee99a01b690c62b 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -322,6 +322,33 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -321,6 +321,33 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * @see GameEvent
       */
      Registry<GameEvent> GAME_EVENT = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.GAME_EVENT); // Paper

--- a/patches/api/0346-Add-EntityDyeEvent-and-CollarColorable-interface.patch
+++ b/patches/api/0346-Add-EntityDyeEvent-and-CollarColorable-interface.patch
@@ -123,10 +123,10 @@ index 0000000000000000000000000000000000000000..c43a3ad32902dbb13287e80137521374
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Cat.java b/src/main/java/org/bukkit/entity/Cat.java
-index 0534fbc228f64cf3b361ab097d9b88212bdb0f36..d03adfaa4176617ef2ace2754fe02b63860e3aee 100644
+index 70cc76f0c1f4ba23bfa78591e8144bbf8d3f0868..60cf07bff0898176c8d7af84b3e65d7a1ee8cf2e 100644
 --- a/src/main/java/org/bukkit/entity/Cat.java
 +++ b/src/main/java/org/bukkit/entity/Cat.java
-@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
+@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
  /**
   * Meow.
   */
@@ -135,7 +135,7 @@ index 0534fbc228f64cf3b361ab097d9b88212bdb0f36..d03adfaa4176617ef2ace2754fe02b63
  
      /**
       * Gets the current type of this cat.
-@@ -31,6 +31,7 @@ public interface Cat extends Tameable, Sittable {
+@@ -36,6 +36,7 @@ public interface Cat extends Tameable, Sittable {
       * @return the color of the collar
       */
      @NotNull
@@ -143,7 +143,7 @@ index 0534fbc228f64cf3b361ab097d9b88212bdb0f36..d03adfaa4176617ef2ace2754fe02b63
      public DyeColor getCollarColor();
  
      /**
-@@ -38,6 +39,7 @@ public interface Cat extends Tameable, Sittable {
+@@ -43,6 +44,7 @@ public interface Cat extends Tameable, Sittable {
       *
       * @param color the color to apply
       */

--- a/patches/api/0374-More-vanilla-friendly-methods-to-update-trades.patch
+++ b/patches/api/0374-More-vanilla-friendly-methods-to-update-trades.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More vanilla friendly methods to update trades
 
 
 diff --git a/src/main/java/org/bukkit/entity/Villager.java b/src/main/java/org/bukkit/entity/Villager.java
-index b3957b3ff64f35fdeb2daa2ed1fb34fd65e24693..48c8af31b2bdc849b5269784ff3829ba31fb3f47 100644
+index 0759f66986cec2c7e3f765aaa5b1654b5ed9f4b5..444744ea6f5921b0ae229995f8b15ea9d980c402 100644
 --- a/src/main/java/org/bukkit/entity/Villager.java
 +++ b/src/main/java/org/bukkit/entity/Villager.java
-@@ -60,8 +60,11 @@ public interface Villager extends AbstractVillager {
+@@ -64,8 +64,11 @@ public interface Villager extends AbstractVillager {
       * A villager with a level of 1 and no experience is liable to lose its
       * profession.
       *
@@ -20,7 +20,7 @@ index b3957b3ff64f35fdeb2daa2ed1fb34fd65e24693..48c8af31b2bdc849b5269784ff3829ba
       */
      public void setVillagerLevel(int level);
  
-@@ -81,6 +84,34 @@ public interface Villager extends AbstractVillager {
+@@ -85,6 +88,34 @@ public interface Villager extends AbstractVillager {
      public void setVillagerExperience(int experience);
  
      // Paper start

--- a/patches/api/0384-Improve-PortalEvents.patch
+++ b/patches/api/0384-Improve-PortalEvents.patch
@@ -84,13 +84,21 @@ index 6818e9f0ba32ca1a1e612703f7526b29f5a6438f..d3724db0a5a67cde15b05fecd32b2ca3
      @Override
      public HandlerList getHandlers() {
 diff --git a/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java b/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
-index 67fb9d93e808e907fa980f3004d415ae5d0a53fc..97e36c7f6e09276fbae20eaeee0965566332ca46 100644
+index d70400236b08217ba675e560877f951ea4f143ca..4544e7e155619a6ae31cbb2999ae3dedfd3b5f4b 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
-@@ -15,15 +15,58 @@ import org.jetbrains.annotations.Nullable;
- public class EntityPortalEvent extends EntityTeleportEvent {
-     private static final HandlerList handlers = new HandlerList();
+@@ -3,6 +3,7 @@ package org.bukkit.event.entity;
+ import org.bukkit.Location;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
+ import org.jetbrains.annotations.NotNull;
+ import org.jetbrains.annotations.Nullable;
+ 
+@@ -17,23 +18,68 @@ public class EntityPortalEvent extends EntityTeleportEvent {
      private int searchRadius = 128;
+     private boolean canCreatePortal = true;
+     private int creationRadius = 16;
 +    private final org.bukkit.PortalType type; // Paper
  
      public EntityPortalEvent(@NotNull final Entity entity, @NotNull final Location from, @Nullable final Location to) {
@@ -102,15 +110,24 @@ index 67fb9d93e808e907fa980f3004d415ae5d0a53fc..97e36c7f6e09276fbae20eaeee096556
          super(entity, from, to);
          this.searchRadius = searchRadius;
 +        this.type = org.bukkit.PortalType.CUSTOM; // Paper
+     }
+ 
+     public EntityPortalEvent(@NotNull Entity entity, @NotNull Location from, @Nullable Location to, int searchRadius, boolean canCreatePortal, int creationRadius) {
++        // Paper start
++        this(entity, from, to, searchRadius, canCreatePortal, creationRadius, org.bukkit.PortalType.CUSTOM);
 +    }
 +
-+    // Paper start
-+    public EntityPortalEvent(@NotNull Entity entity, @NotNull Location from, @Nullable Location to, int searchRadius, final @NotNull org.bukkit.PortalType portalType) {
-+        super(entity, from, to);
-+        this.searchRadius = searchRadius;
++    @ApiStatus.Internal
++    public EntityPortalEvent(@NotNull Entity entity, @NotNull Location from, @Nullable Location to, int searchRadius, boolean canCreatePortal, int creationRadius, final @NotNull org.bukkit.PortalType portalType) {
+         super(entity, from, to);
 +        this.type = portalType;
-+    }
-+
++        // Paper end
+         this.searchRadius = searchRadius;
+         this.canCreatePortal = canCreatePortal;
+         this.creationRadius = creationRadius;
+     }
+ 
++    // Paper start
 +    /**
 +     * Get the portal type relating to this event.
 +     *
@@ -142,11 +159,12 @@ index 67fb9d93e808e907fa980f3004d415ae5d0a53fc..97e36c7f6e09276fbae20eaeee096556
 +    @Override
 +    public void setTo(@Nullable final Location to) {
 +        super.setTo(to);
-     }
++    }
 +    // Paper end
- 
++
      /**
       * Set the Block radius to search in for available portals.
+      *
 diff --git a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
 index 57eeeafae84f83a939925820e827769749ff27ec..929a997671de8202efb9da97fbf9b4a0bf7c37e8 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java

--- a/patches/api/0430-Experimental-annotations-change.patch
+++ b/patches/api/0430-Experimental-annotations-change.patch
@@ -196,33 +196,33 @@ index e404cd1e2ba44e4c2d09524bc7cf730d8ffbdabd..cea0ebf50876dd32ab7fba6025b30f29
  public interface BundleMeta extends ItemMeta {
  
 diff --git a/src/main/java/org/bukkit/map/MapCursor.java b/src/main/java/org/bukkit/map/MapCursor.java
-index 82993302cb3cf62ad4a94a0ebaa7711cc4d8e550..bd37310d27e73bfe65d680594f3a9be8577a72a0 100644
+index 4d96cf385fa5c6d80097bdf6282be5f0eed73307..fb6b1491202bbc1ea0d5475c9c6574b0c16943b4 100644
 --- a/src/main/java/org/bukkit/map/MapCursor.java
 +++ b/src/main/java/org/bukkit/map/MapCursor.java
-@@ -309,12 +309,26 @@ public final class MapCursor {
-         BANNER_RED(24, "banner_red"),
-         BANNER_BLACK(25, "banner_black"),
-         RED_X(26, "red_x"),
+@@ -314,12 +314,26 @@ public final class MapCursor {
+         Type BANNER_RED = getType("banner_red");
+         Type BANNER_BLACK = getType("banner_black");
+         Type RED_X = getType("red_x");
 +        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
 +        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
-         VILLAGE_DESERT(27, "village_desert"),
+         Type VILLAGE_DESERT = getType("village_desert");
 +        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
 +        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
-         VILLAGE_PLAINS(28, "village_plains"),
+         Type VILLAGE_PLAINS = getType("village_plains");
 +        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
 +        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
-         VILLAGE_SAVANNA(29, "village_savanna"),
+         Type VILLAGE_SAVANNA = getType("village_savanna");
 +        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
 +        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
-         VILLAGE_SNOWY(30, "village_snowy"),
+         Type VILLAGE_SNOWY = getType("village_snowy");
 +        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
 +        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
-         VILLAGE_TAIGA(31, "village_taiga"),
+         Type VILLAGE_TAIGA = getType("village_taiga");
 +        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
 +        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
-         JUNGLE_TEMPLE(32, "jungle_temple"),
+         Type JUNGLE_TEMPLE = getType("jungle_temple");
 +        @org.bukkit.MinecraftExperimental(org.bukkit.MinecraftExperimental.Requires.TRADE_REBALANCE) // Paper - add missing annotation
 +        @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
-         SWAMP_HUT(33, "swamp_hut"),
-         TRIAL_CHAMBERS(34, "trial_chambers")
-         ;
+         Type SWAMP_HUT = getType("swamp_hut");
+         Type TRIAL_CHAMBERS = getType("trial_chambers");
+ 

--- a/patches/api/0432-Improve-Registry.patch
+++ b/patches/api/0432-Improve-Registry.patch
@@ -31,10 +31,10 @@ index 62d2b3f950860dee0898d77b0a29635c3f9a7e23..704dba92f9246ef398ed8d162ebee3cf
      @Override
      public @NotNull String translationKey() {
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 17714f04fdd87ed4332ea62bcfab7063560bf1be..27b987db385a594fede4e884b6437dc363f6e817 100644
+index 4d3e0b90579b33ff93fc565e8ee99a01b690c62b..36a8f6082f111a1cbb25e0ff3c968a89f02611a0 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -358,6 +358,79 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -357,6 +357,79 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      @Nullable
      T get(@NotNull NamespacedKey key);
  
@@ -114,7 +114,7 @@ index 17714f04fdd87ed4332ea62bcfab7063560bf1be..27b987db385a594fede4e884b6437dc3
      /**
       * Returns a new stream, which contains all registry items, which are registered to the registry.
       *
-@@ -432,5 +505,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -431,5 +504,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
          public Class<T> getType() {
              return this.type;
          }

--- a/patches/api/0452-Clone-mutables-to-prevent-unexpected-issues.patch
+++ b/patches/api/0452-Clone-mutables-to-prevent-unexpected-issues.patch
@@ -37,10 +37,10 @@ index 1a9575ad4c81aefa5ef0b927f6ac8f7064b55c49..24e1a49e48dd8f9eb2515b2ffe472a0c
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java b/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
-index 099efafa14c10910e4ed04abb1823f0c1a96b6a6..8506fa03293c575c35b55b052224807470fdbd98 100644
+index 50161d313cfcc9e61441589685c3d0e1f057dd86..e468e55d426b8f81f87c0a08451d02b3866c226f 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
-@@ -59,7 +59,7 @@ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
+@@ -72,7 +72,7 @@ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
       */
      @NotNull
      public Location getLocation() {

--- a/patches/api/0475-Registry-Modification-API.patch
+++ b/patches/api/0475-Registry-Modification-API.patch
@@ -790,10 +790,10 @@ index 0000000000000000000000000000000000000000..11d19e339c7c62f2eb4467277552c27e
 +record TagKeyImpl<T>(RegistryKey<T> registryKey, Key key) implements TagKey<T> {
 +}
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 27b987db385a594fede4e884b6437dc363f6e817..9725580b6458e5d37fbc6059869604f9883bd6d1 100644
+index 36a8f6082f111a1cbb25e0ff3c968a89f02611a0..ff4997c6c5cecf7caf957e1aedaafb22df647e7d 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -357,6 +357,27 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -356,6 +356,27 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       */
      @Nullable
      T get(@NotNull NamespacedKey key);
@@ -821,7 +821,7 @@ index 27b987db385a594fede4e884b6437dc363f6e817..9725580b6458e5d37fbc6059869604f9
  
      // Paper start - improve Registry
      /**
-@@ -431,6 +452,34 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -430,6 +451,34 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      }
      // Paper end - improve Registry
  
@@ -856,7 +856,7 @@ index 27b987db385a594fede4e884b6437dc363f6e817..9725580b6458e5d37fbc6059869604f9
      /**
       * Returns a new stream, which contains all registry items, which are registered to the registry.
       *
-@@ -512,5 +561,23 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -511,5 +560,23 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
              return value.getKey();
          }
          // Paper end - improve Registry

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -131,7 +131,7 @@ index feca36209fd2405fab70f564f63e627b8b78ac18..396ec10a76bdadbf5be2f0e15e88eed4
  
      public static PackRepository createPackRepository(Path dataPacksPath, DirectoryValidator symlinkFinder) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 9c232b6eb11d87420fb24a668a2043581cca3bd2..5f73afa688fd1c83af17e6f566862cd5e2603ff3 100644
+index 82b8485a4781105bce874485119110576d1e2d63..a07e26caf48acf9ef193a74497a201166bfbe098 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -210,7 +210,7 @@ public class Main {
@@ -142,7 +142,7 @@ index 9c232b6eb11d87420fb24a668a2043581cca3bd2..5f73afa688fd1c83af17e6f566862cd5
 +                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
  
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -7);
+                     deadline.add(Calendar.DAY_OF_YEAR, -14);
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 index 93046379d0cefd5d3236fc59e698809acdc18f80..774556a62eb240da42e84db4502e2ed43495be17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -5042,10 +5042,10 @@ index e433037a03ffafabb952887ae3980e1d51411d4c..c061813d275fbc48d7629cc59d90dbb4
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6d1d3f9cf7451494af7c57d8bb1cd0ed25ea63e2..f1302dfb68bf8e4e1f4d8b084ad81422f65eecc4 100644
+index e8fac2863c5feb875cf0c78f062b4b87acbcb49b..751900e0c2a946ba4291174c81b2bdbdbe994e94 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -954,6 +954,7 @@ public final class CraftServer implements Server {
+@@ -962,6 +962,7 @@ public final class CraftServer implements Server {
          }
  
          org.spigotmc.SpigotConfig.init((File) this.console.options.valueOf("spigot-settings")); // Spigot
@@ -5054,7 +5054,7 @@ index 6d1d3f9cf7451494af7c57d8bb1cd0ed25ea63e2..f1302dfb68bf8e4e1f4d8b084ad81422
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 5f73afa688fd1c83af17e6f566862cd5e2603ff3..e2bfbedce18c4ecb01ffcc44d495e72b76806a92 100644
+index a07e26caf48acf9ef193a74497a201166bfbe098..dbcde37cfdeb6141c3f5c4f8b95d60fca91c7977 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -142,6 +142,19 @@ public class Main {
@@ -5078,7 +5078,7 @@ index 5f73afa688fd1c83af17e6f566862cd5e2603ff3..e2bfbedce18c4ecb01ffcc44d495e72b
          };
  
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index 192b6fbd34b9b90112f869ae6e367ab9ba5a5906..08b0ca7b68bf238366f4d6904478852ecbe9394a 100644
+index 038fd72710b3084c17d52d4cce087a5bd0aa3a01..e42677a14ec8e1a42747603fb4112822e326fb70 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -96,7 +96,7 @@ public class SpigotConfig

--- a/patches/server/0008-CB-fixes.patch
+++ b/patches/server/0008-CB-fixes.patch
@@ -83,10 +83,10 @@ index 85c7f3027978b1d7d6c31b7ad21b3377cdda5925..e34deaf398dc6722c3128bdd6b9bc16d
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f1302dfb68bf8e4e1f4d8b084ad81422f65eecc4..fe0f57dbeecc4b5a0c81863f33e41d11eb60943a 100644
+index 751900e0c2a946ba4291174c81b2bdbdbe994e94..f04c0f8b3905b488aac221fedde335a54ad1ff58 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2514,7 +2514,13 @@ public final class CraftServer implements Server {
+@@ -2522,7 +2522,13 @@ public final class CraftServer implements Server {
          Preconditions.checkArgument(key != null, "NamespacedKey key cannot be null");
  
          ReloadableServerRegistries.Holder registry = this.getServer().reloadableRegistries();
@@ -102,7 +102,7 @@ index f1302dfb68bf8e4e1f4d8b084ad81422f65eecc4..fe0f57dbeecc4b5a0c81863f33e41d11
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index e2bfbedce18c4ecb01ffcc44d495e72b76806a92..7e3c4c8a4d87e0c616a9fb98f09d89c93597bb23 100644
+index dbcde37cfdeb6141c3f5c4f8b95d60fca91c7977..2122d7316f55ab5bec7058fe1b8ee3ceb42deea7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -123,6 +123,7 @@ public class Main {

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -5376,10 +5376,10 @@ index 9d11fcb3df12182ae00ce73f7e30091fd199a341..4c39d9e0466240b5cd459ee649a22fe3
      public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, PrimaryLevelData iworlddataserver, ResourceKey<Level> resourcekey, LevelStem worlddimension, ChunkProgressListener worldloadlistener, boolean flag, long i, List<CustomSpawner> list, boolean flag1, @Nullable RandomSequences randomsequences, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider) {
          // IRegistryCustom.Dimension iregistrycustom_dimension = minecraftserver.registryAccess(); // CraftBukkit - decompile error
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index defe0b30964613cbae5195485aafff21d73ff18e..8d535d96252068fd2a1608600ce29d5d16690fec 100644
+index ff1a8e62d2bb3de62e0c27b2335cb512ea91dedd..cb136a30287a17947ed018cdc48e6f91ed904072 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -280,6 +280,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -281,6 +281,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      public boolean sentListPacket = false;
      public String kickLeaveMessage = null; // SPIGOT-3034: Forward leave message to PlayerQuitEvent
      // CraftBukkit end
@@ -5461,7 +5461,7 @@ index aede9b65e799a1f123f71f9390fb05acddda676b..2510589400b3012b827efcab477c6483
      @Override
      public void tell(R runnable) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 586acbb52b0fcb09cda195b49b6c737a29a4e35e..b0843917caedc32f800c50cc54706ace9523f64f 100644
+index 05a4056b242159b1c85aa6ebf43b69cf85c00021..06cbe7a7ea131a8bead857cbfbd27810a9093320 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -339,6 +339,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -6032,10 +6032,10 @@ index 34933c5324126f9afdc5cba9dea997ace8f01806..1cfc906317f07a44f06a4adf021c44e3
              return false;
          } else {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fe0f57dbeecc4b5a0c81863f33e41d11eb60943a..9babfd8e6c847ea26863be6243f17fc252dc9e1d 100644
+index f04c0f8b3905b488aac221fedde335a54ad1ff58..7f8864da8a6f9c2410191851add1ba566b8c171c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2593,4 +2593,9 @@ public final class CraftServer implements Server {
+@@ -2601,4 +2601,9 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end
@@ -6165,10 +6165,10 @@ index e130d0aa64d0caaa7760d8de4b1f989523f9de20..9ca244b69995552df63fb5d4e3d6961b
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 48e3923347341f1bb2027cf48b0dea9d0dcd20cf..21ed720118073b14bc8b5d1d665b0e17a8bbc1d2 100644
+index 952c6ebde7031dc060efe98992f82c02bf3534ea..17fa2d3db112762bcb8b941b69b8ddcc53f47224 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -22,6 +22,20 @@ import org.bukkit.material.MaterialData;
+@@ -23,6 +23,20 @@ import org.jetbrains.annotations.ApiStatus;
  @DelegateDeserialization(ItemStack.class)
  public final class CraftItemStack extends ItemStack {
  
@@ -6565,7 +6565,7 @@ index 0c7c97f27853843ec714e47f5b570f9d09bbba14..ff422d4d4f2b764370f0ee2af1303485
          ANIMAL,
          RAIDER,
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index 08b0ca7b68bf238366f4d6904478852ecbe9394a..fbbc08c5a189b99f8047e0f0f5cd31101149dbec 100644
+index e42677a14ec8e1a42747603fb4112822e326fb70..518ff88b32d1b5653a617ec2eaa23813c53b6acc 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -118,7 +118,11 @@ public class SpigotConfig

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2699,10 +2699,10 @@ index cef1761cdaf3e456695f2de61f4295fb99361914..e0b2d474e8d6f2d573d2c1f63e68ba93
  
      public boolean logIPs() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 8d535d96252068fd2a1608600ce29d5d16690fec..a2833b879b7613856706223f6b6e1ceae760f3b3 100644
+index cb136a30287a17947ed018cdc48e6f91ed904072..ee5188f3aa2ff71306f5af8046e8ddf919c8601b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -171,6 +171,7 @@ import net.minecraft.world.item.trading.MerchantOffers;
+@@ -172,6 +172,7 @@ import net.minecraft.world.item.trading.MerchantOffers;
  import net.minecraft.world.scores.Scoreboard;
  import net.minecraft.world.scores.Team;
  import net.minecraft.world.scores.criteria.ObjectiveCriteria;
@@ -2710,7 +2710,7 @@ index 8d535d96252068fd2a1608600ce29d5d16690fec..a2833b879b7613856706223f6b6e1cea
  import org.bukkit.Bukkit;
  import org.bukkit.Location;
  import org.bukkit.WeatherType;
-@@ -236,6 +237,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -237,6 +238,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      private boolean disconnected;
      private int requestedViewDistance;
      public String language = "en_us"; // CraftBukkit - default
@@ -2718,7 +2718,7 @@ index 8d535d96252068fd2a1608600ce29d5d16690fec..a2833b879b7613856706223f6b6e1cea
      @Nullable
      private Vec3 startingToFallPosition;
      @Nullable
-@@ -269,6 +271,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -270,6 +272,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      // CraftBukkit start
      public CraftPlayer.TransferCookieConnection transferCookieConnection;
      public String displayName;
@@ -2726,7 +2726,7 @@ index 8d535d96252068fd2a1608600ce29d5d16690fec..a2833b879b7613856706223f6b6e1cea
      public Component listName;
      public org.bukkit.Location compassTarget;
      public int newExp = 0;
-@@ -352,6 +355,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -353,6 +356,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
          // CraftBukkit start
          this.displayName = this.getScoreboardName();
@@ -2734,7 +2734,7 @@ index 8d535d96252068fd2a1608600ce29d5d16690fec..a2833b879b7613856706223f6b6e1cea
          this.bukkitPickUpLoot = true;
          this.maxHealthCache = this.getMaxHealth();
      }
-@@ -909,22 +913,17 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -910,22 +914,17 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
          String deathmessage = defaultMessage.getString();
          this.keepLevel = keepInventory; // SPIGOT-2222: pre-set keepLevel
@@ -2761,7 +2761,7 @@ index 8d535d96252068fd2a1608600ce29d5d16690fec..a2833b879b7613856706223f6b6e1cea
  
              this.connection.send(new ClientboundPlayerCombatKillPacket(this.getId(), ichatbasecomponent), PacketSendListener.exceptionallySend(() -> {
                  boolean flag1 = true;
-@@ -2024,8 +2023,13 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2025,8 +2024,13 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      }
  
      public void sendChatMessage(OutgoingChatMessage message, boolean filterMaskEnabled, ChatType.Bound params) {
@@ -2776,7 +2776,7 @@ index 8d535d96252068fd2a1608600ce29d5d16690fec..a2833b879b7613856706223f6b6e1cea
          }
  
      }
-@@ -2052,6 +2056,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2053,6 +2057,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          }
          // CraftBukkit end
          this.language = clientOptions.language();
@@ -3326,10 +3326,10 @@ index 49c037e961c5ca5ba8d6a870cb32ffe8719adc91..2772c19f58a35713d61aab24f6f0d6f5
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9babfd8e6c847ea26863be6243f17fc252dc9e1d..0e3ff653211b0210f8679b475d5f62eecbdfd946 100644
+index 7f8864da8a6f9c2410191851add1ba566b8c171c..bec1fdabbc3727c1f7297b2d23914a5179f4adcb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -636,8 +636,10 @@ public final class CraftServer implements Server {
+@@ -644,8 +644,10 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -3340,7 +3340,7 @@ index 9babfd8e6c847ea26863be6243f17fc252dc9e1d..0e3ff653211b0210f8679b475d5f62ee
      }
  
      @Override
-@@ -1613,7 +1615,15 @@ public final class CraftServer implements Server {
+@@ -1621,7 +1623,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -3356,7 +3356,7 @@ index 9babfd8e6c847ea26863be6243f17fc252dc9e1d..0e3ff653211b0210f8679b475d5f62ee
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1787,7 +1797,20 @@ public final class CraftServer implements Server {
+@@ -1795,7 +1805,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -3377,7 +3377,7 @@ index 9babfd8e6c847ea26863be6243f17fc252dc9e1d..0e3ff653211b0210f8679b475d5f62ee
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1795,14 +1818,14 @@ public final class CraftServer implements Server {
+@@ -1803,14 +1826,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -3394,7 +3394,7 @@ index 9babfd8e6c847ea26863be6243f17fc252dc9e1d..0e3ff653211b0210f8679b475d5f62ee
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -2064,6 +2087,14 @@ public final class CraftServer implements Server {
+@@ -2072,6 +2095,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -3409,7 +3409,7 @@ index 9babfd8e6c847ea26863be6243f17fc252dc9e1d..0e3ff653211b0210f8679b475d5f62ee
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Preconditions.checkArgument(type != null, "InventoryType cannot be null");
-@@ -2078,13 +2109,28 @@ public final class CraftServer implements Server {
+@@ -2086,13 +2117,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -3438,7 +3438,7 @@ index 9babfd8e6c847ea26863be6243f17fc252dc9e1d..0e3ff653211b0210f8679b475d5f62ee
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -2149,6 +2195,17 @@ public final class CraftServer implements Server {
+@@ -2157,6 +2203,17 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(this.console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -3456,7 +3456,7 @@ index 9babfd8e6c847ea26863be6243f17fc252dc9e1d..0e3ff653211b0210f8679b475d5f62ee
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2598,4 +2655,57 @@ public final class CraftServer implements Server {
+@@ -2606,4 +2663,57 @@ public final class CraftServer implements Server {
      public double[] getTPS() {
          return new double[]{0, 0, 0}; // TODO
      }
@@ -3627,7 +3627,7 @@ index 69c62699e3412f2730e3db65f196099d77698980..4878a1b085a83dd4a8ffdc86250b8fb4
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 7e3c4c8a4d87e0c616a9fb98f09d89c93597bb23..0736cf0b5ea327e73a457b55c9c0c4bb82d4c6e9 100644
+index 2122d7316f55ab5bec7058fe1b8ee3ceb42deea7..43790f555743e9945c1b82cf8f2f4719feedc165 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -20,6 +20,12 @@ public class Main {
@@ -4147,7 +4147,7 @@ index 55945b83a5426b352bad9507cc9e94afb1278032..9ea1537408ff2d790747b6e5a681d917
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 834b2a3ab2cccbd50686a1a0ca999685638b2a95..2b6912514ab39c26338c6ac580a8d1f33f3df61f 100644
+index 9ca244b69995552df63fb5d4e3d6961b585bcc47..807184636a99c17fe6ed8dd1cd07e1872d613657 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -388,14 +388,40 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -4676,10 +4676,10 @@ index 5725b0281ac53a2354b233223259d6784353bc6e..9ef939b76d06874b856e0c850addb364
      @Override
      public int getLineWidth() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ae357fc3cabd9235488665ef74a3f7c703d64980..3595ff3db5eb0b1da100692702e514cb870220ee 100644
+index 39aad2d00227d94aa1d24c27a10d916b7d64888d..63e20db8ad84b332a4962d5cea83f1064b7c1a3d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -908,7 +908,7 @@ public class CraftEventFactory {
+@@ -911,7 +911,7 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -4688,7 +4688,7 @@ index ae357fc3cabd9235488665ef74a3f7c703d64980..3595ff3db5eb0b1da100692702e514cb
          CraftPlayer entity = victim.getBukkitEntity();
          CraftDamageSource bukkitDamageSource = new CraftDamageSource(damageSource);
          PlayerDeathEvent event = new PlayerDeathEvent(entity, bukkitDamageSource, drops, victim.getExpReward(damageSource.getEntity()), 0, deathMessage);
-@@ -935,7 +935,7 @@ public class CraftEventFactory {
+@@ -944,7 +944,7 @@ public class CraftEventFactory {
       * Server methods
       */
      public static ServerListPingEvent callServerListPingEvent(SocketAddress address, String motd, int numPlayers, int maxPlayers) {

--- a/patches/server/0011-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0011-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -396,7 +396,7 @@ index e9109526880159e2341cc97b53939ba2bcfaeaf9..9dcfcea63f57f45a5584bb80c34fe445
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0e3ff653211b0210f8679b475d5f62eecbdfd946..7eb94216cc556ad4c6c76ffab0ca81861d2c1883 100644
+index bec1fdabbc3727c1f7297b2d23914a5179f4adcb..17df1085e29429b202a6f9003343b15b15e2f8f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -43,7 +43,7 @@ import java.util.logging.Level;
@@ -408,7 +408,7 @@ index 0e3ff653211b0210f8679b475d5f62eecbdfd946..7eb94216cc556ad4c6c76ffab0ca8186
  import net.minecraft.advancements.AdvancementHolder;
  import net.minecraft.commands.CommandSourceStack;
  import net.minecraft.commands.Commands;
-@@ -1346,9 +1346,13 @@ public final class CraftServer implements Server {
+@@ -1354,9 +1354,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  
@@ -423,7 +423,7 @@ index 0e3ff653211b0210f8679b475d5f62eecbdfd946..7eb94216cc556ad4c6c76ffab0ca8186
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 0736cf0b5ea327e73a457b55c9c0c4bb82d4c6e9..3a198718cd4b0d87398f0a54275aad1f419be8b3 100644
+index 43790f555743e9945c1b82cf8f2f4719feedc165..26dfb02286e836cad0242c71f743265d55d9d032 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -13,7 +13,6 @@ import java.util.logging.Logger;

--- a/patches/server/0017-Paper-command.patch
+++ b/patches/server/0017-Paper-command.patch
@@ -617,10 +617,10 @@ index bb59986c211f7d6ea50b1ad4bd5565227bec8a6c..9c950fc1de15b5039e34a9fdf893e97a
          this.setPvpAllowed(dedicatedserverproperties.pvp);
          this.setFlightAllowed(dedicatedserverproperties.allowFlight);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7eb94216cc556ad4c6c76ffab0ca81861d2c1883..e7301f38be4fae26404fd8dd33798ef0764565ac 100644
+index 17df1085e29429b202a6f9003343b15b15e2f8f7..29f94e574e39714caec95af5c176c9dba481728e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -978,6 +978,7 @@ public final class CraftServer implements Server {
+@@ -986,6 +986,7 @@ public final class CraftServer implements Server {
          this.commandMap.clearCommands();
          this.reloadData();
          org.spigotmc.SpigotConfig.registerCommands(); // Spigot
@@ -628,7 +628,7 @@ index 7eb94216cc556ad4c6c76ffab0ca81861d2c1883..e7301f38be4fae26404fd8dd33798ef0
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2703,6 +2704,34 @@ public final class CraftServer implements Server {
+@@ -2711,6 +2712,34 @@ public final class CraftServer implements Server {
      // Paper end
  
      // Paper start

--- a/patches/server/0019-Paper-Plugins.patch
+++ b/patches/server/0019-Paper-Plugins.patch
@@ -7257,7 +7257,7 @@ index 5b4ac7b4fd0077e900e9f788963f1613bbc9a5d0..6afede80c10503a261d0f735c351d943
              Bootstrap.validate();
              Util.startTimerHackThread();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e7301f38be4fae26404fd8dd33798ef0764565ac..3f748a8f067d8ce8c39272cb3decaf4ec4879da5 100644
+index 29f94e574e39714caec95af5c176c9dba481728e..b532c72ec2c048554e496b4b63afa0e9f9932416 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -277,7 +277,8 @@ public final class CraftServer implements Server {
@@ -7270,7 +7270,7 @@ index e7301f38be4fae26404fd8dd33798ef0764565ac..3f748a8f067d8ce8c39272cb3decaf4e
      private final StructureManager structureManager;
      protected final DedicatedServer console;
      protected final DedicatedPlayerList playerList;
-@@ -446,24 +447,7 @@ public final class CraftServer implements Server {
+@@ -454,24 +455,7 @@ public final class CraftServer implements Server {
      }
  
      public void loadPlugins() {
@@ -7296,7 +7296,7 @@ index e7301f38be4fae26404fd8dd33798ef0764565ac..3f748a8f067d8ce8c39272cb3decaf4e
      }
  
      public void enablePlugins(PluginLoadOrder type) {
-@@ -552,15 +536,17 @@ public final class CraftServer implements Server {
+@@ -560,15 +544,17 @@ public final class CraftServer implements Server {
      private void enablePlugin(Plugin plugin) {
          try {
              List<Permission> perms = plugin.getDescription().getPermissions();
@@ -7320,7 +7320,7 @@ index e7301f38be4fae26404fd8dd33798ef0764565ac..3f748a8f067d8ce8c39272cb3decaf4e
  
              this.pluginManager.enablePlugin(plugin);
          } catch (Throwable ex) {
-@@ -1002,6 +988,7 @@ public final class CraftServer implements Server {
+@@ -1010,6 +996,7 @@ public final class CraftServer implements Server {
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));
          }

--- a/patches/server/0020-Plugin-remapping.patch
+++ b/patches/server/0020-Plugin-remapping.patch
@@ -1553,7 +1553,7 @@ index 0000000000000000000000000000000000000000..badff5d6ae6dd8d209c82bc7e8afe370
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b67cb9b027c33494f0ed3c6c6ac354a5c79fbf47..cde2e181bf1aaf92f1e96b00e03b7b001a06e6b3 100644
+index 91800791427e9362baf68ca3cffda5bfa58de2b8..5a4cdbc4b92a48c614564e4e421f05a9eb5b072b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -643,6 +643,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -1904,10 +1904,10 @@ index 0000000000000000000000000000000000000000..73b20a92f330311e3fef8f03b51a0985
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3f748a8f067d8ce8c39272cb3decaf4ec4879da5..d1699fcca66bcfbbe8fcc426802cb766cf1e580b 100644
+index b532c72ec2c048554e496b4b63afa0e9f9932416..7839e34cbd42e1b77c533b0dede42e0a19daf2a4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -992,6 +992,7 @@ public final class CraftServer implements Server {
+@@ -1000,6 +1000,7 @@ public final class CraftServer implements Server {
          this.loadPlugins();
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);

--- a/patches/server/0021-Hook-into-CB-plugin-rewrites.patch
+++ b/patches/server/0021-Hook-into-CB-plugin-rewrites.patch
@@ -8,18 +8,18 @@ our own relocation. Also lets us rewrite NMS calls for when we're
 debugging in an IDE pre-relocate.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index acfb0269e15aba638b87b1e2f483ef96c9552693..8e29fae1be2b4d0b04e7788de7a3802aacae4588 100644
+index 4afaab8978d4c4d9b0e9339f1bea9a9a9963d20d..421ddf6ca955215dff77655a7eda62eb9d90aa92 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -8,6 +8,7 @@ import java.util.ArrayList;
- import java.util.Arrays;
+@@ -11,6 +11,7 @@ import java.util.Arrays;
+ import java.util.Collection;
  import java.util.Collections;
  import java.util.Enumeration;
 +import java.util.HashMap;
  import java.util.HashSet;
  import java.util.List;
  import java.util.Map;
-@@ -17,6 +18,7 @@ import java.util.jar.JarEntry;
+@@ -20,6 +21,7 @@ import java.util.jar.JarEntry;
  import java.util.jar.JarFile;
  import java.util.jar.JarOutputStream;
  import java.util.zip.ZipEntry;
@@ -27,9 +27,9 @@ index acfb0269e15aba638b87b1e2f483ef96c9552693..8e29fae1be2b4d0b04e7788de7a3802a
  import joptsimple.OptionParser;
  import joptsimple.OptionSet;
  import joptsimple.OptionSpec;
-@@ -83,6 +85,40 @@ public class Commodore {
-     private static final Map<String, RerouteMethodData> MATERIAL_METHOD_REROUTE = Commodore.createReroutes(MaterialRerouting.class);
+@@ -99,6 +101,40 @@ public class Commodore {
      private static final Map<String, RerouteMethodData> METHOD_REROUTE = Commodore.createReroutes(MethodRerouting.class);
+     private static final Map<String, RerouteMethodData> ENUM_METHOD_REROUTE = Commodore.createReroutes(EnumEvil.class);
  
 +    // Paper start - Plugin rewrites
 +    private static final Map<String, String> SEARCH_AND_REMOVE = initReplacementsMap();
@@ -68,9 +68,9 @@ index acfb0269e15aba638b87b1e2f483ef96c9552693..8e29fae1be2b4d0b04e7788de7a3802a
      public static void main(String[] args) {
          OptionParser parser = new OptionParser();
          OptionSpec<File> inputFlag = parser.acceptsAll(Arrays.asList("i", "input")).withRequiredArg().ofType(File.class).required();
-@@ -213,9 +249,49 @@ public class Commodore {
-             @Override
-             public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+@@ -252,9 +288,49 @@ public class Commodore {
+                 }
+ 
                  return new MethodVisitor(this.api, super.visitMethod(access, name, desc, signature, exceptions)) {
 +                    // Paper start - Plugin rewrites
 +                    @Override
@@ -118,7 +118,7 @@ index acfb0269e15aba638b87b1e2f483ef96c9552693..8e29fae1be2b4d0b04e7788de7a3802a
                          name = FieldRename.rename(pluginVersion, owner, name);
  
                          if (modern) {
-@@ -331,6 +407,13 @@ public class Commodore {
+@@ -374,6 +450,13 @@ public class Commodore {
                              return;
                          }
  
@@ -132,7 +132,7 @@ index acfb0269e15aba638b87b1e2f483ef96c9552693..8e29fae1be2b4d0b04e7788de7a3802a
                          if (modern) {
                              if (owner.equals("org/bukkit/Material") || (instantiatedMethodType != null && instantiatedMethodType.getDescriptor().startsWith("(Lorg/bukkit/Material;)"))) {
                                  switch (name) {
-@@ -427,6 +510,13 @@ public class Commodore {
+@@ -470,6 +553,13 @@ public class Commodore {
  
                      @Override
                      public void visitLdcInsn(Object value) {
@@ -146,7 +146,7 @@ index acfb0269e15aba638b87b1e2f483ef96c9552693..8e29fae1be2b4d0b04e7788de7a3802a
                          if (value instanceof String && ((String) value).equals("com.mysql.jdbc.Driver")) {
                              super.visitLdcInsn("com.mysql.cj.jdbc.Driver");
                              return;
-@@ -437,6 +527,14 @@ public class Commodore {
+@@ -480,6 +570,14 @@ public class Commodore {
  
                      @Override
                      public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
@@ -161,7 +161,7 @@ index acfb0269e15aba638b87b1e2f483ef96c9552693..8e29fae1be2b4d0b04e7788de7a3802a
                          if (bootstrapMethodHandle.getOwner().equals("java/lang/invoke/LambdaMetafactory")
                                  && bootstrapMethodHandle.getName().equals("metafactory") && bootstrapMethodArguments.length == 3) {
                              Type samMethodType = (Type) bootstrapMethodArguments[0];
-@@ -453,7 +551,7 @@ public class Commodore {
+@@ -496,7 +594,7 @@ public class Commodore {
                                  methodArgs.add(new Handle(newOpcode, newOwner, newName, newDescription, newItf));
                                  methodArgs.add(newInstantiated);
  
@@ -170,7 +170,7 @@ index acfb0269e15aba638b87b1e2f483ef96c9552693..8e29fae1be2b4d0b04e7788de7a3802a
                              }, implMethod.getTag(), implMethod.getOwner(), implMethod.getName(), implMethod.getDesc(), implMethod.isInterface(), samMethodType, instantiatedMethodType);
                              return;
                          }
-@@ -504,6 +602,12 @@ public class Commodore {
+@@ -547,6 +645,12 @@ public class Commodore {
  
              @Override
              public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {

--- a/patches/server/0022-Remap-reflection-calls-in-plugins-using-internals.patch
+++ b/patches/server/0022-Remap-reflection-calls-in-plugins-using-internals.patch
@@ -649,11 +649,11 @@ index 242811578a786e3807a1a7019d472d5a68f87116..0b65fdf53124f3dd042b2363b1b8df8e
              return traceElements;
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 8e29fae1be2b4d0b04e7788de7a3802aacae4588..0bde8fc63d892cb615638769ca84beba9da80ff2 100644
+index 421ddf6ca955215dff77655a7eda62eb9d90aa92..1cef3614e81e751c98b504c26da4718dc88746df 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -86,36 +86,26 @@ public class Commodore {
-     private static final Map<String, RerouteMethodData> METHOD_REROUTE = Commodore.createReroutes(MethodRerouting.class);
+@@ -102,36 +102,26 @@ public class Commodore {
+     private static final Map<String, RerouteMethodData> ENUM_METHOD_REROUTE = Commodore.createReroutes(EnumEvil.class);
  
      // Paper start - Plugin rewrites
 -    private static final Map<String, String> SEARCH_AND_REMOVE = initReplacementsMap();
@@ -700,12 +700,12 @@ index 8e29fae1be2b4d0b04e7788de7a3802aacae4588..0bde8fc63d892cb615638769ca84beba
      }
      // Paper end - Plugin rewrites
  
-@@ -186,7 +176,7 @@ public class Commodore {
-         ClassReader cr = new ClassReader(b);
-         ClassWriter cw = new ClassWriter(cr, 0);
+@@ -214,7 +204,7 @@ public class Commodore {
+             visitor = new LimitedClassRemapper(cw, new SimpleRemapper(Commodore.ENUM_RENAMES));
+         }
  
--        cr.accept(new ClassRemapper(new ClassVisitor(Opcodes.ASM9, cw) {
-+        cr.accept(new ClassRemapper(new ClassVisitor(Opcodes.ASM9, io.papermc.paper.pluginremap.reflect.ReflectionRemapper.visitor(cw)) { // Paper
+-        cr.accept(new ClassRemapper(new ClassVisitor(Opcodes.ASM9, visitor) {
++        cr.accept(new ClassRemapper(new ClassVisitor(Opcodes.ASM9, io.papermc.paper.pluginremap.reflect.ReflectionRemapper.visitor(visitor)) { // Paper
              final Set<RerouteMethodData> rerouteMethodData = new HashSet<>();
              String className;
              boolean isInterface;

--- a/patches/server/0023-Timings-v2.patch
+++ b/patches/server/0023-Timings-v2.patch
@@ -1300,7 +1300,7 @@ index 9dcfcea63f57f45a5584bb80c34fe445d65849e8..765c412cd0c5cd410c224b4bc55dbf43
  
      public UserWhiteList getWhiteList() {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b0843917caedc32f800c50cc54706ace9523f64f..63f45a77c8511e05954030cf117c5e4cda0a518f 100644
+index 06cbe7a7ea131a8bead857cbfbd27810a9093320..0a3ed94165430774c7037e78fd7bffc205c6f72f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -140,7 +140,6 @@ import org.bukkit.command.CommandSender;
@@ -1590,7 +1590,7 @@ index 46a090123e205394791cdbde2af84c58ce55f7e1..47f5f3d58bb3bf85cf35f9baae77df7f
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d1699fcca66bcfbbe8fcc426802cb766cf1e580b..de55611daeb6d55f69c4cb72137eb7b050e727f7 100644
+index 7839e34cbd42e1b77c533b0dede42e0a19daf2a4..f2355612b497079f1de84e953c36720794da51d8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -376,7 +376,7 @@ public final class CraftServer implements Server {
@@ -1602,7 +1602,7 @@ index d1699fcca66bcfbbe8fcc426802cb766cf1e580b..de55611daeb6d55f69c4cb72137eb7b0
          this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
-@@ -2612,12 +2612,31 @@ public final class CraftServer implements Server {
+@@ -2620,12 +2620,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  

--- a/patches/server/0024-Further-improve-server-tick-loop.patch
+++ b/patches/server/0024-Further-improve-server-tick-loop.patch
@@ -146,10 +146,10 @@ index d76dae9ce9022308b316080ac48b7030d674cc6b..e9d56d75b7c648f04d3a56942b286609
                  this.startMetricsRecordingTick();
                  this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index de55611daeb6d55f69c4cb72137eb7b050e727f7..1cb6c21741408ff4628864b52341965dfbfa5711 100644
+index f2355612b497079f1de84e953c36720794da51d8..1056badff06575ef13907afac60af734ffa2b863 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2665,7 +2665,11 @@ public final class CraftServer implements Server {
+@@ -2673,7 +2673,11 @@ public final class CraftServer implements Server {
  
      @Override
      public double[] getTPS() {

--- a/patches/server/0025-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0025-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1cb6c21741408ff4628864b52341965dfbfa5711..a2f784b28c0d974ee45d61d6a3a0096dd7161d3e 100644
+index 1056badff06575ef13907afac60af734ffa2b863..acab477a4a026799319054c2eb4d0f2c99ab3d83 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -450,6 +450,35 @@ public final class CraftServer implements Server {
+@@ -458,6 +458,35 @@ public final class CraftServer implements Server {
          io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.INSTANCE.enter(io.papermc.paper.plugin.entrypoint.Entrypoint.PLUGIN); // Paper - replace implementation
      }
  
@@ -47,7 +47,7 @@ index 1cb6c21741408ff4628864b52341965dfbfa5711..a2f784b28c0d974ee45d61d6a3a0096d
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 3a198718cd4b0d87398f0a54275aad1f419be8b3..bd21da04390e486731a260f8fb0c70921320198e 100644
+index 26dfb02286e836cad0242c71f743265d55d9d032..1c8049bbc08be77673d375205bd42a346ff951b8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -160,6 +160,12 @@ public class Main {

--- a/patches/server/0033-Expose-server-build-information.patch
+++ b/patches/server/0033-Expose-server-build-information.patch
@@ -529,7 +529,7 @@ index f077b8ff0bf0d96628db3569132696b68fd79921..5f11f5b16766f9d1d5640ae037e259be
              value.append("\n   Plugins: {");
              for (Plugin plugin : Bukkit.getPluginManager().getPlugins()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a2f784b28c0d974ee45d61d6a3a0096dd7161d3e..7c97ec4aa57562a8383a40e493eaa8a3697208bb 100644
+index acab477a4a026799319054c2eb4d0f2c99ab3d83..2a36e562967ec6174efe456e489c50ca10ba47e5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -11,8 +11,6 @@ import com.google.common.collect.MapMaker;
@@ -583,7 +583,7 @@ index a2f784b28c0d974ee45d61d6a3a0096dd7161d3e..7c97ec4aa57562a8383a40e493eaa8a3
          this.structureManager = new CraftStructureManager(console.getStructureManager(), console.registryAccess());
          this.dataPackManager = new CraftDataPackManager(this.getServer().getPackRepository());
          this.serverTickManager = new CraftServerTickManager(console.tickRateManager());
-@@ -598,6 +593,13 @@ public final class CraftServer implements Server {
+@@ -606,6 +601,13 @@ public final class CraftServer implements Server {
          return this.bukkitVersion;
      }
  
@@ -598,7 +598,7 @@ index a2f784b28c0d974ee45d61d6a3a0096dd7161d3e..7c97ec4aa57562a8383a40e493eaa8a3
      public List<CraftPlayer> getOnlinePlayers() {
          return this.playerView;
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index bd21da04390e486731a260f8fb0c70921320198e..14f63c179428bee61d3b931ea309f4c94b89a6cc 100644
+index 1c8049bbc08be77673d375205bd42a346ff951b8..e37a7aceae6c69083ecf81af4f750c01a5e0eded 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -15,6 +15,7 @@ import joptsimple.OptionSet;
@@ -610,7 +610,7 @@ index bd21da04390e486731a260f8fb0c70921320198e..14f63c179428bee61d3b931ea309f4c9
      public static boolean useConsole = true;
  
 @@ -252,13 +253,26 @@ public class Main {
-                     deadline.add(Calendar.DAY_OF_YEAR, -7);
+                     deadline.add(Calendar.DAY_OF_YEAR, -14);
                      if (buildDate.before(deadline.getTime())) {
                          System.err.println("*** Error, this build is outdated ***");
 -                        System.err.println("*** Please download a new build as per instructions from https://www.spigotmc.org/go/outdated-spigot ***");

--- a/patches/server/0041-Configurable-end-credits.patch
+++ b/patches/server/0041-Configurable-end-credits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable end credits
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index a2833b879b7613856706223f6b6e1ceae760f3b3..6ecb91a21059f3821f6ac5b1be04c933ceee260e 100644
+index ee5188f3aa2ff71306f5af8046e8ddf919c8601b..decd0dd48d8b77126b184ee21ceaf6c387085946 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1161,6 +1161,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1162,6 +1162,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          this.unRide();
          this.serverLevel().removePlayerImmediately(this, Entity.RemovalReason.CHANGED_DIMENSION);
          if (!this.wonGame) {

--- a/patches/server/0043-Optimize-explosions.patch
+++ b/patches/server/0043-Optimize-explosions.patch
@@ -22,7 +22,7 @@ index 57ec168bac3727feb734e28cebc680328c1c4aec..4f1204661e345462c08cc66e3a885103
  
          this.profiler.popPush("connection");
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index 458020575050284544761ec61c52abac7bfd15be..55d66aa8264d5b444a23e2132206bcc9835cfe00 100644
+index 35d541c549cb07508e68388b18f38a4ffd788176..23a0a8d9beb7ca400134fb6a65b3133baceeed83 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
 @@ -279,7 +279,7 @@ public class Explosion {
@@ -34,7 +34,7 @@ index 458020575050284544761ec61c52abac7bfd15be..55d66aa8264d5b444a23e2132206bcc9
                          double d13;
  
                          if (entity instanceof LivingEntity) {
-@@ -539,4 +539,84 @@ public class Explosion {
+@@ -536,4 +536,84 @@ public class Explosion {
  
          private BlockInteraction() {}
      }
@@ -120,7 +120,7 @@ index 458020575050284544761ec61c52abac7bfd15be..55d66aa8264d5b444a23e2132206bcc9
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index e19ee11905417918c7ec142fd2016ab3f000e4e2..da7b1b705da9f17de858f72a20d3a932cd8f7fad 100644
+index e8b8475dd6fd7b89651f744da2cb9696c73ddc3e..a272aaff11ac077853c06f729a5d8b09f866e0f8 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -168,6 +168,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0048-Use-null-Locale-by-default.patch
+++ b/patches/server/0048-Use-null-Locale-by-default.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use null Locale by default
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 6ecb91a21059f3821f6ac5b1be04c933ceee260e..eb1027c6bb90b5fe249cc4cd11c735a0d217ac0e 100644
+index decd0dd48d8b77126b184ee21ceaf6c387085946..e61460a06708429738e0ed5f903a4226158aa334 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -236,7 +236,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -237,7 +237,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      private int levitationStartTime;
      private boolean disconnected;
      private int requestedViewDistance;
@@ -17,7 +17,7 @@ index 6ecb91a21059f3821f6ac5b1be04c933ceee260e..eb1027c6bb90b5fe249cc4cd11c735a0
      public java.util.Locale adventure$locale = java.util.Locale.US; // Paper
      @Nullable
      private Vec3 startingToFallPosition;
-@@ -292,7 +292,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -293,7 +293,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          this.lastActionTime = Util.getMillis();
          this.recipeBook = new ServerRecipeBook();
          this.requestedViewDistance = 2;
@@ -26,7 +26,7 @@ index 6ecb91a21059f3821f6ac5b1be04c933ceee260e..eb1027c6bb90b5fe249cc4cd11c735a0
          this.lastSectionPos = SectionPos.of(0, 0, 0);
          this.chunkTrackingView = ChunkTrackingView.EMPTY;
          this.respawnDimension = Level.OVERWORLD;
-@@ -2051,7 +2051,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2052,7 +2052,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), this.getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
              this.server.server.getPluginManager().callEvent(event);
          }
@@ -36,7 +36,7 @@ index 6ecb91a21059f3821f6ac5b1be04c933ceee260e..eb1027c6bb90b5fe249cc4cd11c735a0
              this.server.server.getPluginManager().callEvent(event);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c2be21491183f5f113dbfc71a7e0ccd195679296..8a674fe0ceadf278d7b9a525e71b519f8be72289 100644
+index 1a003335a4f3cc2fdeadca9c0c6cdafa61a6a1ac..fb5548b92a0fe7866cf98e25293c4b0702344c9b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2423,7 +2423,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0050-Configurable-container-update-tick-rate.patch
+++ b/patches/server/0050-Configurable-container-update-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable container update tick rate
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index eb1027c6bb90b5fe249cc4cd11c735a0d217ac0e..e9fe09f77aacc0b7b13e95d4d04d94fdfa2181c3 100644
+index e61460a06708429738e0ed5f903a4226158aa334..ed920ed90569b7b8886a09a1c3772fd7147d44f9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -267,6 +267,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -268,6 +268,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      public final Object object;
      private int containerCounter;
      public boolean wonGame;
@@ -16,7 +16,7 @@ index eb1027c6bb90b5fe249cc4cd11c735a0d217ac0e..e9fe09f77aacc0b7b13e95d4d04d94fd
  
      // CraftBukkit start
      public CraftPlayer.TransferCookieConnection transferCookieConnection;
-@@ -695,7 +696,12 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -696,7 +697,12 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
              --this.invulnerableTime;
          }
  

--- a/patches/server/0055-Improve-Player-chat-API-handling.patch
+++ b/patches/server/0055-Improve-Player-chat-API-handling.patch
@@ -40,10 +40,10 @@ index 47e1640cafc8087d94d0b88b8b3117591f9f238e..64db7e017b41bffcaac202ee4ecfd7df
          if ( org.spigotmc.SpigotConfig.logCommands ) // Spigot
          this.LOGGER.info(this.player.getScoreboardName() + " issued server command: " + s);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7c97ec4aa57562a8383a40e493eaa8a3697208bb..78193f0d66c2755ed238824bcd24ced9f9052188 100644
+index 2a36e562967ec6174efe456e489c50ca10ba47e5..b0371c51645da361b63dea02bf7633ae6191560f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -925,7 +925,7 @@ public final class CraftServer implements Server {
+@@ -933,7 +933,7 @@ public final class CraftServer implements Server {
      public boolean dispatchCommand(CommandSender sender, String commandLine) {
          Preconditions.checkArgument(sender != null, "sender cannot be null");
          Preconditions.checkArgument(commandLine != null, "commandLine cannot be null");
@@ -53,7 +53,7 @@ index 7c97ec4aa57562a8383a40e493eaa8a3697208bb..78193f0d66c2755ed238824bcd24ced9
          if (this.commandMap.dispatch(sender, commandLine)) {
              return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8a674fe0ceadf278d7b9a525e71b519f8be72289..68df6270f7d08cde78235749950e05bf60c1641c 100644
+index fb5548b92a0fe7866cf98e25293c4b0702344c9b..52d48ad341c564f0f847e3aad09babee826ebf87 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -546,7 +546,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0057-Expose-server-CommandMap.patch
+++ b/patches/server/0057-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 78193f0d66c2755ed238824bcd24ced9f9052188..4bfb836513d5194be271f4a82990ace98de69640 100644
+index b0371c51645da361b63dea02bf7633ae6191560f..527b3a7ae93ab288b119fe6bfa76cb0ea3ab2561 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2169,6 +2169,7 @@ public final class CraftServer implements Server {
+@@ -2177,6 +2177,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0067-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0067-Default-loading-permissions.yml-before-plugins.patch
@@ -16,10 +16,10 @@ modify that. Under the previous logic, plugins were unable (cleanly) override pe
 A config option has been added for those who depend on the previous behavior, but I don't expect that.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fd31d0e76d1a953b128e777b1bc27e24b1e03ed7..bce780f491ee12dcd23a4ea5dd3ce6e8f92e6267 100644
+index 2b665dafdfd002fbd87dca9d869ee8c2b945a4fb..da2e0bb591468e7940f057a583ce166abc79d399 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -479,6 +479,7 @@ public final class CraftServer implements Server {
+@@ -487,6 +487,7 @@ public final class CraftServer implements Server {
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
              this.helpMap.initializeGeneralTopics();
@@ -27,7 +27,7 @@ index fd31d0e76d1a953b128e777b1bc27e24b1e03ed7..bce780f491ee12dcd23a4ea5dd3ce6e8
          }
  
          Plugin[] plugins = this.pluginManager.getPlugins();
-@@ -498,7 +499,7 @@ public final class CraftServer implements Server {
+@@ -506,7 +507,7 @@ public final class CraftServer implements Server {
              this.commandMap.registerServerAliases();
              DefaultPermissions.registerCorePermissions();
              CraftDefaultPermissions.registerCorePermissions();

--- a/patches/server/0068-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0068-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bce780f491ee12dcd23a4ea5dd3ce6e8f92e6267..f8d2850c35e1b41c1844773c4b0452c17bd72f19 100644
+index da2e0bb591468e7940f057a583ce166abc79d399..99571e69aabbbfb0e439a42d113c206decb1377b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2785,5 +2785,23 @@ public final class CraftServer implements Server {
+@@ -2793,5 +2793,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0069-Remove-Metadata-on-reload.patch
+++ b/patches/server/0069-Remove-Metadata-on-reload.patch
@@ -7,10 +7,10 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f8d2850c35e1b41c1844773c4b0452c17bd72f19..502e7f4e168b7f9c6a0f68695f36b8d44cce218e 100644
+index 99571e69aabbbfb0e439a42d113c206decb1377b..5461e0a1ef7f342cbd9fb6f291e33e645b414058 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -993,8 +993,16 @@ public final class CraftServer implements Server {
+@@ -1001,8 +1001,16 @@ public final class CraftServer implements Server {
              world.spigotConfig.init(); // Spigot
          }
  

--- a/patches/server/0070-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0070-Handle-Item-Meta-Inconsistencies.patch
@@ -80,10 +80,10 @@ index a4f8cb2c9dc464e94483f5574cddab85ef407048..8ac485d82c2d2b32f4d54e02c18c2cb2
  
          public Mutable(ItemEnchantments enchantmentsComponent) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 21ed720118073b14bc8b5d1d665b0e17a8bbc1d2..9fa993ac05092170794911394c994fcad33d648f 100644
+index 17fa2d3db112762bcb8b941b69b8ddcc53f47224..6c76aeddb34239a5acc204a17b2aa2d80e6b2c88 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -191,16 +191,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -214,16 +214,13 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Preconditions.checkArgument(ench != null, "Enchantment cannot be null");
  
@@ -106,7 +106,7 @@ index 21ed720118073b14bc8b5d1d665b0e17a8bbc1d2..9fa993ac05092170794911394c994fca
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -229,24 +226,15 @@ public final class CraftItemStack extends ItemStack {
+@@ -252,24 +249,15 @@ public final class CraftItemStack extends ItemStack {
      public int removeEnchantment(Enchantment ench) {
          Preconditions.checkArgument(ench != null, "Enchantment cannot be null");
  
@@ -139,7 +139,7 @@ index 21ed720118073b14bc8b5d1d665b0e17a8bbc1d2..9fa993ac05092170794911394c994fca
  
          return level;
      }
-@@ -258,7 +246,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -281,7 +269,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public Map<Enchantment, Integer> getEnchantments() {

--- a/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
@@ -59,10 +59,10 @@ index 64db7e017b41bffcaac202ee4ecfd7df46d69331..14a821bfc6b20475889d3138b8da9e6b
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 3595ff3db5eb0b1da100692702e514cb870220ee..9c0e38453e164ef394c8e1860fb92605cda71be5 100644
+index 63e20db8ad84b332a4962d5cea83f1064b7c1a3d..bb296f649afd143adad47595479532cfdd778b71 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1880,4 +1880,13 @@ public class CraftEventFactory {
+@@ -1901,4 +1901,13 @@ public class CraftEventFactory {
  
          Bukkit.getPluginManager().callEvent(new EntityRemoveEvent(entity.getBukkitEntity(), cause));
      }

--- a/patches/server/0101-Fix-global-sound-handling.patch
+++ b/patches/server/0101-Fix-global-sound-handling.patch
@@ -24,10 +24,10 @@ index 223f8d9be5d73e296f5815db7123b95c3b345162..d728afbe1d6882f1ace4ead9d87f4b7d
  
      public int getLogicalHeight() {
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 7432becf1c9a378a62e116153aebad4960c0c7bd..dba973ba5088d253aa67f5577663cccda7f4edd1 100644
+index 0be5ae83d2fa86142e3404393729039c51ae0639..25a429a2d1725d562a28b9d07dba630cfe49d32a 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -696,11 +696,12 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -695,11 +695,12 @@ public class EnderDragon extends Mob implements Enemy {
                  // CraftBukkit start - Use relative location for far away sounds
                  // this.level().globalLevelEvent(1028, this.blockPosition(), 0);
                  int viewDistance = ((ServerLevel) this.level()).getCraftServer().getViewDistance() * 16;
@@ -81,7 +81,7 @@ index 0224a0e901f9430ef06c30432a7988149a67037d..391579b515c5a07066f82b33c4f9ef8e
                              double deltaLength = Math.sqrt(distanceSquared);
                              double relativeX = player.getX() + (deltaX / deltaLength) * viewDistance;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 4abb586f964e342425c7cf0384ab8bf8cdedaea3..008be3aad044d20be14da3a9e96933d265104587 100644
+index 240db0aae0b0e306c90bcc4a537c9afcb290acb3..59992bea10218e48397fa781f895d36e0e1df46e 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -1277,4 +1277,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0104-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0104-Add-setting-for-proxy-online-mode-status.patch
@@ -60,10 +60,10 @@ index a0b0614ac7d2009db5c6c10ab4a5f09dd447c635..653856d0b8dcf2baf4cc77a276f17c8c
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 502e7f4e168b7f9c6a0f68695f36b8d44cce218e..451f2861d601c551845a0676bddcfb60e0a84cf3 100644
+index 5461e0a1ef7f342cbd9fb6f291e33e645b414058..ff807bfe89708d9c680b84eda902b49f3167f3a4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1878,7 +1878,7 @@ public final class CraftServer implements Server {
+@@ -1886,7 +1886,7 @@ public final class CraftServer implements Server {
          if (result == null) {
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0108-Add-EntityZapEvent.patch
+++ b/patches/server/0108-Add-EntityZapEvent.patch
@@ -28,10 +28,10 @@ index 63c10be6eacd7108b8b4795d76bf624e0614440a..243eb1e54293c763a06febff551c0513
                  entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null);
                  entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 9c0e38453e164ef394c8e1860fb92605cda71be5..ba8dfea4a88cb9ba881cd90dfb5d41087498ae54 100644
+index bb296f649afd143adad47595479532cfdd778b71..5cf1b15160647b6e8e42a167502643882a231c55 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1202,6 +1202,14 @@ public class CraftEventFactory {
+@@ -1211,6 +1211,14 @@ public class CraftEventFactory {
          return !event.isCancelled();
      }
  

--- a/patches/server/0111-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0111-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 451f2861d601c551845a0676bddcfb60e0a84cf3..a387fa6ce162531497788e0bbcec3c5ffdfa4c68 100644
+index ff807bfe89708d9c680b84eda902b49f3167f3a4..eb12f17b58256489717a0462964b1cef5bc3624b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2811,5 +2811,24 @@ public final class CraftServer implements Server {
+@@ -2819,5 +2819,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0112-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0112-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index 56402312e44d12c859e2c4b39902d31b7cfd1573..25a45e680f9fdea90f43d59de87a3a50
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ba8dfea4a88cb9ba881cd90dfb5d41087498ae54..a3a63c5988eaa987a3718dfa79876e81d05e7fa6 100644
+index 5cf1b15160647b6e8e42a167502643882a231c55..6ffc5b9eb2fa084c7cf397d944e6fc1d8d770dbb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1155,6 +1155,17 @@ public class CraftEventFactory {
+@@ -1164,6 +1164,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0113-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0113-Add-ProjectileCollideEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add ProjectileCollideEvent
 Deprecated now and replaced with ProjectileHitEvent
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a3a63c5988eaa987a3718dfa79876e81d05e7fa6..0aa10b1709c195d766eb49e21d9bc19d7cecf760 100644
+index 6ffc5b9eb2fa084c7cf397d944e6fc1d8d770dbb..50a4e657508e21717a61900660d85203d9373e19 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1299,6 +1299,17 @@ public class CraftEventFactory {
+@@ -1308,6 +1308,17 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  
@@ -27,7 +27,7 @@ index a3a63c5988eaa987a3718dfa79876e81d05e7fa6..0aa10b1709c195d766eb49e21d9bc19d
      public static ProjectileLaunchEvent callProjectileLaunchEvent(Entity entity) {
          Projectile bukkitEntity = (Projectile) entity.getBukkitEntity();
          ProjectileLaunchEvent event = new ProjectileLaunchEvent(bukkitEntity);
-@@ -1323,8 +1334,15 @@ public class CraftEventFactory {
+@@ -1332,8 +1343,15 @@ public class CraftEventFactory {
          if (position.getType() == HitResult.Type.ENTITY) {
              hitEntity = ((EntityHitResult) position).getEntity().getBukkitEntity();
          }

--- a/patches/server/0120-Properly-fix-item-duplication-bug.patch
+++ b/patches/server/0120-Properly-fix-item-duplication-bug.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Properly fix item duplication bug
 Credit to prplz for figuring out the real issue
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e9fe09f77aacc0b7b13e95d4d04d94fdfa2181c3..269cfe7aa87cf4a73ee2faca142c83e4d10a98c7 100644
+index ed920ed90569b7b8886a09a1c3772fd7147d44f9..9b2861b7894a634ce60a2675ee25c949d6e63ea0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2627,7 +2627,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2628,7 +2628,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
      @Override
      public boolean isImmobile() {

--- a/patches/server/0122-PlayerTeleportEndGatewayEvent.patch
+++ b/patches/server/0122-PlayerTeleportEndGatewayEvent.patch
@@ -7,10 +7,10 @@ Allows you to access the Gateway being used in a teleport event
 Fix the offset used for player teleportation
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 269cfe7aa87cf4a73ee2faca142c83e4d10a98c7..dd2a359eda0ab3aaf5a94e00a1675bae424bd860 100644
+index 9b2861b7894a634ce60a2675ee25c949d6e63ea0..a049a54ee70839706787f8de661ca6e6b1f54071 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1192,11 +1192,22 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1193,11 +1193,22 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
              ResourceKey<LevelStem> resourcekey = worldserver1.getTypeKey();
  
              if (worldserver != null && worldserver.dimension() == worldserver1.dimension()) { // CraftBukkit

--- a/patches/server/0125-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0125-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -198,10 +198,10 @@ index d4659ce017692c6f8cabb56137a231bc566614b0..6f90ee749aed98b97868aa40fc233d16
  
          }
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index dba973ba5088d253aa67f5577663cccda7f4edd1..5e83ca6fa874227b5d63148502405bb77f5345ba 100644
+index 25a429a2d1725d562a28b9d07dba630cfe49d32a..f8283405b3c5bd43746a5738be55f600beea40e3 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -689,7 +689,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -688,7 +688,7 @@ public class EnderDragon extends Mob implements Enemy {
  
          if (this.level() instanceof ServerLevel) {
              if (this.dragonDeathTime > 150 && this.dragonDeathTime % 5 == 0 && true) {  // CraftBukkit - SPIGOT-2420: Already checked for the game rule when calculating the xp
@@ -210,7 +210,7 @@ index dba973ba5088d253aa67f5577663cccda7f4edd1..5e83ca6fa874227b5d63148502405bb7
              }
  
              if (this.dragonDeathTime == 1 && !this.isSilent()) {
-@@ -718,7 +718,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -717,7 +717,7 @@ public class EnderDragon extends Mob implements Enemy {
          this.move(MoverType.SELF, new Vec3(0.0D, 0.10000000149011612D, 0.0D));
          if (this.dragonDeathTime == 200 && this.level() instanceof ServerLevel) {
              if (true) { // CraftBukkit - SPIGOT-2420: Already checked for the game rule when calculating the xp

--- a/patches/server/0130-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0130-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a387fa6ce162531497788e0bbcec3c5ffdfa4c68..859719521b07f061103a5e27a2c134849ecb9b08 100644
+index eb12f17b58256489717a0462964b1cef5bc3624b..1fd2f6053e660674baa239f142a720d59e64c776 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2830,5 +2830,10 @@ public final class CraftServer implements Server {
+@@ -2838,5 +2838,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0136-Basic-PlayerProfile-API.patch
+++ b/patches/server/0136-Basic-PlayerProfile-API.patch
@@ -625,7 +625,7 @@ index 416b26c2ab62b29d640169166980e398d5824b14..774d81c702edb76a2f6184d4dc53687d
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 859719521b07f061103a5e27a2c134849ecb9b08..dc20e2a838d19b378f76592d8eeeb1eaf150393d 100644
+index 1fd2f6053e660674baa239f142a720d59e64c776..5ab2836f14e1a7482e7136004507d66c4abb4bdd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -262,6 +262,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -646,7 +646,7 @@ index 859719521b07f061103a5e27a2c134849ecb9b08..dc20e2a838d19b378f76592d8eeeb1ea
          CraftItemFactory.instance();
          CraftEntityFactory.instance();
      }
-@@ -2835,5 +2839,39 @@ public final class CraftServer implements Server {
+@@ -2843,5 +2847,39 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }

--- a/patches/server/0137-Add-UnknownCommandEvent.patch
+++ b/patches/server/0137-Add-UnknownCommandEvent.patch
@@ -78,10 +78,10 @@ index f94c0106b44d614483184e372c01c1504cb886b0..72756ef14b8ec8afd80313b9f6aaf767
  
              return null;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dc20e2a838d19b378f76592d8eeeb1eaf150393d..e782c6d776f467d29540851eef9428f4d7f80acb 100644
+index 5ab2836f14e1a7482e7136004507d66c4abb4bdd..4280bd6288ce9522d041ec2dc2105d3908514a2f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -939,7 +939,13 @@ public final class CraftServer implements Server {
+@@ -947,7 +947,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
          if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {

--- a/patches/server/0146-Fix-this-stupid-bullshit.patch
+++ b/patches/server/0146-Fix-this-stupid-bullshit.patch
@@ -31,12 +31,12 @@ index 8f1992188f7fd9e735569e099b36a7eafed47aae..061c89b985dafc79c808dd5f0e296b9f
              Bootstrap.isBootstrapped = true;
              Instant instant = Instant.now();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 75a3c7ed5500f0451c9c1efdfc3cb809445c8acf..8245b38d37b4cee6f4e7b61d7af40a18e54a3f43 100644
+index fcc7cdd0adfcaa135d08ea36746dca980590d6eb..4c8d98598b5cdcdbe4a778f1ec142e3a7ab33196 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -260,10 +260,12 @@ public class Main {
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -7);
+                     deadline.add(Calendar.DAY_OF_YEAR, -14);
                      if (buildDate.before(deadline.getTime())) {
 -                        System.err.println("*** Error, this build is outdated ***");
 +                        // Paper start - This is some stupid bullshit

--- a/patches/server/0161-AsyncTabCompleteEvent.patch
+++ b/patches/server/0161-AsyncTabCompleteEvent.patch
@@ -80,10 +80,10 @@ index 7906e163f8d03ba39480526d0293ad48534f11bf..ec80a9138260497d0deccf3ade3f44fc
  
          this.server.getCommands().getDispatcher().getCompletionSuggestions(parseresults).thenAccept((suggestions) -> {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e782c6d776f467d29540851eef9428f4d7f80acb..3b3fe9282251774516c8eae5890bd56645dd38e4 100644
+index 4280bd6288ce9522d041ec2dc2105d3908514a2f..5d8eb3b728359be5f92a255c9637d71713403cc8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2284,7 +2284,7 @@ public final class CraftServer implements Server {
+@@ -2292,7 +2292,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0164-PlayerNaturallySpawnCreaturesEvent.patch
+++ b/patches/server/0164-PlayerNaturallySpawnCreaturesEvent.patch
@@ -60,10 +60,10 @@ index e0c8b89767087cba34fc3c3809db4c386dacb193..a939bad7da9c852827a2d67d9ace5d0d
                  boolean flag1 = this.level.ticksPerSpawnCategory.getLong(org.bukkit.entity.SpawnCategory.ANIMAL) != 0L && this.level.getLevelData().getGameTime() % this.level.ticksPerSpawnCategory.getLong(org.bukkit.entity.SpawnCategory.ANIMAL) == 0L; // CraftBukkit
                  Iterator iterator1 = list.iterator();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index dd2a359eda0ab3aaf5a94e00a1675bae424bd860..db3f5a774daa0750cdcc0c2c47d1bd4fd2900dd9 100644
+index a049a54ee70839706787f8de661ca6e6b1f54071..db72318d822b876eb937f0f0f7f2b2139fb77df7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -285,6 +285,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -286,6 +286,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      public String kickLeaveMessage = null; // SPIGOT-3034: Forward leave message to PlayerQuitEvent
      // CraftBukkit end
      public boolean isRealPlayer; // Paper

--- a/patches/server/0176-Player.setPlayerProfile-API.patch
+++ b/patches/server/0176-Player.setPlayerProfile-API.patch
@@ -77,7 +77,7 @@ index 818df09e9245b5d89b4180b1eaa51470b7539341..461656e1cb095243bfe7a9ee2906e5b0
  
      public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 93550342c6f181b7622f5d649cd3e5075a464e55..19f644442eb7ae352d655d5e62f47f261b7b1b0a 100644
+index 4602c3d0be94f0146a2b205268f70aaf85410f20..422c25577a0d95b31b5528fad8fc9b3ae97fa7f0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -249,11 +249,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -220,10 +220,10 @@ index 93550342c6f181b7622f5d649cd3e5075a464e55..19f644442eb7ae352d655d5e62f47f26
      public void onEntityRemove(Entity entity) {
          this.invertedVisibilityEntities.remove(entity.getUUID());
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 0bde8fc63d892cb615638769ca84beba9da80ff2..a2b1197a26eed4df77d7f770e016f522832d8aa2 100644
+index 1cef3614e81e751c98b504c26da4718dc88746df..eeaa9787c7e04e7155b93aa8d83bd073e8dc209e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -404,6 +404,13 @@ public class Commodore {
+@@ -447,6 +447,13 @@ public class Commodore {
                          }
                          // Paper end - Rewrite plugins
  

--- a/patches/server/0177-getPlayerUniqueId-API.patch
+++ b/patches/server/0177-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3b3fe9282251774516c8eae5890bd56645dd38e4..dd1a6b7a65fe019ee71c659a165283ee9c0e7a4f 100644
+index 5d8eb3b728359be5f92a255c9637d71713403cc8..745970d9f07ed7ca98a653bfff1b861dc4aaa177 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1878,6 +1878,25 @@ public final class CraftServer implements Server {
+@@ -1886,6 +1886,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0192-WitchReadyPotionEvent.patch
+++ b/patches/server/0192-WitchReadyPotionEvent.patch
@@ -22,10 +22,10 @@ index a14e00d55930628333cc63b18727ea56dbdc4ee3..f6d01d21745391595d61b191832be4c2
                      this.setUsingItem(true);
                      if (!this.isSilent()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0aa10b1709c195d766eb49e21d9bc19d7cecf760..9c463d551fc402dbcbc81aad5251a9183596830a 100644
+index 50a4e657508e21717a61900660d85203d9373e19..1c53b872b30bcd8535b8686015935025a4c9837f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1926,4 +1926,14 @@ public class CraftEventFactory {
+@@ -1947,4 +1947,14 @@ public class CraftEventFactory {
          ).callEvent();
      }
      // Paper end - PlayerUseUnknownEntityEvent

--- a/patches/server/0193-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0193-ItemStack-getMaxItemUseDuration.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 9fa993ac05092170794911394c994fcad33d648f..75f9405ee3453620e1561857575cc8700971a865 100644
+index 6c76aeddb34239a5acc204a17b2aa2d80e6b2c88..e8a455eb5e17bcfcae3f03664f2b47773fbdf37e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -7,14 +7,17 @@ import net.minecraft.core.Holder;
@@ -27,7 +27,7 @@ index 9fa993ac05092170794911394c994fcad33d648f..75f9405ee3453620e1561857575cc870
  import org.bukkit.inventory.ItemStack;
  import org.bukkit.inventory.meta.ItemMeta;
  import org.bukkit.material.MaterialData;
-@@ -187,6 +190,21 @@ public final class CraftItemStack extends ItemStack {
+@@ -210,6 +213,21 @@ public final class CraftItemStack extends ItemStack {
          return (this.handle == null) ? Material.AIR.getMaxStackSize() : this.handle.getMaxStackSize();
      }
  

--- a/patches/server/0202-Add-entity-knockback-events.patch
+++ b/patches/server/0202-Add-entity-knockback-events.patch
@@ -11,7 +11,7 @@ Co-authored-by: aerulion <aerulion@gmail.com>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d6017d9d71fb4b3a3df6eaa44da0ebda54c83da4..629942afb41f73ca7a7855cba58c81fd0e734a7a 100644
+index fd49b9d739b1bbab8cf110659cb83bad03b56102..a2b727dea997ed0d7b1ef677a94b5957f12d5abb 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1962,7 +1962,21 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -132,10 +132,10 @@ index aa8909498c26f095060a1df364b9e20d964a6cc3..30502849f79ce0f472e4289043c7d8ec
                  });
          }
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 5e83ca6fa874227b5d63148502405bb77f5345ba..96eccd5f4675019a369a5f8171fb18e7b05b3e48 100644
+index f8283405b3c5bd43746a5738be55f600beea40e3..b02a77b486f8d5eee31850de4a1b033fe6a107c7 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -464,7 +464,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -465,7 +465,7 @@ public class EnderDragon extends Mob implements Enemy {
                  double d3 = entity.getZ() - d1;
                  double d4 = Math.max(d2 * d2 + d3 * d3, 0.1D);
  
@@ -251,7 +251,7 @@ index de2bc78415ab4efb651030be6560d9c9778a1d17..1e00df3fa3c3b61daa3d59ee1173269a
      public abstract void explode(Vec3 pos);
  
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index d93ed33d5ae72e9dd3e6cf044ef79e4b9689dc1c..512d79b66fed3d1bef645c3ecb59bda032c81d15 100644
+index 6476c644d3da824c5ee4190cb45cde678ff1188f..a5f4ecb96c508b94a92a43c864c075f6c61e296e 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
 @@ -297,13 +297,10 @@ public class Explosion {
@@ -273,10 +273,10 @@ index d93ed33d5ae72e9dd3e6cf044ef79e4b9689dc1c..512d79b66fed3d1bef645c3ecb59bda0
                          // CraftBukkit end
                          entity.setDeltaMovement(entity.getDeltaMovement().add(vec3d1));
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 9c463d551fc402dbcbc81aad5251a9183596830a..cf045e3ebe75046212755f18058bf4381bacacc1 100644
+index 1c53b872b30bcd8535b8686015935025a4c9837f..0888692736ef62e741aa41d3a72b9b8c3075dfcd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1888,19 +1888,33 @@ public class CraftEventFactory {
+@@ -1909,19 +1909,33 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0208-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0208-InventoryCloseEvent-Reason-API.patch
@@ -29,10 +29,10 @@ index 1fac100819e59d00f50e530d3a4157b56d966dba..4f777c9d8c3052f68bc0465c8a7386b8
              }
              // Spigot End
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index db3f5a774daa0750cdcc0c2c47d1bd4fd2900dd9..00a1a570e9f7abf97a25b4bab2b7532d3dad7912 100644
+index db72318d822b876eb937f0f0f7f2b2139fb77df7..a3a1450949703851625bbb257e92b3be4d79a06a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -704,7 +704,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -705,7 +705,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          }
          // Paper end - Configurable container update tick rate
          if (!this.level().isClientSide && !this.containerMenu.stillValid(this)) {
@@ -41,7 +41,7 @@ index db3f5a774daa0750cdcc0c2c47d1bd4fd2900dd9..00a1a570e9f7abf97a25b4bab2b7532d
              this.containerMenu = this.inventoryMenu;
          }
  
-@@ -924,7 +924,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -925,7 +925,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
          // SPIGOT-943 - only call if they have an inventory open
          if (this.containerMenu != this.inventoryMenu) {
@@ -50,7 +50,7 @@ index db3f5a774daa0750cdcc0c2c47d1bd4fd2900dd9..00a1a570e9f7abf97a25b4bab2b7532d
          }
  
          net.kyori.adventure.text.Component deathMessage = event.deathMessage() != null ? event.deathMessage() : net.kyori.adventure.text.Component.empty(); // Paper - Adventure
-@@ -1591,7 +1591,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1592,7 +1592,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          }
          // CraftBukkit end
          if (this.containerMenu != this.inventoryMenu) {
@@ -59,7 +59,7 @@ index db3f5a774daa0750cdcc0c2c47d1bd4fd2900dd9..00a1a570e9f7abf97a25b4bab2b7532d
          }
  
          // this.nextContainerCounter(); // CraftBukkit - moved up
-@@ -1621,7 +1621,13 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1622,7 +1622,13 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
      @Override
      public void closeContainer() {
@@ -165,7 +165,7 @@ index 2e02fc22a889c9c8010ae8bff1b59a13219ae014..703bb1bb42b1668c04824489fd2f3490
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index db79201906e231b13c6f237193c3e8597bce9106..7ad63581c7c78a7d8b78be2e95002550b3b2c222 100644
+index 326f36726c124385145c469566c2089439b5dd0f..0b4c5a2604f61a34b5666a9a83a2e644449997fd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1273,7 +1273,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -178,10 +178,10 @@ index db79201906e231b13c6f237193c3e8597bce9106..7ad63581c7c78a7d8b78be2e95002550
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cf045e3ebe75046212755f18058bf4381bacacc1..836eba2f7b4260e5f882b202ef5923bb9bcfcd58 100644
+index 0888692736ef62e741aa41d3a72b9b8c3075dfcd..7fa68654c2e0c87dd779a1354fc103be4d7d7a46 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1268,7 +1268,7 @@ public class CraftEventFactory {
+@@ -1277,7 +1277,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -190,7 +190,7 @@ index cf045e3ebe75046212755f18058bf4381bacacc1..836eba2f7b4260e5f882b202ef5923bb
          }
  
          CraftServer server = player.level().getCraftServer();
-@@ -1455,8 +1455,18 @@ public class CraftEventFactory {
+@@ -1464,8 +1464,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0217-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0217-Vanished-players-don-t-have-rights.patch
@@ -39,7 +39,7 @@ index 6ca74a5cf691ee92c84bd031e875f72440df6b32..cee3f1200af602b5dfd0b27d05eb0182
  
          BlockCanBuildEvent event = new BlockCanBuildEvent(CraftBlock.at(context.getLevel(), context.getClickedPos()), player, CraftBlockData.fromData(state), defaultReturn);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 16c244f56813479b2e51f1d883ff739949fc86e3..c0b0a9328faf93b85ceaf6cc9989f1a59520c7f4 100644
+index a9227581ec78a56e96dc3a342006e4a649906326..5929b450a26e7c3cf63de3dc1d0e67cb781b24c7 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -265,6 +265,45 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -89,10 +89,10 @@ index 16c244f56813479b2e51f1d883ff739949fc86e3..c0b0a9328faf93b85ceaf6cc9989f1a5
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 836eba2f7b4260e5f882b202ef5923bb9bcfcd58..1d2e9f3e5e232faca8de4760d3574fae6200b2b2 100644
+index 7fa68654c2e0c87dd779a1354fc103be4d7d7a46..a221ae7ec1a7db9c38037fa71ea35b5309b99973 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1305,6 +1305,14 @@ public class CraftEventFactory {
+@@ -1314,6 +1314,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0222-Add-TNTPrimeEvent.patch
+++ b/patches/server/0222-Add-TNTPrimeEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add TNTPrimeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 96eccd5f4675019a369a5f8171fb18e7b05b3e48..201ef4a3f5bc8633f7a51e151e9e87efc4004cad 100644
+index b02a77b486f8d5eee31850de4a1b033fe6a107c7..a2cde7b1b316e43382cb1639ffccf29d89f5ebfc 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -574,6 +574,11 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -573,6 +573,11 @@ public class EnderDragon extends Mob implements Enemy {
                      });
                      craftBlock.getNMS().spawnAfterBreak((ServerLevel) this.level(), blockposition, ItemStack.EMPTY, false);
                  }

--- a/patches/server/0227-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0227-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -33,10 +33,10 @@ index c466ec011d059b9960606ef2ee51ea3a3a65f8d0..baf93b5d5883d0a5c360f1a475949804
          com.destroystokyo.paper.Metrics.PaperMetrics.startMetrics(); // Paper - start metrics
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // Paper - load version history now
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dd1a6b7a65fe019ee71c659a165283ee9c0e7a4f..2924bf755df7cc2b8d48e4383b56b2777981231d 100644
+index 745970d9f07ed7ca98a653bfff1b861dc4aaa177..274d7d7f36ce2eb38d2f630ca48b6aa4f791b0e3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -954,6 +954,7 @@ public final class CraftServer implements Server {
+@@ -962,6 +962,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -44,7 +44,7 @@ index dd1a6b7a65fe019ee71c659a165283ee9c0e7a4f..2924bf755df7cc2b8d48e4383b56b277
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -1045,6 +1046,7 @@ public final class CraftServer implements Server {
+@@ -1053,6 +1054,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.pluginsEnabled(); // Paper - Remap plugins
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));
@@ -53,7 +53,7 @@ index dd1a6b7a65fe019ee71c659a165283ee9c0e7a4f..2924bf755df7cc2b8d48e4383b56b277
  
      @Override
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index d063d356388810fb6f0dddfbc8b5885b3e6442aa..ba4fcfc86b385c8f50f414d5448edc5e99d2433a 100644
+index a31953bd4dd9408f83c2ee9816d051a4a842cf6d..df3eb02bc2b5b8fc20496823055c6adf4512b4f9 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -229,7 +229,7 @@ public class SpigotConfig

--- a/patches/server/0243-Improve-death-events.patch
+++ b/patches/server/0243-Improve-death-events.patch
@@ -19,10 +19,10 @@ public net.minecraft.world.entity.LivingEntity getDeathSound()Lnet/minecraft/sou
 public net.minecraft.world.entity.LivingEntity getSoundVolume()F
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 00a1a570e9f7abf97a25b4bab2b7532d3dad7912..0706dd82cfdb6808ef61149b2a8d8be971f19be9 100644
+index a3a1450949703851625bbb257e92b3be4d79a06a..ff3f70b8c266dc3b2ab374ffd6905ecbfe8510be 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -268,6 +268,10 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -269,6 +269,10 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      private int containerCounter;
      public boolean wonGame;
      private int containerUpdateDelay; // Paper - Configurable container update tick rate
@@ -33,7 +33,7 @@ index 00a1a570e9f7abf97a25b4bab2b7532d3dad7912..0706dd82cfdb6808ef61149b2a8d8be9
  
      // CraftBukkit start
      public CraftPlayer.TransferCookieConnection transferCookieConnection;
-@@ -893,7 +897,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -894,7 +898,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
      @Override
      public void die(DamageSource damageSource) {
@@ -42,7 +42,7 @@ index 00a1a570e9f7abf97a25b4bab2b7532d3dad7912..0706dd82cfdb6808ef61149b2a8d8be9
          boolean flag = this.level().getGameRules().getBoolean(GameRules.RULE_SHOWDEATHMESSAGES);
          // CraftBukkit start - fire PlayerDeathEvent
          if (this.isRemoved()) {
-@@ -921,6 +925,16 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -922,6 +926,16 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          String deathmessage = defaultMessage.getString();
          this.keepLevel = keepInventory; // SPIGOT-2222: pre-set keepLevel
          org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, damageSource, loot, PaperAdventure.asAdventure(defaultMessage), keepInventory); // Paper - Adventure
@@ -59,7 +59,7 @@ index 00a1a570e9f7abf97a25b4bab2b7532d3dad7912..0706dd82cfdb6808ef61149b2a8d8be9
  
          // SPIGOT-943 - only call if they have an inventory open
          if (this.containerMenu != this.inventoryMenu) {
-@@ -1069,8 +1083,17 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1070,8 +1084,17 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
                          }
                      }
                  }
@@ -423,7 +423,7 @@ index ee3902cbada46ffb78c42dbf6f00c859546c76e1..92bb0c63330ad3a4cb13b2dc65502071
          // CraftBukkit end
          this.gameEvent(GameEvent.ENTITY_DIE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 597594409b4d1fadf4ae1c3a7156421e70989d97..2d1e0e92e6d98a9cf597c3717c36ea5a337577c3 100644
+index 92f9502a2d5721ebb1757a069a0f138db66628d7..6c5bd88777ff79c7408cf5ffed0f099a79e5429a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2517,7 +2517,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -443,10 +443,10 @@ index 597594409b4d1fadf4ae1c3a7156421e70989d97..2d1e0e92e6d98a9cf597c3717c36ea5a
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 1d2e9f3e5e232faca8de4760d3574fae6200b2b2..e7ba5b503e821d18467c2300f780ef37f996b34d 100644
+index a221ae7ec1a7db9c38037fa71ea35b5309b99973..d3baf38cf45d13eeffedcc697468842e3ac117d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -894,9 +894,16 @@ public class CraftEventFactory {
+@@ -897,9 +897,16 @@ public class CraftEventFactory {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          CraftDamageSource bukkitDamageSource = new CraftDamageSource(damageSource);
          EntityDeathEvent event = new EntityDeathEvent(entity, bukkitDamageSource, drops, victim.getExpReward(damageSource.getEntity()));
@@ -463,7 +463,7 @@ index 1d2e9f3e5e232faca8de4760d3574fae6200b2b2..e7ba5b503e821d18467c2300f780ef37
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -914,7 +921,14 @@ public class CraftEventFactory {
+@@ -917,7 +924,14 @@ public class CraftEventFactory {
          PlayerDeathEvent event = new PlayerDeathEvent(entity, bukkitDamageSource, drops, victim.getExpReward(damageSource.getEntity()), 0, deathMessage);
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
@@ -478,7 +478,7 @@ index 1d2e9f3e5e232faca8de4760d3574fae6200b2b2..e7ba5b503e821d18467c2300f780ef37
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -931,6 +945,31 @@ public class CraftEventFactory {
+@@ -940,6 +954,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0256-Call-player-spectator-target-events-and-improve-impl.patch
+++ b/patches/server/0256-Call-player-spectator-target-events-and-improve-impl.patch
@@ -19,10 +19,10 @@ spectate the target entity.
 Co-authored-by: Spottedleaf <Spottedleaf@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 0706dd82cfdb6808ef61149b2a8d8be971f19be9..ae9d058e9450f59bb6a03ebc6fffed8a0b3ebee8 100644
+index ff3f70b8c266dc3b2ab374ffd6905ecbfe8510be..29dc317d43532399651719d45ca05b086043ae6b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2182,6 +2182,21 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2183,6 +2183,21 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
          this.camera = (Entity) (entity == null ? this : entity);
          if (entity1 != this.camera) {

--- a/patches/server/0260-Reset-players-airTicks-on-respawn.patch
+++ b/patches/server/0260-Reset-players-airTicks-on-respawn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset players airTicks on respawn
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ae9d058e9450f59bb6a03ebc6fffed8a0b3ebee8..dad9d89d77001d2c84fbae7a8a4a4312cc5953dc 100644
+index 29dc317d43532399651719d45ca05b086043ae6b..1108fa6c7ac28304d104d4e5df2bdf4e9a6bd929 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2703,6 +2703,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2704,6 +2704,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
          this.setHealth(this.getMaxHealth());
          this.stopUsingItem(); // CraftBukkit - SPIGOT-6682: Clear active item on reset

--- a/patches/server/0267-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0267-Make-the-default-permission-message-configurable.patch
@@ -18,10 +18,10 @@ index 5b070d158760789bbcaa984426a55d20767abe4a..e1820a339452cd3388dd7cbb928c5f58
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2924bf755df7cc2b8d48e4383b56b2777981231d..006cc9b7817e0413a332c21839549b127ad67cb4 100644
+index 274d7d7f36ce2eb38d2f630ca48b6aa4f791b0e3..c4b1e3064f3778909a2f152a69ca229f4c86b71b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2867,6 +2867,16 @@ public final class CraftServer implements Server {
+@@ -2875,6 +2875,16 @@ public final class CraftServer implements Server {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }
  

--- a/patches/server/0268-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0268-force-entity-dismount-during-teleportation.patch
@@ -20,10 +20,10 @@ this is going to be the best soultion all around.
 Improvements/suggestions welcome!
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index dad9d89d77001d2c84fbae7a8a4a4312cc5953dc..ae7a5e65b9183338ce5ed44807a493ce1f3e8c93 100644
+index 1108fa6c7ac28304d104d4e5df2bdf4e9a6bd929..b4947ee9615b1b2108046b9ab87b65b53dbb23f6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2522,9 +2522,15 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2523,9 +2523,15 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
      @Override
      public void stopRiding() {
@@ -41,7 +41,7 @@ index dad9d89d77001d2c84fbae7a8a4a4312cc5953dc..ae7a5e65b9183338ce5ed44807a493ce
              Iterator iterator = entityliving.getActiveEffects().iterator();
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 131eda47e7a9f90a4057607870acbcb8fecfbf0b..2e376b0b2bf2d49ad0669b6e6fd287628a72ea64 100644
+index d4b1122fcf9c35f492764d0a7b8b4c41e46aa90a..026af10f7de0267c7335385fea53a823f3898e8b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2705,17 +2705,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess

--- a/patches/server/0272-Replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0272-Replace-OfflinePlayer-getLastPlayed.patch
@@ -16,10 +16,10 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ae7a5e65b9183338ce5ed44807a493ce1f3e8c93..cc57c09a38c265040505f17dd0113ab648522490 100644
+index b4947ee9615b1b2108046b9ab87b65b53dbb23f6..dbdc6b4065acc363c128580fdffe9049259386c2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -268,6 +268,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -269,6 +269,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      private int containerCounter;
      public boolean wonGame;
      private int containerUpdateDelay; // Paper - Configurable container update tick rate
@@ -106,7 +106,7 @@ index 461656e1cb095243bfe7a9ee2906e5b00574ae78..411b280ac3e27e72091db813c0c9b69b
      public Location getLastDeathLocation() {
          if (this.getData().contains("LastDeathLocation", 10)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2d1e0e92e6d98a9cf597c3717c36ea5a337577c3..2974f806ef677376ee2b53fccb6ca83151bb8451 100644
+index 6c5bd88777ff79c7408cf5ffed0f099a79e5429a..c3c1dff8afb9d9e27ead7c037626c97696663930 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -210,6 +210,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0273-Workaround-for-vehicle-tracking-issue-on-disconnect.patch
+++ b/patches/server/0273-Workaround-for-vehicle-tracking-issue-on-disconnect.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Workaround for vehicle tracking issue on disconnect
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index cc57c09a38c265040505f17dd0113ab648522490..647cec024d90014a6928d3889f6d1b24d5a4a4de 100644
+index dbdc6b4065acc363c128580fdffe9049259386c2..afed961e6714abc1a1709d12973cbfae40b950fa 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1833,6 +1833,13 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1834,6 +1834,13 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      public void disconnect() {
          this.disconnected = true;
          this.ejectPassengers();

--- a/patches/server/0286-PlayerDeathEvent-getItemsToKeep.patch
+++ b/patches/server/0286-PlayerDeathEvent-getItemsToKeep.patch
@@ -11,10 +11,10 @@ Example Usage: https://gist.github.com/aikar/5bb202de6057a051a950ce1f29feb0b4
 public net.minecraft.world.entity.player.Inventory compartments
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 647cec024d90014a6928d3889f6d1b24d5a4a4de..2bc6228057e01bf197e8b6e58ae6389f2d19ffe5 100644
+index afed961e6714abc1a1709d12973cbfae40b950fa..bac135546695ff575fc32be3ababea5fb9f31d01 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -896,6 +896,46 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -897,6 +897,46 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          });
      }
  
@@ -61,7 +61,7 @@ index 647cec024d90014a6928d3889f6d1b24d5a4a4de..2bc6228057e01bf197e8b6e58ae6389f
      @Override
      public void die(DamageSource damageSource) {
          // this.gameEvent(GameEvent.ENTITY_DIE); // Paper - move below event cancellation check
-@@ -980,7 +1020,12 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -981,7 +1021,12 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          this.dropExperience(damageSource.getEntity());
          // we clean the player's inventory after the EntityDeathEvent is called so plugins can get the exact state of the inventory.
          if (!event.getKeepInventory()) {

--- a/patches/server/0292-Expose-the-internal-current-tick.patch
+++ b/patches/server/0292-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 006cc9b7817e0413a332c21839549b127ad67cb4..264b5781a472f706f525cb07d4ccebac17d4a5d3 100644
+index c4b1e3064f3778909a2f152a69ca229f4c86b71b..510013c4e15595d24cf5d3053cbb7558c2f26569 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2910,5 +2910,10 @@ public final class CraftServer implements Server {
+@@ -2918,5 +2918,10 @@ public final class CraftServer implements Server {
          profile.getGameProfile().getProperties().putAll(((CraftPlayer) player).getHandle().getGameProfile().getProperties());
          return profile;
      }

--- a/patches/server/0303-PlayerDeathEvent-shouldDropExperience.patch
+++ b/patches/server/0303-PlayerDeathEvent-shouldDropExperience.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PlayerDeathEvent#shouldDropExperience
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 2bc6228057e01bf197e8b6e58ae6389f2d19ffe5..46b82351b61e82cd301843bd6a05846181eac6d8 100644
+index bac135546695ff575fc32be3ababea5fb9f31d01..45af5a361e939c07eb3f9316b3fd686d5c2584ba 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1017,7 +1017,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1018,7 +1018,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
              this.tellNeutralMobsThatIDied();
          }
          // SPIGOT-5478 must be called manually now

--- a/patches/server/0321-add-hand-to-BlockMultiPlaceEvent.patch
+++ b/patches/server/0321-add-hand-to-BlockMultiPlaceEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add hand to BlockMultiPlaceEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e7ba5b503e821d18467c2300f780ef37f996b34d..f670ddd3633bf36b653bdf994f459e84e09bfbff 100644
+index d3baf38cf45d13eeffedcc697468842e3ac117d3..3ba695a29dcf9e7137dae16835e6f7a375d560f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -403,13 +403,18 @@ public class CraftEventFactory {
+@@ -406,13 +406,18 @@ public class CraftEventFactory {
          }
  
          org.bukkit.inventory.ItemStack item;

--- a/patches/server/0327-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0327-Add-tick-times-API-and-mspt-command.patch
@@ -184,10 +184,10 @@ index 3ffb330a16797c04694f73b0cd9f5b38a07641b4..ff73167bfe210305491e35f18adc2755
 +    // Paper end - Add tick times API and /mspt command
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 264b5781a472f706f525cb07d4ccebac17d4a5d3..edf6921ed70ea3281cf870dfb779e908ea3d1905 100644
+index 510013c4e15595d24cf5d3053cbb7558c2f26569..a6564ddf47d50b618627680a55b6546bf6d9eab9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2681,6 +2681,16 @@ public final class CraftServer implements Server {
+@@ -2689,6 +2689,16 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0328-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0328-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index edf6921ed70ea3281cf870dfb779e908ea3d1905..cb6f6762b41ca78ff7c13a65690ce0be1bdac292 100644
+index a6564ddf47d50b618627680a55b6546bf6d9eab9..6707e213d9bd2b173928b1e9dae87c403342953b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2925,5 +2925,10 @@ public final class CraftServer implements Server {
+@@ -2933,5 +2933,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0330-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/patches/server/0330-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 46b82351b61e82cd301843bd6a05846181eac6d8..7e60da3249e44b333ea3d22ddee706b270dd9c61 100644
+index 45af5a361e939c07eb3f9316b3fd686d5c2584ba..e754500547df4ae4601e7c6f3a77eb52fda21059 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -269,6 +269,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -270,6 +270,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      public boolean wonGame;
      private int containerUpdateDelay; // Paper - Configurable container update tick rate
      public long loginTime; // Paper - Replace OfflinePlayer#getLastPlayed

--- a/patches/server/0334-Don-t-tick-dead-players.patch
+++ b/patches/server/0334-Don-t-tick-dead-players.patch
@@ -7,10 +7,10 @@ Causes sync chunk loads and who knows what all else.
 This is safe because Spectators are skipped in unloaded chunks too in vanilla.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 7e60da3249e44b333ea3d22ddee706b270dd9c61..6075e536f09875e577cea7caff70d6a417470254 100644
+index e754500547df4ae4601e7c6f3a77eb52fda21059..613eefeb44beb35181243b570bad631f15802918 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -764,7 +764,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -765,7 +765,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
      public void doTick() {
          try {

--- a/patches/server/0336-Don-t-move-existing-players-to-world-spawn.patch
+++ b/patches/server/0336-Don-t-move-existing-players-to-world-spawn.patch
@@ -13,10 +13,10 @@ By skipping this, we avoid potential for a large spike on server start.
 public net.minecraft.server.level.ServerPlayer fudgeSpawnLocation(Lnet/minecraft/server/level/ServerLevel;)V
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 6075e536f09875e577cea7caff70d6a417470254..a9c1aa9e382b0864386030a66158b53d12026a00 100644
+index 613eefeb44beb35181243b570bad631f15802918..9b6887f40dea57d4b5e2f08d7645b1edfaa5b189 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -357,7 +357,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -358,7 +358,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          this.server = server;
          this.stats = server.getPlayerList().getPlayerStats(this);
          this.advancements = server.getPlayerList().getPlayerAdvancements(this);
@@ -25,7 +25,7 @@ index 6075e536f09875e577cea7caff70d6a417470254..a9c1aa9e382b0864386030a66158b53d
          this.updateOptions(clientOptions);
          this.object = null;
  
-@@ -627,7 +627,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -628,7 +628,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
                  position = Vec3.atCenterOf(world.getSharedSpawnPos());
              }
              this.setLevel(world);

--- a/patches/server/0340-Prevent-opening-inventories-when-frozen.patch
+++ b/patches/server/0340-Prevent-opening-inventories-when-frozen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent opening inventories when frozen
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index a9c1aa9e382b0864386030a66158b53d12026a00..2d31cd0924ad44534418ec084507c19f49d95f24 100644
+index 9b6887f40dea57d4b5e2f08d7645b1edfaa5b189..d164ae1b965310a260f79240b6e2fd4ddd7249f3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -709,7 +709,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -710,7 +710,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
              containerUpdateDelay = this.level().paperConfig().tickRates.containerUpdate;
          }
          // Paper end - Configurable container update tick rate
@@ -17,7 +17,7 @@ index a9c1aa9e382b0864386030a66158b53d12026a00..2d31cd0924ad44534418ec084507c19f
              this.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.CANT_USE); // Paper - Inventory close reason
              this.containerMenu = this.inventoryMenu;
          }
-@@ -1634,7 +1634,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1635,7 +1635,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
              } else {
                  // CraftBukkit start
                  this.containerMenu = container;

--- a/patches/server/0342-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0342-Implement-Player-Client-Options-API.patch
@@ -87,10 +87,10 @@ index 0000000000000000000000000000000000000000..b6f4400df3d8ec7e06a996de54f8cabb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 2d31cd0924ad44534418ec084507c19f49d95f24..15df50a36138f29ae278cf1f1f531ad949f4a93e 100644
+index d164ae1b965310a260f79240b6e2fd4ddd7249f3..a794131746c6cfdcbeeb64b31fb122a38be085c1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -358,7 +358,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -359,7 +359,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          this.stats = server.getPlayerList().getPlayerStats(this);
          this.advancements = server.getPlayerList().getPlayerAdvancements(this);
          // this.moveTo(this.adjustSpawnLocation(world, world.getSharedSpawnPos()).getBottomCenter(), 0.0F, 0.0F); // Paper - Don't move existing players to world spawn
@@ -99,7 +99,7 @@ index 2d31cd0924ad44534418ec084507c19f49d95f24..15df50a36138f29ae278cf1f1f531ad9
          this.object = null;
  
          // CraftBukkit start
-@@ -2146,7 +2146,23 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2147,7 +2147,23 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          }
      }
  
@@ -123,7 +123,7 @@ index 2d31cd0924ad44534418ec084507c19f49d95f24..15df50a36138f29ae278cf1f1f531ad9
          // CraftBukkit start
          if (this.getMainArm() != clientOptions.mainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), this.getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
-@@ -2157,6 +2173,11 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2158,6 +2174,11 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
              this.server.server.getPluginManager().callEvent(event);
          }
          // CraftBukkit end
@@ -136,7 +136,7 @@ index 2d31cd0924ad44534418ec084507c19f49d95f24..15df50a36138f29ae278cf1f1f531ad9
          this.adventure$locale = java.util.Objects.requireNonNullElse(net.kyori.adventure.translation.Translator.parseLocale(this.language), java.util.Locale.US); // Paper
          this.requestedViewDistance = clientOptions.viewDistance();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 80a9a4df9b1114f932badd847238c7a0a1a00941..a0835efca3bef35c434b716ceccd05c801d2f240 100644
+index d29107105b7bc56b50864777f32420d0c7f379dc..8c61e7a1681cbf4c2fd153d9cba5929bc853235a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -653,6 +653,28 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0344-Fire-PlayerJoinEvent-when-Player-is-actually-ready.patch
+++ b/patches/server/0344-Fire-PlayerJoinEvent-when-Player-is-actually-ready.patch
@@ -43,10 +43,10 @@ index ee3a5b2f2f1591f68bbacea01b8eafed65c29356..bac8e53cab360142f224965e68d8f9e6
              EntityType<?> entitytypes = entity.getType();
              int i = entitytypes.clientTrackingRange() * 16;
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 15df50a36138f29ae278cf1f1f531ad949f4a93e..b43a32989bd9c05f26da97634149350b311ad820 100644
+index a794131746c6cfdcbeeb64b31fb122a38be085c1..f0103bcfb29b9fed41c7642620d78fe75b978b60 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -288,6 +288,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -289,6 +289,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      public double maxHealthCache;
      public boolean joining = true;
      public boolean sentListPacket = false;

--- a/patches/server/0349-Fix-item-duplication-and-teleport-issues.patch
+++ b/patches/server/0349-Fix-item-duplication-and-teleport-issues.patch
@@ -16,7 +16,7 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 61ae5553a22adc84acbe2962632b8f564ed80d88..2c21ef3f9096d1282091a7ec34e57fd74d815353 100644
+index e61c92d4d510eeb93ad0d72f779f6ac9c3a722f1..4134c858dcca7192ad21d325d67e64bba90bb8b8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2516,11 +2516,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -124,10 +124,10 @@ index 92bb0c63330ad3a4cb13b2dc655020714e9b1ffd..cc1189c2d7dc57ba8f29aad4ba5d2a07
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f670ddd3633bf36b653bdf994f459e84e09bfbff..01c16286cf210a366decf7046a6a6b94284f9934 100644
+index 3ba695a29dcf9e7137dae16835e6f7a375d560f7..e0cbef395c479da40dc7079835f0eae1ee122da1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -896,6 +896,11 @@ public class CraftEventFactory {
+@@ -899,6 +899,11 @@ public class CraftEventFactory {
      }
  
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, DamageSource damageSource, List<org.bukkit.inventory.ItemStack> drops) {
@@ -139,7 +139,7 @@ index f670ddd3633bf36b653bdf994f459e84e09bfbff..01c16286cf210a366decf7046a6a6b94
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          CraftDamageSource bukkitDamageSource = new CraftDamageSource(damageSource);
          EntityDeathEvent event = new EntityDeathEvent(entity, bukkitDamageSource, drops, victim.getExpReward(damageSource.getEntity()));
-@@ -910,11 +915,13 @@ public class CraftEventFactory {
+@@ -913,11 +918,13 @@ public class CraftEventFactory {
          playDeathSound(victim, event);
          // Paper end
          victim.expToDrop = event.getDroppedExp();

--- a/patches/server/0350-Villager-Restocks-API.patch
+++ b/patches/server/0350-Villager-Restocks-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Villager Restocks API
 public net.minecraft.world.entity.npc.Villager numberOfRestocksToday
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-index 3b765b9f3b449ef8ff9c82967e4e730a090d4e5d..423f6fcaf49252553d2285308633f13e2427b607 100644
+index 1b97755b42aaa6cc27b79f0b6369955e9a17c4d4..957c9ec21c7a9888b3038402b0111c68f816f968 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-@@ -87,6 +87,18 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
+@@ -89,6 +89,18 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
          this.getHandle().setVillagerXp(experience);
      }
  

--- a/patches/server/0353-misc-debugging-dumps.patch
+++ b/patches/server/0353-misc-debugging-dumps.patch
@@ -105,10 +105,10 @@ index 5457358bc76889153036818fdfd70a043ec4e40f..880e5c52746e9e3a9a1f42ec6461be54
              this.connection.disconnect(ServerConfigurationPacketListenerImpl.DISCONNECT_REASON_INVALID_DATA);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cb6f6762b41ca78ff7c13a65690ce0be1bdac292..093c2159eb9d9603b5e3f0d420769d6b9d872be8 100644
+index 6707e213d9bd2b173928b1e9dae87c403342953b..b36d62380a939a0b777fecf1472645f148289a6c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1039,6 +1039,7 @@ public final class CraftServer implements Server {
+@@ -1047,6 +1047,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getFullName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/patches/server/0355-Implement-Mob-Goal-API.patch
+++ b/patches/server/0355-Implement-Mob-Goal-API.patch
@@ -780,10 +780,10 @@ index 6667ecc4b7eded4e20a415cef1e1b1179e6710b8..16f9a98b8a939e5ca7e2dc04f87134a7
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 093c2159eb9d9603b5e3f0d420769d6b9d872be8..7eaf0f56cbf0695132a029b0a208f283f43e47b5 100644
+index b36d62380a939a0b777fecf1472645f148289a6c..d3cdb5feb1656249fee14885b1f01c1c0b40ab8e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2931,5 +2931,11 @@ public final class CraftServer implements Server {
+@@ -2939,5 +2939,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0356-Add-villager-reputation-API.patch
+++ b/patches/server/0356-Add-villager-reputation-API.patch
@@ -57,10 +57,10 @@ index f06a5f0d9c5c877ddf963254d3124f5fe2d67282..aa32804bc9affe9a615d3ffaa513f6f0
  
      static record GossipEntry(UUID target, GossipType type, int value) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-index 423f6fcaf49252553d2285308633f13e2427b607..00fb708bce2c79817cd9fccadec72f07f0d26317 100644
+index 957c9ec21c7a9888b3038402b0111c68f816f968..52312bec840322d32ea845f0bd64eb3ca1380854 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-@@ -18,6 +18,13 @@ import org.bukkit.entity.Villager;
+@@ -20,6 +20,13 @@ import org.bukkit.entity.Villager;
  import org.bukkit.entity.ZombieVillager;
  import org.bukkit.event.entity.CreatureSpawnEvent;
  
@@ -74,8 +74,8 @@ index 423f6fcaf49252553d2285308633f13e2427b607..00fb708bce2c79817cd9fccadec72f07
  public class CraftVillager extends CraftAbstractVillager implements Villager {
  
      public CraftVillager(CraftServer server, net.minecraft.world.entity.npc.Villager entity) {
-@@ -176,4 +183,45 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
-                     .getOptional(CraftNamespacedKey.toMinecraft(bukkit.getKey())).orElseThrow();
+@@ -298,4 +305,45 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
+             return this.getKey().hashCode();
          }
      }
 +

--- a/patches/server/0357-ExperienceOrb-merging-stacking-API-and-fixes.patch
+++ b/patches/server/0357-ExperienceOrb-merging-stacking-API-and-fixes.patch
@@ -77,10 +77,10 @@ index 5a7d314ec0562e472f5dc45924a7b24841cff126..650e4a01cecc4cc08e7ff9ebcc4c3670
      public java.util.UUID getTriggerEntityId() {
          return getHandle().triggerEntityId;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 01c16286cf210a366decf7046a6a6b94284f9934..baf282b200a14733cf2148f237d972224d60a266 100644
+index e0cbef395c479da40dc7079835f0eae1ee122da1..ec364ab90df6276c1976e876337636f4bb06d097 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -705,15 +705,29 @@ public class CraftEventFactory {
+@@ -708,15 +708,29 @@ public class CraftEventFactory {
          if (entity instanceof net.minecraft.world.entity.ExperienceOrb xp) {
              double radius = world.spigotConfig.expMerge;
              if (radius > 0) {

--- a/patches/server/0360-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0360-Wait-for-Async-Tasks-during-shutdown.patch
@@ -22,10 +22,10 @@ index 1088a91ee131d1c303961557d8fb90101c2d8d3b..2d25ba18d3db4b3eea8bd30812656f1a
          // CraftBukkit end
          if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.shutdown(); // Paper - Plugin remapping
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7eaf0f56cbf0695132a029b0a208f283f43e47b5..118708bd917518333359ce1407e1e26e4ec6a180 100644
+index d3cdb5feb1656249fee14885b1f01c1c0b40ab8e..c2ccd10efd5096b2683fe235de1e8176ee7d2083 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1050,6 +1050,32 @@ public final class CraftServer implements Server {
+@@ -1058,6 +1058,32 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0375-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0375-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -89,10 +89,10 @@ index 01def06cf90faaf67421b6e5a87f4c47dd4c1142..9f28c9f2e8f8323aa374c2ac5e7610b8
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 118708bd917518333359ce1407e1e26e4ec6a180..9e8de1efa2fc42a8ffb3c29579be48a4b5b97fca 100644
+index c2ccd10efd5096b2683fe235de1e8176ee7d2083..ebe69ce183b8bba43ed4d6fdbac09fdc1eaaa988 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -988,8 +988,8 @@ public final class CraftServer implements Server {
+@@ -996,8 +996,8 @@ public final class CraftServer implements Server {
          org.spigotmc.SpigotConfig.init((File) this.console.options.valueOf("spigot-settings")); // Spigot
          this.console.paperConfigurations.reloadConfigs(this.console);
          for (ServerLevel world : this.console.getAllLevels()) {

--- a/patches/server/0378-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0378-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,7 +22,7 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9e8de1efa2fc42a8ffb3c29579be48a4b5b97fca..010ab9cdf3dbe9b89b58744f37b33a232167f445 100644
+index ebe69ce183b8bba43ed4d6fdbac09fdc1eaaa988..8efa537503ec52de17918e2e99d01015df8bf62a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -380,7 +380,7 @@ public final class CraftServer implements Server {
@@ -34,7 +34,7 @@ index 9e8de1efa2fc42a8ffb3c29579be48a4b5b97fca..010ab9cdf3dbe9b89b58744f37b33a23
          this.minimumAPI = ApiVersion.getOrCreateVersion(this.configuration.getString("settings.minimum-api"));
          this.loadIcon();
          this.loadCompatibilities();
-@@ -967,7 +967,7 @@ public final class CraftServer implements Server {
+@@ -975,7 +975,7 @@ public final class CraftServer implements Server {
          this.console.setMotd(config.motd);
          this.overrideSpawnLimits();
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));

--- a/patches/server/0384-Add-PrepareResultEvent.patch
+++ b/patches/server/0384-Add-PrepareResultEvent.patch
@@ -94,10 +94,10 @@ index 04d9793a83c724350f74616558f650082f9805d9..bb29107cb15e2ec644a14cabb3cf91f4
  
      private static SingleRecipeInput createRecipeInput(Container inventory) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index baf282b200a14733cf2148f237d972224d60a266..cd3c0f9672aca19e28aa3e04e0060bf250f122ce 100644
+index ec364ab90df6276c1976e876337636f4bb06d097..3159e52006ad348bfce4905dcb0987222e4894a5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1657,6 +1657,12 @@ public class CraftEventFactory {
+@@ -1666,6 +1666,12 @@ public class CraftEventFactory {
      }
  
      public static PrepareAnvilEvent callPrepareAnvilEvent(InventoryView view, ItemStack item) {
@@ -110,7 +110,7 @@ index baf282b200a14733cf2148f237d972224d60a266..cd3c0f9672aca19e28aa3e04e0060bf2
          PrepareAnvilEvent event = new PrepareAnvilEvent(view, CraftItemStack.asCraftMirror(item).clone());
          event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
          event.getInventory().setItem(2, event.getResult());
-@@ -1664,6 +1670,12 @@ public class CraftEventFactory {
+@@ -1673,6 +1679,12 @@ public class CraftEventFactory {
      }
  
      public static PrepareGrindstoneEvent callPrepareGrindstoneEvent(InventoryView view, ItemStack item) {
@@ -123,7 +123,7 @@ index baf282b200a14733cf2148f237d972224d60a266..cd3c0f9672aca19e28aa3e04e0060bf2
          PrepareGrindstoneEvent event = new PrepareGrindstoneEvent(view, CraftItemStack.asCraftMirror(item).clone());
          event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
          event.getInventory().setItem(2, event.getResult());
-@@ -1671,12 +1683,39 @@ public class CraftEventFactory {
+@@ -1680,12 +1692,39 @@ public class CraftEventFactory {
      }
  
      public static PrepareSmithingEvent callPrepareSmithingEvent(InventoryView view, ItemStack item) {

--- a/patches/server/0394-Brand-support.patch
+++ b/patches/server/0394-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b43a32989bd9c05f26da97634149350b311ad820..16dca5bcb7b1cbecec9be88c60240f3abe43ffdb 100644
+index f0103bcfb29b9fed41c7642620d78fe75b978b60..3a1d0ab6a7513fad7a3e4530e2fbccd9b20f9702 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -293,6 +293,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -294,6 +294,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      // CraftBukkit end
      public boolean isRealPlayer; // Paper
      public com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper - PlayerNaturallySpawnCreaturesEvent
@@ -57,7 +57,7 @@ index 2d1fad00ee084841618f0da8113c7aac8c0e2b0d..a3c67bdc2c08b3550534f37d15b0db90
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a0835efca3bef35c434b716ceccd05c801d2f240..99799563942693ae36188092d76054fdff97d4ca 100644
+index 8c61e7a1681cbf4c2fd153d9cba5929bc853235a..1292e7b9889777448b728ef3bb3ae4cb25d42d61 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -3139,6 +3139,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0401-Add-BellRingEvent.patch
+++ b/patches/server/0401-Add-BellRingEvent.patch
@@ -7,10 +7,10 @@ Add a new event, BellRingEvent, to trigger whenever a player rings a
 village bell. Passes along the bell block and the player who rang it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cd3c0f9672aca19e28aa3e04e0060bf250f122ce..dc7c73f36b7df05ee34e9686c99c44a24acecdcb 100644
+index 3159e52006ad348bfce4905dcb0987222e4894a5..c803948c713fa898430f478dddfb2a75f6d355ef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -369,10 +369,11 @@ public class CraftEventFactory {
+@@ -372,10 +372,11 @@ public class CraftEventFactory {
          return tradeSelectEvent;
      }
  

--- a/patches/server/0407-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0407-Add-methods-to-get-translation-keys.patch
@@ -26,10 +26,10 @@ index f041b5d80bff9c022b007e04ef1558e9116acc6b..a586442422a2b2c06b785af0d261d3e1
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
-index f6ffb81b68e0cf3afebe901a5ba8e305bb94b77a..f2f62667ddf082796011ad7dd025e8855b765c1f 100644
+index 338a8f4acf413ef24fedab60c19c7a51a0ea19a6..2d8a509446c0ed0d7358f10f67ef29c4df683696 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
-@@ -225,4 +225,11 @@ public class CraftBlockType<B extends BlockData> implements BlockType.Typed<B>,
+@@ -234,4 +234,11 @@ public class CraftBlockType<B extends BlockData> implements BlockType.Typed<B>,
      public Material asMaterial() {
          return Registry.MATERIAL.get(this.key);
      }

--- a/patches/server/0427-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0427-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 010ab9cdf3dbe9b89b58744f37b33a232167f445..92e0f1a948962d4c71f1288dfb8b482d3207cf4c 100644
+index 8efa537503ec52de17918e2e99d01015df8bf62a..856de462a5a92d00896b5454244014eae2cdbf24 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1955,6 +1955,28 @@ public final class CraftServer implements Server {
+@@ -1963,6 +1963,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0433-Add-API-for-quit-reason.patch
+++ b/patches/server/0433-Add-API-for-quit-reason.patch
@@ -28,10 +28,10 @@ index 134810ac91d828d67759cd1ed56f11b71e292917..ba41646a5edb57c4d9766df08bbc5701
                          Connection.LOGGER.debug("Failed to sent packet", throwable);
                          if (this.getSending() == PacketFlow.CLIENTBOUND) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 16dca5bcb7b1cbecec9be88c60240f3abe43ffdb..406dc0516f53fdc779fa611637bca304f5cef2f5 100644
+index 3a1d0ab6a7513fad7a3e4530e2fbccd9b20f9702..c973b003ea22a37e841b20ca8b9e2915264820cf 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -294,6 +294,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -295,6 +295,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      public boolean isRealPlayer; // Paper
      public com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper - PlayerNaturallySpawnCreaturesEvent
      public @Nullable String clientBrandName = null; // Paper - Brand support

--- a/patches/server/0449-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/patches/server/0449-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index dc7c73f36b7df05ee34e9686c99c44a24acecdcb..22bfea79a98963d4f1a7ac61fac7b194e929a4f6 100644
+index c803948c713fa898430f478dddfb2a75f6d355ef..21c8dcf66847c83f38b57a592cf3b58a68a5657f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -304,6 +304,10 @@ public class CraftEventFactory {
+@@ -307,6 +307,10 @@ public class CraftEventFactory {
                          return BedEnterResult.TOO_FAR_AWAY;
                      case NOT_SAFE:
                          return BedEnterResult.NOT_SAFE;

--- a/patches/server/0466-Add-BlockFailedDispenseEvent.patch
+++ b/patches/server/0466-Add-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index a1599eae0d8e9f0298fc6996ad03b0d6ba78f04f..083ddfb8fffa04dad6eeca2274f290a0
              } else {
                  ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 22bfea79a98963d4f1a7ac61fac7b194e929a4f6..3ae196422395302a198b507c16347e7051ff5fd1 100644
+index 21c8dcf66847c83f38b57a592cf3b58a68a5657f..19ca8953facd69a5720652c3bcf1e1e3be34a3a3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2077,4 +2077,12 @@ public class CraftEventFactory {
+@@ -2098,4 +2098,12 @@ public class CraftEventFactory {
          return org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getPotion());
      }
      // Paper end - WitchReadyPotionEvent

--- a/patches/server/0474-Add-RegistryAccess-for-managing-Registries.patch
+++ b/patches/server/0474-Add-RegistryAccess-for-managing-Registries.patch
@@ -12,10 +12,10 @@ public net.minecraft.server.RegistryLayer STATIC_ACCESS
 
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1e098dc25bd338ff179491ff3382ac56aad9948e
+index 0000000000000000000000000000000000000000..ead718efde812846fefec3e86d896fef7deb3d97
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-@@ -0,0 +1,133 @@
+@@ -0,0 +1,141 @@
 +package io.papermc.paper.registry;
 +
 +import io.papermc.paper.adventure.PaperAdventure;
@@ -41,6 +41,9 @@ index 0000000000000000000000000000000000000000..1e098dc25bd338ff179491ff3382ac56
 +import org.bukkit.craftbukkit.block.CraftBlockType;
 +import org.bukkit.craftbukkit.damage.CraftDamageType;
 +import org.bukkit.craftbukkit.enchantments.CraftEnchantment;
++import org.bukkit.craftbukkit.entity.CraftCat;
++import org.bukkit.craftbukkit.entity.CraftFrog;
++import org.bukkit.craftbukkit.entity.CraftVillager;
 +import org.bukkit.craftbukkit.entity.CraftWolf;
 +import org.bukkit.craftbukkit.generator.structure.CraftStructure;
 +import org.bukkit.craftbukkit.generator.structure.CraftStructureType;
@@ -48,15 +51,20 @@ index 0000000000000000000000000000000000000000..1e098dc25bd338ff179491ff3382ac56
 +import org.bukkit.craftbukkit.inventory.trim.CraftTrimMaterial;
 +import org.bukkit.craftbukkit.inventory.trim.CraftTrimPattern;
 +import org.bukkit.craftbukkit.legacy.FieldRename;
++import org.bukkit.craftbukkit.map.CraftMapCursor;
 +import org.bukkit.craftbukkit.potion.CraftPotionEffectType;
 +import org.bukkit.craftbukkit.util.CraftNamespacedKey;
 +import org.bukkit.damage.DamageType;
++import org.bukkit.entity.Cat;
++import org.bukkit.entity.Frog;
++import org.bukkit.entity.Villager;
 +import org.bukkit.entity.Wolf;
 +import org.bukkit.entity.memory.MemoryKey;
 +import org.bukkit.generator.structure.StructureType;
 +import org.bukkit.inventory.ItemType;
 +import org.bukkit.inventory.meta.trim.TrimMaterial;
 +import org.bukkit.inventory.meta.trim.TrimPattern;
++import org.bukkit.map.MapCursor;
 +import org.bukkit.potion.PotionEffectType;
 +import org.checkerframework.checker.nullness.qual.NonNull;
 +import org.checkerframework.checker.nullness.qual.Nullable;
@@ -80,6 +88,11 @@ index 0000000000000000000000000000000000000000..1e098dc25bd338ff179491ff3382ac56
 +            entry(Registries.STRUCTURE_TYPE, RegistryKey.STRUCTURE_TYPE, StructureType.class, CraftStructureType::new),
 +            entry(Registries.BLOCK, RegistryKey.BLOCK, BlockType.class, CraftBlockType::new),
 +            entry(Registries.ITEM, RegistryKey.ITEM, ItemType.class, CraftItemType::new),
++            entry(Registries.CAT_VARIANT, RegistryKey.CAT_VARIANT, Cat.Type.class, CraftCat.CraftType::new),
++            entry(Registries.FROG_VARIANT, RegistryKey.FROG_VARIANT, Frog.Variant.class, CraftFrog.CraftVariant::new),
++            entry(Registries.VILLAGER_PROFESSION, RegistryKey.VILLAGER_PROFESSION, Villager.Profession.class, CraftVillager.CraftProfession::new),
++            entry(Registries.VILLAGER_TYPE, RegistryKey.VILLAGER_TYPE, Villager.Type.class, CraftVillager.CraftType::new),
++            entry(Registries.MAP_DECORATION_TYPE, RegistryKey.MAP_DECORATION_TYPE, MapCursor.Type.class, CraftMapCursor.CraftType::new),
 +
 +            // data-drivens
 +            entry(Registries.STRUCTURE, RegistryKey.STRUCTURE, Structure.class, CraftStructure::new).delayed(),
@@ -95,17 +108,12 @@ index 0000000000000000000000000000000000000000..1e098dc25bd338ff179491ff3382ac56
 +            apiOnly(Registries.PAINTING_VARIANT, RegistryKey.PAINTING_VARIANT, () -> org.bukkit.Registry.ART),
 +            apiOnly(Registries.ATTRIBUTE, RegistryKey.ATTRIBUTE, () -> org.bukkit.Registry.ATTRIBUTE),
 +            apiOnly(Registries.BANNER_PATTERN, RegistryKey.BANNER_PATTERN, () -> org.bukkit.Registry.BANNER_PATTERN),
-+            apiOnly(Registries.CAT_VARIANT, RegistryKey.CAT_VARIANT, () -> org.bukkit.Registry.CAT_VARIANT),
 +            apiOnly(Registries.ENTITY_TYPE, RegistryKey.ENTITY_TYPE, () -> org.bukkit.Registry.ENTITY_TYPE),
 +            apiOnly(Registries.PARTICLE_TYPE, RegistryKey.PARTICLE_TYPE, () -> org.bukkit.Registry.PARTICLE_TYPE),
 +            apiOnly(Registries.POTION, RegistryKey.POTION, () -> org.bukkit.Registry.POTION),
 +            apiOnly(Registries.SOUND_EVENT, RegistryKey.SOUND_EVENT, () -> org.bukkit.Registry.SOUNDS),
-+            apiOnly(Registries.VILLAGER_PROFESSION, RegistryKey.VILLAGER_PROFESSION, () -> org.bukkit.Registry.VILLAGER_PROFESSION),
-+            apiOnly(Registries.VILLAGER_TYPE, RegistryKey.VILLAGER_TYPE, () -> org.bukkit.Registry.VILLAGER_TYPE),
 +            apiOnly(Registries.MEMORY_MODULE_TYPE, RegistryKey.MEMORY_MODULE_TYPE, () -> (org.bukkit.Registry<MemoryKey<?>>) (org.bukkit.Registry) org.bukkit.Registry.MEMORY_MODULE_TYPE),
-+            apiOnly(Registries.FLUID, RegistryKey.FLUID, () -> org.bukkit.Registry.FLUID),
-+            apiOnly(Registries.FROG_VARIANT, RegistryKey.FROG_VARIANT, () -> org.bukkit.Registry.FROG_VARIANT),
-+            apiOnly(Registries.MAP_DECORATION_TYPE, RegistryKey.MAP_DECORATION_TYPE, () -> org.bukkit.Registry.MAP_DECORATION_TYPE)
++            apiOnly(Registries.FLUID, RegistryKey.FLUID, () -> org.bukkit.Registry.FLUID)
 +        );
 +        final Map<RegistryKey<?>, RegistryEntry<?, ?>> byRegistryKey = new IdentityHashMap<>(REGISTRY_ENTRIES.size());
 +        final Map<ResourceKey<?>, RegistryEntry<?, ?>> byResourceKey = new IdentityHashMap<>(REGISTRY_ENTRIES.size());
@@ -719,10 +727,10 @@ index 1dd22f11b7e2983a3069dea94c0f02b43ff1f736..397bdacab9517354875ebc0bc68d3505
                  String string = Registries.elementsDirPath(type.registryKey());
                  SimpleJsonResourceReloadListener.scanDirectory(resourceManager, string, GSON, map);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-index d129f7c15c143843429cf8a56fd1e52684531257..f8cf246913040ea4064f8addee0ec6927eb06237 100644
+index 10ce6b9f748b69283e03454e9b1ed0b7df379a17..002449e66f83a419afa8357d2e7192670eaf869e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-@@ -111,60 +111,12 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -118,75 +118,12 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
                  + ", this can happen if a plugin creates its own registry entry with out properly registering it.");
      }
  
@@ -750,7 +758,13 @@ index d129f7c15c143843429cf8a56fd1e52684531257..f8cf246913040ea4064f8addee0ec692
 -            return new CraftRegistry<>(Structure.class, registryHolder.registryOrThrow(Registries.STRUCTURE), CraftStructure::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == StructureType.class) {
--            return new CraftRegistry<>(StructureType.class, BuiltInRegistries.STRUCTURE_TYPE, CraftStructureType::new, FieldRename.NONE);
+-            return new CraftRegistry<>(StructureType.class, registryHolder.registryOrThrow(Registries.STRUCTURE_TYPE), CraftStructureType::new, FieldRename.NONE);
+-        }
+-        if (bukkitClass == Villager.Type.class) {
+-            return new CraftRegistry<>(Villager.Type.class, registryHolder.registryOrThrow(Registries.VILLAGER_TYPE), CraftVillager.CraftType::new, FieldRename.NONE);
+-        }
+-        if (bukkitClass == Villager.Profession.class) {
+-            return new CraftRegistry<>(Villager.Profession.class, registryHolder.registryOrThrow(Registries.VILLAGER_PROFESSION), CraftVillager.CraftProfession::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == TrimMaterial.class) {
 -            return new CraftRegistry<>(TrimMaterial.class, registryHolder.registryOrThrow(Registries.TRIM_MATERIAL), CraftTrimMaterial::new, FieldRename.NONE);
@@ -773,6 +787,15 @@ index d129f7c15c143843429cf8a56fd1e52684531257..f8cf246913040ea4064f8addee0ec692
 -        if (bukkitClass == ItemType.class) {
 -            return new CraftRegistry<>(ItemType.class, registryHolder.registryOrThrow(Registries.ITEM), CraftItemType::new, FieldRename.NONE);
 -        }
+-        if (bukkitClass == Frog.Variant.class) {
+-            return new CraftRegistry<>(Frog.Variant.class, registryHolder.registryOrThrow(Registries.FROG_VARIANT), CraftFrog.CraftVariant::new, FieldRename.NONE);
+-        }
+-        if (bukkitClass == Cat.Type.class) {
+-            return new CraftRegistry<>(Cat.Type.class, registryHolder.registryOrThrow(Registries.CAT_VARIANT), CraftCat.CraftType::new, FieldRename.NONE);
+-        }
+-        if (bukkitClass == MapCursor.Type.class) {
+-            return new CraftRegistry<>(MapCursor.Type.class, registryHolder.registryOrThrow(Registries.MAP_DECORATION_TYPE), CraftMapCursor.CraftType::new, FieldRename.NONE);
+-        }
 -
 -        return null;
 -    }
@@ -786,7 +809,7 @@ index d129f7c15c143843429cf8a56fd1e52684531257..f8cf246913040ea4064f8addee0ec692
          }
  
          if (bukkit instanceof Registry.SimpleRegistry<?> simple) {
-@@ -190,23 +142,21 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -212,23 +149,21 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
          return bukkit.get(namespacedKey);
      }
  
@@ -816,7 +839,7 @@ index d129f7c15c143843429cf8a56fd1e52684531257..f8cf246913040ea4064f8addee0ec692
      @Override
      public B get(NamespacedKey namespacedKey) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 92e0f1a948962d4c71f1288dfb8b482d3207cf4c..24c8e9a43affa8ca99c03562aefc3d6402c23281 100644
+index 856de462a5a92d00896b5454244014eae2cdbf24..10f99b75406176bc11947dde53d94a714d8d28e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -281,7 +281,7 @@ public final class CraftServer implements Server {
@@ -828,7 +851,7 @@ index 92e0f1a948962d4c71f1288dfb8b482d3207cf4c..24c8e9a43affa8ca99c03562aefc3d64
      private YamlConfiguration configuration;
      private YamlConfiguration commandsConfiguration;
      private final Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
-@@ -2721,7 +2721,7 @@ public final class CraftServer implements Server {
+@@ -2729,7 +2729,7 @@ public final class CraftServer implements Server {
  
      @Override
      public <T extends Keyed> Registry<T> getRegistry(Class<T> aClass) {
@@ -838,11 +861,11 @@ index 92e0f1a948962d4c71f1288dfb8b482d3207cf4c..24c8e9a43affa8ca99c03562aefc3d64
  
      @Deprecated
 diff --git a/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java b/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
-index d2eef51fb508a2cfc45ce8e11bb0fe0e89a24b0e..4ce818047911922857a5d5b377aa34ae0dfecba4 100644
+index 1f58b92c17d28e14621e8dc28042a5368f1f4a1f..ef80e6b4dff557daaab1b9fde4d8d40171017e6c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
 +++ b/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
-@@ -56,11 +56,14 @@ public class FieldRename {
-         return Enum.valueOf(enumClass, FieldRename.rename(apiVersion, enumClass.getName().replace('.', '/'), name));
+@@ -51,11 +51,14 @@ public class FieldRename {
+         };
      }
  
 -    @RequireCompatibility("allow-old-keys-in-registry")
@@ -852,11 +875,11 @@ index d2eef51fb508a2cfc45ce8e11bb0fe0e89a24b0e..4ce818047911922857a5d5b377aa34ae
 -    }
 +    // Paper start - absolutely not, having this as an expectation for plugin developers opens a huge
 +    // can of worms in the future, especially if mojang comes back and reuses some old key
-+    // @RequireCompatibility("allow-old-keys-in-registry")
-+    // public static <T extends Keyed> T get(Registry<T> registry, NamespacedKey namespacedKey) {
-+    //     // We don't have version-specific changes, so just use current, and don't inject a version
-+    //     return CraftRegistry.get(registry, namespacedKey, ApiVersion.CURRENT);
-+    // }
++    //@RequireCompatibility("allow-old-keys-in-registry")
++    //public static <T extends Keyed> T get(Registry<T> registry, NamespacedKey namespacedKey) {
++    //    // We don't have version-specific changes, so just use current, and don't inject a version
++    //    return CraftRegistry.get(registry, namespacedKey, ApiVersion.CURRENT);
++    //}
 +    // Paper end
  
      // PatternType
@@ -869,18 +892,17 @@ index 0000000000000000000000000000000000000000..8a083d45004f82fc9c51c219fb20f346
 @@ -0,0 +1 @@
 +io.papermc.paper.registry.PaperRegistryAccess
 diff --git a/src/main/resources/configurations/bukkit.yml b/src/main/resources/configurations/bukkit.yml
-index 6615fffc4cbeee971f2b0f918cb8a9fd1fac2430..eef7c125b2689f29cae5464659eacdf33f5695b2 100644
+index 543e37737bc6fdca23ed9ed0606805d345515a5a..818a1d2e152e45a28aa5b0d1acd0e6dc300d9054 100644
 --- a/src/main/resources/configurations/bukkit.yml
 +++ b/src/main/resources/configurations/bukkit.yml
-@@ -23,8 +23,6 @@ settings:
-     shutdown-message: Server closed
+@@ -24,7 +24,6 @@ settings:
      minimum-api: none
      use-map-color-cache: true
--    compatibility:
+     compatibility:
 -        allow-old-keys-in-registry: false
+         enum-compatibility-mode: false
  spawn-limits:
      monsters: 70
-     animals: 10
 diff --git a/src/test/java/io/papermc/paper/registry/LegacyRegistryIdentifierTest.java b/src/test/java/io/papermc/paper/registry/LegacyRegistryIdentifierTest.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..b9d00e65639521eecd44bd2be3e012264c3785f5
@@ -1084,7 +1106,7 @@ index bfbd80b60ac5df500d03c80de57e38aa7548dd46..cce9e2226ef554c10e1df1dbaa179165
              when(instance.getTag(any(), any(), any())).then(mock -> {
                  String registry = mock.getArgument(0);
 diff --git a/src/test/java/org/bukkit/support/provider/RegistriesArgumentProvider.java b/src/test/java/org/bukkit/support/provider/RegistriesArgumentProvider.java
-index 23819f05563a1d8c9f13335bc9a77964e3f8b7c6..a480944e1fc1b79b91be7e8d3e3799b9168cf5a0 100644
+index b4d2546094a154af8fca2f63d02090ed9cb355a5..38b0e091234a00d57e9e9d4fb3eac6afb7343477 100644
 --- a/src/test/java/org/bukkit/support/provider/RegistriesArgumentProvider.java
 +++ b/src/test/java/org/bukkit/support/provider/RegistriesArgumentProvider.java
 @@ -1,6 +1,7 @@
@@ -1095,7 +1117,7 @@ index 23819f05563a1d8c9f13335bc9a77964e3f8b7c6..a480944e1fc1b79b91be7e8d3e3799b9
  import java.util.List;
  import java.util.stream.Stream;
  import net.minecraft.core.registries.Registries;
-@@ -43,29 +44,29 @@ public class RegistriesArgumentProvider implements ArgumentsProvider {
+@@ -56,34 +57,34 @@ public class RegistriesArgumentProvider implements ArgumentsProvider {
      private static final List<Arguments> DATA = Lists.newArrayList();
  
      static {
@@ -1106,6 +1128,8 @@ index 23819f05563a1d8c9f13335bc9a77964e3f8b7c6..a480944e1fc1b79b91be7e8d3e3799b9
 -        register(PotionEffectType.class, Registries.MOB_EFFECT, CraftPotionEffectType.class, MobEffect.class);
 -        register(Structure.class, Registries.STRUCTURE, CraftStructure.class, net.minecraft.world.level.levelgen.structure.Structure.class);
 -        register(StructureType.class, Registries.STRUCTURE_TYPE, CraftStructureType.class, net.minecraft.world.level.levelgen.structure.StructureType.class);
+-        register(Villager.Type.class, Registries.VILLAGER_TYPE, CraftVillager.CraftType.class, VillagerType.class);
+-        register(Villager.Profession.class, Registries.VILLAGER_PROFESSION, CraftVillager.CraftProfession.class, VillagerProfession.class);
 -        register(TrimMaterial.class, Registries.TRIM_MATERIAL, CraftTrimMaterial.class, net.minecraft.world.item.armortrim.TrimMaterial.class);
 -        register(TrimPattern.class, Registries.TRIM_PATTERN, CraftTrimPattern.class, net.minecraft.world.item.armortrim.TrimPattern.class);
 -        register(DamageType.class, Registries.DAMAGE_TYPE, CraftDamageType.class, net.minecraft.world.damagesource.DamageType.class);
@@ -1113,6 +1137,9 @@ index 23819f05563a1d8c9f13335bc9a77964e3f8b7c6..a480944e1fc1b79b91be7e8d3e3799b9
 -        register(Wolf.Variant.class, Registries.WOLF_VARIANT, CraftWolf.CraftVariant.class, WolfVariant.class);
 -        register(ItemType.class, Registries.ITEM, CraftItemType.class, net.minecraft.world.item.Item.class, true);
 -        register(BlockType.class, Registries.BLOCK, CraftBlockType.class, net.minecraft.world.level.block.Block.class, true);
+-        register(Frog.Variant.class, Registries.FROG_VARIANT, CraftFrog.CraftVariant.class, FrogVariant.class);
+-        register(Cat.Type.class, Registries.CAT_VARIANT, CraftCat.CraftType.class, CatVariant.class);
+-        register(MapCursor.Type.class, Registries.MAP_DECORATION_TYPE, CraftMapCursor.CraftType.class, MapDecorationType.class);
 +        // Order: RegistryKey, Bukkit class, Minecraft Registry key, CraftBukkit class, Minecraft class
 +        register(RegistryKey.ENCHANTMENT, Enchantment.class, Registries.ENCHANTMENT, CraftEnchantment.class, net.minecraft.world.item.enchantment.Enchantment.class);
 +        register(RegistryKey.GAME_EVENT, GameEvent.class, Registries.GAME_EVENT, CraftGameEvent.class, net.minecraft.world.level.gameevent.GameEvent.class);
@@ -1120,6 +1147,8 @@ index 23819f05563a1d8c9f13335bc9a77964e3f8b7c6..a480944e1fc1b79b91be7e8d3e3799b9
 +        register(RegistryKey.MOB_EFFECT, PotionEffectType.class, Registries.MOB_EFFECT, CraftPotionEffectType.class, MobEffect.class);
 +        register(RegistryKey.STRUCTURE, Structure.class, Registries.STRUCTURE, CraftStructure.class, net.minecraft.world.level.levelgen.structure.Structure.class);
 +        register(RegistryKey.STRUCTURE_TYPE, StructureType.class, Registries.STRUCTURE_TYPE, CraftStructureType.class, net.minecraft.world.level.levelgen.structure.StructureType.class);
++        register(RegistryKey.VILLAGER_TYPE, Villager.Type.class, Registries.VILLAGER_TYPE, CraftVillager.CraftType.class, VillagerType.class);
++        register(RegistryKey.VILLAGER_PROFESSION, Villager.Profession.class, Registries.VILLAGER_PROFESSION, CraftVillager.CraftProfession.class, VillagerProfession.class);
 +        register(RegistryKey.TRIM_MATERIAL, TrimMaterial.class, Registries.TRIM_MATERIAL, CraftTrimMaterial.class, net.minecraft.world.item.armortrim.TrimMaterial.class);
 +        register(RegistryKey.TRIM_PATTERN, TrimPattern.class, Registries.TRIM_PATTERN, CraftTrimPattern.class, net.minecraft.world.item.armortrim.TrimPattern.class);
 +        register(RegistryKey.DAMAGE_TYPE, DamageType.class, Registries.DAMAGE_TYPE, CraftDamageType.class, net.minecraft.world.damagesource.DamageType.class);
@@ -1127,6 +1156,9 @@ index 23819f05563a1d8c9f13335bc9a77964e3f8b7c6..a480944e1fc1b79b91be7e8d3e3799b9
 +        register(RegistryKey.WOLF_VARIANT, Wolf.Variant.class, Registries.WOLF_VARIANT, CraftWolf.CraftVariant.class, WolfVariant.class);
 +        register(RegistryKey.ITEM, ItemType.class, Registries.ITEM, CraftItemType.class, net.minecraft.world.item.Item.class, true);
 +        register(RegistryKey.BLOCK, BlockType.class, Registries.BLOCK, CraftBlockType.class, net.minecraft.world.level.block.Block.class, true);
++        register(RegistryKey.FROG_VARIANT, Frog.Variant.class, Registries.FROG_VARIANT, CraftFrog.CraftVariant.class, FrogVariant.class);
++        register(RegistryKey.CAT_VARIANT, Cat.Type.class, Registries.CAT_VARIANT, CraftCat.CraftType.class, CatVariant.class);
++        register(RegistryKey.MAP_DECORATION_TYPE, MapCursor.Type.class, Registries.MAP_DECORATION_TYPE, CraftMapCursor.CraftType.class, MapDecorationType.class);
  
      }
  

--- a/patches/server/0474-Add-RegistryAccess-for-managing-Registries.patch
+++ b/patches/server/0474-Add-RegistryAccess-for-managing-Registries.patch
@@ -839,7 +839,7 @@ index 10ce6b9f748b69283e03454e9b1ed0b7df379a17..002449e66f83a419afa8357d2e719267
      @Override
      public B get(NamespacedKey namespacedKey) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 856de462a5a92d00896b5454244014eae2cdbf24..10f99b75406176bc11947dde53d94a714d8d28e0 100644
+index 856de462a5a92d00896b5454244014eae2cdbf24..a29f4992f7927d0f241962f972dd13ce77094d97 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -281,7 +281,7 @@ public final class CraftServer implements Server {
@@ -851,7 +851,15 @@ index 856de462a5a92d00896b5454244014eae2cdbf24..10f99b75406176bc11947dde53d94a71
      private YamlConfiguration configuration;
      private YamlConfiguration commandsConfiguration;
      private final Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
-@@ -2729,7 +2729,7 @@ public final class CraftServer implements Server {
+@@ -428,6 +428,7 @@ public final class CraftServer implements Server {
+     }
+ 
+     private void loadCompatibilities() {
++        if (true) return; // Paper - Big nope
+         ConfigurationSection compatibilities = this.configuration.getConfigurationSection("settings.compatibility");
+         if (compatibilities == null) {
+             this.activeCompatibilities = Collections.emptySet();
+@@ -2729,7 +2730,7 @@ public final class CraftServer implements Server {
  
      @Override
      public <T extends Keyed> Registry<T> getRegistry(Class<T> aClass) {
@@ -884,6 +892,47 @@ index 1f58b92c17d28e14621e8dc28042a5368f1f4a1f..ef80e6b4dff557daaab1b9fde4d8d401
  
      // PatternType
      private static final FieldRenameData PATTERN_TYPE_DATA = FieldRenameData.Builder.newBuilder()
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
+index eeaa9787c7e04e7155b93aa8d83bd073e8dc209e..07e3ff72a186165734da56cb0a60138b7b77dc5a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
+@@ -189,20 +189,10 @@ public class Commodore {
+ 
+     public static byte[] convert(byte[] b, final String pluginName, final ApiVersion pluginVersion, final Set<String> activeCompatibilities) {
+         final boolean modern = pluginVersion.isNewerThanOrSameAs(ApiVersion.FLATTENING);
+-        final boolean enumCompatibility = pluginVersion.isOlderThanOrSameAs(ApiVersion.getOrCreateVersion("1.20.6")) && activeCompatibilities.contains("enum-compatibility-mode");
+         ClassReader cr = new ClassReader(b);
+         ClassWriter cw = new ClassWriter(0); // TODO 2024-06-22: Open PR to ASM to included interface in handle hash
+ 
+-        List<String> methodEnumSignatures = Commodore.getMethodSignatures(b);
+-        Multimap<String, String> enumLessToEnum = HashMultimap.create();
+-        for (String method : methodEnumSignatures) {
+-            enumLessToEnum.put(method.replace("Ljava/lang/Enum;", "Ljava/lang/Object;"), method);
+-        }
+-
+         ClassVisitor visitor = cw;
+-        if (enumCompatibility) {
+-            visitor = new LimitedClassRemapper(cw, new SimpleRemapper(Commodore.ENUM_RENAMES));
+-        }
+ 
+         cr.accept(new ClassRemapper(new ClassVisitor(Opcodes.ASM9, io.papermc.paper.pluginremap.reflect.ReflectionRemapper.visitor(visitor)) { // Paper
+             final Set<RerouteMethodData> rerouteMethodData = new HashSet<>();
+@@ -268,15 +258,6 @@ public class Commodore {
+ 
+             @Override
+             public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+-                if (enumCompatibility && (access & Opcodes.ACC_SYNTHETIC) != 0 && (access & Opcodes.ACC_BRIDGE) != 0 && desc.contains("Ljava/lang/Object;")) {
+-                    // SPIGOT-7820: Do not use object method if enum method is present
+-                    // The object method does only redirect to the enum method
+-                    Collection<String> result = enumLessToEnum.get(desc.replace("Ljava/lang/Enum;", "Ljava/lang/Object;") + " " + name);
+-                    if (result.size() == 2) {
+-                        name = name + "_BUKKIT_UNUSED";
+-                    }
+-                }
+-
+                 return new MethodVisitor(this.api, super.visitMethod(access, name, desc, signature, exceptions)) {
+                     // Paper start - Plugin rewrites
+                     @Override
 diff --git a/src/main/resources/META-INF/services/io.papermc.paper.registry.RegistryAccess b/src/main/resources/META-INF/services/io.papermc.paper.registry.RegistryAccess
 new file mode 100644
 index 0000000000000000000000000000000000000000..8a083d45004f82fc9c51c219fb20f34624adb501
@@ -892,17 +941,19 @@ index 0000000000000000000000000000000000000000..8a083d45004f82fc9c51c219fb20f346
 @@ -0,0 +1 @@
 +io.papermc.paper.registry.PaperRegistryAccess
 diff --git a/src/main/resources/configurations/bukkit.yml b/src/main/resources/configurations/bukkit.yml
-index 543e37737bc6fdca23ed9ed0606805d345515a5a..818a1d2e152e45a28aa5b0d1acd0e6dc300d9054 100644
+index 543e37737bc6fdca23ed9ed0606805d345515a5a..eef7c125b2689f29cae5464659eacdf33f5695b2 100644
 --- a/src/main/resources/configurations/bukkit.yml
 +++ b/src/main/resources/configurations/bukkit.yml
-@@ -24,7 +24,6 @@ settings:
+@@ -23,9 +23,6 @@ settings:
+     shutdown-message: Server closed
      minimum-api: none
      use-map-color-cache: true
-     compatibility:
+-    compatibility:
 -        allow-old-keys-in-registry: false
-         enum-compatibility-mode: false
+-        enum-compatibility-mode: false
  spawn-limits:
      monsters: 70
+     animals: 10
 diff --git a/src/test/java/io/papermc/paper/registry/LegacyRegistryIdentifierTest.java b/src/test/java/io/papermc/paper/registry/LegacyRegistryIdentifierTest.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..b9d00e65639521eecd44bd2be3e012264c3785f5

--- a/patches/server/0481-Add-BlockPreDispenseEvent.patch
+++ b/patches/server/0481-Add-BlockPreDispenseEvent.patch
@@ -29,10 +29,10 @@ index 083ddfb8fffa04dad6eeca2274f290a08e62b5eb..45fafee2cf1893dccf477939dad05e9e
                      } else {
                          // CraftBukkit start - Fire event when pushing items into other inventories
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 3ae196422395302a198b507c16347e7051ff5fd1..4be2bbf2c7001c8f716c1cd11b7624e9f3cbe79a 100644
+index 19ca8953facd69a5720652c3bcf1e1e3be34a3a3..5c511fe60bf59ca1fe773b8c9c39bc88eebf2752 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2084,5 +2084,11 @@ public class CraftEventFactory {
+@@ -2105,5 +2105,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0485-Expand-EntityUnleashEvent.patch
+++ b/patches/server/0485-Expand-EntityUnleashEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expand EntityUnleashEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index eafd838e2d87103b7c8d9a04144639c3d13381fa..317115dd54252e882575aa04dbfb3f977ba3df60 100644
+index a46b7e09809937b6e09bc3e08760d34f6eb00c4d..e884f37137799c85e5acc410ae5896364884fd4b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2575,12 +2575,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -121,10 +121,10 @@ index 3c0af74ed65610b1d5e3b72fdcf28c5a3423f0da..01173fc7177d78588978e087e63efda0
                              flag1 = true;
                          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4be2bbf2c7001c8f716c1cd11b7624e9f3cbe79a..87c90c401c965ac65fcbe88bf2e1ef85bfd46755 100644
+index 5c511fe60bf59ca1fe773b8c9c39bc88eebf2752..204c6ef33725eee1c582fdbc4e29caface0f27e9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1574,8 +1574,10 @@ public class CraftEventFactory {
+@@ -1583,8 +1583,10 @@ public class CraftEventFactory {
          Bukkit.getPluginManager().callEvent(new PlayerRecipeBookSettingsChangeEvent(player.getBukkitEntity(), bukkitType, open, filter));
      }
  

--- a/patches/server/0486-Reset-shield-blocking-on-dimension-change.patch
+++ b/patches/server/0486-Reset-shield-blocking-on-dimension-change.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset shield blocking on dimension change
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 406dc0516f53fdc779fa611637bca304f5cef2f5..685601f7ae8396524be6acc1b1394a2403ac6163 100644
+index c973b003ea22a37e841b20ca8b9e2915264820cf..433102e21d18bbfc3cba9abf9f9a760a71d2ba74 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1349,6 +1349,11 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1350,6 +1350,11 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
                  PlayerChangedWorldEvent changeEvent = new PlayerChangedWorldEvent(this.getBukkitEntity(), worldserver1.getWorld());
                  this.level().getCraftServer().getPluginManager().callEvent(changeEvent);
                  // CraftBukkit end

--- a/patches/server/0491-Allow-adding-items-to-BlockDropItemEvent.patch
+++ b/patches/server/0491-Allow-adding-items-to-BlockDropItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow adding items to BlockDropItemEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 87c90c401c965ac65fcbe88bf2e1ef85bfd46755..aa03917f96ed17fad53e07fa58225174846333fd 100644
+index 204c6ef33725eee1c582fdbc4e29caface0f27e9..3d64a514b4932bf80953b8e18b0fc9fd14868021 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -453,13 +453,30 @@ public class CraftEventFactory {
+@@ -456,13 +456,30 @@ public class CraftEventFactory {
      }
  
      public static void handleBlockDropItemEvent(Block block, BlockState state, ServerPlayer player, List<ItemEntity> items) {

--- a/patches/server/0504-Expand-world-key-API.patch
+++ b/patches/server/0504-Expand-world-key-API.patch
@@ -20,10 +20,10 @@ index 1963e826548c5a8859c50f57654784c3aef50e44..04a39cb6c13c26e2cb1d73a9da98df5d
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 24c8e9a43affa8ca99c03562aefc3d6402c23281..ec92033fef581e42fb3f36acaba626894b369f56 100644
+index 10f99b75406176bc11947dde53d94a714d8d28e0..e826af8b23b5850f7a9164d088bce936cc082f4a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1172,9 +1172,15 @@ public final class CraftServer implements Server {
+@@ -1180,9 +1180,15 @@ public final class CraftServer implements Server {
          File folder = new File(this.getWorldContainer(), name);
          World world = this.getWorld(name);
  
@@ -41,7 +41,7 @@ index 24c8e9a43affa8ca99c03562aefc3d6402c23281..ec92033fef581e42fb3f36acaba62689
  
          if (folder.exists()) {
              Preconditions.checkArgument(folder.isDirectory(), "File (%s) exists and isn't a folder", name);
-@@ -1300,7 +1306,7 @@ public final class CraftServer implements Server {
+@@ -1308,7 +1314,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -50,7 +50,7 @@ index 24c8e9a43affa8ca99c03562aefc3d6402c23281..ec92033fef581e42fb3f36acaba62689
          }
  
          // If set to not keep spawn in memory (changed from default) then adjust rule accordingly
-@@ -1396,6 +1402,15 @@ public final class CraftServer implements Server {
+@@ -1404,6 +1410,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0504-Expand-world-key-API.patch
+++ b/patches/server/0504-Expand-world-key-API.patch
@@ -20,10 +20,10 @@ index 1963e826548c5a8859c50f57654784c3aef50e44..04a39cb6c13c26e2cb1d73a9da98df5d
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 10f99b75406176bc11947dde53d94a714d8d28e0..e826af8b23b5850f7a9164d088bce936cc082f4a 100644
+index a29f4992f7927d0f241962f972dd13ce77094d97..f83eb7fd5c9b368ba0bf9e07a568d69c6566a5af 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1180,9 +1180,15 @@ public final class CraftServer implements Server {
+@@ -1181,9 +1181,15 @@ public final class CraftServer implements Server {
          File folder = new File(this.getWorldContainer(), name);
          World world = this.getWorld(name);
  
@@ -41,7 +41,7 @@ index 10f99b75406176bc11947dde53d94a714d8d28e0..e826af8b23b5850f7a9164d088bce936
  
          if (folder.exists()) {
              Preconditions.checkArgument(folder.isDirectory(), "File (%s) exists and isn't a folder", name);
-@@ -1308,7 +1314,7 @@ public final class CraftServer implements Server {
+@@ -1309,7 +1315,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -50,7 +50,7 @@ index 10f99b75406176bc11947dde53d94a714d8d28e0..e826af8b23b5850f7a9164d088bce936
          }
  
          // If set to not keep spawn in memory (changed from default) then adjust rule accordingly
-@@ -1404,6 +1410,15 @@ public final class CraftServer implements Server {
+@@ -1405,6 +1411,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0523-Expand-PlayerRespawnEvent-fix-passed-parameter-issue.patch
+++ b/patches/server/0523-Expand-PlayerRespawnEvent-fix-passed-parameter-issue.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand PlayerRespawnEvent, fix passed parameter issues
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 685601f7ae8396524be6acc1b1394a2403ac6163..3e2a623bda0a65b78cdd725feb4581ded6ec07fe 100644
+index 433102e21d18bbfc3cba9abf9f9a760a71d2ba74..6b2c82d80bc673a74ae894f794eb50402b9cc30d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1194,7 +1194,13 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1195,7 +1195,13 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          Player respawnPlayer = this.getBukkitEntity();
          Location location = CraftLocation.toBukkit(dimensionTransition.pos(), dimensionTransition.newLevel().getWorld(), dimensionTransition.yRot(), dimensionTransition.xRot());
  

--- a/patches/server/0533-Add-basic-Datapack-API.patch
+++ b/patches/server/0533-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e826af8b23b5850f7a9164d088bce936cc082f4a..e0bb97be1a1f082ec647f92271b2b7f8071a49f4 100644
+index f83eb7fd5c9b368ba0bf9e07a568d69c6566a5af..691ad3df67ff32528ac18c2927e96c91db25741e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -305,6 +305,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index e826af8b23b5850f7a9164d088bce936cc082f4a..e0bb97be1a1f082ec647f92271b2b7f8
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -3008,5 +3010,11 @@ public final class CraftServer implements Server {
+@@ -3009,5 +3011,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0533-Add-basic-Datapack-API.patch
+++ b/patches/server/0533-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ec92033fef581e42fb3f36acaba626894b369f56..d0eefb53fb88c56d72dea68269bd2b0ce6fd1c1b 100644
+index e826af8b23b5850f7a9164d088bce936cc082f4a..e0bb97be1a1f082ec647f92271b2b7f8071a49f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -305,6 +305,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index ec92033fef581e42fb3f36acaba626894b369f56..d0eefb53fb88c56d72dea68269bd2b0c
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -3000,5 +3002,11 @@ public final class CraftServer implements Server {
+@@ -3008,5 +3010,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0535-Expand-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0535-Expand-PlayerGameModeChangeEvent.patch
@@ -45,10 +45,10 @@ index 7f09119bc7d661e08a960dd2bd46006efe752d3e..d1da3600dc07107309b20ebe6e7c0c4d
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3e2a623bda0a65b78cdd725feb4581ded6ec07fe..9e9ef3c8e7316fc9d35672ff2a4eb1795c333279 100644
+index 6b2c82d80bc673a74ae894f794eb50402b9cc30d..da783ccab230197a4258a2e8509ad893d5417c18 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2084,10 +2084,18 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2085,10 +2085,18 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      }
  
      public boolean setGameMode(GameType gameMode) {
@@ -69,7 +69,7 @@ index 3e2a623bda0a65b78cdd725feb4581ded6ec07fe..9e9ef3c8e7316fc9d35672ff2a4eb179
          } else {
              this.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.CHANGE_GAME_MODE, (float) gameMode.getId()));
              if (gameMode == GameType.SPECTATOR) {
-@@ -2103,7 +2111,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2104,7 +2112,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
              this.onUpdateAbilities();
              this.updateEffectVisibility();
@@ -78,7 +78,7 @@ index 3e2a623bda0a65b78cdd725feb4581ded6ec07fe..9e9ef3c8e7316fc9d35672ff2a4eb179
          }
      }
  
-@@ -2509,6 +2517,16 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2510,6 +2518,16 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      }
  
      public void loadGameTypes(@Nullable CompoundTag nbt) {
@@ -147,7 +147,7 @@ index 699658bd80eb88907041efb01d31e4051edb91de..58e5acbd00c4f8c0fcafa4f2c21b6a9f
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7652da85170cd5a64d1b443430b85c388e2939a9..6aa9a31b2bba086265c0e83c4ea9181540a0a5f6 100644
+index 963ae66acc25602e15134d30d3e496802b17dc41..3f603688b9ad895edc2bfc07093c42bc17a35b19 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1654,7 +1654,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0558-Fix-potions-splash-events.patch
+++ b/patches/server/0558-Fix-potions-splash-events.patch
@@ -143,10 +143,10 @@ index be787a5b52e90796d4f06e17e564f4324807c3e6..cb34cc9443da56c0497c7a0192c8b836
  
      public boolean isLingering() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index aa03917f96ed17fad53e07fa58225174846333fd..b53b457b55d22eae7114cafc85e63e9aa5b0b4b2 100644
+index 3d64a514b4932bf80953b8e18b0fc9fd14868021..be9fc7a0f5b4ad651847a20367cdc82b8f67ff29 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -877,6 +877,32 @@ public class CraftEventFactory {
+@@ -880,6 +880,32 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0560-Fix-PlayerDropItemEvent-using-wrong-item.patch
+++ b/patches/server/0560-Fix-PlayerDropItemEvent-using-wrong-item.patch
@@ -31,10 +31,10 @@ index c81fd3e1108fb0a02f9240263404af2b968c8494..0d9de4c61c7b26a6ff37c12fde629161
              }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 9e9ef3c8e7316fc9d35672ff2a4eb1795c333279..e3b8c14bdf674663152936df4d1469e91545d640 100644
+index da783ccab230197a4258a2e8509ad893d5417c18..38d493b03c02bbfed297b7735590e799d26c07f7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2486,7 +2486,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2487,7 +2487,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
              if (flag1) {
                  if (!itemstack1.isEmpty()) {

--- a/patches/server/0561-Missing-Entity-API.patch
+++ b/patches/server/0561-Missing-Entity-API.patch
@@ -518,11 +518,11 @@ index cfff1be6a4a4936a2dadb2590abc3d33c123d048..3dac93b0ab5d5acf5b33dc4b0efed603
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftCat.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftCat.java
-index 760e8a59fd1a13d3af722bc18999f943a05151fe..a565ac47b3dc9a27e043fc9cb00b6dea950f08cf 100644
+index 57664124968e6268ad6699c6bd932981cc2fe6ba..88e876da7df64b68a5b71fd1deab75b59c5a64e3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftCat.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftCat.java
-@@ -84,4 +84,26 @@ public class CraftCat extends CraftTameableAnimal implements Cat {
-                     + ", this can happen if a plugin creates its own cat variant with out properly registering it.");
+@@ -139,4 +139,26 @@ public class CraftCat extends CraftTameableAnimal implements Cat {
+             return this.getKey().hashCode();
          }
      }
 +

--- a/patches/server/0566-Fix-kick-event-leave-message-not-being-sent.patch
+++ b/patches/server/0566-Fix-kick-event-leave-message-not-being-sent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix kick event leave message not being sent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e3b8c14bdf674663152936df4d1469e91545d640..36dddec9ddb025790577bdb6b6b21d84bb9d1020 100644
+index 38d493b03c02bbfed297b7735590e799d26c07f7..09e72aee16ceb7b300482fbaf28f856d4ed472d3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -289,7 +289,6 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -290,7 +290,6 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      public boolean joining = true;
      public boolean sentListPacket = false;
      public boolean supressTrackerForLogin = false; // Paper - Fire PlayerJoinEvent when Player is actually ready

--- a/patches/server/0567-Don-t-apply-cramming-damage-to-players.patch
+++ b/patches/server/0567-Don-t-apply-cramming-damage-to-players.patch
@@ -11,7 +11,7 @@ It does not make a lot of sense to damage players if they get crammed,
 For those who really want it a config option is provided.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 36dddec9ddb025790577bdb6b6b21d84bb9d1020..bcb5eac701749516928d9772ca906c51ebab9b34 100644
+index 09e72aee16ceb7b300482fbaf28f856d4ed472d3..e9eec0e4e2e533e4ddc7f52a16a1b2b1ce21d6da 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -95,6 +95,7 @@ import net.minecraft.util.Mth;
@@ -22,7 +22,7 @@ index 36dddec9ddb025790577bdb6b6b21d84bb9d1020..bcb5eac701749516928d9772ca906c51
  import net.minecraft.world.effect.MobEffectInstance;
  import net.minecraft.world.effect.MobEffects;
  import net.minecraft.world.entity.Entity;
-@@ -1545,7 +1546,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1546,7 +1547,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
      @Override
      public boolean isInvulnerableTo(DamageSource damageSource) {

--- a/patches/server/0574-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0574-Add-PlayerSetSpawnEvent.patch
@@ -49,10 +49,10 @@ index a2d0699e8427b2262a2396495111125eccafbb66..15db9368227dbc29d07d74e85bd126b3
      }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index bcb5eac701749516928d9772ca906c51ebab9b34..882dae91f9db702edd233f7cab9f95e9874d1270 100644
+index e9eec0e4e2e533e4ddc7f52a16a1b2b1ce21d6da..db4bdce4eae9a91babe95c28cb0f6c96ab5f10df 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1422,7 +1422,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1423,7 +1423,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
              } else if (this.bedBlocked(blockposition, enumdirection)) {
                  return Either.left(net.minecraft.world.entity.player.Player.BedSleepingProblem.OBSTRUCTED);
              } else {
@@ -61,7 +61,7 @@ index bcb5eac701749516928d9772ca906c51ebab9b34..882dae91f9db702edd233f7cab9f95e9
                  if (this.level().isDay()) {
                      return Either.left(net.minecraft.world.entity.player.Player.BedSleepingProblem.NOT_POSSIBLE_NOW);
                  } else {
-@@ -2399,44 +2399,50 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2400,44 +2400,50 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          this.setRespawnPosition(player.getRespawnDimension(), player.getRespawnPosition(), player.getRespawnAngle(), player.isRespawnForced(), false);
      }
  
@@ -145,7 +145,7 @@ index bcb5eac701749516928d9772ca906c51ebab9b34..882dae91f9db702edd233f7cab9f95e9
          } else {
              this.respawnPosition = null;
              this.respawnDimension = Level.OVERWORLD;
-@@ -2444,6 +2450,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -2445,6 +2451,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
              this.respawnForced = false;
          }
  
@@ -187,7 +187,7 @@ index ba22ad1e4253477572d10d71db6db0ebc14d6755..94d067e9eeee73183de25165d8c97043
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8f78f4879dfc46d2214243b927e0cff0257b7692..395d5b5378e122c820fd4632180cf4f859e1f502 100644
+index 6bc3209b6039ed3d33131e1c6bc56a47916be3ee..37f220976b1f1b0a423d7354e6730b6ad8096495 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1413,9 +1413,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0585-Add-missing-team-sidebar-display-slots.patch
+++ b/patches/server/0585-Add-missing-team-sidebar-display-slots.patch
@@ -9,7 +9,7 @@ public org.bukkit.craftbukkit.scoreboard.CraftScoreboardTranslations toBukkitSlo
 public org.bukkit.craftbukkit.scoreboard.CraftScoreboardTranslations fromBukkitSlot(Lorg/bukkit/scoreboard/DisplaySlot;)Lnet/minecraft/world/scores/DisplaySlot;
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java b/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
-index 4ce818047911922857a5d5b377aa34ae0dfecba4..d0ca716aba5706afdd93900d62d95b7ab5073ca6 100644
+index ef80e6b4dff557daaab1b9fde4d8d40171017e6c..271aad69af4db015970aad842a7bb34dcb6bfd0e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
 +++ b/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
 @@ -35,6 +35,7 @@ public class FieldRename {
@@ -20,8 +20,8 @@ index 4ce818047911922857a5d5b377aa34ae0dfecba4..d0ca716aba5706afdd93900d62d95b7a
              case "org/bukkit/block/banner/PatternType" -> FieldRename.convertPatternTypeName(apiVersion, from);
              case "org/bukkit/enchantments/Enchantment" -> FieldRename.convertEnchantmentName(apiVersion, from);
              case "org/bukkit/block/Biome" -> FieldRename.convertBiomeName(apiVersion, from);
-@@ -65,6 +66,16 @@ public class FieldRename {
-     // }
+@@ -60,6 +61,16 @@ public class FieldRename {
+     //}
      // Paper end
  
 +    // Paper start - DisplaySlot

--- a/patches/server/0590-Add-more-advancement-API.patch
+++ b/patches/server/0590-Add-more-advancement-API.patch
@@ -164,10 +164,10 @@ index 8ca86852319d7463f60832bc98b825b0b4325995..62ada73302c6b3ce3fb2dcc8c31a1d9c
  
      private final DisplayInfo handle;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index eeaa9787c7e04e7155b93aa8d83bd073e8dc209e..ca099f7c94d19890eabf3eaf03e93c0383374d1a 100644
+index 07e3ff72a186165734da56cb0a60138b7b77dc5a..376520f5136dca50a3f35a42bd1f19091df36dfd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -452,6 +452,11 @@ public class Commodore {
+@@ -433,6 +433,11 @@ public class Commodore {
                              super.visitMethodInsn(opcode, owner, name, "()Lcom/destroystokyo/paper/profile/PlayerProfile;", itf);
                              return;
                          }

--- a/patches/server/0590-Add-more-advancement-API.patch
+++ b/patches/server/0590-Add-more-advancement-API.patch
@@ -164,10 +164,10 @@ index 8ca86852319d7463f60832bc98b825b0b4325995..62ada73302c6b3ce3fb2dcc8c31a1d9c
  
      private final DisplayInfo handle;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index a2b1197a26eed4df77d7f770e016f522832d8aa2..d125f79d1416ecf58d4b2ec131c43f1007977c0c 100644
+index eeaa9787c7e04e7155b93aa8d83bd073e8dc209e..ca099f7c94d19890eabf3eaf03e93c0383374d1a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -409,6 +409,11 @@ public class Commodore {
+@@ -452,6 +452,11 @@ public class Commodore {
                              super.visitMethodInsn(opcode, owner, name, "()Lcom/destroystokyo/paper/profile/PlayerProfile;", itf);
                              return;
                          }

--- a/patches/server/0591-Add-ItemFactory-getSpawnEgg-API.patch
+++ b/patches/server/0591-Add-ItemFactory-getSpawnEgg-API.patch
@@ -37,10 +37,10 @@ index eabb8b42b890224dd19b879ff276e9908674310d..803a19063c03627dbea79cb1c395ae35
 +    // Paper end - old getSpawnEgg API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index d125f79d1416ecf58d4b2ec131c43f1007977c0c..1e050ef29593233694e0044bedf4c417d876f362 100644
+index ca099f7c94d19890eabf3eaf03e93c0383374d1a..f379ea0f7b42492dd0bf23202e5f417b2981aea9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -416,6 +416,15 @@ public class Commodore {
+@@ -459,6 +459,15 @@ public class Commodore {
                          }
                          // Paper end
  

--- a/patches/server/0591-Add-ItemFactory-getSpawnEgg-API.patch
+++ b/patches/server/0591-Add-ItemFactory-getSpawnEgg-API.patch
@@ -37,10 +37,10 @@ index eabb8b42b890224dd19b879ff276e9908674310d..803a19063c03627dbea79cb1c395ae35
 +    // Paper end - old getSpawnEgg API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index ca099f7c94d19890eabf3eaf03e93c0383374d1a..f379ea0f7b42492dd0bf23202e5f417b2981aea9 100644
+index 376520f5136dca50a3f35a42bd1f19091df36dfd..0103dcc3f34e07c540e7db0f9bf32c358ccef8f2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -459,6 +459,15 @@ public class Commodore {
+@@ -440,6 +440,15 @@ public class Commodore {
                          }
                          // Paper end
  

--- a/patches/server/0592-Add-critical-damage-API.patch
+++ b/patches/server/0592-Add-critical-damage-API.patch
@@ -61,10 +61,10 @@ index 746bb8a36bd6c6ef953289576af499caad588d79..57ebb96707748e90810dc07471f9769f
          int k = entity.getRemainingFireTicks();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b53b457b55d22eae7114cafc85e63e9aa5b0b4b2..ebe547736862b38dd11727124cdd70c7abe7d791 100644
+index be9fc7a0f5b4ad651847a20367cdc82b8f67ff29..76be6bf839bb6aec7f2ab0295a3509fb106a95bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1065,7 +1065,7 @@ public class CraftEventFactory {
+@@ -1074,7 +1074,7 @@ public class CraftEventFactory {
                  return CraftEventFactory.callEntityDamageEvent(source.getDirectBlock(), source.getDirectBlockState(), entity, DamageCause.BLOCK_EXPLOSION, bukkitDamageSource, modifiers, modifierFunctions, cancelled);
              }
              DamageCause damageCause = (damager.getBukkitEntity() instanceof org.bukkit.entity.TNTPrimed) ? DamageCause.BLOCK_EXPLOSION : DamageCause.ENTITY_EXPLOSION;
@@ -73,7 +73,7 @@ index b53b457b55d22eae7114cafc85e63e9aa5b0b4b2..ebe547736862b38dd11727124cdd70c7
          } else if (damager != null || source.getDirectEntity() != null) {
              DamageCause cause = (source.isSweep()) ? DamageCause.ENTITY_SWEEP_ATTACK : DamageCause.ENTITY_ATTACK;
  
-@@ -1091,7 +1091,7 @@ public class CraftEventFactory {
+@@ -1100,7 +1100,7 @@ public class CraftEventFactory {
                  cause = DamageCause.MAGIC;
              }
  
@@ -82,7 +82,7 @@ index b53b457b55d22eae7114cafc85e63e9aa5b0b4b2..ebe547736862b38dd11727124cdd70c7
          } else if (source.is(DamageTypes.FELL_OUT_OF_WORLD)) {
              return CraftEventFactory.callEntityDamageEvent(source.getDirectBlock(), source.getDirectBlockState(), entity, DamageCause.VOID, bukkitDamageSource, modifiers, modifierFunctions, cancelled);
          } else if (source.is(DamageTypes.LAVA)) {
-@@ -1151,13 +1151,13 @@ public class CraftEventFactory {
+@@ -1160,13 +1160,13 @@ public class CraftEventFactory {
              cause = DamageCause.CUSTOM;
          }
  

--- a/patches/server/0594-Add-hasCollision-methods-to-various-places.patch
+++ b/patches/server/0594-Add-hasCollision-methods-to-various-places.patch
@@ -39,10 +39,10 @@ index 1002123cd0c6f57cecc4e80f5f21cc6ff5886d37..e96023b71845526383288917e8d7c575
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
-index f2f62667ddf082796011ad7dd025e8855b765c1f..5d3ce8c8cb02c5a61f011adbecd10ae041cbb99b 100644
+index 2d8a509446c0ed0d7358f10f67ef29c4df683696..785d3fe4929e008d4150f3ecab258fd5b6d7cdaf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
-@@ -232,4 +232,11 @@ public class CraftBlockType<B extends BlockData> implements BlockType.Typed<B>,
+@@ -241,4 +241,11 @@ public class CraftBlockType<B extends BlockData> implements BlockType.Typed<B>,
          return this.block.getDescriptionId();
      }
      // Paper end - add Translatable

--- a/patches/server/0599-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
+++ b/patches/server/0599-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
@@ -28,10 +28,10 @@ index 778d3f3ea2247be5bd6edd382b872f6de5bc359c..de154106419d57a6b6c410fedc29cec1
          }
          // Spigot End
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 882dae91f9db702edd233f7cab9f95e9874d1270..cf765213001c3c642477658b7aac0916e64ad5e4 100644
+index db4bdce4eae9a91babe95c28cb0f6c96ab5f10df..0d5870ef02467d88cfeccf5aa953fcbcdf43117f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1715,6 +1715,18 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1716,6 +1716,18 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          this.connection.send(new ClientboundContainerClosePacket(this.containerMenu.containerId));
          this.doCloseContainer();
      }

--- a/patches/server/0602-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0602-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -278,10 +278,10 @@ index 58ea6a1f95a09c22125a8262b1b221004ebce0e4..ea6533c1ac218aa075da3401807a06fc
          BlockPos blockposition = NaturalSpawner.getRandomPosWithin(world, chunk);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0fc2e453c63b63e12f33cde28ad5afea5657ac57..3c9a9103783495c9015a8cea415620839f140f9c 100644
+index b788be6e8610d8f5ad4c082bcb6d211dbb46ecdd..fb804ddfe3c1927a36da365a7ba8d3826f61305a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2320,6 +2320,11 @@ public final class CraftServer implements Server {
+@@ -2328,6 +2328,11 @@ public final class CraftServer implements Server {
  
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {

--- a/patches/server/0602-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0602-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -278,10 +278,10 @@ index 58ea6a1f95a09c22125a8262b1b221004ebce0e4..ea6533c1ac218aa075da3401807a06fc
          BlockPos blockposition = NaturalSpawner.getRandomPosWithin(world, chunk);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b788be6e8610d8f5ad4c082bcb6d211dbb46ecdd..fb804ddfe3c1927a36da365a7ba8d3826f61305a 100644
+index c57428b235f7bc0444ba0024d05c7c15b5e74fc4..9707b24da58fdc56732d6372038055e8676e9e0d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2328,6 +2328,11 @@ public final class CraftServer implements Server {
+@@ -2329,6 +2329,11 @@ public final class CraftServer implements Server {
  
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {

--- a/patches/server/0618-Ensure-valid-vehicle-status.patch
+++ b/patches/server/0618-Ensure-valid-vehicle-status.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ensure valid vehicle status
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index cf765213001c3c642477658b7aac0916e64ad5e4..780e9ad1ce3434df6366c0a28cae0ce8727cc32f 100644
+index 0d5870ef02467d88cfeccf5aa953fcbcdf43117f..da53f7d65e5625d7aa8b4a17e8c6194ecd0ef4ea 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -573,7 +573,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -574,7 +574,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
              }
          }
  

--- a/patches/server/0621-Don-t-log-debug-logging-being-disabled.patch
+++ b/patches/server/0621-Don-t-log-debug-logging-being-disabled.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't log debug logging being disabled
 
 
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index ba4fcfc86b385c8f50f414d5448edc5e99d2433a..db9c812cf7267adf0bfd8be7368140e91245d640 100644
+index df3eb02bc2b5b8fc20496823055c6adf4512b4f9..0507182aa6d47da9693363f6b0fadd40d06d66b4 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
-@@ -382,7 +382,7 @@ public class SpigotConfig
+@@ -385,7 +385,7 @@ public class SpigotConfig
              Bukkit.getLogger().info( "Debug logging is enabled" );
          } else
          {

--- a/patches/server/0650-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0650-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,10 +18,10 @@ index 6ad7c34513034c87059f8a0790aea3231dd0d2a9..188b1844ca6ee5a97f7a588121255417
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fb804ddfe3c1927a36da365a7ba8d3826f61305a..935feb8a3beb410702e416eb7c4d21d023fbfc2f 100644
+index 9707b24da58fdc56732d6372038055e8676e9e0d..05dbcff299d42dc05e3a8db0265fb607197731e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1305,7 +1305,7 @@ public final class CraftServer implements Server {
+@@ -1306,7 +1306,7 @@ public final class CraftServer implements Server {
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
          LevelStem worlddimension = iregistry.get(actualDimension);
  

--- a/patches/server/0650-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0650-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,10 +18,10 @@ index 6ad7c34513034c87059f8a0790aea3231dd0d2a9..188b1844ca6ee5a97f7a588121255417
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3c9a9103783495c9015a8cea415620839f140f9c..b3c6ecff971cc6fbff463d17f49f090712c6f9bf 100644
+index fb804ddfe3c1927a36da365a7ba8d3826f61305a..935feb8a3beb410702e416eb7c4d21d023fbfc2f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1297,7 +1297,7 @@ public final class CraftServer implements Server {
+@@ -1305,7 +1305,7 @@ public final class CraftServer implements Server {
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
          LevelStem worlddimension = iregistry.get(actualDimension);
  

--- a/patches/server/0662-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0662-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -122,10 +122,10 @@ index 0000000000000000000000000000000000000000..e3a5f1ec376319bdfda87fa27ae217bf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b3c6ecff971cc6fbff463d17f49f090712c6f9bf..551ae9e529727d84722a0b27d3e3dcc121f51767 100644
+index 935feb8a3beb410702e416eb7c4d21d023fbfc2f..df2117fabddeddd923831de4cbef798e330eb0c7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2151,6 +2151,13 @@ public final class CraftServer implements Server {
+@@ -2159,6 +2159,13 @@ public final class CraftServer implements Server {
          return this.console.console;
      }
  

--- a/patches/server/0662-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0662-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -122,10 +122,10 @@ index 0000000000000000000000000000000000000000..e3a5f1ec376319bdfda87fa27ae217bf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 935feb8a3beb410702e416eb7c4d21d023fbfc2f..df2117fabddeddd923831de4cbef798e330eb0c7 100644
+index 05dbcff299d42dc05e3a8db0265fb607197731e7..e56894f16c49085c2de819334f6d0591c0ee8313 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2159,6 +2159,13 @@ public final class CraftServer implements Server {
+@@ -2160,6 +2160,13 @@ public final class CraftServer implements Server {
          return this.console.console;
      }
  

--- a/patches/server/0665-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0665-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 551ae9e529727d84722a0b27d3e3dcc121f51767..1ffef484192ea535482d42909bdb169892058441 100644
+index df2117fabddeddd923831de4cbef798e330eb0c7..1da887485d858df839cd9c04129fec6a0074f695 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2328,6 +2328,8 @@ public final class CraftServer implements Server {
+@@ -2336,6 +2336,8 @@ public final class CraftServer implements Server {
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
          // Paper start - Add mobcaps commands

--- a/patches/server/0665-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0665-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index df2117fabddeddd923831de4cbef798e330eb0c7..1da887485d858df839cd9c04129fec6a0074f695 100644
+index e56894f16c49085c2de819334f6d0591c0ee8313..4baa784788dba2e3bbb83ed59e003d07646abfc5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2336,6 +2336,8 @@ public final class CraftServer implements Server {
+@@ -2337,6 +2337,8 @@ public final class CraftServer implements Server {
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
          // Paper start - Add mobcaps commands

--- a/patches/server/0666-Add-GameEvent-tags.patch
+++ b/patches/server/0666-Add-GameEvent-tags.patch
@@ -46,10 +46,10 @@ index 0000000000000000000000000000000000000000..e7d9fd2702a1ce96596580fff8f5ee4f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1ffef484192ea535482d42909bdb169892058441..bce783d63dc5d1ed9cda135b22bb78aa1be3ea17 100644
+index 1da887485d858df839cd9c04129fec6a0074f695..64e5cbb77db1f510647dc6cf83bac9e641e6f8cf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2677,6 +2677,15 @@ public final class CraftServer implements Server {
+@@ -2685,6 +2685,15 @@ public final class CraftServer implements Server {
                      return (org.bukkit.Tag<T>) new CraftEntityTag(BuiltInRegistries.ENTITY_TYPE, entityTagKey);
                  }
              }
@@ -65,7 +65,7 @@ index 1ffef484192ea535482d42909bdb169892058441..bce783d63dc5d1ed9cda135b22bb78aa
              default -> throw new IllegalArgumentException();
          }
  
-@@ -2709,6 +2718,13 @@ public final class CraftServer implements Server {
+@@ -2717,6 +2726,13 @@ public final class CraftServer implements Server {
                  net.minecraft.core.Registry<EntityType<?>> entityTags = BuiltInRegistries.ENTITY_TYPE;
                  return entityTags.getTags().map(pair -> (org.bukkit.Tag<T>) new CraftEntityTag(entityTags, pair.getFirst())).collect(ImmutableList.toImmutableList());
              }

--- a/patches/server/0666-Add-GameEvent-tags.patch
+++ b/patches/server/0666-Add-GameEvent-tags.patch
@@ -46,10 +46,10 @@ index 0000000000000000000000000000000000000000..e7d9fd2702a1ce96596580fff8f5ee4f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1da887485d858df839cd9c04129fec6a0074f695..64e5cbb77db1f510647dc6cf83bac9e641e6f8cf 100644
+index 4baa784788dba2e3bbb83ed59e003d07646abfc5..2cf3e1082e7d88d5450b44e99becc9db2c14a4d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2685,6 +2685,15 @@ public final class CraftServer implements Server {
+@@ -2686,6 +2686,15 @@ public final class CraftServer implements Server {
                      return (org.bukkit.Tag<T>) new CraftEntityTag(BuiltInRegistries.ENTITY_TYPE, entityTagKey);
                  }
              }
@@ -65,7 +65,7 @@ index 1da887485d858df839cd9c04129fec6a0074f695..64e5cbb77db1f510647dc6cf83bac9e6
              default -> throw new IllegalArgumentException();
          }
  
-@@ -2717,6 +2726,13 @@ public final class CraftServer implements Server {
+@@ -2718,6 +2727,13 @@ public final class CraftServer implements Server {
                  net.minecraft.core.Registry<EntityType<?>> entityTags = BuiltInRegistries.ENTITY_TYPE;
                  return entityTags.getTags().map(pair -> (org.bukkit.Tag<T>) new CraftEntityTag(entityTags, pair.getFirst())).collect(ImmutableList.toImmutableList());
              }

--- a/patches/server/0672-Put-world-into-worldlist-before-initing-the-world.patch
+++ b/patches/server/0672-Put-world-into-worldlist-before-initing-the-world.patch
@@ -23,10 +23,10 @@ index aa1fbbe55e3dc8fd6bbf021806c66686f8de3d9a..04286e907ff14cc8c45dbfc6ab12f520
  
              if (worlddata.getCustomBossEvents() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bce783d63dc5d1ed9cda135b22bb78aa1be3ea17..dace717d426c1af257ea2f7728d5e5b7850ba568 100644
+index 64e5cbb77db1f510647dc6cf83bac9e641e6f8cf..9a0283d028f1e7035c3954449defe80ff62f6e9a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1323,10 +1323,11 @@ public final class CraftServer implements Server {
+@@ -1331,10 +1331,11 @@ public final class CraftServer implements Server {
              return null;
          }
  

--- a/patches/server/0672-Put-world-into-worldlist-before-initing-the-world.patch
+++ b/patches/server/0672-Put-world-into-worldlist-before-initing-the-world.patch
@@ -23,10 +23,10 @@ index aa1fbbe55e3dc8fd6bbf021806c66686f8de3d9a..04286e907ff14cc8c45dbfc6ab12f520
  
              if (worlddata.getCustomBossEvents() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 64e5cbb77db1f510647dc6cf83bac9e641e6f8cf..9a0283d028f1e7035c3954449defe80ff62f6e9a 100644
+index 2cf3e1082e7d88d5450b44e99becc9db2c14a4d4..6f6d4a82c350864a60f084eb341d59cf025cde77 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1331,10 +1331,11 @@ public final class CraftServer implements Server {
+@@ -1332,10 +1332,11 @@ public final class CraftServer implements Server {
              return null;
          }
  

--- a/patches/server/0673-Custom-Potion-Mixes.patch
+++ b/patches/server/0673-Custom-Potion-Mixes.patch
@@ -282,7 +282,7 @@ index c8f9972ad1c2330908cc840d426f29c20b242ca8..a2fafef89d5354e2cb02f56728109099
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dace717d426c1af257ea2f7728d5e5b7850ba568..958d790d48861871784607a8042e9cf4eaf51d5e 100644
+index 9a0283d028f1e7035c3954449defe80ff62f6e9a..f27961e61c797b5a36999949d14ee6f8ae311986 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -308,6 +308,7 @@ public final class CraftServer implements Server {
@@ -301,7 +301,7 @@ index dace717d426c1af257ea2f7728d5e5b7850ba568..958d790d48861871784607a8042e9cf4
          datapackManager = new io.papermc.paper.datapack.PaperDatapackManager(console.getPackRepository()); // Paper
      }
  
-@@ -3040,5 +3042,9 @@ public final class CraftServer implements Server {
+@@ -3048,5 +3050,9 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0673-Custom-Potion-Mixes.patch
+++ b/patches/server/0673-Custom-Potion-Mixes.patch
@@ -282,7 +282,7 @@ index c8f9972ad1c2330908cc840d426f29c20b242ca8..a2fafef89d5354e2cb02f56728109099
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9a0283d028f1e7035c3954449defe80ff62f6e9a..f27961e61c797b5a36999949d14ee6f8ae311986 100644
+index 6f6d4a82c350864a60f084eb341d59cf025cde77..ee6bdc985e8396e873bfd5c1f1d0046e2e830784 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -308,6 +308,7 @@ public final class CraftServer implements Server {
@@ -301,7 +301,7 @@ index 9a0283d028f1e7035c3954449defe80ff62f6e9a..f27961e61c797b5a36999949d14ee6f8
          datapackManager = new io.papermc.paper.datapack.PaperDatapackManager(console.getPackRepository()); // Paper
      }
  
-@@ -3048,5 +3050,9 @@ public final class CraftServer implements Server {
+@@ -3049,5 +3051,9 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0678-More-Projectile-API.patch
+++ b/patches/server/0678-More-Projectile-API.patch
@@ -713,10 +713,10 @@ index e374b9f40eddca13b30855d25a2030f8df98138f..4fc893378fb0568ddcffc7593d66df6b
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ebe547736862b38dd11727124cdd70c7abe7d791..6bed9cce39eacf0f42ee4c6b007d2bdeb632b68f 100644
+index 76be6bf839bb6aec7f2ab0295a3509fb106a95bf..3504b19a3748c64a6c93c86aa0b4a7a140996e06 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -834,19 +834,19 @@ public class CraftEventFactory {
+@@ -837,19 +837,19 @@ public class CraftEventFactory {
      /**
       * PotionSplashEvent
       */
@@ -739,7 +739,7 @@ index ebe547736862b38dd11727124cdd70c7abe7d791..6bed9cce39eacf0f42ee4c6b007d2bde
              hitEntity = ((EntityHitResult) position).getEntity().getBukkitEntity();
          }
  
-@@ -855,20 +855,20 @@ public class CraftEventFactory {
+@@ -858,20 +858,20 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -764,10 +764,10 @@ index ebe547736862b38dd11727124cdd70c7abe7d791..6bed9cce39eacf0f42ee4c6b007d2bde
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 75f9405ee3453620e1561857575cc8700971a865..8468bf6676b7ade3508085f44fac8980a8c6081e 100644
+index e8a455eb5e17bcfcae3f03664f2b47773fbdf37e..08178a88ba7d0881a6c2843eef24a846cf07adb4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -306,12 +306,23 @@ public final class CraftItemStack extends ItemStack {
+@@ -329,12 +329,23 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0684-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0684-Fix-saving-in-unloadWorld.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix saving in unloadWorld
 Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 958d790d48861871784607a8042e9cf4eaf51d5e..52e90dda0b0b2ac476db540243972519ade022f7 100644
+index f27961e61c797b5a36999949d14ee6f8ae311986..adc8d512bd27bb13fa4896f1930aca70fe16607d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1372,7 +1372,7 @@ public final class CraftServer implements Server {
+@@ -1380,7 +1380,7 @@ public final class CraftServer implements Server {
  
          try {
              if (save) {

--- a/patches/server/0684-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0684-Fix-saving-in-unloadWorld.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix saving in unloadWorld
 Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f27961e61c797b5a36999949d14ee6f8ae311986..adc8d512bd27bb13fa4896f1930aca70fe16607d 100644
+index ee6bdc985e8396e873bfd5c1f1d0046e2e830784..d80691928310059ab9d834ebf050c0214fbdd8bc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1380,7 +1380,7 @@ public final class CraftServer implements Server {
+@@ -1381,7 +1381,7 @@ public final class CraftServer implements Server {
  
          try {
              if (save) {

--- a/patches/server/0687-Fix-new-block-data-for-EntityChangeBlockEvent.patch
+++ b/patches/server/0687-Fix-new-block-data-for-EntityChangeBlockEvent.patch
@@ -196,10 +196,10 @@ index edc20745649b0837f1371c8d29e71fc0c8e5528f..932831bb5632ead5850842fc77192c84
              }
              // CraftBukkit end
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 6bed9cce39eacf0f42ee4c6b007d2bdeb632b68f..4d5507e44d755588f18d992eb5f382f5f4fac273 100644
+index 3504b19a3748c64a6c93c86aa0b4a7a140996e06..55eee3a7d922f8c298b4653d733e30edc12005c5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1365,11 +1365,11 @@ public class CraftEventFactory {
+@@ -1374,11 +1374,11 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0688-fix-player-loottables-running-when-mob-loot-gamerule.patch
+++ b/patches/server/0688-fix-player-loottables-running-when-mob-loot-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] fix player loottables running when mob loot gamerule is false
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 780e9ad1ce3434df6366c0a28cae0ce8727cc32f..787bba01f9cfc735c1082c7c90074f0e0807ec07 100644
+index da53f7d65e5625d7aa8b4a17e8c6194ecd0ef4ea..e87c005cf0e82ce56ca99dd40c1dea161faeedda 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -958,12 +958,14 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -959,12 +959,14 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
                  }
              }
          }

--- a/patches/server/0691-Allow-changing-the-EnderDragon-podium.patch
+++ b/patches/server/0691-Allow-changing-the-EnderDragon-podium.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow changing the EnderDragon podium
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 201ef4a3f5bc8633f7a51e151e9e87efc4004cad..45673a7630977e833df84e29e2f0b0012a3ab049 100644
+index a2cde7b1b316e43382cb1639ffccf29d89f5ebfc..6306f7925ac4852d8eed7508a11764c636dd7d36 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -103,6 +103,10 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -104,6 +104,10 @@ public class EnderDragon extends Mob implements Enemy {
      private final int[] nodeAdjacency;
      private final BinaryHeap openSet;
      private final Explosion explosionSource; // CraftBukkit - reusable source for CraftTNTPrimed.getSource()
@@ -19,7 +19,7 @@ index 201ef4a3f5bc8633f7a51e151e9e87efc4004cad..45673a7630977e833df84e29e2f0b001
  
      public EnderDragon(EntityType<? extends EnderDragon> entitytypes, Level world) {
          super(EntityType.ENDER_DRAGON, world);
-@@ -143,6 +147,19 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -144,6 +148,19 @@ public class EnderDragon extends Mob implements Enemy {
          return Mob.createMobAttributes().add(Attributes.MAX_HEALTH, 200.0D);
      }
  
@@ -39,7 +39,7 @@ index 201ef4a3f5bc8633f7a51e151e9e87efc4004cad..45673a7630977e833df84e29e2f0b001
      @Override
      public boolean isFlapping() {
          float f = Mth.cos(this.flapTime * 6.2831855F);
-@@ -1010,7 +1027,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -1009,7 +1026,7 @@ public class EnderDragon extends Mob implements Enemy {
                  d0 = segment2[1] - segment1[1];
              }
          } else {
@@ -48,7 +48,7 @@ index 201ef4a3f5bc8633f7a51e151e9e87efc4004cad..45673a7630977e833df84e29e2f0b001
              double d1 = Math.max(Math.sqrt(blockposition.distToCenterSqr(this.position())) / 4.0D, 1.0D);
  
              d0 = (double) segmentOffset / d1;
-@@ -1037,7 +1054,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -1036,7 +1053,7 @@ public class EnderDragon extends Mob implements Enemy {
                  vec3d = this.getViewVector(tickDelta);
              }
          } else {

--- a/patches/server/0696-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/server/0696-WorldCreator-keepSpawnLoaded.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index adc8d512bd27bb13fa4896f1930aca70fe16607d..7f34f198335cf025fbfa4b647f2cee4a548844f8 100644
+index d80691928310059ab9d834ebf050c0214fbdd8bc..c5f736ad83c0296c3291ad71278598eb00db436c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1323,7 +1323,7 @@ public final class CraftServer implements Server {
+@@ -1324,7 +1324,7 @@ public final class CraftServer implements Server {
          }
  
          // If set to not keep spawn in memory (changed from default) then adjust rule accordingly

--- a/patches/server/0696-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/server/0696-WorldCreator-keepSpawnLoaded.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 52e90dda0b0b2ac476db540243972519ade022f7..5a56e2b05f993dc1333ffb6e280d7bba97e305d7 100644
+index adc8d512bd27bb13fa4896f1930aca70fe16607d..7f34f198335cf025fbfa4b647f2cee4a548844f8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1315,7 +1315,7 @@ public final class CraftServer implements Server {
+@@ -1323,7 +1323,7 @@ public final class CraftServer implements Server {
          }
  
          // If set to not keep spawn in memory (changed from default) then adjust rule accordingly

--- a/patches/server/0699-Add-EntityDyeEvent-and-CollarColorable-interface.patch
+++ b/patches/server/0699-Add-EntityDyeEvent-and-CollarColorable-interface.patch
@@ -23,10 +23,10 @@ index d44807c16712afd37efdbf434d1afb12a7c3d343..2ed442c8d36f285420cf84a956e90b60
                              this.setCollarColor(enumcolor);
                              itemstack.consume(1, player);
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Wolf.java b/src/main/java/net/minecraft/world/entity/animal/Wolf.java
-index 22e37ac785340e2521f69a144a761732ce0a1a3f..31d7beca9797ab1a26792c3e30171a751c3846b1 100644
+index 00b14e588280e1ff2c9a04a415077399602ce95d..22024d79b566ad5d388ceb644605ada3123ca608 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Wolf.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Wolf.java
-@@ -452,6 +452,14 @@ public class Wolf extends TamableAnimal implements NeutralMob, VariantHolder<Hol
+@@ -457,6 +457,14 @@ public class Wolf extends TamableAnimal implements NeutralMob, VariantHolder<Hol
                          DyeColor enumcolor = itemdye.getDyeColor();
  
                          if (enumcolor != this.getCollarColor()) {

--- a/patches/server/0711-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0711-Throw-exception-on-world-create-while-being-ticked.patch
@@ -45,10 +45,10 @@ index 8142e4a238066404f3d1685f9cee1a2b91cdd371..acdba56f025fe729398c5549175baad8
          this.profiler.popPush("connection");
          MinecraftTimings.connectionTimer.startTiming(); // Spigot // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7f34f198335cf025fbfa4b647f2cee4a548844f8..b3c66e7bda1918b8c7592995ee82f6d5b8700829 100644
+index c5f736ad83c0296c3291ad71278598eb00db436c..92f3435fa4f8d37cc75939426a567dab4fa32707 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -915,6 +915,11 @@ public final class CraftServer implements Server {
+@@ -916,6 +916,11 @@ public final class CraftServer implements Server {
          return new ArrayList<World>(this.worlds.values());
      }
  
@@ -60,7 +60,7 @@ index 7f34f198335cf025fbfa4b647f2cee4a548844f8..b3c66e7bda1918b8c7592995ee82f6d5
      public DedicatedPlayerList getHandle() {
          return this.playerList;
      }
-@@ -1177,6 +1182,7 @@ public final class CraftServer implements Server {
+@@ -1178,6 +1183,7 @@ public final class CraftServer implements Server {
      @Override
      public World createWorld(WorldCreator creator) {
          Preconditions.checkState(this.console.getAllLevels().iterator().hasNext(), "Cannot create additional worlds on STARTUP");
@@ -68,7 +68,7 @@ index 7f34f198335cf025fbfa4b647f2cee4a548844f8..b3c66e7bda1918b8c7592995ee82f6d5
          Preconditions.checkArgument(creator != null, "WorldCreator cannot be null");
  
          String name = creator.name();
-@@ -1353,6 +1359,7 @@ public final class CraftServer implements Server {
+@@ -1354,6 +1360,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean unloadWorld(World world, boolean save) {

--- a/patches/server/0711-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0711-Throw-exception-on-world-create-while-being-ticked.patch
@@ -45,10 +45,10 @@ index 8142e4a238066404f3d1685f9cee1a2b91cdd371..acdba56f025fe729398c5549175baad8
          this.profiler.popPush("connection");
          MinecraftTimings.connectionTimer.startTiming(); // Spigot // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5a56e2b05f993dc1333ffb6e280d7bba97e305d7..986bbc91b82d3062ef1bf1542dd264f4154a7ea1 100644
+index 7f34f198335cf025fbfa4b647f2cee4a548844f8..b3c66e7bda1918b8c7592995ee82f6d5b8700829 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -907,6 +907,11 @@ public final class CraftServer implements Server {
+@@ -915,6 +915,11 @@ public final class CraftServer implements Server {
          return new ArrayList<World>(this.worlds.values());
      }
  
@@ -60,7 +60,7 @@ index 5a56e2b05f993dc1333ffb6e280d7bba97e305d7..986bbc91b82d3062ef1bf1542dd264f4
      public DedicatedPlayerList getHandle() {
          return this.playerList;
      }
-@@ -1169,6 +1174,7 @@ public final class CraftServer implements Server {
+@@ -1177,6 +1182,7 @@ public final class CraftServer implements Server {
      @Override
      public World createWorld(WorldCreator creator) {
          Preconditions.checkState(this.console.getAllLevels().iterator().hasNext(), "Cannot create additional worlds on STARTUP");
@@ -68,7 +68,7 @@ index 5a56e2b05f993dc1333ffb6e280d7bba97e305d7..986bbc91b82d3062ef1bf1542dd264f4
          Preconditions.checkArgument(creator != null, "WorldCreator cannot be null");
  
          String name = creator.name();
-@@ -1345,6 +1351,7 @@ public final class CraftServer implements Server {
+@@ -1353,6 +1359,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean unloadWorld(World world, boolean save) {

--- a/patches/server/0714-Add-option-for-strict-advancement-dimension-checks.patch
+++ b/patches/server/0714-Add-option-for-strict-advancement-dimension-checks.patch
@@ -24,10 +24,10 @@ index 01b8f7024fbc965bc6a7f97f79ba3dec964ef769..801823d003a8e28a13fe90db4604cd09
          } else {
              BlockPos blockPos = BlockPos.containing(x, y, z);
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 787bba01f9cfc735c1082c7c90074f0e0807ec07..ff213eefc93a06c40352f8901c33469ba8863fb5 100644
+index e87c005cf0e82ce56ca99dd40c1dea161faeedda..10ad431d66fcf603f672611759fccb1e2e41cffe 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1387,6 +1387,12 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1388,6 +1388,12 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          ResourceKey<Level> maindimensionkey = CraftDimensionUtil.getMainDimensionKey(origin);
          ResourceKey<Level> maindimensionkey1 = CraftDimensionUtil.getMainDimensionKey(this.level());
  

--- a/patches/server/0717-Don-t-broadcast-messages-to-command-blocks.patch
+++ b/patches/server/0717-Don-t-broadcast-messages-to-command-blocks.patch
@@ -20,10 +20,10 @@ index 8c2dcc4134d96351cee75773214f3f47e71533e9..e6bfcc50cdf728216084bc00a5bb8b6b
              Date date = new Date();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b3c66e7bda1918b8c7592995ee82f6d5b8700829..90b1ccea3c1d8c237d6b6167f79f64f9540759e6 100644
+index 92f3435fa4f8d37cc75939426a567dab4fa32707..29f5da02f69717d8cf5bb480473023655c6d2617 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1922,7 +1922,7 @@ public final class CraftServer implements Server {
+@@ -1923,7 +1923,7 @@ public final class CraftServer implements Server {
          // Paper end
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {

--- a/patches/server/0717-Don-t-broadcast-messages-to-command-blocks.patch
+++ b/patches/server/0717-Don-t-broadcast-messages-to-command-blocks.patch
@@ -20,10 +20,10 @@ index 8c2dcc4134d96351cee75773214f3f47e71533e9..e6bfcc50cdf728216084bc00a5bb8b6b
              Date date = new Date();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 986bbc91b82d3062ef1bf1542dd264f4154a7ea1..5e3488c3d318d8728238f0dc1ccde76817ac7716 100644
+index b3c66e7bda1918b8c7592995ee82f6d5b8700829..90b1ccea3c1d8c237d6b6167f79f64f9540759e6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1914,7 +1914,7 @@ public final class CraftServer implements Server {
+@@ -1922,7 +1922,7 @@ public final class CraftServer implements Server {
          // Paper end
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {

--- a/patches/server/0735-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0735-Add-Velocity-IP-Forwarding-Support.patch
@@ -228,10 +228,10 @@ index e9cd90b6bb2f57d605323add43f12962bd7cb843..0fc30ce511f449d2a3ddab28c86f7e38
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5e3488c3d318d8728238f0dc1ccde76817ac7716..32d2e6a4ce092fee061b65d3c839c2da83865908 100644
+index 90b1ccea3c1d8c237d6b6167f79f64f9540759e6..110b5be90b931ecd83f2b5ab15cee46c0090d770 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -836,7 +836,7 @@ public final class CraftServer implements Server {
+@@ -844,7 +844,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0735-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0735-Add-Velocity-IP-Forwarding-Support.patch
@@ -228,10 +228,10 @@ index e9cd90b6bb2f57d605323add43f12962bd7cb843..0fc30ce511f449d2a3ddab28c86f7e38
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 90b1ccea3c1d8c237d6b6167f79f64f9540759e6..110b5be90b931ecd83f2b5ab15cee46c0090d770 100644
+index 29f5da02f69717d8cf5bb480473023655c6d2617..f63d6b4d759fbbc5f5c5dd6b39179af93f49d10f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -844,7 +844,7 @@ public final class CraftServer implements Server {
+@@ -845,7 +845,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0746-Mitigate-effects-of-WorldCreator-keepSpawnLoaded-ret.patch
+++ b/patches/server/0746-Mitigate-effects-of-WorldCreator-keepSpawnLoaded-ret.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Mitigate effects of WorldCreator#keepSpawnLoaded ret type
 TODO: Remove in 1.21?
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 1e050ef29593233694e0044bedf4c417d876f362..7437228d2b3a724769099b6d03cd83d1e47d9c69 100644
+index f379ea0f7b42492dd0bf23202e5f417b2981aea9..42e43dc442e6cbe4b5289523bcf2f2d43e79ed0c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -414,6 +414,12 @@ public class Commodore {
+@@ -457,6 +457,12 @@ public class Commodore {
                              super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, runtimeCbPkgPrefix() + "advancement/CraftAdvancement", "getDisplay0", desc, false);
                              return;
                          }

--- a/patches/server/0746-Mitigate-effects-of-WorldCreator-keepSpawnLoaded-ret.patch
+++ b/patches/server/0746-Mitigate-effects-of-WorldCreator-keepSpawnLoaded-ret.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Mitigate effects of WorldCreator#keepSpawnLoaded ret type
 TODO: Remove in 1.21?
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index f379ea0f7b42492dd0bf23202e5f417b2981aea9..42e43dc442e6cbe4b5289523bcf2f2d43e79ed0c 100644
+index 0103dcc3f34e07c540e7db0f9bf32c358ccef8f2..1c44050735430f7d9b41a95c64c57fc924b0a7bc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -457,6 +457,12 @@ public class Commodore {
+@@ -438,6 +438,12 @@ public class Commodore {
                              super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, runtimeCbPkgPrefix() + "advancement/CraftAdvancement", "getDisplay0", desc, false);
                              return;
                          }

--- a/patches/server/0754-Correctly-handle-interactions-with-items-on-cooldown.patch
+++ b/patches/server/0754-Correctly-handle-interactions-with-items-on-cooldown.patch
@@ -30,10 +30,10 @@ index 03d89f326d320c5d778c3d1e2db7d6b88753faec..717d015dd4637dd9d568b751be1dc104
          this.interactResult = event.useItemInHand() == Event.Result.DENY;
          this.interactPosition = blockposition.immutable();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4d5507e44d755588f18d992eb5f382f5f4fac273..d248977de4babc7921be8a64ce51577d31365933 100644
+index 55eee3a7d922f8c298b4653d733e30edc12005c5..82b98a9b6418614283ac512f59586877f577b35b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -547,6 +547,12 @@ public class CraftEventFactory {
+@@ -550,6 +550,12 @@ public class CraftEventFactory {
      }
  
      public static PlayerInteractEvent callPlayerInteractEvent(net.minecraft.world.entity.player.Player who, Action action, BlockPos position, Direction direction, ItemStack itemstack, boolean cancelledBlock, InteractionHand hand, Vec3 targetPos) {
@@ -46,7 +46,7 @@ index 4d5507e44d755588f18d992eb5f382f5f4fac273..d248977de4babc7921be8a64ce51577d
          Player player = (who == null) ? null : (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
  
-@@ -581,6 +587,11 @@ public class CraftEventFactory {
+@@ -584,6 +590,11 @@ public class CraftEventFactory {
          if (cancelledBlock) {
              event.setUseInteractedBlock(Event.Result.DENY);
          }

--- a/patches/server/0755-Add-PlayerInventorySlotChangeEvent.patch
+++ b/patches/server/0755-Add-PlayerInventorySlotChangeEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerInventorySlotChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ff213eefc93a06c40352f8901c33469ba8863fb5..84e9478c5dc3f0af57739c4ab107ffe9f76a81a9 100644
+index 10ad431d66fcf603f672611759fccb1e2e41cffe..18da22b7f4775e7e5008ab9f78cb6bb0091205c6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -351,6 +351,25 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -352,6 +352,25 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
                  }
              }

--- a/patches/server/0770-More-vanilla-friendly-methods-to-update-trades.patch
+++ b/patches/server/0770-More-vanilla-friendly-methods-to-update-trades.patch
@@ -35,10 +35,10 @@ index 9d5a5a7fff7f75871e167f83edb0e9d5348748d7..393588661c41b490ee6bce2f687962f7
  
      public void gossip(ServerLevel world, Villager villager, long time) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-index 00fb708bce2c79817cd9fccadec72f07f0d26317..6c15d40979fd3e3d246a447c432b321fbf29ada3 100644
+index 52312bec840322d32ea845f0bd64eb3ca1380854..bd2987fa1fb194a581567134ed980e8fc043f435 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-@@ -95,6 +95,34 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
+@@ -97,6 +97,34 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
      }
  
      // Paper start

--- a/patches/server/0778-Sync-offhand-slot-in-menus.patch
+++ b/patches/server/0778-Sync-offhand-slot-in-menus.patch
@@ -8,10 +8,10 @@ offhand slot isn't sent. This is not correct because you *can* put stuff into th
 by pressing the offhand swap item
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 84e9478c5dc3f0af57739c4ab107ffe9f76a81a9..a755d5d8e435e6545ca433ce5c7ea818d5cd6a28 100644
+index 18da22b7f4775e7e5008ab9f78cb6bb0091205c6..7604aef2e03e7d688e7b6504283ed631488ec2d6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -320,6 +320,13 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -321,6 +321,13 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
              }
  

--- a/patches/server/0787-Improve-PortalEvents.patch
+++ b/patches/server/0787-Improve-PortalEvents.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Improve PortalEvents
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f52d394c90bc326c2a58c4f623df632235e0c599..ec386450f9808c724c1b2b97c6e14fc5292caafc 100644
+index fe70fec5d2d422ea9be18e6d5af377f13090ff73..76028662f54175fa95db581a06c04a140e0247b2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3528,7 +3528,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          org.bukkit.entity.Entity bukkitEntity = entity.getBukkitEntity();
          Location enter = bukkitEntity.getLocation();
  
--        EntityPortalEvent event = new EntityPortalEvent(bukkitEntity, enter, exit, searchRadius);
+-        EntityPortalEvent event = new EntityPortalEvent(bukkitEntity, enter, exit, searchRadius, true, creationRadius);
 +        // Paper start
 +        final org.bukkit.PortalType portalType = switch (cause) {
 +            case END_PORTAL -> org.bukkit.PortalType.ENDER;
@@ -20,7 +20,7 @@ index f52d394c90bc326c2a58c4f623df632235e0c599..ec386450f9808c724c1b2b97c6e14fc5
 +            case END_GATEWAY -> org.bukkit.PortalType.END_GATEWAY; // not actually used yet
 +            default -> org.bukkit.PortalType.CUSTOM;
 +        };
-+        EntityPortalEvent event = new EntityPortalEvent(bukkitEntity, enter, exit, searchRadius, portalType);
++        EntityPortalEvent event = new EntityPortalEvent(bukkitEntity, enter, exit, searchRadius, true, creationRadius, portalType);
 +        // Paper end
          event.getEntity().getServer().getPluginManager().callEvent(event);
          if (event.isCancelled() || event.getTo() == null || event.getTo().getWorld() == null || !entity.isAlive()) {

--- a/patches/server/0797-Remove-CraftItemStack-setAmount-null-assignment.patch
+++ b/patches/server/0797-Remove-CraftItemStack-setAmount-null-assignment.patch
@@ -16,10 +16,10 @@ with less than zero amounts, so this code doesn't create
 a problem with operations on the vanilla ItemStack.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 8468bf6676b7ade3508085f44fac8980a8c6081e..c57051b35cb42d986833030655a63b9dff3c29bb 100644
+index 08178a88ba7d0881a6c2843eef24a846cf07adb4..4d29c34e221b749b6972c7ed79ac1f86da999ed7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -163,7 +163,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -186,7 +186,7 @@ public final class CraftItemStack extends ItemStack {
          }
  
          this.handle.setCount(amount);

--- a/patches/server/0801-Add-EntityFertilizeEggEvent.patch
+++ b/patches/server/0801-Add-EntityFertilizeEggEvent.patch
@@ -69,10 +69,10 @@ index d34d8fe70379dcad9540739ec0ae1c94f01fc46b..fadd341ff398886a4da102eefa1beb95
          this.playSound(SoundEvents.SNIFFER_EGG_PLOP, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 0.5F);
          } // Paper - Call EntityDropItemEvent
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d248977de4babc7921be8a64ce51577d31365933..85621246d1e29d678d8ec1b40893ff6650e08e1e 100644
+index 82b98a9b6418614283ac512f59586877f577b35b..b35c6393c3af2519be648e75c7d09038cf94ccbf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2147,4 +2147,28 @@ public class CraftEventFactory {
+@@ -2168,4 +2168,28 @@ public class CraftEventFactory {
          return event.callEvent();
      }
      // Paper end

--- a/patches/server/0821-Expand-PlayerItemMendEvent.patch
+++ b/patches/server/0821-Expand-PlayerItemMendEvent.patch
@@ -30,7 +30,7 @@ index a758b2456acac23095fe4619ae10300a034cb460..a58ff67052fb5f33782f8b5c83465ec0
                  if (l > 0) {
                      // this.value = l; // CraftBukkit - update exp value of orb for PlayerItemMendEvent calls // Paper - the value field should not be mutated here because it doesn't take "count" into account
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 756ba61af10b552c5c0bf86e506a31df0f0ce6f5..b3faca24fa8bdb22d1bf3e581d0396bc444a9f5f 100644
+index 384165d6747c61d0d306fa63773cbca560dfae9b..e7235efba6b68917a646083c150655cb42a738e5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1853,11 +1853,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -49,10 +49,10 @@ index 756ba61af10b552c5c0bf86e506a31df0f0ce6f5..b3faca24fa8bdb22d1bf3e581d0396bc
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 85621246d1e29d678d8ec1b40893ff6650e08e1e..b1c568200fb6870843b8ace4a9b15041980aceeb 100644
+index b35c6393c3af2519be648e75c7d09038cf94ccbf..23e24853e8540cecb2145471d548cad1b2539447 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1271,10 +1271,10 @@ public class CraftEventFactory {
+@@ -1280,10 +1280,10 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0836-Call-missing-BlockDispenseEvent.patch
+++ b/patches/server/0836-Call-missing-BlockDispenseEvent.patch
@@ -50,10 +50,10 @@ index 96db0b1041a4c0f054d4f3f2bdced960b119664e..78951f50188528718cdb3dbbaabe3f9f
                              for (int k = 0; k < 5; ++k) {
                                  worldserver.sendParticles(ParticleTypes.SPLASH, (double) blockposition.getX() + worldserver.random.nextDouble(), (double) (blockposition.getY() + 1), (double) blockposition.getZ() + worldserver.random.nextDouble(), 1, 0.0D, 0.0D, 0.0D, 1.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b1c568200fb6870843b8ace4a9b15041980aceeb..cbb5baae60e682bc250568327737a1b1994ceb76 100644
+index 23e24853e8540cecb2145471d548cad1b2539447..1f73ee4e284ca6b0bd6d387337a4c1084f3210e5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2148,6 +2148,32 @@ public class CraftEventFactory {
+@@ -2169,6 +2169,32 @@ public class CraftEventFactory {
      }
      // Paper end
  

--- a/patches/server/0845-ExperienceOrb-should-call-EntitySpawnEvent.patch
+++ b/patches/server/0845-ExperienceOrb-should-call-EntitySpawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ExperienceOrb should call EntitySpawnEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cbb5baae60e682bc250568327737a1b1994ceb76..01f6d9a3339529bc3a1ec2bacae422b86f1eb253 100644
+index 1f73ee4e284ca6b0bd6d387337a4c1084f3210e5..35afad4e995f7e94d7a4541157b237c73d1b9635 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -737,7 +737,8 @@ public class CraftEventFactory {
+@@ -740,7 +740,8 @@ public class CraftEventFactory {
          // Spigot start - SPIGOT-7523: Merge after spawn event and only merge if the event was not cancelled (gets checked above)
          if (entity instanceof net.minecraft.world.entity.ExperienceOrb xp) {
              double radius = world.spigotConfig.expMerge;

--- a/patches/server/0851-API-for-updating-recipes-on-clients.patch
+++ b/patches/server/0851-API-for-updating-recipes-on-clients.patch
@@ -39,10 +39,10 @@ index de96d7df65713f2fa7b8f2dd068856bb5fa45a45..be6bf7afa3cea4ed48f363e89ccd0790
          Iterator iterator1 = this.players.iterator();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6d373fb254225aa92a10181d8dd21e2dd7fb063a..71d335984d845c95acf5772e8ae773899a429e84 100644
+index a16d07aa45911b6be258db2b94fa2604cd0f7b04..a10d94316104feb3e90c0d27e35f5d8139defd86 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1165,6 +1165,18 @@ public final class CraftServer implements Server {
+@@ -1173,6 +1173,18 @@ public final class CraftServer implements Server {
          ReloadCommand.reload(this.console);
      }
  
@@ -61,7 +61,7 @@ index 6d373fb254225aa92a10181d8dd21e2dd7fb063a..71d335984d845c95acf5772e8ae77389
      private void loadIcon() {
          this.icon = new CraftIconCache(null);
          try {
-@@ -1544,6 +1556,13 @@ public final class CraftServer implements Server {
+@@ -1552,6 +1564,13 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean addRecipe(Recipe recipe) {
@@ -75,7 +75,7 @@ index 6d373fb254225aa92a10181d8dd21e2dd7fb063a..71d335984d845c95acf5772e8ae77389
          CraftRecipe toAdd;
          if (recipe instanceof CraftRecipe) {
              toAdd = (CraftRecipe) recipe;
-@@ -1573,6 +1592,11 @@ public final class CraftServer implements Server {
+@@ -1581,6 +1600,11 @@ public final class CraftServer implements Server {
              }
          }
          toAdd.addToCraftingManager();
@@ -87,7 +87,7 @@ index 6d373fb254225aa92a10181d8dd21e2dd7fb063a..71d335984d845c95acf5772e8ae77389
          return true;
      }
  
-@@ -1753,10 +1777,23 @@ public final class CraftServer implements Server {
+@@ -1761,10 +1785,23 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean removeRecipe(NamespacedKey recipeKey) {

--- a/patches/server/0851-API-for-updating-recipes-on-clients.patch
+++ b/patches/server/0851-API-for-updating-recipes-on-clients.patch
@@ -39,10 +39,10 @@ index de96d7df65713f2fa7b8f2dd068856bb5fa45a45..be6bf7afa3cea4ed48f363e89ccd0790
          Iterator iterator1 = this.players.iterator();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a16d07aa45911b6be258db2b94fa2604cd0f7b04..a10d94316104feb3e90c0d27e35f5d8139defd86 100644
+index 3e78a420ea183f4044873bb1fd89e9b9749032b8..e81ec7b81302ea5eb5fe75117a7aacbb8b88d0a6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1173,6 +1173,18 @@ public final class CraftServer implements Server {
+@@ -1174,6 +1174,18 @@ public final class CraftServer implements Server {
          ReloadCommand.reload(this.console);
      }
  
@@ -61,7 +61,7 @@ index a16d07aa45911b6be258db2b94fa2604cd0f7b04..a10d94316104feb3e90c0d27e35f5d81
      private void loadIcon() {
          this.icon = new CraftIconCache(null);
          try {
-@@ -1552,6 +1564,13 @@ public final class CraftServer implements Server {
+@@ -1553,6 +1565,13 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean addRecipe(Recipe recipe) {
@@ -75,7 +75,7 @@ index a16d07aa45911b6be258db2b94fa2604cd0f7b04..a10d94316104feb3e90c0d27e35f5d81
          CraftRecipe toAdd;
          if (recipe instanceof CraftRecipe) {
              toAdd = (CraftRecipe) recipe;
-@@ -1581,6 +1600,11 @@ public final class CraftServer implements Server {
+@@ -1582,6 +1601,11 @@ public final class CraftServer implements Server {
              }
          }
          toAdd.addToCraftingManager();
@@ -87,7 +87,7 @@ index a16d07aa45911b6be258db2b94fa2604cd0f7b04..a10d94316104feb3e90c0d27e35f5d81
          return true;
      }
  
-@@ -1761,10 +1785,23 @@ public final class CraftServer implements Server {
+@@ -1762,10 +1786,23 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean removeRecipe(NamespacedKey recipeKey) {

--- a/patches/server/0856-Use-correct-seed-on-api-world-load.patch
+++ b/patches/server/0856-Use-correct-seed-on-api-world-load.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use correct seed on api world load
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 71d335984d845c95acf5772e8ae773899a429e84..67a199f022bc9387f7fd69889efec5bad2ed0a5f 100644
+index a10d94316104feb3e90c0d27e35f5d8139defd86..300a2c334e13ab7ab8f071e7f46038d9b67372a6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1387,7 +1387,7 @@ public final class CraftServer implements Server {
+@@ -1395,7 +1395,7 @@ public final class CraftServer implements Server {
              net.minecraft.server.Main.forceUpgrade(worldSession, DataFixers.getDataFixer(), this.console.options.has("eraseCache"), () -> true, iregistrycustom_dimension, this.console.options.has("recreateRegionFiles"));
          }
  

--- a/patches/server/0856-Use-correct-seed-on-api-world-load.patch
+++ b/patches/server/0856-Use-correct-seed-on-api-world-load.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use correct seed on api world load
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a10d94316104feb3e90c0d27e35f5d8139defd86..300a2c334e13ab7ab8f071e7f46038d9b67372a6 100644
+index e81ec7b81302ea5eb5fe75117a7aacbb8b88d0a6..e77a8a77e1b2d5b91083fab6287467fd947092ee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1395,7 +1395,7 @@ public final class CraftServer implements Server {
+@@ -1396,7 +1396,7 @@ public final class CraftServer implements Server {
              net.minecraft.server.Main.forceUpgrade(worldSession, DataFixers.getDataFixer(), this.console.options.has("eraseCache"), () -> true, iregistrycustom_dimension, this.console.options.has("recreateRegionFiles"));
          }
  

--- a/patches/server/0863-Deprecate-and-replace-methods-with-old-StructureType.patch
+++ b/patches/server/0863-Deprecate-and-replace-methods-with-old-StructureType.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deprecate and replace methods with old StructureType
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 300a2c334e13ab7ab8f071e7f46038d9b67372a6..26ad21ddcd3da1558586889288e1e8ce6ae51959 100644
+index e77a8a77e1b2d5b91083fab6287467fd947092ee..7ea2676397025bdbe20f88ec122bd6d545dcf959 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2000,6 +2000,11 @@ public final class CraftServer implements Server {
+@@ -2001,6 +2001,11 @@ public final class CraftServer implements Server {
  
          ServerLevel worldServer = ((CraftWorld) world).getHandle();
          Location structureLocation = world.locateNearestStructure(location, structureType, radius, findUnexplored);
@@ -20,7 +20,7 @@ index 300a2c334e13ab7ab8f071e7f46038d9b67372a6..26ad21ddcd3da1558586889288e1e8ce
          BlockPos structurePosition = CraftLocation.toBlockPosition(structureLocation);
  
          // Create map with trackPlayer = true, unlimitedTracking = true
-@@ -2010,6 +2015,31 @@ public final class CraftServer implements Server {
+@@ -2011,6 +2016,31 @@ public final class CraftServer implements Server {
  
          return CraftItemStack.asBukkitCopy(stack);
      }

--- a/patches/server/0863-Deprecate-and-replace-methods-with-old-StructureType.patch
+++ b/patches/server/0863-Deprecate-and-replace-methods-with-old-StructureType.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deprecate and replace methods with old StructureType
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 67a199f022bc9387f7fd69889efec5bad2ed0a5f..3ca0d01d4d55d0919624356751144985587ddc25 100644
+index 300a2c334e13ab7ab8f071e7f46038d9b67372a6..26ad21ddcd3da1558586889288e1e8ce6ae51959 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1992,6 +1992,11 @@ public final class CraftServer implements Server {
+@@ -2000,6 +2000,11 @@ public final class CraftServer implements Server {
  
          ServerLevel worldServer = ((CraftWorld) world).getHandle();
          Location structureLocation = world.locateNearestStructure(location, structureType, radius, findUnexplored);
@@ -20,7 +20,7 @@ index 67a199f022bc9387f7fd69889efec5bad2ed0a5f..3ca0d01d4d55d0919624356751144985
          BlockPos structurePosition = CraftLocation.toBlockPosition(structureLocation);
  
          // Create map with trackPlayer = true, unlimitedTracking = true
-@@ -2002,6 +2007,31 @@ public final class CraftServer implements Server {
+@@ -2010,6 +2015,31 @@ public final class CraftServer implements Server {
  
          return CraftItemStack.asBukkitCopy(stack);
      }

--- a/patches/server/0866-Fire-entity-death-event-for-ender-dragon.patch
+++ b/patches/server/0866-Fire-entity-death-event-for-ender-dragon.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fire entity death event for ender dragon
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 45673a7630977e833df84e29e2f0b0012a3ab049..4d2fbade3a01ca26ff107f1323ae23db6dad8ef8 100644
+index 6306f7925ac4852d8eed7508a11764c636dd7d36..5868d2e9e05a698c77117cf87c79b636b50fe289 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -658,6 +658,15 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -657,6 +657,15 @@ public class EnderDragon extends Mob implements Enemy {
  
      @Override
      public void kill() {

--- a/patches/server/0870-Add-BlockFace-to-BlockDamageEvent.patch
+++ b/patches/server/0870-Add-BlockFace-to-BlockDamageEvent.patch
@@ -18,10 +18,10 @@ index c680f081ba548f84f07a968a46811090c53e57e3..d839f8df658c894f144ba4637d290ffb
                  if (blockEvent.isCancelled()) {
                      // Let the client know the block still exists
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 01f6d9a3339529bc3a1ec2bacae422b86f1eb253..9f6d459146f502909d262a7178d5b8d5575c563c 100644
+index 35afad4e995f7e94d7a4541157b237c73d1b9635..9d7bcd7a99cfda0776d267bada384304558fa6fe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -652,13 +652,13 @@ public class CraftEventFactory {
+@@ -655,13 +655,13 @@ public class CraftEventFactory {
      /**
       * BlockDamageEvent
       */

--- a/patches/server/0879-Fix-inventory-desync.patch
+++ b/patches/server/0879-Fix-inventory-desync.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix inventory desync
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index a755d5d8e435e6545ca433ce5c7ea818d5cd6a28..2ba005b04577d424128c60bb77ce07fa63b40251 100644
+index 7604aef2e03e7d688e7b6504283ed631488ec2d6..dc4a01f433bab7e8ecf6a156b748a0db784130e5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -399,6 +399,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -400,6 +400,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
  
      // Use method to resend items in hands in case of client desync, because the item use got cancelled.
      // For example, when cancelling the leash event
@@ -17,7 +17,7 @@ index a755d5d8e435e6545ca433ce5c7ea818d5cd6a28..2ba005b04577d424128c60bb77ce07fa
          this.containerMenu.findSlot(this.getInventory(), this.getInventory().selected).ifPresent(s -> {
              this.containerSynchronizer.sendSlotChange(this.containerMenu, s, this.getMainHandItem());
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 80a29f4818cda4255c82fcd47f0da2235a02da23..23442e0f887cec3c3a65b3dd3d0f4f40db0e54b1 100644
+index ea251819e2563b4350d363d23dc7a8674440bf8a..94b2844adeeca9694dafe7ae79d6c751ac06e794 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2639,8 +2639,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess

--- a/patches/server/0880-Add-titleOverride-to-InventoryOpenEvent.patch
+++ b/patches/server/0880-Add-titleOverride-to-InventoryOpenEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add titleOverride to InventoryOpenEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 2ba005b04577d424128c60bb77ce07fa63b40251..2f880e10c73b48c4989c7623ea6cf368f4afb53a 100644
+index dc4a01f433bab7e8ecf6a156b748a0db784130e5..f56fc6bc4da573cd73c72e3c61a96c4f1eebeb94 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1656,12 +1656,17 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1657,12 +1657,17 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
              this.nextContainerCounter();
              AbstractContainerMenu container = factory.createMenu(this.containerCounter, this.getInventory(), this);
  
@@ -27,7 +27,7 @@ index 2ba005b04577d424128c60bb77ce07fa63b40251..2f880e10c73b48c4989c7623ea6cf368
                  if (container == null && !cancelled) { // Let pre-cancelled events fall through
                      // SPIGOT-5263 - close chest if cancelled
                      if (factory instanceof Container) {
-@@ -1683,7 +1688,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -1684,7 +1689,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
              } else {
                  // CraftBukkit start
                  this.containerMenu = container;
@@ -79,10 +79,10 @@ index 12ab8f7cde88cd6ce3ad474fe2843d5d30c3c0d7..c1bad887d1340ebc7c63fda3dceff929
          if (!player.isImmobile()) player.connection.send(new ClientboundOpenScreenPacket(container.containerId, windowType, io.papermc.paper.adventure.PaperAdventure.asVanilla(adventure$title))); // Paper - Prevent opening inventories when frozen
          player.containerMenu = container;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 9f6d459146f502909d262a7178d5b8d5575c563c..e079e8f4078078d737a9d554dbcd2568b1a1f9eb 100644
+index 9d7bcd7a99cfda0776d267bada384304558fa6fe..6ca59ba6a713e452d146182d143b99b07696af8b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1388,10 +1388,21 @@ public class CraftEventFactory {
+@@ -1397,10 +1397,21 @@ public class CraftEventFactory {
      }
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container) {
@@ -105,7 +105,7 @@ index 9f6d459146f502909d262a7178d5b8d5575c563c..e079e8f4078078d737a9d554dbcd2568
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
              player.connection.handleContainerClose(new ServerboundContainerClosePacket(player.containerMenu.containerId), InventoryCloseEvent.Reason.OPEN_NEW); // Paper - Inventory close reason
          }
-@@ -1406,10 +1417,10 @@ public class CraftEventFactory {
+@@ -1415,10 +1426,10 @@ public class CraftEventFactory {
  
          if (event.isCancelled()) {
              container.transferTo(player.containerMenu, craftPlayer);

--- a/patches/server/0886-Allow-proper-checking-of-empty-item-stacks.patch
+++ b/patches/server/0886-Allow-proper-checking-of-empty-item-stacks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow proper checking of empty item stacks
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index c57051b35cb42d986833030655a63b9dff3c29bb..631076ebbf90d0d597ee2fc49f036d1fba34ab51 100644
+index 4d29c34e221b749b6972c7ed79ac1f86da999ed7..c5a09f086d35f84c0a30266f78e06e2dfb5603e6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -39,12 +39,19 @@ public final class CraftItemStack extends ItemStack {
+@@ -40,12 +40,19 @@ public final class CraftItemStack extends ItemStack {
      }
      // Paper end - MC Utils
  

--- a/patches/server/0916-Restore-vanilla-entity-drops-behavior.patch
+++ b/patches/server/0916-Restore-vanilla-entity-drops-behavior.patch
@@ -9,10 +9,10 @@ on dropping the item instead of generalizing it for all dropped
 items like CB does.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 2f880e10c73b48c4989c7623ea6cf368f4afb53a..7f83f40c76eac2ce5b053dc651224c44701613ea 100644
+index f56fc6bc4da573cd73c72e3c61a96c4f1eebeb94..e45567e8112483d947e2ff12c01219b85b09b205 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -975,20 +975,20 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -976,20 +976,20 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
          if (this.isRemoved()) {
              return;
          }
@@ -23,7 +23,7 @@ index 2f880e10c73b48c4989c7623ea6cf368f4afb53a..7f83f40c76eac2ce5b053dc651224c44
          if (!keepInventory) {
              for (ItemStack item : this.getInventory().getContents()) {
                  if (!item.isEmpty() && !EnchantmentHelper.has(item, EnchantmentEffectComponents.PREVENT_EQUIPMENT_DROP)) {
--                    loot.add(CraftItemStack.asCraftMirror(item));
+-                    loot.add(CraftItemStack.asCraftMirror(item).markForInventoryDrop());
 +                    loot.add(new DefaultDrop(item, stack -> this.drop(stack, true, false, false))); // Paper - Restore vanilla drops behavior; drop function taken from Inventory#dropAll (don't fire drop event)
                  }
              }
@@ -37,7 +37,7 @@ index 2f880e10c73b48c4989c7623ea6cf368f4afb53a..7f83f40c76eac2ce5b053dc651224c44
          loot.addAll(this.drops);
          this.drops.clear(); // SPIGOT-5188: make sure to clear
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 24aacf9997c9ea0bd68ef3803f4a3ee4a920ab44..363fe1aff439983199f5137547cef9516fbab2a8 100644
+index c199de89f5a3a54684800a3aa9043c0f2a511c8f..f19522287c55c2439789e37a03a68daaa3b6901f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2563,6 +2563,25 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -152,10 +152,10 @@ index 5bcb9a53ebebeef4bd6ec2458df4b63002ebd804..2f398750bfee5758ad8b1367b6fc1436
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e079e8f4078078d737a9d554dbcd2568b1a1f9eb..1d958323eccd4cf5e369e99e32d2f1dec0959591 100644
+index 6ca59ba6a713e452d146182d143b99b07696af8b..be1fa84dfdec0e31f9e2ca47ad3719dd6678b49c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -966,18 +966,24 @@ public class CraftEventFactory {
+@@ -969,18 +969,24 @@ public class CraftEventFactory {
      }
  
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, DamageSource damageSource) {
@@ -184,7 +184,7 @@ index e079e8f4078078d737a9d554dbcd2568b1a1f9eb..1d958323eccd4cf5e369e99e32d2f1de
          populateFields(victim, event); // Paper - make cancellable
          CraftWorld world = (CraftWorld) entity.getWorld();
          Bukkit.getServer().getPluginManager().callEvent(event);
-@@ -991,20 +997,24 @@ public class CraftEventFactory {
+@@ -994,20 +1000,24 @@ public class CraftEventFactory {
          victim.expToDrop = event.getDroppedExp();
          lootCheck.run(); // Paper - advancement triggers before destroying items
  
@@ -213,7 +213,7 @@ index e079e8f4078078d737a9d554dbcd2568b1a1f9eb..1d958323eccd4cf5e369e99e32d2f1de
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
          populateFields(victim, event); // Paper - make cancellable
-@@ -1022,10 +1032,14 @@ public class CraftEventFactory {
+@@ -1025,16 +1035,14 @@ public class CraftEventFactory {
          victim.expToDrop = event.getDroppedExp();
          victim.newExp = event.getNewExp();
  
@@ -225,8 +225,46 @@ index e079e8f4078078d737a9d554dbcd2568b1a1f9eb..1d958323eccd4cf5e369e99e32d2f1de
 +            // Paper end - Restore vanilla drops behavior
              if (stack == null || stack.getType() == Material.AIR) continue;
  
--            victim.drop(CraftItemStack.asNMSCopy(stack), true, false, false); // SPIGOT-7800, SPIGOT-7801: Vanilla Behaviour for dropped items
+-            if (stack instanceof CraftItemStack craftItemStack && craftItemStack.isForInventoryDrop()) {
+-                victim.drop(CraftItemStack.asNMSCopy(stack), true, false, false); // SPIGOT-7800, SPIGOT-7801: Vanilla Behaviour for Player Inventory dropped items
+-            } else {
+-                victim.forceDrops = true;
+-                victim.spawnAtLocation(CraftItemStack.asNMSCopy(stack)); // SPIGOT-7806: Vanilla Behaviour for items not related to Player Inventory dropped items
+-                victim.forceDrops = false;
+-            }
 +            drop.runConsumer(entity.getWorld(), entity.getLocation()); // Paper - Restore vanilla drops behavior
          }
  
          return event;
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+index c5a09f086d35f84c0a30266f78e06e2dfb5603e6..f33742ee06e8443a5f5adaaa987d7523dc193b5a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+@@ -130,27 +130,6 @@ public final class CraftItemStack extends ItemStack {
+         this.setItemMeta(itemMeta);
+     }
+ 
+-    /**
+-     * Gets if the item is marked as an inventory drop in death events.
+-     *
+-     * @return true if the item is marked as an inventory drop
+-     */
+-    @ApiStatus.Internal
+-    public boolean isForInventoryDrop() {
+-        return this.isForInventoryDrop;
+-    }
+-
+-    /**
+-     * Marks this item as an inventory drop in death events.
+-     *
+-     * @return the ItemStack marked as an inventory drop
+-     */
+-    @ApiStatus.Internal
+-    public ItemStack markForInventoryDrop() {
+-        this.isForInventoryDrop = true;
+-        return this;
+-    }
+-
+     @Override
+     public MaterialData getData() {
+         return this.handle != null ? CraftMagicNumbers.getMaterialData(this.handle.getItem()) : super.getData();

--- a/patches/server/0919-Improve-Registry.patch
+++ b/patches/server/0919-Improve-Registry.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Improve Registry
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-index f8cf246913040ea4064f8addee0ec6927eb06237..334447e222d88bb24676bb154e7057a4147d0f41 100644
+index 002449e66f83a419afa8357d2e7192670eaf869e..b6c7522ff8522cdadf3b291a9c2ac87c60b85d2a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-@@ -144,6 +144,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -151,6 +151,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
  
      private final Class<?> bukkitClass; // Paper - relax preload class
      private final Map<NamespacedKey, B> cache = new HashMap<>();
@@ -16,7 +16,7 @@ index f8cf246913040ea4064f8addee0ec6927eb06237..334447e222d88bb24676bb154e7057a4
      private final net.minecraft.core.Registry<M> minecraftRegistry;
      private final BiFunction<NamespacedKey, M, B> minecraftToBukkit;
      private final BiFunction<NamespacedKey, ApiVersion, NamespacedKey> serializationUpdater; // Paper - rename to make it *clear* what it is *only* for
-@@ -192,6 +193,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -199,6 +200,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
          }
  
          this.cache.put(namespacedKey, bukkit);
@@ -24,7 +24,7 @@ index f8cf246913040ea4064f8addee0ec6927eb06237..334447e222d88bb24676bb154e7057a4
  
          return bukkit;
      }
-@@ -214,4 +216,11 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -221,4 +223,11 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
  
          return this.minecraftToBukkit.apply(namespacedKey, minecraft);
      }

--- a/patches/server/0922-Add-drops-to-shear-events.patch
+++ b/patches/server/0922-Add-drops-to-shear-events.patch
@@ -317,10 +317,10 @@ index dc6230458e09f7555eee7f6a567ff60ad454666b..9d50b9ac8084f3db1844cc7ad1ce9153
      public boolean readyForShearing() {
          return !this.isSheared() && this.isAlive();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 1d958323eccd4cf5e369e99e32d2f1dec0959591..56869e0d001d984c6b73f5a92c60508e2366eb61 100644
+index be1fa84dfdec0e31f9e2ca47ad3719dd6678b49c..d7bf00745a9016d0fe0c1d39ffaaac44276251d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1673,20 +1673,20 @@ public class CraftEventFactory {
+@@ -1676,20 +1676,20 @@ public class CraftEventFactory {
          player.level().getCraftServer().getPluginManager().callEvent(event);
      }
  
@@ -348,10 +348,10 @@ index 1d958323eccd4cf5e369e99e32d2f1dec0959591..56869e0d001d984c6b73f5a92c60508e
  
      public static Cancellable handleStatisticsIncrease(net.minecraft.world.entity.player.Player entityHuman, net.minecraft.stats.Stat<?> statistic, int current, int newValue) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 631076ebbf90d0d597ee2fc49f036d1fba34ab51..206b5fcb259e0f40f35ae42fe8ebcc986c23ee52 100644
+index f33742ee06e8443a5f5adaaa987d7523dc193b5a..a1a32a77bda0560a7b7f30a5d1c1837ee96997d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -68,6 +68,16 @@ public final class CraftItemStack extends ItemStack {
+@@ -69,6 +69,16 @@ public final class CraftItemStack extends ItemStack {
          return stack;
      }
  

--- a/patches/server/0926-Fixup-NamespacedKey-handling.patch
+++ b/patches/server/0926-Fixup-NamespacedKey-handling.patch
@@ -52,10 +52,10 @@ index e34deaf398dc6722c3128bdd6b9bc16da2d33bf7..f028daa4f23a1f1868c9922991259739
  
      public static NamespacedKey minecraftToBukkitKey(ResourceKey<LootTable> minecraft) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-index 334447e222d88bb24676bb154e7057a4147d0f41..d21b7e39d71c785f47f790e1ad4be33a8e8e6e51 100644
+index b6c7522ff8522cdadf3b291a9c2ac87c60b85d2a..fc9aec589414bf8d3f672183928235b5b51d1a02 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-@@ -111,6 +111,16 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -118,6 +118,16 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
                  + ", this can happen if a plugin creates its own registry entry with out properly registering it.");
      }
  

--- a/patches/server/0932-Add-Lifecycle-Event-system.patch
+++ b/patches/server/0932-Add-Lifecycle-Event-system.patch
@@ -719,10 +719,10 @@ index 2e96308696e131f3f013469a395e5ddda2c5d529..65a66e484c1c39c5f41d97db52f31c67
                  } catch (Throwable e) {
                      LOGGER.error("Failed to run bootstrapper for %s. This plugin will not be loaded.".formatted(provider.getSource()), e);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 26ad21ddcd3da1558586889288e1e8ce6ae51959..2583e4cfab78c160d26356719f983128107dda1f 100644
+index 7ea2676397025bdbe20f88ec122bd6d545dcf959..61c19b1005dc387d671fd72331a8774c4c16c7ed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1046,6 +1046,11 @@ public final class CraftServer implements Server {
+@@ -1047,6 +1047,11 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {

--- a/patches/server/0932-Add-Lifecycle-Event-system.patch
+++ b/patches/server/0932-Add-Lifecycle-Event-system.patch
@@ -719,10 +719,10 @@ index 2e96308696e131f3f013469a395e5ddda2c5d529..65a66e484c1c39c5f41d97db52f31c67
                  } catch (Throwable e) {
                      LOGGER.error("Failed to run bootstrapper for %s. This plugin will not be loaded.".formatted(provider.getSource()), e);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3ca0d01d4d55d0919624356751144985587ddc25..4bb633d202eebd679a07ce45f486b301717dbafd 100644
+index 26ad21ddcd3da1558586889288e1e8ce6ae51959..2583e4cfab78c160d26356719f983128107dda1f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1038,6 +1038,11 @@ public final class CraftServer implements Server {
+@@ -1046,6 +1046,11 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {

--- a/patches/server/0937-improve-BanList-types.patch
+++ b/patches/server/0937-improve-BanList-types.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] improve BanList types
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4bb633d202eebd679a07ce45f486b301717dbafd..70b13bab453d50d72c3df9fed06b3956fe2703fe 100644
+index 2583e4cfab78c160d26356719f983128107dda1f..65b89919440c0c901fcfd981a5abe317bae12c10 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2245,6 +2245,21 @@ public final class CraftServer implements Server {
+@@ -2253,6 +2253,21 @@ public final class CraftServer implements Server {
          };
      }
  

--- a/patches/server/0937-improve-BanList-types.patch
+++ b/patches/server/0937-improve-BanList-types.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] improve BanList types
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2583e4cfab78c160d26356719f983128107dda1f..65b89919440c0c901fcfd981a5abe317bae12c10 100644
+index 61c19b1005dc387d671fd72331a8774c4c16c7ed..b72a71d6a37956b0f4ca74c2ed8eaf044cac4b81 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2253,6 +2253,21 @@ public final class CraftServer implements Server {
+@@ -2254,6 +2254,21 @@ public final class CraftServer implements Server {
          };
      }
  

--- a/patches/server/0940-Deprecate-ItemStack-setType.patch
+++ b/patches/server/0940-Deprecate-ItemStack-setType.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deprecate ItemStack#setType
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 206b5fcb259e0f40f35ae42fe8ebcc986c23ee52..19313d94dc89cf2cce6d0e241e4e4e16eccbd395 100644
+index a1a32a77bda0560a7b7f30a5d1c1837ee96997d3..9be7859ccb5283b2040ba68d72d6dbdafb4d6835 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -415,4 +415,24 @@ public final class CraftItemStack extends ItemStack {
+@@ -417,4 +417,24 @@ public final class CraftItemStack extends ItemStack {
      static boolean hasItemMeta(net.minecraft.world.item.ItemStack item) {
          return !(item == null || item.getComponentsPatch().isEmpty());
      }

--- a/patches/server/0948-Fix-DamageSource-API.patch
+++ b/patches/server/0948-Fix-DamageSource-API.patch
@@ -84,7 +84,7 @@ index caf1d79e2bbdd257a5439e2973653747e678805f..e34584e4780f343d6c946af5377088d5
  
      public DamageSource sonicBoom(Entity attacker) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 363fe1aff439983199f5137547cef9516fbab2a8..2e2101274f3afebbae783fa119f5cae8104de45d 100644
+index f19522287c55c2439789e37a03a68daaa3b6901f..550434981bc395a8fba2c5bd6c4359d1dfb4d147 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3263,7 +3263,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -220,10 +220,10 @@ index 4c6e15535fa40aad8cf1920f392589404f9ba79c..35eb95ef6fb6a0f7ea63351e90741c48
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 56869e0d001d984c6b73f5a92c60508e2366eb61..e9a5f06c405fb81609205b6b96cb0a7e49d5589c 100644
+index d7bf00745a9016d0fe0c1d39ffaaac44276251d4..67aa8ebd1c4915fc7f18e3cf263eedf9b671a632 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1085,7 +1085,7 @@ public class CraftEventFactory {
+@@ -1088,7 +1088,7 @@ public class CraftEventFactory {
  
      private static EntityDamageEvent handleEntityDamageEvent(Entity entity, DamageSource source, Map<DamageModifier, Double> modifiers, Map<DamageModifier, Function<? super Double, Double>> modifierFunctions, boolean cancelled) {
          CraftDamageSource bukkitDamageSource = new CraftDamageSource(source);

--- a/patches/server/0964-Fix-helmet-damage-reduction-inconsistencies.patch
+++ b/patches/server/0964-Fix-helmet-damage-reduction-inconsistencies.patch
@@ -7,10 +7,10 @@ Affect the falling stalactite damage type where the
 reduction is not applied like in Vanilla
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e9a5f06c405fb81609205b6b96cb0a7e49d5589c..9c7cd9387f90d061aec76f7f0451a1da8b42ea3d 100644
+index 67aa8ebd1c4915fc7f18e3cf263eedf9b671a632..0ab53d46f0b8f3f3791dd01766738522c86932e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1219,7 +1219,7 @@ public class CraftEventFactory {
+@@ -1222,7 +1222,7 @@ public class CraftEventFactory {
              modifiers.put(DamageModifier.FREEZING, freezingModifier);
              modifierFunctions.put(DamageModifier.FREEZING, freezing);
          }

--- a/patches/server/0966-improve-checking-handled-tags-in-itemmeta.patch
+++ b/patches/server/0966-improve-checking-handled-tags-in-itemmeta.patch
@@ -154,10 +154,10 @@ index a6c78854c10362864c2297de903ab9594cdb1eb6..251aac8690f15be2ad0e3f6399676205
  
      // We use if instead of a set, since the result gets cached in CraftItemType,
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 19313d94dc89cf2cce6d0e241e4e4e16eccbd395..25096ca7b30483fc9549502caf8b989506405457 100644
+index 9be7859ccb5283b2040ba68d72d6dbdafb4d6835..6a449bfc765bf427d82df4a90bc60471b5de2fd3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -159,10 +159,11 @@ public final class CraftItemStack extends ItemStack {
+@@ -161,10 +161,11 @@ public final class CraftItemStack extends ItemStack {
          } else if (this.handle == null) {
              this.handle = new net.minecraft.world.item.ItemStack(CraftItemType.bukkitToMinecraft(type), 1);
          } else {
@@ -170,7 +170,7 @@ index 19313d94dc89cf2cce6d0e241e4e4e16eccbd395..25096ca7b30483fc9549502caf8b9895
              }
          }
          this.setData(null);
-@@ -323,6 +324,19 @@ public final class CraftItemStack extends ItemStack {
+@@ -325,6 +326,19 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }
@@ -190,7 +190,7 @@ index 19313d94dc89cf2cce6d0e241e4e4e16eccbd395..25096ca7b30483fc9549502caf8b9895
      // Paper start
      public static void applyMetaToItem(net.minecraft.world.item.ItemStack itemStack, ItemMeta itemMeta) {
          final CraftMetaItem.Applicator tag = new CraftMetaItem.Applicator();
-@@ -335,12 +349,17 @@ public final class CraftItemStack extends ItemStack {
+@@ -337,12 +351,17 @@ public final class CraftItemStack extends ItemStack {
      }
      public static ItemMeta getItemMeta(net.minecraft.world.item.ItemStack item, org.bukkit.inventory.ItemType metaForType) {
          // Paper end

--- a/patches/server/0967-General-ItemMeta-fixes.patch
+++ b/patches/server/0967-General-ItemMeta-fixes.patch
@@ -68,10 +68,10 @@ index e28bc898786542f695017ff0a036676840eb79fe..cee3fe00cc662f095e7d726b5f1a913c
      protected void load(T tileEntity) {
          if (tileEntity != null && tileEntity != this.snapshot) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 25096ca7b30483fc9549502caf8b989506405457..369d43f911289b670dcef3b7af3dce73273d95ab 100644
+index 6a449bfc765bf427d82df4a90bc60471b5de2fd3..033918e051ef44de82a74097380cacaf926e5408 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -339,7 +339,14 @@ public final class CraftItemStack extends ItemStack {
+@@ -341,7 +341,14 @@ public final class CraftItemStack extends ItemStack {
      // Paper end - improve handled tags on type change
      // Paper start
      public static void applyMetaToItem(net.minecraft.world.item.ItemStack itemStack, ItemMeta itemMeta) {
@@ -87,7 +87,7 @@ index 25096ca7b30483fc9549502caf8b989506405457..369d43f911289b670dcef3b7af3dce73
          ((CraftMetaItem) itemMeta).applyToItem(tag);
          itemStack.applyComponents(tag.build());
      }
-@@ -387,15 +394,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -389,15 +396,20 @@ public final class CraftItemStack extends ItemStack {
          if (itemMeta == null) return true;
  
          if (!((CraftMetaItem) itemMeta).isEmpty()) {

--- a/patches/server/0972-Brigadier-based-command-API.patch
+++ b/patches/server/0972-Brigadier-based-command-API.patch
@@ -2378,7 +2378,7 @@ index 134f31cce8d8eca669948a784e2766216fb91ab5..60c65af218d533d53b765ba2175fed16
      // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 70b13bab453d50d72c3df9fed06b3956fe2703fe..2f7119ca17cf0df445c0c34804e40acb209a5b0d 100644
+index 65b89919440c0c901fcfd981a5abe317bae12c10..d8edc950000002f048c09d3d6582af1ffb314dde 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -272,11 +272,11 @@ public final class CraftServer implements Server {
@@ -2409,7 +2409,7 @@ index 70b13bab453d50d72c3df9fed06b3956fe2703fe..2f7119ca17cf0df445c0c34804e40acb
  
          CraftRegistry.setMinecraftRegistry(console.registryAccess());
  
-@@ -593,48 +599,11 @@ public final class CraftServer implements Server {
+@@ -601,48 +607,11 @@ public final class CraftServer implements Server {
      }
  
      private void setVanillaCommands(boolean first) { // Spigot
@@ -2460,7 +2460,7 @@ index 70b13bab453d50d72c3df9fed06b3956fe2703fe..2f7119ca17cf0df445c0c34804e40acb
  
          // Refresh commands
          for (ServerPlayer player : this.getHandle().players) {
-@@ -1021,17 +990,31 @@ public final class CraftServer implements Server {
+@@ -1029,17 +998,31 @@ public final class CraftServer implements Server {
              return true;
          }
  
@@ -2502,7 +2502,7 @@ index 70b13bab453d50d72c3df9fed06b3956fe2703fe..2f7119ca17cf0df445c0c34804e40acb
  
          return false;
      }
-@@ -1040,7 +1023,7 @@ public final class CraftServer implements Server {
+@@ -1048,7 +1031,7 @@ public final class CraftServer implements Server {
      public void reload() {
          // Paper start - lifecycle events
          if (io.papermc.paper.plugin.lifecycle.event.LifecycleEventRunner.INSTANCE.blocksPluginReloading()) {
@@ -2511,7 +2511,7 @@ index 70b13bab453d50d72c3df9fed06b3956fe2703fe..2f7119ca17cf0df445c0c34804e40acb
          }
          // Paper end - lifecycle events
          org.spigotmc.WatchdogThread.hasStarted = false; // Paper - Disable watchdog early timeout on reload
-@@ -1094,8 +1077,9 @@ public final class CraftServer implements Server {
+@@ -1102,8 +1085,9 @@ public final class CraftServer implements Server {
          }
  
          Plugin[] pluginClone = pluginManager.getPlugins().clone(); // Paper
@@ -2522,7 +2522,7 @@ index 70b13bab453d50d72c3df9fed06b3956fe2703fe..2f7119ca17cf0df445c0c34804e40acb
          // Paper start
          for (Plugin plugin : pluginClone) {
              entityMetadata.removeAll(plugin);
-@@ -1135,6 +1119,12 @@ public final class CraftServer implements Server {
+@@ -1143,6 +1127,12 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.pluginsEnabled(); // Paper - Remap plugins

--- a/patches/server/0972-Brigadier-based-command-API.patch
+++ b/patches/server/0972-Brigadier-based-command-API.patch
@@ -2378,7 +2378,7 @@ index 134f31cce8d8eca669948a784e2766216fb91ab5..60c65af218d533d53b765ba2175fed16
      // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 65b89919440c0c901fcfd981a5abe317bae12c10..d8edc950000002f048c09d3d6582af1ffb314dde 100644
+index b72a71d6a37956b0f4ca74c2ed8eaf044cac4b81..6321ae23f07bc3e07577914e6cf035e0c2cd4992 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -272,11 +272,11 @@ public final class CraftServer implements Server {
@@ -2409,7 +2409,7 @@ index 65b89919440c0c901fcfd981a5abe317bae12c10..d8edc950000002f048c09d3d6582af1f
  
          CraftRegistry.setMinecraftRegistry(console.registryAccess());
  
-@@ -601,48 +607,11 @@ public final class CraftServer implements Server {
+@@ -602,48 +608,11 @@ public final class CraftServer implements Server {
      }
  
      private void setVanillaCommands(boolean first) { // Spigot
@@ -2460,7 +2460,7 @@ index 65b89919440c0c901fcfd981a5abe317bae12c10..d8edc950000002f048c09d3d6582af1f
  
          // Refresh commands
          for (ServerPlayer player : this.getHandle().players) {
-@@ -1029,17 +998,31 @@ public final class CraftServer implements Server {
+@@ -1030,17 +999,31 @@ public final class CraftServer implements Server {
              return true;
          }
  
@@ -2502,7 +2502,7 @@ index 65b89919440c0c901fcfd981a5abe317bae12c10..d8edc950000002f048c09d3d6582af1f
  
          return false;
      }
-@@ -1048,7 +1031,7 @@ public final class CraftServer implements Server {
+@@ -1049,7 +1032,7 @@ public final class CraftServer implements Server {
      public void reload() {
          // Paper start - lifecycle events
          if (io.papermc.paper.plugin.lifecycle.event.LifecycleEventRunner.INSTANCE.blocksPluginReloading()) {
@@ -2511,7 +2511,7 @@ index 65b89919440c0c901fcfd981a5abe317bae12c10..d8edc950000002f048c09d3d6582af1f
          }
          // Paper end - lifecycle events
          org.spigotmc.WatchdogThread.hasStarted = false; // Paper - Disable watchdog early timeout on reload
-@@ -1102,8 +1085,9 @@ public final class CraftServer implements Server {
+@@ -1103,8 +1086,9 @@ public final class CraftServer implements Server {
          }
  
          Plugin[] pluginClone = pluginManager.getPlugins().clone(); // Paper
@@ -2522,7 +2522,7 @@ index 65b89919440c0c901fcfd981a5abe317bae12c10..d8edc950000002f048c09d3d6582af1f
          // Paper start
          for (Plugin plugin : pluginClone) {
              entityMetadata.removeAll(plugin);
-@@ -1143,6 +1127,12 @@ public final class CraftServer implements Server {
+@@ -1144,6 +1128,12 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.pluginsEnabled(); // Paper - Remap plugins

--- a/patches/server/0982-Adopt-MaterialRerouting.patch
+++ b/patches/server/0982-Adopt-MaterialRerouting.patch
@@ -94,10 +94,10 @@ index 3ff0f0e34356cee4c510fdd60af723b1c5df156a..9c004e7cb46841d874ab997bf2e3b63a
 +    // Paper end - register paper API specific material consumers in rerouting
  }
 diff --git a/src/test/java/org/bukkit/craftbukkit/legacy/MaterialReroutingTest.java b/src/test/java/org/bukkit/craftbukkit/legacy/MaterialReroutingTest.java
-index 26208ca74688be062584824de5d074321b33f1b1..946cd46f3389a4d4ceda86e0115c59c5725a8a0a 100644
+index a5f3d562afec242912589bfc053ff91ede77347e..0fac826b9367a821c6801190997592219cb47f73 100644
 --- a/src/test/java/org/bukkit/craftbukkit/legacy/MaterialReroutingTest.java
 +++ b/src/test/java/org/bukkit/craftbukkit/legacy/MaterialReroutingTest.java
-@@ -55,6 +55,9 @@ public class MaterialReroutingTest extends AbstractTestingBase {
+@@ -56,6 +56,9 @@ public class MaterialReroutingTest extends AbstractTestingBase {
                  .filter(entry -> !entry.getName().endsWith("ItemType.class"))
                  .filter(entry -> !entry.getName().endsWith("Registry.class"))
                  .filter(entry -> !entry.getName().startsWith("org/bukkit/material"))
@@ -107,7 +107,7 @@ index 26208ca74688be062584824de5d074321b33f1b1..946cd46f3389a4d4ceda86e0115c59c5
                  .map(entry -> {
                      try {
                          return MaterialReroutingTest.jarFile.getInputStream(entry);
-@@ -92,6 +95,10 @@ public class MaterialReroutingTest extends AbstractTestingBase {
+@@ -93,6 +96,10 @@ public class MaterialReroutingTest extends AbstractTestingBase {
                              continue;
                          }
                      }
@@ -116,9 +116,9 @@ index 26208ca74688be062584824de5d074321b33f1b1..946cd46f3389a4d4ceda86e0115c59c5
 +                    if (isInternal(methodNode.invisibleAnnotations)) continue;
 +                    // Paper end - filter out more methods from rerouting test
  
-                     if (!Commodore.rerouteMethods(Collections.emptySet(), MaterialReroutingTest.MATERIAL_METHOD_REROUTE, (methodNode.access & Opcodes.ACC_STATIC) != 0, classNode.name, methodNode.name, methodNode.desc, a -> { })) {
+                     if (!Commodore.rerouteMethods(Collections.emptySet(), ApiVersion.CURRENT, MaterialReroutingTest.MATERIAL_METHOD_REROUTE, (methodNode.access & Opcodes.ACC_STATIC) != 0, classNode.name, methodNode.name, methodNode.desc, a -> { })) {
                          missingReroute.add(methodNode.name + " " + methodNode.desc + " " + methodNode.signature);
-@@ -108,6 +115,13 @@ public class MaterialReroutingTest extends AbstractTestingBase {
+@@ -109,6 +116,13 @@ public class MaterialReroutingTest extends AbstractTestingBase {
          }
      }
  

--- a/patches/server/0988-Moonrise-optimisation-patches.patch
+++ b/patches/server/0988-Moonrise-optimisation-patches.patch
@@ -26204,10 +26204,10 @@ index c97292f22a3402dbd59cef4af554954dc1d4f91a..c759555241649cf5b355268066375341
          return crashreportsystemdetails;
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 7f83f40c76eac2ce5b053dc651224c44701613ea..fd61e10fd3151bf8cc206a93d4ede22a7c681dbf 100644
+index e45567e8112483d947e2ff12c01219b85b09b205..e05bd64abb644fa38dbfe1fe97737eaf8f535970 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -199,7 +199,7 @@ import org.bukkit.event.player.PlayerToggleSneakEvent;
+@@ -200,7 +200,7 @@ import org.bukkit.event.player.PlayerToggleSneakEvent;
  import org.bukkit.inventory.MainHand;
  // CraftBukkit end
  
@@ -26216,7 +26216,7 @@ index 7f83f40c76eac2ce5b053dc651224c44701613ea..fd61e10fd3151bf8cc206a93d4ede22a
  
      private static final Logger LOGGER = LogUtils.getLogger();
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_XZ = 32;
-@@ -296,6 +296,36 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
+@@ -297,6 +297,36 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
      public @Nullable String clientBrandName = null; // Paper - Brand support
      public org.bukkit.event.player.PlayerQuitEvent.QuitReason quitReason = null; // Paper - Add API for quit reason; there are a lot of changes to do if we change all methods leading to the event
  
@@ -26903,7 +26903,7 @@ index 50040c497a819cd1229042ab3cb057d34a32cacc..15c5164d0ef41a978c16ee317fa73e97
 +    // Paper end - block counting
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2e2101274f3afebbae783fa119f5cae8104de45d..4f4b7e738fe604808d837a38d23bf437bc1d5329 100644
+index 550434981bc395a8fba2c5bd6c4359d1dfb4d147..9f07343401a03735234b0298b92663b5b94608a8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -167,7 +167,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;
@@ -27683,7 +27683,7 @@ index bd20bea7f76a7307f1698fb2dfef37125032d166..141b748abe80402731cdaf14a3d36aa7
  
      // Paper start - Affects Spawning API
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index bff83fe413c7baef4ba56a3270ea4463a58c792f..a248d859cbce48f4a34c4771a7acffc17d7edc84 100644
+index 32651ed15e5961a8b27fc0dc8fb54ef05b6064fe..6c66ee69beb55e5c5755bbf4d13c256541ce4468 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
 @@ -75,6 +75,247 @@ public class Explosion {
@@ -28156,7 +28156,7 @@ index bff83fe413c7baef4ba56a3270ea4463a58c792f..a248d859cbce48f4a34c4771a7acffc1
      }
  
      public void finalizeExplosion(boolean particles) {
-@@ -547,14 +843,14 @@ public class Explosion {
+@@ -544,14 +840,14 @@ public class Explosion {
          private BlockInteraction() {}
      }
      // Paper start - Optimize explosions
@@ -32699,10 +32699,10 @@ index 69c7fe5bf5b914276a9f7a0e57ce668e569d91f9..33322b57b4c6922f4daad0f584733f0f
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2f7119ca17cf0df445c0c34804e40acb209a5b0d..06215f56f1cae5197c827b8100432ab2ef9aa976 100644
+index d8edc950000002f048c09d3d6582af1ffb314dde..3c53d53579e0ce8054687dcadc8bda901e2931b3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1419,7 +1419,7 @@ public final class CraftServer implements Server {
+@@ -1427,7 +1427,7 @@ public final class CraftServer implements Server {
          // Paper - Put world into worldlist before initing the world; move up
  
          this.getServer().prepareLevels(internal.getChunkSource().chunkMap.progressListener, internal);
@@ -32711,7 +32711,7 @@ index 2f7119ca17cf0df445c0c34804e40acb209a5b0d..06215f56f1cae5197c827b8100432ab2
  
          this.pluginManager.callEvent(new WorldLoadEvent(internal.getWorld()));
          return internal.getWorld();
-@@ -1464,7 +1464,7 @@ public final class CraftServer implements Server {
+@@ -1472,7 +1472,7 @@ public final class CraftServer implements Server {
              }
  
              handle.getChunkSource().close(save);
@@ -32720,7 +32720,7 @@ index 2f7119ca17cf0df445c0c34804e40acb209a5b0d..06215f56f1cae5197c827b8100432ab2
              handle.convertable.close();
          } catch (Exception ex) {
              this.getLogger().log(Level.SEVERE, null, ex);
-@@ -2500,7 +2500,7 @@ public final class CraftServer implements Server {
+@@ -2508,7 +2508,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0988-Moonrise-optimisation-patches.patch
+++ b/patches/server/0988-Moonrise-optimisation-patches.patch
@@ -32699,10 +32699,10 @@ index 69c7fe5bf5b914276a9f7a0e57ce668e569d91f9..33322b57b4c6922f4daad0f584733f0f
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d8edc950000002f048c09d3d6582af1ffb314dde..3c53d53579e0ce8054687dcadc8bda901e2931b3 100644
+index 6321ae23f07bc3e07577914e6cf035e0c2cd4992..cc1f3c7fec4fa794da0b19f44ced9fd482dfdfc7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1427,7 +1427,7 @@ public final class CraftServer implements Server {
+@@ -1428,7 +1428,7 @@ public final class CraftServer implements Server {
          // Paper - Put world into worldlist before initing the world; move up
  
          this.getServer().prepareLevels(internal.getChunkSource().chunkMap.progressListener, internal);
@@ -32711,7 +32711,7 @@ index d8edc950000002f048c09d3d6582af1ffb314dde..3c53d53579e0ce8054687dcadc8bda90
  
          this.pluginManager.callEvent(new WorldLoadEvent(internal.getWorld()));
          return internal.getWorld();
-@@ -1472,7 +1472,7 @@ public final class CraftServer implements Server {
+@@ -1473,7 +1473,7 @@ public final class CraftServer implements Server {
              }
  
              handle.getChunkSource().close(save);
@@ -32720,7 +32720,7 @@ index d8edc950000002f048c09d3d6582af1ffb314dde..3c53d53579e0ce8054687dcadc8bda90
              handle.convertable.close();
          } catch (Exception ex) {
              this.getLogger().log(Level.SEVERE, null, ex);
-@@ -2508,7 +2508,7 @@ public final class CraftServer implements Server {
+@@ -2509,7 +2509,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0998-Optional-per-player-mob-spawns.patch
+++ b/patches/server/0998-Optional-per-player-mob-spawns.patch
@@ -70,10 +70,10 @@ index 17fafa62f21e505f9f77cf486f7f766a404f7c31..2ed9a088d0fd56043d161909ce8e0df6
                  int chunkRange = level.spigotConfig.mobSpawnRange;
                  chunkRange = (chunkRange > level.spigotConfig.viewDistance) ? (byte) level.spigotConfig.viewDistance : chunkRange;
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index fd61e10fd3151bf8cc206a93d4ede22a7c681dbf..23ddb7735623e502eda2b7b3029c6597f4b0f9a0 100644
+index e05bd64abb644fa38dbfe1fe97737eaf8f535970..720a77f7d935292564df3de5cd320d3f75dcd7f9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -275,6 +275,10 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+@@ -276,6 +276,10 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
      public boolean queueHealthUpdatePacket;
      public net.minecraft.network.protocol.game.ClientboundSetHealthPacket queuedHealthUpdatePacket;
      // Paper end - cancellable death event

--- a/patches/server/0999-Anti-Xray.patch
+++ b/patches/server/0999-Anti-Xray.patch
@@ -1168,7 +1168,7 @@ index 9b1a6d8351fb473eec75a2fd08fb892b770e3586..0d0b07c9199be9ca0d5ac3feb1d44f14
          }
          // Paper end - Send empty chunk
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index ecf2f478932c9ccc5a7ac47c8f17bd44217c703b..ae7cd8df617dba09abb9ca1108aff719a9c3304f 100644
+index ce9350ed3c5c5fbbd9b2ade9ae2880e03305c787..87cde688976a45aa8848586b5371b3ab493813ea 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -172,6 +172,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
@@ -1574,10 +1574,10 @@ index 33322b57b4c6922f4daad0f584733f0f24083911..45e262308aebafa377a2353661acdd12
      private static final byte[] EMPTY_LIGHT = new byte[2048];
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 06215f56f1cae5197c827b8100432ab2ef9aa976..81fa2bab6841ab375ff310d0fbbe6349fd44872a 100644
+index 3c53d53579e0ce8054687dcadc8bda901e2931b3..b8eedf9d6bc9ff8477a8da799f071d33e97424a1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2677,7 +2677,7 @@ public final class CraftServer implements Server {
+@@ -2685,7 +2685,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Preconditions.checkArgument(world != null, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();

--- a/patches/server/0999-Anti-Xray.patch
+++ b/patches/server/0999-Anti-Xray.patch
@@ -1574,10 +1574,10 @@ index 33322b57b4c6922f4daad0f584733f0f24083911..45e262308aebafa377a2353661acdd12
      private static final byte[] EMPTY_LIGHT = new byte[2048];
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3c53d53579e0ce8054687dcadc8bda901e2931b3..b8eedf9d6bc9ff8477a8da799f071d33e97424a1 100644
+index cc1f3c7fec4fa794da0b19f44ced9fd482dfdfc7..3a91faeb6957e4e783b1de3e1145e7d1d164a857 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2685,7 +2685,7 @@ public final class CraftServer implements Server {
+@@ -2686,7 +2686,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Preconditions.checkArgument(world != null, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();

--- a/patches/server/1002-Improve-cancelling-PreCreatureSpawnEvent-with-per-pl.patch
+++ b/patches/server/1002-Improve-cancelling-PreCreatureSpawnEvent-with-per-pl.patch
@@ -60,10 +60,10 @@ index 2ed9a088d0fd56043d161909ce8e0df683a6413a..cdb9160244cc69acd36ac9afcfe109a1
                      spawnercreature_d = NaturalSpawner.createState(naturalSpawnChunkCount, this.level.getAllEntities(), this::getFullChunk, null, true);
                  } else {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 23ddb7735623e502eda2b7b3029c6597f4b0f9a0..13ec84754b4fb5e8442fe305d70a24e420945181 100644
+index 720a77f7d935292564df3de5cd320d3f75dcd7f9..dddd4fcdcd08e0221693071894818c7d3bae531b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -279,6 +279,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+@@ -280,6 +280,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
      public static final int MOBCATEGORY_TOTAL_ENUMS = net.minecraft.world.entity.MobCategory.values().length;
      public final int[] mobCounts = new int[MOBCATEGORY_TOTAL_ENUMS]; // Paper
      // Paper end - Optional per player mob spawns

--- a/patches/server/1021-Registry-Modification-API.patch
+++ b/patches/server/1021-Registry-Modification-API.patch
@@ -9,7 +9,7 @@ public net.minecraft.resources.RegistryOps lookupProvider
 public net.minecraft.resources.RegistryOps$HolderLookupAdapter
 
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-index 1e098dc25bd338ff179491ff3382ac56aad9948e..a688af29273ebfbb4f75dd74cd30627fc481c96c 100644
+index a5a985369199dc4528c69c52fd6819e1419a7feb..d64b8eecaf4de2aa2780b6c21335516405bbd401 100644
 --- a/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 @@ -2,6 +2,7 @@ package io.papermc.paper.registry;
@@ -20,7 +20,7 @@ index 1e098dc25bd338ff179491ff3382ac56aad9948e..a688af29273ebfbb4f75dd74cd30627f
  import java.util.Collections;
  import java.util.IdentityHashMap;
  import java.util.List;
-@@ -46,6 +47,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
+@@ -54,6 +55,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
  
  import static io.papermc.paper.registry.entry.RegistryEntry.apiOnly;
  import static io.papermc.paper.registry.entry.RegistryEntry.entry;
@@ -28,7 +28,7 @@ index 1e098dc25bd338ff179491ff3382ac56aad9948e..a688af29273ebfbb4f75dd74cd30627f
  
  @DefaultQualifier(NonNull.class)
  public final class PaperRegistries {
-@@ -128,6 +130,15 @@ public final class PaperRegistries {
+@@ -136,6 +138,15 @@ public final class PaperRegistries {
          return ResourceKey.create((ResourceKey<? extends Registry<M>>) PaperRegistries.registryToNms(typedKey.registryKey()), PaperAdventure.asVanilla(typedKey.key()));
      }
  
@@ -1311,10 +1311,10 @@ index 397bdacab9517354875ebc0bc68d35059b3c318b..908431652a0fea79b5a0cee1efd0c7a7
                  return writableRegistry;
              },
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-index d21b7e39d71c785f47f790e1ad4be33a8e8e6e51..a47421425a8d5d2f07e08890fded0f7bfec4efb7 100644
+index fc9aec589414bf8d3f672183928235b5b51d1a02..0f3c46b8bb93fc42160300c9988d04bed68f493b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-@@ -156,11 +156,11 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -163,11 +163,11 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
      private final Map<NamespacedKey, B> cache = new HashMap<>();
      private final Map<B, NamespacedKey> byValue = new java.util.IdentityHashMap<>(); // Paper - improve Registry
      private final net.minecraft.core.Registry<M> minecraftRegistry;
@@ -1328,7 +1328,7 @@ index d21b7e39d71c785f47f790e1ad4be33a8e8e6e51..a47421425a8d5d2f07e08890fded0f7b
          this.bukkitClass = bukkitClass;
          this.minecraftRegistry = minecraftRegistry;
          this.minecraftToBukkit = minecraftToBukkit;
-@@ -233,4 +233,17 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -240,4 +240,17 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
          return this.byValue.get(value);
      }
      // Paper end - improve Registry

--- a/patches/server/1022-Add-registry-entry-and-builders.patch
+++ b/patches/server/1022-Add-registry-entry-and-builders.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add registry entry and builders
 
 
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-index a688af29273ebfbb4f75dd74cd30627fc481c96c..9c0972023bc9be20ba81bbc2e1d6688b615760c0 100644
+index 722e3786f5b36f9b9ccff4028a58c3893c7960d6..745536f79b376c385247682042ae455d4a0f4ee5 100644
 --- a/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 @@ -1,6 +1,8 @@
@@ -17,7 +17,7 @@ index a688af29273ebfbb4f75dd74cd30627fc481c96c..9c0972023bc9be20ba81bbc2e1d6688b
  import io.papermc.paper.registry.entry.RegistryEntry;
  import io.papermc.paper.registry.tag.TagKey;
  import java.util.Collections;
-@@ -58,7 +60,7 @@ public final class PaperRegistries {
+@@ -66,7 +68,7 @@ public final class PaperRegistries {
      static {
          REGISTRY_ENTRIES = List.of(
              // built-ins
@@ -26,7 +26,7 @@ index a688af29273ebfbb4f75dd74cd30627fc481c96c..9c0972023bc9be20ba81bbc2e1d6688b
              entry(Registries.INSTRUMENT, RegistryKey.INSTRUMENT, MusicInstrument.class, CraftMusicInstrument::new),
              entry(Registries.MOB_EFFECT, RegistryKey.MOB_EFFECT, PotionEffectType.class, CraftPotionEffectType::new),
              entry(Registries.STRUCTURE_TYPE, RegistryKey.STRUCTURE_TYPE, StructureType.class, CraftStructureType::new),
-@@ -71,7 +73,7 @@ public final class PaperRegistries {
+@@ -84,7 +86,7 @@ public final class PaperRegistries {
              entry(Registries.TRIM_PATTERN, RegistryKey.TRIM_PATTERN, TrimPattern.class, CraftTrimPattern::new).delayed(),
              entry(Registries.DAMAGE_TYPE, RegistryKey.DAMAGE_TYPE, DamageType.class, CraftDamageType::new).delayed(),
              entry(Registries.WOLF_VARIANT, RegistryKey.WOLF_VARIANT, Wolf.Variant.class, CraftWolf.CraftVariant::new).delayed(),

--- a/patches/server/1024-Proxy-ItemStack-to-CraftItemStack.patch
+++ b/patches/server/1024-Proxy-ItemStack-to-CraftItemStack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Proxy ItemStack to CraftItemStack
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 369d43f911289b670dcef3b7af3dce73273d95ab..22b0febba8fbfc9b2ab1a623932ffff32ca8040c 100644
+index 033918e051ef44de82a74097380cacaf926e5408..08a1e8087b4f948ae31a3c3ef453261dc3dbc287 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -25,15 +25,57 @@ import org.bukkit.material.MaterialData;
+@@ -26,15 +26,57 @@ import org.jetbrains.annotations.ApiStatus;
  @DelegateDeserialization(ItemStack.class)
  public final class CraftItemStack extends ItemStack {
  
@@ -71,7 +71,7 @@ index 369d43f911289b670dcef3b7af3dce73273d95ab..22b0febba8fbfc9b2ab1a623932ffff3
      public static net.minecraft.world.item.ItemStack getOrCloneOnMutation(ItemStack old, ItemStack newInstance) {
          return old == newInstance ? unwrap(old) : asNMSCopy(newInstance);
      }
-@@ -47,25 +89,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -48,25 +90,13 @@ public final class CraftItemStack extends ItemStack {
      // Paper end - override isEmpty to use vanilla's impl
  
      public static net.minecraft.world.item.ItemStack asNMSCopy(ItemStack original) {
@@ -102,7 +102,7 @@ index 369d43f911289b670dcef3b7af3dce73273d95ab..22b0febba8fbfc9b2ab1a623932ffff3
      }
  
      // Paper start
-@@ -88,14 +118,10 @@ public final class CraftItemStack extends ItemStack {
+@@ -89,14 +119,10 @@ public final class CraftItemStack extends ItemStack {
       * Copies the NMS stack to return as a strictly-Bukkit stack
       */
      public static ItemStack asBukkitCopy(net.minecraft.world.item.ItemStack original) {
@@ -121,7 +121,7 @@ index 369d43f911289b670dcef3b7af3dce73273d95ab..22b0febba8fbfc9b2ab1a623932ffff3
      }
  
      public static CraftItemStack asCraftMirror(net.minecraft.world.item.ItemStack original) {
-@@ -313,11 +339,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -315,11 +341,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public CraftItemStack clone() {
@@ -134,7 +134,7 @@ index 369d43f911289b670dcef3b7af3dce73273d95ab..22b0febba8fbfc9b2ab1a623932ffff3
      }
  
      @Override
-@@ -420,22 +442,14 @@ public final class CraftItemStack extends ItemStack {
+@@ -422,22 +444,14 @@ public final class CraftItemStack extends ItemStack {
          if (stack == this) {
              return true;
          }

--- a/patches/server/1025-Make-a-PDC-view-accessible-directly-from-ItemStack.patch
+++ b/patches/server/1025-Make-a-PDC-view-accessible-directly-from-ItemStack.patch
@@ -97,10 +97,10 @@ index 0000000000000000000000000000000000000000..fac401280d3f3689b00e16c19155ca75
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 22b0febba8fbfc9b2ab1a623932ffff32ca8040c..4a7daf90eaee1c1134c643ea3b227e56a849a0fb 100644
+index 08a1e8087b4f948ae31a3c3ef453261dc3dbc287..d562b17a96431dcff18fe648542f507a8fd354d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -480,4 +480,63 @@ public final class CraftItemStack extends ItemStack {
+@@ -482,4 +482,63 @@ public final class CraftItemStack extends ItemStack {
          return mirrored;
      }
      // Paper end

--- a/patches/server/1039-Incremental-chunk-and-player-saving.patch
+++ b/patches/server/1039-Incremental-chunk-and-player-saving.patch
@@ -96,10 +96,10 @@ index 46e8dd8dae25e1b2124e9c8031844fbe96eb6e1a..2766ec28f028c0bd672009928bf64c1a
          // Paper start - add close param
          this.save(progressListener, flush, savingDisabled, false);
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 13ec84754b4fb5e8442fe305d70a24e420945181..0b6ce3b157c8822c39c492161571c0887ab26262 100644
+index dddd4fcdcd08e0221693071894818c7d3bae531b..5980b70e2d7273239245237189b2debcbccfbac3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -202,6 +202,7 @@ import org.bukkit.inventory.MainHand;
+@@ -203,6 +203,7 @@ import org.bukkit.inventory.MainHand;
  public class ServerPlayer extends net.minecraft.world.entity.player.Player implements ca.spottedleaf.moonrise.patches.chunk_system.player.ChunkSystemServerPlayer { // Paper - rewrite chunk system
  
      private static final Logger LOGGER = LogUtils.getLogger();


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
3a3bea52 SPIGOT-7829: Increase maximum outgoing plugin message size to match Vanilla intention
5cd1c8cb SPIGOT-7831: Add CreatureSpawnEvent.SpawnReason#POTION_EFFECT
a8e278f0 SPIGOT-7827: Sync EntityPortalEvent with PlayerPortalEvent since non-players can now create portals
53729d12 Remove spurious ApiStatus.Internal annotation
b9f57486 SPIGOT-7799, PR-1039: Expose explosion world interaction in EntityExplodeEvent and BlockExplodeEvent
7983b966 PR-1029: Trial changing a small number of inner enums to classes/interfaces to better support custom values

CraftBukkit Changes:
403accd56 SPIGOT-7831: Add CreatureSpawnEvent.SpawnReason#POTION_EFFECT
812761660 Increase outdated build delay
bed1e3ff6 SPIGOT-7827: Sync EntityPortalEvent with PlayerPortalEvent since non-players can now create portals
2444c8b23 SPIGOT-7823: Suspicious sand and gravel material are not marked as having gravity correctly
aceddcd0b SPIGOT-7820: Enum changes - duplicate method name
a0d2d6a84 SPIGOT-7813: Material#isInteractable() always returns false
8fd64b091 SPIGOT-7806: Handle both loot and inventory item drop behaviour in PlayerDeathEvent
a4ee40b74 SPIGOT-7799, PR-1436: Expose explosion world interaction in EntityExplodeEvent and BlockExplodeEvent
082aa51c5 PR-1424: Trial changing a small number of inner enums to classes/interfaces to better support custom values
66e78a96b SPIGOT-7815: Consider EntityDamageEvent status for Wolf armor damage

Spigot Changes:
5bbef5ad SPIGOT-7834: Modify max value for generic.max_absorption