### PR TITLE
Fix some NPEs

### DIFF
--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -4886,7 +4886,7 @@ index 9e05a8515c5f6f340182e91150fcad8bbf80a22b..adf22ce4f0bcd3bd57dc2030c6c92d3d
          @Override
          public CraftMerchant getCraftMerchant() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index 3ab6b212001c2b92cac42c0ff97e59c3d08b3e49..552ebe67f87b48734adf0da8ef78dcac9dd670a2 100644
+index 3ab6b212001c2b92cac42c0ff97e59c3d08b3e49..32e5188442551b3e72e1d4826d836d622d0e438a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 @@ -2,8 +2,9 @@ package org.bukkit.craftbukkit.inventory;
@@ -4900,7 +4900,7 @@ index 3ab6b212001c2b92cac42c0ff97e59c3d08b3e49..552ebe67f87b48734adf0da8ef78dcac
  import java.util.ArrayList;
  import java.util.Arrays;
  import java.util.List;
-@@ -170,6 +171,130 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta, WritableBo
+@@ -170,6 +171,128 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta, WritableBo
      public void setGeneration(Generation generation) {
      }
  
@@ -4927,15 +4927,13 @@ index 3ab6b212001c2b92cac42c0ff97e59c3d08b3e49..552ebe67f87b48734adf0da8ef78dcac
 +
 +    @Override
 +    public net.kyori.adventure.text.Component page(final int page) {
-+        Preconditions.checkArgument(this.isValidPage(page), "Invalid page number");
++        Preconditions.checkArgument(this.isValidPage(page), "Invalid page number (%s/%s)", page, this.getPageCount());
 +        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(this.pages.get(page - 1));
 +    }
 +
 +    @Override
 +    public void page(final int page, net.kyori.adventure.text.Component data) {
-+        if (!this.isValidPage(page)) {
-+            throw new IllegalArgumentException("Invalid page number " + page + "/" + this.pages.size());
-+        }
++        Preconditions.checkArgument(this.isValidPage(page), "Invalid page number (%s/%s)", page, this.getPageCount());
 +        if (data == null) {
 +            data = net.kyori.adventure.text.Component.empty();
 +        }
@@ -5031,7 +5029,7 @@ index 3ab6b212001c2b92cac42c0ff97e59c3d08b3e49..552ebe67f87b48734adf0da8ef78dcac
      @Override
      public String getPage(final int page) {
          Preconditions.checkArgument(this.isValidPage(page), "Invalid page number (%s)", page);
-@@ -286,7 +411,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta, WritableBo
+@@ -286,7 +409,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta, WritableBo
      }
  
      @Override
@@ -5041,7 +5039,7 @@ index 3ab6b212001c2b92cac42c0ff97e59c3d08b3e49..552ebe67f87b48734adf0da8ef78dcac
  
          if (this.pages != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
-index c71a4971f127fdfc753306019313ce1a31201120..162997fc80dfe2df1f13c802c1b610f04cb9d05a 100644
+index c71a4971f127fdfc753306019313ce1a31201120..fd3b12477c30d1eabdbe57ea779027931e9dd957 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
 @@ -346,7 +346,7 @@ public class CraftMetaBookSigned extends CraftMetaItem implements BookMeta {
@@ -5053,7 +5051,7 @@ index c71a4971f127fdfc753306019313ce1a31201120..162997fc80dfe2df1f13c802c1b610f0
          super.serialize(builder);
  
          if (this.hasTitle()) {
-@@ -459,4 +459,113 @@ public class CraftMetaBookSigned extends CraftMetaItem implements BookMeta {
+@@ -459,4 +459,111 @@ public class CraftMetaBookSigned extends CraftMetaItem implements BookMeta {
          return this.spigot;
      }
      // Spigot end
@@ -5120,15 +5118,13 @@ index c71a4971f127fdfc753306019313ce1a31201120..162997fc80dfe2df1f13c802c1b610f0
 +
 +    @Override
 +    public net.kyori.adventure.text.Component page(final int page) {
-+        Preconditions.checkArgument(this.isValidPage(page), "Invalid page number");
++        Preconditions.checkArgument(this.isValidPage(page), "Invalid page number (%s/%s)", page, this.getPageCount());
 +        return io.papermc.paper.adventure.PaperAdventure.asAdventure(this.pages.get(page - 1));
 +    }
 +
 +    @Override
 +    public void page(final int page, net.kyori.adventure.text.Component data) {
-+        if (!this.isValidPage(page)) {
-+            throw new IllegalArgumentException("Invalid page number " + page + "/" + this.pages.size());
-+        }
++        Preconditions.checkArgument(this.isValidPage(page), "Invalid page number (%s/%s)", page, this.getPageCount());
 +        this.pages.set(page - 1, io.papermc.paper.adventure.PaperAdventure.asVanillaNullToEmpty(data));
 +    }
 +
@@ -5592,7 +5588,7 @@ index ff040613083c015d9c52c0995591b64305fd5018..1b552b3f05ac7fc44450de4b1ec78907
  
          boolean hadFormat = false;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 65b92a787b131984ad3e48d8dd6812e1b433c77f..1bf1f10f8691922a69cd13c6a4e643b863801b4f 100644
+index aa6a9dcd5528df38dddc0c661334c35658a19cee..5a89b9ca6a62f0bfb5fe01ed4097870788cf5d83 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -77,6 +77,43 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0967-General-ItemMeta-fixes.patch
+++ b/patches/server/0967-General-ItemMeta-fixes.patch
@@ -68,10 +68,20 @@ index e28bc898786542f695017ff0a036676840eb79fe..cee3fe00cc662f095e7d726b5f1a913c
      protected void load(T tileEntity) {
          if (tileEntity != null && tileEntity != this.snapshot) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 6a449bfc765bf427d82df4a90bc60471b5de2fd3..033918e051ef44de82a74097380cacaf926e5408 100644
+index 6a449bfc765bf427d82df4a90bc60471b5de2fd3..69b7eb7eff112b59b22f1d349831b9ee14c01943 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -341,7 +341,14 @@ public final class CraftItemStack extends ItemStack {
+@@ -279,7 +279,9 @@ public final class CraftItemStack extends ItemStack {
+ 
+     @Override
+     public void removeEnchantments() {
++        if (this.handle != null) { // Paper - fix NPE
+         this.handle.remove(DataComponents.ENCHANTMENTS);
++        } // Paper
+     }
+ 
+     @Override
+@@ -341,7 +343,14 @@ public final class CraftItemStack extends ItemStack {
      // Paper end - improve handled tags on type change
      // Paper start
      public static void applyMetaToItem(net.minecraft.world.item.ItemStack itemStack, ItemMeta itemMeta) {
@@ -87,7 +97,7 @@ index 6a449bfc765bf427d82df4a90bc60471b5de2fd3..033918e051ef44de82a74097380cacaf
          ((CraftMetaItem) itemMeta).applyToItem(tag);
          itemStack.applyComponents(tag.build());
      }
-@@ -389,15 +396,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -389,15 +398,20 @@ public final class CraftItemStack extends ItemStack {
          if (itemMeta == null) return true;
  
          if (!((CraftMetaItem) itemMeta).isEmpty()) {
@@ -445,7 +455,7 @@ index d7e5491cc0296563fb9fdf28d64b21a10c08ea4a..224ea52574b80bb087c5c62eaf1d4626
  
      private static Material shieldToBannerHack() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index e064af399dcae40b4f35aa993d356b1462f91d6c..27a275f324891e395bf3fd3038c0b9a724bbbf66 100644
+index 257c835bc280eee9ee73ae75b5249bb568a687d0..70f20de37c1f8d57a8d9fe00dcd864fdd9948ec2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 @@ -34,7 +34,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta, WritableBo
@@ -458,7 +468,7 @@ index e064af399dcae40b4f35aa993d356b1462f91d6c..27a275f324891e395bf3fd3038c0b9a7
  
      // We store the pages in their raw original text representation. See SPIGOT-5063, SPIGOT-5350, SPIGOT-3206
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
-index 806c1cbee7c4e23eee38c8f400ec2d924c9a360c..d357c8ddf06aea99bac6b43c1e20d2e99f98d034 100644
+index cbb3d80cc7cd81b2505dff999a0baede737165f7..040dac82e484cb44b3afd444b4bbd1fd994bfe7c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
 @@ -124,13 +124,13 @@ public class CraftMetaBookSigned extends CraftMetaItem implements BookMeta {
@@ -1399,7 +1409,7 @@ index ab860f1179fa2618c8fbc30ac5f48ff78b8abb60..7de2ed297d0b2bf8adf2058e75a9b594
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
-index e4b8637e6d82e2ce7cfee2130e6422f0ef4e1fbc..49751354ecd3d401726e8989eb3c09b2de7ae4dc 100644
+index 8ddf091b3ff1262b6c97e8fe72e0a80db5e1037d..be92ccda66f514459773916cc16b6c230e863444 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
 @@ -121,6 +121,7 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {

--- a/patches/server/1024-Proxy-ItemStack-to-CraftItemStack.patch
+++ b/patches/server/1024-Proxy-ItemStack-to-CraftItemStack.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Proxy ItemStack to CraftItemStack
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 033918e051ef44de82a74097380cacaf926e5408..08a1e8087b4f948ae31a3c3ef453261dc3dbc287 100644
+index 69b7eb7eff112b59b22f1d349831b9ee14c01943..f4c7b0e2db55ad9cdf09da80f6756f941315fb30 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -26,15 +26,57 @@ import org.jetbrains.annotations.ApiStatus;
@@ -121,7 +121,7 @@ index 033918e051ef44de82a74097380cacaf926e5408..08a1e8087b4f948ae31a3c3ef453261d
      }
  
      public static CraftItemStack asCraftMirror(net.minecraft.world.item.ItemStack original) {
-@@ -315,11 +341,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -317,11 +343,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public CraftItemStack clone() {
@@ -134,7 +134,7 @@ index 033918e051ef44de82a74097380cacaf926e5408..08a1e8087b4f948ae31a3c3ef453261d
      }
  
      @Override
-@@ -422,22 +444,14 @@ public final class CraftItemStack extends ItemStack {
+@@ -424,22 +446,14 @@ public final class CraftItemStack extends ItemStack {
          if (stack == this) {
              return true;
          }

--- a/patches/server/1025-Make-a-PDC-view-accessible-directly-from-ItemStack.patch
+++ b/patches/server/1025-Make-a-PDC-view-accessible-directly-from-ItemStack.patch
@@ -97,10 +97,10 @@ index 0000000000000000000000000000000000000000..fac401280d3f3689b00e16c19155ca75
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 08a1e8087b4f948ae31a3c3ef453261dc3dbc287..d562b17a96431dcff18fe648542f507a8fd354d7 100644
+index f4c7b0e2db55ad9cdf09da80f6756f941315fb30..40fb5b5e00f6bc82e67d318b8b3d1e7606973f52 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -482,4 +482,63 @@ public final class CraftItemStack extends ItemStack {
+@@ -484,4 +484,63 @@ public final class CraftItemStack extends ItemStack {
          return mirrored;
      }
      // Paper end


### PR DESCRIPTION
Handle those cases
- removing all enchantments from an empty item
- setting a page for a new book throw a NPE instead of the right exception (message is still weird here since it say x/0 but is now consistent with spigot).