### PR TITLE
Fix LivingEntity#damageItemStack javadocs

### DIFF
--- a/patches/api/0376-ItemStack-damage-API.patch
+++ b/patches/api/0376-ItemStack-damage-API.patch
@@ -8,10 +8,10 @@ to simulate damage done to an itemstack and all
 the logic associated with damaging them
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 8dd993ce32686431e1c759d446a3620cb52f7ec1..0d665a31152c9a667576f2e9d91ffec5304ce944 100644
+index 8dd993ce32686431e1c759d446a3620cb52f7ec1..63b646cb40368f4d4dc8d07b272de828960150f4 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1365,4 +1365,53 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1365,4 +1365,54 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      void knockback(double strength, double directionX, double directionZ);
      // Paper end - knockback API
@@ -41,10 +41,10 @@ index 8dd993ce32686431e1c759d446a3620cb52f7ec1..0d665a31152c9a667576f2e9d91ffec5
 +    /**
 +     * Damages the itemstack in this slot by the specified amount.
 +     * <p>
-+     * This runs all logic associated with damaging an itemstack like
-+     * gamemode and enchantment checks, events, stat changes, and advancement
-+     * triggers.
++     * This runs most logic associated with damaging an itemstack like
++     * gamemode, events, stat changes, and advancement triggers.
 +     *
++     * @apiNote This method does not run enchantment logic.
 +     * @param stack the itemstack to damage
 +     * @param amount the amount of damage to do
 +     * @return the damaged itemstack, or an empty stack if it broke. There are no
@@ -55,10 +55,11 @@ index 8dd993ce32686431e1c759d446a3620cb52f7ec1..0d665a31152c9a667576f2e9d91ffec5
 +    /**
 +     * Damages the itemstack in this slot by the specified amount.
 +     * <p>
-+     * This runs all logic associated with damaging an itemstack like
-+     * gamemode and enchantment checks, events, stat changes, advancement
++     * This runs most logic associated with damaging an itemstack like
++     * gamemode, events, stat changes, advancement
 +     * triggers, and notifying clients to play break animations.
 +     *
++     * @apiNote This method does not run enchantment logic.
 +     * @param slot the slot of the stack to damage
 +     * @param amount the amount of damage to do
 +     */

--- a/patches/api/0388-Add-Entity-Body-Yaw-API.patch
+++ b/patches/api/0388-Add-Entity-Body-Yaw-API.patch
@@ -53,10 +53,10 @@ index 6dcaf7e9bc9afb708ab569e82f27c87833450ff1..a76e537c9b3b9519cd46894c90b750f0
  
      // Paper start - Collision API
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index a2c1cc7462564411db71a1e00222ef55633b49c8..4974540e8277011e4eb00f691a5f6f96d3dde20c 100644
+index b7b972bef5fa2185d2c3ee72951b3104ff3b6495..760a5247b6f920852d33cd4e441cfb6c6f63dad1 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1414,4 +1414,22 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1415,4 +1415,22 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      void damageItemStack(org.bukkit.inventory.@NotNull EquipmentSlot slot, int amount);
      // Paper end - ItemStack damage API

--- a/patches/api/0470-Fix-equipment-slot-and-group-API.patch
+++ b/patches/api/0470-Fix-equipment-slot-and-group-API.patch
@@ -10,7 +10,7 @@ Adds the following:
 Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/attribute/AttributeModifier.java b/src/main/java/org/bukkit/attribute/AttributeModifier.java
-index 3808f76d49e24c20156c013f68e00efa9351f1a3..e14b64d3b178791dacc7849e97f2ed95f1919c55 100644
+index c57690798108e9f91f8c552f39dcc2b080fe1b61..bfa378fe3d074bafbc0af2c4d858e2a34d3126bd 100644
 --- a/src/main/java/org/bukkit/attribute/AttributeModifier.java
 +++ b/src/main/java/org/bukkit/attribute/AttributeModifier.java
 @@ -118,6 +118,7 @@ public class AttributeModifier implements ConfigurationSerializable, Keyed {
@@ -22,10 +22,10 @@ index 3808f76d49e24c20156c013f68e00efa9351f1a3..e14b64d3b178791dacc7849e97f2ed95
          return slot == EquipmentSlotGroup.ANY ? null : slot.getExample();
      }
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 5c29956c6db53440322330ff723c7087193641f1..a1e54e9d14393a6c0ea57cca854071c5396d9717 100644
+index 0cb13d21b9a2970bbc0e22d6bd4625f1f262cc2f..d4211229deb70cd58980a4d6342174ac852b7017 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1447,4 +1447,15 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1448,4 +1448,15 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      void setBodyYaw(float bodyYaw);
      // Paper end - body yaw API


### PR DESCRIPTION
https://github.com/PaperMC/Paper/pull/11063 introduced behaviour changes that contradicts the javadocs, confirmed in https://github.com/PaperMC/Paper/issues/11214#issuecomment-2269574514 as intended changes. This pr fixes the javadocs to reflect the current behaviour.