### PR TITLE
Configuration for horizontal-only item merging

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1414,10 +1414,10 @@ index 0000000000000000000000000000000000000000..990d1bb46e0f9719f4e9af928d80ac6f
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7509b17414f836e8b53fc62b02b386ba4e8c5ca9
+index 0000000000000000000000000000000000000000..4bcf27f98765abf693e535cfc1756c27a10cb316
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,551 @@
+@@ -0,0 +1,554 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1474,6 +1474,7 @@ index 0000000000000000000000000000000000000000..7509b17414f836e8b53fc62b02b386ba
 +import org.slf4j.Logger;
 +import org.spigotmc.SpigotWorldConfig;
 +import org.spongepowered.configurate.objectmapping.ConfigSerializable;
++import org.spongepowered.configurate.objectmapping.meta.Comment;
 +import org.spongepowered.configurate.objectmapping.meta.PostProcess;
 +import org.spongepowered.configurate.objectmapping.meta.Required;
 +import org.spongepowered.configurate.objectmapping.meta.Setting;
@@ -1710,6 +1711,8 @@ index 0000000000000000000000000000000000000000..7509b17414f836e8b53fc62b02b386ba
 +
 +            public boolean disablePlayerCrits = false;
 +            public boolean nerfPigmenFromNetherPortals = false;
++            @Comment("Prevents merging items that are not on the same y level, preventing potential visual artifacts.")
++            public boolean onlyMergeItemsHorizontally = false;
 +            public PillagerPatrols pillagerPatrols;
 +
 +            public class PillagerPatrols extends ConfigurationPart {
@@ -5053,7 +5056,7 @@ index e433037a03ffafabb952887ae3980e1d51411d4c..c061813d275fbc48d7629cc59d90dbb4
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e8fac2863c5feb875cf0c78f062b4b87acbcb49b..751900e0c2a946ba4291174c81b2bdbdbe994e94 100644
+index 3c0691ef65c8db1002b76984f4ddfe2072d793c9..b3c4cdd9cfff6857f3007fbd91a280bcc53ab072 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -962,6 +962,7 @@ public final class CraftServer implements Server {

--- a/patches/server/1045-Configuration-for-horizontal-only-item-merging.patch
+++ b/patches/server/1045-Configuration-for-horizontal-only-item-merging.patch
@@ -13,20 +13,8 @@ This patch allows us to configure items to only merge horizontally, which is wha
 This allows us to have both the reduced number of item entities a high item-merge radius provides,
 without most of the visual artifacts caused by items merging vertically.
 
-diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-index 7509b1741..5c5fe0266 100644
---- a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-+++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -290,6 +290,7 @@ public class WorldConfiguration extends ConfigurationPart {
- 
-             public boolean disablePlayerCrits = false;
-             public boolean nerfPigmenFromNetherPortals = false;
-+            public boolean onlyMergeItemsHorizontally = false;
-             public PillagerPatrols pillagerPatrols;
- 
-             public class PillagerPatrols extends ConfigurationPart {
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index ea0d93354..607f1a980 100644
+index ea0d9335446b20073b9aafb9de453097355db79c..607f1a9802eb0ff4865af4c53f302128a6e6fe02 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 @@ -284,7 +284,7 @@ public class ItemEntity extends Entity implements TraceableEntity {

--- a/patches/server/1046-Horizontal-only-item-merging-configuration.patch
+++ b/patches/server/1046-Horizontal-only-item-merging-configuration.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Newwind <support@newwindserver.com>
+Date: Wed, 7 Aug 2024 13:25:55 +0200
+Subject: [PATCH] Configuration for horizontal-only item merging
+
+Most of the visual artifacts that result from having item merge radius above vanilla levels is from items merging vertically,
+which realistically, only happens when a player is dropping items, or items are dropping from breaking a block.
+
+Most of the scenarios where item merging makes sense involves the two item entities being on the same Y level. i.e on the ground next to each other.
+This is even more apparent since paper fixed items being able to merge through blocks.
+
+This patch allows us to configure items to only merge horizontally, which is what vanilla does.
+This allows us to have both the reduced number of item entities a high item-merge radius provides,
+without most of the visual artifacts caused by items merging vertically.
+
+diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+index 7509b1741..5c5fe0266 100644
+--- a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
++++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+@@ -290,6 +290,7 @@ public class WorldConfiguration extends ConfigurationPart {
+ 
+             public boolean disablePlayerCrits = false;
+             public boolean nerfPigmenFromNetherPortals = false;
++            public boolean onlyMergeItemsHorizontally = false;
+             public PillagerPatrols pillagerPatrols;
+ 
+             public class PillagerPatrols extends ConfigurationPart {
+diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
+index ea0d93354..607f1a980 100644
+--- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
++++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
+@@ -284,7 +284,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
+         if (this.isMergable()) {
+             // Spigot start
+             double radius = this.level().spigotConfig.itemMerge;
+-            List<ItemEntity> list = this.level().getEntitiesOfClass(ItemEntity.class, this.getBoundingBox().inflate(radius, radius - 0.5D, radius), (entityitem) -> {
++            List<ItemEntity> list = this.level().getEntitiesOfClass(ItemEntity.class, this.getBoundingBox().inflate(radius, this.level().paperConfig().entities.behavior.onlyMergeItemsHorizontally ? 0 : radius - 0.5D, radius), (entityitem) -> { // Paper - configuration to only merge items horizontally
+                 // Spigot end
+                 return entityitem != this && entityitem.isMergable();
+             });


### PR DESCRIPTION
Most of the visual artifacts that result from having item merge radius above vanilla levels is from items merging vertically,
which realistically, only happens when a player is dropping items, or items are dropping from breaking a block.

Most of the scenarios where item merging makes sense involves the two item entities being on the same Y level. i.e on the ground next to each other.
This is even more apparent since paper fixed items being able to merge through blocks.

This patch allows us to configure items to only merge horizontally, which is what vanilla does.
This allows us to have both the reduced number of item entities a high item-merge radius provides,
without most of the visual artifacts caused by items merging vertically.