### PR TITLE
Correctly launch WindCharges

### DIFF
--- a/patches/server/0674-More-Projectile-API.patch
+++ b/patches/server/0674-More-Projectile-API.patch
@@ -515,7 +515,7 @@ index 6e2f91423371ead9890095cf4b1e2299c4dcba28..9d8f4b7176e60180565e3134a14ecf19
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 097f03c83a90f476b74834407d2dcd0e98fe010a..3210d7c9405a1a335ef92debf4d85957087bfcf3 100644
+index 097f03c83a90f476b74834407d2dcd0e98fe010a..81e554672b329875f1a4621d1f4dc7f1a706406b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -596,7 +596,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
@@ -527,7 +527,28 @@ index 097f03c83a90f476b74834407d2dcd0e98fe010a..3210d7c9405a1a335ef92debf4d85957
          } else if (ThrownPotion.class.isAssignableFrom(projectile)) {
              if (LingeringPotion.class.isAssignableFrom(projectile)) {
                  launch = new net.minecraft.world.entity.projectile.ThrownPotion(world, this.getHandle());
-@@ -650,7 +650,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -622,10 +622,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+                 launch = new net.minecraft.world.entity.projectile.WitherSkull(world, this.getHandle(), vec);
+             } else if (DragonFireball.class.isAssignableFrom(projectile)) {
+                 launch = new net.minecraft.world.entity.projectile.DragonFireball(world, this.getHandle(), vec);
+-            } else if (WindCharge.class.isAssignableFrom(projectile)) {
+-                launch = EntityType.WIND_CHARGE.create(world);
+-                ((net.minecraft.world.entity.projectile.windcharge.WindCharge) launch).setOwner(this.getHandle());
+-                ((net.minecraft.world.entity.projectile.windcharge.WindCharge) launch).assignDirectionalMovement(vec, 0.1D);
++            // Paper start - more projectile API - correctly launch wind charges
++            } else if (org.bukkit.entity.AbstractWindCharge.class.isAssignableFrom(projectile)) {
++                if (org.bukkit.entity.BreezeWindCharge.class.isAssignableFrom(projectile)) {
++                    launch = EntityType.BREEZE_WIND_CHARGE.create(world);
++                } else {
++                    launch = EntityType.WIND_CHARGE.create(world);
++                }
++                ((net.minecraft.world.entity.projectile.windcharge.AbstractWindCharge) launch).setOwner(this.getHandle());
++                ((net.minecraft.world.entity.projectile.windcharge.AbstractWindCharge) launch).assignDirectionalMovement(vec, 0.1D);
++            // Paper end - more projectile API - correctly launch wind charges
+             } else {
+                 launch = new LargeFireball(world, this.getHandle(), vec, 1);
+             }
+@@ -650,7 +656,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          } else if (Firework.class.isAssignableFrom(projectile)) {
              Location location = this.getEyeLocation();
  
@@ -791,3 +812,29 @@ index e8a455eb5e17bcfcae3f03664f2b47773fbdf37e..08178a88ba7d0881a6c2843eef24a846
          return ((CraftItemType<?>) CraftItemType.minecraftToBukkitNew(item.getItem())).getItemMeta(item);
      }
  
+diff --git a/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java b/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
+index 8b57044518fbb0fd507da6ae3ff12b99eff70b37..1ad4eaa5cade3c01e7e484246bc0f8fe7e3e45db 100644
+--- a/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
++++ b/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
+@@ -109,6 +109,21 @@ public class CraftBlockProjectileSource implements BlockProjectileSource {
+                 launch.setPos(d0, d1, d2);
+ 
+                 ((AbstractHurtingProjectile) launch).assignDirectionalMovement(new Vec3(d3, d4, d5), 0.1D);
++            // Paper start - more projectile API - correctly launch wind charges
++            } else if (org.bukkit.entity.AbstractWindCharge.class.isAssignableFrom(projectile)) {
++                if (org.bukkit.entity.BreezeWindCharge.class.isAssignableFrom(projectile)) {
++                    launch = EntityType.BREEZE_WIND_CHARGE.create(world);
++                } else {
++                    launch = EntityType.WIND_CHARGE.create(world);
++                }
++
++                // Copied from net.minecraft.world.item.WindChargeItem.asProjectile
++                double d = random.triangle(enumdirection.getStepX(), 0.11485000000000001);
++                double e = random.triangle(enumdirection.getStepY(), 0.11485000000000001);
++                double f = random.triangle(enumdirection.getStepZ(), 0.11485000000000001);
++                launch.setPos(d0, d1, d2);
++                launch.setDeltaMovement(new Vec3(d, e, f));
++            // Paper end - more projectile API - correctly launch wind charges
+             } else {
+                 launch = EntityType.FIREBALL.create(world);
+                 launch.setPos(d0, d1, d2);

--- a/patches/server/0674-More-Projectile-API.patch
+++ b/patches/server/0674-More-Projectile-API.patch
@@ -515,7 +515,7 @@ index 6e2f91423371ead9890095cf4b1e2299c4dcba28..9d8f4b7176e60180565e3134a14ecf19
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 097f03c83a90f476b74834407d2dcd0e98fe010a..81e554672b329875f1a4621d1f4dc7f1a706406b 100644
+index 097f03c83a90f476b74834407d2dcd0e98fe010a..741cc56304005c48b26966f617d282bae7a87ee6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -596,7 +596,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
@@ -543,7 +543,7 @@ index 097f03c83a90f476b74834407d2dcd0e98fe010a..81e554672b329875f1a4621d1f4dc7f1
 +                    launch = EntityType.WIND_CHARGE.create(world);
 +                }
 +                ((net.minecraft.world.entity.projectile.windcharge.AbstractWindCharge) launch).setOwner(this.getHandle());
