### PR TITLE
chore: fix incorrect commit hash in PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,10 @@ jobs:
         java: [21]
       fail-fast: true
     steps:
-      - uses: actions/checkout@v4
+      - if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v4
+      - if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: JDK ${{ matrix.java }}


### PR DESCRIPTION
When the build workflow runs on the `pull_request` trigger, the commit ref ends up being the merge commit generated for the pull request instead of the actual commit in a PR. This PR fixes that by setting the checkout ref to be the most recent commit pushed in the PR.

Since this workflow also includes the `push` trigger, a conditional step was added to apply the ref only if it's being run under the `pull_request` trigger.

docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
references: https://github.com/actions/checkout/issues/261 https://github.com/actions/checkout#Checkout-pull-request-HEAD-commit-instead-of-merge-commit https://github.com/linz/geostore/pull/2246