### PR TITLE
[ci skip] remove timings from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml
+++ b/.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml
@@ -44,10 +44,10 @@ body:
 
         ```
         > version
-        [20:34:42 INFO]: This server is running Paper version git-Paper-540 (MC: 1.16.5) (Implementing API version 1.16.5-R0.1-SNAPSHOT)
         [20:34:42 INFO]: Checking version, please wait...
-        [20:34:42 INFO]: Previous version: git-Paper-538 (MC: 1.16.5)
+        [20:34:42 INFO]: This server is running Paper version 1.21-105-master@7e91a2c (2024-07-20T21:04:31Z) (Implementing API version 1.21-R0.1-SNAPSHOT)
         [20:34:42 INFO]: You are running the latest version
+        [20:34:42 INFO]: Previous version: 1.21-103-aa3b356 (MC: 1.21)
         ```
 
         </details>

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: Suggest an idea for Paper
   - name: PaperMC Discord
     url: https://discord.gg/papermc
-    about: If you are having issues with timings or have other minor issues, come ask us on our Discord server!
+    about: If you are having issues with spark or have other minor issues, come ask us on our Discord server!
   - name: Exploit Report
     url: https://discord.gg/papermc
     about: |

--- a/.github/ISSUE_TEMPLATE/performance-problem.yml
+++ b/.github/ISSUE_TEMPLATE/performance-problem.yml
@@ -10,9 +10,9 @@ body:
 
   - type: input
     attributes:
-      label: Timings or Profile link
-      description: We ask that all timings/profiles are a link, not a screenshot. Screenshots inhibit our ability to figure out the real cause of the issue.
-      placeholder: "Example: https://timings.aikar.co/?id=6b48586fbbdd48e585ca0ebb07c59dd0"
+      label: Profile link
+      description: We ask that all profiles are a link, not a screenshot. Screenshots inhibit our ability to figure out the real cause of the issue.
+      placeholder: "Example: https://spark.lucko.me/XsN0hxGfsi"
     validations:
       required: true
 
@@ -56,10 +56,10 @@ body:
 
         ```
         > version
-        [20:34:42 INFO]: This server is running Paper version git-Paper-540 (MC: 1.16.5) (Implementing API version 1.16.5-R0.1-SNAPSHOT)
         [20:34:42 INFO]: Checking version, please wait...
-        [20:34:42 INFO]: Previous version: git-Paper-538 (MC: 1.16.5)
+        [20:34:42 INFO]: This server is running Paper version 1.21-105-master@7e91a2c (2024-07-20T21:04:31Z) (Implementing API version 1.21-R0.1-SNAPSHOT)
         [20:34:42 INFO]: You are running the latest version
+        [20:34:42 INFO]: Previous version: 1.21-103-aa3b356 (MC: 1.21)
         ```
 
         </details>

--- a/.github/ISSUE_TEMPLATE/server-crash-or-stacktrace.yml
+++ b/.github/ISSUE_TEMPLATE/server-crash-or-stacktrace.yml
@@ -44,10 +44,10 @@ body:
 
         ```
         > version
-        [20:34:42 INFO]: This server is running Paper version git-Paper-540 (MC: 1.16.5) (Implementing API version 1.16.5-R0.1-SNAPSHOT)
         [20:34:42 INFO]: Checking version, please wait...
-        [20:34:42 INFO]: Previous version: git-Paper-538 (MC: 1.16.5)
+        [20:34:42 INFO]: This server is running Paper version 1.21-105-master@7e91a2c (2024-07-20T21:04:31Z) (Implementing API version 1.21-R0.1-SNAPSHOT)
         [20:34:42 INFO]: You are running the latest version
+        [20:34:42 INFO]: Previous version: 1.21-103-aa3b356 (MC: 1.21)
         ```
 
         </details>


### PR DESCRIPTION
also updates the example versions to 1.21 with the new format