### PR TITLE
Do not NPE on uuid resolution in player profile

### DIFF
--- a/patches/server/0136-Basic-PlayerProfile-API.patch
+++ b/patches/server/0136-Basic-PlayerProfile-API.patch
@@ -16,10 +16,10 @@ public org.bukkit.craftbukkit.profile.CraftPlayerProfile setProperty(Ljava/lang/
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9a7add1a7b137a0c9ca9c69fec674a7720d954eb
+index 0000000000000000000000000000000000000000..8849862b45ccbbc635a1c316e9870bca81e55c04
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
-@@ -0,0 +1,449 @@
+@@ -0,0 +1,451 @@
 +package com.destroystokyo.paper.profile;
 +
 +import com.google.common.base.Preconditions;
@@ -250,6 +250,7 @@ index 0000000000000000000000000000000000000000..9a7add1a7b137a0c9ca9c69fec674a77
 +                // if old has it, assume its newer, so overwrite, else use cached if it was set and ours wasn't
 +                copyProfileProperties(this.profile, profile);
 +                this.profile = profile;
++                this.emptyUUID = false; // UUID was just retrieved from user cache and profile isn't null (so a completed profile was found)
 +            }
 +        }
 +
@@ -261,6 +262,7 @@ index 0000000000000000000000000000000000000000..9a7add1a7b137a0c9ca9c69fec674a77
 +                    // if old has it, assume its newer, so overwrite, else use cached if it was set and ours wasn't
 +                    copyProfileProperties(this.profile, profile);
 +                    this.profile = profile;
++                    this.emptyName = false; // Name was just retrieved via the userCache
 +                } else if (profile != this.profile) {
 +                    copyProfileProperties(profile, this.profile);
 +                }
@@ -281,7 +283,7 @@ index 0000000000000000000000000000000000000000..9a7add1a7b137a0c9ca9c69fec674a77
 +        MinecraftServer server = MinecraftServer.getServer();
 +        boolean isCompleteFromCache = this.completeFromCache(true, onlineMode);
 +        if (onlineMode && (!isCompleteFromCache || (textures && !hasTextures()))) {
-+            ProfileResult result = server.getSessionService().fetchProfile(this.getId(), true);
++            ProfileResult result = server.getSessionService().fetchProfile(this.profile.getId(), true);
 +            if (result != null && result.profile() != null) {
 +                copyProfileProperties(result.profile(), this.profile, true);
 +            }


### PR DESCRIPTION
Band-aid fix for the player profile api resolution for a profile with
name but without uuid. The real solution is a proper refactoring of the
completeFromCache and complete method internally, however this needs
further consideration regarding existing faulty behaviour around name
lookups from uuid-only profiles.

Resolves: #11447
