### PR TITLE
Add BlockCollisionMode, FluidCollisionMode.WATER

### DIFF
--- a/patches/api/0053-Fix-upstream-javadocs.patch
+++ b/patches/api/0053-Fix-upstream-javadocs.patch
@@ -155,10 +155,38 @@ index 0ba391e6a1e585f29930b4111421e99f6eb11b4a..2f68b766267b53e98dee3054e0a69be8
       * @return an array containing all previous players
       */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 9885fd1adc1f93a80d650e6d42dfa3a0b084db9f..c4f2f03ec31998d486dad1d45ef83df3f77b5e28 100644
+index 9885fd1adc1f93a80d650e6d42dfa3a0b084db9f..8573167afa8ec74777801199fda9d0fcc1b56336 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2766,7 +2766,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -870,13 +870,6 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+      * Performs a ray trace that checks for block collisions using the blocks'
+      * precise collision shapes.
+      * <p>
+-     * If collisions with passable blocks are ignored, fluid collisions are
+-     * ignored as well regardless of the fluid collision mode.
+-     * <p>
+-     * Portal blocks are only considered passable if the ray starts within
+-     * them. Apart from that collisions with portal blocks will be considered
+-     * even if collisions with passable blocks are otherwise ignored.
+-     * <p>
+      * This may cause loading of chunks! Some implementations may impose
+      * artificial restrictions on the maximum distance.
+      *
+@@ -898,13 +891,6 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+      * <code>raySize</code> parameter is only taken into account for entity
+      * collision checks.
+      * <p>
+-     * If collisions with passable blocks are ignored, fluid collisions are
+-     * ignored as well regardless of the fluid collision mode.
+-     * <p>
+-     * Portal blocks are only considered passable if the ray starts within them.
+-     * Apart from that collisions with portal blocks will be considered even if
+-     * collisions with passable blocks are otherwise ignored.
+-     * <p>
+      * This may cause loading of chunks! Some implementations may impose
+      * artificial restrictions on the maximum distance.
+      *
+@@ -2766,7 +2752,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      /**
       * Find the closest nearby structure of a given {@link StructureType}.
       * Finding unexplored structures can, and will, block if the world is
@@ -167,7 +195,7 @@ index 9885fd1adc1f93a80d650e6d42dfa3a0b084db9f..c4f2f03ec31998d486dad1d45ef83df3
       * temporarily freezing while locating an unexplored structure.
       * <p>
       * The {@code radius} is not a rigid square radius. Each structure may alter
-@@ -2800,7 +2800,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2800,7 +2786,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      /**
       * Find the closest nearby structure of a given {@link StructureType}.
       * Finding unexplored structures can, and will, block if the world is
@@ -176,7 +204,7 @@ index 9885fd1adc1f93a80d650e6d42dfa3a0b084db9f..c4f2f03ec31998d486dad1d45ef83df3
       * temporarily freezing while locating an unexplored structure.
       * <p>
       * The {@code radius} is not a rigid square radius. Each structure may alter
-@@ -2833,7 +2833,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2833,7 +2819,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      /**
       * Find the closest nearby structure of a given {@link Structure}. Finding
       * unexplored structures can, and will, block if the world is looking in

--- a/patches/api/0098-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0098-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -621,10 +621,10 @@ index de9fd0fadd6d16ffe883a618bf499214878f443d..6f049e9044de4139971312f85ada19fb
       * Options which can be applied to dust particles - a particle
       * color and size.
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 9cf4823ddf1b8291e8c11c39c02c1fed58c18936..44a74f15bea60ecd8380520e8faaea41a6c261c5 100644
+index edab9cf327a08168c7a5404d2b0d816a65a6b048..89b6d1f91e3b13033623d3aac4f6983039b123f6 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2948,7 +2948,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2934,7 +2934,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
       */

