### PR TITLE
Deprecate for removal all OldEnum-related methods

### DIFF
--- a/patches/api/0487-Deprecate-for-removal-all-OldEnum-related-methods.patch
+++ b/patches/api/0487-Deprecate-for-removal-all-OldEnum-related-methods.patch
@@ -1,0 +1,173 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 7 Sep 2024 11:14:31 -0700
+Subject: [PATCH] Deprecate for removal all OldEnum-related methods
+
+
+diff --git a/src/main/java/org/bukkit/block/banner/PatternType.java b/src/main/java/org/bukkit/block/banner/PatternType.java
+index e2afb2582a27b94a922754115dbb6b4ca35e0154..b726cebe9abb7195ab6558609a56f9fd18ef2a00 100644
+--- a/src/main/java/org/bukkit/block/banner/PatternType.java
++++ b/src/main/java/org/bukkit/block/banner/PatternType.java
+@@ -120,7 +120,7 @@ public interface PatternType extends OldEnum<PatternType>, Keyed {
+      * @deprecated only for backwards compatibility, use {@link Registry#get(NamespacedKey)} instead.
+      */
+     @NotNull
+-    @Deprecated(since = "1.21")
++    @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+     static PatternType valueOf(@NotNull String name) {
+         PatternType type = Registry.BANNER_PATTERN.get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+         Preconditions.checkArgument(type != null, "No pattern type found with the name %s", name);
+@@ -132,7 +132,7 @@ public interface PatternType extends OldEnum<PatternType>, Keyed {
+      * @deprecated use {@link Registry#iterator()}.
+      */
+     @NotNull
+-    @Deprecated(since = "1.21")
++    @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+     static PatternType[] values() {
+         return Lists.newArrayList(Registry.BANNER_PATTERN).toArray(new PatternType[0]);
+     }
+diff --git a/src/main/java/org/bukkit/entity/Cat.java b/src/main/java/org/bukkit/entity/Cat.java
+index 60cf07bff0898176c8d7af84b3e65d7a1ee8cf2e..22b7f9c2450698b0cf0807880a3d779a0b4f1c37 100644
+--- a/src/main/java/org/bukkit/entity/Cat.java
++++ b/src/main/java/org/bukkit/entity/Cat.java
+@@ -79,7 +79,7 @@ public interface Cat extends Tameable, Sittable, io.papermc.paper.entity.CollarC
+          * @deprecated only for backwards compatibility, use {@link Registry#get(NamespacedKey)} instead.
+          */
+         @NotNull
+-        @Deprecated(since = "1.21")
++        @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+         static Type valueOf(@NotNull String name) {
+             Type type = Registry.CAT_VARIANT.get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+             Preconditions.checkArgument(type != null, "No cat type found with the name %s", name);
+@@ -91,7 +91,7 @@ public interface Cat extends Tameable, Sittable, io.papermc.paper.entity.CollarC
+          * @deprecated use {@link Registry#iterator()}.
+          */
+         @NotNull
+-        @Deprecated(since = "1.21")
++        @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+         static Type[] values() {
+             return Lists.newArrayList(Registry.CAT_VARIANT).toArray(new Type[0]);
+         }
+diff --git a/src/main/java/org/bukkit/entity/Frog.java b/src/main/java/org/bukkit/entity/Frog.java
+index 7cf8ae63eb7a7f6c09510a4ad9e20336863aefc1..28a255f3a906c3988c7463a9469288fe586073a8 100644
+--- a/src/main/java/org/bukkit/entity/Frog.java
++++ b/src/main/java/org/bukkit/entity/Frog.java
+@@ -78,7 +78,7 @@ public interface Frog extends Animals {
+          * @deprecated only for backwards compatibility, use {@link Registry#get(NamespacedKey)} instead.
+          */
+         @NotNull
+-        @Deprecated(since = "1.21")
++        @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+         static Variant valueOf(@NotNull String name) {
+             Variant variant = Registry.FROG_VARIANT.get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+             Preconditions.checkArgument(variant != null, "No frog variant found with the name %s", name);
+@@ -90,7 +90,7 @@ public interface Frog extends Animals {
+          * @deprecated use {@link Registry#iterator()}.
+          */
+         @NotNull
+-        @Deprecated(since = "1.21")
++        @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+         static Variant[] values() {
+             return Lists.newArrayList(Registry.FROG_VARIANT).toArray(new Variant[0]);
+         }
+diff --git a/src/main/java/org/bukkit/entity/Villager.java b/src/main/java/org/bukkit/entity/Villager.java
+index 444744ea6f5921b0ae229995f8b15ea9d980c402..db5c7434a7e529727b556f314d5cd8e0534114fe 100644
+--- a/src/main/java/org/bukkit/entity/Villager.java
++++ b/src/main/java/org/bukkit/entity/Villager.java
+@@ -194,7 +194,7 @@ public interface Villager extends AbstractVillager {
+          * @deprecated only for backwards compatibility, use {@link Registry#get(NamespacedKey)} instead.
+          */
+         @NotNull
+-        @Deprecated(since = "1.21")
++        @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+         static Type valueOf(@NotNull String name) {
+             Type type = Registry.VILLAGER_TYPE.get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+             Preconditions.checkArgument(type != null, "No villager type found with the name %s", name);
+@@ -206,7 +206,7 @@ public interface Villager extends AbstractVillager {
+          * @deprecated use {@link Registry#iterator()}.
+          */
+         @NotNull
+-        @Deprecated(since = "1.21")
++        @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+         static Type[] values() {
+             return Lists.newArrayList(Registry.VILLAGER_TYPE).toArray(new Type[0]);
+         }
+@@ -305,7 +305,7 @@ public interface Villager extends AbstractVillager {
+          * @deprecated only for backwards compatibility, use {@link Registry#get(NamespacedKey)} instead.
+          */
+         @NotNull
+-        @Deprecated(since = "1.21")
++        @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+         static Profession valueOf(@NotNull String name) {
+             Profession profession = Registry.VILLAGER_PROFESSION.get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+             Preconditions.checkArgument(profession != null, "No villager profession found with the name %s", name);
+@@ -317,7 +317,7 @@ public interface Villager extends AbstractVillager {
+          * @deprecated use {@link Registry#iterator()}.
+          */
+         @NotNull
+-        @Deprecated(since = "1.21")
++        @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+         static Profession[] values() {
+             return Lists.newArrayList(Registry.VILLAGER_PROFESSION).toArray(new Profession[0]);
+         }
+diff --git a/src/main/java/org/bukkit/map/MapCursor.java b/src/main/java/org/bukkit/map/MapCursor.java
+index fb6b1491202bbc1ea0d5475c9c6574b0c16943b4..a5efc52e68c602d84dc0948246a1665448344930 100644
+--- a/src/main/java/org/bukkit/map/MapCursor.java
++++ b/src/main/java/org/bukkit/map/MapCursor.java
+@@ -377,7 +377,7 @@ public final class MapCursor {
+          * @deprecated only for backwards compatibility, use {@link Registry#get(NamespacedKey)} instead.
+          */
+         @NotNull
+-        @Deprecated(since = "1.21")
++        @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+         static Type valueOf(@NotNull String name) {
+             Type type = Registry.MAP_DECORATION_TYPE.get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+             Preconditions.checkArgument(type != null, "No Type found with the name %s", name);
+@@ -389,7 +389,7 @@ public final class MapCursor {
+          * @deprecated use {@link Registry#iterator()}.
+          */
+         @NotNull
+-        @Deprecated(since = "1.21")
++        @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+         static Type[] values() {
+             return Lists.newArrayList(Registry.MAP_DECORATION_TYPE).toArray(new Type[0]);
+         }
+diff --git a/src/main/java/org/bukkit/util/OldEnum.java b/src/main/java/org/bukkit/util/OldEnum.java
+index ce0e5367e5f89e123b8bb6a4581ef0e58036acc5..9360a5918e841346118234068e50740e64f51743 100644
+--- a/src/main/java/org/bukkit/util/OldEnum.java
++++ b/src/main/java/org/bukkit/util/OldEnum.java
+@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
+  * @deprecated only for backwards compatibility.
+  */
+ @ApiStatus.Internal
+-@Deprecated(since = "1.21")
++@Deprecated(since = "1.21", forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+ public interface OldEnum<T extends OldEnum<T>> extends Comparable<T> {
+ 
+     /**
+@@ -20,7 +20,7 @@ public interface OldEnum<T extends OldEnum<T>> extends Comparable<T> {
+      * @deprecated only for backwards compatibility, old enums can not be
+      * compared.
+      */
+-    @Deprecated(since = "1.21")
++    @Deprecated(since = "1.21", forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+     @Override
+     int compareTo(@NotNull T other);
+ 
+@@ -29,7 +29,7 @@ public interface OldEnum<T extends OldEnum<T>> extends Comparable<T> {
+      * @deprecated only for backwards compatibility.
+      */
+     @NotNull
+-    @Deprecated(since = "1.21")
++    @Deprecated(since = "1.21", forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+     String name();
+ 
+     /**
+@@ -37,6 +37,6 @@ public interface OldEnum<T extends OldEnum<T>> extends Comparable<T> {
+      * @deprecated only for backwards compatibility, it is not guaranteed that
+      * an old enum always has the same ordinal.
+      */
+-    @Deprecated(since = "1.21")
++    @Deprecated(since = "1.21", forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
+     int ordinal();
+ }


### PR DESCRIPTION
These methods will be removed from the API and only available via asm-utils bytecode rewriting for older plugins.