### PR TITLE
Fix CraftMagicNumbers#getTag

### DIFF
--- a/patches/server/1014-Registry-Modification-API.patch
+++ b/patches/server/1014-Registry-Modification-API.patch
@@ -9,7 +9,7 @@ public net.minecraft.resources.RegistryOps lookupProvider
 public net.minecraft.resources.RegistryOps$HolderLookupAdapter
 
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-index c92ce42398a9bfd00eb4e05972289c521ee255cf..fba7c1758439db9044d9f7368bc9b79642d6b1b9 100644
+index 633b01431750d4b40159a57bf25fb35c6670ff1b..5cf598905ed6a7ac2b0d9ced3420adaf20ceb6af 100644
 --- a/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 @@ -2,6 +2,7 @@ package io.papermc.paper.registry;
@@ -1357,7 +1357,7 @@ index bd16933a5341908b21e549f66080c33466ad1079..90046c85ce1b9901de7476761da15614
 +    // Paper end - RegistrySet API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 9e0d8fc51196ca07677f45e41614262036155e85..82ebfd09e9baca0a31ee41c0e5228bce3c54e74f 100644
+index 9e0d8fc51196ca07677f45e41614262036155e85..0286375531b944ce572708e6c7cc9982e0d2b5b8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -668,6 +668,21 @@ public final class CraftMagicNumbers implements UnsafeValues {
@@ -1367,7 +1367,7 @@ index 9e0d8fc51196ca07677f45e41614262036155e85..82ebfd09e9baca0a31ee41c0e5228bce
 +    // Paper start - hack to get tags for non server-backed registries
 +    @Override
 +    public <A extends Keyed, M> io.papermc.paper.registry.tag.Tag<A> getTag(final io.papermc.paper.registry.tag.TagKey<A> tagKey) { // TODO remove Keyed
-+        if (tagKey.registryKey() != io.papermc.paper.registry.RegistryKey.ENTITY_TYPE || tagKey.registryKey() != io.papermc.paper.registry.RegistryKey.FLUID) {
++        if (tagKey.registryKey() != io.papermc.paper.registry.RegistryKey.ENTITY_TYPE && tagKey.registryKey() != io.papermc.paper.registry.RegistryKey.FLUID) {
 +            throw new UnsupportedOperationException(tagKey.registryKey() + " doesn't have tags");
 +        }
 +        final net.minecraft.resources.ResourceKey<? extends net.minecraft.core.Registry<M>> nmsKey = io.papermc.paper.registry.PaperRegistries.registryToNms(tagKey.registryKey());


### PR DESCRIPTION
Fix typo `||` -> `&&`.