### PR TITLE
Fixup command precprocess cancellation

### DIFF
--- a/patches/api/0053-Fix-upstream-javadocs.patch
+++ b/patches/api/0053-Fix-upstream-javadocs.patch
@@ -1050,6 +1050,34 @@ index 08a7c564fe5d3d232998d1789d4d4723a59c1430..8a5be3f0322ac19aeac3f00df54add0e
      @NotNull
      @Override
      public AnvilView getView() {
+diff --git a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
+index 48a00fb50fe32c732a578d5179b3bb43ffd68b69..5bd015e293e5c96e059563562a1a731104550a16 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
+@@ -106,7 +106,9 @@ public class PlayerCommandPreprocessEvent extends PlayerEvent implements Cancell
+      *
+      * @param player New player which this event will execute as
+      * @throws IllegalArgumentException if the player provided is null
++     * @deprecated Has no effect, instead use {@link Player#performCommand(String)}
+      */
++    @Deprecated(forRemoval = true, since = "forever ago")
+     public void setPlayer(@NotNull final Player player) throws IllegalArgumentException {
+         Preconditions.checkArgument(player != null, "Player cannot be null");
+         this.player = player;
+@@ -123,11 +125,10 @@ public class PlayerCommandPreprocessEvent extends PlayerEvent implements Cancell
+      * unmodifiable set.
+      *
+      * @return All Players who will see this chat message
+-     * @deprecated This method is provided for backward compatibility with no
+-     *     guarantee to the effect of viewing or modifying the set.
++     * @deprecated This is simply the online players. Modifications have no effect
+      */
+     @NotNull
+-    @Deprecated
++    @Deprecated(forRemoval = true, since = "forever ago")
+     public Set<Player> getRecipients() {
+         return recipients;
+     }
 diff --git a/src/main/java/org/bukkit/event/player/PlayerResourcePackStatusEvent.java b/src/main/java/org/bukkit/event/player/PlayerResourcePackStatusEvent.java
 index e4c32b21ab013703a6a1b07a1ad564d914ebe83f..e58fecf0fe54db06e0e944027923a352fd8005d8 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerResourcePackStatusEvent.java

--- a/patches/api/0053-Fix-upstream-javadocs.patch
+++ b/patches/api/0053-Fix-upstream-javadocs.patch
@@ -1051,7 +1051,7 @@ index 08a7c564fe5d3d232998d1789d4d4723a59c1430..8a5be3f0322ac19aeac3f00df54add0e
      @Override
      public AnvilView getView() {
 diff --git a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
-index 48a00fb50fe32c732a578d5179b3bb43ffd68b69..5bd015e293e5c96e059563562a1a731104550a16 100644
+index 48a00fb50fe32c732a578d5179b3bb43ffd68b69..cc502f95a6bb73c4f65295da3ff702991f4dac35 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
 @@ -106,7 +106,9 @@ public class PlayerCommandPreprocessEvent extends PlayerEvent implements Cancell
@@ -1060,7 +1060,7 @@ index 48a00fb50fe32c732a578d5179b3bb43ffd68b69..5bd015e293e5c96e059563562a1a7311
       * @throws IllegalArgumentException if the player provided is null
 +     * @deprecated Has no effect, instead use {@link Player#performCommand(String)}
       */
-+    @Deprecated(forRemoval = true, since = "forever ago")
++    @Deprecated(forRemoval = true)
      public void setPlayer(@NotNull final Player player) throws IllegalArgumentException {
          Preconditions.checkArgument(player != null, "Player cannot be null");
          this.player = player;
@@ -1074,7 +1074,7 @@ index 48a00fb50fe32c732a578d5179b3bb43ffd68b69..5bd015e293e5c96e059563562a1a7311
       */
      @NotNull
 -    @Deprecated
-+    @Deprecated(forRemoval = true, since = "forever ago")
++    @Deprecated(forRemoval = true)
      public Set<Player> getRecipients() {
          return recipients;
      }

--- a/patches/api/0053-Fix-upstream-javadocs.patch
+++ b/patches/api/0053-Fix-upstream-javadocs.patch
@@ -1051,14 +1051,14 @@ index 08a7c564fe5d3d232998d1789d4d4723a59c1430..8a5be3f0322ac19aeac3f00df54add0e
      @Override
      public AnvilView getView() {
 diff --git a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
-index 48a00fb50fe32c732a578d5179b3bb43ffd68b69..cc502f95a6bb73c4f65295da3ff702991f4dac35 100644
+index 48a00fb50fe32c732a578d5179b3bb43ffd68b69..6d7ee2c6e053ea9af9116e7c2adb521f12b914df 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
 @@ -106,7 +106,9 @@ public class PlayerCommandPreprocessEvent extends PlayerEvent implements Cancell
       *
       * @param player New player which this event will execute as
       * @throws IllegalArgumentException if the player provided is null
-+     * @deprecated Has no effect, instead use {@link Player#performCommand(String)}
++     * @deprecated Only works for sign commands; use {@link Player#performCommand(String)}, including those cases
       */
 +    @Deprecated(forRemoval = true)
      public void setPlayer(@NotNull final Player player) throws IllegalArgumentException {

--- a/patches/api/0182-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/api/0182-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -22,7 +22,7 @@ index 6e67fdb091a006d2d13bc2d93db4d55348af4c8f..e41d5d9b810c8816cd0d1eba5fd1ea56
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index e9c29fc1db686b80bc2477d78ec2b361b8600b9e..dda3a421953761dfca5f2f6498905c43fb6fe37d 100644
+index e9c29fc1db686b80bc2477d78ec2b361b8600b9e..af09398e0864d338da530495bfd577db8adbe65a 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -661,6 +661,117 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
@@ -60,7 +60,7 @@ index e9c29fc1db686b80bc2477d78ec2b361b8600b9e..dda3a421953761dfca5f2f6498905c43
 +    private static final byte ARRAY_SERIALIZATION_VERSION = 1;
 +
 +    /**
-+     * Serializes a collection of items to raw bytes in NBT. Serializes empty items as null.
++     * Serializes a collection of items to raw bytes in NBT. Serializes null items as {@link #empty()}.
 +     * <p>
 +     * If you need a string representation to put into a file, you can for example use {@link java.util.Base64} encoding.
 +     *
@@ -91,7 +91,7 @@ index e9c29fc1db686b80bc2477d78ec2b361b8600b9e..dda3a421953761dfca5f2f6498905c43
 +    }
 +
 +    /**
-+     * Serializes a collection of items to raw bytes in NBT. Serializes empty items as null.
++     * Serializes a collection of items to raw bytes in NBT. Serializes null items as {@link #empty()}.
 +     * <p>
 +     * If you need a string representation to put into a file, you can for example use {@link java.util.Base64} encoding.
 +     *

--- a/patches/server/1058-Fix-PlayerCommandPreprocessEvent-on-signed-commands.patch
+++ b/patches/server/1058-Fix-PlayerCommandPreprocessEvent-on-signed-commands.patch
@@ -1,11 +1,11 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nassim Jahnke <nassim@njahnke.dev>
 Date: Sat, 21 Sep 2024 22:01:52 +0200
-Subject: [PATCH] omg please
+Subject: [PATCH] Fix PlayerCommandPreprocessEvent on signed commands
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index fcccf989c25f0a259b160c4ff7873f7009e64d14..1377471f433500106a2fe98552019499deba56fc 100644
+index fcccf989c25f0a259b160c4ff7873f7009e64d14..befeaac4786760f6847a5945da2296a3e68dbb17 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2245,24 +2245,32 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -22,7 +22,7 @@ index fcccf989c25f0a259b160c4ff7873f7009e64d14..1377471f433500106a2fe98552019499
 -        // CraftBukkit end
 -
 -        Map map;
-+        // Paper start - Bandaid terrible CB diff
++        // Paper start - Fix cancellation and message changing
 +        ParseResults<CommandSourceStack> parseresults = this.parseCommand(packet.command());
  
 +        Map<String, PlayerChatMessage> map;
@@ -45,7 +45,7 @@ index fcccf989c25f0a259b160c4ff7873f7009e64d14..1377471f433500106a2fe98552019499
 +            parseresults = this.parseCommand(command);
 +            map = Collections.emptyMap();
 +        }
-+        // Paper end - Bandaid terrible CB diff
++        // Paper end - Fix cancellation and message changing
 +
          CommandSigningContext.SignedArguments commandsigningcontext_a = new CommandSigningContext.SignedArguments(map);
  

--- a/patches/server/1058-omg-please.patch
+++ b/patches/server/1058-omg-please.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nassim Jahnke <nassim@njahnke.dev>
+Date: Sat, 21 Sep 2024 22:01:52 +0200
+Subject: [PATCH] omg please
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index fcccf989c25f0a259b160c4ff7873f7009e64d14..1377471f433500106a2fe98552019499deba56fc 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -2245,24 +2245,32 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+ 
+         PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(this.getCraftPlayer(), command, new LazyPlayerSet(this.server));
+         this.cserver.getPluginManager().callEvent(event);
+-
+-        if (event.isCancelled()) {
+-            return;
+-        }
+         command = event.getMessage().substring(1);
+ 
+-        ParseResults<CommandSourceStack> parseresults = this.parseCommand(command);
+-        // CraftBukkit end
+-
+-        Map map;
++        // Paper start - Bandaid terrible CB diff
++        ParseResults<CommandSourceStack> parseresults = this.parseCommand(packet.command());
+ 
++        Map<String, PlayerChatMessage> map;
+         try {
+-            map = (packet.command().equals(command)) ? this.collectSignedArguments(packet, SignableCommand.of(parseresults), lastSeenMessages) : Collections.emptyMap(); // CraftBukkit
++            // Always parse the original command to add to the chat chain
++            map = this.collectSignedArguments(packet, SignableCommand.of(parseresults), lastSeenMessages);
+         } catch (SignedMessageChain.DecodeException signedmessagechain_a) {
+             this.handleMessageDecodeFailure(signedmessagechain_a);
+             return;
+         }
+ 
++        if (event.isCancelled()) {
++            // Only now are we actually good to return
++            return;
++        }
++
++        // Remove signed parts if the command was changed
++        if (!command.equals(packet.command())) {
++            parseresults = this.parseCommand(command);
++            map = Collections.emptyMap();
++        }
++        // Paper end - Bandaid terrible CB diff
++
+         CommandSigningContext.SignedArguments commandsigningcontext_a = new CommandSigningContext.SignedArguments(map);
+ 
+         parseresults = Commands.<CommandSourceStack>mapSource(parseresults, (commandlistenerwrapper) -> { // CraftBukkit - decompile error


### PR DESCRIPTION
Fixes cancelling PlayerCommandPreprocessEvent and using setMessage to change the command. The original command *always* has to be parsed and run through to add to the signed argument chain, otherwise it will be broken and all future chat messages/commands fail until the player rejoins (the patch name is WIP).

Also deprecates two methods in the event that have been useless/have had no effect in a decade
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-11424.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1963655566.zip)