### PR TITLE
Resolves #11151 where incorrect JavaDoc description needed updating

### DIFF
--- a/patches/api/0484-fix-HeightMap-JavaDoc-issue.patch
+++ b/patches/api/0484-fix-HeightMap-JavaDoc-issue.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: claibornevv <cvanvoorhis2@gmail.com>
+Date: Mon, 29 Jul 2024 10:57:46 -0400
+Subject: [PATCH] fix HeightMap JavaDoc issue
+
+
+diff --git a/src/main/java/org/bukkit/HeightMap.java b/src/main/java/org/bukkit/HeightMap.java
+index db6fcd635e295e561642d49941fd8e611247d38e..041e5cb89b270c15bab1a85c223abdfada33192b 100644
+--- a/src/main/java/org/bukkit/HeightMap.java
++++ b/src/main/java/org/bukkit/HeightMap.java
+@@ -12,8 +12,8 @@ public enum HeightMap {
+      */
+     MOTION_BLOCKING,
+     /**
+-     * The highest block that blocks motion or contains a fluid or is in the
+-     * {@link Tag#LEAVES}.
++     * The highest block that blocks motion or contains a fluid,
++     * excluding leaves.
+      */
+     MOTION_BLOCKING_NO_LEAVES,
+     /**


### PR DESCRIPTION
HeightMap#MOTION_BLOCKING_NO_LEAVES had an incorrect javadoc description which needed changing as shown in issue #11151 