### PR TITLE
Ensure MaterialChoice materials are items

### DIFF
--- a/patches/api/0469-Fix-issues-with-recipe-API.patch
+++ b/patches/api/0469-Fix-issues-with-recipe-API.patch
@@ -13,6 +13,9 @@ recipes and ingredient slots.
 Also fixes some issues regarding mutability of both ItemStack
 and implementations of RecipeChoice.
 
+Also adds some validation regarding Materials passed to RecipeChoice
+being items.
+
 diff --git a/src/main/java/org/bukkit/inventory/CookingRecipe.java b/src/main/java/org/bukkit/inventory/CookingRecipe.java
 index f7fa79393aef40027446b78bac8e9490cfafd8bc..07906ca1a9b39fcc6774870daa498402f7f37917 100644
 --- a/src/main/java/org/bukkit/inventory/CookingRecipe.java
@@ -126,7 +129,7 @@ index 39f9766a03d420340d79841197f75c8b1dd49f4a..4e59f5176fd6cf92457ad750081c253a
          }
      }
 diff --git a/src/main/java/org/bukkit/inventory/RecipeChoice.java b/src/main/java/org/bukkit/inventory/RecipeChoice.java
-index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..e7796054f3f65f5bea7f93c75320195f6c2f0561 100644
+index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..bf951cf213feb113179d570ce2dd0c2b354baa5f 100644
 --- a/src/main/java/org/bukkit/inventory/RecipeChoice.java
 +++ b/src/main/java/org/bukkit/inventory/RecipeChoice.java
 @@ -22,6 +22,19 @@ import org.jetbrains.annotations.NotNull;
@@ -163,7 +166,26 @@ index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..e7796054f3f65f5bea7f93c75320195f
      /**
       * Represents a choice of multiple matching Materials.
       */
-@@ -152,6 +172,16 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -62,6 +82,10 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+         public MaterialChoice(@NotNull Tag<Material> choices) {
+             Preconditions.checkArgument(choices != null, "choices");
+             this.choices = new ArrayList<>(choices.getValues());
++
++            for (Material choice : this.choices) {
++                Preconditions.checkArgument(choice.isItem(), "Cannot have non-item choice %s", choice);
++            }
+         }
+ 
+         public MaterialChoice(@NotNull List<Material> choices) {
+@@ -78,6 +102,7 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+                 }
+ 
+                 Preconditions.checkArgument(!choice.isAir(), "Cannot have empty/air choice");
++                Preconditions.checkArgument(choice.isItem(), "Cannot have non-item choice %s", choice);
+                 this.choices.add(choice);
+             }
+         }
+@@ -152,6 +177,16 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public String toString() {
              return "MaterialChoice{" + "choices=" + choices + '}';
          }
@@ -180,7 +202,7 @@ index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..e7796054f3f65f5bea7f93c75320195f
      }
  
      /**
-@@ -197,7 +227,12 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -197,7 +232,12 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public ExactChoice clone() {
              try {
                  ExactChoice clone = (ExactChoice) super.clone();
@@ -194,7 +216,7 @@ index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..e7796054f3f65f5bea7f93c75320195f
                  return clone;
              } catch (CloneNotSupportedException ex) {
                  throw new AssertionError(ex);
-@@ -244,5 +279,15 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -244,5 +284,15 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public String toString() {
              return "ExactChoice{" + "choices=" + choices + '}';
          }

--- a/patches/api/0469-Fix-issues-with-recipe-API.patch
+++ b/patches/api/0469-Fix-issues-with-recipe-API.patch
@@ -129,7 +129,7 @@ index 39f9766a03d420340d79841197f75c8b1dd49f4a..4e59f5176fd6cf92457ad750081c253a
          }
      }
 diff --git a/src/main/java/org/bukkit/inventory/RecipeChoice.java b/src/main/java/org/bukkit/inventory/RecipeChoice.java
-index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..9b87fd7a8ee608955e187108f16cabdcdcceba13 100644
+index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..f1aa67997f904953742e8895e49341c2f73d44a2 100644
 --- a/src/main/java/org/bukkit/inventory/RecipeChoice.java
 +++ b/src/main/java/org/bukkit/inventory/RecipeChoice.java
 @@ -22,6 +22,19 @@ import org.jetbrains.annotations.NotNull;
@@ -166,16 +166,17 @@ index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..9b87fd7a8ee608955e187108f16cabdc
      /**
       * Represents a choice of multiple matching Materials.
       */
