### PR TITLE
Fix bundled spark permission check

### DIFF
--- a/patches/server/1038-Bundle-spark.patch
+++ b/patches/server/1038-Bundle-spark.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Bundle spark
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 1a734293c9416f13324bb0edf8f950c9029f8bc4..3588770a9ea6ee0a9508b218758650f43d994715 100644
+index 1a734293c9416f13324bb0edf8f950c9029f8bc4..5e68a68d1ff920eb743795ae2048064a244a761c 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -61,6 +61,10 @@ dependencies {
@@ -14,17 +14,17 @@ index 1a734293c9416f13324bb0edf8f950c9029f8bc4..3588770a9ea6ee0a9508b218758650f4
      // Paper end - Remap reflection
 +    // Paper start - spark
 +    implementation("me.lucko:spark-api:0.1-20240720.200737-2")
-+    implementation("me.lucko:spark-paper:1.10.99-SNAPSHOT")
++    implementation("me.lucko:spark-paper:1.10.100-SNAPSHOT")
 +    // Paper end - spark
  }
  
  paperweight {
 diff --git a/src/main/java/io/papermc/paper/SparksFly.java b/src/main/java/io/papermc/paper/SparksFly.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..19ee43e1ca053574a0151b4c43b01972183657e6
+index 0000000000000000000000000000000000000000..2955b7ec9832a5752ea4aff9fc9d34ae2f9ee83e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/SparksFly.java
-@@ -0,0 +1,200 @@
+@@ -0,0 +1,201 @@
 +package io.papermc.paper;
 +
 +import io.papermc.paper.configuration.GlobalConfiguration;
@@ -32,6 +32,7 @@ index 0000000000000000000000000000000000000000..19ee43e1ca053574a0151b4c43b01972
 +import io.papermc.paper.plugin.provider.classloader.ConfiguredPluginClassLoader;
 +import io.papermc.paper.plugin.provider.classloader.PaperClassLoaderStorage;
 +import io.papermc.paper.util.MCUtil;
++import java.util.Collection;
 +import java.util.List;
 +import java.util.logging.Level;
 +import java.util.logging.Logger;
@@ -167,7 +168,7 @@ index 0000000000000000000000000000000000000000..19ee43e1ca053574a0151b4c43b01972
 +    }
 +
 +    private void registerCommand(final Server server) {
-+        server.getCommandMap().register(COMMAND_NAME, "paper", new CommandImpl(COMMAND_NAME));
++        server.getCommandMap().register(COMMAND_NAME, "paper", new CommandImpl(COMMAND_NAME, this.spark.getPermissions()));
 +    }
 +
 +    public void tickStart() {
@@ -199,9 +200,9 @@ index 0000000000000000000000000000000000000000..19ee43e1ca053574a0151b4c43b01972
 +    }
 +
 +    public static final class CommandImpl extends Command {
-+        CommandImpl(final String name) {
++        CommandImpl(final String name, final Collection<String> permissions) {
 +            super(name);
-+            this.setPermission("spark");
++            this.setPermission(String.join(";", permissions));
 +        }
 +
 +        @Override


### PR DESCRIPTION
Fixes the issue reported in https://github.com/lucko/spark/issues/444

A brief summary is that currently, the bundled spark command is not registered unless the sender has the "spark" permission, whereas it should be registered if the sender has the base "spark" wildcard permission **or** permission for any of the spark sub-commands.

The fix uses the same approach as the built-in `/paper` command, using `;` as delimiter: 

https://github.com/PaperMC/Paper/blob/b483da4e026ad078c9b1dd6e1e5ec25ac450df69/patches/server/0017-Paper-command.patch#L193

We could alternatively override the `testPermissionSilent()` method in `org.bukkit.Command`, but I thought the first option would be preferable.

Related commit in spark https://github.com/lucko/spark/commit/55b38397296813b66082ad935f773357c8ad5282