### PR TITLE
Fix tag key generator output inconsistencies

### DIFF
--- a/paper-api-generator/generated/com/destroystokyo/paper/entity/ai/VanillaGoal.java
+++ b/paper-api-generator/generated/com/destroystokyo/paper/entity/ai/VanillaGoal.java
@@ -51,7 +51,7 @@ import org.bukkit.entity.WanderingTrader;
 import org.bukkit.entity.Wither;
 import org.bukkit.entity.Wolf;
 import org.bukkit.entity.Zombie;
-import org.jetbrains.annotations.NotNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Vanilla keys for Mob Goals.
@@ -436,8 +436,8 @@ public interface VanillaGoal<T extends Mob> extends Goal<T> {
 
     GoalKey<Zombie> ZOMBIE_ATTACK_TURTLE_EGG = create("zombie_attack_turtle_egg", Zombie.class);
 
-    private static <T extends Mob> @NotNull GoalKey<T> create(final @NotNull String key,
-            final @NotNull Class<T> type) {
+    private static <T extends Mob> @NonNull GoalKey<T> create(final @NonNull String key,
+            final @NonNull Class<T> type) {
         return GoalKey.of(type, NamespacedKey.minecraft(key));
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/BiomeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/BiomeKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.block.Biome;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#BIOME}.
@@ -484,7 +484,7 @@ public final class BiomeKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NotNull TypedKey<Biome> create(final @NotNull Key key) {
+    public static @NonNull TypedKey<Biome> create(final @NonNull Key key) {
         return TypedKey.create(RegistryKey.BIOME, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/BiomeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/BiomeKeys.java
@@ -478,7 +478,7 @@ public final class BiomeKeys {
     }
 
     /**
-     * Creates a key for {@link Biome} in a registry.
+     * Creates a key for {@link Biome} in the registry {@code minecraft:worldgen/biome}.
      *
      * @param key the value's key in the registry
      * @return a new typed key

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/DamageTypeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/DamageTypeKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.damage.DamageType;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#DAMAGE_TYPE}.
@@ -365,7 +365,7 @@ public final class DamageTypeKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NotNull TypedKey<DamageType> create(final @NotNull Key key) {
+    public static @NonNull TypedKey<DamageType> create(final @NonNull Key key) {
         return TypedKey.create(RegistryKey.DAMAGE_TYPE, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/DamageTypeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/DamageTypeKeys.java
@@ -359,7 +359,7 @@ public final class DamageTypeKeys {
     }
 
     /**
-     * Creates a key for {@link DamageType} in a registry.
+     * Creates a key for {@link DamageType} in the registry {@code minecraft:damage_type}.
      *
      * @param key the value's key in the registry
      * @return a new typed key

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/EnchantmentKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/EnchantmentKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.enchantments.Enchantment;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#ENCHANTMENT}.
@@ -323,7 +323,7 @@ public final class EnchantmentKeys {
     private EnchantmentKeys() {
     }
 
-    private static @NotNull TypedKey<Enchantment> create(final @NotNull Key key) {
+    private static @NonNull TypedKey<Enchantment> create(final @NonNull Key key) {
         return TypedKey.create(RegistryKey.ENCHANTMENT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/GameEventKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/GameEventKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.GameEvent;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#GAME_EVENT}.
@@ -449,7 +449,7 @@ public final class GameEventKeys {
     private GameEventKeys() {
     }
 
-    private static @NotNull TypedKey<GameEvent> create(final @NotNull Key key) {
+    private static @NonNull TypedKey<GameEvent> create(final @NonNull Key key) {
         return TypedKey.create(RegistryKey.GAME_EVENT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/InstrumentKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/InstrumentKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.MusicInstrument;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#INSTRUMENT}.
@@ -85,7 +85,7 @@ public final class InstrumentKeys {
     private InstrumentKeys() {
     }
 
-    private static @NotNull TypedKey<MusicInstrument> create(final @NotNull Key key) {
+    private static @NonNull TypedKey<MusicInstrument> create(final @NonNull Key key) {
         return TypedKey.create(RegistryKey.INSTRUMENT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/ItemTypeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/ItemTypeKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.inventory.ItemType;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#ITEM}.
@@ -9360,7 +9360,7 @@ public final class ItemTypeKeys {
     private ItemTypeKeys() {
     }
 
-    private static @NotNull TypedKey<ItemType> create(final @NotNull Key key) {
+    private static @NonNull TypedKey<ItemType> create(final @NonNull Key key) {
         return TypedKey.create(RegistryKey.ITEM, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/MobEffectKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/MobEffectKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.potion.PotionEffectType;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#MOB_EFFECT}.
@@ -302,7 +302,7 @@ public final class MobEffectKeys {
     private MobEffectKeys() {
     }
 
-    private static @NotNull TypedKey<PotionEffectType> create(final @NotNull Key key) {
+    private static @NonNull TypedKey<PotionEffectType> create(final @NonNull Key key) {
         return TypedKey.create(RegistryKey.MOB_EFFECT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/StructureKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/StructureKeys.java
@@ -268,7 +268,7 @@ public final class StructureKeys {
     }
 
     /**
-     * Creates a key for {@link Structure} in a registry.
+     * Creates a key for {@link Structure} in the registry {@code minecraft:worldgen/structure}.
      *
      * @param key the value's key in the registry
      * @return a new typed key

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/StructureKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/StructureKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.generator.structure.Structure;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#STRUCTURE}.
@@ -274,7 +274,7 @@ public final class StructureKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NotNull TypedKey<Structure> create(final @NotNull Key key) {
+    public static @NonNull TypedKey<Structure> create(final @NonNull Key key) {
         return TypedKey.create(RegistryKey.STRUCTURE, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/StructureTypeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/StructureTypeKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.generator.structure.StructureType;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#STRUCTURE_TYPE}.
@@ -141,7 +141,7 @@ public final class StructureTypeKeys {
     private StructureTypeKeys() {
     }
 
-    private static @NotNull TypedKey<StructureType> create(final @NotNull Key key) {
+    private static @NonNull TypedKey<StructureType> create(final @NonNull Key key) {
         return TypedKey.create(RegistryKey.STRUCTURE_TYPE, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/TrimMaterialKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/TrimMaterialKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.inventory.meta.trim.TrimMaterial;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#TRIM_MATERIAL}.
@@ -106,7 +106,7 @@ public final class TrimMaterialKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NotNull TypedKey<TrimMaterial> create(final @NotNull Key key) {
+    public static @NonNull TypedKey<TrimMaterial> create(final @NonNull Key key) {
         return TypedKey.create(RegistryKey.TRIM_MATERIAL, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/TrimMaterialKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/TrimMaterialKeys.java
@@ -100,7 +100,7 @@ public final class TrimMaterialKeys {
     }
 
     /**
-     * Creates a key for {@link TrimMaterial} in a registry.
+     * Creates a key for {@link TrimMaterial} in the registry {@code minecraft:trim_material}.
      *
      * @param key the value's key in the registry
      * @return a new typed key

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/TrimPatternKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/TrimPatternKeys.java
@@ -156,7 +156,7 @@ public final class TrimPatternKeys {
     }
 
     /**
-     * Creates a key for {@link TrimPattern} in a registry.
+     * Creates a key for {@link TrimPattern} in the registry {@code minecraft:trim_pattern}.
      *
      * @param key the value's key in the registry
      * @return a new typed key

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/TrimPatternKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/TrimPatternKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.inventory.meta.trim.TrimPattern;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#TRIM_PATTERN}.
@@ -162,7 +162,7 @@ public final class TrimPatternKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NotNull TypedKey<TrimPattern> create(final @NotNull Key key) {
+    public static @NonNull TypedKey<TrimPattern> create(final @NonNull Key key) {
         return TypedKey.create(RegistryKey.TRIM_PATTERN, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/WolfVariantKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/WolfVariantKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.entity.Wolf;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#WOLF_VARIANT}.
@@ -99,7 +99,7 @@ public final class WolfVariantKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NotNull TypedKey<Wolf.Variant> create(final @NotNull Key key) {
+    public static @NonNull TypedKey<Wolf.Variant> create(final @NonNull Key key) {
         return TypedKey.create(RegistryKey.WOLF_VARIANT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/WolfVariantKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/WolfVariantKeys.java
@@ -93,7 +93,7 @@ public final class WolfVariantKeys {
     }
 
     /**
-     * Creates a key for {@link Wolf.Variant} in a registry.
+     * Creates a key for {@link Wolf.Variant} in the registry {@code minecraft:wolf_variant}.
      *
      * @param key the value's key in the registry
      * @return a new typed key

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/tags/EnchantmentTagKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/tags/EnchantmentTagKeys.java
@@ -28,94 +28,18 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Experimental
 public final class EnchantmentTagKeys {
     /**
-     * {@code #minecraft:trades/savanna_special}
+     * {@code #minecraft:curse}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    @ApiStatus.Experimental
-    @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
-    public static final TagKey<Enchantment> TRADES_SAVANNA_SPECIAL = create(key("trades/savanna_special"));
+    public static final TagKey<Enchantment> CURSE = create(key("curse"));
 
     /**
-     * {@code #minecraft:smelts_loot}
+     * {@code #minecraft:double_trade_price}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    public static final TagKey<Enchantment> SMELTS_LOOT = create(key("smelts_loot"));
-
-    /**
-     * {@code #minecraft:exclusive_set/crossbow}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> EXCLUSIVE_SET_CROSSBOW = create(key("exclusive_set/crossbow"));
-
-    /**
-     * {@code #minecraft:tradeable}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> TRADEABLE = create(key("tradeable"));
-
-    /**
-     * {@code #minecraft:exclusive_set/damage}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> EXCLUSIVE_SET_DAMAGE = create(key("exclusive_set/damage"));
-
-    /**
-     * {@code #minecraft:prevents_bee_spawns_when_mining}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> PREVENTS_BEE_SPAWNS_WHEN_MINING = create(key("prevents_bee_spawns_when_mining"));
-
-    /**
-     * {@code #minecraft:in_enchanting_table}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> IN_ENCHANTING_TABLE = create(key("in_enchanting_table"));
-
-    /**
-     * {@code #minecraft:treasure}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> TREASURE = create(key("treasure"));
-
-    /**
-     * {@code #minecraft:exclusive_set/mining}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> EXCLUSIVE_SET_MINING = create(key("exclusive_set/mining"));
-
-    /**
-     * {@code #minecraft:trades/taiga_special}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    @ApiStatus.Experimental
-    @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
-    public static final TagKey<Enchantment> TRADES_TAIGA_SPECIAL = create(key("trades/taiga_special"));
-
-    /**
-     * {@code #minecraft:trades/plains_common}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    @ApiStatus.Experimental
-    @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
-    public static final TagKey<Enchantment> TRADES_PLAINS_COMMON = create(key("trades/plains_common"));
-
-    /**
-     * {@code #minecraft:on_mob_spawn_equipment}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> ON_MOB_SPAWN_EQUIPMENT = create(key("on_mob_spawn_equipment"));
+    public static final TagKey<Enchantment> DOUBLE_TRADE_PRICE = create(key("double_trade_price"));
 
     /**
      * {@code #minecraft:exclusive_set/armor}
@@ -125,6 +49,55 @@ public final class EnchantmentTagKeys {
     public static final TagKey<Enchantment> EXCLUSIVE_SET_ARMOR = create(key("exclusive_set/armor"));
 
     /**
+     * {@code #minecraft:exclusive_set/boots}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> EXCLUSIVE_SET_BOOTS = create(key("exclusive_set/boots"));
+
+    /**
+     * {@code #minecraft:exclusive_set/bow}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> EXCLUSIVE_SET_BOW = create(key("exclusive_set/bow"));
+
+    /**
+     * {@code #minecraft:exclusive_set/crossbow}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> EXCLUSIVE_SET_CROSSBOW = create(key("exclusive_set/crossbow"));
+
+    /**
+     * {@code #minecraft:exclusive_set/damage}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> EXCLUSIVE_SET_DAMAGE = create(key("exclusive_set/damage"));
+
+    /**
+     * {@code #minecraft:exclusive_set/mining}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> EXCLUSIVE_SET_MINING = create(key("exclusive_set/mining"));
+
+    /**
+     * {@code #minecraft:exclusive_set/riptide}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> EXCLUSIVE_SET_RIPTIDE = create(key("exclusive_set/riptide"));
+
+    /**
+     * {@code #minecraft:in_enchanting_table}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> IN_ENCHANTING_TABLE = create(key("in_enchanting_table"));
+
+    /**
      * {@code #minecraft:non_treasure}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
@@ -132,22 +105,92 @@ public final class EnchantmentTagKeys {
     public static final TagKey<Enchantment> NON_TREASURE = create(key("non_treasure"));
 
     /**
-     * {@code #minecraft:trades/snow_special}
+     * {@code #minecraft:on_mob_spawn_equipment}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    @ApiStatus.Experimental
-    @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
-    public static final TagKey<Enchantment> TRADES_SNOW_SPECIAL = create(key("trades/snow_special"));
+    public static final TagKey<Enchantment> ON_MOB_SPAWN_EQUIPMENT = create(key("on_mob_spawn_equipment"));
 
     /**
-     * {@code #minecraft:trades/plains_special}
+     * {@code #minecraft:on_random_loot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> ON_RANDOM_LOOT = create(key("on_random_loot"));
+
+    /**
+     * {@code #minecraft:on_traded_equipment}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> ON_TRADED_EQUIPMENT = create(key("on_traded_equipment"));
+
+    /**
+     * {@code #minecraft:prevents_bee_spawns_when_mining}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> PREVENTS_BEE_SPAWNS_WHEN_MINING = create(key("prevents_bee_spawns_when_mining"));
+
+    /**
+     * {@code #minecraft:prevents_decorated_pot_shattering}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> PREVENTS_DECORATED_POT_SHATTERING = create(key("prevents_decorated_pot_shattering"));
+
+    /**
+     * {@code #minecraft:prevents_ice_melting}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> PREVENTS_ICE_MELTING = create(key("prevents_ice_melting"));
+
+    /**
+     * {@code #minecraft:prevents_infested_spawns}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> PREVENTS_INFESTED_SPAWNS = create(key("prevents_infested_spawns"));
+
+    /**
+     * {@code #minecraft:smelts_loot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> SMELTS_LOOT = create(key("smelts_loot"));
+
+    /**
+     * {@code #minecraft:tooltip_order}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> TOOLTIP_ORDER = create(key("tooltip_order"));
+
+    /**
+     * {@code #minecraft:tradeable}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> TRADEABLE = create(key("tradeable"));
+
+    /**
+     * {@code #minecraft:trades/desert_common}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
     @ApiStatus.Experimental
     @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
-    public static final TagKey<Enchantment> TRADES_PLAINS_SPECIAL = create(key("trades/plains_special"));
+    public static final TagKey<Enchantment> TRADES_DESERT_COMMON = create(key("trades/desert_common"));
+
+    /**
+     * {@code #minecraft:trades/desert_special}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    @ApiStatus.Experimental
+    @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
+    public static final TagKey<Enchantment> TRADES_DESERT_SPECIAL = create(key("trades/desert_special"));
 
     /**
      * {@code #minecraft:trades/jungle_common}
@@ -168,6 +211,24 @@ public final class EnchantmentTagKeys {
     public static final TagKey<Enchantment> TRADES_JUNGLE_SPECIAL = create(key("trades/jungle_special"));
 
     /**
+     * {@code #minecraft:trades/plains_common}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    @ApiStatus.Experimental
+    @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
+    public static final TagKey<Enchantment> TRADES_PLAINS_COMMON = create(key("trades/plains_common"));
+
+    /**
+     * {@code #minecraft:trades/plains_special}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    @ApiStatus.Experimental
+    @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
+    public static final TagKey<Enchantment> TRADES_PLAINS_SPECIAL = create(key("trades/plains_special"));
+
+    /**
      * {@code #minecraft:trades/savanna_common}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
@@ -177,80 +238,13 @@ public final class EnchantmentTagKeys {
     public static final TagKey<Enchantment> TRADES_SAVANNA_COMMON = create(key("trades/savanna_common"));
 
     /**
-     * {@code #minecraft:curse}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> CURSE = create(key("curse"));
-
-    /**
-     * {@code #minecraft:prevents_infested_spawns}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> PREVENTS_INFESTED_SPAWNS = create(key("prevents_infested_spawns"));
-
-    /**
-     * {@code #minecraft:exclusive_set/bow}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> EXCLUSIVE_SET_BOW = create(key("exclusive_set/bow"));
-
-    /**
-     * {@code #minecraft:on_random_loot}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> ON_RANDOM_LOOT = create(key("on_random_loot"));
-
-    /**
-     * {@code #minecraft:exclusive_set/boots}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> EXCLUSIVE_SET_BOOTS = create(key("exclusive_set/boots"));
-
-    /**
-     * {@code #minecraft:trades/taiga_common}
+     * {@code #minecraft:trades/savanna_special}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
     @ApiStatus.Experimental
     @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
-    public static final TagKey<Enchantment> TRADES_TAIGA_COMMON = create(key("trades/taiga_common"));
-
-    /**
-     * {@code #minecraft:trades/desert_special}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    @ApiStatus.Experimental
-    @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
-    public static final TagKey<Enchantment> TRADES_DESERT_SPECIAL = create(key("trades/desert_special"));
-
-    /**
-     * {@code #minecraft:exclusive_set/riptide}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> EXCLUSIVE_SET_RIPTIDE = create(key("exclusive_set/riptide"));
-
-    /**
-     * {@code #minecraft:trades/swamp_special}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    @ApiStatus.Experimental
-    @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
-    public static final TagKey<Enchantment> TRADES_SWAMP_SPECIAL = create(key("trades/swamp_special"));
-
-    /**
-     * {@code #minecraft:prevents_ice_melting}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> PREVENTS_ICE_MELTING = create(key("prevents_ice_melting"));
+    public static final TagKey<Enchantment> TRADES_SAVANNA_SPECIAL = create(key("trades/savanna_special"));
 
     /**
      * {@code #minecraft:trades/snow_common}
@@ -262,18 +256,13 @@ public final class EnchantmentTagKeys {
     public static final TagKey<Enchantment> TRADES_SNOW_COMMON = create(key("trades/snow_common"));
 
     /**
-     * {@code #minecraft:on_traded_equipment}
+     * {@code #minecraft:trades/snow_special}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    public static final TagKey<Enchantment> ON_TRADED_EQUIPMENT = create(key("on_traded_equipment"));
-
-    /**
-     * {@code #minecraft:double_trade_price}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<Enchantment> DOUBLE_TRADE_PRICE = create(key("double_trade_price"));
+    @ApiStatus.Experimental
+    @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
+    public static final TagKey<Enchantment> TRADES_SNOW_SPECIAL = create(key("trades/snow_special"));
 
     /**
      * {@code #minecraft:trades/swamp_common}
@@ -285,33 +274,44 @@ public final class EnchantmentTagKeys {
     public static final TagKey<Enchantment> TRADES_SWAMP_COMMON = create(key("trades/swamp_common"));
 
     /**
-     * {@code #minecraft:trades/desert_common}
+     * {@code #minecraft:trades/swamp_special}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
     @ApiStatus.Experimental
     @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
-    public static final TagKey<Enchantment> TRADES_DESERT_COMMON = create(key("trades/desert_common"));
+    public static final TagKey<Enchantment> TRADES_SWAMP_SPECIAL = create(key("trades/swamp_special"));
 
     /**
-     * {@code #minecraft:prevents_decorated_pot_shattering}
+     * {@code #minecraft:trades/taiga_common}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    public static final TagKey<Enchantment> PREVENTS_DECORATED_POT_SHATTERING = create(key("prevents_decorated_pot_shattering"));
+    @ApiStatus.Experimental
+    @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
+    public static final TagKey<Enchantment> TRADES_TAIGA_COMMON = create(key("trades/taiga_common"));
 
     /**
-     * {@code #minecraft:tooltip_order}
+     * {@code #minecraft:trades/taiga_special}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    public static final TagKey<Enchantment> TOOLTIP_ORDER = create(key("tooltip_order"));
+    @ApiStatus.Experimental
+    @MinecraftExperimental(MinecraftExperimental.Requires.TRADE_REBALANCE)
+    public static final TagKey<Enchantment> TRADES_TAIGA_SPECIAL = create(key("trades/taiga_special"));
+
+    /**
+     * {@code #minecraft:treasure}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<Enchantment> TREASURE = create(key("treasure"));
 
     private EnchantmentTagKeys() {
     }
 
     /**
-     * Creates a tag key for {@link Enchantment} in the registry {@code minecraft:root}.
+     * Creates a tag key for {@link Enchantment} in the registry {@code minecraft:enchantment}.
      *
      * @param key the tag key's key
      * @return a new tag key

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/tags/EnchantmentTagKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/tags/EnchantmentTagKeys.java
@@ -8,8 +8,8 @@ import io.papermc.paper.registry.tag.TagKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.MinecraftExperimental;
 import org.bukkit.enchantments.Enchantment;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#ENCHANTMENT}.
@@ -317,7 +317,7 @@ public final class EnchantmentTagKeys {
      * @return a new tag key
      */
     @ApiStatus.Experimental
-    public static @NotNull TagKey<Enchantment> create(final @NotNull Key key) {
+    public static @NonNull TagKey<Enchantment> create(final @NonNull Key key) {
         return TagKey.create(RegistryKey.ENCHANTMENT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/tags/ItemTypeTagKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/tags/ItemTypeTagKeys.java
@@ -27,18 +27,11 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Experimental
 public final class ItemTypeTagKeys {
     /**
-     * {@code #minecraft:wooden_pressure_plates}
+     * {@code #minecraft:acacia_logs}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    public static final TagKey<ItemType> WOODEN_PRESSURE_PLATES = create(key("wooden_pressure_plates"));
-
-    /**
-     * {@code #minecraft:bookshelf_books}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> BOOKSHELF_BOOKS = create(key("bookshelf_books"));
+    public static final TagKey<ItemType> ACACIA_LOGS = create(key("acacia_logs"));
 
     /**
      * {@code #minecraft:anvil}
@@ -48,914 +41,11 @@ public final class ItemTypeTagKeys {
     public static final TagKey<ItemType> ANVIL = create(key("anvil"));
 
     /**
-     * {@code #minecraft:wooden_buttons}
+     * {@code #minecraft:armadillo_food}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    public static final TagKey<ItemType> WOODEN_BUTTONS = create(key("wooden_buttons"));
-
-    /**
-     * {@code #minecraft:iron_ores}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> IRON_ORES = create(key("iron_ores"));
-
-    /**
-     * {@code #minecraft:lapis_ores}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> LAPIS_ORES = create(key("lapis_ores"));
-
-    /**
-     * {@code #minecraft:sand}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> SAND = create(key("sand"));
-
-    /**
-     * {@code #minecraft:rabbit_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> RABBIT_FOOD = create(key("rabbit_food"));
-
-    /**
-     * {@code #minecraft:saplings}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> SAPLINGS = create(key("saplings"));
-
-    /**
-     * {@code #minecraft:leg_armor}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> LEG_ARMOR = create(key("leg_armor"));
-
-    /**
-     * {@code #minecraft:cow_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> COW_FOOD = create(key("cow_food"));
-
-    /**
-     * {@code #minecraft:enchantable/weapon}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_WEAPON = create(key("enchantable/weapon"));
-
-    /**
-     * {@code #minecraft:strider_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> STRIDER_FOOD = create(key("strider_food"));
-
-    /**
-     * {@code #minecraft:banners}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> BANNERS = create(key("banners"));
-
-    /**
-     * {@code #minecraft:fishes}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> FISHES = create(key("fishes"));
-
-    /**
-     * {@code #minecraft:strider_tempt_items}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> STRIDER_TEMPT_ITEMS = create(key("strider_tempt_items"));
-
-    /**
-     * {@code #minecraft:enchantable/trident}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_TRIDENT = create(key("enchantable/trident"));
-
-    /**
-     * {@code #minecraft:bee_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> BEE_FOOD = create(key("bee_food"));
-
-    /**
-     * {@code #minecraft:decorated_pot_sherds}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> DECORATED_POT_SHERDS = create(key("decorated_pot_sherds"));
-
-    /**
-     * {@code #minecraft:wool_carpets}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> WOOL_CARPETS = create(key("wool_carpets"));
-
-    /**
-     * {@code #minecraft:acacia_logs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ACACIA_LOGS = create(key("acacia_logs"));
-
-    /**
-     * {@code #minecraft:wart_blocks}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> WART_BLOCKS = create(key("wart_blocks"));
-
-    /**
-     * {@code #minecraft:stairs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> STAIRS = create(key("stairs"));
-
-    /**
-     * {@code #minecraft:breaks_decorated_pots}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> BREAKS_DECORATED_POTS = create(key("breaks_decorated_pots"));
-
-    /**
-     * {@code #minecraft:wool}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> WOOL = create(key("wool"));
-
-    /**
-     * {@code #minecraft:crimson_stems}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> CRIMSON_STEMS = create(key("crimson_stems"));
-
-    /**
-     * {@code #minecraft:enchantable/durability}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_DURABILITY = create(key("enchantable/durability"));
-
-    /**
-     * {@code #minecraft:boats}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> BOATS = create(key("boats"));
-
-    /**
-     * {@code #minecraft:sniffer_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> SNIFFER_FOOD = create(key("sniffer_food"));
-
-    /**
-     * {@code #minecraft:piglin_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> PIGLIN_FOOD = create(key("piglin_food"));
-
-    /**
-     * {@code #minecraft:logs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> LOGS = create(key("logs"));
-
-    /**
-     * {@code #minecraft:pickaxes}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> PICKAXES = create(key("pickaxes"));
-
-    /**
-     * {@code #minecraft:piglin_loved}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> PIGLIN_LOVED = create(key("piglin_loved"));
-
-    /**
-     * {@code #minecraft:fox_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> FOX_FOOD = create(key("fox_food"));
-
-    /**
-     * {@code #minecraft:wolf_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> WOLF_FOOD = create(key("wolf_food"));
-
-    /**
-     * {@code #minecraft:terracotta}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> TERRACOTTA = create(key("terracotta"));
-
-    /**
-     * {@code #minecraft:enchantable/bow}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_BOW = create(key("enchantable/bow"));
-
-    /**
-     * {@code #minecraft:lectern_books}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> LECTERN_BOOKS = create(key("lectern_books"));
-
-    /**
-     * {@code #minecraft:smelts_to_glass}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> SMELTS_TO_GLASS = create(key("smelts_to_glass"));
-
-    /**
-     * {@code #minecraft:copper_ores}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> COPPER_ORES = create(key("copper_ores"));
-
-    /**
-     * {@code #minecraft:wooden_trapdoors}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> WOODEN_TRAPDOORS = create(key("wooden_trapdoors"));
-
-    /**
-     * {@code #minecraft:enchantable/armor}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_ARMOR = create(key("enchantable/armor"));
-
-    /**
-     * {@code #minecraft:enchantable/sharp_weapon}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_SHARP_WEAPON = create(key("enchantable/sharp_weapon"));
-
-    /**
-     * {@code #minecraft:non_flammable_wood}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> NON_FLAMMABLE_WOOD = create(key("non_flammable_wood"));
-
-    /**
-     * {@code #minecraft:decorated_pot_ingredients}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> DECORATED_POT_INGREDIENTS = create(key("decorated_pot_ingredients"));
-
-    /**
-     * {@code #minecraft:enchantable/sword}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_SWORD = create(key("enchantable/sword"));
-
-    /**
-     * {@code #minecraft:stone_crafting_materials}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> STONE_CRAFTING_MATERIALS = create(key("stone_crafting_materials"));
-
-    /**
-     * {@code #minecraft:hanging_signs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> HANGING_SIGNS = create(key("hanging_signs"));
-
-    /**
-     * {@code #minecraft:flowers}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> FLOWERS = create(key("flowers"));
-
-    /**
-     * {@code #minecraft:emerald_ores}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> EMERALD_ORES = create(key("emerald_ores"));
-
-    /**
-     * {@code #minecraft:chest_armor}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> CHEST_ARMOR = create(key("chest_armor"));
-
-    /**
-     * {@code #minecraft:buttons}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> BUTTONS = create(key("buttons"));
-
-    /**
-     * {@code #minecraft:leaves}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> LEAVES = create(key("leaves"));
-
-    /**
-     * {@code #minecraft:sheep_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> SHEEP_FOOD = create(key("sheep_food"));
-
-    /**
-     * {@code #minecraft:fence_gates}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> FENCE_GATES = create(key("fence_gates"));
-
-    /**
-     * {@code #minecraft:horse_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> HORSE_FOOD = create(key("horse_food"));
-
-    /**
-     * {@code #minecraft:enchantable/fishing}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_FISHING = create(key("enchantable/fishing"));
-
-    /**
-     * {@code #minecraft:piglin_repellents}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> PIGLIN_REPELLENTS = create(key("piglin_repellents"));
-
-    /**
-     * {@code #minecraft:goat_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> GOAT_FOOD = create(key("goat_food"));
-
-    /**
-     * {@code #minecraft:frog_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> FROG_FOOD = create(key("frog_food"));
-
-    /**
-     * {@code #minecraft:axolotl_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> AXOLOTL_FOOD = create(key("axolotl_food"));
-
-    /**
-     * {@code #minecraft:warped_stems}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> WARPED_STEMS = create(key("warped_stems"));
-
-    /**
-     * {@code #minecraft:slabs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> SLABS = create(key("slabs"));
-
-    /**
-     * {@code #minecraft:walls}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> WALLS = create(key("walls"));
-
-    /**
-     * {@code #minecraft:stone_buttons}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> STONE_BUTTONS = create(key("stone_buttons"));
-
-    /**
-     * {@code #minecraft:axes}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> AXES = create(key("axes"));
-
-    /**
-     * {@code #minecraft:enchantable/chest_armor}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_CHEST_ARMOR = create(key("enchantable/chest_armor"));
-
-    /**
-     * {@code #minecraft:coals}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> COALS = create(key("coals"));
-
-    /**
-     * {@code #minecraft:noteblock_top_instruments}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> NOTEBLOCK_TOP_INSTRUMENTS = create(key("noteblock_top_instruments"));
-
-    /**
-     * {@code #minecraft:beacon_payment_items}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> BEACON_PAYMENT_ITEMS = create(key("beacon_payment_items"));
-
-    /**
-     * {@code #minecraft:signs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> SIGNS = create(key("signs"));
-
-    /**
-     * {@code #minecraft:chest_boats}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> CHEST_BOATS = create(key("chest_boats"));
-
-    /**
-     * {@code #minecraft:completes_find_tree_tutorial}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> COMPLETES_FIND_TREE_TUTORIAL = create(key("completes_find_tree_tutorial"));
-
-    /**
-     * {@code #minecraft:foot_armor}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> FOOT_ARMOR = create(key("foot_armor"));
-
-    /**
-     * {@code #minecraft:wooden_doors}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> WOODEN_DOORS = create(key("wooden_doors"));
-
-    /**
-     * {@code #minecraft:small_flowers}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> SMALL_FLOWERS = create(key("small_flowers"));
-
-    /**
-     * {@code #minecraft:diamond_ores}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> DIAMOND_ORES = create(key("diamond_ores"));
-
-    /**
-     * {@code #minecraft:llama_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> LLAMA_FOOD = create(key("llama_food"));
-
-    /**
-     * {@code #minecraft:planks}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> PLANKS = create(key("planks"));
-
-    /**
-     * {@code #minecraft:hoes}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> HOES = create(key("hoes"));
-
-    /**
-     * {@code #minecraft:oak_logs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> OAK_LOGS = create(key("oak_logs"));
-
-    /**
-     * {@code #minecraft:beds}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> BEDS = create(key("beds"));
-
-    /**
-     * {@code #minecraft:compasses}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> COMPASSES = create(key("compasses"));
-
-    /**
-     * {@code #minecraft:enchantable/vanishing}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_VANISHING = create(key("enchantable/vanishing"));
-
-    /**
-     * {@code #minecraft:shovels}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> SHOVELS = create(key("shovels"));
-
-    /**
-     * {@code #minecraft:creeper_igniters}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> CREEPER_IGNITERS = create(key("creeper_igniters"));
-
-    /**
-     * {@code #minecraft:meat}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> MEAT = create(key("meat"));
-
-    /**
-     * {@code #minecraft:ignored_by_piglin_babies}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> IGNORED_BY_PIGLIN_BABIES = create(key("ignored_by_piglin_babies"));
-
-    /**
-     * {@code #minecraft:coal_ores}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> COAL_ORES = create(key("coal_ores"));
-
-    /**
-     * {@code #minecraft:enchantable/foot_armor}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_FOOT_ARMOR = create(key("enchantable/foot_armor"));
-
-    /**
-     * {@code #minecraft:skulls}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> SKULLS = create(key("skulls"));
-
-    /**
-     * {@code #minecraft:trimmable_armor}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> TRIMMABLE_ARMOR = create(key("trimmable_armor"));
-
-    /**
-     * {@code #minecraft:panda_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> PANDA_FOOD = create(key("panda_food"));
-
-    /**
-     * {@code #minecraft:dark_oak_logs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> DARK_OAK_LOGS = create(key("dark_oak_logs"));
-
-    /**
-     * {@code #minecraft:enchantable/mining}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_MINING = create(key("enchantable/mining"));
-
-    /**
-     * {@code #minecraft:dampens_vibrations}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> DAMPENS_VIBRATIONS = create(key("dampens_vibrations"));
-
-    /**
-     * {@code #minecraft:fences}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> FENCES = create(key("fences"));
-
-    /**
-     * {@code #minecraft:redstone_ores}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> REDSTONE_ORES = create(key("redstone_ores"));
-
-    /**
-     * {@code #minecraft:pig_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> PIG_FOOD = create(key("pig_food"));
-
-    /**
-     * {@code #minecraft:doors}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> DOORS = create(key("doors"));
-
-    /**
-     * {@code #minecraft:ocelot_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> OCELOT_FOOD = create(key("ocelot_food"));
-
-    /**
-     * {@code #minecraft:cluster_max_harvestables}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> CLUSTER_MAX_HARVESTABLES = create(key("cluster_max_harvestables"));
-
-    /**
-     * {@code #minecraft:villager_plantable_seeds}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> VILLAGER_PLANTABLE_SEEDS = create(key("villager_plantable_seeds"));
-
-    /**
-     * {@code #minecraft:jungle_logs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> JUNGLE_LOGS = create(key("jungle_logs"));
-
-    /**
-     * {@code #minecraft:wooden_slabs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> WOODEN_SLABS = create(key("wooden_slabs"));
-
-    /**
-     * {@code #minecraft:dyeable}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> DYEABLE = create(key("dyeable"));
-
-    /**
-     * {@code #minecraft:trapdoors}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> TRAPDOORS = create(key("trapdoors"));
-
-    /**
-     * {@code #minecraft:swords}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> SWORDS = create(key("swords"));
-
-    /**
-     * {@code #minecraft:cherry_logs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> CHERRY_LOGS = create(key("cherry_logs"));
-
-    /**
-     * {@code #minecraft:tall_flowers}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> TALL_FLOWERS = create(key("tall_flowers"));
-
-    /**
-     * {@code #minecraft:mangrove_logs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> MANGROVE_LOGS = create(key("mangrove_logs"));
-
-    /**
-     * {@code #minecraft:birch_logs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> BIRCH_LOGS = create(key("birch_logs"));
-
-    /**
-     * {@code #minecraft:soul_fire_base_blocks}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> SOUL_FIRE_BASE_BLOCKS = create(key("soul_fire_base_blocks"));
-
-    /**
-     * {@code #minecraft:chicken_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> CHICKEN_FOOD = create(key("chicken_food"));
-
-    /**
-     * {@code #minecraft:turtle_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> TURTLE_FOOD = create(key("turtle_food"));
-
-    /**
-     * {@code #minecraft:freeze_immune_wearables}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> FREEZE_IMMUNE_WEARABLES = create(key("freeze_immune_wearables"));
-
-    /**
-     * {@code #minecraft:enchantable/fire_aspect}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_FIRE_ASPECT = create(key("enchantable/fire_aspect"));
-
-    /**
-     * {@code #minecraft:rails}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> RAILS = create(key("rails"));
-
-    /**
-     * {@code #minecraft:trim_materials}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> TRIM_MATERIALS = create(key("trim_materials"));
-
-    /**
-     * {@code #minecraft:parrot_poisonous_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> PARROT_POISONOUS_FOOD = create(key("parrot_poisonous_food"));
-
-    /**
-     * {@code #minecraft:wooden_fences}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> WOODEN_FENCES = create(key("wooden_fences"));
-
-    /**
-     * {@code #minecraft:head_armor}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> HEAD_ARMOR = create(key("head_armor"));
-
-    /**
-     * {@code #minecraft:stone_bricks}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> STONE_BRICKS = create(key("stone_bricks"));
-
-    /**
-     * {@code #minecraft:stone_tool_materials}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> STONE_TOOL_MATERIALS = create(key("stone_tool_materials"));
-
-    /**
-     * {@code #minecraft:llama_tempt_items}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> LLAMA_TEMPT_ITEMS = create(key("llama_tempt_items"));
-
-    /**
-     * {@code #minecraft:gold_ores}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> GOLD_ORES = create(key("gold_ores"));
-
-    /**
-     * {@code #minecraft:cat_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> CAT_FOOD = create(key("cat_food"));
-
-    /**
-     * {@code #minecraft:trim_templates}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> TRIM_TEMPLATES = create(key("trim_templates"));
-
-    /**
-     * {@code #minecraft:hoglin_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> HOGLIN_FOOD = create(key("hoglin_food"));
-
-    /**
-     * {@code #minecraft:logs_that_burn}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> LOGS_THAT_BURN = create(key("logs_that_burn"));
-
-    /**
-     * {@code #minecraft:wooden_stairs}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> WOODEN_STAIRS = create(key("wooden_stairs"));
-
-    /**
-     * {@code #minecraft:enchantable/crossbow}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_CROSSBOW = create(key("enchantable/crossbow"));
-
-    /**
-     * {@code #minecraft:enchantable/mace}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_MACE = create(key("enchantable/mace"));
+    public static final TagKey<ItemType> ARMADILLO_FOOD = create(key("armadillo_food"));
 
     /**
      * {@code #minecraft:arrows}
@@ -965,11 +55,18 @@ public final class ItemTypeTagKeys {
     public static final TagKey<ItemType> ARROWS = create(key("arrows"));
 
     /**
-     * {@code #minecraft:parrot_food}
+     * {@code #minecraft:axes}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    public static final TagKey<ItemType> PARROT_FOOD = create(key("parrot_food"));
+    public static final TagKey<ItemType> AXES = create(key("axes"));
+
+    /**
+     * {@code #minecraft:axolotl_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> AXOLOTL_FOOD = create(key("axolotl_food"));
 
     /**
      * {@code #minecraft:bamboo_blocks}
@@ -979,25 +76,67 @@ public final class ItemTypeTagKeys {
     public static final TagKey<ItemType> BAMBOO_BLOCKS = create(key("bamboo_blocks"));
 
     /**
-     * {@code #minecraft:horse_tempt_items}
+     * {@code #minecraft:banners}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    public static final TagKey<ItemType> HORSE_TEMPT_ITEMS = create(key("horse_tempt_items"));
+    public static final TagKey<ItemType> BANNERS = create(key("banners"));
 
     /**
-     * {@code #minecraft:creeper_drop_music_discs}
+     * {@code #minecraft:beacon_payment_items}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    public static final TagKey<ItemType> CREEPER_DROP_MUSIC_DISCS = create(key("creeper_drop_music_discs"));
+    public static final TagKey<ItemType> BEACON_PAYMENT_ITEMS = create(key("beacon_payment_items"));
 
     /**
-     * {@code #minecraft:enchantable/equippable}
+     * {@code #minecraft:beds}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    public static final TagKey<ItemType> ENCHANTABLE_EQUIPPABLE = create(key("enchantable/equippable"));
+    public static final TagKey<ItemType> BEDS = create(key("beds"));
+
+    /**
+     * {@code #minecraft:bee_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> BEE_FOOD = create(key("bee_food"));
+
+    /**
+     * {@code #minecraft:birch_logs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> BIRCH_LOGS = create(key("birch_logs"));
+
+    /**
+     * {@code #minecraft:boats}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> BOATS = create(key("boats"));
+
+    /**
+     * {@code #minecraft:bookshelf_books}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> BOOKSHELF_BOOKS = create(key("bookshelf_books"));
+
+    /**
+     * {@code #minecraft:breaks_decorated_pots}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> BREAKS_DECORATED_POTS = create(key("breaks_decorated_pots"));
+
+    /**
+     * {@code #minecraft:buttons}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> BUTTONS = create(key("buttons"));
 
     /**
      * {@code #minecraft:camel_food}
@@ -1007,20 +146,6 @@ public final class ItemTypeTagKeys {
     public static final TagKey<ItemType> CAMEL_FOOD = create(key("camel_food"));
 
     /**
-     * {@code #minecraft:enchantable/mining_loot}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ENCHANTABLE_MINING_LOOT = create(key("enchantable/mining_loot"));
-
-    /**
-     * {@code #minecraft:armadillo_food}
-     *
-     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
-     */
-    public static final TagKey<ItemType> ARMADILLO_FOOD = create(key("armadillo_food"));
-
-    /**
      * {@code #minecraft:candles}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
@@ -1028,11 +153,144 @@ public final class ItemTypeTagKeys {
     public static final TagKey<ItemType> CANDLES = create(key("candles"));
 
     /**
-     * {@code #minecraft:spruce_logs}
+     * {@code #minecraft:cat_food}
      *
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
-    public static final TagKey<ItemType> SPRUCE_LOGS = create(key("spruce_logs"));
+    public static final TagKey<ItemType> CAT_FOOD = create(key("cat_food"));
+
+    /**
+     * {@code #minecraft:cherry_logs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> CHERRY_LOGS = create(key("cherry_logs"));
+
+    /**
+     * {@code #minecraft:chest_armor}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> CHEST_ARMOR = create(key("chest_armor"));
+
+    /**
+     * {@code #minecraft:chest_boats}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> CHEST_BOATS = create(key("chest_boats"));
+
+    /**
+     * {@code #minecraft:chicken_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> CHICKEN_FOOD = create(key("chicken_food"));
+
+    /**
+     * {@code #minecraft:cluster_max_harvestables}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> CLUSTER_MAX_HARVESTABLES = create(key("cluster_max_harvestables"));
+
+    /**
+     * {@code #minecraft:coal_ores}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> COAL_ORES = create(key("coal_ores"));
+
+    /**
+     * {@code #minecraft:coals}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> COALS = create(key("coals"));
+
+    /**
+     * {@code #minecraft:compasses}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> COMPASSES = create(key("compasses"));
+
+    /**
+     * {@code #minecraft:completes_find_tree_tutorial}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> COMPLETES_FIND_TREE_TUTORIAL = create(key("completes_find_tree_tutorial"));
+
+    /**
+     * {@code #minecraft:copper_ores}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> COPPER_ORES = create(key("copper_ores"));
+
+    /**
+     * {@code #minecraft:cow_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> COW_FOOD = create(key("cow_food"));
+
+    /**
+     * {@code #minecraft:creeper_drop_music_discs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> CREEPER_DROP_MUSIC_DISCS = create(key("creeper_drop_music_discs"));
+
+    /**
+     * {@code #minecraft:creeper_igniters}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> CREEPER_IGNITERS = create(key("creeper_igniters"));
+
+    /**
+     * {@code #minecraft:crimson_stems}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> CRIMSON_STEMS = create(key("crimson_stems"));
+
+    /**
+     * {@code #minecraft:dampens_vibrations}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> DAMPENS_VIBRATIONS = create(key("dampens_vibrations"));
+
+    /**
+     * {@code #minecraft:dark_oak_logs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> DARK_OAK_LOGS = create(key("dark_oak_logs"));
+
+    /**
+     * {@code #minecraft:decorated_pot_ingredients}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> DECORATED_POT_INGREDIENTS = create(key("decorated_pot_ingredients"));
+
+    /**
+     * {@code #minecraft:decorated_pot_sherds}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> DECORATED_POT_SHERDS = create(key("decorated_pot_sherds"));
+
+    /**
+     * {@code #minecraft:diamond_ores}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> DIAMOND_ORES = create(key("diamond_ores"));
 
     /**
      * {@code #minecraft:dirt}
@@ -1040,6 +298,90 @@ public final class ItemTypeTagKeys {
      * @apiNote This field is version-dependant and may be removed in future Minecraft versions
      */
     public static final TagKey<ItemType> DIRT = create(key("dirt"));
+
+    /**
+     * {@code #minecraft:doors}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> DOORS = create(key("doors"));
+
+    /**
+     * {@code #minecraft:dyeable}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> DYEABLE = create(key("dyeable"));
+
+    /**
+     * {@code #minecraft:emerald_ores}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> EMERALD_ORES = create(key("emerald_ores"));
+
+    /**
+     * {@code #minecraft:enchantable/armor}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_ARMOR = create(key("enchantable/armor"));
+
+    /**
+     * {@code #minecraft:enchantable/bow}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_BOW = create(key("enchantable/bow"));
+
+    /**
+     * {@code #minecraft:enchantable/chest_armor}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_CHEST_ARMOR = create(key("enchantable/chest_armor"));
+
+    /**
+     * {@code #minecraft:enchantable/crossbow}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_CROSSBOW = create(key("enchantable/crossbow"));
+
+    /**
+     * {@code #minecraft:enchantable/durability}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_DURABILITY = create(key("enchantable/durability"));
+
+    /**
+     * {@code #minecraft:enchantable/equippable}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_EQUIPPABLE = create(key("enchantable/equippable"));
+
+    /**
+     * {@code #minecraft:enchantable/fire_aspect}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_FIRE_ASPECT = create(key("enchantable/fire_aspect"));
+
+    /**
+     * {@code #minecraft:enchantable/fishing}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_FISHING = create(key("enchantable/fishing"));
+
+    /**
+     * {@code #minecraft:enchantable/foot_armor}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_FOOT_ARMOR = create(key("enchantable/foot_armor"));
 
     /**
      * {@code #minecraft:enchantable/head_armor}
@@ -1055,11 +397,669 @@ public final class ItemTypeTagKeys {
      */
     public static final TagKey<ItemType> ENCHANTABLE_LEG_ARMOR = create(key("enchantable/leg_armor"));
 
+    /**
+     * {@code #minecraft:enchantable/mace}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_MACE = create(key("enchantable/mace"));
+
+    /**
+     * {@code #minecraft:enchantable/mining}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_MINING = create(key("enchantable/mining"));
+
+    /**
+     * {@code #minecraft:enchantable/mining_loot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_MINING_LOOT = create(key("enchantable/mining_loot"));
+
+    /**
+     * {@code #minecraft:enchantable/sharp_weapon}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_SHARP_WEAPON = create(key("enchantable/sharp_weapon"));
+
+    /**
+     * {@code #minecraft:enchantable/sword}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_SWORD = create(key("enchantable/sword"));
+
+    /**
+     * {@code #minecraft:enchantable/trident}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_TRIDENT = create(key("enchantable/trident"));
+
+    /**
+     * {@code #minecraft:enchantable/vanishing}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_VANISHING = create(key("enchantable/vanishing"));
+
+    /**
+     * {@code #minecraft:enchantable/weapon}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> ENCHANTABLE_WEAPON = create(key("enchantable/weapon"));
+
+    /**
+     * {@code #minecraft:fence_gates}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> FENCE_GATES = create(key("fence_gates"));
+
+    /**
+     * {@code #minecraft:fences}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> FENCES = create(key("fences"));
+
+    /**
+     * {@code #minecraft:fishes}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> FISHES = create(key("fishes"));
+
+    /**
+     * {@code #minecraft:flowers}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> FLOWERS = create(key("flowers"));
+
+    /**
+     * {@code #minecraft:foot_armor}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> FOOT_ARMOR = create(key("foot_armor"));
+
+    /**
+     * {@code #minecraft:fox_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> FOX_FOOD = create(key("fox_food"));
+
+    /**
+     * {@code #minecraft:freeze_immune_wearables}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> FREEZE_IMMUNE_WEARABLES = create(key("freeze_immune_wearables"));
+
+    /**
+     * {@code #minecraft:frog_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> FROG_FOOD = create(key("frog_food"));
+
+    /**
+     * {@code #minecraft:goat_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> GOAT_FOOD = create(key("goat_food"));
+
+    /**
+     * {@code #minecraft:gold_ores}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> GOLD_ORES = create(key("gold_ores"));
+
+    /**
+     * {@code #minecraft:hanging_signs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> HANGING_SIGNS = create(key("hanging_signs"));
+
+    /**
+     * {@code #minecraft:head_armor}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> HEAD_ARMOR = create(key("head_armor"));
+
+    /**
+     * {@code #minecraft:hoes}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> HOES = create(key("hoes"));
+
+    /**
+     * {@code #minecraft:hoglin_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> HOGLIN_FOOD = create(key("hoglin_food"));
+
+    /**
+     * {@code #minecraft:horse_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> HORSE_FOOD = create(key("horse_food"));
+
+    /**
+     * {@code #minecraft:horse_tempt_items}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> HORSE_TEMPT_ITEMS = create(key("horse_tempt_items"));
+
+    /**
+     * {@code #minecraft:ignored_by_piglin_babies}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> IGNORED_BY_PIGLIN_BABIES = create(key("ignored_by_piglin_babies"));
+
+    /**
+     * {@code #minecraft:iron_ores}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> IRON_ORES = create(key("iron_ores"));
+
+    /**
+     * {@code #minecraft:jungle_logs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> JUNGLE_LOGS = create(key("jungle_logs"));
+
+    /**
+     * {@code #minecraft:lapis_ores}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> LAPIS_ORES = create(key("lapis_ores"));
+
+    /**
+     * {@code #minecraft:leaves}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> LEAVES = create(key("leaves"));
+
+    /**
+     * {@code #minecraft:lectern_books}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> LECTERN_BOOKS = create(key("lectern_books"));
+
+    /**
+     * {@code #minecraft:leg_armor}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> LEG_ARMOR = create(key("leg_armor"));
+
+    /**
+     * {@code #minecraft:llama_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> LLAMA_FOOD = create(key("llama_food"));
+
+    /**
+     * {@code #minecraft:llama_tempt_items}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> LLAMA_TEMPT_ITEMS = create(key("llama_tempt_items"));
+
+    /**
+     * {@code #minecraft:logs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> LOGS = create(key("logs"));
+
+    /**
+     * {@code #minecraft:logs_that_burn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> LOGS_THAT_BURN = create(key("logs_that_burn"));
+
+    /**
+     * {@code #minecraft:mangrove_logs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> MANGROVE_LOGS = create(key("mangrove_logs"));
+
+    /**
+     * {@code #minecraft:meat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> MEAT = create(key("meat"));
+
+    /**
+     * {@code #minecraft:non_flammable_wood}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> NON_FLAMMABLE_WOOD = create(key("non_flammable_wood"));
+
+    /**
+     * {@code #minecraft:noteblock_top_instruments}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> NOTEBLOCK_TOP_INSTRUMENTS = create(key("noteblock_top_instruments"));
+
+    /**
+     * {@code #minecraft:oak_logs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> OAK_LOGS = create(key("oak_logs"));
+
+    /**
+     * {@code #minecraft:ocelot_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> OCELOT_FOOD = create(key("ocelot_food"));
+
+    /**
+     * {@code #minecraft:panda_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> PANDA_FOOD = create(key("panda_food"));
+
+    /**
+     * {@code #minecraft:parrot_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> PARROT_FOOD = create(key("parrot_food"));
+
+    /**
+     * {@code #minecraft:parrot_poisonous_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> PARROT_POISONOUS_FOOD = create(key("parrot_poisonous_food"));
+
+    /**
+     * {@code #minecraft:pickaxes}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> PICKAXES = create(key("pickaxes"));
+
+    /**
+     * {@code #minecraft:pig_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> PIG_FOOD = create(key("pig_food"));
+
+    /**
+     * {@code #minecraft:piglin_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> PIGLIN_FOOD = create(key("piglin_food"));
+
+    /**
+     * {@code #minecraft:piglin_loved}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> PIGLIN_LOVED = create(key("piglin_loved"));
+
+    /**
+     * {@code #minecraft:piglin_repellents}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> PIGLIN_REPELLENTS = create(key("piglin_repellents"));
+
+    /**
+     * {@code #minecraft:planks}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> PLANKS = create(key("planks"));
+
+    /**
+     * {@code #minecraft:rabbit_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> RABBIT_FOOD = create(key("rabbit_food"));
+
+    /**
+     * {@code #minecraft:rails}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> RAILS = create(key("rails"));
+
+    /**
+     * {@code #minecraft:redstone_ores}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> REDSTONE_ORES = create(key("redstone_ores"));
+
+    /**
+     * {@code #minecraft:sand}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SAND = create(key("sand"));
+
+    /**
+     * {@code #minecraft:saplings}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SAPLINGS = create(key("saplings"));
+
+    /**
+     * {@code #minecraft:sheep_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SHEEP_FOOD = create(key("sheep_food"));
+
+    /**
+     * {@code #minecraft:shovels}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SHOVELS = create(key("shovels"));
+
+    /**
+     * {@code #minecraft:signs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SIGNS = create(key("signs"));
+
+    /**
+     * {@code #minecraft:skulls}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SKULLS = create(key("skulls"));
+
+    /**
+     * {@code #minecraft:slabs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SLABS = create(key("slabs"));
+
+    /**
+     * {@code #minecraft:small_flowers}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SMALL_FLOWERS = create(key("small_flowers"));
+
+    /**
+     * {@code #minecraft:smelts_to_glass}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SMELTS_TO_GLASS = create(key("smelts_to_glass"));
+
+    /**
+     * {@code #minecraft:sniffer_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SNIFFER_FOOD = create(key("sniffer_food"));
+
+    /**
+     * {@code #minecraft:soul_fire_base_blocks}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SOUL_FIRE_BASE_BLOCKS = create(key("soul_fire_base_blocks"));
+
+    /**
+     * {@code #minecraft:spruce_logs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SPRUCE_LOGS = create(key("spruce_logs"));
+
+    /**
+     * {@code #minecraft:stairs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> STAIRS = create(key("stairs"));
+
+    /**
+     * {@code #minecraft:stone_bricks}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> STONE_BRICKS = create(key("stone_bricks"));
+
+    /**
+     * {@code #minecraft:stone_buttons}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> STONE_BUTTONS = create(key("stone_buttons"));
+
+    /**
+     * {@code #minecraft:stone_crafting_materials}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> STONE_CRAFTING_MATERIALS = create(key("stone_crafting_materials"));
+
+    /**
+     * {@code #minecraft:stone_tool_materials}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> STONE_TOOL_MATERIALS = create(key("stone_tool_materials"));
+
+    /**
+     * {@code #minecraft:strider_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> STRIDER_FOOD = create(key("strider_food"));
+
+    /**
+     * {@code #minecraft:strider_tempt_items}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> STRIDER_TEMPT_ITEMS = create(key("strider_tempt_items"));
+
+    /**
+     * {@code #minecraft:swords}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> SWORDS = create(key("swords"));
+
+    /**
+     * {@code #minecraft:tall_flowers}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> TALL_FLOWERS = create(key("tall_flowers"));
+
+    /**
+     * {@code #minecraft:terracotta}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> TERRACOTTA = create(key("terracotta"));
+
+    /**
+     * {@code #minecraft:trapdoors}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> TRAPDOORS = create(key("trapdoors"));
+
+    /**
+     * {@code #minecraft:trim_materials}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> TRIM_MATERIALS = create(key("trim_materials"));
+
+    /**
+     * {@code #minecraft:trim_templates}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> TRIM_TEMPLATES = create(key("trim_templates"));
+
+    /**
+     * {@code #minecraft:trimmable_armor}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> TRIMMABLE_ARMOR = create(key("trimmable_armor"));
+
+    /**
+     * {@code #minecraft:turtle_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> TURTLE_FOOD = create(key("turtle_food"));
+
+    /**
+     * {@code #minecraft:villager_plantable_seeds}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> VILLAGER_PLANTABLE_SEEDS = create(key("villager_plantable_seeds"));
+
+    /**
+     * {@code #minecraft:walls}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WALLS = create(key("walls"));
+
+    /**
+     * {@code #minecraft:warped_stems}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WARPED_STEMS = create(key("warped_stems"));
+
+    /**
+     * {@code #minecraft:wart_blocks}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WART_BLOCKS = create(key("wart_blocks"));
+
+    /**
+     * {@code #minecraft:wolf_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WOLF_FOOD = create(key("wolf_food"));
+
+    /**
+     * {@code #minecraft:wooden_buttons}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WOODEN_BUTTONS = create(key("wooden_buttons"));
+
+    /**
+     * {@code #minecraft:wooden_doors}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WOODEN_DOORS = create(key("wooden_doors"));
+
+    /**
+     * {@code #minecraft:wooden_fences}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WOODEN_FENCES = create(key("wooden_fences"));
+
+    /**
+     * {@code #minecraft:wooden_pressure_plates}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WOODEN_PRESSURE_PLATES = create(key("wooden_pressure_plates"));
+
+    /**
+     * {@code #minecraft:wooden_slabs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WOODEN_SLABS = create(key("wooden_slabs"));
+
+    /**
+     * {@code #minecraft:wooden_stairs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WOODEN_STAIRS = create(key("wooden_stairs"));
+
+    /**
+     * {@code #minecraft:wooden_trapdoors}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WOODEN_TRAPDOORS = create(key("wooden_trapdoors"));
+
+    /**
+     * {@code #minecraft:wool}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WOOL = create(key("wool"));
+
+    /**
+     * {@code #minecraft:wool_carpets}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TagKey<ItemType> WOOL_CARPETS = create(key("wool_carpets"));
+
     private ItemTypeTagKeys() {
     }
 
     /**
-     * Creates a tag key for {@link ItemType} in the registry {@code minecraft:root}.
+     * Creates a tag key for {@link ItemType} in the registry {@code minecraft:item}.
      *
      * @param key the tag key's key
      * @return a new tag key

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/tags/ItemTypeTagKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/tags/ItemTypeTagKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.tag.TagKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.inventory.ItemType;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Vanilla keys for {@link RegistryKey#ITEM}.
@@ -1065,7 +1065,7 @@ public final class ItemTypeTagKeys {
      * @return a new tag key
      */
     @ApiStatus.Experimental
-    public static @NotNull TagKey<ItemType> create(final @NotNull Key key) {
+    public static @NonNull TagKey<ItemType> create(final @NonNull Key key) {
         return TagKey.create(RegistryKey.ITEM, key);
     }
 }

--- a/paper-api-generator/src/main/java/io/papermc/generator/types/GeneratedKeyType.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/types/GeneratedKeyType.java
@@ -31,8 +31,6 @@ import net.minecraft.core.RegistrySetBuilder;
 import net.minecraft.data.registries.VanillaRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.flag.FeatureElement;
-import net.minecraft.world.flag.FeatureFlags;
-import org.bukkit.MinecraftExperimental;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -72,7 +70,7 @@ public class GeneratedKeyType<T, A> extends SimpleGenerator {
     }
 
     private static final String CREATE_JAVADOC = """
-        Creates a key for {@link $T} in a registry.
+        Creates a key for {@link $T} in the registry {@code $L}.
         
         @param key the value's key in the registry
         @return a new typed key
@@ -102,7 +100,7 @@ public class GeneratedKeyType<T, A> extends SimpleGenerator {
             .returns(returnType.annotated(NOT_NULL));
         if (this.publicCreateKeyMethod) {
             create.addAnnotation(EXPERIMENTAL_API_ANNOTATION); // TODO remove once not experimental
-            create.addJavadoc(CREATE_JAVADOC, this.apiType);
+            create.addJavadoc(CREATE_JAVADOC, this.apiType, this.registryKey.location().toString());
         }
         return create;
     }
@@ -190,8 +188,6 @@ public class GeneratedKeyType<T, A> extends SimpleGenerator {
     @Override
     protected JavaFile.Builder file(final JavaFile.Builder builder) {
         return builder
-            .skipJavaLangImports(true)
-            .addStaticImport(Key.class, "key")
-            .indent("    ");
+            .addStaticImport(Key.class, "key");
     }
 }

--- a/paper-api-generator/src/main/java/io/papermc/generator/types/goal/MobGoalGenerator.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/types/goal/MobGoalGenerator.java
@@ -132,8 +132,7 @@ public class MobGoalGenerator extends SimpleGenerator {
 
     @Override
     protected JavaFile.Builder file(JavaFile.Builder builder) {
-        return builder
-            .skipJavaLangImports(true);
+        return builder;
     }
 
     record DeprecatedEntry(Class<?> entity, String entryName, @Nullable String removalVersion,

--- a/paper-api-generator/src/main/java/io/papermc/generator/utils/Annotations.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/utils/Annotations.java
@@ -7,8 +7,8 @@ import java.util.List;
 import io.papermc.paper.generated.GeneratedFrom;
 import net.minecraft.SharedConstants;
 import org.bukkit.MinecraftExperimental;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class Annotations {
@@ -26,10 +26,10 @@ public final class Annotations {
         return annotationSpecs;
     }
 
-    public static AnnotationSpec deprecatedVersioned(final @Nullable String version, boolean forRemoval) {
-        AnnotationSpec.Builder annotationSpec = AnnotationSpec.builder(Deprecated.class);
+    public static AnnotationSpec deprecatedVersioned(final @Nullable String version, final boolean forRemoval) {
+        final AnnotationSpec.Builder annotationSpec = AnnotationSpec.builder(Deprecated.class);
         if (forRemoval) {
-            annotationSpec.addMember("forRemoval", "$L", forRemoval);
+            annotationSpec.addMember("forRemoval", "$L", true);
         }
         if (version != null) {
             annotationSpec.addMember("since", "$S", version);
@@ -46,7 +46,7 @@ public final class Annotations {
 
     @ApiStatus.Experimental
     public static final AnnotationSpec EXPERIMENTAL_API_ANNOTATION = AnnotationSpec.builder(ApiStatus.Experimental.class).build();
-    public static final AnnotationSpec NOT_NULL = AnnotationSpec.builder(NotNull.class).build();
+    public static final AnnotationSpec NOT_NULL = AnnotationSpec.builder(NonNull.class).build();
     private static final AnnotationSpec SUPPRESS_WARNINGS = AnnotationSpec.builder(SuppressWarnings.class)
         .addMember("value", "$S", "unused")
         .addMember("value", "$S", "SpellCheckingInspection")

--- a/paper-api-generator/src/main/java/io/papermc/generator/utils/CollectingContext.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/utils/CollectingContext.java
@@ -2,7 +2,6 @@ package io.papermc.generator.utils;
 
 import com.mojang.serialization.Lifecycle;
 import io.papermc.generator.Main;
-import java.util.List;
 import java.util.Set;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderGetter;

--- a/paper-api-generator/src/main/java/io/papermc/generator/utils/TagCollector.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/utils/TagCollector.java
@@ -4,7 +4,6 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.mojang.logging.LogUtils;
 import io.papermc.generator.Main;
-import io.papermc.generator.utils.Formatting;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -19,7 +18,6 @@ import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.repository.BuiltInPackSource;
 import net.minecraft.server.packs.resources.MultiPackResourceManager;
 import net.minecraft.tags.TagKey;
-import net.minecraft.tags.TagManager;
 import org.slf4j.Logger;
 
 // collect all the tags by grabbing the json from the data-packs
@@ -50,9 +48,9 @@ public final class TagCollector {
                 }
 
                 result.put(entry.value().getTagNames()
-                               .filter(tagKey -> tagKey.location().getPath().equals(path))
-                               .findFirst()
-                               .orElseThrow(), packId);
+                    .filter(tagKey -> tagKey.location().getPath().equals(path))
+                    .findFirst()
+                    .orElseThrow(), packId);
             });
         });
         return Collections.unmodifiableMap(result);

--- a/patches/server/1021-Add-registry-entry-and-builders.patch
+++ b/patches/server/1021-Add-registry-entry-and-builders.patch
@@ -340,7 +340,7 @@ index 0000000000000000000000000000000000000000..18f9463ae23ba2d9c65ffb7531a87c92
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/data/util/Checks.java b/src/main/java/io/papermc/paper/registry/data/util/Checks.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a66cebe2b918a22b84e346127ffb671621050e5f
+index 0000000000000000000000000000000000000000..3241a94731fe8163876614efdcf30f8b551535af
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/data/util/Checks.java
 @@ -0,0 +1,48 @@
@@ -370,7 +370,7 @@ index 0000000000000000000000000000000000000000..a66cebe2b918a22b84e346127ffb6716
 +
 +    public static <T> T asArgument(final @Nullable T value, final String field) {
 +        if (value == null) {
-+            throw new IllegalArgumentException("argument " + value + " cannot be null");
++            throw new IllegalArgumentException("argument " + field + " cannot be null");
 +        }
 +        return value;
 +    }


### PR DESCRIPTION
The current tag key generator has an arbitrary order of the fields so the output is different each time the generator is ran.
This pr sort the fields alphabetically like the typed key.
Also fixed two typo in the generated tag key create javadoc and for enchantment registry builder when the argument is wrongly null (previously it would say "argument null cannot be null").