-@@ -62,6 +82,8 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -60,8 +80,7 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+          * @param choices the tag
+          */
          public MaterialChoice(@NotNull Tag<Material> choices) {
-             Preconditions.checkArgument(choices != null, "choices");
-             this.choices = new ArrayList<>(choices.getValues());
-+
-+            this.choices.forEach(choice -> Preconditions.checkArgument(choice.isItem(), "Cannot have non-item choice %s", choice)); // Paper - validate material choice input to items
+-            Preconditions.checkArgument(choices != null, "choices");
+-            this.choices = new ArrayList<>(choices.getValues());
++            this(new ArrayList<>(java.util.Objects.requireNonNull(choices, "Cannot create a material choice with null tag").getValues())); // Paper - delegate to list ctor to make sure all checks are called
          }
  
          public MaterialChoice(@NotNull List<Material> choices) {
-@@ -78,6 +100,7 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -78,6 +97,7 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
                  }
  
                  Preconditions.checkArgument(!choice.isAir(), "Cannot have empty/air choice");
@@ -183,7 +184,7 @@ index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..9b87fd7a8ee608955e187108f16cabdc
                  this.choices.add(choice);
              }
          }
-@@ -152,6 +175,16 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -152,6 +172,16 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public String toString() {
              return "MaterialChoice{" + "choices=" + choices + '}';
          }
@@ -200,7 +201,7 @@ index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..9b87fd7a8ee608955e187108f16cabdc
      }
  
      /**
-@@ -197,7 +230,12 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -197,7 +227,12 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public ExactChoice clone() {
              try {
                  ExactChoice clone = (ExactChoice) super.clone();
@@ -214,7 +215,7 @@ index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..9b87fd7a8ee608955e187108f16cabdc
                  return clone;
              } catch (CloneNotSupportedException ex) {
                  throw new AssertionError(ex);
-@@ -244,5 +282,15 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -244,5 +279,15 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public String toString() {
              return "ExactChoice{" + "choices=" + choices + '}';
          }

--- a/patches/api/0469-Fix-issues-with-recipe-API.patch
+++ b/patches/api/0469-Fix-issues-with-recipe-API.patch
@@ -129,7 +129,7 @@ index 39f9766a03d420340d79841197f75c8b1dd49f4a..4e59f5176fd6cf92457ad750081c253a
          }
      }
 diff --git a/src/main/java/org/bukkit/inventory/RecipeChoice.java b/src/main/java/org/bukkit/inventory/RecipeChoice.java
-index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..bf951cf213feb113179d570ce2dd0c2b354baa5f 100644
+index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..9b87fd7a8ee608955e187108f16cabdcdcceba13 100644
 --- a/src/main/java/org/bukkit/inventory/RecipeChoice.java
 +++ b/src/main/java/org/bukkit/inventory/RecipeChoice.java
 @@ -22,6 +22,19 @@ import org.jetbrains.annotations.NotNull;
@@ -166,26 +166,24 @@ index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..bf951cf213feb113179d570ce2dd0c2b
      /**
       * Represents a choice of multiple matching Materials.
       */
-@@ -62,6 +82,10 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -62,6 +82,8 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public MaterialChoice(@NotNull Tag<Material> choices) {
              Preconditions.checkArgument(choices != null, "choices");
              this.choices = new ArrayList<>(choices.getValues());
 +
-+            for (Material choice : this.choices) {
-+                Preconditions.checkArgument(choice.isItem(), "Cannot have non-item choice %s", choice);
-+            }
++            this.choices.forEach(choice -> Preconditions.checkArgument(choice.isItem(), "Cannot have non-item choice %s", choice)); // Paper - validate material choice input to items
          }
  
          public MaterialChoice(@NotNull List<Material> choices) {
-@@ -78,6 +102,7 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -78,6 +100,7 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
                  }
  
                  Preconditions.checkArgument(!choice.isAir(), "Cannot have empty/air choice");
