### PR TITLE
Fix indestructable light blocks (#11252)

### DIFF
--- a/patches/server/1045-Fix-indestructable-light-blocks.patch
+++ b/patches/server/1045-Fix-indestructable-light-blocks.patch
@@ -1,17 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Newwind <support@newwindserver.com>
+From: Abel van Hulst <abelvanhulst@gmail.com>
 Date: Wed, 7 Aug 2024 13:25:55 +0200
-Subject: [PATCH] Configuration for horizontal-only item merging
+Subject: [PATCH] Fix indestructable light blocks
 
-Most of the visual artifacts that result from having item merge radius above vanilla levels is from items merging vertically,
-which realistically, only happens when a player is dropping items, or items are dropping from breaking a block.
-
-Most of the scenarios where item merging makes sense involves the two item entities being on the same Y level. i.e on the ground next to each other.
-This is even more apparent since paper fixed items being able to merge through blocks.
-
-This patch allows us to configure items to only merge horizontally, which is what vanilla does.
-This allows us to have both the reduced number of item entities a high item-merge radius provides,
-without most of the visual artifacts caused by items merging vertically.
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 index ea0d9335446b20073b9aafb9de453097355db79c..607f1a9802eb0ff4865af4c53f302128a6e6fe02 100644
@@ -26,3 +17,15 @@ index ea0d9335446b20073b9aafb9de453097355db79c..607f1a9802eb0ff4865af4c53f302128
                  // Spigot end
                  return entityitem != this && entityitem.isMergable();
              });
+diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
+index a7108b2be0746aa1f0e574d8c6f5ffad6d369835..29947de9eb6887f2e61516523ff08d8b581b0f53 100644
+--- a/src/main/java/net/minecraft/world/level/block/Block.java
++++ b/src/main/java/net/minecraft/world/level/block/Block.java
+@@ -92,7 +92,6 @@ public class Block extends BlockBehaviour implements ItemLike {
+     public final boolean isDestroyable() {
+         return io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.allowPermanentBlockBreakExploits ||
+             this != Blocks.BARRIER &&
+-            this != Blocks.LIGHT &&
+             this != Blocks.BEDROCK &&
+             this != Blocks.END_PORTAL_FRAME &&
+             this != Blocks.END_PORTAL &&


### PR DESCRIPTION
This patch edits commit [2773dc4](https://github.com/PaperMC/Paper/commit/2773dc484735a8ba9cd83354c76e733454f332d5), which adds light blocks to net.minecraft.world.level.block.Block.isDestroyable();. However, this makes it that no blocks can be placed inside of light blocks (see #11252), which this pull request fixes.