### PR TITLE
Fix CraftMetaShield equality

### DIFF
--- a/patches/server/0966-General-ItemMeta-fixes.patch
+++ b/patches/server/0966-General-ItemMeta-fixes.patch
@@ -1388,7 +1388,7 @@ index 7f9182809f6e67ff571db0f365bc7e05f600775a..01c49df291f721bab3acb788ff2f2787
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaShield.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaShield.java
-index 967d8940aec0065bce496d5d7a8c73de5733bd2c..57a2dc0581d1e59ce201d84ca0c0f7606577bf4c 100644
+index 967d8940aec0065bce496d5d7a8c73de5733bd2c..e229ca6acb6dbc3185f326f6653b3d66d835a9e5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaShield.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaShield.java
 @@ -28,17 +28,29 @@ public class CraftMetaShield extends CraftMetaItem implements ShieldMeta, BlockS
@@ -1618,7 +1618,7 @@ index 967d8940aec0065bce496d5d7a8c73de5733bd2c..57a2dc0581d1e59ce201d84ca0c0f760
          }
          if (meta instanceof CraftMetaShield that) {
 -            return Objects.equal(this.banner, that.banner);
-+            return Objects.equal(this.baseColor, that.baseColor) && Objects.equal(this.hasPatterns(), that.hasPatterns()); // Paper - general item meta fixes - decoupled base colour and patterns
++            return Objects.equal(this.baseColor, that.baseColor) && Objects.equal(this.patterns, that.patterns); // Paper - general item meta fixes - decoupled base colour and patterns
          }
          return true;
      }


### PR DESCRIPTION
Previously different patterns set would be equals but the hashCode was different.