### PR TITLE
Add a New and Improved Lidded API

### DIFF
--- a/patches/api/0490-New-and-Improved-Lidded-API.patch
+++ b/patches/api/0490-New-and-Improved-Lidded-API.patch
@@ -77,15 +77,16 @@ index 0000000000000000000000000000000000000000..ea775e7cd28b68e520d1381eee8c732f
 +}
 diff --git a/src/main/java/io/papermc/paper/block/Lidded.java b/src/main/java/io/papermc/paper/block/Lidded.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b432f070e1689b0a0c65ca8015760c8b24c4769f
+index 0000000000000000000000000000000000000000..0f73d78a95cde2326aed4885d01282d177c2f245
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/block/Lidded.java
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,40 @@
 +package io.papermc.paper.block;
 +
++import org.bukkit.block.TileState;
 +import org.jetbrains.annotations.NotNull;
 +
-+public interface Lidded {
++public interface Lidded extends TileState {
 +
 +    /**
 +     * Gets the current state of the block, respecting the lidded mode.

--- a/patches/api/0490-New-and-Improved-Lidded-API.patch
+++ b/patches/api/0490-New-and-Improved-Lidded-API.patch
@@ -77,11 +77,13 @@ index 0000000000000000000000000000000000000000..ea775e7cd28b68e520d1381eee8c732f
 +}
 diff --git a/src/main/java/io/papermc/paper/block/Lidded.java b/src/main/java/io/papermc/paper/block/Lidded.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b75f79695d898c0d02968bb2c10af6255bac63d8
+index 0000000000000000000000000000000000000000..b432f070e1689b0a0c65ca8015760c8b24c4769f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/block/Lidded.java
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,39 @@
 +package io.papermc.paper.block;
++
++import org.jetbrains.annotations.NotNull;
 +
 +public interface Lidded {
 +
@@ -90,12 +92,14 @@ index 0000000000000000000000000000000000000000..b75f79695d898c0d02968bb2c10af625
 +     *
 +     * @return the effective lid state
 +     */
++    @NotNull
 +    LidState getEffectiveLidState();
 +
 +    /**
 +     * Gets how the lid would be without any lidded mode, based on players interacting with the block.
 +     * @return the true lid state
 +     */
++    @NotNull
 +    LidState getTrueLidState();
 +
 +    /**
@@ -103,6 +107,7 @@ index 0000000000000000000000000000000000000000..b75f79695d898c0d02968bb2c10af625
 +     *
 +     * @return the lid mode
 +     */
++    @NotNull
 +    LidMode getLidMode();
 +
 +    /**
@@ -111,7 +116,8 @@ index 0000000000000000000000000000000000000000..b75f79695d898c0d02968bb2c10af625
 +     * @param mode the new lid mode
 +     * @return the actually set lid mode
 +     */
-+    LidMode setLidMode(LidMode mode);
++    @NotNull
++    LidMode setLidMode(@NotNull LidMode mode);
 +
 +}
 diff --git a/src/main/java/org/bukkit/block/Barrel.java b/src/main/java/org/bukkit/block/Barrel.java

--- a/patches/api/0490-New-and-Improved-Lidded-API.patch
+++ b/patches/api/0490-New-and-Improved-Lidded-API.patch
@@ -1,0 +1,208 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Isaac - The456 <the456@the456gamer.dev>
+Date: Sun, 8 Sep 2024 23:57:54 +0100
+Subject: [PATCH] New and Improved Lidded API
+
+Featuring
+- 5 LidModes, 3 of which were not possible before
+- The ability to get if the lid actually should be open, if a player is in the container
+- The ability to get if the is open, from api or the player itself
+
+This also deprecates Bukkits api because of the confusing and outright incorrect javadocs (so those now accurately represent the behaviour)
+
+diff --git a/src/main/java/io/papermc/paper/block/LidMode.java b/src/main/java/io/papermc/paper/block/LidMode.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..0b1a6c09fefb5150bf3536f68a18504ed2b43beb
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/block/LidMode.java
+@@ -0,0 +1,47 @@
++package io.papermc.paper.block;
++
++/**
++ * Represents how the lid of a block behaves.
++ */
++public enum LidMode {
++    /**
++     * The default lid mode, the lid will open and close based on player interaction.
++     * <p/>
++     * the state used for this is provided with {@link Lidded#getTrueLidState()}
++     */
++    DEFAULT,
++
++    /**
++     * The lid will be forced open, regardless of player interaction.
++     * <p/>
++     * This needs to be manually unset with another call to {@link Lidded#setLidMode(LidMode)}.
++     */
++    FORCED_OPEN,
++
++    /**
++     * The lid will be forced closed, regardless of player interaction.
++     * <p/>
++     * This needs to be manually unset with another call to {@link Lidded#setLidMode(LidMode)}.
++     */
++    FORCED_CLOSED,
++
++    /**
++     * The lid will be forced open until at least one player has opened it.
++     * <p/>
++     * It will then revert to {@link #DEFAULT}.
++     * <p/>
++     * If at least one player is viewing it when this is set, it will immediately revert to
++     * {@link #DEFAULT}.
++     */
++    OPEN_UNTIL_VIEWED,
++
++    /**
++     * The lid will be forced closed until all players currently viewing it have closed it.
++     * <p/>
++     * It will then revert to {@link #DEFAULT}.
++     * <p/>
++     * If no players are viewing it when this is set, it will immediately revert to
++     * {@link #DEFAULT}.
++     */
++    CLOSED_UNTIL_NOT_VIEWED
++}
+diff --git a/src/main/java/io/papermc/paper/block/LidState.java b/src/main/java/io/papermc/paper/block/LidState.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ea775e7cd28b68e520d1381eee8c732f3fa17bfc
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/block/LidState.java
+@@ -0,0 +1,6 @@
++package io.papermc.paper.block;
++
++public enum LidState {
++    OPEN,
++    CLOSED
++}
+diff --git a/src/main/java/io/papermc/paper/block/Lidded.java b/src/main/java/io/papermc/paper/block/Lidded.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..b75f79695d898c0d02968bb2c10af6255bac63d8
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/block/Lidded.java
+@@ -0,0 +1,33 @@
++package io.papermc.paper.block;
++
++public interface Lidded {
++
++    /**
++     * Gets the current state of the block, respecting the lidded mode.
++     *
++     * @return the effective lid state
++     */
++    LidState getEffectiveLidState();
++
++    /**
++     * Gets how the lid would be without any lidded mode, based on players interacting with the block.
++     * @return the true lid state
++     */
++    LidState getTrueLidState();
++
++    /**
++     * Gets the current lid mode of the block.
++     *
++     * @return the lid mode
++     */
++    LidMode getLidMode();
++
++    /**
++     * Sets the lid mode of the block.
++     *
++     * @param mode the new lid mode
++     * @return the actually set lid mode
++     */
++    LidMode setLidMode(LidMode mode);
++
++}
+diff --git a/src/main/java/org/bukkit/block/Barrel.java b/src/main/java/org/bukkit/block/Barrel.java
+index d3789b2b7dd71d7c1872a0d84698d35a1884101b..b5a6d961327547a5424a34608d07f2e9d606fa6c 100644
+--- a/src/main/java/org/bukkit/block/Barrel.java
++++ b/src/main/java/org/bukkit/block/Barrel.java
+@@ -5,4 +5,4 @@ import org.bukkit.loot.Lootable;
+ /**
+  * Represents a captured state of a Barrel.
+  */
+-public interface Barrel extends Container, com.destroystokyo.paper.loottable.LootableBlockInventory, Lidded { } // Paper
++public interface Barrel extends Container, com.destroystokyo.paper.loottable.LootableBlockInventory, Lidded, io.papermc.paper.block.Lidded { } // Paper  // Paper - Add Improved Lidded Api
+diff --git a/src/main/java/org/bukkit/block/Chest.java b/src/main/java/org/bukkit/block/Chest.java
+index 5d02f9c938d0d7d0f4e491ccfaf6beb0a7a61aa4..c49553b586009904b34e58d3e173e47bb51f9f36 100644
+--- a/src/main/java/org/bukkit/block/Chest.java
++++ b/src/main/java/org/bukkit/block/Chest.java
+@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
+ /**
+  * Represents a captured state of a chest.
+  */
+-public interface Chest extends Container, LootableBlockInventory, Lidded { // Paper
++public interface Chest extends Container, LootableBlockInventory, Lidded, io.papermc.paper.block.Lidded { // Paper // Paper - Add Improved Lidded Api
+ 
+     /**
+      * Gets the inventory of the chest block represented by this block state.
+diff --git a/src/main/java/org/bukkit/block/EnderChest.java b/src/main/java/org/bukkit/block/EnderChest.java
+index 6b66f38e5509f90aad5ee1fffca01003dcbe9896..c155e01136227c9334d0e9cd9d912b014b86c5e5 100644
+--- a/src/main/java/org/bukkit/block/EnderChest.java
++++ b/src/main/java/org/bukkit/block/EnderChest.java
+@@ -3,7 +3,7 @@ package org.bukkit.block;
+ /**
+  * Represents a captured state of an ender chest.
+  */
+-public interface EnderChest extends Lidded, TileState {
++public interface EnderChest extends Lidded, TileState, io.papermc.paper.block.Lidded {  // Paper - Add Improved Lidded Api
+     // Paper start - More Chest Block API
+     /**
+      * Checks whether this ender chest is blocked by a block above
+diff --git a/src/main/java/org/bukkit/block/Lidded.java b/src/main/java/org/bukkit/block/Lidded.java
+index 30c7df0021df44a411e50636d906d4a1d30fd927..e867187db2d0752d8b18baaebcdbf0ecdbdac833 100644
+--- a/src/main/java/org/bukkit/block/Lidded.java
++++ b/src/main/java/org/bukkit/block/Lidded.java
+@@ -1,25 +1,34 @@
+ package org.bukkit.block;
+ 
++/**
++ * @deprecated Incomplete api. Use {@link io.papermc.paper.block.Lidded} instead.
++ */
++@Deprecated // Paper - Deprecate Bukkit's Lidded API
+ public interface Lidded {
+ 
+     /**
+      * Sets the block's animated state to open and prevents it from being closed
+      * until {@link #close()} is called.
++     * @deprecated Use {@link io.papermc.paper.block.Lidded#setLidMode(io.papermc.paper.block.LidMode)}
+      */
++    @Deprecated // Paper - Deprecate Bukkit's Lidded API
+     void open();
+ 
+     /**
+-     * Sets the block's animated state to closed even if a player is currently
+-     * viewing this block.
++     * Unsets a corresponding call to {@link #open()}.
++     * @deprecated Misleading name. Use {@link io.papermc.paper.block.Lidded#setLidMode(io.papermc.paper.block.LidMode)}
+      */
++    @Deprecated // Paper - Deprecate Bukkit's Lidded API
+     void close();
+ 
+     // Paper start - More Lidded Block API
+     /**
+-     * Checks if the block's animation state.
++     * Checks is the Lid is currently forced open.
+      *
+-     * @return true if the block's animation state is set to open.
++     * @return true if the block's animation state is force open.
++     * @deprecated Misleading name. Use {@link io.papermc.paper.block.Lidded#getLidMode()} for the direct replacement, or {@link io.papermc.paper.block.Lidded#getEffectiveLidState()} to tell if the lid is visibly open to the player Instead.
+      */
++    @Deprecated // Paper - Deprecate Bukkit's Lidded API
+     boolean isOpen();
+     // Paper end - More Lidded Block API
+ }
+diff --git a/src/main/java/org/bukkit/block/ShulkerBox.java b/src/main/java/org/bukkit/block/ShulkerBox.java
+index 5dc5318b0a451937228a8a059dfec1cd9de389a6..e82501813ce1fac49d1f9bf2c63c3b6e2dfdd76f 100644
+--- a/src/main/java/org/bukkit/block/ShulkerBox.java
++++ b/src/main/java/org/bukkit/block/ShulkerBox.java
+@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
+ /**
+  * Represents a captured state of a ShulkerBox.
+  */
+-public interface ShulkerBox extends Container, LootableBlockInventory, Lidded { // Paper
++public interface ShulkerBox extends Container, LootableBlockInventory, Lidded, io.papermc.paper.block.Lidded { // Paper  // Paper - Add Improved Lidded Api
+ 
+     /**
+      * Get the {@link DyeColor} corresponding to this ShulkerBox

--- a/patches/api/0490-New-and-Improved-Lidded-API.patch
+++ b/patches/api/0490-New-and-Improved-Lidded-API.patch
@@ -12,7 +12,7 @@ This also deprecates Bukkits api because of the confusing and outright incorrect
 
 diff --git a/src/main/java/io/papermc/paper/block/LidMode.java b/src/main/java/io/papermc/paper/block/LidMode.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0b1a6c09fefb5150bf3536f68a18504ed2b43beb
+index 0000000000000000000000000000000000000000..fb7eea1ddda3cded5c4416d32bb48ef71aa25343
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/block/LidMode.java
 @@ -0,0 +1,47 @@
@@ -24,30 +24,30 @@ index 0000000000000000000000000000000000000000..0b1a6c09fefb5150bf3536f68a18504e
 +public enum LidMode {
 +    /**
 +     * The default lid mode, the lid will open and close based on player interaction.
-+     * <p/>
++     * <p>
 +     * the state used for this is provided with {@link Lidded#getTrueLidState()}
 +     */
 +    DEFAULT,
 +
 +    /**
 +     * The lid will be forced open, regardless of player interaction.
-+     * <p/>
++     * <p>
 +     * This needs to be manually unset with another call to {@link Lidded#setLidMode(LidMode)}.
 +     */
 +    FORCED_OPEN,
 +
 +    /**
 +     * The lid will be forced closed, regardless of player interaction.
-+     * <p/>
++     * <p>
 +     * This needs to be manually unset with another call to {@link Lidded#setLidMode(LidMode)}.
 +     */
 +    FORCED_CLOSED,
 +
 +    /**
 +     * The lid will be forced open until at least one player has opened it.
-+     * <p/>
++     * <p>
 +     * It will then revert to {@link #DEFAULT}.
-+     * <p/>
++     * <p>
 +     * If at least one player is viewing it when this is set, it will immediately revert to
 +     * {@link #DEFAULT}.
 +     */
@@ -55,9 +55,9 @@ index 0000000000000000000000000000000000000000..0b1a6c09fefb5150bf3536f68a18504e
 +
 +    /**
 +     * The lid will be forced closed until all players currently viewing it have closed it.
-+     * <p/>
++     * <p>
 +     * It will then revert to {@link #DEFAULT}.
-+     * <p/>
++     * <p>
 +     * If no players are viewing it when this is set, it will immediately revert to
 +     * {@link #DEFAULT}.
 +     */

--- a/patches/api/0491-Add-PlayerLiddedOpenEvent.patch
+++ b/patches/api/0491-Add-PlayerLiddedOpenEvent.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Isaac - The456 <the456@the456gamer.dev>
+Date: Fri, 13 Sep 2024 00:29:06 +0100
+Subject: [PATCH] Add PlayerLiddedOpenEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/player/PlayerLiddedOpenEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerLiddedOpenEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..35fdc0d95d4bcdad81de6f5c287705d5f85c2160
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/player/PlayerLiddedOpenEvent.java
+@@ -0,0 +1,55 @@
++package io.papermc.paper.event.player;
++
++import io.papermc.paper.block.Lidded;
++import org.bukkit.block.Block;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.NotNull;
++
++public class PlayerLiddedOpenEvent extends PlayerEvent implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++    private boolean cancelled;
++    private final Lidded blockState;
++    private final Block block;
++
++    @ApiStatus.Internal
++    public PlayerLiddedOpenEvent(final @NotNull Player who, final @NotNull Lidded blockState, final @NotNull Block block) {
++        super(who);
++        this.cancelled = false;
++        this.blockState = blockState;
++        this.block = block;
++    }
++
++    public static @NotNull HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(final boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++
++    public Lidded getLidded() {
++        return blockState;
++    }
++
++    public Block getBlock() {
++        return block;
++    }
++
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++}

--- a/patches/api/0491-Add-PlayerLiddedOpenEvent.patch
+++ b/patches/api/0491-Add-PlayerLiddedOpenEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerLiddedOpenEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerLiddedOpenEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerLiddedOpenEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..913e872b51d3e053f0c773c2264b92794dea4c8a
+index 0000000000000000000000000000000000000000..1128b3980644b10e0f1d03ee90c52afb8eb7c68a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerLiddedOpenEvent.java
-@@ -0,0 +1,85 @@
+@@ -0,0 +1,87 @@
 +package io.papermc.paper.event.player;
 +
 +import io.papermc.paper.block.LidMode;
@@ -32,6 +32,8 @@ index 0000000000000000000000000000000000000000..913e872b51d3e053f0c773c2264b9279
 + * <p>
 + * Cancelling this event prevents the player from being considered in other {@link Lidded} methods:
 + * they will not contribute to the {@link Lidded#getTrueLidState()} and {@link Lidded#getEffectiveLidState()}.
++ * <p>
++ * This event is called twice for double chests, once for each half.
 + */
 +public class PlayerLiddedOpenEvent extends PlayerEvent implements Cancellable {
 +

--- a/patches/api/0491-Add-PlayerLiddedOpenEvent.patch
+++ b/patches/api/0491-Add-PlayerLiddedOpenEvent.patch
@@ -6,12 +6,14 @@ Subject: [PATCH] Add PlayerLiddedOpenEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerLiddedOpenEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerLiddedOpenEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..35fdc0d95d4bcdad81de6f5c287705d5f85c2160
+index 0000000000000000000000000000000000000000..913e872b51d3e053f0c773c2264b92794dea4c8a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerLiddedOpenEvent.java
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,85 @@
 +package io.papermc.paper.event.player;
 +
++import io.papermc.paper.block.LidMode;
++import io.papermc.paper.block.LidState;
 +import io.papermc.paper.block.Lidded;
 +import org.bukkit.block.Block;
 +import org.bukkit.entity.Player;
@@ -21,12 +23,22 @@ index 0000000000000000000000000000000000000000..35fdc0d95d4bcdad81de6f5c287705d5
 +import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
++/**
++ * Called when a player opens a {@link Lidded} block.
++ *
++ * <p>
++ * This is called every time a player opens a {@link Lidded} block
++ * regardless of if the lid is already open (e.g. multiple players).
++ * <p>
++ * Cancelling this event prevents the player from being considered in other {@link Lidded} methods:
++ * they will not contribute to the {@link Lidded#getTrueLidState()} and {@link Lidded#getEffectiveLidState()}.
++ */
 +public class PlayerLiddedOpenEvent extends PlayerEvent implements Cancellable {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
-+    private boolean cancelled;
 +    private final Lidded blockState;
 +    private final Block block;
++    private boolean cancelled;
 +
 +    @ApiStatus.Internal
 +    public PlayerLiddedOpenEvent(final @NotNull Player who, final @NotNull Lidded blockState, final @NotNull Block block) {
@@ -36,9 +48,6 @@ index 0000000000000000000000000000000000000000..35fdc0d95d4bcdad81de6f5c287705d5
 +        this.block = block;
 +    }
 +
-+    public static @NotNull HandlerList getHandlerList() {
-+        return HANDLER_LIST;
-+    }
 +
 +    @Override
 +    public boolean isCancelled() {
@@ -50,18 +59,39 @@ index 0000000000000000000000000000000000000000..35fdc0d95d4bcdad81de6f5c287705d5
 +        this.cancelled = cancel;
 +    }
 +
-+
++    /**
++     * Gets the {@link Lidded} block involved in this event.
++     * @return the lidded block
++     */
++    @NotNull
 +    public Lidded getLidded() {
 +        return blockState;
 +    }
 +
++    /**
++     * Gets the block involved in this event.
++     * @return the block
++     */
++    @NotNull
 +    public Block getBlock() {
 +        return block;
 +    }
 +
++    /**
++     * Gets if the block would appear to open, if this event is not cancelled.
++     * return if the block would appear to open
++     */
++    public boolean isOpening() {
++        return blockState.getLidMode() == LidMode.DEFAULT && blockState.getTrueLidState() == LidState.CLOSED;
++    }
 +
 +    @Override
-+    public @NotNull HandlerList getHandlers() {
++    @NotNull
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public static @NotNull HandlerList getHandlerList() {
 +        return HANDLER_LIST;
 +    }
 +}

--- a/patches/server/1060-New-and-Improved-Lidded-API.patch
+++ b/patches/server/1060-New-and-Improved-Lidded-API.patch
@@ -1,0 +1,939 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Isaac - The456 <the456@the456gamer.dev>
+Date: Mon, 9 Sep 2024 00:06:05 +0100
+Subject: [PATCH] New and Improved Lidded API
+
+Featuring
+- 5 LidModes, 3 of which were not possible before
+- The ability to get if the lid actually should be open, if a player is in the container
+- The ability to get if the is open, from api or the player itself
+
+This Implementation provides the now-deprecated bukkit api of the same name in a compatible way.
+
+the bulk of the general logic is in PaperLidded, which handles the transitions to/from LidModes, which call the implementation specific internals to start/stop open/close.
+
+diff --git a/src/main/java/io/papermc/paper/block/PaperLidded.java b/src/main/java/io/papermc/paper/block/PaperLidded.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..a1ed3487a58c5cc101a0c06b7922407b59d69290
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/block/PaperLidded.java
+@@ -0,0 +1,84 @@
++package io.papermc.paper.block;
++
++public interface PaperLidded extends Lidded, org.bukkit.block.Lidded {
++
++    @Override
++    default LidMode setLidMode(final LidMode targetLidMode) {
++        final LidMode oldLidMode = getLidMode();
++        final LidMode newLidMode = getResultantLidMode(targetLidMode);
++
++        if (oldLidMode == newLidMode) {
++            // already in correct state
++            return newLidMode;
++        }
++
++        boolean wasForcedOpen =
++            oldLidMode == LidMode.FORCED_OPEN || oldLidMode == LidMode.OPEN_UNTIL_VIEWED;
++        boolean wasForcedClosed =
++            oldLidMode == LidMode.FORCED_CLOSED || oldLidMode == LidMode.CLOSED_UNTIL_NOT_VIEWED;
++        boolean isForcedOpen =
++            newLidMode == LidMode.FORCED_OPEN || newLidMode == LidMode.OPEN_UNTIL_VIEWED;
++        boolean isForcedClosed =
++            newLidMode == LidMode.FORCED_CLOSED || newLidMode == LidMode.CLOSED_UNTIL_NOT_VIEWED;
++
++        // stop any existing force open/close, if next state doesn't need it.
++        if (wasForcedOpen && !isForcedOpen) {
++            stopForceLiddedLidOpen();
++        } else if (wasForcedClosed && !isForcedClosed) {
++            stopForceLiddedLidClose();
++        }
++
++        // start new force open/close, if it wasn't previously.
++        if (isForcedOpen && !wasForcedOpen) {
++            startForceLiddedLidOpen();
++        } else if (isForcedClosed && !wasForcedClosed) {
++            startForceLiddedLidClose();
++        }
++
++        // return the new lid mode, so it can be stored by the implementation.
++        return newLidMode;
++    }
++
++    private LidMode getResultantLidMode(LidMode targetLidMode) {
++        final LidState trueLidState = getTrueLidState();
++
++        // check that target lid mode is valid for true lid state.
++        LidMode newLidMode;
++
++        if (targetLidMode == LidMode.CLOSED_UNTIL_NOT_VIEWED
++            && trueLidState == LidState.CLOSED) {
++            // insta-revert to default, as the lid is already closed.
++            newLidMode = LidMode.DEFAULT;
++        } else if (targetLidMode == LidMode.OPEN_UNTIL_VIEWED
++            && trueLidState == LidState.OPEN) {
++            // insta-revert to default, as the lid is already open.
++            newLidMode = LidMode.DEFAULT;
++        } else {
++            newLidMode = targetLidMode;
++        }
++        return newLidMode;
++    }
++
++    // these should be similar to the vanilla open/close behavior.
++    void startForceLiddedLidOpen();
++    void stopForceLiddedLidOpen();
++    void startForceLiddedLidClose();
++    void stopForceLiddedLidClose();
++
++    // bukkit lidded impl using the paper lidded api.
++
++    @Override
++    default boolean isOpen() {
++        return getLidMode() == LidMode.FORCED_OPEN || getLidMode() == LidMode.OPEN_UNTIL_VIEWED;
++    }
++
++    @Override
++    default void close() {
++        setLidMode(LidMode.DEFAULT);
++    }
++
++    @Override
++    default void open() {
++        setLidMode(LidMode.FORCED_OPEN);
++    }
++}
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java b/src/main/java/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
+index 86dce6796f92a5b0ae2b1bd837267c4e3f6754d0..dfc184ed9f49524cf198ff672282326c16b41441 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
+@@ -17,7 +17,7 @@ public abstract class ContainerOpenersCounter {
+     private static final int CHECK_TICK_DELAY = 5;
+     private int openCount;
+     private double maxInteractionRange;
+-    public boolean opened; // CraftBukkit
++    //public boolean opened; // CraftBukkit // Paper - replace with new Lidded API
+ 
+     public ContainerOpenersCounter() {}
+ 
+@@ -28,25 +28,79 @@ public abstract class ContainerOpenersCounter {
+     protected abstract void openerCountChanged(Level world, BlockPos pos, BlockState state, int oldViewerCount, int newViewerCount);
+ 
+     // CraftBukkit start
+-    public void onAPIOpen(Level world, BlockPos blockposition, BlockState iblockdata) {
+-        this.onOpen(world, blockposition, iblockdata);
+-    }
+-
+-    public void onAPIClose(Level world, BlockPos blockposition, BlockState iblockdata) {
+-        this.onClose(world, blockposition, iblockdata);
+-    }
+-
+-    public void openerAPICountChanged(Level world, BlockPos blockposition, BlockState iblockdata, int i, int j) {
+-        this.openerCountChanged(world, blockposition, iblockdata, i, j);
+-    }
++    // Paper Start - Replace with new Lidded API
++    // public void onAPIOpen(Level world, BlockPos blockposition, BlockState iblockdata) {
++    //     this.onOpen(world, blockposition, iblockdata);
++    // }
++    //
++    // public void onAPIClose(Level world, BlockPos blockposition, BlockState iblockdata) {
++    //     this.onClose(world, blockposition, iblockdata);
++    // }
++    //
++    // public void openerAPICountChanged(Level world, BlockPos blockposition, BlockState iblockdata, int i, int j) {
++    //     this.openerCountChanged(world, blockposition, iblockdata, i, j);
++    // }
++    // Paper end - Replace with new Lidded API
+     // CraftBukkit end
+ 
+     protected abstract boolean isOwnContainer(Player player);
+ 
+-    public void incrementOpeners(Player player, Level world, BlockPos pos, BlockState state) {
++    // Paper start - add Improved Lidded API
++    private io.papermc.paper.block.LidMode apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++    public void startForceLiddedLidOpen(Level level, BlockPos pos, BlockState state) {
++        incrementOpeners(null, level, pos, state);
++    }
++    public void stopForceLiddedLidOpen(Level level, BlockPos pos, BlockState state) {
++        decrementOpeners(null, level, pos, state);
++        apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++    }
++    public void startForceLiddedLidClose(Level level, BlockPos pos, BlockState state) {
++        if (this.getTrueLidState() == io.papermc.paper.block.LidState.OPEN) {
++            this.onClose(level, pos, state);
++            level.gameEvent(null, GameEvent.CONTAINER_CLOSE, pos);
++        }
++        this.openerCountChanged(level, pos, state, this.openCount, 0);
++    }
++    public void stopForceLiddedLidClose(Level level, BlockPos pos, BlockState state) {
++        if (this.getTrueLidState() == io.papermc.paper.block.LidState.OPEN) {
++            this.onOpen(level, pos, state);
++            level.gameEvent(null, GameEvent.CONTAINER_OPEN, pos);
++            scheduleRecheck(level, pos, state);
++        }
++        this.openerCountChanged(level, pos, state, 0, this.openCount);
++        apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++    }
++    public io.papermc.paper.block.LidMode getLidMode() {
++        return apiLidMode;
++    }
++    public void setLidMode(final io.papermc.paper.block.LidMode targetLidMode) {
++        apiLidMode = targetLidMode;
++    }
++    public io.papermc.paper.block.LidState getEffectiveLidState() {
++        return switch (apiLidMode) {
++            case OPEN_UNTIL_VIEWED, FORCED_OPEN -> io.papermc.paper.block.LidState.OPEN;
++            case CLOSED_UNTIL_NOT_VIEWED, FORCED_CLOSED -> io.papermc.paper.block.LidState.CLOSED;
++            default -> getTrueLidState();
++        };
++    }
++    public io.papermc.paper.block.LidState getTrueLidState() {
++        boolean virtualViewerPresent = (apiLidMode == io.papermc.paper.block.LidMode.FORCED_OPEN || apiLidMode == io.papermc.paper.block.LidMode.OPEN_UNTIL_VIEWED);
++        int trueOpenCount = this.openCount - (virtualViewerPresent ? 1 : 0);
++        if (trueOpenCount < 0) {
++            throw new IllegalStateException("trueOpenCount is negative: " + trueOpenCount + " openCount: " + openCount + " virtualViewerPresent: " + virtualViewerPresent);
++        }
++        return trueOpenCount > 0 ? io.papermc.paper.block.LidState.OPEN : io.papermc.paper.block.LidState.CLOSED;
++    }
++
++    public void incrementOpeners(@javax.annotation.Nullable Player player, Level world, BlockPos pos, BlockState state) { // Paper - make player nullable for New Lidded API
++        if (this.openCount == 0 && apiLidMode == io.papermc.paper.block.LidMode.CLOSED_UNTIL_NOT_VIEWED) {
++            apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++            stopForceLiddedLidClose(world, pos, state);
++        }
++        // Paper end - add Improved Lidded API
+         int oldPower = Math.max(0, Math.min(15, this.openCount)); // CraftBukkit - Get power before new viewer is added
+         int i = this.openCount++;
+-
++        if (apiLidMode == io.papermc.paper.block.LidMode.FORCED_CLOSED || apiLidMode == io.papermc.paper.block.LidMode.CLOSED_UNTIL_NOT_VIEWED) return; // Paper - add improved Lidded API
+         // CraftBukkit start - Call redstone event
+         if (world.getBlockState(pos).is(net.minecraft.world.level.block.Blocks.TRAPPED_CHEST)) {
+             int newPower = Math.max(0, Math.min(15, this.openCount));
+@@ -64,14 +118,30 @@ public abstract class ContainerOpenersCounter {
+         }
+ 
+         this.openerCountChanged(world, pos, state, i, this.openCount);
++        if (player != null) // Paper - make player nullable for improved Lidded API
+         this.maxInteractionRange = Math.max(player.blockInteractionRange(), this.maxInteractionRange);
++        // Paper start - add Improved Lidded API
++        if (player != null && apiLidMode == io.papermc.paper.block.LidMode.OPEN_UNTIL_VIEWED) {
++            // reset to default
++            apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++            stopForceLiddedLidOpen(world, pos, state);
++        }
++        // Paper end - add Improved Lidded API
+     }
+ 
+-    public void decrementOpeners(Player player, Level world, BlockPos pos, BlockState state) {
++    public void decrementOpeners(@javax.annotation.Nullable Player player, Level world, BlockPos pos, BlockState state) { // Paper - make player nullable for New Lidded API
+         int oldPower = Math.max(0, Math.min(15, this.openCount)); // CraftBukkit - Get power before new viewer is added
+         if (this.openCount == 0) return; // Paper - Prevent ContainerOpenersCounter openCount from going negative
+         int i = this.openCount--;
+-
++        // Paper start - add Improved Lidded API
++        if (apiLidMode == io.papermc.paper.block.LidMode.FORCED_CLOSED || apiLidMode == io.papermc.paper.block.LidMode.CLOSED_UNTIL_NOT_VIEWED) {
++            if (this.openCount == 0 && apiLidMode == io.papermc.paper.block.LidMode.CLOSED_UNTIL_NOT_VIEWED) {
++                apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++                stopForceLiddedLidClose(world, pos, state);
++            }
++        return;
++        }
++        // Paper end - add Improved Lidded API
+         // CraftBukkit start - Call redstone event
+         if (world.getBlockState(pos).is(net.minecraft.world.level.block.Blocks.TRAPPED_CHEST)) {
+             int newPower = Math.max(0, Math.min(15, this.openCount));
+@@ -109,9 +179,13 @@ public abstract class ContainerOpenersCounter {
+             entityhuman = (Player) iterator.next();
+         }
+ 
+-        int i = list.size();
+-        if (this.opened) i++; // CraftBukkit - add dummy count from API
+-        int j = this.openCount;
++        // Paper Start - Replace with add Improved Lidded API
++        boolean forceClosed = apiLidMode == io.papermc.paper.block.LidMode.CLOSED_UNTIL_NOT_VIEWED || apiLidMode == io.papermc.paper.block.LidMode.FORCED_CLOSED;
++        boolean forceOpened = apiLidMode == io.papermc.paper.block.LidMode.OPEN_UNTIL_VIEWED || apiLidMode == io.papermc.paper.block.LidMode.FORCED_OPEN;
++        int i = forceClosed ? 0 : list.size() + (forceOpened ? 1 : 0);
++        // if (this.opened) i++; // CraftBukkit - add dummy count from API
++        int j = forceClosed ? 0 : this.openCount;
++        // Paper End - Replace with add Improved Lidded API
+ 
+         if (j != i) {
+             boolean flag = i != 0;
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
+index 0d68db20f5fbe5e834f12c1e8fd429099a44e4b6..53a77dddfd6ae8b0cf102acd5a8e7679df500704 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
+@@ -59,7 +59,7 @@ public class ShulkerBoxBlockEntity extends RandomizableContainerBlockEntity impl
+     // CraftBukkit start - add fields and methods
+     public List<HumanEntity> transaction = new java.util.ArrayList<HumanEntity>();
+     private int maxStack = MAX_STACK;
+-    public boolean opened;
++    // public boolean opened; // Paper - replace with new Lidded API
+ 
+     public List<ItemStack> getContents() {
+         return this.itemStacks;
+@@ -180,7 +180,7 @@ public class ShulkerBoxBlockEntity extends RandomizableContainerBlockEntity impl
+     @Override
+     public boolean triggerEvent(int type, int data) {
+         if (type == 1) {
+-            this.openCount = data;
++            if (apiLidMode != io.papermc.paper.block.LidMode.FORCED_CLOSED && apiLidMode != io.papermc.paper.block.LidMode.CLOSED_UNTIL_NOT_VIEWED) this.openCount = data; // Paper - Skip Mutate when forced closed by lidded api
+             if (data == 0) {
+                 this.animationStatus = ShulkerBoxBlockEntity.AnimationStatus.CLOSING;
+             }
+@@ -200,20 +200,94 @@ public class ShulkerBoxBlockEntity extends RandomizableContainerBlockEntity impl
+         world.updateNeighborsAt(pos, state.getBlock());
+     }
+ 
++    // Paper start - add Improved Lidded API
++    private io.papermc.paper.block.LidMode apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++    public void startForceLiddedLidOpen() {
++        this.openCount++;
++        this.level.blockEvent(this.worldPosition, this.getBlockState().getBlock(), 1, this.openCount);
++        if (this.openCount == 1) {
++            this.level.gameEvent(null, GameEvent.CONTAINER_OPEN, this.worldPosition);
++            this.level.playSound(null, this.worldPosition, SoundEvents.SHULKER_BOX_OPEN, SoundSource.BLOCKS, 0.5F, this.level.random.nextFloat() * 0.1F + 0.9F);
++        }
++    }
++    public void stopForceLiddedLidOpen() {
++        this.openCount--;
++        this.level.blockEvent(this.worldPosition, this.getBlockState().getBlock(), 1, this.openCount);
++        if (this.openCount <= 0) {
++            this.level.gameEvent(null, GameEvent.CONTAINER_CLOSE, this.worldPosition);
++            this.level.playSound(null, this.worldPosition, SoundEvents.SHULKER_BOX_CLOSE, SoundSource.BLOCKS, 0.5F, this.level.random.nextFloat() * 0.1F + 0.9F);
++        }
++        apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++    }
++    public void startForceLiddedLidClose() {
++        if (this.getTrueLidState() == io.papermc.paper.block.LidState.OPEN) {
++            this.level.gameEvent(null, GameEvent.CONTAINER_CLOSE, this.worldPosition);
++            this.level.playSound(null, this.worldPosition, SoundEvents.SHULKER_BOX_CLOSE, SoundSource.BLOCKS, 0.5F, this.level.random.nextFloat() * 0.1F + 0.9F);
++        }
++        this.level.blockEvent(this.worldPosition, this.getBlockState().getBlock(), 1, 0);
++    }
++    public void stopForceLiddedLidClose() {
++        if (this.getTrueLidState() == io.papermc.paper.block.LidState.OPEN) {
++            this.level.gameEvent(null, GameEvent.CONTAINER_OPEN, this.worldPosition);
++            this.level.playSound(null, this.worldPosition, SoundEvents.SHULKER_BOX_OPEN, SoundSource.BLOCKS, 0.5F, this.level.random.nextFloat() * 0.1F + 0.9F);
++        }
++        this.level.blockEvent(this.worldPosition, this.getBlockState().getBlock(), 1, this.openCount);
++    }
++    public io.papermc.paper.block.LidMode getLidMode() {
++        return apiLidMode;
++    }
++    public void setLidMode(final io.papermc.paper.block.LidMode lidMode) {
++        this.apiLidMode = lidMode;
++    }
++    public io.papermc.paper.block.LidState getEffectiveLidState() {
++        return switch (apiLidMode) {
++            case OPEN_UNTIL_VIEWED, FORCED_OPEN -> io.papermc.paper.block.LidState.OPEN;
++            case CLOSED_UNTIL_NOT_VIEWED, FORCED_CLOSED -> io.papermc.paper.block.LidState.CLOSED;
++            default -> getTrueLidState();
++        };
++    }
++    public io.papermc.paper.block.LidState getTrueLidState() {
++        boolean virtualViewerPresent = (apiLidMode == io.papermc.paper.block.LidMode.FORCED_OPEN || apiLidMode == io.papermc.paper.block.LidMode.OPEN_UNTIL_VIEWED);
++        int trueOpenCount = this.openCount - (virtualViewerPresent ? 1 : 0);
++        // ensure trueOpenCount is never negative, throw
++        if (trueOpenCount < 0) {
++            throw new IllegalStateException("trueOpenCount is negative: " + trueOpenCount + " openCount: " + openCount + " virtualViewerPresent: " + virtualViewerPresent);
++        }
++        return trueOpenCount > 0 ? io.papermc.paper.block.LidState.OPEN : io.papermc.paper.block.LidState.CLOSED;
++    }
++    // Paper end - add Improved Lidded API
+     @Override
+     public void startOpen(Player player) {
+         if (!this.remove && !player.isSpectator()) {
+             if (this.openCount < 0) {
+                 this.openCount = 0;
+             }
++            // Paper start - add Improved Lidded API
++            if (this.openCount == 0) {
++                if (apiLidMode == io.papermc.paper.block.LidMode.CLOSED_UNTIL_NOT_VIEWED) {
++                    apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++                    stopForceLiddedLidClose();
++                }
++            }
++            // Paper end - add Improved Lidded API
+ 
+             ++this.openCount;
+-            if (this.opened) return; // CraftBukkit - only animate if the ShulkerBox hasn't been forced open already by an API call.
++            // Paper start - replace with Improved Lidded API
++            //if (this.opened) return; // CraftBukkit - only animate if the ShulkerBox hasn't been forced open already by an API call.
++            if (this.apiLidMode == io.papermc.paper.block.LidMode.FORCED_CLOSED || this.apiLidMode == io.papermc.paper.block.LidMode.CLOSED_UNTIL_NOT_VIEWED) return;
++            // Paper end - replace with Improved Lidded API
+             this.level.blockEvent(this.worldPosition, this.getBlockState().getBlock(), 1, this.openCount);
+             if (this.openCount == 1) {
+                 this.level.gameEvent((Entity) player, (Holder) GameEvent.CONTAINER_OPEN, this.worldPosition);
+                 this.level.playSound((Player) null, this.worldPosition, SoundEvents.SHULKER_BOX_OPEN, SoundSource.BLOCKS, 0.5F, this.level.random.nextFloat() * 0.1F + 0.9F);
+             }
++            // Paper start -
++            if (apiLidMode == io.papermc.paper.block.LidMode.OPEN_UNTIL_VIEWED) {
++            // reset to default
++            apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++            stopForceLiddedLidOpen();
++            }
++            // Paper end - add Improved Lidded API
+         }
+ 
+     }
+@@ -222,7 +296,17 @@ public class ShulkerBoxBlockEntity extends RandomizableContainerBlockEntity impl
+     public void stopOpen(Player player) {
+         if (!this.remove && !player.isSpectator()) {
+             --this.openCount;
+-            if (this.opened) return; // CraftBukkit - only animate if the ShulkerBox hasn't been forced open already by an API call.
++            // Paper start - add Improved Lidded API
++            // if (this.opened) return; // CraftBukkit - only animate if the ShulkerBox hasn't been forced open already by an API call.
++            if (this.apiLidMode == io.papermc.paper.block.LidMode.FORCED_CLOSED || this.apiLidMode == io.papermc.paper.block.LidMode.CLOSED_UNTIL_NOT_VIEWED) {
++                if (this.openCount <= 0 && this.apiLidMode == io.papermc.paper.block.LidMode.CLOSED_UNTIL_NOT_VIEWED) {
++                    this.openCount = 0;
++                    this.apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++                    this.stopForceLiddedLidClose();
++                }
++                return;
++            }
++            // Paper end - add Improved Lidded API
+             this.level.blockEvent(this.worldPosition, this.getBlockState().getBlock(), 1, this.openCount);
+             if (this.openCount <= 0) {
+                 this.level.gameEvent((Entity) player, (Holder) GameEvent.CONTAINER_CLOSE, this.worldPosition);
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBarrel.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBarrel.java
+index 6063f0e1fdc232d063105971359ae688168a2bc4..657184a1137d35ee57d3fe2c1b106a67cc88205a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBarrel.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBarrel.java
+@@ -10,7 +10,7 @@ import org.bukkit.block.Barrel;
+ import org.bukkit.craftbukkit.inventory.CraftInventory;
+ import org.bukkit.inventory.Inventory;
+ 
+-public class CraftBarrel extends CraftLootable<BarrelBlockEntity> implements Barrel {
++public class CraftBarrel extends CraftLootable<BarrelBlockEntity> implements Barrel, io.papermc.paper.block.PaperLidded { // Paper - Add Improved Lidded Api
+ 
+     public CraftBarrel(World world, BarrelBlockEntity tileEntity) {
+         super(world, tileEntity);
+@@ -34,35 +34,37 @@ public class CraftBarrel extends CraftLootable<BarrelBlockEntity> implements Bar
+         return new CraftInventory(this.getTileEntity());
+     }
+ 
+-    @Override
+-    public void open() {
+-        this.requirePlaced();
+-        if (!this.getTileEntity().openersCounter.opened) {
+-            BlockState blockData = this.getTileEntity().getBlockState();
+-            boolean open = blockData.getValue(BarrelBlock.OPEN);
+-
+-            if (!open) {
+-                this.getTileEntity().updateBlockState(blockData, true);
+-                if (this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
+-                    this.getTileEntity().playSound(blockData, SoundEvents.BARREL_OPEN);
+-                }
+-            }
+-        }
+-        this.getTileEntity().openersCounter.opened = true;
+-    }
+-
+-    @Override
+-    public void close() {
+-        this.requirePlaced();
+-        if (this.getTileEntity().openersCounter.opened) {
+-            BlockState blockData = this.getTileEntity().getBlockState();
+-            this.getTileEntity().updateBlockState(blockData, false);
+-            if (this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
+-                this.getTileEntity().playSound(blockData, SoundEvents.BARREL_CLOSE);
+-            }
+-        }
+-        this.getTileEntity().openersCounter.opened = false;
+-    }
++    // Paper start - Replace with Improved Lidded API
++    // @Override
++    // public void open() {
++    //     this.requirePlaced();
++    //     if (!this.getTileEntity().openersCounter.opened) {
++    //         BlockState blockData = this.getTileEntity().getBlockState();
++    //         boolean open = blockData.getValue(BarrelBlock.OPEN);
++    //
++    //         if (!open) {
++    //             this.getTileEntity().updateBlockState(blockData, true);
++    //             if (this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
++    //                 this.getTileEntity().playSound(blockData, SoundEvents.BARREL_OPEN);
++    //             }
++    //         }
++    //     }
++    //     this.getTileEntity().openersCounter.opened = true;
++    // }
++    //
++    // @Override
++    // public void close() {
++    //     this.requirePlaced();
++    //     if (this.getTileEntity().openersCounter.opened) {
++    //         BlockState blockData = this.getTileEntity().getBlockState();
++    //         this.getTileEntity().updateBlockState(blockData, false);
++    //         if (this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
++    //             this.getTileEntity().playSound(blockData, SoundEvents.BARREL_CLOSE);
++    //         }
++    //     }
++    //     this.getTileEntity().openersCounter.opened = false;
++    // }
++    // Paper end - Replace with Improved Lidded API
+ 
+     @Override
+     public CraftBarrel copy() {
+@@ -75,9 +77,56 @@ public class CraftBarrel extends CraftLootable<BarrelBlockEntity> implements Bar
+     }
+ 
+     // Paper start - More Lidded Block API
++    // Paper start - Replace with Improved Lidded API
++    // @Override
++    // public boolean isOpen() {
++    //     return getTileEntity().openersCounter.opened;
++    // }
++    // Paper end - Replace with Improved Lidded API
++    // Paper end - More Lidded Block API
++
++    // Paper start - add Improved Lidded API
+     @Override
+-    public boolean isOpen() {
+-        return getTileEntity().openersCounter.opened;
++    public void startForceLiddedLidOpen() {
++        this.requirePlaced();
++        this.getTileEntity().openersCounter.startForceLiddedLidOpen(this.getTileEntity().getLevel(), this.getTileEntity().getBlockPos(), this.getTileEntity().getBlockState());
+     }
+-    // Paper end - More Lidded Block API
++    @Override
++    public void stopForceLiddedLidOpen() {
++        this.requirePlaced();
++        this.getTileEntity().openersCounter.stopForceLiddedLidOpen(this.getTileEntity().getLevel(), this.getTileEntity().getBlockPos(), this.getTileEntity().getBlockState());
++    }
++    @Override
++    public void startForceLiddedLidClose() {
++        this.requirePlaced();
++        this.getTileEntity().openersCounter.startForceLiddedLidClose(this.getTileEntity().getLevel(), this.getTileEntity().getBlockPos(), this.getTileEntity().getBlockState());
++    }
++    @Override
++    public void stopForceLiddedLidClose() {
++        this.requirePlaced();
++        this.getTileEntity().openersCounter.stopForceLiddedLidClose(this.getTileEntity().getLevel(), this.getTileEntity().getBlockPos(), this.getTileEntity().getBlockState());
++    }
++    @Override
++    public io.papermc.paper.block.LidState getEffectiveLidState() {
++        this.requirePlaced();
++        return this.getTileEntity().openersCounter.getEffectiveLidState();
++    }
++    @Override
++    public io.papermc.paper.block.LidState getTrueLidState() {
++        this.requirePlaced();
++        return this.getTileEntity().openersCounter.getTrueLidState();
++    }
++    @Override
++    public io.papermc.paper.block.LidMode getLidMode() {
++        this.requirePlaced();
++        return this.getTileEntity().openersCounter.getLidMode();
++    }
++    @Override
++    public io.papermc.paper.block.LidMode setLidMode(final io.papermc.paper.block.LidMode targetLidMode) {
++        this.requirePlaced();
++        io.papermc.paper.block.LidMode newEffectiveMode = io.papermc.paper.block.PaperLidded.super.setLidMode(targetLidMode);
++        this.getTileEntity().openersCounter.setLidMode(newEffectiveMode);
++        return newEffectiveMode;
++    }
++    // Paper end - add Improved Lidded API
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
+index cc7bf4d39b834fba472bc163226a01a0cd4b6010..63909cc516dd991c508ba5fb97a4539277aa86ad 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
+@@ -14,7 +14,7 @@ import org.bukkit.craftbukkit.inventory.CraftInventory;
+ import org.bukkit.craftbukkit.inventory.CraftInventoryDoubleChest;
+ import org.bukkit.inventory.Inventory;
+ 
+-public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest {
++public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest, io.papermc.paper.block.PaperLidded { // Paper - Add Improved Lidded Api
+ 
+     public CraftChest(World world, ChestBlockEntity tileEntity) {
+         super(world, tileEntity);
+@@ -57,31 +57,33 @@ public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest
+         return inventory;
+     }
+ 
+-    @Override
+-    public void open() {
+-        this.requirePlaced();
+-        if (!this.getTileEntity().openersCounter.opened && this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
+-            BlockState block = this.getTileEntity().getBlockState();
+-            int openCount = this.getTileEntity().openersCounter.getOpenerCount();
+-
+-            this.getTileEntity().openersCounter.onAPIOpen((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block);
+-            this.getTileEntity().openersCounter.openerAPICountChanged((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block, openCount, openCount + 1);
+-        }
+-        this.getTileEntity().openersCounter.opened = true;
+-    }
+-
+-    @Override
+-    public void close() {
+-        this.requirePlaced();
+-        if (this.getTileEntity().openersCounter.opened && this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
+-            BlockState block = this.getTileEntity().getBlockState();
+-            int openCount = this.getTileEntity().openersCounter.getOpenerCount();
+-
+-            this.getTileEntity().openersCounter.onAPIClose((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block);
+-            this.getTileEntity().openersCounter.openerAPICountChanged((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block, openCount, 0);
+-        }
+-        this.getTileEntity().openersCounter.opened = false;
+-    }
++    // Paper start - Replace with Improved Lidded API
++    // @Override
++    // public void open() {
++    //     this.requirePlaced();
++    //     if (!this.getTileEntity().openersCounter.opened && this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
++    //         BlockState block = this.getTileEntity().getBlockState();
++    //         int openCount = this.getTileEntity().openersCounter.getOpenerCount();
++    //
++    //         this.getTileEntity().openersCounter.onAPIOpen((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block);
++    //         this.getTileEntity().openersCounter.openerAPICountChanged((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block, openCount, openCount + 1);
++    //     }
++    //     this.getTileEntity().openersCounter.opened = true;
++    // }
++    //
++    // @Override
++    // public void close() {
++    //     this.requirePlaced();
++    //     if (this.getTileEntity().openersCounter.opened && this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
++    //         BlockState block = this.getTileEntity().getBlockState();
++    //         int openCount = this.getTileEntity().openersCounter.getOpenerCount();
++    //
++    //         this.getTileEntity().openersCounter.onAPIClose((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block);
++    //         this.getTileEntity().openersCounter.openerAPICountChanged((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block, openCount, 0);
++    //     }
++    //     this.getTileEntity().openersCounter.opened = false;
++    // }
++    // Paper end - Replace with Improved Lidded API
+ 
+     @Override
+     public CraftChest copy() {
+@@ -94,10 +96,12 @@ public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest
+     }
+ 
+     // Paper start - More Lidded Block API
+-    @Override
+-    public boolean isOpen() {
+-        return getTileEntity().openersCounter.opened;
+-    }
++    // Paper start - Replace with Improved Lidded API
++    // @Override
++    // public boolean isOpen() {
++    //     return getTileEntity().openersCounter.opened;
++    // }
++    // Paper end - Replace with Improved Lidded API
+     // Paper end - More Lidded Block API
+ 
+     // Paper start - More Chest Block API
+@@ -124,4 +128,49 @@ public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest
+             && ChestBlock.isChestBlockedAt(world, neighbourBlockPos);
+     }
+     // Paper end - More Chest Block API
++
++    // Paper start - add Improved Lidded API
++    @Override
++    public void startForceLiddedLidOpen() {
++        this.requirePlaced();
++        this.getTileEntity().openersCounter.startForceLiddedLidOpen(this.getTileEntity().getLevel(), this.getTileEntity().getBlockPos(), this.getTileEntity().getBlockState());
++    }
++    @Override
++    public void stopForceLiddedLidOpen() {
++        this.requirePlaced();
++        this.getTileEntity().openersCounter.stopForceLiddedLidOpen(this.getTileEntity().getLevel(), this.getTileEntity().getBlockPos(), this.getTileEntity().getBlockState());
++    }
++    @Override
++    public void startForceLiddedLidClose() {
++        this.requirePlaced();
++        this.getTileEntity().openersCounter.startForceLiddedLidClose(this.getTileEntity().getLevel(), this.getTileEntity().getBlockPos(), this.getTileEntity().getBlockState());
++    }
++    @Override
++    public void stopForceLiddedLidClose() {
++        this.requirePlaced();
++        this.getTileEntity().openersCounter.stopForceLiddedLidClose(this.getTileEntity().getLevel(), this.getTileEntity().getBlockPos(), this.getTileEntity().getBlockState());
++    }
++    @Override
++    public io.papermc.paper.block.LidState getEffectiveLidState() {
++        this.requirePlaced();
++        return this.getTileEntity().openersCounter.getEffectiveLidState();
++    }
++    @Override
++    public io.papermc.paper.block.LidState getTrueLidState() {
++        this.requirePlaced();
++        return this.getTileEntity().openersCounter.getTrueLidState();
++    }
++    @Override
++    public io.papermc.paper.block.LidMode getLidMode() {
++        this.requirePlaced();
++        return this.getTileEntity().openersCounter.getLidMode();
++    }
++    @Override
++    public io.papermc.paper.block.LidMode setLidMode(final io.papermc.paper.block.LidMode targetLidMode) {
++        this.requirePlaced();
++        io.papermc.paper.block.LidMode newEffectiveMode = io.papermc.paper.block.PaperLidded.super.setLidMode(targetLidMode);
++        this.getTileEntity().openersCounter.setLidMode(newEffectiveMode);
++        return newEffectiveMode;
++    }
++    // Paper end - add Improved Lidded API
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftEnderChest.java b/src/main/java/org/bukkit/craftbukkit/block/CraftEnderChest.java
+index f45ee675a10729845bf376fa95e648b23b9aac12..40cd86856105c054f5debd0eae5e7cecc46f9cf6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftEnderChest.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftEnderChest.java
+@@ -6,7 +6,7 @@ import org.bukkit.Location;
+ import org.bukkit.World;
+ import org.bukkit.block.EnderChest;
+ 
+-public class CraftEnderChest extends CraftBlockEntityState<EnderChestBlockEntity> implements EnderChest {
++public class CraftEnderChest extends CraftBlockEntityState<EnderChestBlockEntity> implements EnderChest, io.papermc.paper.block.PaperLidded { // Paper - Add Improved Lidded Api
+ 
+     public CraftEnderChest(World world, EnderChestBlockEntity tileEntity) {
+         super(world, tileEntity);
+@@ -16,31 +16,33 @@ public class CraftEnderChest extends CraftBlockEntityState<EnderChestBlockEntity
+         super(state, location);
+     }
+ 
+-    @Override
+-    public void open() {
+-        this.requirePlaced();
+-        if (!this.getTileEntity().openersCounter.opened && this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
+-            BlockState block = this.getTileEntity().getBlockState();
+-            int openCount = this.getTileEntity().openersCounter.getOpenerCount();
+-
+-            this.getTileEntity().openersCounter.onAPIOpen((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block);
+-            this.getTileEntity().openersCounter.openerAPICountChanged((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block, openCount, openCount + 1);
+-        }
+-        this.getTileEntity().openersCounter.opened = true;
+-    }
+-
+-    @Override
+-    public void close() {
+-        this.requirePlaced();
+-        if (this.getTileEntity().openersCounter.opened && this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
+-            BlockState block = this.getTileEntity().getBlockState();
+-            int openCount = this.getTileEntity().openersCounter.getOpenerCount();
+-
+-            this.getTileEntity().openersCounter.onAPIClose((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block);
+-            this.getTileEntity().openersCounter.openerAPICountChanged((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block, openCount, 0);
+-        }
+-        this.getTileEntity().openersCounter.opened = false;
+-    }
++    // Paper start - Replace with Improved Lidded API
++    // @Override
++    // public void open() {
++    //     this.requirePlaced();
++    //     if (!this.getTileEntity().openersCounter.opened && this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
++    //         BlockState block = this.getTileEntity().getBlockState();
++    //         int openCount = this.getTileEntity().openersCounter.getOpenerCount();
++    //
++    //         this.getTileEntity().openersCounter.onAPIOpen((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block);
++    //         this.getTileEntity().openersCounter.openerAPICountChanged((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block, openCount, openCount + 1);
++    //     }
++    //     this.getTileEntity().openersCounter.opened = true;
++    // }
++    //
++    // @Override
++    // public void close() {
++    //     this.requirePlaced();
++    //     if (this.getTileEntity().openersCounter.opened && this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
++    //         BlockState block = this.getTileEntity().getBlockState();
++    //         int openCount = this.getTileEntity().openersCounter.getOpenerCount();
++    //
++    //         this.getTileEntity().openersCounter.onAPIClose((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block);
++    //         this.getTileEntity().openersCounter.openerAPICountChanged((net.minecraft.world.level.Level) this.getWorldHandle(), this.getPosition(), block, openCount, 0);
++    //     }
++    //     this.getTileEntity().openersCounter.opened = false;
++    // }
++    // Paper end - Replace with Improved Lidded API
+ 
+     @Override
+     public CraftEnderChest copy() {
+@@ -53,10 +55,12 @@ public class CraftEnderChest extends CraftBlockEntityState<EnderChestBlockEntity
+     }
+ 
+     // Paper start - More Lidded Block API
+-    @Override
+-    public boolean isOpen() {
+-        return getTileEntity().openersCounter.opened;
+-    }
++    // Paper start - Replace with Improved Lidded API
++    // @Override
++    // public boolean isOpen() {
++    //     return getTileEntity().openersCounter.opened;
++    // }
++    // Paper end - Replace with Improved Lidded API
+     // Paper end - More Lidded Block API
+ 
+     // Paper start - More Chest Block API
+@@ -67,4 +71,49 @@ public class CraftEnderChest extends CraftBlockEntityState<EnderChestBlockEntity
+         return this.isPlaced() && this.getWorldHandle().getBlockState(abovePos).isRedstoneConductor(this.getWorldHandle(), abovePos);
+     }
+     // Paper end - More Chest Block API
++
++    // Paper start - add Improved Lidded API
++    @Override
++    public void startForceLiddedLidOpen() {
++        this.requirePlaced();
++        this.getTileEntity().openersCounter.startForceLiddedLidOpen(this.getTileEntity().getLevel(), this.getTileEntity().getBlockPos(), this.getTileEntity().getBlockState());
++    }
++    @Override
++    public void stopForceLiddedLidOpen() {
++        this.requirePlaced();
++        this.getTileEntity().openersCounter.stopForceLiddedLidOpen(this.getTileEntity().getLevel(), this.getTileEntity().getBlockPos(), this.getTileEntity().getBlockState());
++    }
++    @Override
++    public void startForceLiddedLidClose() {
++        this.requirePlaced();
++        this.getTileEntity().openersCounter.startForceLiddedLidClose(this.getTileEntity().getLevel(), this.getTileEntity().getBlockPos(), this.getTileEntity().getBlockState());
++    }
++    @Override
++    public void stopForceLiddedLidClose() {
++        this.requirePlaced();
++        this.getTileEntity().openersCounter.stopForceLiddedLidClose(this.getTileEntity().getLevel(), this.getTileEntity().getBlockPos(), this.getTileEntity().getBlockState());
++    }
++    @Override
++    public io.papermc.paper.block.LidState getEffectiveLidState() {
++        this.requirePlaced();
++        return this.getTileEntity().openersCounter.getEffectiveLidState();
++    }
++    @Override
++    public io.papermc.paper.block.LidState getTrueLidState() {
++        this.requirePlaced();
++        return this.getTileEntity().openersCounter.getTrueLidState();
++    }
++    @Override
++    public io.papermc.paper.block.LidMode getLidMode() {
++        this.requirePlaced();
++        return this.getTileEntity().openersCounter.getLidMode();
++    }
++    @Override
++    public io.papermc.paper.block.LidMode setLidMode(final io.papermc.paper.block.LidMode targetLidMode) {
++        this.requirePlaced();
++        io.papermc.paper.block.LidMode newEffectiveMode = io.papermc.paper.block.PaperLidded.super.setLidMode(targetLidMode);
++        this.getTileEntity().openersCounter.setLidMode(newEffectiveMode);
++        return newEffectiveMode;
++    }
++    // Paper end - add Improved Lidded API
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftShulkerBox.java b/src/main/java/org/bukkit/craftbukkit/block/CraftShulkerBox.java
+index f7b199fbc7a740de3ee6952ce12ef2c35f057d7a..ee3acbbf3751a21555ebbacae8e2916e7712b684 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftShulkerBox.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftShulkerBox.java
+@@ -11,7 +11,7 @@ import org.bukkit.block.ShulkerBox;
+ import org.bukkit.craftbukkit.inventory.CraftInventory;
+ import org.bukkit.inventory.Inventory;
+ 
+-public class CraftShulkerBox extends CraftLootable<ShulkerBoxBlockEntity> implements ShulkerBox {
++public class CraftShulkerBox extends CraftLootable<ShulkerBoxBlockEntity> implements ShulkerBox, io.papermc.paper.block.PaperLidded { // Paper - Add Improved Lidded Api
+ 
+     public CraftShulkerBox(World world, ShulkerBoxBlockEntity tileEntity) {
+         super(world, tileEntity);
+@@ -42,27 +42,29 @@ public class CraftShulkerBox extends CraftLootable<ShulkerBoxBlockEntity> implem
+         return (color == null) ? null : DyeColor.getByWoolData((byte) color.getId());
+     }
+ 
+-    @Override
+-    public void open() {
+-        this.requirePlaced();
+-        if (!this.getTileEntity().opened && this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
+-            net.minecraft.world.level.Level world = this.getTileEntity().getLevel();
+-            world.blockEvent(this.getPosition(), this.getTileEntity().getBlockState().getBlock(), 1, 1);
+-            world.playSound(null, this.getPosition(), SoundEvents.SHULKER_BOX_OPEN, SoundSource.BLOCKS, 0.5F, world.random.nextFloat() * 0.1F + 0.9F);
+-        }
+-        this.getTileEntity().opened = true;
+-    }
+-
+-    @Override
+-    public void close() {
+-        this.requirePlaced();
+-        if (this.getTileEntity().opened && this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
+-            net.minecraft.world.level.Level world = this.getTileEntity().getLevel();
+-            world.blockEvent(this.getPosition(), this.getTileEntity().getBlockState().getBlock(), 1, 0);
+-            world.playSound(null, this.getPosition(), SoundEvents.SHULKER_BOX_CLOSE, SoundSource.BLOCKS, 0.5F, world.random.nextFloat() * 0.1F + 0.9F); // Paper - More Lidded Block API (Wrong sound)
+-        }
+-        this.getTileEntity().opened = false;
+-    }
++    // Paper start - Replace with Improved Lidded API
++    // @Override
++    // public void open() {
++    //     this.requirePlaced();
++    //     if (!this.getTileEntity().opened && this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
++    //         net.minecraft.world.level.Level world = this.getTileEntity().getLevel();
++    //         world.blockEvent(this.getPosition(), this.getTileEntity().getBlockState().getBlock(), 1, 1);
++    //         world.playSound(null, this.getPosition(), SoundEvents.SHULKER_BOX_OPEN, SoundSource.BLOCKS, 0.5F, world.random.nextFloat() * 0.1F + 0.9F);
++    //     }
++    //     this.getTileEntity().opened = true;
++    // }
++    //
++    // @Override
++    // public void close() {
++    //     this.requirePlaced();
++    //     if (this.getTileEntity().opened && this.getWorldHandle() instanceof net.minecraft.world.level.Level) {
++    //         net.minecraft.world.level.Level world = this.getTileEntity().getLevel();
++    //         world.blockEvent(this.getPosition(), this.getTileEntity().getBlockState().getBlock(), 1, 0);
++    //         world.playSound(null, this.getPosition(), SoundEvents.SHULKER_BOX_CLOSE, SoundSource.BLOCKS, 0.5F, world.random.nextFloat() * 0.1F + 0.9F); // Paper - More Lidded Block API (Wrong sound)
++    //     }
++    //     this.getTileEntity().opened = false;
++    // }
++    // Paper end - Replace with Improved Lidded API
+ 
+     @Override
+     public CraftShulkerBox copy() {
+@@ -75,9 +77,56 @@ public class CraftShulkerBox extends CraftLootable<ShulkerBoxBlockEntity> implem
+     }
+ 
+     // Paper start - More Lidded Block API
++    // Paper start - Replace with Improved Lidded API
++    // @Override
++    // public boolean isOpen() {
++    //     return getTileEntity().opened;
++    // }
++    // Paper end - Replace with Improved Lidded API
++    // Paper end - More Lidded Block API
++
++    // Paper start - add Improved Lidded API
+     @Override
+-    public boolean isOpen() {
+-        return getTileEntity().opened;
++    public void startForceLiddedLidOpen() {
++        this.requirePlaced();
++        this.getTileEntity().startForceLiddedLidOpen();
+     }
+-    // Paper end - More Lidded Block API
++    @Override
++    public void stopForceLiddedLidOpen() {
++        this.requirePlaced();
++        this.getTileEntity().stopForceLiddedLidOpen();
++    }
++    @Override
++    public void startForceLiddedLidClose() {
++        this.requirePlaced();
++        this.getTileEntity().startForceLiddedLidClose();
++    }
++    @Override
++    public void stopForceLiddedLidClose() {
++        this.requirePlaced();
++        this.getTileEntity().stopForceLiddedLidClose();
++    }
++    @Override
++    public io.papermc.paper.block.LidState getEffectiveLidState() {
++        this.requirePlaced();
++        return this.getTileEntity().getEffectiveLidState();
++    }
++    @Override
++    public io.papermc.paper.block.LidState getTrueLidState() {
++        this.requirePlaced();
++        return this.getTileEntity().getTrueLidState();
++    }
++    @Override
++    public io.papermc.paper.block.LidMode getLidMode() {
++        this.requirePlaced();
++        return this.getTileEntity().getLidMode();
++    }
++    @Override
++    public io.papermc.paper.block.LidMode setLidMode(final io.papermc.paper.block.LidMode targetLidMode) {
++        this.requirePlaced();
++        io.papermc.paper.block.LidMode newEffectiveMode = io.papermc.paper.block.PaperLidded.super.setLidMode(targetLidMode);
++        this.getTileEntity().setLidMode(newEffectiveMode);
++        return newEffectiveMode;
++    }
++    // Paper end - add Improved Lidded API
+ }

--- a/patches/server/1061-Add-PlayerLiddedOpenEvent.patch
+++ b/patches/server/1061-Add-PlayerLiddedOpenEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerLiddedOpenEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java b/src/main/java/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
-index dfc184ed9f49524cf198ff672282326c16b41441..bdb80c8c07c18140232b248b88849ab76461c7cc 100644
+index dfc184ed9f49524cf198ff672282326c16b41441..46b4b6212d47bc18daa0ae326227631fafee1005 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
 @@ -47,6 +47,7 @@ public abstract class ContainerOpenersCounter {
@@ -21,7 +21,7 @@ index dfc184ed9f49524cf198ff672282326c16b41441..bdb80c8c07c18140232b248b88849ab7
  
      public void incrementOpeners(@javax.annotation.Nullable Player player, Level world, BlockPos pos, BlockState state) { // Paper - make player nullable for New Lidded API
 +        // Paper start - Call PlayerLiddedOpenEvent
-+        if (player != null && org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerLiddedOpenEvent(player, world, pos)) {
++        if (player != null && !org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerLiddedOpenEvent(player, world, pos)) {
 +            cancelledPlayers.add(player);
 +            return;
 +        }
@@ -50,7 +50,7 @@ index dfc184ed9f49524cf198ff672282326c16b41441..bdb80c8c07c18140232b248b88849ab7
  
          Player entityhuman;
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
-index 53a77dddfd6ae8b0cf102acd5a8e7679df500704..5f7ecfe65bd3528443abed923711283f784da6fb 100644
+index 53a77dddfd6ae8b0cf102acd5a8e7679df500704..347c7d09784ebd8435134d2797f6cf16dfb0fb29 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
 @@ -202,6 +202,7 @@ public class ShulkerBoxBlockEntity extends RandomizableContainerBlockEntity impl
@@ -66,7 +66,7 @@ index 53a77dddfd6ae8b0cf102acd5a8e7679df500704..5f7ecfe65bd3528443abed923711283f
                  this.openCount = 0;
              }
 +            // Paper start - Call PlayerLiddedOpenEvent
-+            if (org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerLiddedOpenEvent(player, this.level, this.worldPosition)) {
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerLiddedOpenEvent(player, this.level, this.worldPosition)) {
 +                cancelledPlayers.add(player);
 +                return;
 +            }

--- a/patches/server/1061-Add-PlayerLiddedOpenEvent.patch
+++ b/patches/server/1061-Add-PlayerLiddedOpenEvent.patch
@@ -1,0 +1,106 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Isaac - The456 <the456@the456gamer.dev>
+Date: Fri, 13 Sep 2024 00:28:27 +0100
+Subject: [PATCH] Add PlayerLiddedOpenEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java b/src/main/java/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
+index dfc184ed9f49524cf198ff672282326c16b41441..bdb80c8c07c18140232b248b88849ab76461c7cc 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
+@@ -47,6 +47,7 @@ public abstract class ContainerOpenersCounter {
+ 
+     // Paper start - add Improved Lidded API
+     private io.papermc.paper.block.LidMode apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++    private final java.util.Set<Player> cancelledPlayers = new java.util.HashSet<>(); // Paper - store players whose opening was cancelled by PlayerLiddedOpenEvent
+     public void startForceLiddedLidOpen(Level level, BlockPos pos, BlockState state) {
+         incrementOpeners(null, level, pos, state);
+     }
+@@ -93,6 +94,12 @@ public abstract class ContainerOpenersCounter {
+     }
+ 
+     public void incrementOpeners(@javax.annotation.Nullable Player player, Level world, BlockPos pos, BlockState state) { // Paper - make player nullable for New Lidded API
++        // Paper start - Call PlayerLiddedOpenEvent
++        if (player != null && org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerLiddedOpenEvent(player, world, pos)) {
++            cancelledPlayers.add(player);
++            return;
++        }
++        // Paper end - Call PlayerLiddedOpenEvent
+         if (this.openCount == 0 && apiLidMode == io.papermc.paper.block.LidMode.CLOSED_UNTIL_NOT_VIEWED) {
+             apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
+             stopForceLiddedLidClose(world, pos, state);
+@@ -130,6 +137,7 @@ public abstract class ContainerOpenersCounter {
+     }
+ 
+     public void decrementOpeners(@javax.annotation.Nullable Player player, Level world, BlockPos pos, BlockState state) { // Paper - make player nullable for New Lidded API
++        if (player != null && cancelledPlayers.remove(player)) return; // Paper - do not decrement if player's opening was cancelled by PlayerLiddedOpenEvent
+         int oldPower = Math.max(0, Math.min(15, this.openCount)); // CraftBukkit - Get power before new viewer is added
+         if (this.openCount == 0) return; // Paper - Prevent ContainerOpenersCounter openCount from going negative
+         int i = this.openCount--;
+@@ -171,6 +179,11 @@ public abstract class ContainerOpenersCounter {
+     public void recheckOpeners(Level world, BlockPos pos, BlockState state) {
+         List<Player> list = this.getPlayersWithContainerOpen(world, pos);
+ 
++        // Paper start - maintain cancelledPlayers, list of players with the chest open, but without the lid.
++        cancelledPlayers.removeIf(java.util.function.Predicate.not(list::contains));
++        list.removeIf(cancelledPlayers::contains);
++        // Paper end - maintain cancelledPlayers, list of players with the chest open, but without the lid.
++
+         this.maxInteractionRange = 0.0D;
+ 
+         Player entityhuman;
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
+index 53a77dddfd6ae8b0cf102acd5a8e7679df500704..5f7ecfe65bd3528443abed923711283f784da6fb 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
+@@ -202,6 +202,7 @@ public class ShulkerBoxBlockEntity extends RandomizableContainerBlockEntity impl
+ 
+     // Paper start - add Improved Lidded API
+     private io.papermc.paper.block.LidMode apiLidMode = io.papermc.paper.block.LidMode.DEFAULT;
++    private final java.util.Set<Player> cancelledPlayers = new java.util.HashSet<>(); // Paper - store players whose opening was cancelled by PlayerLiddedOpenEvent
+     public void startForceLiddedLidOpen() {
+         this.openCount++;
+         this.level.blockEvent(this.worldPosition, this.getBlockState().getBlock(), 1, this.openCount);
+@@ -262,6 +263,12 @@ public class ShulkerBoxBlockEntity extends RandomizableContainerBlockEntity impl
+             if (this.openCount < 0) {
+                 this.openCount = 0;
+             }
++            // Paper start - Call PlayerLiddedOpenEvent
++            if (org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerLiddedOpenEvent(player, this.level, this.worldPosition)) {
++                cancelledPlayers.add(player);
++                return;
++            }
++            // Paper end - Call PlayerLiddedOpenEvent
+             // Paper start - add Improved Lidded API
+             if (this.openCount == 0) {
+                 if (apiLidMode == io.papermc.paper.block.LidMode.CLOSED_UNTIL_NOT_VIEWED) {
+@@ -295,6 +302,7 @@ public class ShulkerBoxBlockEntity extends RandomizableContainerBlockEntity impl
+     @Override
+     public void stopOpen(Player player) {
+         if (!this.remove && !player.isSpectator()) {
++            if (cancelledPlayers.remove(player)) return; // Paper - do not decrement if player's opening was cancelled by PlayerLiddedOpenEvent
+             --this.openCount;
+             // Paper start - add Improved Lidded API
+             // if (this.opened) return; // CraftBukkit - only animate if the ShulkerBox hasn't been forced open already by an API call.
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 77ef27f9254235180a8596c6c8c4af750dc759d1..bdbee31dad9839d2504fb2a29e89b222f4b7fc9d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -2267,4 +2267,17 @@ public class CraftEventFactory {
+         return event;
+     }
+     // Paper end - add EntityFertilizeEggEvent
++
++    // Paper start - Add PlayerLiddedOpenEvent
++    public static boolean callPlayerLiddedOpenEvent(net.minecraft.world.entity.player.Player who, final Level world, final BlockPos pos) {
++
++        Player player = (Player) who.getBukkitEntity();
++        Block block = CraftBlock.at(world, pos);
++        io.papermc.paper.block.PaperLidded blockState = (io.papermc.paper.block.PaperLidded) CraftBlockStates.getBlockState(block);
++
++        io.papermc.paper.event.player.PlayerLiddedOpenEvent event = new io.papermc.paper.event.player.PlayerLiddedOpenEvent(player, blockState, block);
++
++        return event.callEvent();
++    }
++    // Paper end - Add PlayerLiddedOpenEvent
+ }

--- a/test-plugin/src/main/java/io/papermc/testplugin/LiddedTestListener.java
+++ b/test-plugin/src/main/java/io/papermc/testplugin/LiddedTestListener.java
@@ -1,0 +1,52 @@
+package io.papermc.testplugin;
+
+import io.papermc.paper.event.player.PlayerLiddedOpenEvent;
+import io.papermc.paper.registry.RegistryAccess;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.TypedKey;
+import io.papermc.paper.registry.tag.Tag;
+import io.papermc.paper.registry.tag.TagKey;
+import java.util.Objects;
+import java.util.logging.Logger;
+import net.kyori.adventure.key.Key;
+import org.bukkit.Registry;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ItemType;
+
+public class LiddedTestListener implements Listener {
+
+    private static final TagKey<ItemType> WOOL_TAG_KEY = TagKey.create(RegistryKey.ITEM,
+        Key.key("minecraft:wool"));
+    private final Logger logger;
+
+    public LiddedTestListener(Logger logger) {
+        this.logger = logger;
+    }
+
+    @EventHandler
+    public void onLiddedEvent(PlayerLiddedOpenEvent event) {
+        Registry<ItemType> itemTypeRegistry = RegistryAccess.registryAccess()
+            .getRegistry(RegistryKey.ITEM);
+        if (!itemTypeRegistry.hasTag(WOOL_TAG_KEY)) {
+            logger.warning("Wool tag not found");
+            return;
+        }
+        Tag<ItemType> woolTag = itemTypeRegistry.getTag(WOOL_TAG_KEY);
+
+        ItemStack mainHandItem = event.getPlayer().getInventory().getItemInMainHand();
+
+        boolean isWool = woolTag.contains(
+            TypedKey.create(RegistryKey.ITEM, itemTypeRegistry.getKeyOrThrow(
+                Objects.requireNonNull(mainHandItem.getType().asItemType()))));
+
+        if (isWool) {
+            event.getPlayer().sendRichMessage(
+                "<gray>Opening <gold>" + event.getLidded().getType().getKey().asString()
+                    + "</gold> Quietly");
+            event.setCancelled(true);
+        }
+    }
+
+}

--- a/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
+++ b/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
@@ -1,15 +1,320 @@
 package io.papermc.testplugin;
 
+import com.mojang.brigadier.LiteralMessage;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.Dynamic3CommandExceptionType;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import io.papermc.paper.block.LidMode;
+import io.papermc.paper.block.LidState;
+import io.papermc.paper.command.brigadier.Commands;
+import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
+import io.papermc.paper.command.brigadier.argument.CustomArgumentType;
+import io.papermc.paper.command.brigadier.argument.resolvers.BlockPositionResolver;
+import io.papermc.paper.math.BlockPosition;
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEventManager;
+import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Location;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Lidded;
 import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+
+import static net.kyori.adventure.text.Component.text;
 
 public final class TestPlugin extends JavaPlugin implements Listener {
+
+    private final Dynamic3CommandExceptionType NOT_LIDDED = new Dynamic3CommandExceptionType(
+        (objPos, objExpected, objActual) -> {
+            if (!(objPos instanceof BlockPosition pos) || !(objExpected instanceof String expected)
+                || !(objActual instanceof String actual)) {
+                getLogger().warning(
+                    "Internal Exception while making error message" + objPos.getClass()
+                        + objExpected.getClass() + objActual.getClass());
+                return new LiteralMessage("Internal Exception while making error message");
+            }
+
+            return new LiteralMessage(
+                "Block at %d, %d, %d is not a lidded block. Expected: \"%s\", Actual: \"%s\"".formatted(
+                    pos.blockX(), pos.blockY(), pos.blockZ(), expected, actual));
+        });
+
+    private io.papermc.paper.block.Lidded getPaperLidded(
+        CommandContext<io.papermc.paper.command.brigadier.CommandSourceStack> context,
+        BlockPosition pos
+    )
+        throws CommandSyntaxException {
+
+        Location targetLoc = new Location(context.getSource().getLocation().getWorld(),
+            pos.blockX(), pos.blockY(), pos.blockZ());
+        BlockState state = targetLoc.getBlock().getState();
+        if (state instanceof io.papermc.paper.block.Lidded lidded) {
+            return lidded;
+        }
+        throw NOT_LIDDED.create(pos, "A block Implementing Paper Lidded",
+            state.getType().key().asString());
+    }
+
+    private Lidded getBukkitLidded(
+        CommandContext<io.papermc.paper.command.brigadier.CommandSourceStack> context,
+        BlockPosition pos
+    ) throws CommandSyntaxException {
+        Location targetLoc = new Location(context.getSource().getLocation().getWorld(),
+            pos.blockX(), pos.blockY(), pos.blockZ());
+        BlockState state = targetLoc.getBlock().getState();
+        if (state instanceof Lidded lidded) {
+            return lidded;
+        }
+        throw NOT_LIDDED.create(pos, "A block Implementing Bukkit Lidded",
+            state.getType().key().asString());
+    }
 
     @Override
     public void onEnable() {
         this.getServer().getPluginManager().registerEvents(this, this);
 
+        LifecycleEventManager<Plugin> lifecycleManager = this.getLifecycleManager();
+
+        lifecycleManager.registerEventHandler(LifecycleEvents.COMMANDS, event -> {
+            event.registrar().register(
+                Commands.literal("test_lidded_new")
+                    .then(Commands.argument("pos", ArgumentTypes.blockPosition())
+                        .then(Commands.literal("query")
+                            .executes(context -> {
+                                BlockPosition pos = context.getArgument("pos",
+                                    BlockPositionResolver.class).resolve(context.getSource());
+                                io.papermc.paper.block.Lidded lidded = getPaperLidded(context, pos);
+                                if (!(lidded instanceof BlockState state)) {
+                                    throw new IllegalStateException("Impossible");
+                                }
+                                Component msg = text()
+                                    .append(text("---", NamedTextColor.DARK_GRAY)).appendNewline()
+                                    .append(text("Lidded Block: "))
+                                    .append(text(state.getType().key().asString())).appendNewline()
+                                    .append(text("Lid Mode: "))
+                                    .append(text(lidded.getLidMode().name())).appendNewline()
+                                    .append(text("Effective LidState: "))
+                                    .append(text(lidded.getEffectiveLidState().name(), lidded.getEffectiveLidState() == LidState.OPEN ? NamedTextColor.GREEN : NamedTextColor.RED)).appendSpace()
+                                    .append(text("True LidState: "))
+                                    .append(text(lidded.getTrueLidState().name(), lidded.getTrueLidState() == LidState.OPEN ? NamedTextColor.GREEN : NamedTextColor.RED))
+                                    .build();
+                                context.getSource().getSender().sendMessage(msg);
+                                return 1;
+                            })
+                        )
+                        .then(Commands.literal("set")
+                            .then(Commands.argument("lidMode", LidModeArgument.lidMode())
+                                .executes(context -> {
+                                        BlockPosition pos = context.getArgument("pos",
+                                            BlockPositionResolver.class).resolve(context.getSource());
+                                        io.papermc.paper.block.Lidded lidded = getPaperLidded(context, pos);
+                                        if (!(lidded instanceof BlockState state)) {
+                                            throw new IllegalStateException("Impossible");
+                                        }
+
+                                        LidMode previousMode = lidded.getLidMode();
+                                        LidState oldEffectiveState = lidded.getEffectiveLidState();
+                                        LidState oldTrueState = lidded.getTrueLidState();
+                                        LidMode targetMode = LidModeArgument.getLidMode(context, "lidMode");
+                                        LidMode resultantMode = lidded.setLidMode(targetMode);
+
+                                        Component msg = text()
+                                            .append(text("---", NamedTextColor.DARK_GRAY)).appendNewline()
+                                            .append(text("Lidded Block: "))
+                                            .append(text(state.getType().key().asString())).appendNewline()
+                                            .append(text("Lid Mode: "))
+                                            .append(text("Old: "))
+                                            .append(text(previousMode.name())).appendSpace()
+                                            .append(text("Target: "))
+                                            .append(text(targetMode.name())).appendSpace()
+                                            .append(text("New: "))
+                                            .append(text(resultantMode.name())).appendNewline()
+                                            .append(text("Effective LidState: "))
+                                            .append(text("Old: "))
+                                            .append(text(oldEffectiveState.name(), oldEffectiveState == LidState.OPEN ? NamedTextColor.GREEN : NamedTextColor.RED)).appendSpace()
+                                            .append(text("New: "))
+                                            .append(text(lidded.getEffectiveLidState().name(), lidded.getEffectiveLidState() == LidState.OPEN ? NamedTextColor.GREEN : NamedTextColor.RED)).appendNewline()
+                                            .append(text("True LidState: "))
+                                            .append(text("Old: "))
+                                            .append(text(oldTrueState.name(), oldTrueState == LidState.OPEN ? NamedTextColor.GREEN : NamedTextColor.RED)).appendSpace()
+                                            .append(text("New: "))
+                                            .append(text(lidded.getTrueLidState().name(), lidded.getTrueLidState() == LidState.OPEN ? NamedTextColor.GREEN : NamedTextColor.RED))
+                                            .build();
+                                        context.getSource().getSender().sendMessage(msg);
+
+
+                                        return 1;
+                                    }
+                                )
+                            )
+                        )
+                    )
+                    .build()
+            );
+            event.registrar().register(
+                Commands.literal("test_lidded_old")
+                    .then(Commands.argument("pos", ArgumentTypes.blockPosition())
+                        .then(Commands.literal("is_open")
+                            .executes(context -> {
+                                BlockPosition pos = context.getArgument("pos",
+                                    BlockPositionResolver.class).resolve(context.getSource());
+                                Lidded lidded = getBukkitLidded(context, pos);
+                                if (!(lidded instanceof BlockState state)) {
+                                    throw new IllegalStateException("Impossible");
+                                }
+
+                                Component msg = text()
+                                    .append(text("Lidded Block: "))
+                                    .append(text(state.getType().key().asString()))
+                                    .append(text(" is open: "))
+                                    .append(text(lidded.isOpen() ? "Yes" : "No", lidded.isOpen() ? NamedTextColor.GREEN : NamedTextColor.RED))
+                                    .build();
+
+                                context.getSource().getSender().sendMessage(msg);
+
+
+                                return 1;
+                            })
+                        )
+                        .then(Commands.literal("open")
+                            .executes(context -> {
+                                BlockPosition pos = context.getArgument("pos",
+                                    BlockPositionResolver.class).resolve(context.getSource());
+                                Lidded lidded = getBukkitLidded(context, pos);
+                                if (!(lidded instanceof BlockState state)) {
+                                    throw new IllegalStateException("Impossible");
+                                }
+
+                                lidded.open();
+
+                                Component msg = text()
+                                    .append(text("Lidded Block: "))
+                                    .append(text(state.getType().key().asString()))
+                                    .append(text(" set "))
+                                    .append(text("open", NamedTextColor.GREEN))
+                                    .build();
+
+                                context.getSource().getSender().sendMessage(msg);
+
+                                return 1;
+                            })
+                        )
+                        .then(Commands.literal("close")
+                            .executes(context -> {
+                                BlockPosition pos = context.getArgument("pos",
+                                    BlockPositionResolver.class).resolve(context.getSource());
+                                Lidded lidded = getBukkitLidded(context, pos);
+                                if (!(lidded instanceof BlockState state)) {
+                                    throw new IllegalStateException("Impossible");
+                                }
+
+                                lidded.close();
+                                Component msg = text()
+                                    .append(text("Lidded Block: "))
+                                    .append(text(state.getType().key().asString()))
+                                    .append(text(" set "))
+                                    .append(text("closed", NamedTextColor.RED))
+                                    .build();
+
+                                context.getSource().getSender().sendMessage(msg);
+
+                                return 1;
+                            })
+                        )
+                    )
+                    .build()
+            );
+
+
+        });
+
         // io.papermc.testplugin.brigtests.Registration.registerViaOnEnable(this);
     }
+
+    public static class LidModeArgument implements CustomArgumentType.Converted<LidMode, String> {
+
+        private static final SimpleCommandExceptionType INVALID_MODE = new SimpleCommandExceptionType(
+            new LiteralMessage("Invalid lid mode"));
+
+        private static final LinkedHashMap<String, LidMode> BY_STRING = Arrays.stream(
+                LidMode.values())
+            .collect(
+                Collectors.toMap(LidMode::name, Function.identity(), (lidMode, lidMode2) -> lidMode,
+                    LinkedHashMap::new));
+
+        static boolean matchesSubStr(String remaining, String candidate) {
+            for (int i = 0; !candidate.startsWith(remaining, i); i++) {
+                int j = candidate.indexOf(46, i);
+                int k = candidate.indexOf(95, i);
+                if (Math.max(j, k) < 0) {
+                    return false;
+                }
+
+                if (j >= 0 && k >= 0) {
+                    i = Math.min(k, j);
+                } else {
+                    i = j >= 0 ? j : k;
+                }
+            }
+
+            return true;
+        }
+
+        public static LidModeArgument lidMode() {
+            return new LidModeArgument();
+        }
+
+        public static LidMode getLidMode(CommandContext<?> context, String name) {
+            return context.getArgument(name, LidMode.class);
+        }
+
+        @Override
+        public @NotNull LidMode convert(@NotNull final String nativeType)
+            throws CommandSyntaxException {
+            LidMode mode = BY_STRING.get(nativeType.toUpperCase(Locale.ROOT));
+            if (mode == null) {
+                throw INVALID_MODE.create();
+            }
+            return mode;
+        }
+
+        @Override
+        public @NotNull ArgumentType<String> getNativeType() {
+            return StringArgumentType.word();
+        }
+
+        @Override
+        public @NotNull Collection<String> getExamples() {
+            return BY_STRING.keySet();
+        }
+
+        @Override
+        public @NotNull <S> CompletableFuture<Suggestions> listSuggestions(
+            final @NotNull CommandContext<S> context, final @NotNull SuggestionsBuilder builder
+        ) {
+
+            String string = builder.getRemaining().toLowerCase(Locale.ROOT);
+            BY_STRING.keySet().stream()
+                .filter(candidate -> matchesSubStr(string, candidate.toLowerCase(Locale.ROOT)))
+                .forEach(builder::suggest);
+            return builder.buildFuture();
+        }
+    }
+
 
 }

--- a/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
+++ b/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
@@ -243,6 +243,8 @@ public final class TestPlugin extends JavaPlugin implements Listener {
 
         });
 
+        getServer().getPluginManager().registerEvents(new LiddedTestListener(this.getLogger()), this);
+
         // io.papermc.testplugin.brigtests.Registration.registerViaOnEnable(this);
     }
 


### PR DESCRIPTION
Featuring
- 5 LidModes, 3 of which were not possible before
- The ability to get if the lid actually should be open, if a player is in the container
- The ability to get if the is open, from api or the player itself

This also deprecates Bukkits api because of the confusing and outright incorrect javadocs (so those now accurately represent the behaviour)

Testable with the included testplugin commands.

Im not 100% sure if the PaperLidded interface is the best way of doing this, but it is working
Also, let me know if the naming needs to change.


```[tasklist]
### Tasks
- [ ] see if anything important is skipped in the check method scheduled every 5 ticks on chests 
``` 