### PR TITLE
Handle custom registry elements properly

### DIFF
--- a/patches/api/0432-Improve-Registry.patch
+++ b/patches/api/0432-Improve-Registry.patch
@@ -9,8 +9,26 @@ items need to exist without having a key and so
 getKey() methods on Keyed objects that have a registry
 are marked as Deprecated or Obsolete.
 
+diff --git a/src/main/java/org/bukkit/Art.java b/src/main/java/org/bukkit/Art.java
+index 042d1d932a33022e4fc873652f70dc6ed342d46a..dbbd997d4693f1d9f551bae2ed1d7906c9f39c12 100644
+--- a/src/main/java/org/bukkit/Art.java
++++ b/src/main/java/org/bukkit/Art.java
+@@ -103,6 +103,13 @@ public enum Art implements Keyed {
+         return id;
+     }
+ 
++    // Paper start - deprecate getKey
++    /**
++     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#ART}. Painting variants
++     * can exist without a key.
++     */
++    @Deprecated(since = "1.21")
++    // Paper end - deprecate getKey
+     @NotNull
+     @Override
+     public NamespacedKey getKey() {
 diff --git a/src/main/java/org/bukkit/MusicInstrument.java b/src/main/java/org/bukkit/MusicInstrument.java
-index 62d2b3f950860dee0898d77b0a29635c3f9a7e23..704dba92f9246ef398ed8d162ebee3cf305960e1 100644
+index 62d2b3f950860dee0898d77b0a29635c3f9a7e23..98fdfc8978fea1937e31a7427433a1927d42ec7d 100644
 --- a/src/main/java/org/bukkit/MusicInstrument.java
 +++ b/src/main/java/org/bukkit/MusicInstrument.java
 @@ -53,6 +53,16 @@ public abstract class MusicInstrument implements Keyed, net.kyori.adventure.tran
@@ -22,7 +40,7 @@ index 62d2b3f950860dee0898d77b0a29635c3f9a7e23..704dba92f9246ef398ed8d162ebee3cf
 +     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#INSTRUMENT}. MusicInstruments
 +     * can exist without a key.
 +     */
-+    @Deprecated
++    @Deprecated(forRemoval = true, since = "1.20.5")
 +    @Override
 +    public abstract @NotNull NamespacedKey getKey();
 +    // Paper end - deprecate getKey
@@ -31,7 +49,7 @@ index 62d2b3f950860dee0898d77b0a29635c3f9a7e23..704dba92f9246ef398ed8d162ebee3cf
      @Override
      public @NotNull String translationKey() {
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 0ee9a8728035217bb95c7fba917b45a5ef2ea533..cd1e38debbec745dd13cd895327f544dcf42594d 100644
+index 1df2b8fcf90333d5981f16d9dddddd48289f94e4..5d21459e9128c515508a2b4b2265d9824e10d9d5 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
 @@ -359,6 +359,79 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
@@ -127,8 +145,26 @@ index 0ee9a8728035217bb95c7fba917b45a5ef2ea533..cd1e38debbec745dd13cd895327f544d
 +        // Paper end - improve Registry
      }
  }
