### PR TITLE
PlayerInventory#setItem check for slot outside of inventory

### DIFF
--- a/patches/server/1060-check-for-slot-outside-of-inventory.patch
+++ b/patches/server/1060-check-for-slot-outside-of-inventory.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: strnq <dev@aruus.uk>
+Date: Fri, 13 Sep 2024 23:48:01 +0300
+Subject: [PATCH] check for slot outside of inventory
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
+index af1ae3dacb628da23f7d2988c6e76d3fb2d64103..9fdeea10a253fd9369821faac2d53fbca0cb7522 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
+@@ -97,6 +97,11 @@ public class CraftInventory implements Inventory {
+ 
+     @Override
+     public void setItem(int index, ItemStack item) {
++        // Paper start - Validate setItem index
++        if (index < 0 || index > 40) {
++            throw new ArrayIndexOutOfBoundsException("Index must be between 0 and 40");
++        }
++        // Paper end - Validate setItem index
+         this.getInventory().setItem(index, CraftItemStack.asNMSCopy(item));
+     }
+ 


### PR DESCRIPTION
This solves #11391 
```playerInventory.setItem(46, someItemStack);``` should throw error as described in [the javadoc](https://jd.papermc.io/paper/1.21.1/org/bukkit/inventory/PlayerInventory.html#setItem(int,org.bukkit.inventory.ItemStack)) as the slot is outside of this inventory. But the server accept it.