### PR TITLE
Configurable bypass for anvil enchantment over the max level

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -487,10 +487,10 @@ index 0000000000000000000000000000000000000000..d9502ba028a96f9cc846f9ed428bd806
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b92bfd89e32becde2e7630c6116c16f8a4f6614a
+index 0000000000000000000000000000000000000000..9cc4f615a5c853141bc3890cf6ddc97a926a9a81
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,331 @@
+@@ -0,0 +1,333 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -811,6 +811,8 @@ index 0000000000000000000000000000000000000000..b92bfd89e32becde2e7630c6116c16f8
 +        public IntOr.Default compressionLevel = IntOr.Default.USE_DEFAULT;
 +        @Comment("Defines the leniency distance added on the server to the interaction range of a player when validating interact packets.")
 +        public DoubleOr.Default clientInteractionLeniencyDistance = DoubleOr.Default.USE_DEFAULT;
++        @Comment("Allow anvils to ignore the max level for apply enchantments")
++        public boolean allowAnvilApplyEnchantmentOverMaxLevel = false;
 +    }
 +
 +    public BlockUpdates blockUpdates;

--- a/patches/server/1065-Configurable-bypass-for-anvil-max-level-enchantment-.patch
+++ b/patches/server/1065-Configurable-bypass-for-anvil-max-level-enchantment-.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Doc <nachito94@msn.com>
+Date: Sun, 6 Oct 2024 11:04:15 -0300
+Subject: [PATCH] Configurable bypass for anvil max level enchantment
+ restriction
+
+If in anvil you try enchant with a level over the max the anvil use the max level for the result item ignoring the level passed, this PR make this configurable
+
+diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
+index d685511104ac552dfc9ae2111e1bfb60fa812102..c4808bb2b6f0e12f607c089d6ce9e4b9990b6edc 100644
+--- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
+@@ -231,7 +231,7 @@ public class AnvilMenu extends ItemCombinerMenu {
+                             flag2 = true;
+                         } else {
+                             flag1 = true;
+-                            if (i2 > enchantment.getMaxLevel()) {
++                            if (i2 > enchantment.getMaxLevel() && !io.papermc.paper.configuration.GlobalConfiguration.get().misc.allowAnvilApplyEnchantmentOverMaxLevel) { // Paper - Allow by config ignore this override for max enchantment level
+                                 i2 = enchantment.getMaxLevel();
+                             }
+ 


### PR DESCRIPTION
Currently if you try to use an anvil with a enchantment book using levels over the max defined then the anvil just ignore level in book and override with the max level defined in registry, this PR allow by config disable this for allow using that enchantment books.

PS: Talking about why this... in my case is just wanna give books with things like sharpness 7 and dont wanna listen the PrepareAnvilEvent and make a whole thing for check compatibility and manually set all in code... and also dont wanna override the max level in bootstrap because this make players can get this levels in vanilla ways.