### PR TITLE
deprecate for removal Block#isValidTool

### DIFF
--- a/patches/api/0252-Add-Block-isValidTool.patch
+++ b/patches/api/0252-Add-Block-isValidTool.patch
@@ -3,24 +3,29 @@ From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Mon, 6 Jul 2020 12:44:23 -0700
 Subject: [PATCH] Add Block#isValidTool
 
+Deprecated for removal
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 36e177757624c4fc7835e253d3b2dd773f50f43d..6ada8c036f1a112f11a9fbc3baf1f79b3f1bfc8e 100644
+index 36e177757624c4fc7835e253d3b2dd773f50f43d..9b0a3b4a62387d07143341756b858e15e61a9c03 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -230,6 +230,15 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
-     public static int getBlockKeyZ(long packed) {
-         return (int) ((packed << 10) >> 37);
+@@ -232,6 +232,19 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
      }
-+
+     // Paper end
+ 
++    // Paper start - add isValidTool
 +    /**
 +     * Checks if the itemstack is a valid tool to
 +     * break the block with
 +     *
 +     * @param itemStack The (tool) itemstack
 +     * @return whether the block will drop items
++     * @deprecated partially replaced by {@link Block#isPreferredTool(ItemStack)}
 +     */
++    @Deprecated(since = "1.21", forRemoval = true) // Paper
 +    boolean isValidTool(@NotNull ItemStack itemStack);
-     // Paper end
- 
++    // Paper end - add isValidTool
++
      /**
+      * Gets the Location of the block
+      *

--- a/patches/api/0309-Add-hasCollision-methods-to-various-places.patch
+++ b/patches/api/0309-Add-hasCollision-methods-to-various-places.patch
@@ -31,10 +31,10 @@ index 5c869feaecd95dbdd658e16f5739bb41540f18bd..6959f36023b12ec2dece9b91a3b8a5d0
       * Do not use for any reason.
       *
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 6ada8c036f1a112f11a9fbc3baf1f79b3f1bfc8e..02361d58ac723d02d93db80a721b27d37f7dc3c1 100644
+index 9b0a3b4a62387d07143341756b858e15e61a9c03..cfa49e21feec7226e83e97e1053388f854b70337 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -482,6 +482,13 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
+@@ -486,6 +486,13 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
       * @return true if block is solid
       */
      boolean isSolid();

--- a/patches/api/0339-Add-getComputedBiome-API.patch
+++ b/patches/api/0339-Add-getComputedBiome-API.patch
@@ -51,10 +51,10 @@ index b68367f123f029c3ff47eab6bfabd7a894a99da4..44ee56a5956cc17194c767a0c1071a2a
       * Sets the {@link Biome} at the given {@link Location}.
       *
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 02361d58ac723d02d93db80a721b27d37f7dc3c1..87327df6a37668eaf87394b6b049e6d4badec6df 100644
+index cfa49e21feec7226e83e97e1053388f854b70337..f7d999d702151b50fd6ed956b59645ae2820fd27 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -371,10 +371,22 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
+@@ -375,10 +375,22 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
       * Returns the biome that this block resides in
       *
       * @return Biome type containing this block

--- a/patches/api/0357-Block-Ticking-API.patch
+++ b/patches/api/0357-Block-Ticking-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Block Ticking API
 
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 87327df6a37668eaf87394b6b049e6d4badec6df..a13c8ddd4a1222e7a16debb61769af3758502d7c 100644
+index f7d999d702151b50fd6ed956b59645ae2820fd27..0efd8bb70ebdb86372022c9e12ec89f229ab3b52 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -589,6 +589,41 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
+@@ -593,6 +593,41 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
       * @return true if the block was destroyed
       */
      boolean breakNaturally(@NotNull ItemStack tool, boolean triggerEffect, boolean dropExperience);


### PR DESCRIPTION
The method's implementation uses Block#getDrops which re-computes the drops from the loot table each call leading to isValidTool returning different values with subsequent calls.