--- a/patches/api/0112-Expand-Explosions-API.patch
+++ b/patches/api/0112-Expand-Explosions-API.patch
@@ -108,10 +108,10 @@ index 3161eae2fa5f03b7d3a5e9945ab659c15cf568c6..af737017ee397f80c44ee02c6cc60cef
      /**
       * Returns a list of entities within a bounding box centered around a Location.
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 44a74f15bea60ecd8380520e8faaea41a6c261c5..50c1e4957f66826feb0a2eb04293dbd6b5595700 100644
+index 89b6d1f91e3b13033623d3aac4f6983039b123f6..80c711999869dfe769564ece937aa5cb5e14bad7 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1424,6 +1424,88 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1410,6 +1410,88 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public boolean createExplosion(@NotNull Location loc, float power, boolean setFire);
  

--- a/patches/api/0150-Add-sun-related-API.patch
+++ b/patches/api/0150-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 6242b64416fdea1f3fd6378ba26ed7bb33ab4cc4..fcdc5d83621acff5f9210585455be1ea50abb77c 100644
+index 72fd2a107086f30df2656f553c3079f72f3b1e75..ed140e7a1483cbd6a65b58a54834cf202acec2f2 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1798,6 +1798,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1784,6 +1784,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public void setFullTime(long time);
  

--- a/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
@@ -618,7 +618,7 @@ index e455eb21abf121dc6ff10ff8a13dd06f67096a8f..bbc01e7c192ae6689c301670047ff114
          return origin;
      }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index fcdc5d83621acff5f9210585455be1ea50abb77c..216995288f6b8b407ef8240411b5ed4713379a7a 100644
+index ed140e7a1483cbd6a65b58a54834cf202acec2f2..f5f6db00d3c27060b572a4b75bd51ff8012553fa 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -418,9 +418,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -632,7 +632,7 @@ index fcdc5d83621acff5f9210585455be1ea50abb77c..216995288f6b8b407ef8240411b5ed47
      public boolean refreshChunk(int x, int z);
  
      /**
-@@ -3797,6 +3796,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3783,6 +3782,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      StructureSearchResult locateNearestStructure(@NotNull Location origin, @NotNull Structure structure, int radius, boolean findUnexplored);
  
      // Spigot start
@@ -640,7 +640,7 @@ index fcdc5d83621acff5f9210585455be1ea50abb77c..216995288f6b8b407ef8240411b5ed47
      public class Spigot {
  
          /**
-@@ -3830,7 +3830,11 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3816,7 +3816,11 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
          }
      }
  
@@ -652,7 +652,7 @@ index fcdc5d83621acff5f9210585455be1ea50abb77c..216995288f6b8b407ef8240411b5ed47
      Spigot spigot();
      // Spigot end
  
-@@ -4048,9 +4052,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -4034,9 +4038,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
           * Gets the dimension ID of this environment
           *
           * @return dimension ID
@@ -664,7 +664,7 @@ index fcdc5d83621acff5f9210585455be1ea50abb77c..216995288f6b8b407ef8240411b5ed47
          public int getId() {
              return id;
          }
-@@ -4060,9 +4064,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -4046,9 +4050,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
           *
           * @param id The ID of the environment
           * @return The environment

--- a/patches/api/0260-More-World-API.patch
+++ b/patches/api/0260-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 216995288f6b8b407ef8240411b5ed4713379a7a..d3fc033aba36c5fd99846e9200ed0071fddd6045 100644
+index f5f6db00d3c27060b572a4b75bd51ff8012553fa..04510e42e11eb3c8d00cb6dd4dcef48ed7dcbee7 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3795,6 +3795,72 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3781,6 +3781,72 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      StructureSearchResult locateNearestStructure(@NotNull Location origin, @NotNull Structure structure, int radius, boolean findUnexplored);
  

--- a/patches/api/0348-Expand-FallingBlock-API.patch
+++ b/patches/api/0348-Expand-FallingBlock-API.patch
@@ -10,10 +10,10 @@ Subject: [PATCH] Expand FallingBlock API
 Co-authored-by: Lukas Planz <lukas.planz@web.de>
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 8e9ab00503167799c6c929d00e48c07cb328848c..907906e15c9250fea385e49f10d3c248236fd004 100644
+index d5964008d36c837ccac3e7498f63dbfb5964a380..54aee8522a1506b7c6ae48acece59858a162c920 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2228,8 +2228,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2214,8 +2214,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The spawned {@link FallingBlock} instance
       * @throws IllegalArgumentException if {@link Location} or {@link
       *     MaterialData} are null or {@link Material} of the {@link MaterialData} is not a block
@@ -24,7 +24,7 @@ index 8e9ab00503167799c6c929d00e48c07cb328848c..907906e15c9250fea385e49f10d3c248
      public FallingBlock spawnFallingBlock(@NotNull Location location, @NotNull MaterialData data) throws IllegalArgumentException;
  
      /**
-@@ -2242,8 +2244,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2228,8 +2230,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The spawned {@link FallingBlock} instance
       * @throws IllegalArgumentException if {@link Location} or {@link
       *     BlockData} are null
@@ -35,7 +35,7 @@ index 8e9ab00503167799c6c929d00e48c07cb328848c..907906e15c9250fea385e49f10d3c248
      public FallingBlock spawnFallingBlock(@NotNull Location location, @NotNull BlockData data) throws IllegalArgumentException;
  
      /**
-@@ -2260,7 +2264,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2246,7 +2250,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The spawned {@link FallingBlock} instance
       * @throws IllegalArgumentException if {@link Location} or {@link
       *     Material} are null or {@link Material} is not a block

--- a/patches/api/0424-Additional-raytrace-API.patch
+++ b/patches/api/0424-Additional-raytrace-API.patch
@@ -1,11 +1,59 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: TonytheMacaroni <tonythemacaroni123@gmail.com>
 Date: Wed, 6 Sep 2023 19:24:53 -0400
-Subject: [PATCH] Add predicate for blocks when raytracing
+Subject: [PATCH] Additional raytrace API
 
 
+diff --git a/src/main/java/io/papermc/paper/raytrace/BlockCollisionMode.java b/src/main/java/io/papermc/paper/raytrace/BlockCollisionMode.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..a2dd14244b17201a04b2ae1412339a874cb01269
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/raytrace/BlockCollisionMode.java
+@@ -0,0 +1,25 @@
++package io.papermc.paper.raytrace;
++
++/**
++ * Determines the collision behavior when blocks get hit during ray tracing.
++ */
++public enum BlockCollisionMode {
++
++    /**
++     * Use the collision shape.
++     */
++    COLLIDER,
++    /**
++     * Use the outline shape.
++     */
++    OUTLINE,
++    /**
++     * Use the visual shape.
++     */
++    VISUAL,
++    /**
++     * Use the shape of a full block, but only consider blocks tagged with {@link org.bukkit.Tag#FALL_DAMAGE_RESETTING}.
++     */
++    FALL_DAMAGE_RESETTING
++
++}
+diff --git a/src/main/java/org/bukkit/FluidCollisionMode.java b/src/main/java/org/bukkit/FluidCollisionMode.java
+index ae28958941d7a7e66ce3e1215260d3624d4c8122..f960e2998cc591e63cd6a2f6603cd4d8d1366861 100644
+--- a/src/main/java/org/bukkit/FluidCollisionMode.java
++++ b/src/main/java/org/bukkit/FluidCollisionMode.java
+@@ -13,6 +13,12 @@ public enum FluidCollisionMode {
+      * Only collide with source fluid blocks.
+      */
+     SOURCE_ONLY,
++    // Paper start - Additional raytrace API
++    /**
++     * Collide only with water.
++     */
++    WATER,
++    // Paper end - Additional raytrace API
+     /**
+      * Collide with all fluids.
+      */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 907906e15c9250fea385e49f10d3c248236fd004..02184b68cc126b278985fd966e3c8e4ade18c464 100644
+index 54aee8522a1506b7c6ae48acece59858a162c920..bfe5ccc228e8f97694a43142be0530b3899c7f29 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -1649,6 +1649,27 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -36,21 +84,14 @@ index 907906e15c9250fea385e49f10d3c248236fd004..02184b68cc126b278985fd966e3c8e4a
      /**
       * Performs a ray trace that checks for block collisions using the blocks'
       * precise collision shapes.
-@@ -1712,6 +1733,34 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1705,6 +1726,45 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public RayTraceResult rayTraceBlocks(@NotNull Location start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks);
  
-+    // Paper start
++    // Paper start - Additional raytrace API
 +    /**
 +     * Performs a ray trace that checks for block collisions using the blocks'
 +     * precise collision shapes.
-+     * <p>
-+     * If collisions with passable blocks are ignored, fluid collisions are
-+     * ignored as well regardless of the fluid collision mode.
-+     * <p>
-+     * Portal blocks are only considered passable if the ray starts within
-+     * them. Apart from that collisions with portal blocks will be considered
-+     * even if collisions with passable blocks are otherwise ignored.
 +     * <p>
 +     * This may cause loading of chunks! Some implementations may impose
 +     * artificial restrictions on the maximum distance.
@@ -66,12 +107,30 @@ index 907906e15c9250fea385e49f10d3c248236fd004..02184b68cc126b278985fd966e3c8e4a
 +     * @return the ray trace hit result, or <code>null</code> if there is no hit
 +     */
 +    @Nullable RayTraceResult rayTraceBlocks(io.papermc.paper.math.@NotNull Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, @Nullable Predicate<? super Block> canCollide);
-+    // Paper end
++
++    /**
++     * Performs a ray trace that checks for block collisions using the blocks'
++     * precise shape.
++     * <p>
++     * This may cause loading of chunks! Some implementations may impose
++     * artificial restrictions on the maximum distance.
++     *
++     * @param start the start position
++     * @param direction the ray direction
++     * @param maxDistance the maximum distance
++     * @param fluidCollisionMode the fluid collision mode
++     * @param blockCollisionMode the block collision mode
++     * @param canCollide predicate for blocks the ray can potentially collide
++     *     with, or <code>null</code> to consider all blocks
++     * @return the ray trace hit result, or <code>null</code> if there is no hit
++     */
++    @Nullable RayTraceResult rayTraceBlocks(io.papermc.paper.math.@NotNull Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, @NotNull io.papermc.paper.raytrace.BlockCollisionMode blockCollisionMode, @Nullable Predicate<? super Block> canCollide);
++    // Paper end - Additional raytrace API
 +
      /**
       * Performs a ray trace that checks for both block and entity collisions.
       * <p>
-@@ -1745,6 +1794,42 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1731,6 +1791,61 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public RayTraceResult rayTrace(@NotNull Location start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, @Nullable Predicate<? super Entity> filter);
  
@@ -82,13 +141,6 @@ index 907906e15c9250fea385e49f10d3c248236fd004..02184b68cc126b278985fd966e3c8e4a
 +     * Block collisions use the blocks' precise collision shapes. The
 +     * <code>raySize</code> parameter is only taken into account for entity
 +     * collision checks.
-+     * <p>
-+     * If collisions with passable blocks are ignored, fluid collisions are
-+     * ignored as well regardless of the fluid collision mode.
-+     * <p>
-+     * Portal blocks are only considered passable if the ray starts within them.
-+     * Apart from that collisions with portal blocks will be considered even if
-+     * collisions with passable blocks are otherwise ignored.
 +     * <p>
 +     * This may cause loading of chunks! Some implementations may impose
 +     * artificial restrictions on the maximum distance.
@@ -109,6 +161,32 @@ index 907906e15c9250fea385e49f10d3c248236fd004..02184b68cc126b278985fd966e3c8e4a
 +     *     entity, or <code>null</code> if there is no hit
 +     */
 +    @Nullable RayTraceResult rayTrace(io.papermc.paper.math.@NotNull Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, @Nullable Predicate<? super Entity> filter, @Nullable Predicate<? super Block> canCollide);
++
++    /**
++     * Performs a ray trace that checks for both block and entity collisions.
++     * <p>
++     * Block collisions use the blocks' precise shape. The
++     * <code>raySize</code> parameter is only taken into account for entity
++     * collision checks.
++     * <p>
++     * This may cause loading of chunks! Some implementations may impose
++     * artificial restrictions on the maximum distance.
++     *
++     * @param start the start position
++     * @param direction the ray direction
++     * @param maxDistance the maximum distance
++     * @param fluidCollisionMode the fluid collision mode
++     * @param blockCollisionMode the block collision mode
++     * @param raySize entity bounding boxes will be uniformly expanded (or
++     *     shrinked) by this value before doing collision checks
++     * @param filter only entities that fulfill this predicate are considered,
++     *     or <code>null</code> to consider all entities
++     * @param canCollide predicate for blocks the ray can potentially collide
++     *     with, or <code>null</code> to consider all blocks
++     * @return the closest ray trace hit result with either a block or an
++     *     entity, or <code>null</code> if there is no hit
++     */
++    @Nullable RayTraceResult rayTrace(io.papermc.paper.math.@NotNull Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, @NotNull io.papermc.paper.raytrace.BlockCollisionMode blockCollisionMode, double raySize, @Nullable Predicate<? super Entity> filter, @Nullable Predicate<? super Block> canCollide);
 +    // Paper end
 +
      /**

--- a/patches/api/0458-More-Raid-API.patch
+++ b/patches/api/0458-More-Raid-API.patch
@@ -39,10 +39,10 @@ index 983a8c20a06d2b509602b27f49c090598b8ecc42..fa98599e3eee37bf68f0e9813497c718
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index ecc2d486cfec79cce27a947dfeed4853575a594d..d8a23aa0d898ca3360757721e38ddb97387f7d21 100644
+index 764ad397eadd91c27812a6cac61eacc1522441c5..5a509bba105d39897e0485301d1c770af944ded4 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -4111,6 +4111,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -4127,6 +4127,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public Raid locateNearestRaid(@NotNull Location location, int radius);
  

--- a/patches/server/0904-Additional-raytrace-API.patch
+++ b/patches/server/0904-Additional-raytrace-API.patch
@@ -1,23 +1,23 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: TonytheMacaroni <tonythemacaroni123@gmail.com>
 Date: Wed, 6 Sep 2023 19:24:16 -0400
-Subject: [PATCH] Add predicate for blocks when raytracing
+Subject: [PATCH] Additional raytrace API
 
 
 diff --git a/src/main/java/net/minecraft/world/level/BlockGetter.java b/src/main/java/net/minecraft/world/level/BlockGetter.java
-index c978f3b2d42f512e982f289e76c2422e41b7eec6..bb8e962e63c7a2d931f9bd7f7c002aa35cfa5fd3 100644
+index c978f3b2d42f512e982f289e76c2422e41b7eec6..aa376e6fa6f3bd55c9466685103e529eee2b4d43 100644
 --- a/src/main/java/net/minecraft/world/level/BlockGetter.java
 +++ b/src/main/java/net/minecraft/world/level/BlockGetter.java
 @@ -70,6 +70,12 @@ public interface BlockGetter extends LevelHeightAccessor {
  
      // CraftBukkit start - moved block handling into separate method for use by Block#rayTrace
      default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition) {
-+        // Paper start - Add predicate for blocks when raytracing
++        // Paper start - Additional raytrace API
 +        return clip(raytrace1, blockposition, null);
 +    }
 +
 +    default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition, java.util.function.Predicate<? super org.bukkit.block.Block> canCollide) {
-+            // Paper end - Add predicate for blocks when raytracing
++            // Paper end - Additional raytrace API
              // Paper start - Prevent raytrace from loading chunks
              BlockState iblockdata = this.getBlockStateIfLoaded(blockposition);
              if (iblockdata == null) {
@@ -34,27 +34,42 @@ index c978f3b2d42f512e982f289e76c2422e41b7eec6..bb8e962e63c7a2d931f9bd7f7c002aa3
      // CraftBukkit end
  
      default BlockHitResult clip(ClipContext context) {
-+        // Paper start - Add predicate for blocks when raytracing
++        // Paper start - Additional raytrace API
 +        return clip(context, (java.util.function.Predicate<org.bukkit.block.Block>) null);
 +    }
 +
 +    default BlockHitResult clip(ClipContext context, java.util.function.Predicate<? super org.bukkit.block.Block> canCollide) {
-+        // Paper end - Add predicate for blocks when raytracing
++        // Paper end - Additional raytrace API
          return (BlockHitResult) BlockGetter.traverseBlocks(context.getFrom(), context.getTo(), context, (raytrace1, blockposition) -> {
 -            return this.clip(raytrace1, blockposition); // CraftBukkit - moved into separate method
-+            return this.clip(raytrace1, blockposition, canCollide); // CraftBukkit - moved into separate method // Paper - Add predicate for blocks when raytracing
++            return this.clip(raytrace1, blockposition, canCollide); // CraftBukkit - moved into separate method // Paper - Additional raytrace API
          }, (raytrace1) -> {
              Vec3 vec3d = raytrace1.getFrom().subtract(raytrace1.getTo());
  
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftFluidCollisionMode.java b/src/main/java/org/bukkit/craftbukkit/CraftFluidCollisionMode.java
+index 2178d65faedeb5aec2a82d1ae76161e49f3537b2..ce9fc8e519c6efa915a58ca3a53a6fca44345743 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftFluidCollisionMode.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftFluidCollisionMode.java
+@@ -13,6 +13,10 @@ public final class CraftFluidCollisionMode {
+         switch (fluidCollisionMode) {
+             case ALWAYS:
+                 return Fluid.ANY;
++            // Paper start - Additional raytrace API
++            case WATER:
++                return Fluid.WATER;
++            // Paper end - Additional raytrace API
+             case SOURCE_ONLY:
+                 return Fluid.SOURCE_ONLY;
+             case NEVER:
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5c83ca573ccaa75a1d4e8129c96a24e3cf0f3266..29fa82c15411fbdae09e45e334209dcc93aa1789 100644
+index 5c83ca573ccaa75a1d4e8129c96a24e3cf0f3266..1b24b94b9913cadc19a36bbee38e032e268de066 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1094,9 +1094,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public RayTraceResult rayTraceEntities(Location start, Vector direction, double maxDistance, double raySize, Predicate<? super Entity> filter) {
-+        // Paper start - Add predicate for blocks when raytracing
++        // Paper start - Additional raytrace API
 +        return rayTraceEntities((io.papermc.paper.math.Position) start, direction, maxDistance, raySize, filter);
 +    }
 +
@@ -64,38 +79,44 @@ index 5c83ca573ccaa75a1d4e8129c96a24e3cf0f3266..29fa82c15411fbdae09e45e334209dcc
 -        start.checkFinite();
 +        Preconditions.checkArgument(!(start instanceof Location location) || this.equals(location.getWorld()), "Location start cannot be in a different world");
 +        Preconditions.checkArgument(start.isFinite(), "Location start is not finite");
-+        // Paper end - Add predicate for blocks when raytracing
++        // Paper end - Additional raytrace API
  
          Preconditions.checkArgument(direction != null, "Vector direction cannot be null");
          direction.checkFinite();
-@@ -1146,9 +1152,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1146,9 +1152,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks) {
-+        // Paper start - Add predicate for blocks when raytracing
++        // Paper start - Additional raytrace API
 +        return this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, null);
 +    }
 +
 +    @Override
 +    public RayTraceResult rayTraceBlocks(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, Predicate<? super Block> canCollide) {
++        return this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks ? io.papermc.paper.raytrace.BlockCollisionMode.COLLIDER : io.papermc.paper.raytrace.BlockCollisionMode.OUTLINE, canCollide);
++    }
++
++    @Override
++    public RayTraceResult rayTraceBlocks(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, io.papermc.paper.raytrace.BlockCollisionMode blockCollisionMode, Predicate<? super Block> canCollide) {
          Preconditions.checkArgument(start != null, "Location start cannot be null");
 -        Preconditions.checkArgument(this.equals(start.getWorld()), "Location start cannot be in a different world");
 -        start.checkFinite();
 +        Preconditions.checkArgument(!(start instanceof Location location) || this.equals(location.getWorld()), "Location start cannot be in a different world");
 +        Preconditions.checkArgument(start.isFinite(), "Location start is not finite");
-+        // Paper end - Add predicate for blocks when raytracing
++        Preconditions.checkArgument(blockCollisionMode != null, "BlockCollisionMode cannot be null");
++        // Paper end - Additional raytrace API
  
          Preconditions.checkArgument(direction != null, "Vector direction cannot be null");
          direction.checkFinite();
-@@ -1161,16 +1174,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1161,16 +1180,28 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
  
          Vector dir = direction.clone().normalize().multiply(maxDistance);
 -        Vec3 startPos = CraftLocation.toVec3D(start);
-+        Vec3 startPos = io.papermc.paper.util.MCUtil.toVec3(start); // Paper - Add predicate for blocks when raytracing
++        Vec3 startPos = io.papermc.paper.util.MCUtil.toVec3(start); // Paper - Additional raytrace API
          Vec3 endPos = startPos.add(dir.getX(), dir.getY(), dir.getZ());
 -        HitResult nmsHitResult = this.getHandle().clip(new ClipContext(startPos, endPos, ignorePassableBlocks ? ClipContext.Block.COLLIDER : ClipContext.Block.OUTLINE, CraftFluidCollisionMode.toNMS(fluidCollisionMode), CollisionContext.empty()));
-+        HitResult nmsHitResult = this.getHandle().clip(new ClipContext(startPos, endPos, ignorePassableBlocks ? ClipContext.Block.COLLIDER : ClipContext.Block.OUTLINE, CraftFluidCollisionMode.toNMS(fluidCollisionMode), CollisionContext.empty()), canCollide); // Paper - Add predicate for blocks when raytracing
++        HitResult nmsHitResult = this.getHandle().clip(new ClipContext(startPos, endPos, ClipContext.Block.values()[blockCollisionMode.ordinal()], CraftFluidCollisionMode.toNMS(fluidCollisionMode), CollisionContext.empty()), canCollide); // Paper - Additional raytrace API
  
          return CraftRayTraceResult.fromNMS(this, nmsHitResult);
      }
@@ -103,14 +124,19 @@ index 5c83ca573ccaa75a1d4e8129c96a24e3cf0f3266..29fa82c15411fbdae09e45e334209dcc
      @Override
      public RayTraceResult rayTrace(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<? super Entity> filter) {
 -        RayTraceResult blockHit = this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks);
-+        // Paper start - Add predicate for blocks when raytracing
++        // Paper start - Additional raytrace API
 +        return this.rayTrace(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, raySize, filter, null);
 +    }
 +
 +    @Override
 +    public RayTraceResult rayTrace(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<? super Entity> filter, Predicate<? super Block> canCollide) {
-+        RayTraceResult blockHit = this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, canCollide);
-+        // Paper end - Add predicate for blocks when raytracing
++        return this.rayTrace(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks ? io.papermc.paper.raytrace.BlockCollisionMode.COLLIDER : io.papermc.paper.raytrace.BlockCollisionMode.OUTLINE, raySize, filter, null);
++    }
++
++    @Override
++    public RayTraceResult rayTrace(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, io.papermc.paper.raytrace.BlockCollisionMode blockCollisionMode, double raySize, Predicate<? super Entity> filter, Predicate<? super Block> canCollide) {
++        RayTraceResult blockHit = this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, blockCollisionMode, canCollide);
++        // Paper end - Additional raytrace API
          Vector startVec = null;
          double blockHitDistance = maxDistance;
  

--- a/patches/server/0942-More-Raid-API.patch
+++ b/patches/server/0942-More-Raid-API.patch
@@ -86,10 +86,10 @@ index b8ce1c1c2447f9cff1717bfcfd6eb911ade0d4b3..51f21af9d75769abdcba713b9aa33392
 +    // Paper end - more Raid API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ebb119ab9f5a8ae580e54cb3c102cd86f948a8d2..94640aa827c9b2e1d0174eb012fdb37c0851f501 100644
+index 981dac6d1c35b74c25370d4689e32139eebdbe79..b860a173d3de72faf771a86b17b70b5388865b52 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2306,6 +2306,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2317,6 +2317,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (raid == null) ? null : new CraftRaid(raid);
      }
  

--- a/patches/server/0988-Moonrise-optimisation-patches.patch
+++ b/patches/server/0988-Moonrise-optimisation-patches.patch
@@ -32714,7 +32714,7 @@ index 6321ae23f07bc3e07577914e6cf035e0c2cd4992..cc1f3c7fec4fa794da0b19f44ced9fd4
  
      // Paper start - Adventure
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 94640aa827c9b2e1d0174eb012fdb37c0851f501..5ad2ceb1274648631689215702a12463c681152c 100644
+index b860a173d3de72faf771a86b17b70b5388865b52..6618a90c6fd6969e58835d356d82d7dc39ef0239 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -456,10 +456,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -32776,7 +32776,7 @@ index 94640aa827c9b2e1d0174eb012fdb37c0851f501..5ad2ceb1274648631689215702a12463
              long chunkKey = chunkTickets.getLongKey();
              SortedArraySet<Ticket<?>> tickets = chunkTickets.getValue();
  
-@@ -1290,12 +1281,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1301,12 +1292,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public int getViewDistance() {
@@ -32791,7 +32791,7 @@ index 94640aa827c9b2e1d0174eb012fdb37c0851f501..5ad2ceb1274648631689215702a12463
      }
  
      public BlockMetadataStore getBlockMetadata() {
-@@ -2433,17 +2424,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2444,17 +2435,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setSimulationDistance(final int simulationDistance) {

--- a/patches/server/0993-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
+++ b/patches/server/0993-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
@@ -39,7 +39,7 @@ index 9adaf1269e3eea6c0b62b5127317be7bfd651330..5deec2f7ab0f550b574b777f5a8eeb02
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/BlockGetter.java b/src/main/java/net/minecraft/world/level/BlockGetter.java
-index bb8e962e63c7a2d931f9bd7f7c002aa35cfa5fd3..0fa131a6c98adb498fc8d534e0e39647e80c6923 100644
+index aa376e6fa6f3bd55c9466685103e529eee2b4d43..63bfc6837e6687cd935016706a6f77541478ff24 100644
 --- a/src/main/java/net/minecraft/world/level/BlockGetter.java
 +++ b/src/main/java/net/minecraft/world/level/BlockGetter.java
 @@ -68,6 +68,18 @@ public interface BlockGetter extends LevelHeightAccessor {
@@ -60,9 +60,9 @@ index bb8e962e63c7a2d931f9bd7f7c002aa35cfa5fd3..0fa131a6c98adb498fc8d534e0e39647
 +    // Paper end
      // CraftBukkit start - moved block handling into separate method for use by Block#rayTrace
      default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition) {
-         // Paper start - Add predicate for blocks when raytracing
+         // Paper start - Additional raytrace API
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 5b893b93a3495b13ae266fb8054d0a454cf02660..77b7c252d27f527d9b51e8419abe7af1d4b51d29 100644
+index c69ed3e899fc8d48afeb731bb3b2d97b5969e6e3..574175449af5b767f28e95ff8708ed37fedf4c7d 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -816,10 +816,87 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl


### PR DESCRIPTION
- Adds overloads to `World#rayTrace` and `World#rayTraceBlocks` that take a `BlockCollisionMode`, instead of the boolean `ignorePassableBlocks`, to determine block collisions.
- Add missing `FluidCollisionMode.WATER`.
- Remove outdated javadocs on `World#rayTrace` and `World#rayTraceBlocks` that mention caveats with portal blocks and fluids that no longer exist. Portal blocks are always considered passable, and the value of `ignorePassableBlocks` has no effect on fluid collisions.