### PR TITLE
verify returned suggestion type

### DIFF
--- a/patches/server/1051-verify-returned-suggestion-type.patch
+++ b/patches/server/1051-verify-returned-suggestion-type.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Isaac - The456 <the456@the456gamer.dev>
+Date: Mon, 19 Aug 2024 12:14:38 +0100
+Subject: [PATCH] verify returned suggestion type
+
+since generic types get erased at runtime, java doesn't actually know what is in the returned. List
+convert it to a String array, which only accepts the one type, which throws the ArrayStoreException when failed. additionally, since this occurs in BukkitCommandNode, the plugin/commands class is not in the stacktrace.
+
+diff --git a/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
+index 0c3c82b28e581286b798ee58ca4193efc2faff4a..e38b5fb5d20cbd1cc7435395f9694bf0d08684a3 100644
+--- a/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
++++ b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
+@@ -116,9 +116,10 @@ public class BukkitCommandNode extends LiteralCommandNode<CommandSourceStack> {
+             Location pos = context.getSource().getLocation();
+             try {
+                 results = this.command.tabComplete(sender, this.literal, args, pos.clone());
+-            } catch (CommandException ex) {
++                results.toArray(new String[0]);
++            } catch (CommandException | ArrayStoreException ex) {
+                 sender.sendMessage(ChatColor.RED + "An internal error occurred while attempting to tab-complete this command");
+-                Bukkit.getServer().getLogger().log(Level.SEVERE, "Exception when " + sender.getName() + " attempted to tab complete " + builder.getRemaining(), ex);
++                Bukkit.getServer().getLogger().log(Level.SEVERE, "Exception when " + sender.getName() + " attempted to tab complete " + builder.getRemaining() + "from command "+this.command.getClass(), ex);
+             }
+ 
+             if (sender instanceof final Player player) {

--- a/patches/server/1051-verify-returned-suggestion-type.patch
+++ b/patches/server/1051-verify-returned-suggestion-type.patch
@@ -7,7 +7,7 @@ since generic types get erased at runtime, java doesn't actually know what is in
 convert it to a String array, which only accepts the one type, which throws the ArrayStoreException when failed. additionally, since this occurs in BukkitCommandNode, the plugin/commands class is not in the stacktrace.
 
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
-index 0c3c82b28e581286b798ee58ca4193efc2faff4a..e38b5fb5d20cbd1cc7435395f9694bf0d08684a3 100644
+index 0c3c82b28e581286b798ee58ca4193efc2faff4a..b7ff65d4ad8cedf2bac3f038b07afeb5de4a4baf 100644
 --- a/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
 +++ b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
 @@ -116,9 +116,10 @@ public class BukkitCommandNode extends LiteralCommandNode<CommandSourceStack> {
@@ -19,7 +19,7 @@ index 0c3c82b28e581286b798ee58ca4193efc2faff4a..e38b5fb5d20cbd1cc7435395f9694bf0
 +            } catch (CommandException | ArrayStoreException ex) {
                  sender.sendMessage(ChatColor.RED + "An internal error occurred while attempting to tab-complete this command");
 -                Bukkit.getServer().getLogger().log(Level.SEVERE, "Exception when " + sender.getName() + " attempted to tab complete " + builder.getRemaining(), ex);
-+                Bukkit.getServer().getLogger().log(Level.SEVERE, "Exception when " + sender.getName() + " attempted to tab complete " + builder.getRemaining() + "from command "+this.command.getClass(), ex);
++                Bukkit.getServer().getLogger().log(Level.SEVERE, "Exception when " + sender.getName() + " attempted to tab complete " + builder.getRemaining() + " from command " + this.command.getClass(), ex);
              }
  
              if (sender instanceof final Player player) {


### PR DESCRIPTION
draft: need to figure out where else in the api is/isnt typesafe for lists.

since generic types get erased at runtime, java doesn't actually know what is in the returned. 
here i convert it to a String array, 
which only accepts the one type, which throws the ArrayStoreException when failed. 

additionally, since this occurs in BukkitCommandNode, the plugin/commands class is not in the stacktrace, so i add the command class to the error log.

made to help diagnose what plugin was causing [this](https://discord.com/channels/289587909051416579/289587909051416579/1275042054480597015)
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-11299.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1827170120.zip)