### PR TITLE
Prevent NPE when serializing unresolved profile

### DIFF
--- a/patches/server/0136-Basic-PlayerProfile-API.patch
+++ b/patches/server/0136-Basic-PlayerProfile-API.patch
@@ -16,7 +16,7 @@ public org.bukkit.craftbukkit.profile.CraftPlayerProfile setProperty(Ljava/lang/
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..23181027bb077417655913c29377bed720c9e9c1
+index 0000000000000000000000000000000000000000..9a7add1a7b137a0c9ca9c69fec674a7720d954eb
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 @@ -0,0 +1,449 @@
@@ -357,10 +357,10 @@ index 0000000000000000000000000000000000000000..23181027bb077417655913c29377bed7
 +    @Override
 +    public @NotNull Map<String, Object> serialize() {
 +        Map<String, Object> map = new LinkedHashMap<>();
-+        if (this.getId() != null) {
++        if (!this.emptyUUID) {
 +            map.put("uniqueId", this.getId().toString());
 +        }
-+        if (!this.getName().isEmpty()) {
++        if (!this.emptyName) {
 +            map.put("name", getName());
 +        }
 +        if (!this.properties.isEmpty()) {


### PR DESCRIPTION
In the recent upstream update, the paper player profile was updated to
correctly return null for both name and id if constructed as such. This
change however broke the serialisation logic, as it depended on the name
never being null.

The commit moves the checks over to the newly introduced emptyName/UUID
fields that track if the profile was constructed with a null name or
uuid to differentiate it against an empty string or the NIL_UUID.
