### PR TITLE
Use components properly in ProfileWhitelistVerifyEvent

### DIFF
--- a/patches/api/0066-ProfileWhitelistVerifyEvent.patch
+++ b/patches/api/0066-ProfileWhitelistVerifyEvent.patch
@@ -9,10 +9,10 @@ Allows you to do dynamic whitelisting and change of kick message
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/profile/ProfileWhitelistVerifyEvent.java b/src/main/java/com/destroystokyo/paper/event/profile/ProfileWhitelistVerifyEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..31884c55d45931a313292df552b604d929a22586
+index 0000000000000000000000000000000000000000..901efb61fdc02b3228cc25649926d691c4617512
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/profile/ProfileWhitelistVerifyEvent.java
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,146 @@
 +/*
 + * Copyright (c) 2017 - Daniel Ennis (Aikar) - MIT License
 + *
@@ -44,6 +44,7 @@ index 0000000000000000000000000000000000000000..31884c55d45931a313292df552b604d9
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.Contract;
 +import org.jspecify.annotations.NullMarked;
 +import org.jspecify.annotations.Nullable;
 +
@@ -100,6 +101,7 @@ index 0000000000000000000000000000000000000000..31884c55d45931a313292df552b604d9
 +    /**
 +     * @return the currently planned message to send to the user if they are not whitelisted
 +     */
++    @Contract(pure = true)
 +    public @Nullable Component kickMessage() {
 +        return this.kickMessage;
 +    }

