### PR TITLE
Disable pretty printing for advancement saving

### DIFF
--- a/patches/server/1058-Disable-pretty-printing-for-advancement-saving.patch
+++ b/patches/server/1058-Disable-pretty-printing-for-advancement-saving.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Newwind <support@newwindserver.com>
+Date: Fri, 20 Sep 2024 14:17:37 +0200
+Subject: [PATCH] Disable pretty printing for advancement saving
+
+Reduces json size by about 25%
+Not sure why advancements even had pretty printing enabled.
+My best guess was by accident on mojang's part, especially since stats json files don't have pretty printing.
+
+diff --git a/src/main/java/net/minecraft/server/PlayerAdvancements.java b/src/main/java/net/minecraft/server/PlayerAdvancements.java
+index 9fabf9322..862a4bf00 100644
+--- a/src/main/java/net/minecraft/server/PlayerAdvancements.java
++++ b/src/main/java/net/minecraft/server/PlayerAdvancements.java
+@@ -50,7 +50,7 @@ import org.slf4j.Logger;
+ public class PlayerAdvancements {
+ 
+     private static final Logger LOGGER = LogUtils.getLogger();
+-    private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().create();
++    private static final Gson GSON = (new GsonBuilder()).create(); // Paper - Remove pretty printing from advancements
+     private final PlayerList playerList;
+     private final Path playerSavePath;
+     private AdvancementTree tree;


### PR DESCRIPTION
Reduces json size by about 25%
Not sure why advancements even had pretty printing enabled.
My best guess was by accident on mojang's part, especially since stats json files don't have pretty printing.