-+                ((net.minecraft.world.entity.projectile.windcharge.AbstractWindCharge) launch).assignDirectionalMovement(vec, 0.1D);
++                ((net.minecraft.world.entity.projectile.windcharge.AbstractWindCharge) launch).shootFromRotation(this.getHandle(), this.getHandle().getXRot(), this.getHandle().getYRot(), 0.0F, 1.5F, 1.0F); // Paper - copied from net.minecraft.world.item.WindChargeItem.use
 +            // Paper end - more projectile API - correctly launch wind charges
              } else {
                  launch = new LargeFireball(world, this.getHandle(), vec, 1);
@@ -812,29 +812,3 @@ index e8a455eb5e17bcfcae3f03664f2b47773fbdf37e..08178a88ba7d0881a6c2843eef24a846
          return ((CraftItemType<?>) CraftItemType.minecraftToBukkitNew(item.getItem())).getItemMeta(item);
      }
  
-diff --git a/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java b/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
-index 8b57044518fbb0fd507da6ae3ff12b99eff70b37..1ad4eaa5cade3c01e7e484246bc0f8fe7e3e45db 100644
---- a/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
-+++ b/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
-@@ -109,6 +109,21 @@ public class CraftBlockProjectileSource implements BlockProjectileSource {
-                 launch.setPos(d0, d1, d2);
- 
-                 ((AbstractHurtingProjectile) launch).assignDirectionalMovement(new Vec3(d3, d4, d5), 0.1D);
-+            // Paper start - more projectile API - correctly launch wind charges
-+            } else if (org.bukkit.entity.AbstractWindCharge.class.isAssignableFrom(projectile)) {
-+                if (org.bukkit.entity.BreezeWindCharge.class.isAssignableFrom(projectile)) {
-+                    launch = EntityType.BREEZE_WIND_CHARGE.create(world);
-+                } else {
-+                    launch = EntityType.WIND_CHARGE.create(world);
-+                }
-+
-+                // Copied from net.minecraft.world.item.WindChargeItem.asProjectile
-+                double d = random.triangle(enumdirection.getStepX(), 0.11485000000000001);
-+                double e = random.triangle(enumdirection.getStepY(), 0.11485000000000001);
-+                double f = random.triangle(enumdirection.getStepZ(), 0.11485000000000001);
-+                launch.setPos(d0, d1, d2);
-+                launch.setDeltaMovement(new Vec3(d, e, f));
-+            // Paper end - more projectile API - correctly launch wind charges
-             } else {
-                 launch = EntityType.FIREBALL.create(world);
-                 launch.setPos(d0, d1, d2);

--- a/patches/server/0739-Add-a-consumer-parameter-to-ProjectileSource-launchP.patch
+++ b/patches/server/0739-Add-a-consumer-parameter-to-ProjectileSource-launchP.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add a consumer parameter to ProjectileSource#launchProjectile
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 81e554672b329875f1a4621d1f4dc7f1a706406b..f6999207658253699ca8f8df8bfa19f39cd59f86 100644
+index 741cc56304005c48b26966f617d282bae7a87ee6..e6727100c3ec18a32e08d027cd1b4c39b913d554 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -569,8 +569,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
@@ -38,7 +38,7 @@ index 81e554672b329875f1a4621d1f4dc7f1a706406b..f6999207658253699ca8f8df8bfa19f3
          world.addFreshEntity(launch);
          return (T) launch.getBukkitEntity();
 diff --git a/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java b/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
-index 1ad4eaa5cade3c01e7e484246bc0f8fe7e3e45db..e0f81d331dbe4a3a723c783b43ad6ae10657c2ea 100644
+index 8b57044518fbb0fd507da6ae3ff12b99eff70b37..2a6c4a74ff065110bb09b528f2d5f80b560a587a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
 +++ b/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
 @@ -56,6 +56,13 @@ public class CraftBlockProjectileSource implements BlockProjectileSource {
@@ -55,7 +55,7 @@ index 1ad4eaa5cade3c01e7e484246bc0f8fe7e3e45db..e0f81d331dbe4a3a723c783b43ad6ae1
          Preconditions.checkArgument(this.getBlock().getType() == Material.DISPENSER, "Block is no longer dispenser");
          // Copied from BlockDispenser.dispense()
          BlockSource sourceblock = new BlockSource((ServerLevel) this.dispenserBlock.getLevel(), this.dispenserBlock.getBlockPos(), this.dispenserBlock.getBlockState(), this.dispenserBlock);
-@@ -155,6 +162,11 @@ public class CraftBlockProjectileSource implements BlockProjectileSource {
+@@ -140,6 +147,11 @@ public class CraftBlockProjectileSource implements BlockProjectileSource {
          if (velocity != null) {
              ((T) launch.getBukkitEntity()).setVelocity(velocity);
          }

--- a/patches/server/0739-Add-a-consumer-parameter-to-ProjectileSource-launchP.patch
+++ b/patches/server/0739-Add-a-consumer-parameter-to-ProjectileSource-launchP.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add a consumer parameter to ProjectileSource#launchProjectile
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 3210d7c9405a1a335ef92debf4d85957087bfcf3..ae3bf4adc93ebd5a3d19536ac0e0889599aa4e6b 100644
+index 81e554672b329875f1a4621d1f4dc7f1a706406b..f6999207658253699ca8f8df8bfa19f39cd59f86 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -569,8 +569,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
@@ -25,7 +25,7 @@ index 3210d7c9405a1a335ef92debf4d85957087bfcf3..ae3bf4adc93ebd5a3d19536ac0e08895
          Preconditions.checkState(!this.getHandle().generation, "Cannot launch projectile during world generation");
  
          net.minecraft.world.level.Level world = ((CraftWorld) this.getWorld()).getHandle();
-@@ -659,6 +666,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -665,6 +672,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          if (velocity != null) {
              ((T) launch.getBukkitEntity()).setVelocity(velocity);
          }
@@ -38,7 +38,7 @@ index 3210d7c9405a1a335ef92debf4d85957087bfcf3..ae3bf4adc93ebd5a3d19536ac0e08895
          world.addFreshEntity(launch);
          return (T) launch.getBukkitEntity();
 diff --git a/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java b/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
-index 8b57044518fbb0fd507da6ae3ff12b99eff70b37..2a6c4a74ff065110bb09b528f2d5f80b560a587a 100644
+index 1ad4eaa5cade3c01e7e484246bc0f8fe7e3e45db..e0f81d331dbe4a3a723c783b43ad6ae10657c2ea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
 +++ b/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
 @@ -56,6 +56,13 @@ public class CraftBlockProjectileSource implements BlockProjectileSource {
@@ -55,7 +55,7 @@ index 8b57044518fbb0fd507da6ae3ff12b99eff70b37..2a6c4a74ff065110bb09b528f2d5f80b
          Preconditions.checkArgument(this.getBlock().getType() == Material.DISPENSER, "Block is no longer dispenser");
          // Copied from BlockDispenser.dispense()
          BlockSource sourceblock = new BlockSource((ServerLevel) this.dispenserBlock.getLevel(), this.dispenserBlock.getBlockPos(), this.dispenserBlock.getBlockState(), this.dispenserBlock);
-@@ -140,6 +147,11 @@ public class CraftBlockProjectileSource implements BlockProjectileSource {
+@@ -155,6 +162,11 @@ public class CraftBlockProjectileSource implements BlockProjectileSource {
          if (velocity != null) {
              ((T) launch.getBukkitEntity()).setVelocity(velocity);
          }

--- a/patches/server/0753-Add-entity-knockback-API.patch
+++ b/patches/server/0753-Add-entity-knockback-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add entity knockback API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index ae3bf4adc93ebd5a3d19536ac0e0889599aa4e6b..2b53f1daa4f22ee1b52443ae8589c62807d22903 100644
+index f6999207658253699ca8f8df8bfa19f39cd59f86..8babdfe0c6bd921f95cf55313197d576035b0891 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1103,4 +1103,12 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1109,4 +1109,12 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          throw new UnsupportedOperationException("Cannot set the hurt direction on a non player");
      }
      // Paper end - hurt direction API

--- a/patches/server/0769-ItemStack-damage-API.patch
+++ b/patches/server/0769-ItemStack-damage-API.patch
@@ -53,10 +53,10 @@ index bee59df6a8f30416f94c1a4fbd5e2629336e842f..e64cc91b416bbbefe6aadf1c6b685346
  
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 2b53f1daa4f22ee1b52443ae8589c62807d22903..9134ce983f5c798e2925348ac9d3b8570965d415 100644
+index 8babdfe0c6bd921f95cf55313197d576035b0891..f1d2a1610649779da09a76ede7fdfa14658c82ba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1111,4 +1111,48 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1117,4 +1117,48 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          this.getHandle().knockback(strength, directionX, directionZ);
      };
      // Paper end - knockback API

--- a/patches/server/0770-Friction-API.patch
+++ b/patches/server/0770-Friction-API.patch
@@ -133,10 +133,10 @@ index 1a291dd8a287db30e71dcb315599fc4b038764c4..30d62ee4d5cd2ddacb8783b5bbbf475d
      public int getHealth() {
          return this.getHandle().health;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 9134ce983f5c798e2925348ac9d3b8570965d415..89b66fd33cdeab03a6b208f9c59df767787a42bf 100644
+index f1d2a1610649779da09a76ede7fdfa14658c82ba..7afa1fdc9e2cd517c8e173275b2882666e720bcf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1155,4 +1155,17 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1161,4 +1161,17 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          nmsStack.hurtAndBreak(amount, this.getHandle(), slot, true);
      }
      // Paper end - ItemStack damage API

--- a/patches/server/0794-Add-Entity-Body-Yaw-API.patch
+++ b/patches/server/0794-Add-Entity-Body-Yaw-API.patch
@@ -43,10 +43,10 @@ index ac513d3162a0794f226abc80bff21c799fe5802c..7c7501b4b21530d0641774f64e87d7d1
      @Override
      public boolean isInvisible() {  // Paper - moved up from LivingEntity
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 89b66fd33cdeab03a6b208f9c59df767787a42bf..a5d30e5657edd7d71ea521f81faa6d3088164291 100644
+index 7afa1fdc9e2cd517c8e173275b2882666e720bcf..563da83fe7159aa5bc8e5387734ee502045b3f15 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1168,4 +1168,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1174,4 +1174,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          this.getHandle().frictionState = state;
      }
      // Paper end - friction API

--- a/patches/server/0968-Fix-equipment-slot-and-group-API.patch
+++ b/patches/server/0968-Fix-equipment-slot-and-group-API.patch
@@ -10,10 +10,10 @@ Adds the following:
 Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 6c44aaef8f09b2a10183dba751557ac5c6233a87..a54cf98661cc678277855f21735e98fafd018ded 100644
+index d3bbf5dea0d26603f76293ebf64a86366f5ad3a1..d759a2adc77e35d66a1ff1c9f227cded6f0e9963 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1187,4 +1187,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1193,4 +1193,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          this.getHandle().setYBodyRot(bodyYaw);
      }
      // Paper end - body yaw API

--- a/patches/server/1043-Leashable-API.patch
+++ b/patches/server/1043-Leashable-API.patch
@@ -74,10 +74,10 @@ index e33b1b6fd50a4eea57500cc00dba20d6edcab75d..01a9660de65688b7c1a4f9dafcb65077
      public CraftBoat(CraftServer server, net.minecraft.world.entity.vehicle.Boat entity) {
          super(server, entity);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index a54cf98661cc678277855f21735e98fafd018ded..a46fbd2a5e31dd9aa7fcf0867c91ec8d28990861 100644
+index d759a2adc77e35d66a1ff1c9f227cded6f0e9963..6fc0d13a308b70e78bf0e24a3d33f90f5bac97ff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -753,43 +753,17 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -759,43 +759,17 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
  
      @Override
      public boolean isLeashed() {


### PR DESCRIPTION
The launch API on LivingEntity only respected the WindCharge type, not
its near-clone BreezeWindCharge.

This commit correctly accounts for BreezeWindCharge in
CraftLivingEntity.

Resolves: #11417
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-11418.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1961954719.zip)