--- a/patches/server/0145-ProfileWhitelistVerifyEvent.patch
+++ b/patches/server/0145-ProfileWhitelistVerifyEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ProfileWhitelistVerifyEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index d5f17d7e3b56ca87ec9070b69265ce098de61f69..768a5c6ebc4466aae4108a79e1564b2bfc93463a 100644
+index d5f17d7e3b56ca87ec9070b69265ce098de61f69..c08ffdbc9afb2fe7abbf5567dc1fb1e2bcb01b96 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -624,9 +624,9 @@ public abstract class PlayerList {
@@ -21,24 +21,25 @@ index d5f17d7e3b56ca87ec9070b69265ce098de61f69..768a5c6ebc4466aae4108a79e1564b2b
          } else if (this.getIpBans().isBanned(socketaddress) && !this.getIpBans().get(socketaddress).hasExpired()) {
              IpBanListEntry ipbanentry = this.ipBans.get(socketaddress);
  
-@@ -993,7 +993,24 @@ public abstract class PlayerList {
+@@ -993,7 +993,25 @@ public abstract class PlayerList {
      }
  
      public boolean isWhiteListed(GameProfile profile) {
 -        return !this.doWhiteList || this.ops.contains(profile) || this.whitelist.contains(profile);
 +        // Paper start - ProfileWhitelistVerifyEvent
-+        return isWhiteListed(profile, null);
++        return this.isWhiteListed(profile, null);
 +    }
-+    public boolean isWhiteListed(GameProfile gameprofile, org.bukkit.event.player.PlayerLoginEvent loginEvent) {
++    public boolean isWhiteListed(GameProfile gameprofile, @Nullable org.bukkit.event.player.PlayerLoginEvent loginEvent) {
 +        boolean isOp = this.ops.contains(gameprofile);
 +        boolean isWhitelisted = !this.doWhiteList || isOp || this.whitelist.contains(gameprofile);
 +        final com.destroystokyo.paper.event.profile.ProfileWhitelistVerifyEvent event;
 +
-+        event = new com.destroystokyo.paper.event.profile.ProfileWhitelistVerifyEvent(com.destroystokyo.paper.profile.CraftPlayerProfile.asBukkitMirror(gameprofile), this.doWhiteList, isWhitelisted, isOp, org.spigotmc.SpigotConfig.whitelistMessage);
++        final net.kyori.adventure.text.Component configuredMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(org.spigotmc.SpigotConfig.whitelistMessage);
++        event = new com.destroystokyo.paper.event.profile.ProfileWhitelistVerifyEvent(com.destroystokyo.paper.profile.CraftPlayerProfile.asBukkitMirror(gameprofile), this.doWhiteList, isWhitelisted, isOp, configuredMessage);
 +        event.callEvent();
 +        if (!event.isWhitelisted()) {
 +            if (loginEvent != null) {
-+                loginEvent.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(event.getKickMessage() == null ? org.spigotmc.SpigotConfig.whitelistMessage : event.getKickMessage()));
++                loginEvent.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, event.kickMessage() == null ? configuredMessage : event.kickMessage());
 +            }
 +            return false;
 +        }

--- a/patches/server/0279-Call-WhitelistToggleEvent-when-whitelist-is-toggled.patch
+++ b/patches/server/0279-Call-WhitelistToggleEvent-when-whitelist-is-toggled.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Call WhitelistToggleEvent when whitelist is toggled
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index cdd1d8222ad1796abd0858b9ed0e2ddc9be83c93..2f1d075b8dbcf173c51f3e6396ccbc61b64f75df 100644
+index 7f8081446704ea9642275cb2bc139fed174a2f1f..0bac75f111398fd22df978a09dcd4cdc22998894 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1127,6 +1127,7 @@ public abstract class PlayerList {
+@@ -1128,6 +1128,7 @@ public abstract class PlayerList {
      }
  
      public void setUsingWhiteList(boolean whitelistEnabled) {

--- a/patches/server/0543-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0543-Add-PlayerKickEvent-causes.patch
@@ -443,7 +443,7 @@ index d2d153e587e624025ef01fbe3dcfa4bf06f1a06b..e0a10f1d8bf2c0df66e62bdf2a174ce6
      }
      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index bbc6f64a3b2c0702a0a752acd48145cdcafd742e..55a2f234436808258ef59f889a9b253fe79b82e8 100644
+index f7e442cd5eff3d7c6932d16c93a7a097f11251f9..393a93198b3a1d95a6cc5eb1d19e392f9ab7e2b9 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -675,7 +675,7 @@ public abstract class PlayerList {
@@ -455,7 +455,7 @@ index bbc6f64a3b2c0702a0a752acd48145cdcafd742e..55a2f234436808258ef59f889a9b253f
          }
  
          // Instead of kicking then returning, we need to store the kick reason
-@@ -1277,7 +1277,7 @@ public abstract class PlayerList {
+@@ -1278,7 +1278,7 @@ public abstract class PlayerList {
          // Paper end
          // CraftBukkit start - disconnect safely
          for (ServerPlayer player : this.players) {

--- a/patches/server/0690-Use-username-instead-of-display-name-in-PlayerList-g.patch
+++ b/patches/server/0690-Use-username-instead-of-display-name-in-PlayerList-g.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Use username instead of display name in
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index e30ad8c7e85c25f3133bbd23dcbe59ae4c2f8db5..03572023ae7f061bf34fed8ac27852e08d6412c0 100644
+index 06bcc9974b4a63c174c51df332ff9ddd7eb6a159..0bded2c55d6c826e2f3dcb89995712c92348a3c7 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1393,7 +1393,7 @@ public abstract class PlayerList {
+@@ -1394,7 +1394,7 @@ public abstract class PlayerList {
      // CraftBukkit start
      public ServerStatsCounter getPlayerStats(ServerPlayer entityhuman) {
          ServerStatsCounter serverstatisticmanager = entityhuman.getStats();

--- a/patches/server/0845-API-for-updating-recipes-on-clients.patch
+++ b/patches/server/0845-API-for-updating-recipes-on-clients.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for updating recipes on clients
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index e85b91036c2470b2f164a4641d1c07d27553a078..387470d6cfd34dc6f9c895a962ddcdf92583ab8c 100644
+index 2912b15ccda373cf52cec020b0e06ac2c5cf2950..a6caf3a0df22f124a4ee1cfb3981bbeb23a8630e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1489,6 +1489,13 @@ public abstract class PlayerList {
+@@ -1490,6 +1490,13 @@ public abstract class PlayerList {
      }
  
      public void reloadResources() {
@@ -22,7 +22,7 @@ index e85b91036c2470b2f164a4641d1c07d27553a078..387470d6cfd34dc6f9c895a962ddcdf9
          // CraftBukkit start
          /*Iterator iterator = this.advancements.values().iterator();
  
-@@ -1504,7 +1511,15 @@ public abstract class PlayerList {
+@@ -1505,7 +1512,15 @@ public abstract class PlayerList {
          }
          // CraftBukkit end
  

--- a/patches/server/1030-Incremental-chunk-and-player-saving.patch
+++ b/patches/server/1030-Incremental-chunk-and-player-saving.patch
@@ -56,7 +56,7 @@ index b64c3e29e2b8e890073fee0b45c8b8dfc2b642fd..aa38e3b297209cc121e7dc7a6ac9588c
          try (co.aikar.timings.Timing ignored = MinecraftTimings.processTasksTimer.startTiming()) {
              this.runAllTasks();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 2931e1dd0c8ae5ac1c9ec42f90dd5ab57595bf60..c96f3dcd365bc140b1f4680ef6bd770c80f8eda1 100644
+index 202975cf97ae143622a0c19826b0d63ad2afa0ce..f9abf63e12ea930275121b470e4e4906cff0fc12 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1315,6 +1315,35 @@ public class ServerLevel extends Level implements WorldGenLevel, ca.spottedleaf.
@@ -108,7 +108,7 @@ index 8dc3ba983fd4c61e463867be8d224aa90424215a..6c280abdef5f80b668d6090f9d35283a
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      private static final int FLY_STAT_RECORDING_SPEED = 25;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0cfaf31273bbec7640eb3a2b16a8d2c816b0ed61..c13922d2fb1c15f895b14d4cb6d5379b59ea1ef8 100644
+index 30b6f5d4af1dc799d5ffee6a345bcf92528df7cd..5e2c4969e77c669acbb4a13c07033cb267c3d586 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -569,6 +569,7 @@ public abstract class PlayerList {
@@ -119,7 +119,7 @@ index 0cfaf31273bbec7640eb3a2b16a8d2c816b0ed61..c13922d2fb1c15f895b14d4cb6d5379b
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
  
-@@ -1192,10 +1193,22 @@ public abstract class PlayerList {
+@@ -1193,10 +1194,22 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {


### PR DESCRIPTION
The server implementation of the event was still doing a legacy conversion. While the input to the event currently has to use the legacy serializer (cause the message source is the spigot config), after the event is fired, we should just use the component set directly.