### PR TITLE
Fix `TooltipContext.create` being wrong (#11253)

### DIFF
--- a/patches/api/0444-ItemStack-Tooltip-API.patch
+++ b/patches/api/0444-ItemStack-Tooltip-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] ItemStack Tooltip API
 
 diff --git a/src/main/java/io/papermc/paper/inventory/tooltip/TooltipContext.java b/src/main/java/io/papermc/paper/inventory/tooltip/TooltipContext.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..39ac768b3c5148544cb1aaf2c817e661f6856f64
+index 0000000000000000000000000000000000000000..65bdf398d303b0c5a9d1eeb2830f4327592884cf
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/inventory/tooltip/TooltipContext.java
 @@ -0,0 +1,75 @@
@@ -32,7 +32,7 @@ index 0000000000000000000000000000000000000000..39ac768b3c5148544cb1aaf2c817e661
 +     */
 +    @Contract("_, _ -> new")
 +    static @NotNull TooltipContext create(final boolean advanced, final boolean creative) {
-+        return new TooltipContextImpl(advanced, creative);
++        return new TooltipContextImpl(creative, advanced);
 +    }
 +
 +    /**

--- a/patches/api/0444-ItemStack-Tooltip-API.patch
+++ b/patches/api/0444-ItemStack-Tooltip-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] ItemStack Tooltip API
 
 diff --git a/src/main/java/io/papermc/paper/inventory/tooltip/TooltipContext.java b/src/main/java/io/papermc/paper/inventory/tooltip/TooltipContext.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..65bdf398d303b0c5a9d1eeb2830f4327592884cf
+index 0000000000000000000000000000000000000000..39ac768b3c5148544cb1aaf2c817e661f6856f64
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/inventory/tooltip/TooltipContext.java
 @@ -0,0 +1,75 @@
@@ -32,7 +32,7 @@ index 0000000000000000000000000000000000000000..65bdf398d303b0c5a9d1eeb2830f4327
 +     */
 +    @Contract("_, _ -> new")
 +    static @NotNull TooltipContext create(final boolean advanced, final boolean creative) {
-+        return new TooltipContextImpl(creative, advanced);
++        return new TooltipContextImpl(advanced, creative);
 +    }
 +
 +    /**
@@ -87,7 +87,7 @@ index 0000000000000000000000000000000000000000..65bdf398d303b0c5a9d1eeb2830f4327
 +}
 diff --git a/src/main/java/io/papermc/paper/inventory/tooltip/TooltipContextImpl.java b/src/main/java/io/papermc/paper/inventory/tooltip/TooltipContextImpl.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1d9bed6691f581529c53b577b26f1d0f902ccb0d
+index 0000000000000000000000000000000000000000..c9c0ce750f93ae55e0b2d322a738919474d2d5dd
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/inventory/tooltip/TooltipContextImpl.java
 @@ -0,0 +1,16 @@
@@ -95,16 +95,16 @@ index 0000000000000000000000000000000000000000..1d9bed6691f581529c53b577b26f1d0f
 +
 +import org.jetbrains.annotations.NotNull;
 +
-+record TooltipContextImpl(boolean isCreative, boolean isAdvanced) implements TooltipContext {
++record TooltipContextImpl(boolean isAdvanced, boolean isCreative) implements TooltipContext {
 +
 +    @Override
 +    public @NotNull TooltipContext asCreative() {
-+        return new TooltipContextImpl(true, this.isAdvanced);
++        return new TooltipContextImpl(this.isAdvanced, true);
 +    }
 +
 +    @Override
 +    public @NotNull TooltipContext asAdvanced() {
-+        return new TooltipContextImpl(this.isCreative, true);
++        return new TooltipContextImpl(true, this.isCreative);
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java


### PR DESCRIPTION
Swaps to the correct order, closes #11253.