### PR TITLE
Check dead flag in isAlive()

### DIFF
--- a/patches/server/1055-Check-dead-flag-in-isAlive().patch
+++ b/patches/server/1055-Check-dead-flag-in-isAlive().patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Newwind <support@newwindserver.com>
+Date: Mon, 26 Aug 2024 14:01:37 +0200
+Subject: [PATCH] Check dead flag in isAlive()
+
+If a plugin sets the health of a living entity above 0 after it has already died, the entity will be "revived".
+It will behave the exact same as before, except with the internal "dead" flag set, resulting in 2 behavior changes,
+A: it's completely invulnerable to all damage
+B: it's unable to pickup items
+
+isValid() for these bugged entities will return true, isDead() will return false, despite the dead flag.
+This patch checks that the mob isn't dead before saying its alive.
+
+Also, even if the plugin is responsibly checking !isDead() before modifying health, on very rare circumstances 
+I am currently unable to replicate, these "revived" entities can still appear
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index ccd9dff20..783f58a3f 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -2096,7 +2096,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+ 
+     @Override
+     public boolean isAlive() {
+-        return !this.isRemoved() && this.getHealth() > 0.0F;
++        return !this.isRemoved() && this.getHealth() > 0.0F && !this.dead; // Paper - Check this.dead
+     }
+ 
+     @Override

--- a/patches/server/1057-Check-dead-flag-in-isAlive.patch
+++ b/patches/server/1057-Check-dead-flag-in-isAlive.patch
@@ -11,11 +11,11 @@ B: it's unable to pickup items
 isValid() for these bugged entities will return true, isDead() will return false, despite the dead flag.
 This patch checks that the mob isn't dead before saying its alive.
 
-Also, even if the plugin is responsibly checking !isDead() before modifying health, on very rare circumstances 
+Also, even if the plugin is responsibly checking !isDead() before modifying health, on very rare circumstances
 I am currently unable to replicate, these "revived" entities can still appear
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ccd9dff20..783f58a3f 100644
+index ccd9dff20a60f019e0c320acfb526b8bf3e5f806..9c9e2377f44b1f1bbd8bb0e8bc963a80f4f9ee68 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -2096,7 +2096,7 @@ public abstract class LivingEntity extends Entity implements Attackable {


### PR DESCRIPTION
If a plugin sets the health of a living entity above 0 after it has already died, but before its death ticks reach 20 and remove it fully, the entity will be "revived".
It will behave the exact same as before, except with the internal "dead" flag set, resulting in 2 behavior changes,
A: it's completely invulnerable to all damage
B: it's unable to pickup items

isValid() for these bugged entities will return true, isDead() will return false, despite the dead flag.
This patch checks that the mob isn't dead before saying its alive.

Also, even if the plugin is responsibly checking !isDead() before modifying health, on very rare circumstances 
I am currently unable to replicate, these "revived" entities can still appear