+diff --git a/src/main/java/org/bukkit/Sound.java b/src/main/java/org/bukkit/Sound.java
+index 8c7b50906fc5b84c5570408f357410810bbfbded..7a35120c82b88774de777d3c3176ef553a8e9244 100644
+--- a/src/main/java/org/bukkit/Sound.java
++++ b/src/main/java/org/bukkit/Sound.java
+@@ -1636,6 +1636,13 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
+         this.key = NamespacedKey.minecraft(key);
+     }
+ 
++    // Paper start - deprecate getKey
++    /**
++     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#SOUNDS}. Sounds
++     * can exist without a key.
++     */
++    @Deprecated(since = "1.20.5")
++    // Paper end - deprecate getKey
+     @NotNull
+     @Override
+     public NamespacedKey getKey() {
 diff --git a/src/main/java/org/bukkit/block/banner/PatternType.java b/src/main/java/org/bukkit/block/banner/PatternType.java
-index 9e90572745909538e942b7fbe788b5286c6cc9a3..100f93358e0a1fa8507775a2afd29314ff353a87 100644
+index 9e90572745909538e942b7fbe788b5286c6cc9a3..e2afb2582a27b94a922754115dbb6b4ca35e0154 100644
 --- a/src/main/java/org/bukkit/block/banner/PatternType.java
 +++ b/src/main/java/org/bukkit/block/banner/PatternType.java
 @@ -56,6 +56,13 @@ public interface PatternType extends OldEnum<PatternType>, Keyed {
@@ -140,7 +176,7 @@ index 9e90572745909538e942b7fbe788b5286c6cc9a3..100f93358e0a1fa8507775a2afd29314
 +     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#BANNER_PATTERN}. PatternTypes
 +     * can exist without a key.
 +     */
-+    @Deprecated
++    @Deprecated(since = "1.20.5")
 +    // Paper end - deprecate getKey
      @Override
      @NotNull

--- a/patches/server/0467-Add-PlayerLoomPatternSelectEvent.patch
+++ b/patches/server/0467-Add-PlayerLoomPatternSelectEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerLoomPatternSelectEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/LoomMenu.java b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
-index 2de558dd205a1078fdcac1bce256d059b9bf5d5f..f76ef029132c6a08d4e70585bc440eccdc626b16 100644
+index 2de558dd205a1078fdcac1bce256d059b9bf5d5f..dc23b646e55bb66e0aa584d82b75b4b3d233276a 100644
 --- a/src/main/java/net/minecraft/world/inventory/LoomMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
 @@ -174,8 +174,32 @@ public class LoomMenu extends AbstractContainerMenu {
@@ -16,7 +16,7 @@ index 2de558dd205a1078fdcac1bce256d059b9bf5d5f..f76ef029132c6a08d4e70585bc440ecc
 -            this.setupResultSlot((Holder) this.selectablePatterns.get(id));
 +            // Paper start - Add PlayerLoomPatternSelectEvent
 +            int selectablePatternIndex = id;
-+            io.papermc.paper.event.player.PlayerLoomPatternSelectEvent event = new io.papermc.paper.event.player.PlayerLoomPatternSelectEvent((Player) player.getBukkitEntity(), ((CraftInventoryLoom) getBukkitView().getTopInventory()), org.bukkit.craftbukkit.block.banner.CraftPatternType.minecraftHolderToBukkit((this.selectablePatterns.get(selectablePatternIndex))));
++            io.papermc.paper.event.player.PlayerLoomPatternSelectEvent event = new io.papermc.paper.event.player.PlayerLoomPatternSelectEvent((Player) player.getBukkitEntity(), ((CraftInventoryLoom) getBukkitView().getTopInventory()), org.bukkit.craftbukkit.block.banner.CraftPatternType.minecraftHolderToBukkit(this.selectablePatterns.get(selectablePatternIndex)));
 +            if (!event.callEvent()) {
 +                player.containerMenu.sendAllDataToRemote();
 +                return false;

--- a/patches/server/0925-Fixup-NamespacedKey-handling.patch
+++ b/patches/server/0925-Fixup-NamespacedKey-handling.patch
@@ -68,7 +68,7 @@ index afed8bdb9bd6a135e9b5f7bd9bfc61964cb240f7..bb2d1dddca6bfe719b28df136e80a7c5
          }
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
-index bcac1359c667ef1ee46384f9c7a5adf4010d2b08..f2a4dfc80ccd9594ebfef7c49583cf6a090712e0 100644
+index bcac1359c667ef1ee46384f9c7a5adf4010d2b08..8a22842f96c3d27bd308fc2bcb932e0653d42c36 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
 @@ -16,7 +16,7 @@ public class CraftPainting extends CraftHanging implements Painting {
@@ -76,7 +76,7 @@ index bcac1359c667ef1ee46384f9c7a5adf4010d2b08..f2a4dfc80ccd9594ebfef7c49583cf6a
      @Override
      public Art getArt() {
 -        return CraftArt.minecraftHolderToBukkit(this.getHandle().getVariant());
-+        return org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.ART, this.getHandle().getVariant()).orElseThrow(() -> new IllegalStateException("Inlined or datapack made painting variant are not supported yet in the API!")); // Paper
++        return org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.ART, this.getHandle().getVariant()).orElseThrow(() -> new IllegalStateException("Inlined painting variant are not supported yet in the API!")); // Paper
      }
  
      @Override

--- a/patches/server/0925-Fixup-NamespacedKey-handling.patch
+++ b/patches/server/0925-Fixup-NamespacedKey-handling.patch
@@ -4,40 +4,6 @@ Date: Sat, 6 Jan 2024 14:31:00 +0100
 Subject: [PATCH] Fixup NamespacedKey handling
 
 
-diff --git a/src/main/java/net/minecraft/world/inventory/LoomMenu.java b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
-index 7d7b4e53682107a1a75a7aa205be1e6bfdc8c551..0e954dfe82ed263cbe63dbf49ff49e83f38228b8 100644
---- a/src/main/java/net/minecraft/world/inventory/LoomMenu.java
-+++ b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
-@@ -171,12 +171,28 @@ public class LoomMenu extends AbstractContainerMenu {
-         return stillValid(this.access, player, Blocks.LOOM);
-     }
- 
-+    private static final org.slf4j.Logger LOGGER = com.mojang.logging.LogUtils.getLogger(); // Paper - handle custom banner pattern, skip the event
-+    private static boolean PRINTED_PATTERN_TYPE_NAG = false; // Paper - handle custom banner pattern, skip the event
-+
-     @Override
-     public boolean clickMenuButton(net.minecraft.world.entity.player.Player player, int id) {
-         if (id >= 0 && id < this.selectablePatterns.size()) {
-+            // Paper start - handle custom banner pattern, skip the event (todo remove once this is supported)
-+            java.util.Optional<org.bukkit.block.banner.PatternType> patternType = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.BANNER_PATTERN, this.selectablePatterns.get(id));
-+            if (patternType.isEmpty()) {
-+                if (!PRINTED_PATTERN_TYPE_NAG) {
-+                    LOGGER.warn("A datapack added a custom banner pattern, those are not supported yet in the API, skipping the PlayerLoomPatternSelectEvent for {}.", player.getScoreboardName());
-+                    PRINTED_PATTERN_TYPE_NAG = true;
-+                }
-+                this.selectedBannerPatternIndex.set(id);
-+                this.setupResultSlot((Holder) this.selectablePatterns.get(id));
-+                return true;
-+            }
-+            // Paper end - handle custom banner pattern
-+
-             // Paper start - Add PlayerLoomPatternSelectEvent
-             int selectablePatternIndex = id;
--            io.papermc.paper.event.player.PlayerLoomPatternSelectEvent event = new io.papermc.paper.event.player.PlayerLoomPatternSelectEvent((Player) player.getBukkitEntity(), ((CraftInventoryLoom) getBukkitView().getTopInventory()), org.bukkit.craftbukkit.block.banner.CraftPatternType.minecraftHolderToBukkit((this.selectablePatterns.get(selectablePatternIndex))));
-+            io.papermc.paper.event.player.PlayerLoomPatternSelectEvent event = new io.papermc.paper.event.player.PlayerLoomPatternSelectEvent((Player) player.getBukkitEntity(), ((CraftInventoryLoom) getBukkitView().getTopInventory()), patternType.get());
-             if (!event.callEvent()) {
-                 player.containerMenu.sendAllDataToRemote();
-                 return false;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java b/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
 index e34deaf398dc6722c3128bdd6b9bc16da2d33bf7..f028daa4f23a1f1868c9922991259739cadc5da2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
@@ -85,7 +51,7 @@ index cc97638e038ea64ad180ebfded2528aa07d1809e..10e4318782107644f67818109784fff6
          // Now also convert from when keys where saved
          return CraftRegistry.get(Registry.ATTRIBUTE, key, ApiVersion.CURRENT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBanner.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBanner.java
-index afed8bdb9bd6a135e9b5f7bd9bfc61964cb240f7..26088d4039599e7bd1ad8017d845e7b1c15be9e1 100644
+index afed8bdb9bd6a135e9b5f7bd9bfc61964cb240f7..bb2d1dddca6bfe719b28df136e80a7c5a339a5ce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBanner.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBanner.java
 @@ -38,7 +38,11 @@ public class CraftBanner extends CraftBlockEntityState<BannerBlockEntity> implem
@@ -93,14 +59,27 @@ index afed8bdb9bd6a135e9b5f7bd9bfc61964cb240f7..26088d4039599e7bd1ad8017d845e7b1
              for (int i = 0; i < banner.getPatterns().layers().size(); i++) {
                  BannerPatternLayers.Layer p = banner.getPatterns().layers().get(i);
 -                this.patterns.add(new Pattern(DyeColor.getByWoolData((byte) p.color().getId()), CraftPatternType.minecraftHolderToBukkit(p.pattern())));
-+                // Paper start - fix upstream not handling custom banner pattern
++                // Paper start - fix upstream not handling inlined banner pattern
 +                java.util.Optional<org.bukkit.block.banner.PatternType> type = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.BANNER_PATTERN, p.pattern());
 +                if (type.isEmpty()) continue;
 +                this.patterns.add(new Pattern(DyeColor.getByWoolData((byte) p.color().getId()), type.get()));
-+                // Paper end
++                // Paper end - fix upstream not handling inlined banner pattern
              }
          }
      }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
+index bcac1359c667ef1ee46384f9c7a5adf4010d2b08..f2a4dfc80ccd9594ebfef7c49583cf6a090712e0 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
+@@ -16,7 +16,7 @@ public class CraftPainting extends CraftHanging implements Painting {
+ 
+     @Override
+     public Art getArt() {
+-        return CraftArt.minecraftHolderToBukkit(this.getHandle().getVariant());
++        return org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.ART, this.getHandle().getVariant()).orElseThrow(() -> new IllegalStateException("Inlined or datapack made painting variant are not supported yet in the API!")); // Paper
+     }
+ 
+     @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmor.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmor.java
 index 2c57fd269484ed79814d974877585f9f7e6393d3..865977ce17fbb8793a1eefd71079729e83f5cfaf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmor.java
@@ -118,7 +97,7 @@ index 2c57fd269484ed79814d974877585f9f7e6393d3..865977ce17fbb8793a1eefd71079729e
              this.trim = new ArmorTrim(trimMaterial, trimPattern);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
-index 1c1a2d66d1ebcbe2ded732e759d0f9d471d43b56..c56fb1eeea79176c4dbb1e9c0a8023f86220fe6a 100644
+index 1c1a2d66d1ebcbe2ded732e759d0f9d471d43b56..eb44c19f6af624df458981e46c73a64358d6e1ce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
 @@ -42,7 +42,7 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
@@ -126,12 +105,12 @@ index 1c1a2d66d1ebcbe2ded732e759d0f9d471d43b56..c56fb1eeea79176c4dbb1e9c0a8023f8
                  BannerPatternLayers.Layer p = patterns.get(i);
                  DyeColor color = DyeColor.getByWoolData((byte) p.color().getId());
 -                PatternType pattern = CraftPatternType.minecraftHolderToBukkit(p.pattern());
-+                PatternType pattern = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.BANNER_PATTERN, p.pattern()).orElse(null); // Paper - fix upstream not handling custom banner pattern
++                PatternType pattern = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.BANNER_PATTERN, p.pattern()).orElse(null); // Paper - fix upstream not handling inlined banner pattern
  
                  if (color != null && pattern != null) {
                      this.patterns.add(new Pattern(color, pattern));
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java
-index 478059eb3ad76b41e6a20e9b489a2a4fb19e7c7c..3599ef1675b6091e9b67fb5241886460f106f9b4 100644
+index 478059eb3ad76b41e6a20e9b489a2a4fb19e7c7c..76a3e4893cbdba903a712d6db1d30b9c644795be 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java
 @@ -30,7 +30,7 @@ public class CraftMetaMusicInstrument extends CraftMetaItem implements MusicInst
@@ -139,7 +118,7 @@ index 478059eb3ad76b41e6a20e9b489a2a4fb19e7c7c..3599ef1675b6091e9b67fb5241886460
  
          getOrEmpty(tag, CraftMetaMusicInstrument.GOAT_HORN_INSTRUMENT).ifPresent((instrument) -> {
 -            this.instrument = CraftMusicInstrument.minecraftHolderToBukkit(instrument);
-+            this.instrument = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.INSTRUMENT, instrument).orElse(null); // Paper - fix upstream not handling custom instruments
++            this.instrument = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.INSTRUMENT, instrument).orElse(null); // Paper - fix upstream not handling inlined instrument
          });
      }
  