-+                Preconditions.checkArgument(choice.isItem(), "Cannot have non-item choice %s", choice);
++                Preconditions.checkArgument(choice.isItem(), "Cannot have non-item choice %s", choice); // Paper - validate material choice input to items
                  this.choices.add(choice);
              }
          }
-@@ -152,6 +177,16 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -152,6 +175,16 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public String toString() {
              return "MaterialChoice{" + "choices=" + choices + '}';
          }
@@ -202,7 +200,7 @@ index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..bf951cf213feb113179d570ce2dd0c2b
      }
  
      /**
-@@ -197,7 +232,12 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -197,7 +230,12 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public ExactChoice clone() {
              try {
                  ExactChoice clone = (ExactChoice) super.clone();
@@ -216,7 +214,7 @@ index 91bfeffcdbe47208c7d0ddbe013cd0f11fddfa32..bf951cf213feb113179d570ce2dd0c2b
                  return clone;
              } catch (CloneNotSupportedException ex) {
                  throw new AssertionError(ex);
-@@ -244,5 +284,15 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -244,5 +282,15 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
          public String toString() {
              return "ExactChoice{" + "choices=" + choices + '}';
          }


### PR DESCRIPTION
Passing a non-item Material to a MaterialChoice results in an obscure and hard-to-debug error in the depths of the Minecraft codecs.

<details>
<summary>Example of error that doesn't offer any help with identifiying what recipe has a non-item</summary>

```


        [20:17:16 ERROR]: Error sending packet clientbound/minecraft:update_recipes (skippable? false)
        io.netty.handler.codec.EncoderException: Failed to encode packet 'clientbound/minecraft:update_recipes'
                at net.minecraft.network.codec.IdDispatchCodec.encode(IdDispatchCodec.java:53) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.IdDispatchCodec.encode(IdDispatchCodec.java:20) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.PacketEncoder.encode(PacketEncoder.java:26) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.PacketEncoder.encode(PacketEncoder.java:12) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:107) ~[netty-codec-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:113) ~[netty-codec-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.ChannelOutboundHandlerAdapter.write(ChannelOutboundHandlerAdapter.java:113) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at net.minecraft.network.Connection$2.write(Connection.java:807) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:940) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:966) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:934) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:984) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1025) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:306) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
                at net.minecraft.network.Connection.doSendPacket(Connection.java:532) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.Connection.lambda$sendPacket$13(Connection.java:517) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:413) ~[netty-transport-classes-epoll-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
                at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
                at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
        Caused by: io.netty.handler.codec.EncoderException: Empty ItemStack not allowed
                at net.minecraft.world.item.ItemStack$2.encode(ItemStack.java:214) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.world.item.ItemStack$2.encode(ItemStack.java:201) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.ByteBufCodecs$19.encode(ByteBufCodecs.java:413) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.ByteBufCodecs$19.encode(ByteBufCodecs.java:395) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.StreamCodec$4.encode(StreamCodec.java:72) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.world.item.crafting.ShapedRecipePattern.toNetwork(ShapedRecipePattern.java:167) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.StreamCodec$2.encode(StreamCodec.java:38) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.world.item.crafting.ShapedRecipe$Serializer.toNetwork(ShapedRecipe.java:208) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.StreamCodec$1.encode(StreamCodec.java:24) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.StreamCodec$6.encode(StreamCodec.java:107) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.StreamCodec$8.encode(StreamCodec.java:141) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.ByteBufCodecs$19.encode(ByteBufCodecs.java:413) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.ByteBufCodecs$19.encode(ByteBufCodecs.java:395) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.StreamCodec$7.encode(StreamCodec.java:122) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.StreamCodec$5.encode(StreamCodec.java:88) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                at net.minecraft.network.codec.StreamCodec$5.encode(StreamCodec.java:78) ~[folia-1.20.6.jar:1.20.6-DEV-d797082]
                ... 32 more
```

</details>