### PR TITLE
Fix Selector Arguments not working with permission

### DIFF
--- a/patches/server/0764-Fix-EntityArgument-and-EntitySelectorParser-permissi.patch
+++ b/patches/server/0764-Fix-EntityArgument-and-EntitySelectorParser-permissi.patch
@@ -1,15 +1,15 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
 Date: Wed, 26 Oct 2022 13:13:12 -0700
-Subject: [PATCH] Fix EntityArgument suggestion permissions to align with
- EntitySelector#checkPermissions
+Subject: [PATCH] Fix EntityArgument and EntitySelectorParser permissions to
+ align with EntitySelector#checkPermissions
 
 Fixes where the user has permission for selectors but not their
 suggestions, which especially matters when we force suggestions to
 the server for this type
 
 diff --git a/src/main/java/net/minecraft/commands/arguments/EntityArgument.java b/src/main/java/net/minecraft/commands/arguments/EntityArgument.java
-index a327939abe2cce22747366051b6b7aaa2db3a8cc..a8487c18d7ef28143a7750bf096d00bcf1e67113 100644
+index a327939abe2cce22747366051b6b7aaa2db3a8cc..3281ea4dca20d2bb22b2b1c6b9abb1329bc829c1 100644
 --- a/src/main/java/net/minecraft/commands/arguments/EntityArgument.java
 +++ b/src/main/java/net/minecraft/commands/arguments/EntityArgument.java
 @@ -135,7 +135,12 @@ public class EntityArgument implements ArgumentType<EntitySelector> {
@@ -17,12 +17,25 @@ index a327939abe2cce22747366051b6b7aaa2db3a8cc..a8487c18d7ef28143a7750bf096d00bc
  
              stringreader.setCursor(suggestionsbuilder.getStart());
 -            EntitySelectorParser argumentparserselector = new EntitySelectorParser(stringreader, EntitySelectorParser.allowSelectors(icompletionprovider));
-+            // Paper start - Fix EntityArgument suggestion permissions
++            // Paper start - Fix EntityArgument permissions
 +            final boolean permission = object instanceof CommandSourceStack stack
 +                    ? stack.bypassSelectorPermissions || stack.hasPermission(2, "minecraft.command.selector")
 +                    : icompletionprovider.hasPermission(2);
 +            EntitySelectorParser argumentparserselector = new EntitySelectorParser(stringreader, permission);
-+            // Paper end - Fix EntityArgument suggestion permissions
++            // Paper end - Fix EntityArgument permissions
  
              try {
                  argumentparserselector.parse();
+diff --git a/src/main/java/net/minecraft/commands/arguments/selector/EntitySelectorParser.java b/src/main/java/net/minecraft/commands/arguments/selector/EntitySelectorParser.java
+index dd50a530439576f56f245ff0b7eb090f9f0c9180..9d31e29ec62f437e642ed60da69c4b106bd9e770 100644
+--- a/src/main/java/net/minecraft/commands/arguments/selector/EntitySelectorParser.java
++++ b/src/main/java/net/minecraft/commands/arguments/selector/EntitySelectorParser.java
+@@ -133,7 +133,7 @@ public class EntitySelectorParser {
+         boolean flag;
+ 
+         if (source instanceof SharedSuggestionProvider icompletionprovider) {
+-            if (icompletionprovider.hasPermission(2)) {
++            if (source instanceof net.minecraft.commands.CommandSourceStack stack ? stack.bypassSelectorPermissions || stack.hasPermission(2, "minecraft.command.selector") : icompletionprovider.hasPermission(2)) { // Paper - Fix EntityArgument permissions
+                 flag = true;
+                 return flag;
+             }

--- a/patches/server/1012-Fix-entity-type-tags-suggestions-in-selectors.patch
+++ b/patches/server/1012-Fix-entity-type-tags-suggestions-in-selectors.patch
@@ -60,7 +60,7 @@ index e8dcbe7c6d6ed20ad19d2ba1893ad16d917b9993..3e454515360c22a26c9329e4032d5255
                  }
  
 diff --git a/src/main/java/net/minecraft/commands/arguments/EntityArgument.java b/src/main/java/net/minecraft/commands/arguments/EntityArgument.java
-index a8487c18d7ef28143a7750bf096d00bcf1e67113..208b56fff4925cad8d4e0bc843c07372fad034c8 100644
+index 3281ea4dca20d2bb22b2b1c6b9abb1329bc829c1..716d37ea7c398c4f15f362c7759daca9d3fe32cb 100644
 --- a/src/main/java/net/minecraft/commands/arguments/EntityArgument.java
 +++ b/src/main/java/net/minecraft/commands/arguments/EntityArgument.java
 @@ -139,7 +139,7 @@ public class EntityArgument implements ArgumentType<EntitySelector> {
@@ -69,7 +69,7 @@ index a8487c18d7ef28143a7750bf096d00bcf1e67113..208b56fff4925cad8d4e0bc843c07372
                      : icompletionprovider.hasPermission(2);
 -            EntitySelectorParser argumentparserselector = new EntitySelectorParser(stringreader, permission);
 +            EntitySelectorParser argumentparserselector = new EntitySelectorParser(stringreader, permission, true); // Paper - tell clients to ask server for suggestions for EntityArguments
-             // Paper end - Fix EntityArgument suggestion permissions
+             // Paper end - Fix EntityArgument permissions
  
              try {
 @@ -149,7 +149,19 @@ public class EntityArgument implements ArgumentType<EntitySelector> {
@@ -94,7 +94,7 @@ index a8487c18d7ef28143a7750bf096d00bcf1e67113..208b56fff4925cad8d4e0bc843c07372
  
                  SharedSuggestionProvider.suggest((Iterable) iterable, suggestionsbuilder1);
 diff --git a/src/main/java/net/minecraft/commands/arguments/selector/EntitySelectorParser.java b/src/main/java/net/minecraft/commands/arguments/selector/EntitySelectorParser.java
-index dd50a530439576f56f245ff0b7eb090f9f0c9180..1f05594d5f00b6d57ec189273edbd25f2d679d61 100644
+index 9d31e29ec62f437e642ed60da69c4b106bd9e770..ce200e673b54c66cfdf34657db28d3eee28dc4e0 100644
 --- a/src/main/java/net/minecraft/commands/arguments/selector/EntitySelectorParser.java
 +++ b/src/main/java/net/minecraft/commands/arguments/selector/EntitySelectorParser.java
 @@ -116,8 +116,15 @@ public class EntitySelectorParser {


### PR DESCRIPTION
Aligns EntitySelectorParser with everything else.

maybe fixes #11285 and an issue where non-op users cannot use selectors, even if they have minecraft.command.selector