### PR TITLE
add ItemFrameMeta API

### DIFF
--- a/patches/api/0484-add-ItemFrameMeta-API.patch
+++ b/patches/api/0484-add-ItemFrameMeta-API.patch
@@ -1,0 +1,88 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TehBrian <tehbrian@proton.me>
+Date: Thu, 15 Aug 2024 17:06:29 -0400
+Subject: [PATCH] add ItemFrameMeta API
+
+
+diff --git a/src/main/java/io/papermc/paper/inventory/meta/ItemFrameMeta.java b/src/main/java/io/papermc/paper/inventory/meta/ItemFrameMeta.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..65b388e0a48a5927448a79b0f2e7742895038034
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/inventory/meta/ItemFrameMeta.java
+@@ -0,0 +1,53 @@
++package io.papermc.paper.inventory.meta;
++
++import org.bukkit.inventory.meta.ItemMeta;
++
++public interface ItemFrameMeta extends ItemMeta {
++    /**
++     * Gets whether the item frame is fixed.
++     *
++     * <p>Fixed item frames:</p>
++     * <ul>
++     *     <li>Cannot have its contents modified or rotated.</li>
++     *     <li>Will not break in absence of a supporting block.</li>
++     *     <li>Will not take damage (except by players in creative).</li>
++     *     <li>Cannot be moved by pistons.</li>
++     * </ul>
++     *
++     * @return whether the item frame is fixed
++     */
++    boolean isFixed();
++
++    /**
++     * Sets whether the item frame is fixed.
++     *
++     * <p>Fixed item frames:</p>
++     * <ul>
++     *     <li>Cannot have its contents modified or rotated.</li>
++     *     <li>Will not break in absence of a supporting block.</li>
++     *     <li>Will not take damage (except by players in creative).</li>
++     *     <li>Cannot be moved by pistons.</li>
++     * </ul>
++     *
++     * @param fixed true if the item frame is fixed
++     */
++    void setFixed(boolean fixed);
++
++    /**
++     * Gets whether the item frame's <b>frame</b> (background) is invisible.
++     *
++     * <p>Contents (items, maps) within invisible item frames are still visible.</p>
++     *
++     * @return whether the frame is invisible
++     */
++    boolean isInvisible();
++
++    /**
++     * Sets whether the item frame's <b>frame</b> (background) is invisible.
++     *
++     * <p>Contents (items, maps) within invisible item frames are still visible.</p>
++     *
++     * @param invisible true if the frame is invisible
++     */
++    void setInvisible(boolean invisible);
++}
+diff --git a/src/main/java/org/bukkit/inventory/ItemType.java b/src/main/java/org/bukkit/inventory/ItemType.java
+index 0168f0a14a3e899e84c5e36963ff79950ab580fb..b52c871297fb351e3781fe6163790def4f95f17f 100644
+--- a/src/main/java/org/bukkit/inventory/ItemType.java
++++ b/src/main/java/org/bukkit/inventory/ItemType.java
+@@ -1733,8 +1733,16 @@ public interface ItemType extends Keyed, Translatable, net.kyori.adventure.trans
+      */
+     ItemType.Typed<BookMeta> WRITTEN_BOOK = getItemType("written_book");
+     ItemType.Typed<ItemMeta> MACE = getItemType("mace");
+-    ItemType.Typed<ItemMeta> ITEM_FRAME = getItemType("item_frame");
+-    ItemType.Typed<ItemMeta> GLOW_ITEM_FRAME = getItemType("glow_item_frame");
++    // Paper start - add ItemFrameMeta API
++    /**
++     * ItemMeta: {@link io.papermc.paper.inventory.meta.ItemFrameMeta}
++     */
++    ItemType.Typed<io.papermc.paper.inventory.meta.ItemFrameMeta> ITEM_FRAME = getItemType("item_frame");
++    /**
++     * ItemMeta: {@link io.papermc.paper.inventory.meta.ItemFrameMeta}
++     */
++    ItemType.Typed<io.papermc.paper.inventory.meta.ItemFrameMeta> GLOW_ITEM_FRAME = getItemType("glow_item_frame");
++    // Paper end - add ItemFrameMeta API
+     ItemType.Typed<ItemMeta> FLOWER_POT = getItemType("flower_pot");
+     ItemType.Typed<ItemMeta> CARROT = getItemType("carrot");
+     ItemType.Typed<ItemMeta> POTATO = getItemType("potato");

