### PR TITLE
Early Access to Dispatcher

### DIFF
--- a/patches/server/1045-Early-Dispatcher-Access.patch
+++ b/patches/server/1045-Early-Dispatcher-Access.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: dueris <jedimastertoothless@hotmail.com>
+Date: Mon, 22 Jul 2024 00:56:21 -0700
+Subject: [PATCH] Early Dispatcher Access
+
+
+diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
+index 1d1e76de60e40224f5cb81893f9ee50fe987badb..62a1255031ce8f50fbd2f95774a04d76b39987f2 100644
+--- a/src/main/java/net/minecraft/commands/Commands.java
++++ b/src/main/java/net/minecraft/commands/Commands.java
+@@ -152,7 +152,10 @@ public class Commands {
+     public static final int LEVEL_GAMEMASTERS = 2;
+     public static final int LEVEL_ADMINS = 3;
+     public static final int LEVEL_OWNERS = 4;
+-    private final com.mojang.brigadier.CommandDispatcher<CommandSourceStack> dispatcher = new com.mojang.brigadier.CommandDispatcher();
++    // Paper start - Early access to dispatcher
++    public static final com.mojang.brigadier.CommandDispatcher<CommandSourceStack> DISPATCHER = new com.mojang.brigadier.CommandDispatcher();
++    private final com.mojang.brigadier.CommandDispatcher<CommandSourceStack> dispatcher = DISPATCHER;
++    // Paper end
+ 
+     public Commands(Commands.CommandSelection environment, CommandBuildContext commandRegistryAccess) {
+         // Paper


### PR DESCRIPTION
This adds a static variable to the Commands class to provide early access to the command dispatcher before bootstrapping the command system or before MinecraftServer has been loaded.

This is mainly needed for a plugin I'm working on, which needs access to the command dispatcher at plugin bootstrap to allow for mcfunctions to access the commands I add. Previously, I needed to wait for the Commands class to be created for bootstrapping, which occurs after plugin bootstrapping.