### PR TITLE
Prevent duplicate pickup event for piglins

### DIFF
--- a/patches/server/0752-EntityPickupItemEvent-fixes.patch
+++ b/patches/server/0752-EntityPickupItemEvent-fixes.patch
@@ -25,7 +25,7 @@ index d2dfa49e124460f4762b950f9ded106d2ec15dc2..bc58323801ee16fe9b63c21332144ec0
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java b/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java
-index d3d50ec0f4466464c048449d8a844569c447d59b..ef9a16d425bbb6bcb8f39f4ca3b230a61e08571d 100644
+index d3d50ec0f4466464c048449d8a844569c447d59b..b9810a1f6ac91ae9631dd1ebc225f009d91b7845 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java
 @@ -242,11 +242,16 @@ public class PiglinAi {
@@ -51,7 +51,7 @@ index d3d50ec0f4466464c048449d8a844569c447d59b..ef9a16d425bbb6bcb8f39f4ca3b230a6
              PiglinAi.eat(piglin);
          } else {
 -            boolean flag = !piglin.equipItemIfPossible(itemstack, drop).equals(ItemStack.EMPTY); // CraftBukkit
-+            boolean flag = !piglin.equipItemIfPossible(itemstack).equals(ItemStack.EMPTY); // CraftBukkit // Paper - prevent duplicate event call
++            boolean flag = !piglin.equipItemIfPossible(itemstack, null).equals(ItemStack.EMPTY); // CraftBukkit // Paper - pass null item entity to prevent duplicate pickup item event call - called above.
  
              if (!flag) {
                  PiglinAi.putInInventory(piglin, itemstack);

--- a/patches/server/0752-EntityPickupItemEvent-fixes.patch
+++ b/patches/server/0752-EntityPickupItemEvent-fixes.patch
@@ -25,7 +25,7 @@ index d2dfa49e124460f4762b950f9ded106d2ec15dc2..bc58323801ee16fe9b63c21332144ec0
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java b/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java
-index d3d50ec0f4466464c048449d8a844569c447d59b..0192b62fd66621a72fcf2f20896647e5950ba993 100644
+index d3d50ec0f4466464c048449d8a844569c447d59b..ef9a16d425bbb6bcb8f39f4ca3b230a61e08571d 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java
 @@ -242,11 +242,16 @@ public class PiglinAi {
@@ -46,6 +46,15 @@ index d3d50ec0f4466464c048449d8a844569c447d59b..0192b62fd66621a72fcf2f20896647e5
              piglin.take(drop, 1);
              itemstack = PiglinAi.removeOneItemFromItemEntity(drop);
          } else {
+@@ -261,7 +266,7 @@ public class PiglinAi {
+         } else if (PiglinAi.isFood(itemstack) && !PiglinAi.hasEatenRecently(piglin)) {
+             PiglinAi.eat(piglin);
+         } else {
+-            boolean flag = !piglin.equipItemIfPossible(itemstack, drop).equals(ItemStack.EMPTY); // CraftBukkit
++            boolean flag = !piglin.equipItemIfPossible(itemstack).equals(ItemStack.EMPTY); // CraftBukkit // Paper - prevent duplicate event call
+ 
+             if (!flag) {
+                 PiglinAi.putInInventory(piglin, itemstack);
 diff --git a/src/main/java/net/minecraft/world/entity/raid/Raider.java b/src/main/java/net/minecraft/world/entity/raid/Raider.java
 index 174d246b0a4d0fc9d769aad08da627ca8487bdf2..bbf21ea433f9e3963aac0ede597ed8d3c8e50ed8 100644
 --- a/src/main/java/net/minecraft/world/entity/raid/Raider.java


### PR DESCRIPTION
Piglins currently call the EntityPickupItemEvent twice when taking gold nugget / armor items (not golden) if the event is not cancelled.