### PR TITLE
Return null in getRegistry(Class) for unknown type

### DIFF
--- a/patches/server/0471-Add-RegistryAccess-for-managing-Registries.patch
+++ b/patches/server/0471-Add-RegistryAccess-for-managing-Registries.patch
@@ -164,10 +164,10 @@ index 0000000000000000000000000000000000000000..70e2c3b5cac9a0dfb043de218df20dc1
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistryAccess.java b/src/main/java/io/papermc/paper/registry/PaperRegistryAccess.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d591e3a2e19d5358a0d25a5a681368943622d231
+index 0000000000000000000000000000000000000000..35b6a7c5bac9640332a833bd3627f2bcb1bbf2f3
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistryAccess.java
-@@ -0,0 +1,124 @@
+@@ -0,0 +1,127 @@
 +package io.papermc.paper.registry;
 +
 +import io.papermc.paper.registry.entry.ApiRegistryEntry;
@@ -213,10 +213,13 @@ index 0000000000000000000000000000000000000000..d591e3a2e19d5358a0d25a5a68136894
 +    @Deprecated(forRemoval = true)
 +    @Override
 +    public <T extends Keyed> @Nullable Registry<T> getRegistry(final Class<T> type) {
-+        final RegistryKey<T> registryKey;
-+        final @Nullable RegistryEntry<?, T> entry;
-+        registryKey = requireNonNull(byType(type), () -> type + " is not a valid registry type");
-+        entry = PaperRegistries.getEntry(registryKey);
++        final @Nullable RegistryKey<T> registryKey = byType(type);
++        // If our mapping from Class -> RegistryKey did not contain the passed type it was either a completely invalid type or a registry
++        // that merely exists as a SimpleRegistry in the org.bukkit.Registry type. We cannot return a registry for these, return null
++        // as per method contract in Bukkit#getRegistry.
++        if (registryKey == null) return null;
++
++        final @Nullable RegistryEntry<?, T> entry = PaperRegistries.getEntry(registryKey);
 +        final @Nullable RegistryHolder<T> registry = (RegistryHolder<T>) this.registries.get(registryKey);
 +        if (registry != null) {
 +            // if the registry exists, return right away. Since this is the "legacy" method, we return DelayedRegistry

--- a/patches/server/1015-Registry-Modification-API.patch
+++ b/patches/server/1015-Registry-Modification-API.patch
@@ -45,10 +45,10 @@ index 70e2c3b5cac9a0dfb043de218df20dc1ab2cc070..38222dca2497cec5b104b21429a9ec3a
      }
  }
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistryAccess.java b/src/main/java/io/papermc/paper/registry/PaperRegistryAccess.java
-index d591e3a2e19d5358a0d25a5a681368943622d231..f05ebf453406a924da3de6fb250f4793a1b3c612 100644
+index 35b6a7c5bac9640332a833bd3627f2bcb1bbf2f3..1026b9c04f94ed73049b980822a2eafdbacea7fd 100644
 --- a/src/main/java/io/papermc/paper/registry/PaperRegistryAccess.java
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistryAccess.java
-@@ -80,6 +80,14 @@ public class PaperRegistryAccess implements RegistryAccess {
+@@ -83,6 +83,14 @@ public class PaperRegistryAccess implements RegistryAccess {
          return possiblyUnwrap(registryHolder.get());
      }
  


### PR DESCRIPTION
The Bukkit#getRegistry(Class) method contract specifies that it returns
null for unknown registry types. The current implementation however
requires the passed class to be mappable to a known registry key.

For types like Material, which have a SimpleRegistry in bukkit's
Registry interface, no server side registry exists and such the type
cannot be mapped to a registry key.

The commit correctly returns null for types that are not mappable to a
registry key instead of throwing a NullPointerException.

Resolves: #11421
