### PR TITLE
Fix indestructable light blocks (#11252)

### DIFF
--- a/patches/server/0954-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/0954-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -13,7 +13,7 @@ A config is provided if you rather let players use these exploits, and let
 them destroy the worlds End Portals and get on top of the nether easy.
 
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index 0add20466890db9d2af7c595806d5e767b7ee117..32651ed15e5961a8b27fc0dc8fb54ef05b6064fe 100644
+index 6a1e2614453bc3d6fe082c1fd43228c4a182442e..b70ac21d8dc70fb1513ea7ce5270fb381552c29a 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
 @@ -193,6 +193,7 @@ public class Explosion {
@@ -40,17 +40,16 @@ index b7bf7b3b91046c81467aeb483087e12b6d9191bf..a2877f3eb206ab9ccb93e3606f1c9b34
              if (blockstate == null) {
                  blockstate = CapturedBlockState.getTreeBlockState(this, pos, flags);
 diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
-index bf52c36f31992a01a7403d8c85151327c9e944c4..d775ab8b0d37797f29e650842191d40691fb7afc 100644
+index bf52c36f31992a01a7403d8c85151327c9e944c4..3b06c080afebde1d649f05eca0af938ba32931c1 100644
 --- a/src/main/java/net/minecraft/world/level/block/Block.java
 +++ b/src/main/java/net/minecraft/world/level/block/Block.java
-@@ -89,6 +89,20 @@ public class Block extends BlockBehaviour implements ItemLike {
+@@ -89,6 +89,19 @@ public class Block extends BlockBehaviour implements ItemLike {
      protected final StateDefinition<Block, BlockState> stateDefinition;
      private BlockState defaultBlockState;
      // Paper start
 +    public final boolean isDestroyable() {
 +        return io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.allowPermanentBlockBreakExploits ||
 +            this != Blocks.BARRIER &&
-+            this != Blocks.LIGHT &&
 +            this != Blocks.BEDROCK &&
 +            this != Blocks.END_PORTAL_FRAME &&
 +            this != Blocks.END_PORTAL &&

--- a/patches/server/0987-Moonrise-optimisation-patches.patch
+++ b/patches/server/0987-Moonrise-optimisation-patches.patch
@@ -26236,7 +26236,7 @@ index c97292f22a3402dbd59cef4af554954dc1d4f91a..b2c5ead035f583585b79f7eba51d66da
          return crashreportsystemdetails;
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 5b68fa9758d410ebe7b9bf7fd4221835fbce3d0b..45839cca7dd2e0ec3b6f146df4938da3e4b2c275 100644
+index 62ec627e80b87a92a2a51ba9fc3626a67636855f..30f53916a9e49165bcfef2bea2c0b50a26f5a8a3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -200,7 +200,7 @@ import org.bukkit.event.player.PlayerToggleSneakEvent;
@@ -28968,10 +28968,10 @@ index 15f82c9a1ce1fef2e951d1b3c7a65e64b82061ea..90c165c890a2d998e3b0af9b4310e399
  
      public boolean shouldFreeze(LevelReader world, BlockPos blockPos) {
 diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
-index d775ab8b0d37797f29e650842191d40691fb7afc..a7108b2be0746aa1f0e574d8c6f5ffad6d369835 100644
+index 3b06c080afebde1d649f05eca0af938ba32931c1..29947de9eb6887f2e61516523ff08d8b581b0f53 100644
 --- a/src/main/java/net/minecraft/world/level/block/Block.java
 +++ b/src/main/java/net/minecraft/world/level/block/Block.java
-@@ -280,7 +280,7 @@ public class Block extends BlockBehaviour implements ItemLike {
+@@ -279,7 +279,7 @@ public class Block extends BlockBehaviour implements ItemLike {
      }
  
      public static boolean isShapeFullBlock(VoxelShape shape) {
@@ -32864,7 +32864,7 @@ index 94640aa827c9b2e1d0174eb012fdb37c0851f501..5ad2ceb1274648631689215702a12463
  
      // Paper start - implement pointers
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 12010a078542b7e89f0f4c0e7983eb15e75c4f1f..2f56cbcc1d1af98f58c310ff8b4ce33cc950e977 100644
+index 63b8e0e95e960d3a5e2f321896346b9c69f1bcc4..1def2a09427de70646802fd876a5805489a3d129 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -3497,7 +3497,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {


### PR DESCRIPTION
This patch edits commit [2773dc4](https://github.com/PaperMC/Paper/commit/2773dc484735a8ba9cd83354c76e733454f332d5), which adds light blocks to net.minecraft.world.level.block.Block.isDestroyable();. However, this makes it that no blocks can be placed inside of light blocks (see #11252), which this pull request fixes.