### PR TITLE
fix ItemStack#removeEnchantments creating non-stackable items

### DIFF
--- a/patches/server/0960-General-ItemMeta-fixes.patch
+++ b/patches/server/0960-General-ItemMeta-fixes.patch
@@ -68,15 +68,16 @@ index f9eb60d5a70da9a4d485288ab03d80829cf171a9..440b4c13121e3ac2bab937a83d20cc3f
      protected void load(T tileEntity) {
          if (tileEntity != null && tileEntity != this.snapshot) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 6a449bfc765bf427d82df4a90bc60471b5de2fd3..aef5c0d1be9c4aa62d9b7c5cacbb42066a802729 100644
+index 6a449bfc765bf427d82df4a90bc60471b5de2fd3..efb7fb8dbaa7446e394f55b021692c11a25fd29f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -279,7 +279,9 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public void removeEnchantments() {
+-        this.handle.remove(DataComponents.ENCHANTMENTS);
 +        if (this.handle != null) { // Paper - fix NPE
-         this.handle.remove(DataComponents.ENCHANTMENTS);
++        this.handle.set(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY); // Paper - set to default instead of removing the component
 +        } // Paper
      }
  


### PR DESCRIPTION
Shouldn't use nms.ItemStack#remove which will create a patch to remove the implicit enchantments component on all items.