### PR TITLE
Fix NPE for PlayerPostRespawnEvent#getRespawnedLocation

### DIFF
--- a/patches/server/0283-Add-PlayerPostRespawnEvent.patch
+++ b/patches/server/0283-Add-PlayerPostRespawnEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerPostRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 8f90e8cd36348089799097807ead774e186c2604..f0cc34002e260567322d7acaf803f43a8b92e563 100644
+index 79203d0e5cdb86d9e2fb22cdaeb8cf3a93e43dcc..a2a913e20cdea9518da5ad0d1ef8908538860890 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -738,6 +738,10 @@ public abstract class PlayerList {
@@ -19,15 +19,18 @@ index 8f90e8cd36348089799097807ead774e186c2604..f0cc34002e260567322d7acaf803f43a
  
          // CraftBukkit start - fire PlayerRespawnEvent
          DimensionTransition dimensiontransition;
-@@ -745,6 +749,7 @@ public abstract class PlayerList {
+@@ -745,6 +749,10 @@ public abstract class PlayerList {
              dimensiontransition = entityplayer.findRespawnPositionAndUseSpawnBlock(flag, DimensionTransition.DO_NOTHING, reason);
  
              if (!flag) entityplayer.reset(); // SPIGOT-4785
-+            isRespawn = true; // Paper - Add PlayerPostRespawnEvent
++            // Paper start - Add PlayerPostRespawnEvent
++            isRespawn = true;
++            location = CraftLocation.toBukkit(dimensiontransition.pos(), dimensiontransition.newLevel().getWorld(), dimensiontransition.yRot(), dimensiontransition.xRot());
++            // Paper end - Add PlayerPostRespawnEvent
          } else {
              dimensiontransition = new DimensionTransition(((CraftWorld) location.getWorld()).getHandle(), CraftLocation.toVec3D(location), Vec3.ZERO, location.getYaw(), location.getPitch(), DimensionTransition.DO_NOTHING);
          }
-@@ -795,6 +800,11 @@ public abstract class PlayerList {
+@@ -795,6 +803,11 @@ public abstract class PlayerList {
              if (iblockdata.is(Blocks.RESPAWN_ANCHOR)) {
                  entityplayer1.connection.send(new ClientboundSoundPacket(SoundEvents.RESPAWN_ANCHOR_DEPLETE, SoundSource.BLOCKS, (double) blockposition.getX(), (double) blockposition.getY(), (double) blockposition.getZ(), 1.0F, 1.0F, worldserver.getRandom().nextLong()));
              }
@@ -39,7 +42,7 @@ index 8f90e8cd36348089799097807ead774e186c2604..f0cc34002e260567322d7acaf803f43a
          }
          // Added from changeDimension
          this.sendAllPlayerInfo(entityplayer); // Update health, etc...
-@@ -816,6 +826,13 @@ public abstract class PlayerList {
+@@ -816,6 +829,13 @@ public abstract class PlayerList {
          if (entityplayer.connection.isDisconnected()) {
              this.save(entityplayer);
          }

--- a/patches/server/0472-Add-sendOpLevel-API.patch
+++ b/patches/server/0472-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 44422100246a61f8353f26d5149f3e96c8832fea..3c7d31725c4a5dd7728fa394f88d37a0e493e919 100644
+index 23bd0e0b62fef174b55b5915a44fee32db02c656..7c334ac1ae2a1b14b7570127e775a5e7d7ab2ae7 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1062,6 +1062,11 @@ public abstract class PlayerList {
+@@ -1065,6 +1065,11 @@ public abstract class PlayerList {
      }
  
      private void sendPlayerPermissionLevel(ServerPlayer player, int permissionLevel) {
@@ -20,7 +20,7 @@ index 44422100246a61f8353f26d5149f3e96c8832fea..3c7d31725c4a5dd7728fa394f88d37a0
          if (player.connection != null) {
              byte b0;
  
-@@ -1076,8 +1081,10 @@ public abstract class PlayerList {
+@@ -1079,8 +1084,10 @@ public abstract class PlayerList {
              player.connection.send(new ClientboundEntityEventPacket(player, b0));
          }
  
@@ -32,7 +32,7 @@ index 44422100246a61f8353f26d5149f3e96c8832fea..3c7d31725c4a5dd7728fa394f88d37a0
  
      public boolean isWhiteListed(GameProfile profile) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a3b1a19fb28dfba93ae04ea0859f744ede1579f6..963ae66acc25602e15134d30d3e496802b17dc41 100644
+index 39e8dff2a1b62b8313b4d87ce8d2fad7516452c3..3bc62788d63e98eb9b2a2b381272b262040dcb5f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -677,6 +677,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0546-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0546-Add-PlayerKickEvent-causes.patch
@@ -419,7 +419,7 @@ index b908e292d7b2fbff6cc5058ea32648dbde52fa19..c07d6a05737da570e7dc52e73b45e755
  
              }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0cbd4e6bc9b3695fd2ff0b943a69b8fd393e0f36..46f46685081c3c164bd4ba306dfb1220a4e13e52 100644
+index 28d99ca33606d2ff44c639c78edfcaa131faf626..2b15648549245962c6427af27c3ea34e443b37f3 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -675,7 +675,7 @@ public abstract class PlayerList {
@@ -431,7 +431,7 @@ index 0cbd4e6bc9b3695fd2ff0b943a69b8fd393e0f36..46f46685081c3c164bd4ba306dfb1220
          }
  
          // Instead of kicking then returning, we need to store the kick reason
-@@ -1273,7 +1273,7 @@ public abstract class PlayerList {
+@@ -1276,7 +1276,7 @@ public abstract class PlayerList {
          // Paper end
          // CraftBukkit start - disconnect safely
          for (ServerPlayer player : this.players) {
@@ -471,7 +471,7 @@ index f472dea0bd4f834c0c8f0aa59ae7cdae082b14af..2fa51c3a70f43cd23b8f494fc643d66c
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3f603688b9ad895edc2bfc07093c42bc17a35b19..6bc3209b6039ed3d33131e1c6bc56a47916be3ee 100644
+index c9dc7c570e86f420cf8c6343c6ffbdbca427e7a7..7fb6bfe2863d856f27da29a77026f4bc821c929c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -635,7 +635,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0573-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0573-Add-PlayerSetSpawnEvent.patch
@@ -154,10 +154,10 @@ index d1b21afe48dbe1e53d4a046434336be580497165..2dd10cada8d36ed5565481f3f5a5fba1
  
      public SectionPos getLastSectionPos() {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index b36cb031b153c452c7f030105f6963072b5858fc..d4fa173cebcef5fa86e5d077c2bad8e831392bf0 100644
+index 2f22ae87cd467b73883a38553fab23f8590d17a1..bc5088b4b8a60dcd87eb9a7e0858a5c45bd9a7d4 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -841,7 +841,7 @@ public abstract class PlayerList {
+@@ -844,7 +844,7 @@ public abstract class PlayerList {
          // CraftBukkit end
          if (dimensiontransition.missingRespawnBlock()) {
              entityplayer1.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.NO_RESPAWN_BLOCK_AVAILABLE, 0.0F));

--- a/patches/server/0693-Use-username-instead-of-display-name-in-PlayerList-g.patch
+++ b/patches/server/0693-Use-username-instead-of-display-name-in-PlayerList-g.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Use username instead of display name in
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 2916328a5b94783e68688756b5ad7685f180e27f..b0a1f6cf2cc96a2ddc8232f929c134501d99411e 100644
+index 22c1bf5989065016364505a0665a5205fd8528b5..be842c81ae6c6ec64a233f126d7221a37d66439c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1389,7 +1389,7 @@ public abstract class PlayerList {
+@@ -1392,7 +1392,7 @@ public abstract class PlayerList {
      // CraftBukkit start
      public ServerStatsCounter getPlayerStats(ServerPlayer entityhuman) {
          ServerStatsCounter serverstatisticmanager = entityhuman.getStats();

--- a/patches/server/0850-API-for-updating-recipes-on-clients.patch
+++ b/patches/server/0850-API-for-updating-recipes-on-clients.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for updating recipes on clients
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index f9dcbf7d51680e8dfdda1350e0632dec675f3d44..1b83d8f723410c405746faa59783e6ba7a66fd56 100644
+index b8e79cf272f0a87b0fc0c0f61d325ec780b0f6b5..1eed5ebf96f8e8889d5af346d45a401b282bab21 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1485,6 +1485,13 @@ public abstract class PlayerList {
+@@ -1488,6 +1488,13 @@ public abstract class PlayerList {
      }
  
      public void reloadResources() {
@@ -22,7 +22,7 @@ index f9dcbf7d51680e8dfdda1350e0632dec675f3d44..1b83d8f723410c405746faa59783e6ba
          // CraftBukkit start
          /*Iterator iterator = this.advancements.values().iterator();
  
-@@ -1500,7 +1507,15 @@ public abstract class PlayerList {
+@@ -1503,7 +1510,15 @@ public abstract class PlayerList {
          }
          // CraftBukkit end
  
@@ -39,7 +39,7 @@ index f9dcbf7d51680e8dfdda1350e0632dec675f3d44..1b83d8f723410c405746faa59783e6ba
          Iterator iterator1 = this.players.iterator();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3e78a420ea183f4044873bb1fd89e9b9749032b8..e81ec7b81302ea5eb5fe75117a7aacbb8b88d0a6 100644
+index fffdb6db002ce36ecd60bd8f916c878ac8423fed..d7b495643914d651d7b8b04e9a5595ff1e05e4e2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1174,6 +1174,18 @@ public final class CraftServer implements Server {

--- a/patches/server/1003-Optimize-Collision-to-not-load-chunks.patch
+++ b/patches/server/1003-Optimize-Collision-to-not-load-chunks.patch
@@ -14,10 +14,10 @@ movement will load only the chunk the player enters anyways and avoids loading
 massive amounts of surrounding chunks due to large AABB lookups.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0a97d45f96b3b3cd12fa99373fcb5999c3fba96b..e597a7ef6e702c7e3703e1ba29a7b919d1c20877 100644
+index 96eea87534b6e28a56c9eea0f30bfb41793440e7..24ff10c4ed69deed2ce9ba25835575419165e2af 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -865,6 +865,7 @@ public abstract class PlayerList {
+@@ -868,6 +868,7 @@ public abstract class PlayerList {
          Vec3 vec3d = dimensiontransition.pos();
  
          entityplayer1.forceSetPositionRotation(vec3d.x, vec3d.y, vec3d.z, dimensiontransition.yRot(), dimensiontransition.xRot());

--- a/patches/server/1037-Incremental-chunk-and-player-saving.patch
+++ b/patches/server/1037-Incremental-chunk-and-player-saving.patch
@@ -96,7 +96,7 @@ index e50df5a1f3b89b3d0687d6584bdd977f8b71a3f6..2fe9d9b38c01d04416843fdd48d3e338
          // Paper start - add close param
          this.save(progressListener, flush, savingDisabled, false);
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index dddd4fcdcd08e0221693071894818c7d3bae531b..5980b70e2d7273239245237189b2debcbccfbac3 100644
+index 8dc3ba983fd4c61e463867be8d224aa90424215a..6c280abdef5f80b668d6090f9d35283a33e21e0c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -203,6 +203,7 @@ import org.bukkit.inventory.MainHand;
@@ -108,7 +108,7 @@ index dddd4fcdcd08e0221693071894818c7d3bae531b..5980b70e2d7273239245237189b2debc
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      private static final int FLY_STAT_RECORDING_SPEED = 25;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c38c688417f769a6022dd40d6652b00e14c4df94..43eeb8ce4bc350c2b524ade11ca25d8d4d21bea5 100644
+index eb94c0a962de4dc389eb309d264b6e1c6c7229aa..0368d6ba9cc9fe557d3c7172a87a7a5b15445e47 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -569,6 +569,7 @@ public abstract class PlayerList {
@@ -119,7 +119,7 @@ index c38c688417f769a6022dd40d6652b00e14c4df94..43eeb8ce4bc350c2b524ade11ca25d8d
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
  
-@@ -1183,10 +1184,22 @@ public abstract class PlayerList {
+@@ -1186,10 +1187,22 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {


### PR DESCRIPTION
The respawn logic now rely on DimensionTransition however the event was not updated properly and now always have a null respawned location.