### PR TITLE
Fix horse inventories

### DIFF
--- a/patches/server/1031-fix-horse-inventories.patch
+++ b/patches/server/1031-fix-horse-inventories.patch
@@ -23,10 +23,10 @@ index 9bcc0931510607b8fbd01233e2b3c346369b214d..467693a60786688b753cebac3b0a8889
  
      // Paper start - Horse API
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryAbstractHorse.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryAbstractHorse.java
-index 4946da593713f4d11d88ac1bb68a089f2f6d5ae0..bae0db99a8159bdea71182485b22cce9fc61e00a 100644
+index 4946da593713f4d11d88ac1bb68a089f2f6d5ae0..abef7f23361e6c5d18243dd18439ffd13ac787ae 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryAbstractHorse.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryAbstractHorse.java
-@@ -6,17 +6,64 @@ import org.bukkit.inventory.ItemStack;
+@@ -6,17 +6,73 @@ import org.bukkit.inventory.ItemStack;
  
  public class CraftInventoryAbstractHorse extends CraftInventory implements AbstractHorseInventory {
  
@@ -76,10 +76,15 @@ index 4946da593713f4d11d88ac1bb68a089f2f6d5ae0..bae0db99a8159bdea71182485b22cce9
 +    @Override
 +    public ItemStack getItem(final int index) {
 +        if (index == net.minecraft.world.inventory.HorseInventoryMenu.SLOT_BODY_ARMOR) {
-+            final net.minecraft.world.item.ItemStack item = this.getArmorInventory().getItem(index);
++            final net.minecraft.world.item.ItemStack item = this.getArmorInventory().getItem(0);
 +            return item.isEmpty() ? null : CraftItemStack.asCraftMirror(item);
 +        } else {
-+            final net.minecraft.world.item.ItemStack item = this.getMainInventory().getItem(index);
++            int shiftedIndex = index;
++            if (index > net.minecraft.world.inventory.HorseInventoryMenu.SLOT_BODY_ARMOR) {
++                shiftedIndex--;
++            }
++
++            final net.minecraft.world.item.ItemStack item = this.getMainInventory().getItem(shiftedIndex);
 +            return item.isEmpty() ? null : CraftItemStack.asCraftMirror(item);
 +        }
 +    }
@@ -87,9 +92,13 @@ index 4946da593713f4d11d88ac1bb68a089f2f6d5ae0..bae0db99a8159bdea71182485b22cce9
 +    @Override
 +    public void setItem(final int index, final ItemStack item) {
 +        if (index == net.minecraft.world.inventory.HorseInventoryMenu.SLOT_BODY_ARMOR) {
-+            this.getArmorInventory().setItem(index, CraftItemStack.asNMSCopy(item));
++            this.getArmorInventory().setItem(0, CraftItemStack.asNMSCopy(item));
 +        } else {
-+            this.getMainInventory().setItem(index, CraftItemStack.asNMSCopy(item));
++            int shiftedIndex = index;
++            if (index > net.minecraft.world.inventory.HorseInventoryMenu.SLOT_BODY_ARMOR) {
++                shiftedIndex--;
++            }
++            this.getMainInventory().setItem(shiftedIndex, CraftItemStack.asNMSCopy(item));
 +        }
 +    }
 +    // Paper end - combine both horse inventories


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/11135

I also noticed that currently it's not possible to set any item in slot 2 (first slot in the chest for llama/mule) which is the slot hidden by the armor slot in the implementation. This pr fixes that by shifting the index for slot greater than the armor slot to cover the missing slot and realign the index to be consistent with the inventory size.