### PR TITLE
Some small touchups to the GUI

### DIFF
--- a/patches/server/0318-Make-the-GUI-graph-fancier.patch
+++ b/patches/server/0318-Make-the-GUI-graph-fancier.patch
@@ -236,10 +236,10 @@ index 0000000000000000000000000000000000000000..f93373d28d741e1f8a53e07b4e328ce9
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/gui/RAMGraph.java b/src/main/java/com/destroystokyo/paper/gui/RAMGraph.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c3e54da4ab6440811aab2f9dd1e218802ac13285
+index 0000000000000000000000000000000000000000..a844669c57290cbdf66245d91fc9d2fbf23ba947
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/gui/RAMGraph.java
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,156 @@
 +package com.destroystokyo.paper.gui;
 +
 +import javax.swing.JComponent;
@@ -313,7 +313,14 @@ index 0000000000000000000000000000000000000000..c3e54da4ab6440811aab2f9dd1e21880
 +        Runtime jvm = Runtime.getRuntime();
 +        DATA.add(new GraphData(jvm.totalMemory(), jvm.freeMemory(), jvm.maxMemory()));
 +
-+        PointerInfo pointerInfo = MouseInfo.getPointerInfo();
++        PointerInfo pointerInfo = null;
++        // I think I recall spotting a bug report where this throwed an exception once
++        // not sure it's of concern here
++        try {
++            pointerInfo = MouseInfo.getPointerInfo();
++        } catch (NullPointerException | ArrayIndexOutOfBoundsException ignored) {
++            // https://bugs.openjdk.org/browse/JDK-6840067
++        }
 +        if (pointerInfo != null) {
 +            Point point = pointerInfo.getLocation();
 +            if (point != null) {
@@ -360,7 +367,12 @@ index 0000000000000000000000000000000000000000..c3e54da4ab6440811aab2f9dd1e21880
 +        graphics.setColor(new Color(0xFF000000));
 +        graphics.drawRect(0, 0, 348, 100);
 +
-+        Point m = getMousePosition();
++        Point m = null;
++        try {
++            m = getMousePosition();
++        } catch (NullPointerException ignored) {
++            // https://bugs.openjdk.org/browse/JDK-6840067
++        }
 +        if (m != null && m.x > 0 && m.x < 348 && m.y > 0 && m.y < 100) {
 +            GraphData data = DATA.get(m.x);
 +            int used = data.getUsedPercent();

--- a/patches/server/0493-Improve-ServerGUI.patch
+++ b/patches/server/0493-Improve-ServerGUI.patch
@@ -7,15 +7,20 @@ Subject: [PATCH] Improve ServerGUI
 - Show tps in the server stats
 
 diff --git a/src/main/java/com/destroystokyo/paper/gui/RAMDetails.java b/src/main/java/com/destroystokyo/paper/gui/RAMDetails.java
-index f93373d28d741e1f8a53e07b4e328ce9c4e1657f..039a86034928a5eb7aaa2d7ca76a7bddcca346bd 100644
+index f93373d28d741e1f8a53e07b4e328ce9c4e1657f..12b327eea95e0de9e9c39b7d039badee8ec46508 100644
 --- a/src/main/java/com/destroystokyo/paper/gui/RAMDetails.java
 +++ b/src/main/java/com/destroystokyo/paper/gui/RAMDetails.java
-@@ -58,9 +58,17 @@ public class RAMDetails extends JList<String> {
+@@ -58,9 +58,22 @@ public class RAMDetails extends JList<String> {
      public void update() {
          GraphData data = RAMGraph.DATA.peekLast();
          Vector<String> vector = new Vector<>();
 +
-+        double[] tps = org.bukkit.Bukkit.getTPS();
++        // Follows CraftServer#getTPS
++        double[] tps = new double[] {
++            server.tps1.getAverage(),
++            server.tps5.getAverage(),
++            server.tps15.getAverage()
++        };
 +        String[] tpsAvg = new String[tps.length];
 +
 +        for ( int g = 0; g < tps.length; g++) {
@@ -28,7 +33,7 @@ index f93373d28d741e1f8a53e07b4e328ce9c4e1657f..039a86034928a5eb7aaa2d7ca76a7bdd
          setListData(vector);
      }
  
-@@ -71,4 +79,8 @@ public class RAMDetails extends JList<String> {
+@@ -71,4 +84,8 @@ public class RAMDetails extends JList<String> {
          }
          return ((double) total / (double) tickTimes.length) * 1.0E-6D;
      }


### PR DESCRIPTION
Fixes #11494 - As noted on the issue, the method here can blow up in certain cases, the GUI logic already handles "the mouse is missing", and so, we'll just catch this and move on.

Misc fix - There is probably an issue report for this somewhere, but, the details section utilised the bukkit singleton to try to get the TPS from the server. We already have the MinecraftServer instance passed into us, and so we'll just get the information directly from there instead.