--- a/patches/server/0925-Fixup-NamespacedKey-handling.patch
+++ b/patches/server/0925-Fixup-NamespacedKey-handling.patch
@@ -68,7 +68,7 @@ index afed8bdb9bd6a135e9b5f7bd9bfc61964cb240f7..bb2d1dddca6bfe719b28df136e80a7c5
          }
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
-index bcac1359c667ef1ee46384f9c7a5adf4010d2b08..8a22842f96c3d27bd308fc2bcb932e0653d42c36 100644
+index bcac1359c667ef1ee46384f9c7a5adf4010d2b08..98a4463c9f194f33f4f85d95a0b9fa061cf6faaf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
 @@ -16,7 +16,7 @@ public class CraftPainting extends CraftHanging implements Painting {
@@ -76,7 +76,7 @@ index bcac1359c667ef1ee46384f9c7a5adf4010d2b08..8a22842f96c3d27bd308fc2bcb932e06
      @Override
      public Art getArt() {
 -        return CraftArt.minecraftHolderToBukkit(this.getHandle().getVariant());
-+        return org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.ART, this.getHandle().getVariant()).orElseThrow(() -> new IllegalStateException("Inlined painting variant are not supported yet in the API!")); // Paper
++        return org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.ART, this.getHandle().getVariant()).orElseThrow(() -> new IllegalStateException("Inlined/custom painting variants are not supported yet in the API!")); // Paper
      }
  
      @Override

