### PR TITLE
Remove arbitrary writable book page limit

### DIFF
--- a/patches/server/0270-Book-size-limits.patch
+++ b/patches/server/0270-Book-size-limits.patch
@@ -1,15 +1,15 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 16 Nov 2018 23:08:50 -0500
-Subject: [PATCH] Book Size Limits
+Subject: [PATCH] Book size limits
 
 Puts some limits on the size of books.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2e35c6cfdf0cded5adc9f512612faaa68876961c..abab7c6ce2079a0101c59c130fd65db7b2a73498 100644
+index 2e35c6cfdf0cded5adc9f512612faaa68876961c..d69b678b2611f3d1b1ef64541863256868969671 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1043,6 +1043,45 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1043,6 +1043,40 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void handleEditBook(ServerboundEditBookPacket packet) {
@@ -18,15 +18,10 @@ index 2e35c6cfdf0cded5adc9f512612faaa68876961c..abab7c6ce2079a0101c59c130fd65db7
 +            List<String> pageList = packet.pages();
 +            long byteTotal = 0;
 +            int maxBookPageSize = io.papermc.paper.configuration.GlobalConfiguration.get().itemValidation.bookSize.pageMax;
-+            double multiplier = Math.max(0.3D, Math.min(1D, io.papermc.paper.configuration.GlobalConfiguration.get().itemValidation.bookSize.totalMultiplier));
++            double multiplier = Math.clamp(io.papermc.paper.configuration.GlobalConfiguration.get().itemValidation.bookSize.totalMultiplier, 0.3D, 1D);
 +            long byteAllowed = maxBookPageSize;
 +            for (String testString : pageList) {
 +                int byteLength = testString.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
-+                if (byteLength > 256 * 4) {
-+                    ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send a book with with a page too large!");
-+                    this.disconnect(Component.literal("Book too large!"));
-+                    return;
-+                }
 +                byteTotal += byteLength;
 +                int length = testString.length();
 +                int multibytes = 0;
@@ -37,7 +32,7 @@ index 2e35c6cfdf0cded5adc9f512612faaa68876961c..abab7c6ce2079a0101c59c130fd65db7
 +                        }
 +                    }
 +                }
-+                byteAllowed += (maxBookPageSize * Math.min(1, Math.max(0.1D, (double) length / 255D))) * multiplier;
++                byteAllowed += maxBookPageSize * Math.clamp((double) length / 255D, 0.1D, 1) * multiplier;
 +
 +                if (multibytes > 1) {
 +                    // penalize MB
@@ -46,7 +41,7 @@ index 2e35c6cfdf0cded5adc9f512612faaa68876961c..abab7c6ce2079a0101c59c130fd65db7
 +            }
 +
 +            if (byteTotal > byteAllowed) {
-+                ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send too large of a book. Book Size: " + byteTotal + " - Allowed:  "+ byteAllowed + " - Pages: " + pageList.size());
++                ServerGamePacketListenerImpl.LOGGER.warn("{} tried to send a book too large. Book size: {} - Allowed: {} - Pages: {}", this.player.getScoreboardName(), byteTotal, byteAllowed, pageList.size());
 +                this.disconnect(Component.literal("Book too large!"));
 +                return;
 +            }

