### PR TITLE
Fix `AttributeModifier#getUniqueId`

### DIFF
--- a/patches/api/0426-Attribute-Modifier-API-improvements.patch
+++ b/patches/api/0426-Attribute-Modifier-API-improvements.patch
@@ -4,6 +4,7 @@ Date: Thu, 9 Nov 2023 20:35:35 -0500
 Subject: [PATCH] Attribute Modifier API improvements
 
 Co-authored-by: Malfrador <malfrador@gmail.com>
+Co-authored-by: Lexi <lexi@qixils.dev>
 
 diff --git a/src/main/java/org/bukkit/attribute/AttributeInstance.java b/src/main/java/org/bukkit/attribute/AttributeInstance.java
 index f08ee26cc4d479e1bfc5264b8cbe721315de91f2..f1fa86ddf1f50a357c9e94cc61261d8c96a2da6f 100644
@@ -70,7 +71,7 @@ index f08ee26cc4d479e1bfc5264b8cbe721315de91f2..f1fa86ddf1f50a357c9e94cc61261d8c
       * Remove a modifier from this instance.
       *
 diff --git a/src/main/java/org/bukkit/attribute/AttributeModifier.java b/src/main/java/org/bukkit/attribute/AttributeModifier.java
-index c6b8700d258b859d246118868167497397010292..3808f76d49e24c20156c013f68e00efa9351f1a3 100644
+index ee39c0b83e558681e8b006172d34c98e2c83cda2..73a3d068f9f204b6411874367d86c84e10f7050a 100644
 --- a/src/main/java/org/bukkit/attribute/AttributeModifier.java
 +++ b/src/main/java/org/bukkit/attribute/AttributeModifier.java
 @@ -25,26 +25,32 @@ public class AttributeModifier implements ConfigurationSerializable, Keyed {
@@ -110,12 +111,30 @@ index c6b8700d258b859d246118868167497397010292..3808f76d49e24c20156c013f68e00efa
      public AttributeModifier(@NotNull NamespacedKey key, double amount, @NotNull Operation operation, @NotNull EquipmentSlotGroup slot) {
          Preconditions.checkArgument(key != null, "Key cannot be null");
          Preconditions.checkArgument(operation != null, "Operation cannot be null");
-@@ -63,7 +69,7 @@ public class AttributeModifier implements ConfigurationSerializable, Keyed {
+@@ -56,16 +62,22 @@ public class AttributeModifier implements ConfigurationSerializable, Keyed {
+     }
+ 
+     /**
+-     * Get the unique ID for this modifier.
++     * Get the unique ID for this modifier if it has one, else null. <!-- Paper -->
+      *
+      * @return unique id
+      * @see #getKey()
       * @deprecated attributes are now identified by keys
       */
-     @NotNull
+-    @NotNull
 -    @Deprecated
++    // Paper start
++    @Nullable
 +    @Deprecated(forRemoval = true, since = "1.21")
      public UUID getUniqueId() {
-         return UUID.fromString(getKey().toString());
+-        return UUID.fromString(getKey().toString());
++        try {
++            return UUID.fromString(key.getKey());
++        } catch (IllegalArgumentException e) {
++            return null;
++        }
++    // Paper end
      }
+ 
+     @NotNull

--- a/patches/api/0470-Fix-equipment-slot-and-group-API.patch
+++ b/patches/api/0470-Fix-equipment-slot-and-group-API.patch
@@ -10,10 +10,10 @@ Adds the following:
 Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/attribute/AttributeModifier.java b/src/main/java/org/bukkit/attribute/AttributeModifier.java
-index 3808f76d49e24c20156c013f68e00efa9351f1a3..e14b64d3b178791dacc7849e97f2ed95f1919c55 100644
+index 73a3d068f9f204b6411874367d86c84e10f7050a..5185deca30d9c952d36dad30e609b4245ee27307 100644
 --- a/src/main/java/org/bukkit/attribute/AttributeModifier.java
 +++ b/src/main/java/org/bukkit/attribute/AttributeModifier.java
-@@ -118,6 +118,7 @@ public class AttributeModifier implements ConfigurationSerializable, Keyed {
+@@ -124,6 +124,7 @@ public class AttributeModifier implements ConfigurationSerializable, Keyed {
       */
      @Nullable
      @Deprecated
@@ -22,7 +22,7 @@ index 3808f76d49e24c20156c013f68e00efa9351f1a3..e14b64d3b178791dacc7849e97f2ed95
          return slot == EquipmentSlotGroup.ANY ? null : slot.getExample();
      }
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 5c29956c6db53440322330ff723c7087193641f1..a1e54e9d14393a6c0ea57cca854071c5396d9717 100644
+index 8369da45206d2606f0715f3d803163dd8028251e..fcdc5fce88720cc926a3953d80b5045113d1516c 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
 @@ -1447,4 +1447,15 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource


### PR DESCRIPTION
Returning null is a subjective fix (throwing an exception in a getter is odd but I can revert if desired), but the key changes are an objective fix to a completely broken method (`minecraft:305cec29-c12a-49ba-aebc-38b2b61dcd40` is not a valid UUID!)