--- a/patches/server/1046-add-ItemFrameMeta-API.patch
+++ b/patches/server/1046-add-ItemFrameMeta-API.patch
@@ -1,0 +1,314 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TehBrian <tehbrian@proton.me>
+Date: Thu, 15 Aug 2024 17:06:38 -0400
+Subject: [PATCH] add ItemFrameMeta API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemMetas.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemMetas.java
+index 0930d827e96e0b41296d7723238e6735106fd3d5..0f5f8f8af07403587ea74bc13f3ee2806cc5b09c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemMetas.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemMetas.java
+@@ -155,6 +155,12 @@ public final class CraftItemMetas {
+             (item, extras) -> new CraftMetaOminousBottle(item.getComponentsPatch(), extras),
+             (type, meta) -> meta instanceof CraftMetaOminousBottle musicInstrument ? musicInstrument : new CraftMetaOminousBottle(meta));
+ 
++    // Paper start - add ItemFrameMeta API
++    private static final ItemMetaData<io.papermc.paper.inventory.meta.ItemFrameMeta> ITEM_FRAME_META_DATA = new ItemMetaData<>(io.papermc.paper.inventory.meta.ItemFrameMeta.class,
++            (item, extras) -> new CraftMetaItemFrame(item.getComponentsPatch(), extras),
++            (type, meta) -> meta instanceof CraftMetaItemFrame itemFrame ? itemFrame : new CraftMetaItemFrame(meta));
++    // Paper end - add ItemFrameMeta API
++
+     // We use if instead of a set, since the result gets cached in CraftItemType,
+     // which would result in dead memory once all ItemTypes have cached the data.
+     public static <I extends ItemMeta> ItemMetaData<I> getItemMetaData(CraftItemType<?> itemType) {
+@@ -263,11 +269,15 @@ public final class CraftItemMetas {
+         if (itemType == ItemType.SUSPICIOUS_STEW) {
+             return CraftItemMetas.asType(CraftItemMetas.SUSPICIOUS_STEW_META_DATA);
+         }
++        // Paper start - add ItemFrameMeta API
+         if (itemType == ItemType.COD_BUCKET || itemType == ItemType.PUFFERFISH_BUCKET || itemType == ItemType.TADPOLE_BUCKET // Paper
+-                || itemType == ItemType.SALMON_BUCKET || itemType == ItemType.ITEM_FRAME
+-                || itemType == ItemType.GLOW_ITEM_FRAME || itemType == ItemType.PAINTING) {
++                || itemType == ItemType.SALMON_BUCKET || itemType == ItemType.PAINTING) {
+             return CraftItemMetas.asType(CraftItemMetas.ENTITY_TAG_META_DATA);
+         }
++        if (itemType == ItemType.ITEM_FRAME || itemType == ItemType.GLOW_ITEM_FRAME) {
++            return CraftItemMetas.asType(CraftItemMetas.ITEM_FRAME_META_DATA);
++        }
++        // Paper end - add ItemFrameMeta API
+         if (itemType == ItemType.COMPASS) {
+             return CraftItemMetas.asType(CraftItemMetas.COMPASS_META_DATA);
+         }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaEntityTag.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaEntityTag.java
+index da474a5b963d8e6769d120e9091e60ed0a468a9f..c113001a2353ec1234a18c3291504f48389482be 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaEntityTag.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaEntityTag.java
+@@ -20,8 +20,10 @@ public class CraftMetaEntityTag extends CraftMetaItem {
+             Material.PUFFERFISH_BUCKET,
+             Material.SALMON_BUCKET,
+             Material.TADPOLE_BUCKET, // Paper
+-            Material.ITEM_FRAME,
+-            Material.GLOW_ITEM_FRAME,
++            // Paper start - add ItemFrameMeta API
++            // Material.ITEM_FRAME,
++            // Material.GLOW_ITEM_FRAME,
++            // Paper end - add ItemFrameMeta API
+             Material.PAINTING
+     );
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+index 5c45946f54e4b16440c15a9165ef85be43e53c84..07ad086bfa77a4b3bcaa188ea65ceb7250da9c04 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+@@ -2132,6 +2132,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+                 map.put(CraftMetaEnchantedBook.class, Set.of(CraftMetaEnchantedBook.STORED_ENCHANTMENTS.TYPE));
+                 map.put(CraftMetaEntityTag.class, Set.of(CraftMetaEntityTag.ENTITY_TAG.TYPE));
+                 map.put(CraftMetaFirework.class, Set.of(CraftMetaFirework.FIREWORKS.TYPE));
++                map.put(CraftMetaItemFrame.class, Set.of(CraftMetaItemFrame.ENTITY_TAG.TYPE)); // Paper - add ItemFrameMeta API
+                 map.put(CraftMetaKnowledgeBook.class, Set.of(CraftMetaKnowledgeBook.BOOK_RECIPES.TYPE));
+                 map.put(CraftMetaLeatherArmor.class, Set.of(CraftMetaLeatherArmor.COLOR.TYPE));
+                 map.put(CraftMetaMap.class, Set.of(CraftMetaMap.MAP_COLOR.TYPE, CraftMetaMap.MAP_POST_PROCESSING.TYPE, CraftMetaMap.MAP_ID.TYPE));
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItemFrame.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItemFrame.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..01695bfe1e2e0909cfcfc0cd9892b5a83dccd1b6
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItemFrame.java
+@@ -0,0 +1,197 @@
++// Paper start - add ItemFrameMeta API
++package org.bukkit.craftbukkit.inventory;
++
++import com.google.common.collect.ImmutableMap;
++import com.google.common.collect.Sets;
++import io.papermc.paper.inventory.meta.ItemFrameMeta;
++import java.util.Map;
++import java.util.Set;
++import net.minecraft.core.component.DataComponentPatch;
++import net.minecraft.core.component.DataComponentType;
++import net.minecraft.core.component.DataComponents;
++import net.minecraft.nbt.CompoundTag;
++import net.minecraft.nbt.Tag;
++import net.minecraft.world.item.component.CustomData;
++import org.bukkit.Material;
++import org.bukkit.configuration.serialization.DelegateDeserialization;
++
++@DelegateDeserialization(SerializableMeta.class)
++public class CraftMetaItemFrame extends CraftMetaItem implements ItemFrameMeta {
++
++    private static final Set<Material> ENTITY_TAGGABLE_MATERIALS = Sets.newHashSet(
++        Material.ITEM_FRAME,
++        Material.GLOW_ITEM_FRAME
++    );
++
++    static final ItemMetaKeyType<CustomData> ENTITY_TAG = new ItemMetaKeyType<>(DataComponents.ENTITY_DATA, "EntityTag", "entity-tag");
++    CompoundTag entityTag;
++
++    static final ItemMetaKey FIXED = new ItemMetaKey("Fixed", "fixed");
++    static final ItemMetaKey INVISIBLE = new ItemMetaKey("Invisible", "invisible");
++    private Boolean fixed = null;
++    private Boolean invisible = null;
++
++    CraftMetaItemFrame(CraftMetaItem meta) {
++        super(meta);
++
++        if (meta instanceof CraftMetaItemFrame itemFrame) {
++            this.entityTag = itemFrame.entityTag;
++            this.fixed = itemFrame.fixed;
++            this.invisible = itemFrame.invisible;
++        }
++    }
++
++    CraftMetaItemFrame(DataComponentPatch tag, final Set<DataComponentType<?>> extraHandledDcts) {
++        super(tag, extraHandledDcts);
++
++        getOrEmpty(tag, CraftMetaItemFrame.ENTITY_TAG).ifPresent((nbt) -> {
++            this.entityTag = nbt.copyTag();
++
++            if (entityTag.contains(FIXED.NBT)) {
++                this.fixed = entityTag.getBoolean(FIXED.NBT);
++            }
++
++            if (entityTag.contains(INVISIBLE.NBT)) {
++                this.invisible = entityTag.getBoolean(INVISIBLE.NBT);
++            }
++        });
++    }
++
++    CraftMetaItemFrame(Map<String, Object> map) {
++        super(map);
++
++        this.fixed = SerializableMeta.getBoolean(map, FIXED.BUKKIT);
++        this.invisible = SerializableMeta.getBoolean(map, INVISIBLE.BUKKIT);
++    }
++
++    @Override
++    void deserializeInternal(CompoundTag tag, Object context) {
++        super.deserializeInternal(tag, context);
++
++        if (tag.contains(CraftMetaItemFrame.ENTITY_TAG.NBT)) {
++            this.entityTag = tag.getCompound(CraftMetaItemFrame.ENTITY_TAG.NBT);
++        }
++    }
++
++    @Override
++    void serializeInternal(Map<String, Tag> internalTags) {
++        if (this.entityTag != null && !this.entityTag.isEmpty()) {
++            internalTags.put(CraftMetaItemFrame.ENTITY_TAG.NBT, this.entityTag);
++        }
++    }
++
++    @Override
++    protected void applyToItem(CraftMetaItem.Applicator tag) {
++        super.applyToItem(tag);
++
++        if (!isItemFrameEmpty() && this.entityTag == null) {
++            this.entityTag = new CompoundTag();
++        }
++
++        if (this.fixed != null) {
++            this.entityTag.putBoolean(FIXED.NBT, this.fixed);
++        }
++
++        if (this.invisible != null) {
++            this.entityTag.putBoolean(INVISIBLE.NBT, this.invisible);
++        }
++
++        if (this.entityTag != null) {
++            tag.put(CraftMetaItemFrame.ENTITY_TAG, CustomData.of(this.entityTag));
++        }
++    }
++
++    @Override
++    boolean applicableTo(Material type) {
++        return CraftMetaItemFrame.ENTITY_TAGGABLE_MATERIALS.contains(type);
++    }
++
++    @Override
++    boolean isEmpty() {
++        return super.isEmpty() && this.isItemFrameEmpty();
++    }
++
++    boolean isItemFrameEmpty() {
++        return !(this.fixed != null || this.invisible != null || this.entityTag != null);
++    }
++
++    @Override
++    boolean equalsCommon(CraftMetaItem meta) {
++        if (!super.equalsCommon(meta)) {
++            return false;
++        }
++        if (meta instanceof CraftMetaItemFrame that) {
++            return java.util.Objects.equals(this.entityTag, that.entityTag) &&
++                this.fixed == that.fixed &&
++                this.invisible == that.invisible;
++        }
++        return true;
++    }
++
++    @Override
++    boolean notUncommon(CraftMetaItem meta) {
++        return super.notUncommon(meta) && (meta instanceof CraftMetaItemFrame || this.isItemFrameEmpty());
++    }
++
++    @Override
++    int applyHash() {
++        final int original;
++        int hash = original = super.applyHash();
++
++        if (this.entityTag != null) {
++            hash = 73 * hash + this.entityTag.hashCode();
++        }
++
++        hash = 61 * hash + (this.fixed != null ? Boolean.hashCode(this.isFixed()) : 0);
++        hash = 61 * hash + (this.invisible != null ? Boolean.hashCode(this.isInvisible()) : 0);
++
++        return original != hash ? CraftMetaArmorStand.class.hashCode() ^ hash : hash;
++    }
++
++    @Override
++    ImmutableMap.Builder<String, Object> serialize(ImmutableMap.Builder<String, Object> builder) {
++        super.serialize(builder);
++
++        if (this.fixed != null) {
++            builder.put(FIXED.BUKKIT, this.fixed);
++        }
++
++        if (this.invisible != null) {
++            builder.put(INVISIBLE.BUKKIT, this.invisible);
++        }
++
++        return builder;
++    }
++
++    @Override
++    public CraftMetaItemFrame clone() {
++        CraftMetaItemFrame clone = (CraftMetaItemFrame) super.clone();
++
++        if (this.entityTag != null) {
++            clone.entityTag = this.entityTag.copy();
++        }
++
++        return clone;
++    }
++
++    @Override
++    public boolean isFixed() {
++        return this.fixed != null && this.fixed;
++    }
++
++    @Override
++    public void setFixed(boolean fixed) {
++        this.fixed = fixed;
++    }
++
++    @Override
++    public boolean isInvisible() {
++        return this.invisible != null && this.invisible;
++    }
++
++    @Override
++    public void setInvisible(boolean invisible) {
++        this.invisible = invisible;
++    }
++}
++// Paper end - add ItemFrameMeta API
+diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
+index 1a582ee78334835df79f93cc9fd3669c347d8b3a..144071b0a4bffb80011b86a508c9f2ef043cc4ac 100644
+--- a/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
++++ b/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
+@@ -211,6 +211,7 @@ public class ItemMetaTest extends AbstractTestingBase {
+     // Paper start - check entity tag metas
+     private static final java.util.Set<Class<?>> ENTITY_TAG_METAS = java.util.Set.of(
+         CraftMetaEntityTag.class,
++        CraftMetaItemFrame.class,
+         CraftMetaTropicalFishBucket.class,
+         CraftMetaAxolotlBucket.class
+     );
+@@ -398,15 +399,26 @@ public class ItemMetaTest extends AbstractTestingBase {
+                     return cleanStack;
+                 }
+             },
+-            new StackProvider(Material.ITEM_FRAME) {
++            new StackProvider(Material.COD_BUCKET) { // Paper - add ItemFrameMeta API
+                 @Override ItemStack operate(ItemStack cleanStack) {
+                     final CraftMetaEntityTag meta = ((CraftMetaEntityTag) cleanStack.getItemMeta());
+                     meta.entityTag = new CompoundTag();
+-                    meta.entityTag.putBoolean("Invisible", true);
++                    meta.entityTag.putBoolean("NoAI", true); // Paper - add ItemFrameMeta API
++                    cleanStack.setItemMeta(meta);
++                    return cleanStack;
++                }
++            },
++            // Paper start - add ItemFrameMeta API
++            new StackProvider(Material.ITEM_FRAME) {
++                @Override ItemStack operate(ItemStack cleanStack) {
++                    final CraftMetaItemFrame meta = ((CraftMetaItemFrame) cleanStack.getItemMeta());
++                    meta.setFixed(true);
++                    meta.setInvisible(true);
+                     cleanStack.setItemMeta(meta);
+                     return cleanStack;
+                 }
+             },
++            // Paper end - add ItemFrameMeta API
+             new StackProvider(Material.COMPASS) {
+                 @Override ItemStack operate(ItemStack cleanStack) {
+                     final CraftMetaCompass meta = ((CraftMetaCompass) cleanStack.getItemMeta());

--- a/patches/server/1046-add-ItemFrameMeta-API.patch
+++ b/patches/server/1046-add-ItemFrameMeta-API.patch
@@ -70,22 +70,30 @@ index 5c45946f54e4b16440c15a9165ef85be43e53c84..07ad086bfa77a4b3bcaa188ea65ceb72
                  map.put(CraftMetaMap.class, Set.of(CraftMetaMap.MAP_COLOR.TYPE, CraftMetaMap.MAP_POST_PROCESSING.TYPE, CraftMetaMap.MAP_ID.TYPE));
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItemFrame.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItemFrame.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..01695bfe1e2e0909cfcfc0cd9892b5a83dccd1b6
+index 0000000000000000000000000000000000000000..b59e7fa357281c6282cf2c7a41c2a6c7c05b06ec
 --- /dev/null
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItemFrame.java
-@@ -0,0 +1,197 @@
+@@ -0,0 +1,203 @@
 +// Paper start - add ItemFrameMeta API
 +package org.bukkit.craftbukkit.inventory;
 +
 +import com.google.common.collect.ImmutableMap;
 +import com.google.common.collect.Sets;
 +import io.papermc.paper.inventory.meta.ItemFrameMeta;
++import java.io.ByteArrayInputStream;
++import java.io.ByteArrayOutputStream;
++import java.io.IOException;
++import java.util.Base64;
 +import java.util.Map;
 +import java.util.Set;
++import java.util.logging.Level;
++import java.util.logging.Logger;
 +import net.minecraft.core.component.DataComponentPatch;
 +import net.minecraft.core.component.DataComponentType;
 +import net.minecraft.core.component.DataComponents;
 +import net.minecraft.nbt.CompoundTag;
++import net.minecraft.nbt.NbtAccounter;
++import net.minecraft.nbt.NbtIo;
 +import net.minecraft.nbt.Tag;
 +import net.minecraft.world.item.component.CustomData;
 +import org.bukkit.Material;
@@ -102,42 +110,45 @@ index 0000000000000000000000000000000000000000..01695bfe1e2e0909cfcfc0cd9892b5a8
 +    static final ItemMetaKeyType<CustomData> ENTITY_TAG = new ItemMetaKeyType<>(DataComponents.ENTITY_DATA, "EntityTag", "entity-tag");
 +    CompoundTag entityTag;
 +
++    static final ItemMetaKey ENTITY_ID = new ItemMetaKey("id", "entity-id");
 +    static final ItemMetaKey FIXED = new ItemMetaKey("Fixed", "fixed");
 +    static final ItemMetaKey INVISIBLE = new ItemMetaKey("Invisible", "invisible");
-+    private Boolean fixed = null;
-+    private Boolean invisible = null;
 +
 +    CraftMetaItemFrame(CraftMetaItem meta) {
 +        super(meta);
 +
 +        if (meta instanceof CraftMetaItemFrame itemFrame) {
 +            this.entityTag = itemFrame.entityTag;
-+            this.fixed = itemFrame.fixed;
-+            this.invisible = itemFrame.invisible;
 +        }
 +    }
 +
 +    CraftMetaItemFrame(DataComponentPatch tag, final Set<DataComponentType<?>> extraHandledDcts) {
 +        super(tag, extraHandledDcts);
 +
-+        getOrEmpty(tag, CraftMetaItemFrame.ENTITY_TAG).ifPresent((nbt) -> {
-+            this.entityTag = nbt.copyTag();
-+
-+            if (entityTag.contains(FIXED.NBT)) {
-+                this.fixed = entityTag.getBoolean(FIXED.NBT);
-+            }
-+
-+            if (entityTag.contains(INVISIBLE.NBT)) {
-+                this.invisible = entityTag.getBoolean(INVISIBLE.NBT);
-+            }
-+        });
++        getOrEmpty(tag, CraftMetaItemFrame.ENTITY_TAG).ifPresent((nbt) -> this.entityTag = nbt.copyTag());
 +    }
 +
 +    CraftMetaItemFrame(Map<String, Object> map) {
 +        super(map);
 +
-+        this.fixed = SerializableMeta.getBoolean(map, FIXED.BUKKIT);
-+        this.invisible = SerializableMeta.getBoolean(map, INVISIBLE.BUKKIT);
++        String entityTag = SerializableMeta.getString(map, ENTITY_TAG.BUKKIT, true);
++        if (entityTag != null) {
++            ByteArrayInputStream buf = new ByteArrayInputStream(Base64.getDecoder().decode(entityTag));
++            try {
++                this.entityTag = NbtIo.readCompressed(buf, NbtAccounter.unlimitedHeap());
++            } catch (IOException ex) {
++                Logger.getLogger(CraftMetaItem.class.getName()).log(Level.SEVERE, null, ex);
++            }
++            return;
++        }
++        SerializableMeta.getObjectOptionally(Boolean.class, map, FIXED.BUKKIT, true).ifPresent((value) -> {
++            populateTagIfNull();
++            this.entityTag.putBoolean(FIXED.NBT, value);
++        });
++        SerializableMeta.getObjectOptionally(Boolean.class, map, INVISIBLE.BUKKIT, true).ifPresent((value) -> {
++            populateTagIfNull();
++            this.entityTag.putBoolean(INVISIBLE.NBT, value);
++        });
 +    }
 +
 +    @Override
@@ -160,18 +171,6 @@ index 0000000000000000000000000000000000000000..01695bfe1e2e0909cfcfc0cd9892b5a8
 +    protected void applyToItem(CraftMetaItem.Applicator tag) {
 +        super.applyToItem(tag);
 +
-+        if (!isItemFrameEmpty() && this.entityTag == null) {
-+            this.entityTag = new CompoundTag();
-+        }
-+
-+        if (this.fixed != null) {
-+            this.entityTag.putBoolean(FIXED.NBT, this.fixed);
-+        }
-+
-+        if (this.invisible != null) {
-+            this.entityTag.putBoolean(INVISIBLE.NBT, this.invisible);
-+        }
-+
 +        if (this.entityTag != null) {
 +            tag.put(CraftMetaItemFrame.ENTITY_TAG, CustomData.of(this.entityTag));
 +        }
@@ -188,7 +187,7 @@ index 0000000000000000000000000000000000000000..01695bfe1e2e0909cfcfc0cd9892b5a8
 +    }
 +
 +    boolean isItemFrameEmpty() {
-+        return !(this.fixed != null || this.invisible != null || this.entityTag != null);
++        return this.entityTag == null || this.entityTag.isEmpty();
 +    }
 +
 +    @Override
@@ -197,9 +196,7 @@ index 0000000000000000000000000000000000000000..01695bfe1e2e0909cfcfc0cd9892b5a8
 +            return false;
 +        }
 +        if (meta instanceof CraftMetaItemFrame that) {
-+            return java.util.Objects.equals(this.entityTag, that.entityTag) &&
-+                this.fixed == that.fixed &&
-+                this.invisible == that.invisible;
++            return java.util.Objects.equals(this.entityTag, that.entityTag);
 +        }
 +        return true;
 +    }
@@ -218,9 +215,6 @@ index 0000000000000000000000000000000000000000..01695bfe1e2e0909cfcfc0cd9892b5a8
 +            hash = 73 * hash + this.entityTag.hashCode();
 +        }
 +
-+        hash = 61 * hash + (this.fixed != null ? Boolean.hashCode(this.isFixed()) : 0);
-+        hash = 61 * hash + (this.invisible != null ? Boolean.hashCode(this.isInvisible()) : 0);
-+
 +        return original != hash ? CraftMetaArmorStand.class.hashCode() ^ hash : hash;
 +    }
 +
@@ -228,15 +222,18 @@ index 0000000000000000000000000000000000000000..01695bfe1e2e0909cfcfc0cd9892b5a8
 +    ImmutableMap.Builder<String, Object> serialize(ImmutableMap.Builder<String, Object> builder) {
 +        super.serialize(builder);
 +
-+        if (this.fixed != null) {
-+            builder.put(FIXED.BUKKIT, this.fixed);
++        if (this.entityTag == null) {
++            return builder;
++        } else {
++            ByteArrayOutputStream buf = new ByteArrayOutputStream();
++            try {
++                NbtIo.writeCompressed(entityTag, buf);
++            } catch (IOException ex) {
++                Logger.getLogger(CraftMetaItem.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
++            }
++            builder.put(ENTITY_TAG.BUKKIT, Base64.getEncoder().encodeToString(buf.toByteArray()));
++            return builder;
 +        }
-+
-+        if (this.invisible != null) {
-+            builder.put(INVISIBLE.BUKKIT, this.invisible);
-+        }
-+
-+        return builder;
 +    }
 +
 +    @Override
@@ -250,24 +247,33 @@ index 0000000000000000000000000000000000000000..01695bfe1e2e0909cfcfc0cd9892b5a8
 +        return clone;
 +    }
 +
-+    @Override
-+    public boolean isFixed() {
-+        return this.fixed != null && this.fixed;
++    private void populateTagIfNull() {
++        if (this.entityTag == null) {
++            this.entityTag = new CompoundTag();
++            this.entityTag.putString(ENTITY_ID.NBT, "minecraft:item_frame");
++        }
 +    }
 +
 +    @Override
-+    public void setFixed(boolean fixed) {
-+        this.fixed = fixed;
++    public boolean isFixed() {
++        return this.entityTag != null && this.entityTag.getBoolean(FIXED.NBT);
 +    }
 +
 +    @Override
 +    public boolean isInvisible() {
-+        return this.invisible != null && this.invisible;
++        return this.entityTag != null && this.entityTag.getBoolean(INVISIBLE.NBT);
++    }
++
++    @Override
++    public void setFixed(boolean fixed) {
++        this.populateTagIfNull();
++        this.entityTag.putBoolean(FIXED.NBT, fixed);
 +    }
 +
 +    @Override
 +    public void setInvisible(boolean invisible) {
-+        this.invisible = invisible;
++        this.populateTagIfNull();
++        this.entityTag.putBoolean(INVISIBLE.NBT, invisible);
 +    }
 +}
 +// Paper end - add ItemFrameMeta API

--- a/patches/server/1048-add-ItemFrameMeta-API.patch
+++ b/patches/server/1048-add-ItemFrameMeta-API.patch
@@ -70,14 +70,14 @@ index 5c45946f54e4b16440c15a9165ef85be43e53c84..07ad086bfa77a4b3bcaa188ea65ceb72
                  map.put(CraftMetaMap.class, Set.of(CraftMetaMap.MAP_COLOR.TYPE, CraftMetaMap.MAP_POST_PROCESSING.TYPE, CraftMetaMap.MAP_ID.TYPE));
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItemFrame.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItemFrame.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b59e7fa357281c6282cf2c7a41c2a6c7c05b06ec
+index 0000000000000000000000000000000000000000..b13444c63c37e5c9f4ff969ad473f9280a961332
 --- /dev/null
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItemFrame.java
-@@ -0,0 +1,203 @@
+@@ -0,0 +1,206 @@
 +// Paper start - add ItemFrameMeta API
 +package org.bukkit.craftbukkit.inventory;
 +
-+import com.google.common.collect.ImmutableMap;
++import com.google.common.collect.ImmutableMap.Builder;
 +import com.google.common.collect.Sets;
 +import io.papermc.paper.inventory.meta.ItemFrameMeta;
 +import java.io.ByteArrayInputStream;
@@ -85,6 +85,7 @@ index 0000000000000000000000000000000000000000..b59e7fa357281c6282cf2c7a41c2a6c7
 +import java.io.IOException;
 +import java.util.Base64;
 +import java.util.Map;
++import java.util.Objects;
 +import java.util.Set;
 +import java.util.logging.Level;
 +import java.util.logging.Logger;
@@ -157,14 +158,17 @@ index 0000000000000000000000000000000000000000..b59e7fa357281c6282cf2c7a41c2a6c7
 +
 +        if (tag.contains(CraftMetaItemFrame.ENTITY_TAG.NBT)) {
 +            this.entityTag = tag.getCompound(CraftMetaItemFrame.ENTITY_TAG.NBT);
++
++            // fix up legacy item frame metas that did not include entity ID.
++            if (!this.entityTag.contains(ENTITY_ID.NBT)) {
++                this.entityTag.putString(ENTITY_ID.NBT, "minecraft:item_frame");
++            }
 +        }
 +    }
 +
 +    @Override
 +    void serializeInternal(Map<String, Tag> internalTags) {
-+        if (this.entityTag != null && !this.entityTag.isEmpty()) {
-+            internalTags.put(CraftMetaItemFrame.ENTITY_TAG.NBT, this.entityTag);
-+        }
++        // correctly serialised as entity tag.
 +    }
 +
 +    @Override
@@ -196,7 +200,7 @@ index 0000000000000000000000000000000000000000..b59e7fa357281c6282cf2c7a41c2a6c7
 +            return false;
 +        }
 +        if (meta instanceof CraftMetaItemFrame that) {
-+            return java.util.Objects.equals(this.entityTag, that.entityTag);
++            return Objects.equals(this.entityTag, that.entityTag);
 +        }
 +        return true;
 +    }