--- a/patches/server/0279-Limit-Client-Sign-length-more.patch
+++ b/patches/server/0279-Limit-Client-Sign-length-more.patch
@@ -22,7 +22,7 @@ it only impacts data sent from the client.
 Set -DPaper.maxSignLength=XX to change limit or -1 to disable
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 29678ddb0cb53fae9ae497614690f9d855f9eb86..86cb92b7cf18272ee4b46c292ed4a7192119ce1a 100644
+index 1c91e1812e536bb59dbb37aec47afca1d59ffa8d..e78a6234d6699e7f14c5ac7faa7d1ee60e46d7f9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -299,6 +299,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -33,7 +33,7 @@ index 29678ddb0cb53fae9ae497614690f9d855f9eb86..86cb92b7cf18272ee4b46c292ed4a719
  
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player, CommonListenerCookie clientData) {
          super(server, connection, clientData, player); // CraftBukkit
-@@ -3151,7 +3152,19 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3146,7 +3147,19 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void handleSignUpdate(ServerboundSignUpdatePacket packet) {

--- a/patches/server/0354-Prevent-teleporting-dead-entities.patch
+++ b/patches/server/0354-Prevent-teleporting-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent teleporting dead entities
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9103d27e5a80c095b22569bb1bba754f98a9b43c..9b77b711a172d653a4a96d667551ce83040112e4 100644
+index 2fb31c0223f2638de0ebec170095fa20991738ff..e62415cf6a13634f85289c875092bb706c316fd3 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1553,6 +1553,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1548,6 +1548,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      }
  
      public void internalTeleport(double d0, double d1, double d2, float f, float f1, Set<RelativeMovement> set) { // Paper

--- a/patches/server/0369-Prevent-position-desync-causing-tp-exploit.patch
+++ b/patches/server/0369-Prevent-position-desync-causing-tp-exploit.patch
@@ -13,10 +13,10 @@ behaviour, we need to move all of this dangerous logic outside
 of the move call and into an appropriate place in the tick method.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9b77b711a172d653a4a96d667551ce83040112e4..151f078ab6081637189d3d532718dac0ec5e46df 100644
+index e62415cf6a13634f85289c875092bb706c316fd3..d93415023bed72d736f625977ca3e21497bc8f74 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1350,6 +1350,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1345,6 +1345,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              this.player.move(MoverType.PLAYER, new Vec3(d6, d7, d8));
                              this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move

--- a/patches/server/0371-Add-PlayerRecipeBookClickEvent.patch
+++ b/patches/server/0371-Add-PlayerRecipeBookClickEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerRecipeBookClickEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 151f078ab6081637189d3d532718dac0ec5e46df..090b42aba7353d232a210d67936d024d00388047 100644
+index d93415023bed72d736f625977ca3e21497bc8f74..d003494e741b97cbb8541d3132c7c448219e8ced 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3058,16 +3058,40 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3053,16 +3053,40 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              if (!this.player.containerMenu.stillValid(this.player)) {
                  ServerGamePacketListenerImpl.LOGGER.debug("Player {} interacted with invalid menu {}", this.player, this.player.containerMenu);
              } else {

--- a/patches/server/0375-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0375-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -76,10 +76,10 @@ index d6dc8c983d26ce89f17a990be4284fdc78ad164b..2b1d7a2360a9ee7bca9d93a2dc8c61d1
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 01def06cf90faaf67421b6e5a87f4c47dd4c1142..9f28c9f2e8f8323aa374c2ac5e7610b825890b18 100644
+index dae64538b34c7cc7d1af0f58e3a150c7f5e3c1c9..19f49465cfc80c1cf36755f24aa246e0656da75a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3261,7 +3261,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3256,7 +3256,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      public void handleChangeDifficulty(ServerboundChangeDifficultyPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (this.player.hasPermissions(2) || this.isSingleplayerOwner()) {

--- a/patches/server/0381-Do-not-accept-invalid-client-settings.patch
+++ b/patches/server/0381-Do-not-accept-invalid-client-settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Do not accept invalid client settings
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9f28c9f2e8f8323aa374c2ac5e7610b825890b18..762998180eb7b10151f390ee79690c68d66622f2 100644
+index 19f49465cfc80c1cf36755f24aa246e0656da75a..19f13d845467364a25417ac8fd6404f16e18eaa2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3253,6 +3253,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3248,6 +3248,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      @Override
      public void handleClientInformation(ServerboundClientInformationPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());

--- a/patches/server/0409-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0409-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -9,7 +9,7 @@ as this is how Vanilla teleports entities.
 Cancel any pending motion when teleported.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 762998180eb7b10151f390ee79690c68d66622f2..d97b1040ecec1d30fdd1bf309a8215955642fb93 100644
+index 19f13d845467364a25417ac8fd6404f16e18eaa2..45313a53ef181e4494e4d024c5b79a3ca7f803e1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -679,7 +679,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -21,7 +21,7 @@ index 762998180eb7b10151f390ee79690c68d66622f2..d97b1040ecec1d30fdd1bf309a821595
              this.lastGoodX = this.awaitingPositionFromClient.x;
              this.lastGoodY = this.awaitingPositionFromClient.y;
              this.lastGoodZ = this.awaitingPositionFromClient.z;
-@@ -1595,7 +1595,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1590,7 +1590,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // CraftBukkit end
  
          this.awaitingTeleportTime = this.tickCount;

--- a/patches/server/0419-Fix-for-large-move-vectors-crashing-server.patch
+++ b/patches/server/0419-Fix-for-large-move-vectors-crashing-server.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix for large move vectors crashing server
 Check movement distance also based on current position.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d97b1040ecec1d30fdd1bf309a8215955642fb93..7a743d81c387179218c519a7e27702605069caeb 100644
+index 45313a53ef181e4494e4d024c5b79a3ca7f803e1..ffdd7c427bf563b1d87d65586b125fd081e73dd8 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -492,9 +492,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -53,7 +53,7 @@ index d97b1040ecec1d30fdd1bf309a8215955642fb93..7a743d81c387179218c519a7e2770260
                  boolean flag1 = entity.verticalCollisionBelow;
  
                  if (entity instanceof LivingEntity) {
-@@ -1254,7 +1263,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1249,7 +1258,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                          double d7 = d1 - this.firstGoodY;
                          double d8 = d2 - this.firstGoodZ;
                          double d9 = this.player.getDeltaMovement().lengthSqr();
@@ -71,7 +71,7 @@ index d97b1040ecec1d30fdd1bf309a8215955642fb93..7a743d81c387179218c519a7e2770260
  
                          if (this.player.isSleeping()) {
                              if (d10 > 1.0D) {
-@@ -1310,9 +1328,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1305,9 +1323,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              AABB axisalignedbb = this.player.getBoundingBox();
  

--- a/patches/server/0443-Limit-recipe-packets.patch
+++ b/patches/server/0443-Limit-recipe-packets.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Limit recipe packets
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 7a743d81c387179218c519a7e27702605069caeb..a0bac2fe6222964b098cfaf9470f09c43328fcf5 100644
+index ffdd7c427bf563b1d87d65586b125fd081e73dd8..cdf29c17cac7a5bcfcd12d6e306efad0bc87a382 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -266,6 +266,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -24,7 +24,7 @@ index 7a743d81c387179218c519a7e27702605069caeb..a0bac2fe6222964b098cfaf9470f09c4
          /* Use thread-safe field access instead
          if (this.chatSpamTickCount > 0) {
              --this.chatSpamTickCount;
-@@ -3070,6 +3072,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3065,6 +3067,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void handlePlaceRecipe(ServerboundPlaceRecipePacket packet) {

--- a/patches/server/0458-Fix-interact-event-not-being-called-sometimes.patch
+++ b/patches/server/0458-Fix-interact-event-not-being-called-sometimes.patch
@@ -11,10 +11,10 @@ Subject: [PATCH] Fix interact event not being called sometimes
 Co-authored-by: Moulberry <james.jenour@protonmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a0bac2fe6222964b098cfaf9470f09c43328fcf5..09e40d6e50b7c1ddd1451981d05ecbbef43cfed2 100644
+index cdf29c17cac7a5bcfcd12d6e306efad0bc87a382..afed142d5155c178807c6b26cb5766ae7d6e328a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1771,7 +1771,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1766,7 +1766,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  MutableComponent ichatmutablecomponent = Component.translatable("build.tooHigh", i - 1).withStyle(ChatFormatting.RED);
  
                                  this.player.sendSystemMessage(ichatmutablecomponent, true);
@@ -23,7 +23,7 @@ index a0bac2fe6222964b098cfaf9470f09c43328fcf5..09e40d6e50b7c1ddd1451981d05ecbbe
                                  this.player.swing(enumhand, true);
                              }
                          }
-@@ -2392,13 +2392,20 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2387,13 +2387,20 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          double d3 = Math.max(this.player.blockInteractionRange(), this.player.entityInteractionRange());
          // SPIGOT-5607: Only call interact event if no block or entity is being clicked. Use bukkit ray trace method, because it handles blocks and entities at the same time
          // SPIGOT-7429: Make sure to call PlayerInteractEvent for spectators and non-pickable entities

--- a/patches/server/0502-Allow-using-signs-inside-spawn-protection.patch
+++ b/patches/server/0502-Allow-using-signs-inside-spawn-protection.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow using signs inside spawn protection
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 09e40d6e50b7c1ddd1451981d05ecbbef43cfed2..95942fcf46bb14257faa7f5095bbf853b589be1e 100644
+index afed142d5155c178807c6b26cb5766ae7d6e328a..8e888be601190e69389fa5a8596a4e7d52dd1749 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1759,8 +1759,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1754,8 +1754,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      int i = this.player.level().getMaxBuildHeight();
  
                      if (blockposition.getY() < i) {

--- a/patches/server/0507-Don-t-ignore-result-of-PlayerEditBookEvent.patch
+++ b/patches/server/0507-Don-t-ignore-result-of-PlayerEditBookEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't ignore result of PlayerEditBookEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 95942fcf46bb14257faa7f5095bbf853b589be1e..80b0da98233dd98a05c898a73e519db9d30a3e74 100644
+index 8e888be601190e69389fa5a8596a4e7d52dd1749..773ada940f3bb2cf6a9ff1c32b3306d91dda27d9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1155,7 +1155,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1150,7 +1150,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              List<Filterable<String>> list1 = pages.stream().map(this::filterableFromOutgoing).toList();
  
              itemstack.set(DataComponents.WRITABLE_BOOK_CONTENT, new WritableBookContent(list1));

--- a/patches/server/0517-fix-PlayerItemHeldEvent-firing-twice.patch
+++ b/patches/server/0517-fix-PlayerItemHeldEvent-firing-twice.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] fix PlayerItemHeldEvent firing twice
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 80b0da98233dd98a05c898a73e519db9d30a3e74..699658bd80eb88907041efb01d31e4051edb91de 100644
+index 773ada940f3bb2cf6a9ff1c32b3306d91dda27d9..4ed4a2f5f03790fab394429334881377c1b3ab60 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1934,6 +1934,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1929,6 +1929,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (this.player.isImmobile()) return; // CraftBukkit
          if (packet.getSlot() >= 0 && packet.getSlot() < Inventory.getSelectionSize()) {

--- a/patches/server/0534-Expand-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0534-Expand-PlayerGameModeChangeEvent.patch
@@ -134,10 +134,10 @@ index 5de472df78940d1b8320f73d18b2edf3a796227e..073cf184a0e7af41048ae67a9b17b4cd
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 699658bd80eb88907041efb01d31e4051edb91de..58e5acbd00c4f8c0fcafa4f2c21b6a9f4dcc4151 100644
+index 4ed4a2f5f03790fab394429334881377c1b3ab60..e91200b8b1da00b4b13697e950433de661a4e419 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2732,7 +2732,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2727,7 +2727,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                      this.player = this.server.getPlayerList().respawn(this.player, false, Entity.RemovalReason.KILLED, RespawnReason.DEATH); // CraftBukkit
                      if (this.server.isHardcore()) {

--- a/patches/server/0537-Move-range-check-for-block-placing-up.patch
+++ b/patches/server/0537-Move-range-check-for-block-placing-up.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Move range check for block placing up
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 58e5acbd00c4f8c0fcafa4f2c21b6a9f4dcc4151..e713a2abca824e92a4922c34fca8c1f0bfdcdf68 100644
+index e91200b8b1da00b4b13697e950433de661a4e419..091863f559b74b93f129cc0bf5413ab4b81a0155 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1746,6 +1746,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1741,6 +1741,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          if (itemstack.isItemEnabled(worldserver.enabledFeatures())) {
              BlockHitResult movingobjectpositionblock = packet.getHitResult();
              Vec3 vec3d = movingobjectpositionblock.getLocation();

--- a/patches/server/0540-Add-Unix-domain-socket-support.patch
+++ b/patches/server/0540-Add-Unix-domain-socket-support.patch
@@ -87,10 +87,10 @@ index d6d7f1c446ba5507f67038ff27775ba75156f4a7..c63c194c44646e6bc1a5942655278701
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e713a2abca824e92a4922c34fca8c1f0bfdcdf68..ada5016ee354e799a8241a0706ea04e236efd1eb 100644
+index 091863f559b74b93f129cc0bf5413ab4b81a0155..9aceb641acde6840b45899e60fe3319a4a89b357 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2551,6 +2551,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2546,6 +2546,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      // Spigot Start
      public SocketAddress getRawAddress()
      {

--- a/patches/server/0546-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0546-Add-PlayerKickEvent-causes.patch
@@ -218,7 +218,7 @@ index 24bf661e76fb421a8be565d9ea68edf7205254d2..feb529adf2168025c785ab92d95a3246
          if (this.cserver.getServer().isRunning()) {
              this.cserver.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8fba97228 100644
+index b908e292d7b2fbff6cc5058ea32648dbde52fa19..c07d6a05737da570e7dc52e73b45e7550dcc61d0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -349,7 +349,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -284,19 +284,10 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
              return;
          }
          this.player.getInventory().pickSlot(packet.getSlot()); // Paper - Diff above if changed
-@@ -1088,7 +1088,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
-                 int byteLength = testString.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
-                 if (byteLength > 256 * 4) {
-                     ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send a book with with a page too large!");
--                    this.disconnect(Component.literal("Book too large!"));
-+                    this.disconnect(Component.literal("Book too large!"), org.bukkit.event.player.PlayerKickEvent.Cause.ILLEGAL_ACTION); // Paper - kick event cause
-                     return;
-                 }
-                 byteTotal += byteLength;
-@@ -1111,14 +1111,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1106,14 +1106,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
              if (byteTotal > byteAllowed) {
-                 ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send too large of a book. Book Size: " + byteTotal + " - Allowed:  "+ byteAllowed + " - Pages: " + pageList.size());
+                 ServerGamePacketListenerImpl.LOGGER.warn("{} tried to send a book too large. Book size: {} - Allowed: {} - Pages: {}", this.player.getScoreboardName(), byteTotal, byteAllowed, pageList.size());
 -                this.disconnect(Component.literal("Book too large!"));
 +                this.disconnect(Component.literal("Book too large!"), org.bukkit.event.player.PlayerKickEvent.Cause.ILLEGAL_ACTION); // Paper - kick event cause
                  return;
@@ -310,7 +301,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
              return;
          }
          this.lastBookTick = MinecraftServer.currentTick;
-@@ -1230,7 +1230,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1225,7 +1225,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      public void handleMovePlayer(ServerboundMovePlayerPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (ServerGamePacketListenerImpl.containsInvalidValues(packet.getX(0.0D), packet.getY(0.0D), packet.getZ(0.0D), packet.getYRot(0.0F), packet.getXRot(0.0F))) {
@@ -319,7 +310,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
          } else {
              ServerLevel worldserver = this.player.serverLevel();
  
-@@ -1668,7 +1668,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1663,7 +1663,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                          this.dropCount++;
                          if (this.dropCount >= 20) {
                              ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " dropped their items too quickly!");
@@ -328,7 +319,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
                              return;
                          }
                      }
-@@ -1956,7 +1956,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1951,7 +1951,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              this.player.resetLastActionTime();
          } else {
              ServerGamePacketListenerImpl.LOGGER.warn("{} tried to set an invalid carried item", this.player.getName().getString());
@@ -337,7 +328,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
          }
      }
  
-@@ -2154,7 +2154,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2149,7 +2149,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      private void tryHandleChat(String s, Runnable runnable, boolean sync) { // CraftBukkit
          if (ServerGamePacketListenerImpl.isChatMessageIllegal(s)) {
@@ -346,7 +337,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
          } else if (this.player.isRemoved() || this.player.getChatVisibility() == ChatVisiblity.HIDDEN) { // CraftBukkit - dead men tell no tales
              this.send(new ClientboundSystemChatPacket(Component.translatable("chat.disabled.options").withStyle(ChatFormatting.RED), false));
          } else {
-@@ -2177,7 +2177,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2172,7 +2172,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
              if (optional.isEmpty()) {
                  ServerGamePacketListenerImpl.LOGGER.warn("Failed to validate message acknowledgements from {}", this.player.getName().getString());
@@ -355,7 +346,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
              }
  
              return optional;
-@@ -2363,7 +2363,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2358,7 +2358,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // this.chatSpamTickCount += 20;
          if (this.chatSpamTickCount.addAndGet(20) > 200 && !this.server.getPlayerList().isOp(this.player.getGameProfile()) && !this.server.isSingleplayerOwner(this.player.getGameProfile())) {
              // CraftBukkit end
@@ -364,7 +355,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
          }
  
      }
-@@ -2375,7 +2375,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2370,7 +2370,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          synchronized (this.lastSeenMessages) {
              if (!this.lastSeenMessages.applyOffset(packet.offset())) {
                  ServerGamePacketListenerImpl.LOGGER.warn("Failed to validate message acknowledgements from {}", this.player.getName().getString());
@@ -373,7 +364,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
              }
  
          }
-@@ -2523,7 +2523,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2518,7 +2518,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              }
  
              if (i > 4096) {
@@ -382,7 +373,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
              }
  
          }
-@@ -2581,7 +2581,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2576,7 +2576,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // Spigot Start
          if ( entity == this.player && !this.player.isSpectator() )
          {
@@ -391,7 +382,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
              return;
          }
          // Spigot End
-@@ -2695,7 +2695,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2690,7 +2690,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              }
                          }
  
@@ -400,7 +391,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
                          ServerGamePacketListenerImpl.LOGGER.warn("Player {} tried to attack an invalid entity", ServerGamePacketListenerImpl.this.player.getName().getString());
                      }
                  });
-@@ -3092,7 +3092,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3087,7 +3087,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // Paper start - auto recipe limit
          if (!org.bukkit.Bukkit.isPrimaryThread()) {
              if (this.recipeSpamPackets.addAndGet(io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.recipeSpamIncrement) > io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.recipeSpamLimit) {
@@ -409,7 +400,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
                  return;
              }
          }
-@@ -3334,7 +3334,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3329,7 +3329,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
          if (!Objects.equals(profilepublickey_a, profilepublickey_a1)) {
              if (profilepublickey_a != null && profilepublickey_a1.expiresAt().isBefore(profilepublickey_a.expiresAt())) {
@@ -418,7 +409,7 @@ index ada5016ee354e799a8241a0706ea04e236efd1eb..70b215dfbe53bd475192ca1d021032c8
              } else {
                  try {
                      SignatureValidator signaturevalidator = this.server.getProfileKeySignatureValidator();
-@@ -3347,7 +3347,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3342,7 +3342,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      this.resetPlayerChatState(remotechatsession_a.validate(this.player.getGameProfile(), signaturevalidator));
                  } catch (ProfilePublicKey.ValidationException profilepublickey_b) {
                      ServerGamePacketListenerImpl.LOGGER.error("Failed to validate profile key: {}", profilepublickey_b.getMessage());

--- a/patches/server/0564-Add-PlayerArmSwingEvent.patch
+++ b/patches/server/0564-Add-PlayerArmSwingEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerArmSwingEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 70b215dfbe53bd475192ca1d021032c8fba97228..0a5cad166e852888208125a80b5e2d5e7e9a3a82 100644
+index 3a656daa941993f240fa7fc54ee1106eaa504673..633c13dc22793f5a5c4c137c614c1bb695308888 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2413,7 +2413,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2408,7 +2408,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          } // Paper end - Call interact event
  
          // Arm swing animation

--- a/patches/server/0565-Fix-kick-event-leave-message-not-being-sent.patch
+++ b/patches/server/0565-Fix-kick-event-leave-message-not-being-sent.patch
@@ -55,10 +55,10 @@ index feb529adf2168025c785ab92d95a3246e73c0236..b43f87ff4b9853b5d4bbea5ff9686d64
          MinecraftServer minecraftserver = this.server;
          Connection networkmanager = this.connection;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0a5cad166e852888208125a80b5e2d5e7e9a3a82..dd728c297335581ad69c94f768ec5201b7879264 100644
+index 633c13dc22793f5a5c4c137c614c1bb695308888..5276ce5b6fa19e0810da61c9a3c51b6318356339 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1895,6 +1895,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1890,6 +1890,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void onDisconnect(DisconnectionDetails info) {
@@ -71,7 +71,7 @@ index 0a5cad166e852888208125a80b5e2d5e7e9a3a82..dd728c297335581ad69c94f768ec5201
          // CraftBukkit start - Rarely it would send a disconnect line twice
          if (this.processedDisconnect) {
              return;
-@@ -1903,11 +1909,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1898,11 +1904,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
          // CraftBukkit end
          ServerGamePacketListenerImpl.LOGGER.info("{} lost connection: {}", this.player.getName().getString(), info.reason().getString());
@@ -91,7 +91,7 @@ index 0a5cad166e852888208125a80b5e2d5e7e9a3a82..dd728c297335581ad69c94f768ec5201
          this.chatMessageChain.close();
          // CraftBukkit start - Replace vanilla quit message handling with our own.
          /*
-@@ -1917,7 +1929,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1912,7 +1924,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
          this.player.disconnect();
          // Paper start - Adventure

--- a/patches/server/0600-Improve-and-expand-AsyncCatcher.patch
+++ b/patches/server/0600-Improve-and-expand-AsyncCatcher.patch
@@ -17,10 +17,10 @@ Async catch modifications to critical entity state
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 93a9ef3fc5620c622ce0dfb010c6dafad8fcdb71..987ad7f7130c45a4b3843e186b6a5662859a06ae 100644
+index 1e442429d30886eee96f68d212548ff741e3e07e..fa1fbd41fce44bb8bb9e3435abfcac4e0652c968 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1578,6 +1578,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1573,6 +1573,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      }
  
      public void internalTeleport(double d0, double d1, double d2, float f, float f1, Set<RelativeMovement> set) { // Paper

--- a/patches/server/0692-Prevent-tile-entity-copies-loading-chunks.patch
+++ b/patches/server/0692-Prevent-tile-entity-copies-loading-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent tile entity copies loading chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f26d092e50e5f1e320ba2e3a264573ad862aca26..c87e243744166fb736ca8db65ac268072e353e16 100644
+index 15bee10f167ebd134688ff570c4773fe088e149a..efa6e8a85f27c18bddd91b7f83656457e58a16bd 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3202,7 +3202,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3197,7 +3197,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  BlockPos blockposition = BlockEntity.getPosFromTag(customdata.getUnsafe());
  
                  if (this.player.level().isLoaded(blockposition)) {

--- a/patches/server/0723-Fix-Spigot-Config-not-using-commands.spam-exclusions.patch
+++ b/patches/server/0723-Fix-Spigot-Config-not-using-commands.spam-exclusions.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Spigot Config not using commands.spam-exclusions
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c87e243744166fb736ca8db65ac268072e353e16..8f65943161a6621f8f7926c48322e26a854ae139 100644
+index efa6e8a85f27c18bddd91b7f83656457e58a16bd..52ff31d33edb0c55e2ec4a982525d47e4a19428b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2384,7 +2384,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2379,7 +2379,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
          // Spigot end
          // this.chatSpamTickCount += 20;

--- a/patches/server/0724-More-Teleport-API.patch
+++ b/patches/server/0724-More-Teleport-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More Teleport API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8f65943161a6621f8f7926c48322e26a854ae139..58fd502c2a735d4a102de451a002cfd622c58294 100644
+index 52ff31d33edb0c55e2ec4a982525d47e4a19428b..77e31c3851813651dc00e59f8ef31134e3540b91 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1566,11 +1566,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1561,11 +1561,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              return true; // CraftBukkit - Return event status
          }
  

--- a/patches/server/0727-Send-block-entities-after-destroy-prediction.patch
+++ b/patches/server/0727-Send-block-entities-after-destroy-prediction.patch
@@ -57,10 +57,10 @@ index 4d024956156aefde7df308642dfd0a40779e0633..6abecaac8407b992d208a9108e11fd49
              }
          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 58fd502c2a735d4a102de451a002cfd622c58294..3b1e231c637750821a756c877c9c6b7150b184b8 100644
+index 77e31c3851813651dc00e59f8ef31134e3540b91..719f44cf1bca2cd834b7909e135b0a636c4ccb5e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1712,8 +1712,28 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1707,8 +1707,28 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      return;
                  }
                  // Paper end - Don't allow digging into unloaded chunks

--- a/patches/server/0785-Improve-logging-and-errors.patch
+++ b/patches/server/0785-Improve-logging-and-errors.patch
@@ -52,10 +52,10 @@ index aa39bdb0a4ba8fedf5052ea9700afa7d4d2a4300..b4af03c4bdd1ce0861f36c3b75fc7e89
          }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3b1e231c637750821a756c877c9c6b7150b184b8..e5b466f71d4c65eb31210ccad05a9fb603d53098 100644
+index 719f44cf1bca2cd834b7909e135b0a636c4ccb5e..af2fb05406616849c8f65bbd971b354d1931a6ac 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3400,7 +3400,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3395,7 +3395,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                      this.resetPlayerChatState(remotechatsession_a.validate(this.player.getGameProfile(), signaturevalidator));
                  } catch (ProfilePublicKey.ValidationException profilepublickey_b) {

--- a/patches/server/0788-Add-missing-SpigotConfig-logCommands-check.patch
+++ b/patches/server/0788-Add-missing-SpigotConfig-logCommands-check.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing SpigotConfig logCommands check
 Co-authored-by: david <mrminecraft00@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e5b466f71d4c65eb31210ccad05a9fb603d53098..1b486d09bd1a84835183a6c8181933fcabb3373f 100644
+index af2fb05406616849c8f65bbd971b354d1931a6ac..50896a73387f9467b83f9a685ab346e3edb4e040 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2058,7 +2058,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2053,7 +2053,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      private void performUnsignedChatCommand(String command) {
          // CraftBukkit start
          String command1 = "/" + command;
@@ -19,7 +19,7 @@ index e5b466f71d4c65eb31210ccad05a9fb603d53098..1b486d09bd1a84835183a6c8181933fc
  
          PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(this.getCraftPlayer(), command1, new LazyPlayerSet(this.server));
          this.cserver.getPluginManager().callEvent(event);
-@@ -2098,7 +2100,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2093,7 +2095,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      private void performSignedChatCommand(ServerboundChatCommandSignedPacket packet, LastSeenMessages lastSeenMessages) {
          // CraftBukkit start
          String command = "/" + packet.command();

--- a/patches/server/0793-Use-single-player-info-update-packet-on-join.patch
+++ b/patches/server/0793-Use-single-player-info-update-packet-on-join.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use single player info update packet on join
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 1b486d09bd1a84835183a6c8181933fcabb3373f..62b022a72954eeecfa141f4ec93ccb44d955e54b 100644
+index 50896a73387f9467b83f9a685ab346e3edb4e040..e38c437a2e55d0e1cc7ed60f7994232880342c9e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3438,7 +3438,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3433,7 +3433,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          this.signedMessageDecoder = session.createMessageDecoder(this.player.getUUID());
          this.chatMessageChain.append(() -> {
              this.player.setChatSession(session);

--- a/patches/server/0810-Treat-sequence-violations-like-they-should-be.patch
+++ b/patches/server/0810-Treat-sequence-violations-like-they-should-be.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Treat sequence violations like they should be
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 62b022a72954eeecfa141f4ec93ccb44d955e54b..664d9cfacb87b1d9193376261f7102b64c906ddc 100644
+index e38c437a2e55d0e1cc7ed60f7994232880342c9e..207cc06d857ffca4c0aac98221a31014b42fac3f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1977,6 +1977,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1972,6 +1972,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      public void ackBlockChangesUpTo(int sequence) {
          if (sequence < 0) {

--- a/patches/server/0811-Prevent-causing-expired-keys-from-impacting-new-join.patch
+++ b/patches/server/0811-Prevent-causing-expired-keys-from-impacting-new-join.patch
@@ -26,7 +26,7 @@ index 68c062cbaa030d62d97c9c003651f8fc17a00a6b..6247a21c9c391abf1f6db3482c659593
          UPDATE_GAME_MODE((serialized, buf) -> serialized.gameMode = GameType.byId(buf.readVarInt()), (buf, entry) -> buf.writeVarInt(entry.gameMode().getId())),
          UPDATE_LISTED((serialized, buf) -> serialized.listed = buf.readBoolean(), (buf, entry) -> buf.writeBoolean(entry.listed())),
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 664d9cfacb87b1d9193376261f7102b64c906ddc..977af8887ac331576a1c4441fcfad681f69a9929 100644
+index 207cc06d857ffca4c0aac98221a31014b42fac3f..d3e0fb1292e1bae22ea70835b45fc36aa9cf254c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -295,6 +295,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -51,7 +51,7 @@ index 664d9cfacb87b1d9193376261f7102b64c906ddc..977af8887ac331576a1c4441fcfad681
      }
  
      private int getMaximumFlyingTicks(Entity vehicle) {
-@@ -3436,6 +3444,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3431,6 +3439,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      private void resetPlayerChatState(RemoteChatSession session) {
          this.chatSession = session;

--- a/patches/server/0847-Implement-PlayerFailMoveEvent.patch
+++ b/patches/server/0847-Implement-PlayerFailMoveEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement PlayerFailMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 977af8887ac331576a1c4441fcfad681f69a9929..46bb2031141b88416f2df1fb8bca76638ef66dae 100644
+index d3e0fb1292e1bae22ea70835b45fc36aa9cf254c..be9c3a48fd1c44b5b5e2680c35c91c5058010e23 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1261,8 +1261,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1256,8 +1256,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      double d0 = ServerGamePacketListenerImpl.clampHorizontal(packet.getX(this.player.getX())); final double toX = d0; // Paper - OBFHELPER
                      double d1 = ServerGamePacketListenerImpl.clampVertical(packet.getY(this.player.getY())); final double toY = d1; // Paper - OBFHELPER
                      double d2 = ServerGamePacketListenerImpl.clampHorizontal(packet.getZ(this.player.getZ())); final double toZ = d2; // Paper - OBFHELPER
@@ -19,7 +19,7 @@ index 977af8887ac331576a1c4441fcfad681f69a9929..46bb2031141b88416f2df1fb8bca7663
  
                      if (this.player.isPassenger()) {
                          this.player.absMoveTo(this.player.getX(), this.player.getY(), this.player.getZ(), f, f1);
-@@ -1329,8 +1329,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1324,8 +1324,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  }
                                  // Paper start - Prevent moving into unloaded chunks
                                  if (this.player.level().paperConfig().chunks.preventMovingIntoUnloadedChunks && (this.player.getX() != toX || this.player.getZ() != toZ) && !worldserver.areChunksLoadedForMove(this.player.getBoundingBox().expandTowards(new Vec3(toX, toY, toZ).subtract(this.player.position())))) {
@@ -36,7 +36,7 @@ index 977af8887ac331576a1c4441fcfad681f69a9929..46bb2031141b88416f2df1fb8bca7663
                                  }
                                  // Paper end - Prevent moving into unloaded chunks
  
-@@ -1339,9 +1345,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1334,9 +1340,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                                      if (d10 - d9 > Math.max(f2, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isSingleplayerOwner()) {
                                      // CraftBukkit end
@@ -56,7 +56,7 @@ index 977af8887ac331576a1c4441fcfad681f69a9929..46bb2031141b88416f2df1fb8bca7663
                                      }
                                  }
                              }
-@@ -1403,14 +1416,31 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1398,14 +1411,31 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              d8 = d2 - this.player.getZ();
                              d10 = d6 * d6 + d7 * d7 + d8 * d8;
@@ -91,7 +91,7 @@ index 977af8887ac331576a1c4441fcfad681f69a9929..46bb2031141b88416f2df1fb8bca7663
                                  this.internalTeleport(d3, d4, d5, f, f1, Collections.emptySet()); // CraftBukkit - SPIGOT-1807: Don't call teleport event, when the client thinks the player is falling, because the chunks are not loaded on the client yet.
                                  this.player.doCheckFallDamage(this.player.getX() - d3, this.player.getY() - d4, this.player.getZ() - d5, packet.isOnGround());
                              } else {
-@@ -3467,4 +3497,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3462,4 +3492,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
          InteractionResult run(ServerPlayer player, Entity entity, InteractionHand hand);
      }

--- a/patches/server/0883-Add-slot-sanity-checks-in-container-clicks.patch
+++ b/patches/server/0883-Add-slot-sanity-checks-in-container-clicks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add slot sanity checks in container clicks
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0ed03a8ec85d8491d96c7b3ac3feff805a773539..5d7b443173c3f11fc402e96db109e4382466d182 100644
+index c17115368e36bce710a494334969676edb0f9a5c..599c620cfbf478cd3674bf4691d70000d1fd6987 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2987,6 +2987,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2982,6 +2982,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              break;
                          case SWAP:
                              if ((packet.getButtonNum() >= 0 && packet.getButtonNum() < 9) || packet.getButtonNum() == 40) {

--- a/patches/server/0940-Add-CartographyItemEvent.patch
+++ b/patches/server/0940-Add-CartographyItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add CartographyItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 5d7b443173c3f11fc402e96db109e4382466d182..449fd298293f4fb996b7ddae6b174d6a28e95eb6 100644
+index 599c620cfbf478cd3674bf4691d70000d1fd6987..137754d5fe819956f29f2dd2a97bb4427e0d5339 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3109,6 +3109,19 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3104,6 +3104,19 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              }
                          }
  

--- a/patches/server/0950-Improve-tag-parser-handling.patch
+++ b/patches/server/0950-Improve-tag-parser-handling.patch
@@ -109,6 +109,19 @@ index da101bca71f4710812621b98f0a0d8cab180346a..3cd112584accb8e8f050ac99738eed11
 +        }
 +    }
  }
+diff --git a/src/main/java/net/minecraft/network/chat/contents/SelectorContents.java b/src/main/java/net/minecraft/network/chat/contents/SelectorContents.java
+index 1337853badf8e124aa8439ce33a255bc4164125b..a1869eee2da9b1993b1348ed40ef8fdac092b72a 100644
+--- a/src/main/java/net/minecraft/network/chat/contents/SelectorContents.java
++++ b/src/main/java/net/minecraft/network/chat/contents/SelectorContents.java
+@@ -50,7 +50,7 @@ public class SelectorContents implements ComponentContents {
+             EntitySelectorParser entitySelectorParser = new EntitySelectorParser(new StringReader(pattern), true);
+             entitySelector = entitySelectorParser.parse();
+         } catch (CommandSyntaxException var3) {
+-            LOGGER.warn("Invalid selector component: {}: {}", pattern, var3.getMessage());
++            return null; // Paper
+         }
+ 
+         return entitySelector;
 diff --git a/src/main/java/net/minecraft/network/chat/contents/TranslatableContents.java b/src/main/java/net/minecraft/network/chat/contents/TranslatableContents.java
 index 56e641bc5f6edc657647993ea2efbb7bb9c2f732..4aa6232bf0f72fcde32d257100bd15b1c5192aaa 100644
 --- a/src/main/java/net/minecraft/network/chat/contents/TranslatableContents.java
@@ -169,7 +182,7 @@ index 898b19887ed34c87003fc63cb5905df2ba6234a5..b47eeb23055b135d5567552ba983bfbc
  
      private void write(FriendlyByteBuf buf) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 449fd298293f4fb996b7ddae6b174d6a28e95eb6..134f31cce8d8eca669948a784e2766216fb91ab5 100644
+index d4803b966301ac732c9ca9e53fba1d28ff9878bf..c32487782a02cfa1f9d594a28c45121f4eeaa29c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -766,6 +766,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl

--- a/patches/server/0971-Brigadier-based-command-API.patch
+++ b/patches/server/0971-Brigadier-based-command-API.patch
@@ -2350,10 +2350,10 @@ index b4af03c4bdd1ce0861f36c3b75fc7e89d701c46a..0761d5bc5f2813bb4a9f664ac7a05b97
          this.setPvpAllowed(dedicatedserverproperties.pvp);
          this.setFlightAllowed(dedicatedserverproperties.allowFlight);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 134f31cce8d8eca669948a784e2766216fb91ab5..60c65af218d533d53b765ba2175fed163c32c126 100644
+index ef646b717323933f4b84e963ab8139dd241843bc..4f9a17e7cd5aca2e8bd55b4892a20dce181289cd 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2408,33 +2408,20 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2403,33 +2403,20 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
      }
  

--- a/patches/server/0975-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0975-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -201,10 +201,10 @@ index 0e7ace92522fbd4cef7b2c2b8a0f8b86c2cce192..1d849ce4e2c85f149af25318b8ffb6dc
              ((LivingEntity) this.entity).detectEquipmentUpdatesPublic(); // CraftBukkit - SPIGOT-3789: sync again immediately after sending
          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 60c65af218d533d53b765ba2175fed163c32c126..a0f5839719ca0ce6ed048229f074041b4f64cc97 100644
+index 4f9a17e7cd5aca2e8bd55b4892a20dce181289cd..a04fdcecf00f128f0afba1a33fad1d9e7694ef63 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2732,7 +2732,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2727,7 +2727,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  entity.refreshEntityData(ServerGamePacketListenerImpl.this.player);
                                  // SPIGOT-7136 - Allays
                                  if (entity instanceof Allay) {

--- a/patches/server/0979-Deprecate-InvAction-HOTBAR_MOVE_AND_READD.patch
+++ b/patches/server/0979-Deprecate-InvAction-HOTBAR_MOVE_AND_READD.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deprecate InvAction#HOTBAR_MOVE_AND_READD
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a0f5839719ca0ce6ed048229f074041b4f64cc97..a8debfad8c8e66099f8a9aedc6f1971a8576dade 100644
+index a04fdcecf00f128f0afba1a33fad1d9e7694ef63..566bbc8f2976bc492049fcddca5976a0ae48d14d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2998,14 +2998,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2993,14 +2993,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  Slot clickedSlot = this.player.containerMenu.getSlot(packet.getSlotNum());
                                  if (clickedSlot.mayPickup(this.player)) {
                                      ItemStack hotbar = this.player.getInventory().getItem(packet.getButtonNum());

--- a/patches/server/1019-Properly-resend-entities.patch
+++ b/patches/server/1019-Properly-resend-entities.patch
@@ -81,10 +81,10 @@ index e9dcdb1e09e84a9b451034ff4bdfa6eae2dd1c04..24b1715397ba8e6f5e9841a030d0e3d9
              }
          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a8debfad8c8e66099f8a9aedc6f1971a8576dade..7796e191747be545e744564a2b0b65790f69114d 100644
+index 566bbc8f2976bc492049fcddca5976a0ae48d14d..f1ca57b98fe04df2722114743c2d746c0a679c1f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1949,6 +1949,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1944,6 +1944,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              }
  
              if (cancelled) {
@@ -92,7 +92,7 @@ index a8debfad8c8e66099f8a9aedc6f1971a8576dade..7796e191747be545e744564a2b0b6579
                  this.player.getBukkitEntity().updateInventory(); // SPIGOT-2524
                  return;
              }
-@@ -2718,7 +2719,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2713,7 +2714,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              // Entity in bucket - SPIGOT-4048 and SPIGOT-6859a
                              if ((entity instanceof Bucketable && entity instanceof LivingEntity && origItem != null && origItem.asItem() == Items.WATER_BUCKET) && (event.isCancelled() || ServerGamePacketListenerImpl.this.player.getInventory().getSelected() == null || ServerGamePacketListenerImpl.this.player.getInventory().getSelected().getItem() != origItem)) {

--- a/patches/server/1041-Make-interaction-leniency-distance-configurable.patch
+++ b/patches/server/1041-Make-interaction-leniency-distance-configurable.patch
@@ -12,10 +12,10 @@ This value however may be too low in high latency environments.
 The patch exposes a new configuration option to configure said value.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 7796e191747be545e744564a2b0b65790f69114d..624b80c796e9c95040d71d1595d11f98e2899cf3 100644
+index f1ca57b98fe04df2722114743c2d746c0a679c1f..4d697cd7aa5a74c2016644385f59e461f660c8bd 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2703,7 +2703,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2698,7 +2698,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
              AABB axisalignedbb = entity.getBoundingBox();
  


### PR DESCRIPTION
The previous limit was 1024 bytes per page which doesn't make sense since the game allow up to 1024 chars per page and a character might take more bytes. So using some large unicode char the limit can be reach easily using a vanilla client.
It should be safe to not check this for now since the item meta conversion that happens in the later event should trim the page anyway.

This might be related to https://github.com/PaperMC/Paper/issues/10354