### PR TITLE
Fix structure check API

### DIFF
--- a/patches/server/0913-Add-Structure-check-API.patch
+++ b/patches/server/0913-Add-Structure-check-API.patch
@@ -5,24 +5,19 @@ Subject: [PATCH] Add Structure check API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 612dc787880e58e8325a658a63f9fe7536d0860c..cb6df90fd65f0286f4ff74e6d1e203293e6e0429 100644
+index 612dc787880e58e8325a658a63f9fe7536d0860c..c664e8ca115c0a0f64e6b54478a0a2e88e8a58b7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -236,6 +236,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -236,6 +236,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          };
      }
      // Paper end
 +    // Paper start - structure check API
 +    @Override
 +    public boolean hasStructureAt(final io.papermc.paper.math.Position position, final Structure structure) {
-+        net.minecraft.world.level.levelgen.structure.Structure vanillaStructure = this.world.registryAccess()
-+            .registryOrThrow(net.minecraft.core.registries.Registries.STRUCTURE)
-+            .getHolder(CraftNamespacedKey.toMinecraft(structure.getKey()))
-+            .orElseThrow()
-+            .value();
 +        return this.world.structureManager().getStructureWithPieceAt(
 +            io.papermc.paper.util.MCUtil.toBlockPos(position),
-+            vanillaStructure
++            CraftSructure.bukkitToMinecraft(structure)
 +        ).isValid();
 +    }
 +    // Paper end

