### PR TITLE
Adjust HAProxy's existance to log for console masters.

### DIFF
--- a/patches/server/1059-Adjust-HAProxy-s-existance-to-log-for-console-master.patch
+++ b/patches/server/1059-Adjust-HAProxy-s-existance-to-log-for-console-master.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stefano <stefano@stefanocoding.me>
+Date: Mon, 23 Sep 2024 22:58:25 +0000
+Subject: [PATCH] Adjust HAProxy's existance to log for console masters.
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerConnectionListener.java b/src/main/java/net/minecraft/server/network/ServerConnectionListener.java
+index 8aff5129f85ab5729b3da2e465871be62d15bdf2..4aaefac704778ae2f9efee27f154c5661c27de1b 100644
+--- a/src/main/java/net/minecraft/server/network/ServerConnectionListener.java
++++ b/src/main/java/net/minecraft/server/network/ServerConnectionListener.java
+@@ -168,6 +168,13 @@ public class ServerConnectionListener {
+                 }
+             }).group(eventloopgroup).localAddress(address)).option(ChannelOption.AUTO_READ, false).bind().syncUninterruptibly()); // CraftBukkit // Paper - Unix domain socket support
+         }
++
++        // Paper start - Warn people with console access that HAProxy is in use.
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().proxies.proxyProtocol) {
++            ServerConnectionListener.LOGGER.warn("Using HAProxy, please ensure the server port is adequately firewalled.");
++        }
++        // Paper end - Warn people with console access that HAProxy is in use.
++
+     }
+ 
+     // CraftBukkit start


### PR DESCRIPTION
This is a VERY minor change, so minimal but VERY useful for system administrators. (I am one, and this was so confusing).

Exact same PR concept as: https://github.com/PaperMC/Velocity/pull/1436