@@ -215,25 +219,24 @@ index 0000000000000000000000000000000000000000..b59e7fa357281c6282cf2c7a41c2a6c7
 +            hash = 73 * hash + this.entityTag.hashCode();
 +        }
 +
-+        return original != hash ? CraftMetaArmorStand.class.hashCode() ^ hash : hash;
++        return original != hash ? CraftMetaItemFrame.class.hashCode() ^ hash : hash;
 +    }
 +
 +    @Override
-+    ImmutableMap.Builder<String, Object> serialize(ImmutableMap.Builder<String, Object> builder) {
++    Builder<String, Object> serialize(Builder<String, Object> builder) {
 +        super.serialize(builder);
 +
-+        if (this.entityTag == null) {
-+            return builder;
-+        } else {
++        if (this.entityTag != null) {
 +            ByteArrayOutputStream buf = new ByteArrayOutputStream();
 +            try {
-+                NbtIo.writeCompressed(entityTag, buf);
++                NbtIo.writeCompressed(this.entityTag, buf);
 +            } catch (IOException ex) {
-+                Logger.getLogger(CraftMetaItem.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
++                Logger.getLogger(CraftMetaItem.class.getName()).log(Level.SEVERE, null, ex);
 +            }
 +            builder.put(ENTITY_TAG.BUKKIT, Base64.getEncoder().encodeToString(buf.toByteArray()));
-+            return builder;
 +        }
++
++        return builder;
 +    }
 +
 +    @Override
@@ -256,12 +259,12 @@ index 0000000000000000000000000000000000000000..b59e7fa357281c6282cf2c7a41c2a6c7
 +
 +    @Override
 +    public boolean isFixed() {
-+        return this.entityTag != null && this.entityTag.getBoolean(FIXED.NBT);
++        return this.entityTag != null && this.entityTag.contains(FIXED.NBT) && this.entityTag.getBoolean(FIXED.NBT);
 +    }
 +
 +    @Override
 +    public boolean isInvisible() {
-+        return this.entityTag != null && this.entityTag.getBoolean(INVISIBLE.NBT);
++        return this.entityTag != null && this.entityTag.contains(INVISIBLE.NBT) && this.entityTag.getBoolean(INVISIBLE.NBT);
 +    }
 +
 +    @Override


### PR DESCRIPTION
~~Draft PR; CraftMetaItemFrame is (probably) currently non-functional, but I wanted to share progress so far.~~

The second commit is a rewrite based on https://github.com/PaperMC/Paper/pull/11107, ~~and I'm waiting on that PR to finalize changes here.~~

Concerns:
- Do we have to care about entity ID being different for glow item frames? Does that warrant a separate GlowItemFrameMeta? Entity IDs only even seem to matter on spawn eggs.
- Should CraftMetaItemFrame be wrapped in // Paper? It's in org.bukkit (because there were a nightmarish amount of access transformers until I moved it from io.papermc), but it's also a new file.

Please let me know your thoughts :D