### PR TITLE
Fix NPE while trying to respawn an already disconnected player

### DIFF
--- a/patches/server/0282-Add-PlayerPostRespawnEvent.patch
+++ b/patches/server/0282-Add-PlayerPostRespawnEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerPostRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 79203d0e5cdb86d9e2fb22cdaeb8cf3a93e43dcc..f9952da3e7463f9ef1d2444c5ac4fd2b22bcb02e 100644
+index 79203d0e5cdb86d9e2fb22cdaeb8cf3a93e43dcc..b85111d34388bc0e49891b10e28d19f7c643e5c0 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -738,6 +738,10 @@ public abstract class PlayerList {
@@ -33,7 +33,7 @@ index 79203d0e5cdb86d9e2fb22cdaeb8cf3a93e43dcc..f9952da3e7463f9ef1d2444c5ac4fd2b
          }
          // Spigot Start
 -        if (dimensiontransition == null) {
-+        if (dimensiontransition == null) { // Paper - Add PlayerPostRespawnEvent - diff on change - spigot early reaturns if respawn pos is null, that is how they handle disconnected player in respawn event
++        if (dimensiontransition == null) { // Paper - Add PlayerPostRespawnEvent - diff on change - spigot early returns if respawn pos is null, that is how they handle disconnected player in respawn event
              return entityplayer;
          }
          // Spigot End

--- a/patches/server/0282-Add-PlayerPostRespawnEvent.patch
+++ b/patches/server/0282-Add-PlayerPostRespawnEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerPostRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 79203d0e5cdb86d9e2fb22cdaeb8cf3a93e43dcc..a2a913e20cdea9518da5ad0d1ef8908538860890 100644
+index 79203d0e5cdb86d9e2fb22cdaeb8cf3a93e43dcc..f9952da3e7463f9ef1d2444c5ac4fd2b22bcb02e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -738,6 +738,10 @@ public abstract class PlayerList {
@@ -19,18 +19,25 @@ index 79203d0e5cdb86d9e2fb22cdaeb8cf3a93e43dcc..a2a913e20cdea9518da5ad0d1ef89085
  
          // CraftBukkit start - fire PlayerRespawnEvent
          DimensionTransition dimensiontransition;
-@@ -745,6 +749,10 @@ public abstract class PlayerList {
+@@ -745,11 +749,16 @@ public abstract class PlayerList {
              dimensiontransition = entityplayer.findRespawnPositionAndUseSpawnBlock(flag, DimensionTransition.DO_NOTHING, reason);
  
              if (!flag) entityplayer.reset(); // SPIGOT-4785
 +            // Paper start - Add PlayerPostRespawnEvent
++            if (dimensiontransition == null) return entityplayer; // Early exit, mirrors belows early return for disconnected players in kick event
 +            isRespawn = true;
 +            location = CraftLocation.toBukkit(dimensiontransition.pos(), dimensiontransition.newLevel().getWorld(), dimensiontransition.yRot(), dimensiontransition.xRot());
 +            // Paper end - Add PlayerPostRespawnEvent
          } else {
              dimensiontransition = new DimensionTransition(((CraftWorld) location.getWorld()).getHandle(), CraftLocation.toVec3D(location), Vec3.ZERO, location.getYaw(), location.getPitch(), DimensionTransition.DO_NOTHING);
          }
-@@ -795,6 +803,11 @@ public abstract class PlayerList {
+         // Spigot Start
+-        if (dimensiontransition == null) {
++        if (dimensiontransition == null) { // Paper - Add PlayerPostRespawnEvent - diff on change - spigot early reaturns if respawn pos is null, that is how they handle disconnected player in respawn event
+             return entityplayer;
+         }
+         // Spigot End
+@@ -795,6 +804,11 @@ public abstract class PlayerList {
              if (iblockdata.is(Blocks.RESPAWN_ANCHOR)) {
                  entityplayer1.connection.send(new ClientboundSoundPacket(SoundEvents.RESPAWN_ANCHOR_DEPLETE, SoundSource.BLOCKS, (double) blockposition.getX(), (double) blockposition.getY(), (double) blockposition.getZ(), 1.0F, 1.0F, worldserver.getRandom().nextLong()));
              }
@@ -42,7 +49,7 @@ index 79203d0e5cdb86d9e2fb22cdaeb8cf3a93e43dcc..a2a913e20cdea9518da5ad0d1ef89085
          }
          // Added from changeDimension
          this.sendAllPlayerInfo(entityplayer); // Update health, etc...
-@@ -816,6 +829,13 @@ public abstract class PlayerList {
+@@ -816,6 +830,13 @@ public abstract class PlayerList {
          if (entityplayer.connection.isDisconnected()) {
              this.save(entityplayer);
          }

--- a/patches/server/0282-Add-PlayerPostRespawnEvent.patch
+++ b/patches/server/0282-Add-PlayerPostRespawnEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerPostRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 79203d0e5cdb86d9e2fb22cdaeb8cf3a93e43dcc..b85111d34388bc0e49891b10e28d19f7c643e5c0 100644
+index 79203d0e5cdb86d9e2fb22cdaeb8cf3a93e43dcc..8cd80ea83ddcfd5052c8d8c19d3edb42538d1e15 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -738,6 +738,10 @@ public abstract class PlayerList {
@@ -24,7 +24,7 @@ index 79203d0e5cdb86d9e2fb22cdaeb8cf3a93e43dcc..b85111d34388bc0e49891b10e28d19f7
  
              if (!flag) entityplayer.reset(); // SPIGOT-4785
 +            // Paper start - Add PlayerPostRespawnEvent
-+            if (dimensiontransition == null) return entityplayer; // Early exit, mirrors belows early return for disconnected players in kick event
++            if (dimensiontransition == null) return entityplayer; // Early exit, mirrors belows early return for disconnected players in respawn event
 +            isRespawn = true;
 +            location = CraftLocation.toBukkit(dimensiontransition.pos(), dimensiontransition.newLevel().getWorld(), dimensiontransition.yRot(), dimensiontransition.xRot());
 +            // Paper end - Add PlayerPostRespawnEvent

--- a/patches/server/0471-Add-sendOpLevel-API.patch
+++ b/patches/server/0471-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 23bd0e0b62fef174b55b5915a44fee32db02c656..7c334ac1ae2a1b14b7570127e775a5e7d7ab2ae7 100644
+index ffb94fd3e375d7a6520a57e8869583695745a722..40a7ba1b3edab95e245b227d61d5ea14812ceb2e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1065,6 +1065,11 @@ public abstract class PlayerList {
+@@ -1066,6 +1066,11 @@ public abstract class PlayerList {
      }
  
      private void sendPlayerPermissionLevel(ServerPlayer player, int permissionLevel) {
@@ -20,7 +20,7 @@ index 23bd0e0b62fef174b55b5915a44fee32db02c656..7c334ac1ae2a1b14b7570127e775a5e7
          if (player.connection != null) {
              byte b0;
  
-@@ -1079,8 +1084,10 @@ public abstract class PlayerList {
+@@ -1080,8 +1085,10 @@ public abstract class PlayerList {
              player.connection.send(new ClientboundEntityEventPacket(player, b0));
          }
  

--- a/patches/server/0545-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0545-Add-PlayerKickEvent-causes.patch
@@ -419,7 +419,7 @@ index 568f5d7165521304c7a92f32984a1d605d545ad5..b30c71ad0cc2602d2c026433a94c9ca4
  
              }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 28d99ca33606d2ff44c639c78edfcaa131faf626..2b15648549245962c6427af27c3ea34e443b37f3 100644
+index a0e570ae008647c236d24a86325d9bab404f6c9e..a8a92f0bb76467c106da62720dbf9be29caac265 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -675,7 +675,7 @@ public abstract class PlayerList {
@@ -431,7 +431,7 @@ index 28d99ca33606d2ff44c639c78edfcaa131faf626..2b15648549245962c6427af27c3ea34e
          }
  
          // Instead of kicking then returning, we need to store the kick reason
-@@ -1276,7 +1276,7 @@ public abstract class PlayerList {
+@@ -1277,7 +1277,7 @@ public abstract class PlayerList {
          // Paper end
          // CraftBukkit start - disconnect safely
          for (ServerPlayer player : this.players) {

--- a/patches/server/0572-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0572-Add-PlayerSetSpawnEvent.patch
@@ -154,10 +154,10 @@ index d1b21afe48dbe1e53d4a046434336be580497165..2dd10cada8d36ed5565481f3f5a5fba1
  
      public SectionPos getLastSectionPos() {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 2f22ae87cd467b73883a38553fab23f8590d17a1..bc5088b4b8a60dcd87eb9a7e0858a5c45bd9a7d4 100644
+index 3e323c55c01d75b7d2f25d32710afb990b0eee10..5665a0d6ed14e17e1a343794f10e173d864ad9de 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -844,7 +844,7 @@ public abstract class PlayerList {
+@@ -845,7 +845,7 @@ public abstract class PlayerList {
          // CraftBukkit end
          if (dimensiontransition.missingRespawnBlock()) {
              entityplayer1.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.NO_RESPAWN_BLOCK_AVAILABLE, 0.0F));

--- a/patches/server/0692-Use-username-instead-of-display-name-in-PlayerList-g.patch
+++ b/patches/server/0692-Use-username-instead-of-display-name-in-PlayerList-g.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Use username instead of display name in
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 22c1bf5989065016364505a0665a5205fd8528b5..be842c81ae6c6ec64a233f126d7221a37d66439c 100644
+index 4f4546523ec4b7d0dd65b37b5cca128b4d4da793..ada1e8d168b0d4df1a8b9326b6321badef892e39 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1392,7 +1392,7 @@ public abstract class PlayerList {
+@@ -1393,7 +1393,7 @@ public abstract class PlayerList {
      // CraftBukkit start
      public ServerStatsCounter getPlayerStats(ServerPlayer entityhuman) {
          ServerStatsCounter serverstatisticmanager = entityhuman.getStats();

--- a/patches/server/0849-API-for-updating-recipes-on-clients.patch
+++ b/patches/server/0849-API-for-updating-recipes-on-clients.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for updating recipes on clients
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index b8e79cf272f0a87b0fc0c0f61d325ec780b0f6b5..1eed5ebf96f8e8889d5af346d45a401b282bab21 100644
+index b2e131f45e8f1bbefc42b6e16ac482b2fbeafb12..b7fbf6e395aeaaf2353a3d047a0321d4a9b6de3c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1488,6 +1488,13 @@ public abstract class PlayerList {
+@@ -1489,6 +1489,13 @@ public abstract class PlayerList {
      }
  
      public void reloadResources() {
@@ -22,7 +22,7 @@ index b8e79cf272f0a87b0fc0c0f61d325ec780b0f6b5..1eed5ebf96f8e8889d5af346d45a401b
          // CraftBukkit start
          /*Iterator iterator = this.advancements.values().iterator();
  
-@@ -1503,7 +1510,15 @@ public abstract class PlayerList {
+@@ -1504,7 +1511,15 @@ public abstract class PlayerList {
          }
          // CraftBukkit end
  

--- a/patches/server/1002-Optimize-Collision-to-not-load-chunks.patch
+++ b/patches/server/1002-Optimize-Collision-to-not-load-chunks.patch
@@ -14,10 +14,10 @@ movement will load only the chunk the player enters anyways and avoids loading
 massive amounts of surrounding chunks due to large AABB lookups.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 96eea87534b6e28a56c9eea0f30bfb41793440e7..24ff10c4ed69deed2ce9ba25835575419165e2af 100644
+index 59f09e8d08453ef25b7f9f49db0aa7513014779c..cad21e40aafc9c34de10007d881135657ed3d910 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -868,6 +868,7 @@ public abstract class PlayerList {
+@@ -869,6 +869,7 @@ public abstract class PlayerList {
          Vec3 vec3d = dimensiontransition.pos();
  
          entityplayer1.forceSetPositionRotation(vec3d.x, vec3d.y, vec3d.z, dimensiontransition.yRot(), dimensiontransition.xRot());

--- a/patches/server/1036-Incremental-chunk-and-player-saving.patch
+++ b/patches/server/1036-Incremental-chunk-and-player-saving.patch
@@ -108,7 +108,7 @@ index 8dc3ba983fd4c61e463867be8d224aa90424215a..6c280abdef5f80b668d6090f9d35283a
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      private static final int FLY_STAT_RECORDING_SPEED = 25;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index eb94c0a962de4dc389eb309d264b6e1c6c7229aa..0368d6ba9cc9fe557d3c7172a87a7a5b15445e47 100644
+index 0184b807cc23719e91a1b1fdf1788e97e505346a..8d0e2bb3ed6651d4fb0dce02bbad36915a04f8ee 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -569,6 +569,7 @@ public abstract class PlayerList {
@@ -119,7 +119,7 @@ index eb94c0a962de4dc389eb309d264b6e1c6c7229aa..0368d6ba9cc9fe557d3c7172a87a7a5b
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
  
-@@ -1186,10 +1187,22 @@ public abstract class PlayerList {
+@@ -1187,10 +1188,22 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/11352 by adding a new check for not run the method if the connection is in disconnect state, the method depends in many other methods related to connections then can cause NPE in many places of the respawn logic call the method for things like respawn a player in the disconnection state.

Example related to the issue reported for replicate and test.
```java
@EventHandler
public void onQuit(PlayerQuitEvent event) {
    this.getLogger().info("Try to kill " + event.getPlayer().getName());
    event.getPlayer().setHealth(0);
}

@EventHandler
public void onPlayerDeath(EntityDeathEvent event) {
    if (event.getEntity() instanceof Player player) {
        this.getLogger().info("Try to Respawn " + player.getName());
        player.spigot().respawn();
    }
}
```