--- a/patches/server/0965-improve-checking-handled-tags-in-itemmeta.patch
+++ b/patches/server/0965-improve-checking-handled-tags-in-itemmeta.patch
@@ -276,7 +276,7 @@ index c4beb94d8e5448e69f31f30299448f344b5d8f59..169fefb64e1af444f7c2efb1234cb6e7
          getOrEmpty(tag, CraftMetaAxolotlBucket.ENTITY_TAG).ifPresent((nbt) -> {
              this.entityTag = nbt.copyTag();
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
-index c56fb1eeea79176c4dbb1e9c0a8023f86220fe6a..1c17fb294d83d99ae657eff6a8a986bf72c6ec47 100644
+index eb44c19f6af624df458981e46c73a64358d6e1ce..d0a8cd89da3b8d87248494056470c306f8fb5ae8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
 @@ -34,8 +34,8 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
@@ -669,7 +669,7 @@ index 08e18dcabbf52aae5c3843d49a72d1d52baa729b..149356981e586e4f67d4543d3df94a2e
          getOrEmpty(tag, CraftMetaMap.MAP_ID).ifPresent((mapId) -> {
              this.mapId = mapId.id();
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java
-index 3599ef1675b6091e9b67fb5241886460f106f9b4..2664d0dbe0d828a67ef551aa341a497a8bd0ea14 100644
+index 76a3e4893cbdba903a712d6db1d30b9c644795be..a80b9b142ca99c7c0257b1bdeb059dce5f92ae93 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaMusicInstrument.java
 @@ -26,8 +26,8 @@ public class CraftMetaMusicInstrument extends CraftMetaItem implements MusicInst
@@ -682,7 +682,7 @@ index 3599ef1675b6091e9b67fb5241886460f106f9b4..2664d0dbe0d828a67ef551aa341a497a
 +        super(tag, extraHandledDcts); // Paper
  
          getOrEmpty(tag, CraftMetaMusicInstrument.GOAT_HORN_INSTRUMENT).ifPresent((instrument) -> {
-             this.instrument = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.INSTRUMENT, instrument).orElse(null); // Paper - fix upstream not handling custom instruments
+             this.instrument = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.INSTRUMENT, instrument).orElse(null); // Paper - fix upstream not handling inlined instrument
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaOminousBottle.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaOminousBottle.java
 index 17336c177a969f04c51ff12de4599ef261d79fef..90c554dcbfe2bcca3f742379499f1e8e8665c512 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaOminousBottle.java
@@ -714,7 +714,7 @@ index d1cb8d520b6d7b0981d70412def71e7aab04560a..7f9182809f6e67ff571db0f365bc7e05
              potionContents.potion().ifPresent((potion) -> {
                  this.type = CraftPotionType.minecraftHolderToBukkit(potion);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaShield.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaShield.java
-index c10609472c1b86c3abb19a62bef4c9ce436307ea..d2b74daa5788c1e6d9eaddb47bc3a062287ba036 100644
+index bcd6cc29e4e621805cbd923d747f652ced240c6d..967d8940aec0065bce496d5d7a8c73de5733bd2c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaShield.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaShield.java
 @@ -42,8 +42,8 @@ public class CraftMetaShield extends CraftMetaItem implements ShieldMeta, BlockS


### PR DESCRIPTION
Remove the unneeded warning for the loom menu, now that spigot support datapack banner pattern and inlined banner pattern can't show in the menu. And improve error message for inlined/datapack made painting variant