### PR TITLE
Fix: synchronise sending chat to client with updating message signature cache

### DIFF
--- a/patches/server/1055-Fix-synchronise-sending-chat-to-client-with-updating.patch
+++ b/patches/server/1055-Fix-synchronise-sending-chat-to-client-with-updating.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gegy <gegy.dev@gmail.com>
+Date: Mon, 26 Aug 2024 19:45:07 +0200
+Subject: [PATCH] Fix: synchronise sending chat to client with updating message
+ signature cache
+
+In the case where multiple messages from different players are being processed in parallel, there was a potential race condition where the messages would be sent to the client in a different order than the message signature cache was updated. However, the cache relies on the fact that the client and server get the exact same updates in the same order. This race condition would cause the caches to become corrupted, and any future message received by the client would fail to validate.
+
+This also applies to the last seen state of the server, which becomes inconsistent in the same way as the message signature cache and would cause any messages sent to be rejected by the server too.
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index b13057c0792067cc6b0abdf0d64a9be2cc9389a4..1eb56c606712a84a96d1d678ce9070b3d46e5c01 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -2715,8 +2715,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+             return;
+         }
+         // CraftBukkit end
++        // Paper start - Ensure that client receives chat packets in the same order that we add into the message signature cache
++        synchronized (this.messageSignatureCache) {
+         this.send(new ClientboundPlayerChatPacket(message.link().sender(), message.link().index(), message.signature(), message.signedBody().pack(this.messageSignatureCache), message.unsignedContent(), message.filterMask(), params));
+         this.addPendingMessage(message);
++        }
++        // Paper end
+     }
+ 
+     public void sendDisguisedChatMessage(Component message, ChatType.Bound params) {

--- a/patches/server/1055-Fix-synchronise-sending-chat-to-client-with-updating.patch
+++ b/patches/server/1055-Fix-synchronise-sending-chat-to-client-with-updating.patch
@@ -21,7 +21,7 @@ index b13057c0792067cc6b0abdf0d64a9be2cc9389a4..1eb56c606712a84a96d1d678ce9070b3
          this.send(new ClientboundPlayerChatPacket(message.link().sender(), message.link().index(), message.signature(), message.signedBody().pack(this.messageSignatureCache), message.unsignedContent(), message.filterMask(), params));
          this.addPendingMessage(message);
 +        }
-+        // Paper end
++        // Paper end - Ensure that client receives chat packets in the same order that we add into the message signature cache
      }
  
      public void sendDisguisedChatMessage(Component message, ChatType.Bound params) {


### PR DESCRIPTION
In the case where multiple messages from different players are being processed in parallel, there was a potential race condition where the messages would be sent to the client in a different order than the message signature cache was updated. However, the cache relies on the fact that the client and server get the exact same updates in the same order. This race condition would cause the caches to become corrupted, and any future message received by the client would fail to validate.

This also applies to the last seen state of the server, which becomes inconsistent in the same way as the message signature cache and would cause any messages sent to be rejected by the server too.

This can be easily reproduced by having two players very rapidly send chat messages to the server at the same time.