### PR TITLE
Always send Banner patterns to the client (Fixes #11487)

### DIFF
--- a/patches/server/1068-Always-send-Banner-patterns-to-the-client.patch
+++ b/patches/server/1068-Always-send-Banner-patterns-to-the-client.patch
@@ -9,7 +9,7 @@ flow for them, this is not all too surprising. So, we shall resort to always
 sending the patterns over the network for update packets.
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java
-index 60c26076e7acf869fa0e20fdc14eeec341387d99..41ca62d6b4579c5d7365c4473df82a9dbce4bde1 100644
+index 60c26076e7acf869fa0e20fdc14eeec341387d99..5ddada37ad0d4c19438cd02415bad628012f7c90 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java
 @@ -63,7 +63,7 @@ public class BannerBlockEntity extends BlockEntity implements Nameable {
@@ -26,16 +26,16 @@ index 60c26076e7acf869fa0e20fdc14eeec341387d99..41ca62d6b4579c5d7365c4473df82a9d
      }
  
 +    // Paper start - always send patterns to client
-+    boolean serialisingForNetwork = false;
++    ThreadLocal<Boolean> serialisingForNetwork = ThreadLocal.withInitial(() -> Boolean.FALSE);
      @Override
      public CompoundTag getUpdateTag(HolderLookup.Provider registryLookup) {
 -        return this.saveWithoutMetadata(registryLookup);
-+        boolean wasSerialisingForNetwork = serialisingForNetwork;
++        final Boolean wasSerialisingForNetwork = serialisingForNetwork.get();
 +        try {
-+            serialisingForNetwork = true;
++            serialisingForNetwork.set(Boolean.TRUE);
 +            return this.saveWithoutMetadata(registryLookup);
 +        } finally {
-+            serialisingForNetwork = wasSerialisingForNetwork;
++            serialisingForNetwork.set(wasSerialisingForNetwork);
 +        }
 +        // Paper end - always send patterns to client
      }

--- a/patches/server/1068-Always-send-Banner-patterns-to-the-client.patch
+++ b/patches/server/1068-Always-send-Banner-patterns-to-the-client.patch
@@ -9,7 +9,7 @@ flow for them, this is not all too surprising. So, we shall resort to always
 sending the patterns over the network for update packets.
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java
-index 60c26076e7acf869fa0e20fdc14eeec341387d99..5ddada37ad0d4c19438cd02415bad628012f7c90 100644
+index 60c26076e7acf869fa0e20fdc14eeec341387d99..60a9f3c7f007d268f24a4fe9e87029fdbc8360f9 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java
 @@ -63,7 +63,7 @@ public class BannerBlockEntity extends BlockEntity implements Nameable {
@@ -17,7 +17,7 @@ index 60c26076e7acf869fa0e20fdc14eeec341387d99..5ddada37ad0d4c19438cd02415bad628
      protected void saveAdditional(CompoundTag nbt, HolderLookup.Provider registryLookup) {
          super.saveAdditional(nbt, registryLookup);
 -        if (!this.patterns.equals(BannerPatternLayers.EMPTY)) {
-+        if (!this.patterns.equals(BannerPatternLayers.EMPTY) || serialisingForNetwork) { // Paper - always send patterns to client
++        if (!this.patterns.equals(BannerPatternLayers.EMPTY) || serialisingForNetwork.get()) { // Paper - always send patterns to client
              nbt.put("patterns", (Tag) BannerPatternLayers.CODEC.encodeStart(registryLookup.createSerializationContext(NbtOps.INSTANCE), this.patterns).getOrThrow());
          }
  

--- a/patches/server/1068-Always-send-Banner-patterns-to-the-client.patch
+++ b/patches/server/1068-Always-send-Banner-patterns-to-the-client.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Sun, 20 Oct 2024 18:23:59 +0100
+Subject: [PATCH] Always send Banner patterns to the client
+
+The mojang client will not remove patterns from a Banner when none
+are sent inside of an update packet, given that this is not an expected
+flow for them, this is not all too surprising. So, we shall resort to always
+sending the patterns over the network for update packets.
+
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java
+index 60c26076e7acf869fa0e20fdc14eeec341387d99..91352f49fba00481027824a87d30b5f5974c09d4 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java
+@@ -63,7 +63,7 @@ public class BannerBlockEntity extends BlockEntity implements Nameable {
+     @Override
+     protected void saveAdditional(CompoundTag nbt, HolderLookup.Provider registryLookup) {
+         super.saveAdditional(nbt, registryLookup);
+-        if (!this.patterns.equals(BannerPatternLayers.EMPTY)) {
++        if (!this.patterns.equals(BannerPatternLayers.EMPTY) || serialisingForNetwork) { // Paper - always send patterns to client
+             nbt.put("patterns", (Tag) BannerPatternLayers.CODEC.encodeStart(registryLookup.createSerializationContext(NbtOps.INSTANCE), this.patterns).getOrThrow());
+         }
+ 
+@@ -95,9 +95,17 @@ public class BannerBlockEntity extends BlockEntity implements Nameable {
+         return ClientboundBlockEntityDataPacket.create(this);
+     }
+ 
++    // Paper start
++    boolean serialisingForNetwork = false; // paper - always send patterns to client
+     @Override
+     public CompoundTag getUpdateTag(HolderLookup.Provider registryLookup) {
+-        return this.saveWithoutMetadata(registryLookup);
++        boolean wasSerialisingForNetwork = serialisingForNetwork;
++        try {
++            serialisingForNetwork = true;
++            return this.saveWithoutMetadata(registryLookup);
++        } finally {
++            serialisingForNetwork = wasSerialisingForNetwork;
++        }
+     }
+ 
+     public BannerPatternLayers getPatterns() {

--- a/patches/server/1068-Always-send-Banner-patterns-to-the-client.patch
+++ b/patches/server/1068-Always-send-Banner-patterns-to-the-client.patch
@@ -9,7 +9,7 @@ flow for them, this is not all too surprising. So, we shall resort to always
 sending the patterns over the network for update packets.
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java
-index 60c26076e7acf869fa0e20fdc14eeec341387d99..91352f49fba00481027824a87d30b5f5974c09d4 100644
+index 60c26076e7acf869fa0e20fdc14eeec341387d99..41ca62d6b4579c5d7365c4473df82a9dbce4bde1 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BannerBlockEntity.java
 @@ -63,7 +63,7 @@ public class BannerBlockEntity extends BlockEntity implements Nameable {
@@ -21,12 +21,12 @@ index 60c26076e7acf869fa0e20fdc14eeec341387d99..91352f49fba00481027824a87d30b5f5
              nbt.put("patterns", (Tag) BannerPatternLayers.CODEC.encodeStart(registryLookup.createSerializationContext(NbtOps.INSTANCE), this.patterns).getOrThrow());
          }
  
-@@ -95,9 +95,17 @@ public class BannerBlockEntity extends BlockEntity implements Nameable {
+@@ -95,9 +95,18 @@ public class BannerBlockEntity extends BlockEntity implements Nameable {
          return ClientboundBlockEntityDataPacket.create(this);
      }
  
-+    // Paper start
-+    boolean serialisingForNetwork = false; // paper - always send patterns to client
++    // Paper start - always send patterns to client
++    boolean serialisingForNetwork = false;
      @Override
      public CompoundTag getUpdateTag(HolderLookup.Provider registryLookup) {
 -        return this.saveWithoutMetadata(registryLookup);
@@ -37,6 +37,7 @@ index 60c26076e7acf869fa0e20fdc14eeec341387d99..91352f49fba00481027824a87d30b5f5
 +        } finally {
 +            serialisingForNetwork = wasSerialisingForNetwork;
 +        }
++        // Paper end - always send patterns to client
      }
  
      public BannerPatternLayers getPatterns() {


### PR DESCRIPTION
The mojang client will not remove patterns from a Banner when none
are sent inside of an update packet, given that this is not an expected
flow for them, this is not all too surprising. So, we shall resort to always
sending the patterns over the network for update packets.
