### PR TITLE
Deprecate BlockType#isInteractable

### DIFF
--- a/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
@@ -714,6 +714,25 @@ index 3e07fc1bc0e08d0cfd998711c7fd547b2b7b6b73..f4a739d8022d19a7ae0ee9bf93eb5c48
      void setData(@NotNull MaterialData data);
  
      /**
+diff --git a/src/main/java/org/bukkit/block/BlockType.java b/src/main/java/org/bukkit/block/BlockType.java
+index dfd8187ef941e8afe9cb28a26bf0d2cf2e4c4bc5..d285a1df492d2155f179e8abc17d0bf7527e6d38 100644
+--- a/src/main/java/org/bukkit/block/BlockType.java
++++ b/src/main/java/org/bukkit/block/BlockType.java
+@@ -3433,9 +3433,14 @@ public interface BlockType extends Keyed, Translatable {
+      * state as well. This method will return true if there is at least one
+      * state in which additional interact handling is performed for the
+      * block type.
++     * 
++     * @deprecated This method is not comprehensive and does not accurately reflect what block types are
++     * interactable. Many "interactions" are defined on the item not block, and many are conditional on some other world state
++     * checks being true.
+      *
+      * @return true if this block type can be interacted with.
+      */
++    @Deprecated // Paper
+     boolean isInteractable();
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/block/BrushableBlock.java b/src/main/java/org/bukkit/block/BrushableBlock.java
 index 4bd127b3646307398e0c937c3e36ab671235b72b..f2557a87f468ee20c2d276dbfc0e9a976656c75c 100644
 --- a/src/main/java/org/bukkit/block/BrushableBlock.java

--- a/patches/api/0202-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0202-Add-methods-to-get-translation-keys.patch
@@ -312,7 +312,7 @@ index 745413357506fa7399f8ba44dfe222d1f0c919f1..25db31b2e9a6d75f0c59f75237842f9a
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/BlockType.java b/src/main/java/org/bukkit/block/BlockType.java
-index dfd8187ef941e8afe9cb28a26bf0d2cf2e4c4bc5..8d85d74605457724cc206a55dbb16679c3791ea1 100644
+index d285a1df492d2155f179e8abc17d0bf7527e6d38..fc21405a18bac88678653674f9d42a08b3d7cb9b 100644
 --- a/src/main/java/org/bukkit/block/BlockType.java
 +++ b/src/main/java/org/bukkit/block/BlockType.java
 @@ -125,7 +125,7 @@ import org.jetbrains.annotations.Nullable;
@@ -324,7 +324,7 @@ index dfd8187ef941e8afe9cb28a26bf0d2cf2e4c4bc5..8d85d74605457724cc206a55dbb16679
  
      /**
       * Typed represents a subtype of {@link BlockType}s that have a known block
-@@ -3493,4 +3493,13 @@ public interface BlockType extends Keyed, Translatable {
+@@ -3498,4 +3498,13 @@ public interface BlockType extends Keyed, Translatable {
      @Nullable
      @Deprecated
      Material asMaterial();

--- a/patches/api/0309-Add-hasCollision-methods-to-various-places.patch
+++ b/patches/api/0309-Add-hasCollision-methods-to-various-places.patch
@@ -67,10 +67,10 @@ index f4a739d8022d19a7ae0ee9bf93eb5c4846b4bd40..94e1278340c0d9d2be9edc68f6454143
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/BlockType.java b/src/main/java/org/bukkit/block/BlockType.java
-index 8d85d74605457724cc206a55dbb16679c3791ea1..3dc165265af4a9cb0e05018b9273b7dfdecf730a 100644
+index fc21405a18bac88678653674f9d42a08b3d7cb9b..0fa0fa4aaf55710030a2220dee98e11764d8d27a 100644
 --- a/src/main/java/org/bukkit/block/BlockType.java
 +++ b/src/main/java/org/bukkit/block/BlockType.java
-@@ -3502,4 +3502,13 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
+@@ -3507,4 +3507,13 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
      @Override
      @NotNull String getTranslationKey();
      // Paper end - add Translatable

--- a/patches/api/0486-Add-FeatureFlag-API.patch
+++ b/patches/api/0486-Add-FeatureFlag-API.patch
@@ -242,7 +242,7 @@ index 330e3013eda204aa9b33d5e1c3104e0b595abdbc..c80e0ef587a001ee6de3f5c182cc9696
      /**
       * Do not use, method will get removed, and the plugin won't run
 diff --git a/src/main/java/org/bukkit/block/BlockType.java b/src/main/java/org/bukkit/block/BlockType.java
-index 3dc165265af4a9cb0e05018b9273b7dfdecf730a..72aa7e4004afcaa132dc4dbbe2ff050b503928af 100644
+index 0fa0fa4aaf55710030a2220dee98e11764d8d27a..e85bdd92466ee9bfcf8a82614ad09c1e2963731b 100644
 --- a/src/main/java/org/bukkit/block/BlockType.java
 +++ b/src/main/java/org/bukkit/block/BlockType.java
 @@ -125,7 +125,7 @@ import org.jetbrains.annotations.Nullable;
@@ -254,7 +254,7 @@ index 3dc165265af4a9cb0e05018b9273b7dfdecf730a..72aa7e4004afcaa132dc4dbbe2ff050b
  
      /**
       * Typed represents a subtype of {@link BlockType}s that have a known block
-@@ -3481,7 +3481,9 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
+@@ -3486,7 +3486,9 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
       *
       * @param world the world to check
       * @return true if this BlockType can be used in this World.


### PR DESCRIPTION
While BlockType is still marked as internal, it mirrors the already
paper-deprecated method #isInteractable.

The commit marks said method as deprecated if/when BlockType becomes
experimental/non-internal.
