### PR TITLE
Preserve command node when re-registering modern commands through old API

### DIFF
--- a/patches/server/0972-Brigadier-based-command-API.patch
+++ b/patches/server/0972-Brigadier-based-command-API.patch
@@ -1508,10 +1508,10 @@ index 0000000000000000000000000000000000000000..c59bbd90fdf04db837366218b312e7fb
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitBrigForwardingMap.java b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitBrigForwardingMap.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f0cc27640bb3db275295a298d608c9d9f88df617
+index 0000000000000000000000000000000000000000..46213c0d7ea777f829d6da6ea4ebe2620d5dce8c
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitBrigForwardingMap.java
-@@ -0,0 +1,332 @@
+@@ -0,0 +1,338 @@
 +package io.papermc.paper.command.brigadier.bukkit;
 +
 +import com.google.common.collect.Iterators;
@@ -1534,6 +1534,7 @@ index 0000000000000000000000000000000000000000..f0cc27640bb3db275295a298d608c9d9
 +import java.util.function.Consumer;
 +import java.util.stream.Stream;
 +import org.bukkit.command.Command;
++import org.bukkit.craftbukkit.command.VanillaCommandWrapper;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -1604,12 +1605,17 @@ index 0000000000000000000000000000000000000000..f0cc27640bb3db275295a298d608c9d9
 +        return PaperBrigadier.wrapNode(node);
 +    }
 +
++    @SuppressWarnings({"unchecked", "rawtypes"})
 +    @Nullable
 +    @Override
 +    public Command put(String key, Command value) {
 +        Command old = this.get(key);
 +        this.getDispatcher().getRoot().removeCommand(key); // Override previous command
-+        this.getDispatcher().getRoot().addChild(BukkitCommandNode.of(key, value));
++        if (value instanceof VanillaCommandWrapper wrapper) {
++            this.getDispatcher().getRoot().addChild((CommandNode) wrapper.vanillaCommand);
++        } else {
++            this.getDispatcher().getRoot().addChild(BukkitCommandNode.of(key, value));
++        }
 +        return old;
 +    }
 +

--- a/patches/server/0972-Brigadier-based-command-API.patch
+++ b/patches/server/0972-Brigadier-based-command-API.patch
@@ -1508,7 +1508,7 @@ index 0000000000000000000000000000000000000000..c59bbd90fdf04db837366218b312e7fb
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitBrigForwardingMap.java b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitBrigForwardingMap.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..46213c0d7ea777f829d6da6ea4ebe2620d5dce8c
+index 0000000000000000000000000000000000000000..5eef7ae5197bd395fbd6800530ffe34d147651ff
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitBrigForwardingMap.java
 @@ -0,0 +1,338 @@
@@ -1517,10 +1517,10 @@ index 0000000000000000000000000000000000000000..46213c0d7ea777f829d6da6ea4ebe262
 +import com.google.common.collect.Iterators;
 +import com.mojang.brigadier.CommandDispatcher;
 +import com.mojang.brigadier.tree.CommandNode;
-+import com.mojang.brigadier.tree.LiteralCommandNode;
 +import io.papermc.paper.command.brigadier.CommandSourceStack;
 +import io.papermc.paper.command.brigadier.PaperBrigadier;
 +import io.papermc.paper.command.brigadier.PaperCommands;
++import io.papermc.paper.command.brigadier.PluginVanillaCommandWrapper;
 +import java.util.AbstractCollection;
 +import java.util.AbstractSet;
 +import java.util.ArrayList;
@@ -1534,7 +1534,6 @@ index 0000000000000000000000000000000000000000..46213c0d7ea777f829d6da6ea4ebe262
 +import java.util.function.Consumer;
 +import java.util.stream.Stream;
 +import org.bukkit.command.Command;
-+import org.bukkit.craftbukkit.command.VanillaCommandWrapper;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -1611,7 +1610,8 @@ index 0000000000000000000000000000000000000000..46213c0d7ea777f829d6da6ea4ebe262
 +    public Command put(String key, Command value) {
 +        Command old = this.get(key);
 +        this.getDispatcher().getRoot().removeCommand(key); // Override previous command
-+        if (value instanceof VanillaCommandWrapper wrapper) {
++        if (value instanceof PluginVanillaCommandWrapper wrapper && wrapper.getName().equals(key)) {
++            // Don't break when some plugin tries to remove and add back a plugin command registered with modern API...
 +            this.getDispatcher().getRoot().addChild((CommandNode) wrapper.vanillaCommand);
 +        } else {
 +            this.getDispatcher().getRoot().addChild(BukkitCommandNode.of(key, value));


### PR DESCRIPTION

<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-11184.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1756877154.zip)