### PR TITLE
Shutdown L4J cordially if the server stops before it's even started

### DIFF
--- a/patches/server/1023-Improved-Watchdog-Support.patch
+++ b/patches/server/1023-Improved-Watchdog-Support.patch
@@ -58,6 +58,38 @@ index 6aaed8e8bf8c721fc834da5c76ac72a4c3e92458..4b002e8b75d117b726b0de274a76d359
  
          // Many servers tend to restart at a fixed time at xx:00 which causes an uneven distribution of requests on the
          // bStats backend. To circumvent this problem, we introduce some randomness into the initial and second delay.
+diff --git a/src/main/java/io/papermc/paper/util/LogManagerShutdownThread.java b/src/main/java/io/papermc/paper/util/LogManagerShutdownThread.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..d164fade5ba21b147f3b26638e9b385deb1a1bee
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/util/LogManagerShutdownThread.java
+@@ -0,0 +1,26 @@
++package io.papermc.paper.util;
++
++public class LogManagerShutdownThread extends Thread {
++
++    static LogManagerShutdownThread INSTANCE = new LogManagerShutdownThread();
++    public static final void hook() {
++        if (INSTANCE == null) {
++          throw new IllegalStateException("Cannot re-hook after being unhooked");
++        }
++        Runtime.getRuntime().addShutdownHook(INSTANCE);
++    }
++
++    public static final void unhook() {
++        Runtime.getRuntime().removeShutdownHook(INSTANCE);
++        INSTANCE = null;
++    }
++
++    private LogManagerShutdownThread() {
++        super("Log4j2 Shutdown Thread");
++    }
++
++    @Override
++    public void run() {
++        org.apache.logging.log4j.LogManager.shutdown();
++    }
++}
 diff --git a/src/main/java/net/minecraft/CrashReport.java b/src/main/java/net/minecraft/CrashReport.java
 index 589a8bf75be6ccc59f1e5dd5d8d9afed41c4772d..b24265573fdef5d9a964bcd76146f34542c420cf 100644
 --- a/src/main/java/net/minecraft/CrashReport.java
@@ -70,8 +102,20 @@ index 589a8bf75be6ccc59f1e5dd5d8d9afed41c4772d..b24265573fdef5d9a964bcd76146f345
          while (cause instanceof CompletionException && cause.getCause() != null) {
              cause = cause.getCause();
          }
+diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
+index 244a19ecd0234fa1d7a6ecfea20751595688605d..581bd217304e0f9e0b2113c335694805dfb4e2a1 100644
+--- a/src/main/java/net/minecraft/server/Main.java
++++ b/src/main/java/net/minecraft/server/Main.java
+@@ -77,6 +77,7 @@ public class Main {
+ 
+     @DontObfuscate
+     public static void main(final OptionSet optionset) { // CraftBukkit - replaces main(String[] astring)
++        io.papermc.paper.util.LogManagerShutdownThread.hook(); // Paper
+         SharedConstants.tryDetectVersion();
+         /* CraftBukkit start - Replace everything
+         OptionParser optionparser = new OptionParser();
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index fb3dcce4e1888f96fdd260740d9d955962d879fc..6313726359a1c15ee1d4d93b872849a1535539e1 100644
+index fb3dcce4e1888f96fdd260740d9d955962d879fc..93ebdbfad4f9f300f31a124d8d4b36c4f5ce382c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -307,7 +307,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -93,7 +137,15 @@ index fb3dcce4e1888f96fdd260740d9d955962d879fc..6313726359a1c15ee1d4d93b872849a1
      public static <S extends MinecraftServer> S spin(Function<Thread, S> serverFactory) {
          AtomicReference<S> atomicreference = new AtomicReference();
          Thread thread = new ca.spottedleaf.moonrise.common.util.TickThread(() -> { // Paper - rewrite chunk system
-@@ -1005,6 +1008,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -489,6 +492,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         }
+         */
+         // Paper end
++        io.papermc.paper.util.LogManagerShutdownThread.unhook(); // Paper
+         Runtime.getRuntime().addShutdownHook(new org.bukkit.craftbukkit.util.ServerShutdownThread(this));
+         // CraftBukkit end
+         this.paperConfigurations = services.paperConfigurations(); // Paper - add paper configuration files
+@@ -1005,6 +1009,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      // CraftBukkit start
      private boolean hasStopped = false;
      private boolean hasLoggedStop = false; // Paper - Debugging
@@ -101,7 +153,7 @@ index fb3dcce4e1888f96fdd260740d9d955962d879fc..6313726359a1c15ee1d4d93b872849a1
      private final Object stopLock = new Object();
      public final boolean hasStopped() {
          synchronized (this.stopLock) {
-@@ -1020,6 +1024,10 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1020,6 +1025,10 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.hasStopped = true;
          }
          if (!hasLoggedStop && isDebugging()) io.papermc.paper.util.TraceUtil.dumpTraceForThread("Server stopped"); // Paper - Debugging
@@ -112,7 +164,7 @@ index fb3dcce4e1888f96fdd260740d9d955962d879fc..6313726359a1c15ee1d4d93b872849a1
          // CraftBukkit end
          if (this.metricsRecorder.isRecording()) {
              this.cancelRecordingMetrics();
-@@ -1093,7 +1101,17 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1093,7 +1102,17 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
          // Spigot end
  
@@ -130,7 +182,7 @@ index fb3dcce4e1888f96fdd260740d9d955962d879fc..6313726359a1c15ee1d4d93b872849a1
      }
  
      public String getLocalIp() {
-@@ -1188,6 +1206,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1188,6 +1207,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      protected void runServer() {
          try {
@@ -138,7 +190,7 @@ index fb3dcce4e1888f96fdd260740d9d955962d879fc..6313726359a1c15ee1d4d93b872849a1
              if (!this.initServer()) {
                  throw new IllegalStateException("Failed to initialize server");
              }
-@@ -1197,6 +1216,17 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1197,6 +1217,17 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.status = this.buildServerStatus();
  
              // Spigot start
@@ -156,7 +208,7 @@ index fb3dcce4e1888f96fdd260740d9d955962d879fc..6313726359a1c15ee1d4d93b872849a1
              org.spigotmc.WatchdogThread.hasStarted = true; // Paper
              Arrays.fill( this.recentTps, 20 );
              // Paper start - further improve server tick loop
-@@ -1292,6 +1322,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1292,6 +1323,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  JvmProfiler.INSTANCE.onServerTick(this.smoothedTickTimeMillis);
              }
          } catch (Throwable throwable) {
@@ -169,7 +221,7 @@ index fb3dcce4e1888f96fdd260740d9d955962d879fc..6313726359a1c15ee1d4d93b872849a1
              MinecraftServer.LOGGER.error("Encountered an unexpected exception", throwable);
              CrashReport crashreport = MinecraftServer.constructOrExtractCrashReport(throwable);
  
-@@ -1316,15 +1352,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1316,15 +1353,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                      this.services.profileCache().clearExecutor();
                  }
  
@@ -189,7 +241,7 @@ index fb3dcce4e1888f96fdd260740d9d955962d879fc..6313726359a1c15ee1d4d93b872849a1
              }
  
          }
-@@ -1447,6 +1483,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1447,6 +1484,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      @Override
      public TickTask wrapRunnable(Runnable runnable) {
@@ -202,7 +254,7 @@ index fb3dcce4e1888f96fdd260740d9d955962d879fc..6313726359a1c15ee1d4d93b872849a1
          return new TickTask(this.tickCount, runnable);
      }
  
-@@ -2266,7 +2308,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2266,7 +2309,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.worldData.setDataConfiguration(worlddataconfiguration);
              this.resources.managers.updateRegistryTags();
              this.potionBrewing = this.potionBrewing.reload(this.worldData.enabledFeatures()); // Paper - Custom Potion Mixes

--- a/patches/server/1023-Improved-Watchdog-Support.patch
+++ b/patches/server/1023-Improved-Watchdog-Support.patch
@@ -60,7 +60,7 @@ index 6aaed8e8bf8c721fc834da5c76ac72a4c3e92458..4b002e8b75d117b726b0de274a76d359
          // bStats backend. To circumvent this problem, we introduce some randomness into the initial and second delay.
 diff --git a/src/main/java/io/papermc/paper/util/LogManagerShutdownThread.java b/src/main/java/io/papermc/paper/util/LogManagerShutdownThread.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d164fade5ba21b147f3b26638e9b385deb1a1bee
+index 0000000000000000000000000000000000000000..183e141d0c13190c6905dc4510d891992afef878
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/LogManagerShutdownThread.java
 @@ -0,0 +1,26 @@
@@ -71,7 +71,7 @@ index 0000000000000000000000000000000000000000..d164fade5ba21b147f3b26638e9b385d
 +    static LogManagerShutdownThread INSTANCE = new LogManagerShutdownThread();
 +    public static final void hook() {
 +        if (INSTANCE == null) {
-+          throw new IllegalStateException("Cannot re-hook after being unhooked");
++            throw new IllegalStateException("Cannot re-hook after being unhooked");
 +        }
 +        Runtime.getRuntime().addShutdownHook(INSTANCE);
 +    }

--- a/patches/server/1034-Lag-compensation-ticks.patch
+++ b/patches/server/1034-Lag-compensation-ticks.patch
@@ -8,7 +8,7 @@ Areas affected by lag comepnsation:
  - Eating food items
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 6313726359a1c15ee1d4d93b872849a1535539e1..7e5adfddced650cf227b540f3b40573cdf5b0f7c 100644
+index 93ebdbfad4f9f300f31a124d8d4b36c4f5ce382c..a2875f7cdfb6b43ed59cff41ab4122a08c4cc57f 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -322,6 +322,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -19,7 +19,7 @@ index 6313726359a1c15ee1d4d93b872849a1535539e1..7e5adfddced650cf227b540f3b40573c
  
      public static <S extends MinecraftServer> S spin(Function<Thread, S> serverFactory) {
          AtomicReference<S> atomicreference = new AtomicReference();
-@@ -1764,6 +1765,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1765,6 +1766,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              worldserver.hasPhysicsEvent = org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
              worldserver.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - Add EntityMoveEvent
              net.minecraft.world.level.block.entity.HopperBlockEntity.skipHopperEvents = worldserver.paperConfig().hopper.disableMoveEvent || org.bukkit.event.inventory.InventoryMoveItemEvent.getHandlerList().getRegisteredListeners().length == 0; // Paper - Perf: Optimize Hoppers

--- a/patches/server/1039-Incremental-chunk-and-player-saving.patch
+++ b/patches/server/1039-Incremental-chunk-and-player-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Incremental chunk and player saving
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7e5adfddced650cf227b540f3b40573cdf5b0f7c..8160c35368fc2c52d6f4a42df27adb2ef6eb87f3 100644
+index a2875f7cdfb6b43ed59cff41ab4122a08c4cc57f..45695abbeb0a6d47b31b23ba6c464f17e99d7898 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -992,7 +992,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -993,7 +993,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
          try {
              this.isSaving = true;
@@ -17,7 +17,7 @@ index 7e5adfddced650cf227b540f3b40573cdf5b0f7c..8160c35368fc2c52d6f4a42df27adb2e
              flag3 = this.saveAllChunks(suppressLogs, flush, force);
          } finally {
              this.isSaving = false;
-@@ -1596,16 +1596,28 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1597,16 +1597,28 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
  
          --this.ticksUntilAutosave;

--- a/patches/server/1043-Bundle-spark.patch
+++ b/patches/server/1043-Bundle-spark.patch
@@ -268,10 +268,10 @@ index 6b8ed8a0baaf4a57d20e57cec3400af5561ddd79..48604e7f96adc9e226e034054c5e2bad
      }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 8160c35368fc2c52d6f4a42df27adb2ef6eb87f3..9325d6f95165a7cee00d7de736af723681cc16b4 100644
+index 45695abbeb0a6d47b31b23ba6c464f17e99d7898..23ddd26af762c1cd7fb3920669abb96b3213ab37 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -751,6 +751,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -752,6 +752,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // Paper end - Configurable player collision
  
          this.server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.POSTWORLD);
@@ -280,7 +280,7 @@ index 8160c35368fc2c52d6f4a42df27adb2ef6eb87f3..9325d6f95165a7cee00d7de736af7236
          if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.pluginsEnabled(); // Paper - Remap plugins
          io.papermc.paper.command.brigadier.PaperCommands.INSTANCE.setValid(); // Paper - reset invalid state for event fire below
          io.papermc.paper.plugin.lifecycle.event.LifecycleEventRunner.INSTANCE.callReloadableRegistrarEvent(io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents.COMMANDS, io.papermc.paper.command.brigadier.PaperCommands.INSTANCE, org.bukkit.plugin.Plugin.class, io.papermc.paper.plugin.lifecycle.event.registrar.ReloadableRegistrarEvent.Cause.INITIAL); // Paper - call commands event for regular plugins
-@@ -1037,6 +1039,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1038,6 +1040,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          MinecraftServer.LOGGER.info("Stopping server");
          Commands.COMMAND_SENDING_POOL.shutdownNow(); // Paper - Perf: Async command map building; Shutdown and don't bother finishing
          MinecraftTimings.stopServer(); // Paper
@@ -288,7 +288,7 @@ index 8160c35368fc2c52d6f4a42df27adb2ef6eb87f3..9325d6f95165a7cee00d7de736af7236
          // CraftBukkit start
          if (this.server != null) {
              this.server.disablePlugins();
-@@ -1226,6 +1229,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1227,6 +1230,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              // tasks are default scheduled at -1 + delay, and first tick will tick at 1
              final long actualDoneTimeMs = System.currentTimeMillis() - org.bukkit.craftbukkit.Main.BOOT_TIME.toEpochMilli(); // Paper - Add total time
              LOGGER.info("Done ({})! For help, type \"help\"", String.format(java.util.Locale.ROOT, "%.3fs", actualDoneTimeMs / 1000.00D)); // Paper - Add total time
@@ -296,7 +296,7 @@ index 8160c35368fc2c52d6f4a42df27adb2ef6eb87f3..9325d6f95165a7cee00d7de736af7236
              org.spigotmc.WatchdogThread.tick();
              // Paper end - Improved Watchdog Support
              org.spigotmc.WatchdogThread.hasStarted = true; // Paper
-@@ -1585,6 +1589,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1586,6 +1590,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          });
          isOversleep = false;MinecraftTimings.serverOversleep.stopTiming();
          // Paper end
@@ -304,7 +304,7 @@ index 8160c35368fc2c52d6f4a42df27adb2ef6eb87f3..9325d6f95165a7cee00d7de736af7236
          new com.destroystokyo.paper.event.server.ServerTickStartEvent(this.tickCount+1).callEvent(); // Paper - Server Tick Events
  
          ++this.tickCount;
-@@ -1627,6 +1632,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1628,6 +1633,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          long endTime = System.nanoTime();
          long remaining = (TICK_TIME - (endTime - lastTick)) - catchupTime;
          new com.destroystokyo.paper.event.server.ServerTickEndEvent(this.tickCount, ((double)(endTime - lastTick) / 1000000D), remaining).callEvent();


### PR DESCRIPTION
primarily, this allows us to ensure that appenders are flushed, console, log files
before the JVM exits to avoid issues such as error messages disappearing
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-11172.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1751384428.zip)