### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0053-Fix-upstream-javadocs.patch
+++ b/patches/api/0053-Fix-upstream-javadocs.patch
@@ -1548,21 +1548,6 @@ index 35c6594fd1040a1af1029e7260e5e3a9307b107d..d58719ee75bef8bc265bfc81bc5d88a4
       */
      void addChargedProjectile(@NotNull ItemStack item);
  }
-diff --git a/src/main/java/org/bukkit/inventory/meta/FireworkMeta.java b/src/main/java/org/bukkit/inventory/meta/FireworkMeta.java
-index cdbcc8dbab2456cc2bc1f3084cbb1ced1698b7f5..d528b066c2aaa3fb097931914ff2181f8f64e520 100644
---- a/src/main/java/org/bukkit/inventory/meta/FireworkMeta.java
-+++ b/src/main/java/org/bukkit/inventory/meta/FireworkMeta.java
-@@ -86,8 +86,8 @@ public interface FireworkMeta extends ItemMeta {
-      * Sets the approximate power of the firework. Each level of power is half
-      * a second of flight time.
-      *
--     * @param power the power of the firework, from 0-127
--     * @throws IllegalArgumentException if {@literal height<0 or height>127}
-+     * @param power the power of the firework, from 0-255
-+     * @throws IllegalArgumentException if {@literal power < 0 or power > 255}
-      */
-     void setPower(int power) throws IllegalArgumentException;
- 
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 index 014c1a0379e532a5c924694a8e0715eb0ba50ec2..10ca843e57c74dfa32d539acd174c8867dfd56ec 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java

--- a/patches/api/0472-General-ItemMeta-fixes.patch
+++ b/patches/api/0472-General-ItemMeta-fixes.patch
@@ -92,6 +92,31 @@ index ff6818b6d9e0207eafdd749928f33aeac3f27191..992f39da07bafe9769effaa7dc6adc01
      /**
       * Checks to see if this item has a maximum amount of damage.
       *
+diff --git a/src/main/java/org/bukkit/inventory/meta/FireworkMeta.java b/src/main/java/org/bukkit/inventory/meta/FireworkMeta.java
+index 9bd15803cd3526da951ed197305a1b9385305927..5833c4c16b08a0f338a5cd7c0011e82eeda222c2 100644
+--- a/src/main/java/org/bukkit/inventory/meta/FireworkMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/FireworkMeta.java
+@@ -75,10 +75,20 @@ public interface FireworkMeta extends ItemMeta {
+      */
+     boolean hasEffects();
+ 
++    // Paper start - add hasPower
++    /**
++     * Checks if power is defined on this meta.
++     *
++     * @return true if there is a power specified
++     */
++    boolean hasPower();
++    // Paper end - add hasPower
++
+     /**
+      * Gets the approximate height the firework will fly.
+      *
+      * @return approximate flight height of the firework.
++     * @see #hasPower()
+      */
+     int getPower();
+ 
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 index 1a4260b00b193b94ce4b1b2954644f4e41baff4c..5d5fcb2720b62e47d47f441032c4de02574b051a 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2872,7 +2872,7 @@ index e7c407039fef88ef01ba9b6be9ae5bcc3edc026f..5457358bc76889153036818fdfd70a04
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e244ac9f51a08603a7877e7e655fda26cd396772..556d8f23ee2de77cea71abcc0e56718e60b20b05 100644
+index 2de70e3a3038b2d2bb47b58f0e14d937c35d55ba..4acee8121ff62413dbbf2294d17da3bd2f974d5a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -45,6 +45,7 @@ import net.minecraft.nbt.CompoundTag;
@@ -4677,10 +4677,10 @@ index 5725b0281ac53a2354b233223259d6784353bc6e..9ef939b76d06874b856e0c850addb364
      @Override
      public int getLineWidth() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 938a7ee49a727d5929d1d049c61d2881cf24ff9c..78f4bb474c85e32448a385e108707d92082bfe02 100644
+index 20eb63eeac7f5c9a1d98a9aa8f90a588cb036c70..8f468a3bfa8ef381eabb45ebb3dd9a4942e98dd5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -915,7 +915,7 @@ public class CraftEventFactory {
+@@ -917,7 +917,7 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -4689,7 +4689,7 @@ index 938a7ee49a727d5929d1d049c61d2881cf24ff9c..78f4bb474c85e32448a385e108707d92
          CraftPlayer entity = victim.getBukkitEntity();
          CraftDamageSource bukkitDamageSource = new CraftDamageSource(damageSource);
          PlayerDeathEvent event = new PlayerDeathEvent(entity, bukkitDamageSource, drops, victim.getExpReward(damageSource.getEntity()), 0, deathMessage);
-@@ -948,7 +948,7 @@ public class CraftEventFactory {
+@@ -950,7 +950,7 @@ public class CraftEventFactory {
       * Server methods
       */
      public static ServerListPingEvent callServerListPingEvent(SocketAddress address, String motd, int numPlayers, int maxPlayers) {

--- a/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
@@ -28,7 +28,7 @@ index 1e9c68cd1868d083e6a790d56006dd4aa432010a..8a0ee9564fc36a2badf1357f7e6c47b5
 +    // Paper end - PlayerUseUnknownEntityEvent
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 64db7e017b41bffcaac202ee4ecfd7df46d69331..14a821bfc6b20475889d3138b8da9e6bfaf1787c 100644
+index 02b9e1ed57f5d65698c461387ff7d48450e6a70f..0d18b12d0755c14bd041e0f98177469612262fde 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2493,7 +2493,26 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -59,10 +59,10 @@ index 64db7e017b41bffcaac202ee4ecfd7df46d69331..14a821bfc6b20475889d3138b8da9e6b
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 78f4bb474c85e32448a385e108707d92082bfe02..b68068c783f782258f86e5ecf54664916f069e38 100644
+index 8f468a3bfa8ef381eabb45ebb3dd9a4942e98dd5..96e0fc5c8a018fd579f24529175decdac634cfa1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1915,4 +1915,13 @@ public class CraftEventFactory {
+@@ -1931,4 +1931,13 @@ public class CraftEventFactory {
  
          Bukkit.getPluginManager().callEvent(new EntityRemoveEvent(entity.getBukkitEntity(), cause));
      }

--- a/patches/server/0108-Add-EntityZapEvent.patch
+++ b/patches/server/0108-Add-EntityZapEvent.patch
@@ -28,10 +28,10 @@ index 63c10be6eacd7108b8b4795d76bf624e0614440a..243eb1e54293c763a06febff551c0513
                  entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null);
                  entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b68068c783f782258f86e5ecf54664916f069e38..44c416f812867f19a26aeefc5710a7aef9dfdf64 100644
+index 96e0fc5c8a018fd579f24529175decdac634cfa1..50f33c6029c190f947b6bf6215004416b034c0cc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1215,6 +1215,14 @@ public class CraftEventFactory {
+@@ -1217,6 +1217,14 @@ public class CraftEventFactory {
          return !event.isCancelled();
      }
  

--- a/patches/server/0112-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0112-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index 56402312e44d12c859e2c4b39902d31b7cfd1573..25a45e680f9fdea90f43d59de87a3a50
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 44c416f812867f19a26aeefc5710a7aef9dfdf64..a83b7f350bf20f944de92df76e112aaa49dc608d 100644
+index 50f33c6029c190f947b6bf6215004416b034c0cc..d36e039aa5f1cf84179def5df5addaf448f54bd2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1168,6 +1168,17 @@ public class CraftEventFactory {
+@@ -1170,6 +1170,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0113-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0113-Add-ProjectileCollideEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add ProjectileCollideEvent
 Deprecated now and replaced with ProjectileHitEvent
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a83b7f350bf20f944de92df76e112aaa49dc608d..b5b237c56575e8ceb3e6471deec1e7712891a8e0 100644
+index d36e039aa5f1cf84179def5df5addaf448f54bd2..91180d7ad705ca97c0df43debc14b204127165d0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1321,6 +1321,16 @@ public class CraftEventFactory {
+@@ -1323,6 +1323,16 @@ public class CraftEventFactory {
          Bukkit.getPluginManager().callEvent(crafterCraftEvent);
          return crafterCraftEvent;
      }
@@ -26,7 +26,7 @@ index a83b7f350bf20f944de92df76e112aaa49dc608d..b5b237c56575e8ceb3e6471deec1e771
  
      public static ProjectileLaunchEvent callProjectileLaunchEvent(Entity entity) {
          Projectile bukkitEntity = (Projectile) entity.getBukkitEntity();
-@@ -1346,8 +1356,15 @@ public class CraftEventFactory {
+@@ -1348,8 +1358,15 @@ public class CraftEventFactory {
          if (position.getType() == HitResult.Type.ENTITY) {
              hitEntity = ((EntityHitResult) position).getEntity().getBukkitEntity();
          }

--- a/patches/server/0141-Entity-fromMobSpawner.patch
+++ b/patches/server/0141-Entity-fromMobSpawner.patch
@@ -49,10 +49,10 @@ index aa54237205989f619ac6a3faa2e4285427b9e31d..43d399e1a0ba2fb0541f851a28032fa6
                          if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, pos).isCancelled()) {
                              continue;
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/trialspawner/TrialSpawner.java b/src/main/java/net/minecraft/world/level/block/entity/trialspawner/TrialSpawner.java
-index 571756dacfa16f6755b67457e17969c35104f971..52d71a03cd5b2af56704f265ce5b5f14d3236ebb 100644
+index 55d63de57ec740fc4ea5faa3db9a092b8e4fed95..c3f6522a7dc0777c5b3fa2bac63a8901f96d9f38 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/trialspawner/TrialSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/trialspawner/TrialSpawner.java
-@@ -225,6 +225,7 @@ public final class TrialSpawner {
+@@ -230,6 +230,7 @@ public final class TrialSpawner {
                                  optional1.ifPresent(entityinsentient::equip);
                              }
  

--- a/patches/server/0192-WitchReadyPotionEvent.patch
+++ b/patches/server/0192-WitchReadyPotionEvent.patch
@@ -22,10 +22,10 @@ index a14e00d55930628333cc63b18727ea56dbdc4ee3..f6d01d21745391595d61b191832be4c2
                      this.setUsingItem(true);
                      if (!this.isSilent()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b5b237c56575e8ceb3e6471deec1e7712891a8e0..cfdabb93c2d30845af9108552ed9bee9929250ce 100644
+index 91180d7ad705ca97c0df43debc14b204127165d0..e3af0db8082e4e90902197f96f1c833405bf5f63 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1960,4 +1960,14 @@ public class CraftEventFactory {
+@@ -1976,4 +1976,14 @@ public class CraftEventFactory {
          ).callEvent();
      }
      // Paper end - PlayerUseUnknownEntityEvent

--- a/patches/server/0202-Add-entity-knockback-events.patch
+++ b/patches/server/0202-Add-entity-knockback-events.patch
@@ -276,7 +276,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b
 index cfdabb93c2d30845af9108552ed9bee9929250ce..9225746382bcecb0bab655a8232fecc09169225d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1922,19 +1922,33 @@ public class CraftEventFactory {
+@@ -1938,19 +1938,33 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0208-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0208-InventoryCloseEvent-Reason-API.patch
@@ -75,7 +75,7 @@ index fb5130b6378554ccb23fb7992e408497ca093ff3..0dee94f1dd27a0d7e709367450c5ef79
          this.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 72edfb965aca81c2d2442b794b42baa04ec713b3..a954d3b0ff0917d857002dba70c54b3fcdf77943 100644
+index 0073c6c5433be3193a01257a26c7035e544f37dd..0321128ab745250e79fa5f66079c9aeb7f394cc0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2619,10 +2619,15 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -178,10 +178,10 @@ index 4e5dba1da323f12d77a36635c9227b1239856254..12c61db6d4b1284765f9bed3ae26131a
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 9225746382bcecb0bab655a8232fecc09169225d..bf3995795295c3224db97e4d6809c0f5da6ce55c 100644
+index 3059a21b554db99af96c76f72dd08591c00e3e08..9b6607700ed23b97755a2171a49b22d498a60626 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1281,7 +1281,7 @@ public class CraftEventFactory {
+@@ -1283,7 +1283,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -190,7 +190,7 @@ index 9225746382bcecb0bab655a8232fecc09169225d..bf3995795295c3224db97e4d6809c0f5
          }
  
          CraftServer server = player.level().getCraftServer();
-@@ -1477,8 +1477,18 @@ public class CraftEventFactory {
+@@ -1479,8 +1479,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0217-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0217-Vanished-players-don-t-have-rights.patch
@@ -89,10 +89,10 @@ index a9227581ec78a56e96dc3a342006e4a649906326..5929b450a26e7c3cf63de3dc1d0e67cb
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ad271871b207b425ef8d599fe74a67d065d66686..d1b473ef83df0ed4ae7cd9dd0525dac5e8a41223 100644
+index 9b6607700ed23b97755a2171a49b22d498a60626..0613bdf3c2325d5cab64783af7211b07fcf5124a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1327,6 +1327,14 @@ public class CraftEventFactory {
+@@ -1329,6 +1329,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0243-Improve-death-events.patch
+++ b/patches/server/0243-Improve-death-events.patch
@@ -446,7 +446,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b
 index d63cf5933fdcff6d71c7ddbfed3640acd1646b70..1f4c686e92e7449556ee5067553ed4473ba2f50e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -901,9 +901,16 @@ public class CraftEventFactory {
+@@ -903,9 +903,16 @@ public class CraftEventFactory {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          CraftDamageSource bukkitDamageSource = new CraftDamageSource(damageSource);
          EntityDeathEvent event = new EntityDeathEvent(entity, bukkitDamageSource, drops, victim.getExpReward(damageSource.getEntity()));
@@ -463,7 +463,7 @@ index d63cf5933fdcff6d71c7ddbfed3640acd1646b70..1f4c686e92e7449556ee5067553ed447
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -921,7 +928,14 @@ public class CraftEventFactory {
+@@ -923,7 +930,14 @@ public class CraftEventFactory {
          PlayerDeathEvent event = new PlayerDeathEvent(entity, bukkitDamageSource, drops, victim.getExpReward(damageSource.getEntity()), 0, deathMessage);
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
@@ -478,7 +478,7 @@ index d63cf5933fdcff6d71c7ddbfed3640acd1646b70..1f4c686e92e7449556ee5067553ed447
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -944,6 +958,31 @@ public class CraftEventFactory {
+@@ -946,6 +960,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0281-Fixes-and-additions-to-the-spawn-reason-API.patch
+++ b/patches/server/0281-Fixes-and-additions-to-the-spawn-reason-API.patch
@@ -202,10 +202,10 @@ index dbc0b69603dcffbf3d41d79719aa0f2b7da4a131..dd86f5ec5b2051aeea4e19ff97146362
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/trialspawner/TrialSpawner.java b/src/main/java/net/minecraft/world/level/block/entity/trialspawner/TrialSpawner.java
-index 52d71a03cd5b2af56704f265ce5b5f14d3236ebb..ffca6563c20f53c92b162054fec727d83e54e58a 100644
+index c3f6522a7dc0777c5b3fa2bac63a8901f96d9f38..9b336f651ead8111a0b2c0fedad9331f594b2990 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/trialspawner/TrialSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/trialspawner/TrialSpawner.java
-@@ -226,6 +226,7 @@ public final class TrialSpawner {
+@@ -231,6 +231,7 @@ public final class TrialSpawner {
                              }
  
                              entity.spawnedViaMobSpawner = true; // Paper

--- a/patches/server/0321-add-hand-to-BlockMultiPlaceEvent.patch
+++ b/patches/server/0321-add-hand-to-BlockMultiPlaceEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add hand to BlockMultiPlaceEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a9a2b35378d6654ba00a48737f596553445214aa..7d21f3ec394b53461ca5fb73449b551fbe6e96aa 100644
+index 6a018f9c289a539b07855d75e4cc2d3c2828ded1..e25ca301a4b9b252d3f75013e4e14df9b14aa7b9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -410,13 +410,18 @@ public class CraftEventFactory {
+@@ -412,13 +412,18 @@ public class CraftEventFactory {
          }
  
          org.bukkit.inventory.ItemStack item;

--- a/patches/server/0349-Fix-item-duplication-and-teleport-issues.patch
+++ b/patches/server/0349-Fix-item-duplication-and-teleport-issues.patch
@@ -69,7 +69,7 @@ index d80fd4e2f41583f83c9527ccf4ce80afe851276a..bd5291ca4680572d2c5f3cec1231b1a3
  
      public float getBlockExplosionResistance(Explosion explosion, BlockGetter world, BlockPos pos, BlockState blockState, FluidState fluidState, float max) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f2e66b50b32d197f9a8d4a9672ebf1413e66d59b..fe73a6728de0fad50451d3090002b6c0421d4c43 100644
+index 926c8fd21bb610dc07658c41431a7795ba4f2870..c0bbeaa4a37c1ba9f5125a0c68f4511aac6a0e71 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1728,9 +1728,9 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -124,10 +124,10 @@ index 92bb0c63330ad3a4cb13b2dc655020714e9b1ffd..cc1189c2d7dc57ba8f29aad4ba5d2a07
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 7d21f3ec394b53461ca5fb73449b551fbe6e96aa..408f677337759f529fa41f6ba2b516b71a7940f1 100644
+index e25ca301a4b9b252d3f75013e4e14df9b14aa7b9..9548ee5b43458ccc865f800d1f1b69245a821658 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -903,6 +903,11 @@ public class CraftEventFactory {
+@@ -905,6 +905,11 @@ public class CraftEventFactory {
      }
  
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, DamageSource damageSource, List<org.bukkit.inventory.ItemStack> drops) {
@@ -139,7 +139,7 @@ index 7d21f3ec394b53461ca5fb73449b551fbe6e96aa..408f677337759f529fa41f6ba2b516b7
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          CraftDamageSource bukkitDamageSource = new CraftDamageSource(damageSource);
          EntityDeathEvent event = new EntityDeathEvent(entity, bukkitDamageSource, drops, victim.getExpReward(damageSource.getEntity()));
-@@ -917,11 +922,13 @@ public class CraftEventFactory {
+@@ -919,11 +924,13 @@ public class CraftEventFactory {
          playDeathSound(victim, event);
          // Paper end
          victim.expToDrop = event.getDroppedExp();

--- a/patches/server/0357-ExperienceOrb-merging-stacking-API-and-fixes.patch
+++ b/patches/server/0357-ExperienceOrb-merging-stacking-API-and-fixes.patch
@@ -77,10 +77,10 @@ index 5a7d314ec0562e472f5dc45924a7b24841cff126..650e4a01cecc4cc08e7ff9ebcc4c3670
      public java.util.UUID getTriggerEntityId() {
          return getHandle().triggerEntityId;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 408f677337759f529fa41f6ba2b516b71a7940f1..1177a9310f686f3b4d75a713cdac75c5628e8bbb 100644
+index 9548ee5b43458ccc865f800d1f1b69245a821658..752aba27c3eb9815bdd2b4683483c70e891711e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -712,15 +712,29 @@ public class CraftEventFactory {
+@@ -714,15 +714,29 @@ public class CraftEventFactory {
          if (entity instanceof net.minecraft.world.entity.ExperienceOrb xp) {
              double radius = world.spigotConfig.expMerge;
              if (radius > 0) {

--- a/patches/server/0384-Add-PrepareResultEvent.patch
+++ b/patches/server/0384-Add-PrepareResultEvent.patch
@@ -94,10 +94,10 @@ index 30ea1f9e97db86a2ad7baeea4f5a76c821874daa..5b4f03128499b0c1a4b8c5f5ccd17e4b
  
      private static SingleRecipeInput createRecipeInput(Container inventory) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 1177a9310f686f3b4d75a713cdac75c5628e8bbb..838ad7bc8a7488adf52d462e1a3f2faa275bebd0 100644
+index 752aba27c3eb9815bdd2b4683483c70e891711e7..44fd82bf887e5c6d946d7eed18e21f966efda9de 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1679,6 +1679,12 @@ public class CraftEventFactory {
+@@ -1681,6 +1681,12 @@ public class CraftEventFactory {
      }
  
      public static PrepareAnvilEvent callPrepareAnvilEvent(AnvilView view, ItemStack item) {
@@ -110,7 +110,7 @@ index 1177a9310f686f3b4d75a713cdac75c5628e8bbb..838ad7bc8a7488adf52d462e1a3f2faa
          PrepareAnvilEvent event = new PrepareAnvilEvent(view, CraftItemStack.asCraftMirror(item).clone());
          event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
          event.getInventory().setItem(2, event.getResult());
-@@ -1686,6 +1692,12 @@ public class CraftEventFactory {
+@@ -1688,6 +1694,12 @@ public class CraftEventFactory {
      }
  
      public static PrepareGrindstoneEvent callPrepareGrindstoneEvent(InventoryView view, ItemStack item) {
@@ -123,7 +123,7 @@ index 1177a9310f686f3b4d75a713cdac75c5628e8bbb..838ad7bc8a7488adf52d462e1a3f2faa
          PrepareGrindstoneEvent event = new PrepareGrindstoneEvent(view, CraftItemStack.asCraftMirror(item).clone());
          event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
          event.getInventory().setItem(2, event.getResult());
-@@ -1693,12 +1705,39 @@ public class CraftEventFactory {
+@@ -1695,12 +1707,39 @@ public class CraftEventFactory {
      }
  
      public static PrepareSmithingEvent callPrepareSmithingEvent(InventoryView view, ItemStack item) {

--- a/patches/server/0401-Add-BellRingEvent.patch
+++ b/patches/server/0401-Add-BellRingEvent.patch
@@ -7,10 +7,10 @@ Add a new event, BellRingEvent, to trigger whenever a player rings a
 village bell. Passes along the bell block and the player who rang it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a3e359d174e4c175e49a6e7c03cbca0661cf8b34..2596159784a6ae0502b9a1b5a7cc573966021380 100644
+index 44fd82bf887e5c6d946d7eed18e21f966efda9de..241e6527575c6d6b4facbd3ae1e4a8b65708e397 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -376,10 +376,11 @@ public class CraftEventFactory {
+@@ -378,10 +378,11 @@ public class CraftEventFactory {
          return tradeSelectEvent;
      }
  

--- a/patches/server/0406-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0406-Add-methods-to-get-translation-keys.patch
@@ -74,10 +74,10 @@ index d20fdd4f06faa09c7d9f9e04f379cf0fa68db9bb..66d773cadb74f9176e6cf68a56556803
 +    // Paper end - add Translatable
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
-index 305eac6845119c36d041bf75930eb0909405911c..8c1d2d0521da52f9a1262f5433da21700b9b0454 100644
+index 56dad5ebba54642e783146f1233d6ef44bb866a5..8725cd736d255b070f9f8ce7cf47b21e2407fbdd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
-@@ -110,7 +110,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -123,7 +123,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
          return new FireworkExplosion(CraftMetaFirework.getNBT(effect.getType()), colors, fadeColors, effect.hasTrail(), effect.hasFlicker());
      }
  

--- a/patches/server/0448-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/patches/server/0448-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2596159784a6ae0502b9a1b5a7cc573966021380..2be5135d3e17c3344ffbdb3f2f55d45eb6753c61 100644
+index 241e6527575c6d6b4facbd3ae1e4a8b65708e397..f4a1f96340f8521bc2fecfb2565f7cc8c6453d47 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -311,6 +311,10 @@ public class CraftEventFactory {
+@@ -313,6 +313,10 @@ public class CraftEventFactory {
                          return BedEnterResult.TOO_FAR_AWAY;
                      case NOT_SAFE:
                          return BedEnterResult.NOT_SAFE;

--- a/patches/server/0465-Add-BlockFailedDispenseEvent.patch
+++ b/patches/server/0465-Add-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index a08e8571f3a83afc80c2f1758a9029cd28ed6947..91b514967405115f22edf4255775361a
              } else {
                  ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2be5135d3e17c3344ffbdb3f2f55d45eb6753c61..c01d4302e145c779cc4031927ab555e1c7748155 100644
+index f4a1f96340f8521bc2fecfb2565f7cc8c6453d47..c5166b0876eb925d30803277beb181ee01120586 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2111,4 +2111,12 @@ public class CraftEventFactory {
+@@ -2127,4 +2127,12 @@ public class CraftEventFactory {
          return org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getPotion());
      }
      // Paper end - WitchReadyPotionEvent

--- a/patches/server/0480-Add-BlockPreDispenseEvent.patch
+++ b/patches/server/0480-Add-BlockPreDispenseEvent.patch
@@ -29,10 +29,10 @@ index 91b514967405115f22edf4255775361a672e5c2f..ddecf443df3679e3098eb54edd19585a
                      } else {
                          // CraftBukkit start - Fire event when pushing items into other inventories
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c01d4302e145c779cc4031927ab555e1c7748155..97a17f2b782196b51ebbc6740aad1768fc73f7ba 100644
+index c5166b0876eb925d30803277beb181ee01120586..6cc729446ff21a5718ff01fcea1496c71f77480c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2118,5 +2118,11 @@ public class CraftEventFactory {
+@@ -2134,5 +2134,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0484-Expand-EntityUnleashEvent.patch
+++ b/patches/server/0484-Expand-EntityUnleashEvent.patch
@@ -124,7 +124,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b
 index 6e5bfdc0a5b39977c4550876470c9a2534160056..e3cf4febcb51db96fcd162b2af77dd92e7d49365 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1596,8 +1596,10 @@ public class CraftEventFactory {
+@@ -1598,8 +1598,10 @@ public class CraftEventFactory {
          Bukkit.getPluginManager().callEvent(new PlayerRecipeBookSettingsChangeEvent(player.getBukkitEntity(), bukkitType, open, filter));
      }
  

--- a/patches/server/0490-Allow-adding-items-to-BlockDropItemEvent.patch
+++ b/patches/server/0490-Allow-adding-items-to-BlockDropItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow adding items to BlockDropItemEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2786398e99af94d8dc1251009cdb5fa71206bcf3..4f05f8d73b824cd2985e6c6d90338fc7479ef2a5 100644
+index ad49a7cb16de3dac7a5232abded3635a4b0b8848..3e1a70fe1e523946512ac71772439f7fd292623f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -460,13 +460,30 @@ public class CraftEventFactory {
+@@ -462,13 +462,30 @@ public class CraftEventFactory {
      }
  
      public static void handleBlockDropItemEvent(Block block, BlockState state, ServerPlayer player, List<ItemEntity> items) {

--- a/patches/server/0557-Fix-potions-splash-events.patch
+++ b/patches/server/0557-Fix-potions-splash-events.patch
@@ -143,10 +143,10 @@ index be787a5b52e90796d4f06e17e564f4324807c3e6..cb34cc9443da56c0497c7a0192c8b836
  
      public boolean isLingering() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4f05f8d73b824cd2985e6c6d90338fc7479ef2a5..61caedf05b28b2ba351e231c5f76e4df1ebd271a 100644
+index 3e1a70fe1e523946512ac71772439f7fd292623f..88a5b50396fddc18b733a52ad66eedd10751f8ea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -884,6 +884,32 @@ public class CraftEventFactory {
+@@ -886,6 +886,32 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0591-Add-critical-damage-API.patch
+++ b/patches/server/0591-Add-critical-damage-API.patch
@@ -61,10 +61,10 @@ index 746bb8a36bd6c6ef953289576af499caad588d79..57ebb96707748e90810dc07471f9769f
          int k = entity.getRemainingFireTicks();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 61caedf05b28b2ba351e231c5f76e4df1ebd271a..4180b86620aa18a95e0793f646515779801a343e 100644
+index 88a5b50396fddc18b733a52ad66eedd10751f8ea..03a6ca13218d43ad0c5fc461564d004008ee3e06 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1078,7 +1078,7 @@ public class CraftEventFactory {
+@@ -1080,7 +1080,7 @@ public class CraftEventFactory {
                  return CraftEventFactory.callEntityDamageEvent(source.getDirectBlock(), source.getDirectBlockState(), entity, DamageCause.BLOCK_EXPLOSION, bukkitDamageSource, modifiers, modifierFunctions, cancelled);
              }
              DamageCause damageCause = (damager.getBukkitEntity() instanceof org.bukkit.entity.TNTPrimed) ? DamageCause.BLOCK_EXPLOSION : DamageCause.ENTITY_EXPLOSION;
@@ -73,7 +73,7 @@ index 61caedf05b28b2ba351e231c5f76e4df1ebd271a..4180b86620aa18a95e0793f646515779
          } else if (damager != null || source.getDirectEntity() != null) {
              DamageCause cause = (source.isSweep()) ? DamageCause.ENTITY_SWEEP_ATTACK : DamageCause.ENTITY_ATTACK;
  
-@@ -1104,7 +1104,7 @@ public class CraftEventFactory {
+@@ -1106,7 +1106,7 @@ public class CraftEventFactory {
                  cause = DamageCause.MAGIC;
              }
  
@@ -82,7 +82,7 @@ index 61caedf05b28b2ba351e231c5f76e4df1ebd271a..4180b86620aa18a95e0793f646515779
          } else if (source.is(DamageTypes.FELL_OUT_OF_WORLD)) {
              return CraftEventFactory.callEntityDamageEvent(source.getDirectBlock(), source.getDirectBlockState(), entity, DamageCause.VOID, bukkitDamageSource, modifiers, modifierFunctions, cancelled);
          } else if (source.is(DamageTypes.LAVA)) {
-@@ -1164,13 +1164,13 @@ public class CraftEventFactory {
+@@ -1166,13 +1166,13 @@ public class CraftEventFactory {
              cause = DamageCause.CUSTOM;
          }
  

--- a/patches/server/0677-More-Projectile-API.patch
+++ b/patches/server/0677-More-Projectile-API.patch
@@ -713,10 +713,10 @@ index e374b9f40eddca13b30855d25a2030f8df98138f..4fc893378fb0568ddcffc7593d66df6b
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 48f320333fa859796f4fff01f721fda903238197..9c85cbc65bf7e1f539f12644ed391c98118c08d2 100644
+index 03a6ca13218d43ad0c5fc461564d004008ee3e06..6aa954c168e5503c1e4cf069e13f518da277cdef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -841,19 +841,19 @@ public class CraftEventFactory {
+@@ -843,19 +843,19 @@ public class CraftEventFactory {
      /**
       * PotionSplashEvent
       */
@@ -739,7 +739,7 @@ index 48f320333fa859796f4fff01f721fda903238197..9c85cbc65bf7e1f539f12644ed391c98
              hitEntity = ((EntityHitResult) position).getEntity().getBukkitEntity();
          }
  
-@@ -862,20 +862,20 @@ public class CraftEventFactory {
+@@ -864,20 +864,20 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0686-Fix-new-block-data-for-EntityChangeBlockEvent.patch
+++ b/patches/server/0686-Fix-new-block-data-for-EntityChangeBlockEvent.patch
@@ -196,10 +196,10 @@ index edc20745649b0837f1371c8d29e71fc0c8e5528f..932831bb5632ead5850842fc77192c84
              }
              // CraftBukkit end
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ffc55cf79d0e7f90ba2816d7604477f018d75ecd..697ef7d19cca2d3f51ccff9e4ab14d87a7ddaf00 100644
+index 6aa954c168e5503c1e4cf069e13f518da277cdef..d793566b2b5b0e996e4122087a883e92b24c216f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1378,11 +1378,11 @@ public class CraftEventFactory {
+@@ -1380,11 +1380,11 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0724-More-Teleport-API.patch
+++ b/patches/server/0724-More-Teleport-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] More Teleport API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 52ff31d33edb0c55e2ec4a982525d47e4a19428b..77e31c3851813651dc00e59f8ef31134e3540b91 100644
+index 1d91e106b5cef0ab735e916ae32970fd793c8915..48470ab53797a14955ecc1c8368de4ca53dc560b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1561,11 +1561,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -23,8 +23,8 @@ index 52ff31d33edb0c55e2ec4a982525d47e4a19428b..77e31c3851813651dc00e59f8ef31134
          this.cserver.getPluginManager().callEvent(event);
  
          if (event.isCancelled() || !to.equals(event.getTo())) {
--            set.clear(); // Can't relative teleport
-+            // set.clear(); // Can't relative teleport // Paper - Teleport API; Now you can!
+-            set = Collections.emptySet(); // Can't relative teleport
++            // set = Collections.emptySet(); // Can't relative teleport // Paper - Teleport API; Now you can!
              to = event.isCancelled() ? event.getFrom() : event.getTo();
              d0 = to.getX();
              d1 = to.getY();
@@ -112,7 +112,7 @@ index 4c09f2529dd8eb7ac7d260d177f5292ff2339442..94051ae8ea93ab144f3767345b1cda04
      private final org.bukkit.entity.Entity.Spigot spigot = new org.bukkit.entity.Entity.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4b7b812a0203ef8a586c0e0cee10c41935487309..d2f6fb41b16468bf03675b3a331c707e21f8c9ce 100644
+index 252309281f440e9b7a6be3118363c4d97e5dd767..78c11d99b6dfdf742dbe24f7b3c2ddbcfd433fd6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1286,13 +1286,101 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0753-Correctly-handle-interactions-with-items-on-cooldown.patch
+++ b/patches/server/0753-Correctly-handle-interactions-with-items-on-cooldown.patch
@@ -30,10 +30,10 @@ index 03d89f326d320c5d778c3d1e2db7d6b88753faec..717d015dd4637dd9d568b751be1dc104
          this.interactResult = event.useItemInHand() == Event.Result.DENY;
          this.interactPosition = blockposition.immutable();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 697ef7d19cca2d3f51ccff9e4ab14d87a7ddaf00..668becf24a16af6b834d05608787c8f9420e9ad3 100644
+index d793566b2b5b0e996e4122087a883e92b24c216f..e1e5a195c2a415d214c5bf8a2364835f7332751b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -554,6 +554,12 @@ public class CraftEventFactory {
+@@ -556,6 +556,12 @@ public class CraftEventFactory {
      }
  
      public static PlayerInteractEvent callPlayerInteractEvent(net.minecraft.world.entity.player.Player who, Action action, BlockPos position, Direction direction, ItemStack itemstack, boolean cancelledBlock, InteractionHand hand, Vec3 targetPos) {
@@ -46,7 +46,7 @@ index 697ef7d19cca2d3f51ccff9e4ab14d87a7ddaf00..668becf24a16af6b834d05608787c8f9
          Player player = (who == null) ? null : (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
  
-@@ -588,6 +594,11 @@ public class CraftEventFactory {
+@@ -590,6 +596,11 @@ public class CraftEventFactory {
          if (cancelledBlock) {
              event.setUseInteractedBlock(Event.Result.DENY);
          }

--- a/patches/server/0800-Add-EntityFertilizeEggEvent.patch
+++ b/patches/server/0800-Add-EntityFertilizeEggEvent.patch
@@ -69,10 +69,10 @@ index d34d8fe70379dcad9540739ec0ae1c94f01fc46b..fadd341ff398886a4da102eefa1beb95
          this.playSound(SoundEvents.SNIFFER_EGG_PLOP, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 0.5F);
          } // Paper - Call EntityDropItemEvent
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 668becf24a16af6b834d05608787c8f9420e9ad3..8a1f52eeace48ed65bdc077923d0763d5e4369b6 100644
+index e1e5a195c2a415d214c5bf8a2364835f7332751b..2eb6080c92b2557c77d826300db5104db830bc7f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2181,4 +2181,28 @@ public class CraftEventFactory {
+@@ -2197,4 +2197,28 @@ public class CraftEventFactory {
          return event.callEvent();
      }
      // Paper end

--- a/patches/server/0820-Expand-PlayerItemMendEvent.patch
+++ b/patches/server/0820-Expand-PlayerItemMendEvent.patch
@@ -30,7 +30,7 @@ index a758b2456acac23095fe4619ae10300a034cb460..a58ff67052fb5f33782f8b5c83465ec0
                  if (l > 0) {
                      // this.value = l; // CraftBukkit - update exp value of orb for PlayerItemMendEvent calls // Paper - the value field should not be mutated here because it doesn't take "count" into account
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 384165d6747c61d0d306fa63773cbca560dfae9b..e7235efba6b68917a646083c150655cb42a738e5 100644
+index 34c16525d9393a3f111e3df387b55d28b875cb06..d7437bdfca45ee89cef23c6466c3d7d8a3f5c8d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1853,11 +1853,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -49,10 +49,10 @@ index 384165d6747c61d0d306fa63773cbca560dfae9b..e7235efba6b68917a646083c150655cb
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8a1f52eeace48ed65bdc077923d0763d5e4369b6..bbc5143940b5f028051cb5897a5b510e35a5d354 100644
+index 2eb6080c92b2557c77d826300db5104db830bc7f..3af97418a7e28037ed59dea7f37e0785cf9d46e4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1284,10 +1284,10 @@ public class CraftEventFactory {
+@@ -1286,10 +1286,10 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0835-Call-missing-BlockDispenseEvent.patch
+++ b/patches/server/0835-Call-missing-BlockDispenseEvent.patch
@@ -50,10 +50,10 @@ index 96db0b1041a4c0f054d4f3f2bdced960b119664e..78951f50188528718cdb3dbbaabe3f9f
                              for (int k = 0; k < 5; ++k) {
                                  worldserver.sendParticles(ParticleTypes.SPLASH, (double) blockposition.getX() + worldserver.random.nextDouble(), (double) (blockposition.getY() + 1), (double) blockposition.getZ() + worldserver.random.nextDouble(), 1, 0.0D, 0.0D, 0.0D, 1.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index bbc5143940b5f028051cb5897a5b510e35a5d354..fd648c176733dcaa03d2bbec4000381d58fc357e 100644
+index 3af97418a7e28037ed59dea7f37e0785cf9d46e4..736244853af33891609ab71fc50d259918574f3d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2182,6 +2182,32 @@ public class CraftEventFactory {
+@@ -2198,6 +2198,32 @@ public class CraftEventFactory {
      }
      // Paper end
  

--- a/patches/server/0844-ExperienceOrb-should-call-EntitySpawnEvent.patch
+++ b/patches/server/0844-ExperienceOrb-should-call-EntitySpawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ExperienceOrb should call EntitySpawnEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index fd648c176733dcaa03d2bbec4000381d58fc357e..3f9a309d4d0685aec0fabb16a1bd51931048525b 100644
+index 736244853af33891609ab71fc50d259918574f3d..50346dda83472bddc043f8e8c45f9131c2e5958c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -744,7 +744,8 @@ public class CraftEventFactory {
+@@ -746,7 +746,8 @@ public class CraftEventFactory {
          // Spigot start - SPIGOT-7523: Merge after spawn event and only merge if the event was not cancelled (gets checked above)
          if (entity instanceof net.minecraft.world.entity.ExperienceOrb xp) {
              double radius = world.spigotConfig.expMerge;

--- a/patches/server/0869-Add-BlockFace-to-BlockDamageEvent.patch
+++ b/patches/server/0869-Add-BlockFace-to-BlockDamageEvent.patch
@@ -18,10 +18,10 @@ index c680f081ba548f84f07a968a46811090c53e57e3..d839f8df658c894f144ba4637d290ffb
                  if (blockEvent.isCancelled()) {
                      // Let the client know the block still exists
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 3f9a309d4d0685aec0fabb16a1bd51931048525b..3dae4bc26ac6de7ee07eeca7763e2078cb2b7101 100644
+index 50346dda83472bddc043f8e8c45f9131c2e5958c..d80587afa3d0c8c5a0dd8112bbb73bc56ac1722d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -659,13 +659,13 @@ public class CraftEventFactory {
+@@ -661,13 +661,13 @@ public class CraftEventFactory {
      /**
       * BlockDamageEvent
       */

--- a/patches/server/0879-Add-titleOverride-to-InventoryOpenEvent.patch
+++ b/patches/server/0879-Add-titleOverride-to-InventoryOpenEvent.patch
@@ -79,10 +79,10 @@ index 12ab8f7cde88cd6ce3ad474fe2843d5d30c3c0d7..c1bad887d1340ebc7c63fda3dceff929
          if (!player.isImmobile()) player.connection.send(new ClientboundOpenScreenPacket(container.containerId, windowType, io.papermc.paper.adventure.PaperAdventure.asVanilla(adventure$title))); // Paper - Prevent opening inventories when frozen
          player.containerMenu = container;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e5fa1ece90c38bb73bba5721e6f8d4ea240a1d6d..786b3c60086faee8d6ee23c862f3ad7ff4f3581e 100644
+index d80587afa3d0c8c5a0dd8112bbb73bc56ac1722d..3e1ef91d7f0bd098e7c7ebee49c43ca9436947b8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1401,10 +1401,21 @@ public class CraftEventFactory {
+@@ -1403,10 +1403,21 @@ public class CraftEventFactory {
      }
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container) {
@@ -105,7 +105,7 @@ index e5fa1ece90c38bb73bba5721e6f8d4ea240a1d6d..786b3c60086faee8d6ee23c862f3ad7f
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
              player.connection.handleContainerClose(new ServerboundContainerClosePacket(player.containerMenu.containerId), InventoryCloseEvent.Reason.OPEN_NEW); // Paper - Inventory close reason
          }
-@@ -1419,10 +1430,10 @@ public class CraftEventFactory {
+@@ -1421,10 +1432,10 @@ public class CraftEventFactory {
  
          if (event.isCancelled()) {
              container.transferTo(player.containerMenu, craftPlayer);

--- a/patches/server/0915-Restore-vanilla-entity-drops-behavior.patch
+++ b/patches/server/0915-Restore-vanilla-entity-drops-behavior.patch
@@ -9,7 +9,7 @@ on dropping the item instead of generalizing it for all dropped
 items like CB does.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index f56fc6bc4da573cd73c72e3c61a96c4f1eebeb94..e45567e8112483d947e2ff12c01219b85b09b205 100644
+index b65d816bb9feb18ecf74e10e9728c302e5657587..62ec627e80b87a92a2a51ba9fc3626a67636855f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -976,20 +976,20 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
@@ -91,7 +91,7 @@ index 25890e244d8909fdd6f48e148209107a30e3382e..33274654dd7faed3642770fc1d94718f
              return this.spawnAtLocation(entityitem);
          }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2cbb4ff57117382791eefa4881fc0b328c77d58a..3def6b7919484c330bc1c4aea1a8e2c6ad21f999 100644
+index b28e2d35df067e5f526d8990d633ca4a6d6c453b..306b55276189099bbbc8f2c86ad7428381fcf58c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -278,7 +278,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -152,10 +152,10 @@ index 5bcb9a53ebebeef4bd6ec2458df4b63002ebd804..2f398750bfee5758ad8b1367b6fc1436
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a8365c67e28d530734b8527ce67d83decee41beb..5ba2fb40e4db033a069b7368b481ac81be109e94 100644
+index 3e1ef91d7f0bd098e7c7ebee49c43ca9436947b8..5dea6473f04bcbbb7d0d8c9289fe31434233065e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -973,18 +973,24 @@ public class CraftEventFactory {
+@@ -975,18 +975,24 @@ public class CraftEventFactory {
      }
  
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, DamageSource damageSource) {
@@ -184,7 +184,7 @@ index a8365c67e28d530734b8527ce67d83decee41beb..5ba2fb40e4db033a069b7368b481ac81
          populateFields(victim, event); // Paper - make cancellable
          CraftWorld world = (CraftWorld) entity.getWorld();
          Bukkit.getServer().getPluginManager().callEvent(event);
-@@ -998,20 +1004,24 @@ public class CraftEventFactory {
+@@ -1000,20 +1006,24 @@ public class CraftEventFactory {
          victim.expToDrop = event.getDroppedExp();
          lootCheck.run(); // Paper - advancement triggers before destroying items
  
@@ -213,7 +213,7 @@ index a8365c67e28d530734b8527ce67d83decee41beb..5ba2fb40e4db033a069b7368b481ac81
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
          populateFields(victim, event); // Paper - make cancellable
-@@ -1029,16 +1039,14 @@ public class CraftEventFactory {
+@@ -1031,16 +1041,14 @@ public class CraftEventFactory {
          victim.expToDrop = event.getDroppedExp();
          victim.newExp = event.getNewExp();
  

--- a/patches/server/0921-Add-drops-to-shear-events.patch
+++ b/patches/server/0921-Add-drops-to-shear-events.patch
@@ -317,10 +317,10 @@ index dc6230458e09f7555eee7f6a567ff60ad454666b..9d50b9ac8084f3db1844cc7ad1ce9153
      public boolean readyForShearing() {
          return !this.isSheared() && this.isAlive();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 5ba2fb40e4db033a069b7368b481ac81be109e94..5af27ba31f293ba6bcac37047b760db1c3bd8c5f 100644
+index 5dea6473f04bcbbb7d0d8c9289fe31434233065e..4efd60ec678a8f291401e293862f6bfbf376a2b0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1689,20 +1689,20 @@ public class CraftEventFactory {
+@@ -1691,20 +1691,20 @@ public class CraftEventFactory {
          player.level().getCraftServer().getPluginManager().callEvent(event);
      }
  

--- a/patches/server/0947-Fix-DamageSource-API.patch
+++ b/patches/server/0947-Fix-DamageSource-API.patch
@@ -220,10 +220,10 @@ index 4c6e15535fa40aad8cf1920f392589404f9ba79c..35eb95ef6fb6a0f7ea63351e90741c48
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 5af27ba31f293ba6bcac37047b760db1c3bd8c5f..c21acdf5b445a7f24e0d7a6dfd07a097cb6a95b4 100644
+index 4efd60ec678a8f291401e293862f6bfbf376a2b0..9f66fd2f248f0f63c729eb7bb902a5786dfa2cbd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1092,7 +1092,7 @@ public class CraftEventFactory {
+@@ -1094,7 +1094,7 @@ public class CraftEventFactory {
  
      private static EntityDamageEvent handleEntityDamageEvent(Entity entity, DamageSource source, Map<DamageModifier, Double> modifiers, Map<DamageModifier, Function<? super Double, Double>> modifierFunctions, boolean cancelled) {
          CraftDamageSource bukkitDamageSource = new CraftDamageSource(source);

--- a/patches/server/0963-Fix-helmet-damage-reduction-inconsistencies.patch
+++ b/patches/server/0963-Fix-helmet-damage-reduction-inconsistencies.patch
@@ -7,10 +7,10 @@ Affect the falling stalactite damage type where the
 reduction is not applied like in Vanilla
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c21acdf5b445a7f24e0d7a6dfd07a097cb6a95b4..10598b112b66d660f1b1362d9af1ac85201cd0af 100644
+index 9f66fd2f248f0f63c729eb7bb902a5786dfa2cbd..77ef27f9254235180a8596c6c8c4af750dc759d1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1226,7 +1226,7 @@ public class CraftEventFactory {
+@@ -1228,7 +1228,7 @@ public class CraftEventFactory {
              modifiers.put(DamageModifier.FREEZING, freezingModifier);
              modifierFunctions.put(DamageModifier.FREEZING, freezing);
          }

--- a/patches/server/0965-improve-checking-handled-tags-in-itemmeta.patch
+++ b/patches/server/0965-improve-checking-handled-tags-in-itemmeta.patch
@@ -246,7 +246,7 @@ index 865977ce17fbb8793a1eefd71079729e83f5cfaf..889d43acf4cf7a5917f110105ed05838
          getOrEmpty(tag, CraftMetaArmor.TRIM).ifPresent((trimCompound) -> {
              TrimMaterial trimMaterial = org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(io.papermc.paper.registry.RegistryKey.TRIM_MATERIAL, trimCompound.material()).orElse(null); // Paper - fix upstream not being correct
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
-index b675326f6a4572c60f20efab01f577804eda9221..10d8c2d2d45905745d8dc09b45933307c0aacdc4 100644
+index ecce5d0da946ca279c5608068442cc53437dd2a5..00b5c4ab6111f980db1b9e99f901667741266440 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
 @@ -35,8 +35,8 @@ public class CraftMetaArmorStand extends CraftMetaItem implements com.destroysto
@@ -441,10 +441,10 @@ index 3ff0340c40e9dc9a6e690de15ccade7a0c4e8f02..3f6c5cbbf63631e4b72dc43558651ea9
          getOrEmpty(tag, CraftMetaEntityTag.ENTITY_TAG).ifPresent((nbt) -> {
              this.entityTag = nbt.copyTag();
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
-index 8c1d2d0521da52f9a1262f5433da21700b9b0454..9600b23666668d7d581e2920a4e03e59cc2339fb 100644
+index 8725cd736d255b070f9f8ce7cf47b21e2407fbdd..e9a9882d5030040fb3759c623e99d74f8e5292b2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
-@@ -59,8 +59,8 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -60,8 +60,8 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
          }
      }
  

--- a/patches/server/0966-General-ItemMeta-fixes.patch
+++ b/patches/server/0966-General-ItemMeta-fixes.patch
@@ -659,7 +659,7 @@ index 3f6c5cbbf63631e4b72dc43558651ea94f31ca78..da474a5b963d8e6769d120e9091e60ed
          return true;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
-index e9a9882d5030040fb3759c623e99d74f8e5292b2..6b956ca21f2d1d83194358fdd773fe074b484508 100644
+index e9a9882d5030040fb3759c623e99d74f8e5292b2..b4dd2bd0fac4dbc010190188ea27c5f1d630cd02 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
 @@ -55,7 +55,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
@@ -728,7 +728,7 @@ index e9a9882d5030040fb3759c623e99d74f8e5292b2..6b956ca21f2d1d83194358fdd773fe07
              effects.add((FireworkEffect) obj);
          }
      }
-@@ -215,7 +219,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -215,10 +219,10 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
      }
  
      boolean isFireworkEmpty() {
@@ -736,7 +736,11 @@ index e9a9882d5030040fb3759c623e99d74f8e5292b2..6b956ca21f2d1d83194358fdd773fe07
 +        return !(this.effects != null || this.hasPower()); // Paper - empty effects list should stay on the item
      }
  
-     boolean hasPower() {
+-    boolean hasPower() {
++    public boolean hasPower() { // Paper - add hasPower to API
+         return this.power != null;
+     }
+ 
 @@ -231,7 +235,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
          if (meta instanceof CraftMetaFirework that) {
  
@@ -789,6 +793,15 @@ index e9a9882d5030040fb3759c623e99d74f8e5292b2..6b956ca21f2d1d83194358fdd773fe07
          Preconditions.checkArgument(effects != null, "effects cannot be null");
 -        this.safelyAddEffects(effects);
 +        this.safelyAddEffects(effects, true); // Paper - limit firework effects
+     }
+ 
+     @Override
+@@ -340,7 +349,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+ 
+     @Override
+     public int getPower() {
+-        return this.hasPower() ? this.power : 1;
++        return this.hasPower() ? this.power : 0; // Paper - 0 is correct
      }
  
      @Override

--- a/patches/server/0966-General-ItemMeta-fixes.patch
+++ b/patches/server/0966-General-ItemMeta-fixes.patch
@@ -12,7 +12,7 @@ public net/minecraft/world/level/block/entity/BlockEntity saveId(Lnet/minecraft/
 Co-authored-by: GhastCraftHD <julius.gruenberg@leghast.de>
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index ebe470ca361ec5747a843b60d82f567d41d7c9fa..f9a4bebb321207abb00b1af1c17ebda623cc950e 100644
+index e22d6f787d73fda00bc0961bd3279da2a8ab56e3..17923ab1ca4d8e04fbbac0471f88a856bbb92d10 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -1275,6 +1275,11 @@ public final class ItemStack implements DataComponentHolder {
@@ -146,7 +146,7 @@ index 169fefb64e1af444f7c2efb1234cb6e7779fb717..cb49ff5c94f33f00f626a31d958d2025
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
-index 1c17fb294d83d99ae657eff6a8a986bf72c6ec47..b9d6a4a8f78a0e26d888b6bfdff25c3a3ac17e48 100644
+index d0a8cd89da3b8d87248494056470c306f8fb5ae8..fdc0c1d73bb523f003e4169589f1002375b9c88c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
 @@ -69,6 +69,7 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
@@ -659,10 +659,10 @@ index 3f6c5cbbf63631e4b72dc43558651ea94f31ca78..da474a5b963d8e6769d120e9091e60ed
          return true;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
-index 9600b23666668d7d581e2920a4e03e59cc2339fb..0eceacbb096481d3bd31f5f99e964c88aea2e3fb 100644
+index e9a9882d5030040fb3759c623e99d74f8e5292b2..6b956ca21f2d1d83194358fdd773fe074b484508 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
-@@ -54,7 +54,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -55,7 +55,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
  
          this.power = that.power;
  
@@ -671,7 +671,16 @@ index 9600b23666668d7d581e2920a4e03e59cc2339fb..0eceacbb096481d3bd31f5f99e964c88
              this.effects = new ArrayList<>(that.effects);
          }
      }
-@@ -85,19 +85,14 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -88,7 +88,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+         }
+ 
+         Iterable<?> effects = SerializableMeta.getObject(Iterable.class, map, CraftMetaFirework.EXPLOSIONS.BUKKIT, true);
+-        this.safelyAddEffects(effects);
++        this.safelyAddEffects(effects, false); // Paper - limit firework effects
+     }
+ 
+     static FireworkEffect getEffect(FireworkExplosion explosion) {
+@@ -98,19 +98,14 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
                  .with(CraftMetaFirework.getEffectType(explosion.shape()));
  
          IntList colors = explosion.colors();
@@ -694,16 +703,7 @@ index 9600b23666668d7d581e2920a4e03e59cc2339fb..0eceacbb096481d3bd31f5f99e964c88
          }
  
          return effect.build();
-@@ -153,7 +148,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
-         }
- 
-         Iterable<?> effects = SerializableMeta.getObject(Iterable.class, map, CraftMetaFirework.EXPLOSIONS.BUKKIT, true);
--        this.safelyAddEffects(effects);
-+        this.safelyAddEffects(effects, false); // Paper - limit firework effects
-     }
- 
-     @Override
-@@ -161,7 +156,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -162,7 +157,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
          return !(this.effects == null || this.effects.isEmpty());
      }
  
@@ -712,7 +712,7 @@ index 9600b23666668d7d581e2920a4e03e59cc2339fb..0eceacbb096481d3bd31f5f99e964c88
          if (collection == null || (collection instanceof Collection && ((Collection<?>) collection).isEmpty())) {
              return;
          }
-@@ -173,6 +168,15 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -174,6 +169,15 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
  
          for (Object obj : collection) {
              Preconditions.checkArgument(obj instanceof FireworkEffect, "%s in %s is not a FireworkEffect", obj, collection);
@@ -728,7 +728,7 @@ index 9600b23666668d7d581e2920a4e03e59cc2339fb..0eceacbb096481d3bd31f5f99e964c88
              effects.add((FireworkEffect) obj);
          }
      }
-@@ -214,7 +218,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -215,7 +219,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
      }
  
      boolean isFireworkEmpty() {
@@ -737,16 +737,16 @@ index 9600b23666668d7d581e2920a4e03e59cc2339fb..0eceacbb096481d3bd31f5f99e964c88
      }
  
      boolean hasPower() {
-@@ -230,7 +234,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -231,7 +235,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
          if (meta instanceof CraftMetaFirework that) {
  
-             return (this.hasPower() ? that.hasPower() && this.power == that.power : !that.hasPower())
+             return (Objects.equals(this.power, that.power))
 -                    && (this.hasEffects() ? that.hasEffects() && this.effects.equals(that.effects) : !that.hasEffects());
 +                    && (this.effects != null ? that.effects != null && this.effects.equals(that.effects) : that.effects == null); // Paper
          }
  
          return true;
-@@ -248,7 +252,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -249,7 +253,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
          if (this.hasPower()) {
              hash = 61 * hash + this.power;
          }
@@ -755,7 +755,7 @@ index 9600b23666668d7d581e2920a4e03e59cc2339fb..0eceacbb096481d3bd31f5f99e964c88
              hash = 61 * hash + 13 * this.effects.hashCode();
          }
          return hash != original ? CraftMetaFirework.class.hashCode() ^ hash : hash;
-@@ -258,7 +262,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -259,7 +263,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
      Builder<String, Object> serialize(Builder<String, Object> builder) {
          super.serialize(builder);
  
@@ -764,7 +764,7 @@ index 9600b23666668d7d581e2920a4e03e59cc2339fb..0eceacbb096481d3bd31f5f99e964c88
              builder.put(CraftMetaFirework.EXPLOSIONS.BUKKIT, ImmutableList.copyOf(this.effects));
          }
  
-@@ -283,6 +287,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -284,6 +288,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
      @Override
      public void addEffect(FireworkEffect effect) {
          Preconditions.checkArgument(effect != null, "FireworkEffect cannot be null");
@@ -772,7 +772,7 @@ index 9600b23666668d7d581e2920a4e03e59cc2339fb..0eceacbb096481d3bd31f5f99e964c88
          if (this.effects == null) {
              this.effects = new ArrayList<FireworkEffect>();
          }
-@@ -292,6 +297,10 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -293,6 +298,10 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
      @Override
      public void addEffects(FireworkEffect... effects) {
          Preconditions.checkArgument(effects != null, "effects cannot be null");
@@ -783,7 +783,7 @@ index 9600b23666668d7d581e2920a4e03e59cc2339fb..0eceacbb096481d3bd31f5f99e964c88
          if (effects.length == 0) {
              return;
          }
-@@ -310,7 +319,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+@@ -311,7 +320,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
      @Override
      public void addEffects(Iterable<FireworkEffect> effects) {
          Preconditions.checkArgument(effects != null, "effects cannot be null");
@@ -792,15 +792,6 @@ index 9600b23666668d7d581e2920a4e03e59cc2339fb..0eceacbb096481d3bd31f5f99e964c88
      }
  
      @Override
-@@ -345,7 +354,7 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
-     @Override
-     public void setPower(int power) {
-         Preconditions.checkArgument(power >= 0, "power cannot be less than zero: %s", power);
--        Preconditions.checkArgument(power < 0x80, "power cannot be more than 127: %s", power);
-+        Preconditions.checkArgument(power <= 0xFF, "power cannot be more than 255: %s", power); // Paper - set correct limit
-         this.power = power;
-     }
- }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 index bee2f2f5675b8aaeb2a04ada1f6dba9aa9a14ed3..67181b215312f1f572d6ac5afd289c6540b12829 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
@@ -1857,19 +1848,6 @@ index 6bed0a5c8d9f1ca72678cdf4699128e441a24541..8e03e14d0e65bfdf2196a08220d1408b
          itemMeta.applyToItem(compound);
  
          assertEquals(itemMeta, new CraftMetaItem(compound.build(), null)); // Paper
-diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
-index b6da1c2902139d4c7b01ac7b3407d4f6ac3990e2..1a582ee78334835df79f93cc9fd3669c347d8b3a 100644
---- a/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
-+++ b/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
-@@ -66,7 +66,7 @@ import org.junit.jupiter.api.Test;
- 
- public class ItemMetaTest extends AbstractTestingBase {
- 
--    static final int MAX_FIREWORK_POWER = 127; // Please update ItemStackFireworkTest if/when this gets changed.
-+    static final int MAX_FIREWORK_POWER = 255; // Please update ItemStackFireworkTest if/when this gets changed. // Paper - it changed
- 
-     @Test
-     public void testPowerLimitExact() {
 diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java
 index 6f94c7a19f2f598a836ec7db30332dd95f8675a6..54ffbfd91a03efa2d0d271ed10db4209a2309638 100644
 --- a/src/test/java/org/bukkit/craftbukkit/inventory/PersistentDataContainerTest.java


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
4068c6aa PR-1053: Change docs for max power in FireworkMeta
6b3c241b SPIGOT-7783, SPIGOT-7784, PR-1051: Add Trial Vault & Spawner event API
5fe300ec PR-1052: Fix broken links and minor improvement for checkstyle.xml

CraftBukkit Changes:
7548afcf2 SPIGOT-7872: Fix crash with event-modified teleports
93480d5d6 SPIGOT-7868, PR-1463: Fix default and max power in FireworkMeta
5060d1a84 SPIGOT-7783, SPIGOT-7784, PR-1460: Add Trial Vault & Spawner event API
11dfcae71 PR-1462: Fix broken links and minor improvement for checkstyle.xml

Spigot Changes:
ca581228 Rebuild patches