### PR TITLE
Revert velocity natives to 3.1.2

### DIFF
--- a/patches/server/1001-Use-Velocity-compression-and-cipher-natives.patch
+++ b/patches/server/1001-Use-Velocity-compression-and-cipher-natives.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Use Velocity compression and cipher natives
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 9de7a09c5f1b23754a2823978fa3ff218aadcfa7..4f6136ae3ac4890b21a5fb3f69f9c1474a0773d1 100644
+index 9de7a09c5f1b23754a2823978fa3ff218aadcfa7..1a734293c9416f13324bb0edf8f950c9029f8bc4 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -37,6 +37,11 @@ dependencies {
@@ -13,7 +13,7 @@ index 9de7a09c5f1b23754a2823978fa3ff218aadcfa7..4f6136ae3ac4890b21a5fb3f69f9c147
      runtimeOnly("com.mysql:mysql-connector-j:8.4.0")
      runtimeOnly("com.lmax:disruptor:3.4.4") // Paper
 +    // Paper start - Use Velocity cipher
-+    implementation("com.velocitypowered:velocity-native:3.3.0-SNAPSHOT") {
++    implementation("com.velocitypowered:velocity-native:3.1.2-SNAPSHOT") {
 +        isTransitive = false
 +    }
 +    // Paper end - Use Velocity cipher


### PR DESCRIPTION
The updated velocity native compilation pipeline seems to emit binaries that are not compatible with alpine.
The commit temporarily reverts the natives included until a proper solution is found.

Resolves: #11367
Reverts: https://github.com/PaperMC/Paper/pull/11347