### PR TITLE
Change condition check order of entity tracking Y

### DIFF
--- a/patches/server/0865-Configurable-entity-tracking-range-by-Y-coordinate.patch
+++ b/patches/server/0865-Configurable-entity-tracking-range-by-Y-coordinate.patch
@@ -6,14 +6,16 @@ Subject: [PATCH] Configurable entity tracking range by Y coordinate
 Options to configure entity tracking by Y coordinate, also for each entity category.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index dca6087dc4e1c177c3dfdae01f140cf80c179803..11397b845d5a2dab5d134be8daddc8942d1a63a0 100644
+index dca6087dc4e1c177c3dfdae01f140cf80c179803..57af5d1986021c9a135599c6f55b091aebd3bab7 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1525,6 +1525,15 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1524,7 +1524,17 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+                 double d0 = (double) Math.min(this.getEffectiveRange(), i * 16);
                  double d1 = vec3d.x * vec3d.x + vec3d.z * vec3d.z;
                  double d2 = d0 * d0;
-                 boolean flag = d1 <= d2 && this.entity.broadcastToPlayer(player) && ChunkMap.this.isChunkTracked(player, this.entity.chunkPosition().x, this.entity.chunkPosition().z);
+-                boolean flag = d1 <= d2 && this.entity.broadcastToPlayer(player) && ChunkMap.this.isChunkTracked(player, this.entity.chunkPosition().x, this.entity.chunkPosition().z);
 +                // Paper start - Configurable entity tracking range by Y
++                boolean flag = d1 <= d2;
 +                if (flag && level.paperConfig().entities.trackingRangeY.enabled) {
 +                    double rangeY = level.paperConfig().entities.trackingRangeY.get(this.entity, -1);
 +                    if (rangeY != -1) {
@@ -21,6 +23,7 @@ index dca6087dc4e1c177c3dfdae01f140cf80c179803..11397b845d5a2dab5d134be8daddc894
 +                        flag = vec3d_dy * vec3d_dy <= rangeY * rangeY;
 +                    }
 +                }
++                flag = flag && this.entity.broadcastToPlayer(player) && ChunkMap.this.isChunkTracked(player, this.entity.chunkPosition().x, this.entity.chunkPosition().z);
 +                // Paper end - Configurable entity tracking range by Y
  
                  // CraftBukkit start - respect vanish API

--- a/patches/server/0897-Don-t-check-if-we-can-see-non-visible-entities.patch
+++ b/patches/server/0897-Don-t-check-if-we-can-see-non-visible-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check if we can see non-visible entities
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 11397b845d5a2dab5d134be8daddc8942d1a63a0..babe11e3c76ebb725ff62d1c77744101ba9b4dec 100644
+index 57af5d1986021c9a135599c6f55b091aebd3bab7..6c667823c2ef15766f3afc1a9c819cb6c24b0912 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1536,7 +1536,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1537,7 +1537,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                  // Paper end - Configurable entity tracking range by Y
  
                  // CraftBukkit start - respect vanish API

--- a/patches/server/0926-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
+++ b/patches/server/0926-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
@@ -18,7 +18,7 @@ index a043ac10834562d357ef0b5aded2e916e2a0d056..74276c368016fcc4dbf9579b2ecbadc9
      @VisibleForTesting
      static long encode(double value) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index babe11e3c76ebb725ff62d1c77744101ba9b4dec..6e084fd84c76c32319c6a321650ca2bb8332c704 100644
+index 6c667823c2ef15766f3afc1a9c819cb6c24b0912..4c1cf5798209297e1e8a634b63770e917a84a63c 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1519,10 +1519,14 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -36,8 +36,8 @@ index babe11e3c76ebb725ff62d1c77744101ba9b4dec..6e084fd84c76c32319c6a321650ca2bb
 -                double d1 = vec3d.x * vec3d.x + vec3d.z * vec3d.z;
 +                double d1 = vec3d_dx * vec3d_dx + vec3d_dz * vec3d_dz; // Paper
                  double d2 = d0 * d0;
-                 boolean flag = d1 <= d2 && this.entity.broadcastToPlayer(player) && ChunkMap.this.isChunkTracked(player, this.entity.chunkPosition().x, this.entity.chunkPosition().z);
                  // Paper start - Configurable entity tracking range by Y
+                 boolean flag = d1 <= d2;
 diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
 index a2fbbbd7a66d4e7b1063638f8467e8887a417282..0e7ace92522fbd4cef7b2c2b8a0f8b86c2cce192 100644
 --- a/src/main/java/net/minecraft/server/level/ServerEntity.java

--- a/patches/server/1030-Fix-entity-tracker-desync-when-new-players-are-added.patch
+++ b/patches/server/1030-Fix-entity-tracker-desync-when-new-players-are-added.patch
@@ -48,10 +48,10 @@ index 854baa554da2215a656f976ae2973341c3b2d61c..792b9a72a610cc512a8920d61013b6ba
              entityTrackerEntry.getLastSentYRot(),
              entity.getType(),
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index a183414631a2e640f68370772fe59110c30be98c..1e0a6e5a3c907ab55ee6f2780a7d43bd455f2b7b 100644
+index 21370ed6c7d98d3f3546f0365ac50e5c26ba3bde..af8cb316ac169aa8d98a88765b85bb013b9ba961 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1268,6 +1268,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1269,6 +1269,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                          this.serverEntity.addPairing(player);
                          }
                          // Paper end - entity tracking events


### PR DESCRIPTION
Change the order so that other condition checks are performed after the x, y coordinate condition check.

Before: `x z check` -> `broadcastToPlayer check` -> `ChunkMap.this.isChunkTracked check` -> `y check` -> `canSee check`
After: `x z check` -> `y check` -> `broadcastToPlayer check` -> `ChunkMap.this.isChunkTracked check` -> `canSee check`