### PR TITLE
Update item data sanitization

### DIFF
--- a/patches/server/0975-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0975-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -7,15 +7,16 @@ Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/util/DataSanitizationUtil.java b/src/main/java/io/papermc/paper/util/DataSanitizationUtil.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8be7e1fa0652ccd9cbb809d81254e5aa1a97b776
+index 0000000000000000000000000000000000000000..72483dedd3b1864fca3463d3ba3f6fad22680b97
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/DataSanitizationUtil.java
-@@ -0,0 +1,98 @@
+@@ -0,0 +1,108 @@
 +package io.papermc.paper.util;
 +
 +import java.util.List;
 +import java.util.concurrent.atomic.AtomicBoolean;
 +import java.util.function.UnaryOperator;
++import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 +import net.minecraft.network.RegistryFriendlyByteBuf;
 +import net.minecraft.network.codec.StreamCodec;
 +import net.minecraft.util.Mth;
@@ -24,6 +25,7 @@ index 0000000000000000000000000000000000000000..8be7e1fa0652ccd9cbb809d81254e5aa
 +import net.minecraft.world.item.component.BundleContents;
 +import net.minecraft.world.item.component.ChargedProjectiles;
 +import net.minecraft.world.item.component.ItemContainerContents;
++import org.apache.commons.lang3.math.Fraction;
 +import org.checkerframework.checker.nullness.qual.NonNull;
 +import org.checkerframework.framework.qual.DefaultQualifier;
 +
@@ -60,13 +62,21 @@ index 0000000000000000000000000000000000000000..8be7e1fa0652ccd9cbb809d81254e5aa
 +        }
 +
 +        // Bundles change their texture based on their fullness.
++        // A bundles content weight may be anywhere from 0 to, basically, infinity.
++        // A weight of 1 is the usual maximum case
 +        int sizeUsed = Mth.mulAndTruncate(contents.weight(), 64);
-+        if (sizeUsed == 0) {
-+            // When the max stack size is above 64 the bundle fullness might be too small, so avoid empty item in that case.
-+            sizeUsed++;
++        // Early out, *most* bundles should not be overfilled above a weight of one.
++        if (sizeUsed <= 64) return new BundleContents(List.of(new ItemStack(Items.PAPER, Math.max(1, sizeUsed))));
++
++        final List<ItemStack> sanitizedRepresentation = new ObjectArrayList<>(sizeUsed / 64 + 1);
++        while (sizeUsed > 0) {
++            final int stackCount = Math.min(64, sizeUsed);
++            sanitizedRepresentation.add(new ItemStack(Items.PAPER, stackCount));
++            sizeUsed -= stackCount;
 +        }
 +        // Now we add a single fake item that uses the same amount of slots as all other items.
-+        return new BundleContents(List.of(new ItemStack(Items.PAPER, sizeUsed)));
++        // Ensure that potentially overstacked bundles are not represented by empty (count=0) itemstacks.
++        return new BundleContents(sanitizedRepresentation);
 +    }
 +
 +    private static <B, A> StreamCodec<B, A> codec(final StreamCodec<B, A> delegate, final UnaryOperator<A> sanitizer) {
@@ -199,7 +209,7 @@ index 0e7ace92522fbd4cef7b2c2b8a0f8b86c2cce192..1d849ce4e2c85f149af25318b8ffb6dc
              ((LivingEntity) this.entity).detectEquipmentUpdatesPublic(); // CraftBukkit - SPIGOT-3789: sync again immediately after sending
          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4f9a17e7cd5aca2e8bd55b4892a20dce181289cd..a04fdcecf00f128f0afba1a33fad1d9e7694ef63 100644
+index d5f33021754047971b69f90caff3664f596d6eec..9da231673888bb8ba2ed922204ddfd0220f091b1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2727,7 +2727,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl

--- a/patches/server/0975-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0975-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -7,18 +7,18 @@ Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/util/DataSanitizationUtil.java b/src/main/java/io/papermc/paper/util/DataSanitizationUtil.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e9436f8a73ee0a02096d66e14d73edaae28d5a41
+index 0000000000000000000000000000000000000000..8be7e1fa0652ccd9cbb809d81254e5aa1a97b776
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/DataSanitizationUtil.java
-@@ -0,0 +1,100 @@
+@@ -0,0 +1,98 @@
 +package io.papermc.paper.util;
 +
-+import java.util.ArrayList;
 +import java.util.List;
 +import java.util.concurrent.atomic.AtomicBoolean;
 +import java.util.function.UnaryOperator;
 +import net.minecraft.network.RegistryFriendlyByteBuf;
 +import net.minecraft.network.codec.StreamCodec;
++import net.minecraft.util.Mth;
 +import net.minecraft.world.item.ItemStack;
 +import net.minecraft.world.item.Items;
 +import net.minecraft.world.item.component.BundleContents;
@@ -48,26 +48,25 @@ index 0000000000000000000000000000000000000000..e9436f8a73ee0a02096d66e14d73edaa
 +        if (projectiles.isEmpty()) {
 +            return projectiles;
 +        }
-+        final List<ItemStack> items = projectiles.getItems();
-+        final List<ItemStack> sanitized = new ArrayList<>();
-+        for (int i = 0; i < Math.min(items.size(), 3); i++) {
-+            // we want to preserve item type as vanilla client can change visuals based on type
-+            sanitized.add(new ItemStack(items.get(i).getItemHolder()));
-+        }
-+        return ChargedProjectiles.of(sanitized);
++
++        return ChargedProjectiles.of(List.of(
++            new ItemStack(projectiles.contains(Items.FIREWORK_ROCKET) ? Items.FIREWORK_ROCKET : Items.ARROW)
++        ));
 +    }
 +
 +    private static BundleContents sanitizeBundleContents(final BundleContents contents) {
++        if (contents.isEmpty()) {
++            return contents;
++        }
++
 +        // Bundles change their texture based on their fullness.
-+        int sizeUsed = 0;
-+        for (final ItemStack item : contents.items()) {
-+            final int scale = 64 / item.getMaxStackSize();
-+            sizeUsed += scale * item.getCount();
++        int sizeUsed = Mth.mulAndTruncate(contents.weight(), 64);
++        if (sizeUsed == 0) {
++            // When the max stack size is above 64 the bundle fullness might be too small, so avoid empty item in that case.
++            sizeUsed++;
 +        }
 +        // Now we add a single fake item that uses the same amount of slots as all other items.
-+        final List<ItemStack> items = new ArrayList<>();
-+        items.add(new ItemStack(Items.PAPER, sizeUsed));
-+        return new BundleContents(items);
++        return new BundleContents(List.of(new ItemStack(Items.PAPER, sizeUsed)));
 +    }
 +
 +    private static <B, A> StreamCodec<B, A> codec(final StreamCodec<B, A> delegate, final UnaryOperator<A> sanitizer) {
@@ -109,7 +108,6 @@ index 0000000000000000000000000000000000000000..e9436f8a73ee0a02096d66e14d73edaa
 +
 +    private DataSanitizationUtil() {
 +    }
-+
 +}
 diff --git a/src/main/java/net/minecraft/core/component/DataComponents.java b/src/main/java/net/minecraft/core/component/DataComponents.java
 index c9aef759c1485da753e820f9b509117ca50a31e4..60757f8df706cba92350d73503b73913cff3bcfc 100644


### PR DESCRIPTION
Closes #11217

Should also fix the wrong render of bundle fullness with bee inside bee hive and nested bundle which might be exposed with a resource pack.