### PR TITLE
Fix potion effect overriding

### DIFF
--- a/patches/server/0678-More-Projectile-API.patch
+++ b/patches/server/0678-More-Projectile-API.patch
@@ -248,7 +248,7 @@ index 329ca9c743a7f2feeabbfb769ff9a71f60165006..faa08ad912fa43e7a6c5a2359e23c04c
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
-index 81f5e1d866128af8fb2acc13aca715580fdf9886..a988b8465a2c115414fb7ee540fa41bb8dcd6d9d 100644
+index 81f5e1d866128af8fb2acc13aca715580fdf9886..d6ee4870e562a7d53e34eb87d515499558553066 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
 @@ -125,7 +125,7 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
@@ -268,7 +268,7 @@ index 81f5e1d866128af8fb2acc13aca715580fdf9886..a988b8465a2c115414fb7ee540fa41bb
 -            if (!override) {
 -                return false;
 -            }
-+        if (override && this.hasCustomEffect(effect.getType())) { // Paper - support multiple effects of the same type
++        if (override) { // Paper - support multiple effects of the same type
              this.removeCustomEffect(effect.getType());
          }
          this.getHandle().addEffect(CraftPotionUtil.fromBukkit(effect));
@@ -287,7 +287,7 @@ index 81f5e1d866128af8fb2acc13aca715580fdf9886..a988b8465a2c115414fb7ee540fa41bb
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
-index 5232fbef0d014edd32a5d18d4a1500ab215313f5..0d5564d21e8c16d4d6fe6e4c23f672e635cf07ae 100644
+index 5232fbef0d014edd32a5d18d4a1500ab215313f5..2474c78c52e21e29a37555a19170e076271dbd54 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
 @@ -36,14 +36,11 @@ public class CraftArrow extends CraftAbstractArrow implements Arrow {
@@ -298,7 +298,7 @@ index 5232fbef0d014edd32a5d18d4a1500ab215313f5..0d5564d21e8c16d4d6fe6e4c23f672e6
 -            if (!override) {
 -                return false;
 -            }
-+        if (override && this.hasCustomEffect(effect.getType())) { // Paper - support multiple effects of the same type
++        if (override) { // Paper - support multiple effects of the same type
              this.removeCustomEffect(effect.getType());
          }
          this.getHandle().addEffect(CraftPotionUtil.fromBukkit(effect));

--- a/patches/server/0678-More-Projectile-API.patch
+++ b/patches/server/0678-More-Projectile-API.patch
@@ -248,7 +248,7 @@ index 329ca9c743a7f2feeabbfb769ff9a71f60165006..faa08ad912fa43e7a6c5a2359e23c04c
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
-index 81f5e1d866128af8fb2acc13aca715580fdf9886..88f2a9f310f30a08893f3fa68af13a54cf72fa7f 100644
+index 81f5e1d866128af8fb2acc13aca715580fdf9886..a988b8465a2c115414fb7ee540fa41bb8dcd6d9d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
 @@ -125,7 +125,7 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
@@ -260,7 +260,15 @@ index 81f5e1d866128af8fb2acc13aca715580fdf9886..88f2a9f310f30a08893f3fa68af13a54
      }
  
      @Override
-@@ -143,7 +143,7 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
+@@ -136,14 +136,11 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
+ 
+     @Override
+     public boolean addCustomEffect(PotionEffect effect, boolean override) {
+-        if (this.hasCustomEffect(effect.getType())) {
+-            if (!override) {
+-                return false;
+-            }
++        if (override && this.hasCustomEffect(effect.getType())) { // Paper - support multiple effects of the same type
              this.removeCustomEffect(effect.getType());
          }
          this.getHandle().addEffect(CraftPotionUtil.fromBukkit(effect));
@@ -269,7 +277,7 @@ index 81f5e1d866128af8fb2acc13aca715580fdf9886..88f2a9f310f30a08893f3fa68af13a54
          return true;
      }
  
-@@ -151,7 +151,7 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
+@@ -151,7 +148,7 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
      public void clearCustomEffects() {
          PotionContents old = this.getHandle().potionContents;
          this.getHandle().setPotionContents(new PotionContents(old.potion(), old.customColor(), List.of()));
@@ -279,10 +287,18 @@ index 81f5e1d866128af8fb2acc13aca715580fdf9886..88f2a9f310f30a08893f3fa68af13a54
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
-index 5232fbef0d014edd32a5d18d4a1500ab215313f5..071be344c3265a0cd52b31ffbb02ff7a70bdf231 100644
+index 5232fbef0d014edd32a5d18d4a1500ab215313f5..0d5564d21e8c16d4d6fe6e4c23f672e635cf07ae 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
-@@ -43,7 +43,7 @@ public class CraftArrow extends CraftAbstractArrow implements Arrow {
+@@ -36,14 +36,11 @@ public class CraftArrow extends CraftAbstractArrow implements Arrow {
+ 
+     @Override
+     public boolean addCustomEffect(PotionEffect effect, boolean override) {
+-        if (this.hasCustomEffect(effect.getType())) {
+-            if (!override) {
+-                return false;
+-            }
++        if (override && this.hasCustomEffect(effect.getType())) { // Paper - support multiple effects of the same type
              this.removeCustomEffect(effect.getType());
          }
          this.getHandle().addEffect(CraftPotionUtil.fromBukkit(effect));
@@ -291,7 +307,7 @@ index 5232fbef0d014edd32a5d18d4a1500ab215313f5..071be344c3265a0cd52b31ffbb02ff7a
          return true;
      }
  
-@@ -51,7 +51,7 @@ public class CraftArrow extends CraftAbstractArrow implements Arrow {
+@@ -51,7 +48,7 @@ public class CraftArrow extends CraftAbstractArrow implements Arrow {
      public void clearCustomEffects() {
          PotionContents old = this.getHandle().getPotionContents();
          this.getHandle().setPotionContents(new PotionContents(old.potion(), old.customColor(), List.of()));
@@ -300,7 +316,7 @@ index 5232fbef0d014edd32a5d18d4a1500ab215313f5..071be344c3265a0cd52b31ffbb02ff7a
      }
  
      @Override
-@@ -117,16 +117,17 @@ public class CraftArrow extends CraftAbstractArrow implements Arrow {
+@@ -117,16 +114,17 @@ public class CraftArrow extends CraftAbstractArrow implements Arrow {
  
      @Override
      public void setColor(Color color) {

--- a/patches/server/0750-Fix-a-bunch-of-vanilla-bugs.patch
+++ b/patches/server/0750-Fix-a-bunch-of-vanilla-bugs.patch
@@ -52,6 +52,9 @@ https://bugs.mojang.com/browse/MC-200092
 https://bugs.mojang.com/browse/MC-158900
   Fix error when joining after tempban expired
 
+https://bugs.mojang.com/browse/MC-259832
+  Fix hidden potion effects disappearing
+
 == AT ==
 public net/minecraft/world/entity/Mob leashInfoTag
 
@@ -85,7 +88,7 @@ index 6854ca4d4fec2b4fa541c3fabf63787665572609..e7b444a10b244828827b3c66c5346520
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index b953def299faf1a13e1893d17a476f36e2d6337a..d409791325771909faaef0dffb0f7f02d1bf71af 100644
+index 071e9ef3680c5dc492c6142ccd05f6788ebc3035..61fda6927f060cdf8bcfddaaa08bbbe2c514c630 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1027,7 +1027,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -124,7 +127,7 @@ index 6abecaac8407b992d208a9108e11fd4954a4106f..03d89f326d320c5d778c3d1e2db7d6b8
              this.player.server.getPlayerList().broadcastAll(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE, this.player), this.player); // CraftBukkit
              this.level.updateSleepingPlayerList();
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index d430e6c08bae0a630e71c11c9eae26bef85bde36..a929b8f1c452db08a64e4be53b488cf2676e0a94 100644
+index b0a1f6cf2cc96a2ddc8232f929c134501d99411e..84add5cc89ec912389500b6140a39d6b7ddc9e86 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -260,7 +260,7 @@ public abstract class PlayerList {
@@ -149,6 +152,19 @@ index d430e6c08bae0a630e71c11c9eae26bef85bde36..a929b8f1c452db08a64e4be53b488cf2
  
              ichatmutablecomponent = Component.translatable("multiplayer.disconnect.banned.reason", gameprofilebanentry.getReason());
              if (gameprofilebanentry.getExpires() != null) {
+diff --git a/src/main/java/net/minecraft/world/effect/MobEffectInstance.java b/src/main/java/net/minecraft/world/effect/MobEffectInstance.java
+index 959c0f82a3a7dae801914be5a126c87ac3b99a63..31a4f5716e646ea7cb4eead94b20694d97480709 100644
+--- a/src/main/java/net/minecraft/world/effect/MobEffectInstance.java
++++ b/src/main/java/net/minecraft/world/effect/MobEffectInstance.java
+@@ -224,7 +224,7 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+             }
+ 
+             this.tickDownDuration();
+-            if (this.duration == 0 && this.hiddenEffect != null) {
++            while (this.duration == 0 && this.hiddenEffect != null) { // Paper - Fix MC-259832
+                 this.setDetailsFrom(this.hiddenEffect);
+                 this.hiddenEffect = this.hiddenEffect.hiddenEffect;
+                 overwriteCallback.run();
 diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java
 index 784a894688f98f9d0368a36d456c5c94e1ee3695..a85885ee51df585fa11ae9f8fcd67ff2a71c5a18 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java

--- a/patches/server/0750-Fix-a-bunch-of-vanilla-bugs.patch
+++ b/patches/server/0750-Fix-a-bunch-of-vanilla-bugs.patch
@@ -153,10 +153,10 @@ index b0a1f6cf2cc96a2ddc8232f929c134501d99411e..84add5cc89ec912389500b6140a39d6b
              ichatmutablecomponent = Component.translatable("multiplayer.disconnect.banned.reason", gameprofilebanentry.getReason());
              if (gameprofilebanentry.getExpires() != null) {
 diff --git a/src/main/java/net/minecraft/world/effect/MobEffectInstance.java b/src/main/java/net/minecraft/world/effect/MobEffectInstance.java
-index 959c0f82a3a7dae801914be5a126c87ac3b99a63..31a4f5716e646ea7cb4eead94b20694d97480709 100644
+index 959c0f82a3a7dae801914be5a126c87ac3b99a63..6ce34b6c32d6a65a5a791c296edbdb1c384d6423 100644
 --- a/src/main/java/net/minecraft/world/effect/MobEffectInstance.java
 +++ b/src/main/java/net/minecraft/world/effect/MobEffectInstance.java
-@@ -224,7 +224,7 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+@@ -224,10 +224,10 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
              }
  
              this.tickDownDuration();
@@ -164,7 +164,11 @@ index 959c0f82a3a7dae801914be5a126c87ac3b99a63..31a4f5716e646ea7cb4eead94b20694d
 +            while (this.duration == 0 && this.hiddenEffect != null) { // Paper - Fix MC-259832
                  this.setDetailsFrom(this.hiddenEffect);
                  this.hiddenEffect = this.hiddenEffect.hiddenEffect;
-                 overwriteCallback.run();
+-                overwriteCallback.run();
++                if (this.duration != 0) overwriteCallback.run(); // Paper - don't run callback for expired effects
+             }
+         }
+ 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java
 index 784a894688f98f9d0368a36d456c5c94e1ee3695..a85885ee51df585fa11ae9f8fcd67ff2a71c5a18 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java

--- a/patches/server/0967-General-ItemMeta-fixes.patch
+++ b/patches/server/0967-General-ItemMeta-fixes.patch
@@ -1345,7 +1345,7 @@ index 90c554dcbfe2bcca3f742379499f1e8e8665c512..14acdd2bd02de7e99b7f237151633ed7
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
-index 7f9182809f6e67ff571db0f365bc7e05f600775a..52d0fb3e08c93892ca401f721359cfac8d96e2c9 100644
+index 7f9182809f6e67ff571db0f365bc7e05f600775a..cae26785e72106f4a95de8344aeea6d27c395563 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
 @@ -37,7 +37,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
@@ -1384,29 +1384,36 @@ index 7f9182809f6e67ff571db0f365bc7e05f600775a..52d0fb3e08c93892ca401f721359cfac
  
          List<MobEffectInstance> effectList = new ArrayList<>();
          if (this.customEffects != null) {
-@@ -189,25 +189,24 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+@@ -189,25 +189,27 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
      public boolean addCustomEffect(PotionEffect effect, boolean overwrite) {
          Preconditions.checkArgument(effect != null, "Potion effect cannot be null");
  
 -        int index = this.indexOfEffect(effect.getType());
 -        if (index != -1) {
 -            if (overwrite) {
+-                PotionEffect old = this.customEffects.get(index);
+-                if (old.getAmplifier() == effect.getAmplifier() && old.getDuration() == effect.getDuration() && old.isAmbient() == effect.isAmbient()) {
+-                    return false;
 +        // Paper start - support multiple effects of the same type
-+        if (overwrite) {
-+            int index = this.indexOfEffect(effect.getType());
-+            if (index != -1) {
-+        // Paper end - support multiple effects of the same type
-                 PotionEffect old = this.customEffects.get(index);
-                 if (old.getAmplifier() == effect.getAmplifier() && old.getDuration() == effect.getDuration() && old.isAmbient() == effect.isAmbient()) {
-                     return false;
++        if (overwrite && hasCustomEffects()) {
++            int index = -1;
++            for (int i = this.customEffects.size() - 1; i >= 0; i--) {
++                PotionEffect eff = this.customEffects.get(i);
++                if (eff.getType().equals(effect.getType())) {
++                    this.customEffects.remove(i);
++                    index = i;
                  }
-                 this.customEffects.set(index, effect);
+-                this.customEffects.set(index, effect);
++            }
++            if (index != -1) {
++                this.customEffects.add(index, effect);
                  return true;
 -            } else {
 -                return false;
              }
 -        } else {
-+        } // Paper - support multiple effects of the same type
++        }
++        // Paper end - support multiple effects of the same type
              if (this.customEffects == null) {
                  this.customEffects = new ArrayList<>();
              }
@@ -1416,7 +1423,7 @@ index 7f9182809f6e67ff571db0f365bc7e05f600775a..52d0fb3e08c93892ca401f721359cfac
      }
  
      @Override
-@@ -280,12 +279,12 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+@@ -280,12 +282,12 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
  
      @Override
      public Color getColor() {

--- a/patches/server/0967-General-ItemMeta-fixes.patch
+++ b/patches/server/0967-General-ItemMeta-fixes.patch
@@ -1345,7 +1345,7 @@ index 90c554dcbfe2bcca3f742379499f1e8e8665c512..14acdd2bd02de7e99b7f237151633ed7
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
-index 7f9182809f6e67ff571db0f365bc7e05f600775a..01c49df291f721bab3acb788ff2f27879b38bfc7 100644
+index 7f9182809f6e67ff571db0f365bc7e05f600775a..52d0fb3e08c93892ca401f721359cfac8d96e2c9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
 @@ -37,7 +37,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
@@ -1366,6 +1366,15 @@ index 7f9182809f6e67ff571db0f365bc7e05f600775a..01c49df291f721bab3acb788ff2f2787
                  } catch (IllegalArgumentException ex) {
                      // Invalid colour
                  }
+@@ -107,7 +107,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+ 
+         for (Object obj : rawEffectList) {
+             Preconditions.checkArgument(obj instanceof PotionEffect, "Object (%s) in effect list is not valid", obj.getClass());
+-            this.addCustomEffect((PotionEffect) obj, true);
++            this.addCustomEffect((PotionEffect) obj, false); // Paper - support multiple effects of the same type
+         }
+     }
+ 
 @@ -116,7 +116,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
          super.applyToItem(tag);
  
@@ -1375,7 +1384,39 @@ index 7f9182809f6e67ff571db0f365bc7e05f600775a..01c49df291f721bab3acb788ff2f2787
  
          List<MobEffectInstance> effectList = new ArrayList<>();
          if (this.customEffects != null) {
-@@ -280,12 +280,12 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+@@ -189,25 +189,24 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+     public boolean addCustomEffect(PotionEffect effect, boolean overwrite) {
+         Preconditions.checkArgument(effect != null, "Potion effect cannot be null");
+ 
+-        int index = this.indexOfEffect(effect.getType());
+-        if (index != -1) {
+-            if (overwrite) {
++        // Paper start - support multiple effects of the same type
++        if (overwrite) {
++            int index = this.indexOfEffect(effect.getType());
++            if (index != -1) {
++        // Paper end - support multiple effects of the same type
+                 PotionEffect old = this.customEffects.get(index);
+                 if (old.getAmplifier() == effect.getAmplifier() && old.getDuration() == effect.getDuration() && old.isAmbient() == effect.isAmbient()) {
+                     return false;
+                 }
+                 this.customEffects.set(index, effect);
+                 return true;
+-            } else {
+-                return false;
+             }
+-        } else {
++        } // Paper - support multiple effects of the same type
+             if (this.customEffects == null) {
+                 this.customEffects = new ArrayList<>();
+             }
+             this.customEffects.add(effect);
+             return true;
+-        }
+     }
+ 
+     @Override
+@@ -280,12 +279,12 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
  
      @Override
      public Color getColor() {

--- a/patches/server/1047-Fix-EntityPotionEffectEvent-effect-overriding.patch
+++ b/patches/server/1047-Fix-EntityPotionEffectEvent-effect-overriding.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TonytheMacaroni <tonythemacaroni123@gmail.com>
+Date: Sun, 28 Jul 2024 17:45:03 -0400
+Subject: [PATCH] Fix EntityPotionEffectEvent effect overriding
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index fe435d4a387bb28be6831cec0c8bb0a7c8b603a4..715d7dcda5a149ae26b4982122db5ee297ee421f 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -1159,10 +1159,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+             boolean flag = false;
+ 
+             // CraftBukkit start
+-            boolean override = false;
+-            if (mobeffect1 != null) {
+-                override = new MobEffectInstance(mobeffect1).update(mobeffect);
+-            }
++            boolean override = false; // Paper start - properly override effects
+ 
+             if (fireEvent) { // Paper - Don't fire sync event during generation
+             EntityPotionEffectEvent event = CraftEventFactory.callEntityPotionEffectChangeEvent(this, mobeffect1, mobeffect, cause, override);
+@@ -1179,8 +1176,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+                 flag = true;
+                 mobeffect.onEffectAdded(this);
+                 // CraftBukkit start
+-            } else if (override) { // Paper - Don't fire sync event during generation
+-                mobeffect1.update(mobeffect);
++                // Paper start - properly override effects
++            } else if (override) {
++                forceAddEffect(mobeffect, entity);
++                flag = true;
++            } else if (mobeffect1.update(mobeffect)) { // Paper - Don't fire sync event during generation
++                // Paper end - properly override effects
+                 this.onEffectUpdated(mobeffect1, true, entity);
+                 // CraftBukkit end
+                 flag = true;

--- a/patches/server/1047-Fix-EntityPotionEffectEvent-effect-overriding.patch
+++ b/patches/server/1047-Fix-EntityPotionEffectEvent-effect-overriding.patch
@@ -5,22 +5,21 @@ Subject: [PATCH] Fix EntityPotionEffectEvent effect overriding
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index fe435d4a387bb28be6831cec0c8bb0a7c8b603a4..715d7dcda5a149ae26b4982122db5ee297ee421f 100644
+index fe435d4a387bb28be6831cec0c8bb0a7c8b603a4..0d56560baf3568344cf0370e4863124eefa21e95 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1159,10 +1159,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
-             boolean flag = false;
+@@ -1160,9 +1160,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
              // CraftBukkit start
--            boolean override = false;
+             boolean override = false;
 -            if (mobeffect1 != null) {
 -                override = new MobEffectInstance(mobeffect1).update(mobeffect);
 -            }
-+            boolean override = false; // Paper start - properly override effects
++            // Paper - properly override effects
  
              if (fireEvent) { // Paper - Don't fire sync event during generation
              EntityPotionEffectEvent event = CraftEventFactory.callEntityPotionEffectChangeEvent(this, mobeffect1, mobeffect, cause, override);
-@@ -1179,8 +1176,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1179,8 +1177,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  flag = true;
                  mobeffect.onEffectAdded(this);
                  // CraftBukkit start


### PR DESCRIPTION
Removed arbitrary restrictions in `CraftAreaEffectCloud`, `CraftArrow` and `CraftMetaPotion` that prevented adding multiple potion effects of the same type. There seems to be no such restriction in vanilla, and multiple effects of the same type do apply properly.

During testing, I noticed an issue introduced by the handling of `EntityPotionEffectEvent` that prevented some potion effects from properly applying, when compared to vanilla. I wasn't entirely sure of the best approach to fix this - as such, I tried sticking to the Javadoc description of [`EntityPotionEffectEvent#isOverride`](https://jd.papermc.io/paper/1.21/org/bukkit/event/entity/EntityPotionEffectEvent.html#isOverride()), where if `override` is true, the previous effect is entirely replaced. As such, a new effect hiding a previous effect is currently not considered "overriding", and `EntityPotionEffectEvent#setOverride(true)` force applies the new effect, removing the old effect.

Also includes a fix for [MC-259832](https://bugs.mojang.com/browse/MC-259832). There's a remaining issue with the `/effect` command improperly considering applying an effect with a lower amplifier, but longer duration as compared to the current effect, as failing to apply, but I'm unsure of how best to fix that. It only impacts messaging, so I did not attempt to fix it.