### PR TITLE
Fix damaging itemstacks without damage-component set

### DIFF
--- a/patches/server/0773-ItemStack-damage-API.patch
+++ b/patches/server/0773-ItemStack-damage-API.patch
@@ -11,9 +11,18 @@ the logic associated with damaging them
 public net.minecraft.world.entity.LivingEntity entityEventForEquipmentBreak(Lnet/minecraft/world/entity/EquipmentSlot;)B
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 598507684aed7978fa2e9bae0d959c7d0f9e53d6..7c52ae813bfe47983ca94f4daf68f17e899949da 100644
+index 598507684aed7978fa2e9bae0d959c7d0f9e53d6..811d0c51997f50039a3da4954a52b74f798125f6 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
+@@ -627,7 +627,7 @@ public final class ItemStack implements DataComponentHolder {
+     }
+ 
+     public boolean isDamageableItem() {
+-        return this.has(DataComponents.MAX_DAMAGE) && !this.has(DataComponents.UNBREAKABLE) && this.has(DataComponents.DAMAGE);
++        return this.has(DataComponents.MAX_DAMAGE) && !this.has(DataComponents.UNBREAKABLE); // Paper - itemstack damage API
+     }
+ 
+     public boolean isDamaged() {
 @@ -647,11 +647,16 @@ public final class ItemStack implements DataComponentHolder {
      }
  


### PR DESCRIPTION
Currently an item with MAX_DAMAGE-component but without DAMAGE-component is not considered damageable.
Thus trying to use Player#damageItemstack will have no effect, when logically an item with max-damage should be considered damageable.
This issue doesnt apply to vanilla tools as they by default have damage-component
Whilst adding damage-component with 0 damage does fix this, this feels like a bug as I cant imagine a scenario where this behaviour would be wanted

This PR fixes it by ignoring the damage-component, which will be set later on down after damage-calculations
![image](https://github.com/user-attachments/assets/3c859842-54b1-47a9-bbd6-e7f4c60eba5d)

Before fix trying to call Player#damageItemstack (with only maxDamage component):

https://github.com/user-attachments/assets/a9cb7a59-6a5a-47a4-aca6-8d3e5053ecf8

After fix calling Player#damageItemstack on item with max-damage but wihtout damage:

https://github.com/user-attachments/assets/03eb7515-65df-4fd2-8a4e-6490fbc76093

