### PR TITLE
Fix allowSpiderWorldBorderClimbing world config

### DIFF
--- a/patches/server/0786-Add-config-option-for-spider-worldborder-climbing.patch
+++ b/patches/server/0786-Add-config-option-for-spider-worldborder-climbing.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add config option for spider worldborder climbing
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Spider.java b/src/main/java/net/minecraft/world/entity/monster/Spider.java
-index c80019f0c9f814c5259b4d3ec2d8a85669dc728f..6006480d9f6d60bb7b5628eabe6740013066cde4 100644
+index 02171952fad7a17d93e81d95498b8244b807ffe2..a30fb47559eb74b7fe634678e63a85e7e2cad9a4 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Spider.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Spider.java
 @@ -82,7 +82,7 @@ public class Spider extends Monster {
@@ -13,7 +13,7 @@ index c80019f0c9f814c5259b4d3ec2d8a85669dc728f..6006480d9f6d60bb7b5628eabe674001
          super.tick();
          if (!this.level().isClientSide) {
 -            this.setClimbing(this.horizontalCollision);
-+            this.setClimbing(this.horizontalCollision && (this.level().paperConfig().entities.behavior.allowSpiderWorldBorderClimbing)); // Paper - Add config option for spider worldborder climbing
++            this.setClimbing(this.horizontalCollision && (this.level().paperConfig().entities.behavior.allowSpiderWorldBorderClimbing || !(ca.spottedleaf.moonrise.patches.collisions.CollisionUtil.isCollidingWithBorder(this.level().getWorldBorder(), this.getBoundingBox().inflate(ca.spottedleaf.moonrise.patches.collisions.CollisionUtil.COLLISION_EPSILON)) && this.level().getWorldBorder().isInsideCloseToBorder(this, this.getBoundingBox())))); // Paper - Add config option for spider worldborder climbing (Inflate by +EPSILON as collision will just barely place us outside border)
          }
  
      }

--- a/patches/server/0911-Don-t-fire-sync-events-during-worldgen.patch
+++ b/patches/server/0911-Don-t-fire-sync-events-during-worldgen.patch
@@ -107,7 +107,7 @@ index e8a5bd0341115094a729914611430c9f28c77d84..b28e2d35df067e5f526d8990d633ca4a
                  this.onEffectUpdated(mobeffect1, true, entity);
                  // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Spider.java b/src/main/java/net/minecraft/world/entity/monster/Spider.java
-index 6006480d9f6d60bb7b5628eabe6740013066cde4..f0127f1b55999aa4a841341ad02cbcde45702b50 100644
+index c80019f0c9f814c5259b4d3ec2d8a85669dc728f..e7ed427dbbbf4582ea1cb7bba530368cc19d8749 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Spider.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Spider.java
 @@ -172,7 +172,7 @@ public class Spider extends Monster {

--- a/patches/server/0955-Add-config-for-mobs-immune-to-default-effects.patch
+++ b/patches/server/0955-Add-config-for-mobs-immune-to-default-effects.patch
@@ -18,7 +18,7 @@ index 62271e74399a827a488159da234465ef18e15e6e..d3b4d492aee380dc17f4232d90eaae4f
  
      private class WitherDoNothingGoal extends Goal {
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Spider.java b/src/main/java/net/minecraft/world/entity/monster/Spider.java
-index f0127f1b55999aa4a841341ad02cbcde45702b50..e675f1e3e5b6f9e1aa0d928ebb9abe76458edb38 100644
+index e7ed427dbbbf4582ea1cb7bba530368cc19d8749..02171952fad7a17d93e81d95498b8244b807ffe2 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Spider.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Spider.java
 @@ -126,7 +126,7 @@ public class Spider extends Monster {


### PR DESCRIPTION
The implementation has been dropped some version ago and now only toggle the climbing ability of spiders without checking the border collision. Additionally fixed a flaw in the previous implementation that disallowed spider outside the border to climb any block.