--- a/patches/server/0913-Add-Structure-check-API.patch
+++ b/patches/server/0913-Add-Structure-check-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add Structure check API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 612dc787880e58e8325a658a63f9fe7536d0860c..ebb119ab9f5a8ae580e54cb3c102cd86f948a8d2 100644
+index 612dc787880e58e8325a658a63f9fe7536d0860c..cb6df90fd65f0286f4ff74e6d1e203293e6e0429 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -236,6 +236,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -17,7 +17,7 @@ index 612dc787880e58e8325a658a63f9fe7536d0860c..ebb119ab9f5a8ae580e54cb3c102cd86
 +    public boolean hasStructureAt(final io.papermc.paper.math.Position position, final Structure structure) {
 +        net.minecraft.world.level.levelgen.structure.Structure vanillaStructure = this.world.registryAccess()
 +            .registryOrThrow(net.minecraft.core.registries.Registries.STRUCTURE)
-+            .getHolder(CraftNamespacedKey.toMinecraft(structure.getStructureType().getKey()))
++            .getHolder(CraftNamespacedKey.toMinecraft(structure.getKey()))
 +            .orElseThrow()
 +            .value();
 +        return this.world.structureManager().getStructureWithPieceAt(

--- a/patches/server/0913-Add-Structure-check-API.patch
+++ b/patches/server/0913-Add-Structure-check-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add Structure check API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 612dc787880e58e8325a658a63f9fe7536d0860c..c664e8ca115c0a0f64e6b54478a0a2e88e8a58b7 100644
+index 612dc787880e58e8325a658a63f9fe7536d0860c..7d54a29047d210170edf61c6182a6a8d02aa5f72 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -236,6 +236,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -17,7 +17,7 @@ index 612dc787880e58e8325a658a63f9fe7536d0860c..c664e8ca115c0a0f64e6b54478a0a2e8
 +    public boolean hasStructureAt(final io.papermc.paper.math.Position position, final Structure structure) {
 +        return this.world.structureManager().getStructureWithPieceAt(
 +            io.papermc.paper.util.MCUtil.toBlockPos(position),
-+            CraftSructure.bukkitToMinecraft(structure)
++            CraftStructure.bukkitToMinecraft(structure)
 +        ).isValid();
 +    }
 +    // Paper end

--- a/patches/server/0941-More-Raid-API.patch
+++ b/patches/server/0941-More-Raid-API.patch
@@ -86,10 +86,10 @@ index b8ce1c1c2447f9cff1717bfcfd6eb911ade0d4b3..51f21af9d75769abdcba713b9aa33392
 +    // Paper end - more Raid API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ebb119ab9f5a8ae580e54cb3c102cd86f948a8d2..94640aa827c9b2e1d0174eb012fdb37c0851f501 100644
+index c664e8ca115c0a0f64e6b54478a0a2e88e8a58b7..1beb22285857778f7b0f33daa265046f657be854 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2306,6 +2306,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2301,6 +2301,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (raid == null) ? null : new CraftRaid(raid);
      }
  

--- a/patches/server/0987-Moonrise-optimisation-patches.patch
+++ b/patches/server/0987-Moonrise-optimisation-patches.patch
@@ -32731,7 +32731,7 @@ index 69c7fe5bf5b914276a9f7a0e57ce668e569d91f9..33322b57b4c6922f4daad0f584733f0f
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 43a94a67b337f40522c25cc2252a6a5e1294ca0b..40c6ce263c025d26190f21adceaf899723da5a19 100644
+index d8b842bfd1507ace84943ff1f9ddc6ea153e54db..266b720ffe2a684dcf54456e3a198f90baf96ba3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1428,7 +1428,7 @@ public final class CraftServer implements Server {
@@ -32762,10 +32762,10 @@ index 43a94a67b337f40522c25cc2252a6a5e1294ca0b..40c6ce263c025d26190f21adceaf8997
  
      // Paper start - Adventure
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 94640aa827c9b2e1d0174eb012fdb37c0851f501..5ad2ceb1274648631689215702a12463c681152c 100644
+index 1beb22285857778f7b0f33daa265046f657be854..f8d9446acd34d8f1d2e58288d742dbb4da2691ce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -456,10 +456,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -451,10 +451,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          ChunkHolder playerChunk = this.world.getChunkSource().chunkMap.getVisibleChunkIfPresent(ChunkPos.asLong(x, z));
          if (playerChunk == null) return false;
  
@@ -32783,7 +32783,7 @@ index 94640aa827c9b2e1d0174eb012fdb37c0851f501..5ad2ceb1274648631689215702a12463
  
                  ClientboundLevelChunkWithLightPacket refreshPacket = new ClientboundLevelChunkWithLightPacket(chunk, this.world.getLightEngine(), null, null);
                  for (ServerPlayer player : playersInRange) {
-@@ -467,8 +471,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -462,8 +466,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
                      player.connection.send(refreshPacket);
                  }
@@ -32793,7 +32793,7 @@ index 94640aa827c9b2e1d0174eb012fdb37c0851f501..5ad2ceb1274648631689215702a12463
  
          return true;
      }
-@@ -572,20 +575,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -567,20 +570,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public Collection<Plugin> getPluginChunkTickets(int x, int z) {
          DistanceManager chunkDistanceManager = this.world.getChunkSource().chunkMap.distanceManager;
@@ -32815,7 +32815,7 @@ index 94640aa827c9b2e1d0174eb012fdb37c0851f501..5ad2ceb1274648631689215702a12463
      }
  
      @Override
-@@ -593,7 +584,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -588,7 +579,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Map<Plugin, ImmutableList.Builder<Chunk>> ret = new HashMap<>();
          DistanceManager chunkDistanceManager = this.world.getChunkSource().chunkMap.distanceManager;
  
@@ -32824,7 +32824,7 @@ index 94640aa827c9b2e1d0174eb012fdb37c0851f501..5ad2ceb1274648631689215702a12463
              long chunkKey = chunkTickets.getLongKey();
              SortedArraySet<Ticket<?>> tickets = chunkTickets.getValue();
  
-@@ -1290,12 +1281,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1285,12 +1276,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public int getViewDistance() {
@@ -32839,7 +32839,7 @@ index 94640aa827c9b2e1d0174eb012fdb37c0851f501..5ad2ceb1274648631689215702a12463
      }
  
      public BlockMetadataStore getBlockMetadata() {
-@@ -2433,17 +2424,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2428,17 +2419,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setSimulationDistance(final int simulationDistance) {

--- a/patches/server/0998-Anti-Xray.patch
+++ b/patches/server/0998-Anti-Xray.patch
@@ -1155,7 +1155,7 @@ index 32634e45ac8433648e49e47e20081e15ad41ff15..dafa2cf7d3c49fc5bdcd68d2a9528127
          if (io.papermc.paper.event.packet.PlayerChunkLoadEvent.getHandlerList().getRegisteredListeners().length > 0) {
              new io.papermc.paper.event.packet.PlayerChunkLoadEvent(new org.bukkit.craftbukkit.CraftChunk(chunk), handler.getPlayer().getBukkitEntity()).callEvent();
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index eec536d493575f593dd71c63944b047566f3822d..0a97d45f96b3b3cd12fa99373fcb5999c3fba96b 100644
+index 4b597ed9a71908ecec3b6da5b6a4a735cf22498b..96eea87534b6e28a56c9eea0f30bfb41793440e7 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -414,7 +414,7 @@ public abstract class PlayerList {
@@ -1231,7 +1231,7 @@ index a7fc4b027cee8e1ed2678be7060040494a65682a..75c8125e20b70433fe9d143a3193d821
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 3fa7bfa09b9d529b5cb9cad923f21343159cfa35..8c865cd4e50ad55679a8bd89835caa40cc101f35 100644
+index d94e24cfc56c195a47665c212f8fcc901648a4a1..b1a6dc25b04ab6a43e8d62378e14d88d1c60bbbe 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -91,7 +91,7 @@ public class LevelChunk extends ChunkAccess implements ca.spottedleaf.moonrise.p
@@ -1574,7 +1574,7 @@ index 33322b57b4c6922f4daad0f584733f0f24083911..45e262308aebafa377a2353661acdd12
      private static final byte[] EMPTY_LIGHT = new byte[2048];
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cc1f3c7fec4fa794da0b19f44ced9fd482dfdfc7..3a91faeb6957e4e783b1de3e1145e7d1d164a857 100644
+index 266b720ffe2a684dcf54456e3a198f90baf96ba3..05001bb637d55aaf36359b37a42ef33e4557b9f2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2686,7 +2686,7 @@ public final class CraftServer implements Server {
@@ -1587,10 +1587,10 @@ index cc1f3c7fec4fa794da0b19f44ced9fd482dfdfc7..3a91faeb6957e4e783b1de3e1145e7d1
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5ad2ceb1274648631689215702a12463c681152c..86ed89a2eae5f36d902cd8dc4bd0389e066b4bba 100644
+index f8d9446acd34d8f1d2e58288d742dbb4da2691ce..0b9e4f68df87e89bda458ce715982c6db780ebc4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -465,11 +465,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -460,11 +460,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  List<ServerPlayer> playersInRange = playerChunk.playerProvider.getPlayers(playerChunk.getPos(), false);
                  if (playersInRange.isEmpty()) return true; // Paper - chunk system
  

--- a/patches/server/1028-Fix-CraftWorld-isChunkGenerated.patch
+++ b/patches/server/1028-Fix-CraftWorld-isChunkGenerated.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix CraftWorld#isChunkGenerated
 The upstream implementation is returning true for non-full chunks.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 86ed89a2eae5f36d902cd8dc4bd0389e066b4bba..362ca138a5cd5ad19f1300015c2571794adc3649 100644
+index 0b9e4f68df87e89bda458ce715982c6db780ebc4..7f523399774ba395a6bc99d92553c6e4def80eab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -367,11 +367,28 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -362,11 +362,28 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {


### PR DESCRIPTION
Fixes structure check API to look for structure in the Structures registry, instead of trying to look for structure types in the Structures registry (which throws an exception when looking for villages and other structures that doesn't have the same structure id and structure type id)