### PR TITLE
Allow using old ender pearl behavior & apply ender pearl exploit patch

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1423,10 +1423,10 @@ index 0000000000000000000000000000000000000000..279b24c689b9979884b65df7eb1f0590
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a81a332ffb80e67d7f886295099b5cd2ae8994c5
+index 0000000000000000000000000000000000000000..dad3fcc689ec806f985122a7cbd501a7d0fd0d36
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,580 @@
+@@ -0,0 +1,581 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1889,7 +1889,7 @@ index 0000000000000000000000000000000000000000..a81a332ffb80e67d7f886295099b5cd2
 +
 +    public class Fixes extends ConfigurationPart {
 +        public boolean fixItemsMergingThroughWalls = false;
-+        public boolean disableUnloadedChunkEnderpearlExploit = true;
++        public boolean disableUnloadedChunkEnderpearlExploit = false;
 +        public boolean preventTntFromMovingInWater = false;
 +        public boolean splitOverstackedLoot = true;
 +        public IntOr.Disabled fallingBlockHeightNerf = IntOr.Disabled.DISABLED;
@@ -1997,6 +1997,7 @@ index 0000000000000000000000000000000000000000..a81a332ffb80e67d7f886295099b5cd2
 +        public boolean disableSprintInterruptionOnAttack = false;
 +        public int shieldBlockingDelay = 5;
 +        public boolean disableRelativeProjectileVelocity = false;
++        public boolean legacyEnderPearlBehavior = false;
 +
 +        public enum RedstoneImplementation {
 +            VANILLA, EIGENCRAFT, ALTERNATE_CURRENT

--- a/patches/server/0211-PlayerElytraBoostEvent.patch
+++ b/patches/server/0211-PlayerElytraBoostEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] PlayerElytraBoostEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index 46eff02aa250890485d58a10e76d571052086aa8..fd8afa4b12d66d1e0a789cef41ca77c45c64e2e8 100644
+index fed01aea47090b990939becde837add6c36bf418..f8ae12a3540c4a7aa7e2c1656cbd866e33e11f57 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -219,11 +219,34 @@ public abstract class Projectile extends Entity implements TraceableEntity {

--- a/patches/server/0212-PlayerLaunchProjectileEvent.patch
+++ b/patches/server/0212-PlayerLaunchProjectileEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] PlayerLaunchProjectileEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index fd8afa4b12d66d1e0a789cef41ca77c45c64e2e8..d29d58fd9879d69a7d3fd7cbcad8cc31c89fa679 100644
+index f8ae12a3540c4a7aa7e2c1656cbd866e33e11f57..d6dfda0580d919eb8a000113e7f9dd9794117b45 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -197,7 +197,12 @@ public abstract class Projectile extends Entity implements TraceableEntity {

--- a/patches/server/0215-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0215-Vanished-players-don-t-have-rights.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Vanished players don't have rights
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index d29d58fd9879d69a7d3fd7cbcad8cc31c89fa679..07b7187382fefc8b03a8822a097fb04e647f7732 100644
+index d6dfda0580d919eb8a000113e7f9dd9794117b45..6c7f644738548da30908a08dcfde8142b597c0b7 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -387,6 +387,15 @@ public abstract class Projectile extends Entity implements TraceableEntity {

--- a/patches/server/0278-Fixes-and-additions-to-the-spawn-reason-API.patch
+++ b/patches/server/0278-Fixes-and-additions-to-the-spawn-reason-API.patch
@@ -173,7 +173,7 @@ index 2eecdcbea3d51b1fb6e0c3db0667464a699ca0df..c68ddccd5fbe27f6a62cedbdc2337f1b
                  this.discard(EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
              }
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index 07b7187382fefc8b03a8822a097fb04e647f7732..e21b9a34d07fcd75f9c470074c545862d0aa9363 100644
+index 6c7f644738548da30908a08dcfde8142b597c0b7..80637835a35dbfd7c7458b246ddee9d836e5101a 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -214,7 +214,12 @@ public abstract class Projectile extends Entity implements TraceableEntity {

--- a/patches/server/0291-Configurable-projectile-relative-velocity.patch
+++ b/patches/server/0291-Configurable-projectile-relative-velocity.patch
@@ -25,7 +25,7 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index e21b9a34d07fcd75f9c470074c545862d0aa9363..09d1131c7f2b32b6c032341a60521608b098c109 100644
+index 80637835a35dbfd7c7458b246ddee9d836e5101a..0e4ba92d97998937ccb83ebd60aaad3fb68f7546 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -192,8 +192,11 @@ public abstract class Projectile extends Entity implements TraceableEntity {

--- a/patches/server/0669-More-Projectile-API.patch
+++ b/patches/server/0669-More-Projectile-API.patch
@@ -54,7 +54,7 @@ index 536196a740f607adda2a5ae7f644981ac26bef98..1f95234c0a1457050574aa0f6c4b2a8c
      public boolean calculateOpenWater(BlockPos pos) {
          FishingHook.OpenWaterType entityfishinghook_waterposition = FishingHook.OpenWaterType.INVALID;
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index 09d1131c7f2b32b6c032341a60521608b098c109..824090367e833c57a22c1017981f0508b28a35d2 100644
+index 0e4ba92d97998937ccb83ebd60aaad3fb68f7546..01684c903930b14a0df3a146176e2b476a374efb 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -288,7 +288,7 @@ public abstract class Projectile extends Entity implements TraceableEntity {

--- a/patches/server/0728-Stop-large-look-changes-from-crashing-the-server.patch
+++ b/patches/server/0728-Stop-large-look-changes-from-crashing-the-server.patch
@@ -54,7 +54,7 @@ index 786ac2127bc743cf2a33776314a4b5c197f35538..b367f6e329f44801c6f0d34f44749709
          gameprofilerfiller.pop();
          this.animStep += f2;
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index 824090367e833c57a22c1017981f0508b28a35d2..df0417f27bbf0f18f007746afe24fab48e2a0a08 100644
+index 01684c903930b14a0df3a146176e2b476a374efb..bf7f81d99af300e89834981eab32568a3747d270 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -428,13 +428,7 @@ public abstract class Projectile extends Entity implements TraceableEntity {

--- a/patches/server/0809-Refresh-ProjectileSource-for-projectiles.patch
+++ b/patches/server/0809-Refresh-ProjectileSource-for-projectiles.patch
@@ -26,7 +26,7 @@ index 0e52f67f0185cba47838f0a99a97b4d70314c8fa..e126f1d5117a5826c5bfec20719633d7
      public boolean lastDamageCancelled; // SPIGOT-5339, SPIGOT-6252, SPIGOT-6777: Keep track if the event was canceled
      public boolean persistentInvisibility = false;
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index df0417f27bbf0f18f007746afe24fab48e2a0a08..1a45fca020f5ecee7af837af01b60ed4590b845a 100644
+index bf7f81d99af300e89834981eab32568a3747d270..52d539d54113c4dcd2d8d748ae0abf6dec5bfc72 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -63,17 +63,35 @@ public abstract class Projectile extends Entity implements TraceableEntity {

--- a/patches/server/1005-Fix-PickupStatus-getting-reset.patch
+++ b/patches/server/1005-Fix-PickupStatus-getting-reset.patch
@@ -24,7 +24,7 @@ index 14e31ae88e90d8ea1a98800cc6c1c3527bb2ed6b..accc246f441c8bf5e1a755cfc0db8f97
          byte b0 = 0;
  
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index 1a45fca020f5ecee7af837af01b60ed4590b845a..49c0f09f91f9ea2428fd3b13b00c99073074beba 100644
+index 52d539d54113c4dcd2d8d748ae0abf6dec5bfc72..bf2e79c50092acd13e97ab6e32471a9c527a524e 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -353,7 +353,13 @@ public abstract class Projectile extends Entity implements TraceableEntity {

--- a/patches/server/1055-Allow-using-old-ender-pearl-behavior.patch
+++ b/patches/server/1055-Allow-using-old-ender-pearl-behavior.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
+Date: Sun, 27 Oct 2024 12:36:53 -0700
+Subject: [PATCH] Allow using old ender pearl behavior
+
+When enabled, ender pearls will not load chunks and will save to the world instead of the player.
+
+== AT ==
+public net.minecraft.world.entity.projectile.Projectile cachedOwner
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 4e4e5b7e8c387cf13cf5bc5e39d334c3222c9103..cffbd3300967e5d80b5973b35a76235bb2aa1b73 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -836,6 +836,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+ 
+             while (iterator.hasNext()) {
+                 ThrownEnderpearl entityenderpearl = (ThrownEnderpearl) iterator.next();
++                if (entityenderpearl.level().paperConfig().misc.legacyEnderPearlBehavior) continue; // Paper - Allow using old ender pearl behavior
+ 
+                 if (entityenderpearl.isRemoved()) {
+                     ServerPlayer.LOGGER.warn("Trying to save removed ender pearl, skipping");
+@@ -3146,7 +3147,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+     }
+ 
+     public static long placeEnderPearlTicket(ServerLevel world, ChunkPos chunkPos) {
+-        world.getChunkSource().addRegionTicket(TicketType.ENDER_PEARL, chunkPos, 2, chunkPos);
++        if (!world.paperConfig().misc.legacyEnderPearlBehavior) world.getChunkSource().addRegionTicket(TicketType.ENDER_PEARL, chunkPos, 2, chunkPos); // Paper - Allow using old ender pearl behavior
+         return TicketType.ENDER_PEARL.timeout();
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index cf42042c754b30e41c0ec8a6a15195369bdbd199..1fcd9cd9344b0d2c4752042b07142db7d727dce8 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -602,7 +602,13 @@ public abstract class PlayerList {
+         while (iterator.hasNext()) {
+             ThrownEnderpearl entityenderpearl = (ThrownEnderpearl) iterator.next();
+ 
++            // Paper start - Allow using old ender pearl behavior
++            if (!entityenderpearl.level().paperConfig().misc.legacyEnderPearlBehavior) {
+             entityenderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, EntityRemoveEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause
++            } else {
++                entityenderpearl.cachedOwner = null;
++            }
++            // Paper end - Allow using old ender pearl behavior
+         }
+ 
+         worldserver.removePlayerImmediately(entityplayer, Entity.RemovalReason.UNLOADED_WITH_PLAYER);
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
+index 5f790dd24f2bdae827c6dc597064b9b265089751..bd2684528157f928460f2143dd71a48e11983123 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
+@@ -252,7 +252,7 @@ public class ThrownEnderpearl extends ThrowableItemProjectile {
+         Entity entity = super.teleport(teleportTarget);
+ 
+         if (entity != null) {
+-            entity.placePortalTicket(BlockPos.containing(entity.position()));
++            if (!this.level().paperConfig().misc.legacyEnderPearlBehavior) entity.placePortalTicket(BlockPos.containing(entity.position())); // Paper - Allow using old ender pearl behavior
+         }
+ 
+         return entity;

--- a/patches/server/1056-Block-Enderpearl-Travel-Exploit.patch
+++ b/patches/server/1056-Block-Enderpearl-Travel-Exploit.patch
@@ -16,19 +16,18 @@ Might be worth to re-add once an option to disable the above vanilla mechanic is
 fully prevent enderpearl travel exploits.
 
 == AT ==
-public net.minecraft.world.entity.projectile.Projectile cachedOwner
 public net.minecraft.world.entity.projectile.Projectile ownerUUID
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 21c3d771a3dd921767c2cba1e11583d015879ca9..332d378979925f1197f4218919442688a4c47c23 100644
+index e65cfb1132f5f0c9e1fa5ae4a46a8abed0c56be1..d5b9db881a49612c7587f8821adf923e28791d07 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2194,6 +2194,12 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2658,6 +2658,12 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
  
          public void onTickingEnd(Entity entity) {
              ServerLevel.this.entityTickList.remove(entity);
 +            // Paper start - Reset pearls when they stop being ticked
-+            if (paperConfig().fixes.disableUnloadedChunkEnderpearlExploit && entity instanceof net.minecraft.world.entity.projectile.ThrownEnderpearl pearl) {
++            if (ServerLevel.this.paperConfig().fixes.disableUnloadedChunkEnderpearlExploit && ServerLevel.this.paperConfig().misc.legacyEnderPearlBehavior && entity instanceof net.minecraft.world.entity.projectile.ThrownEnderpearl pearl) {
 +                pearl.cachedOwner = null;
 +                pearl.ownerUUID = null;
 +            }
@@ -37,14 +36,14 @@ index 21c3d771a3dd921767c2cba1e11583d015879ca9..332d378979925f1197f4218919442688
  
          public void onTrackingStart(Entity entity) {
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index fed01aea47090b990939becde837add6c36bf418..a1840bb4a3307492f80f93c4433eec3be7f862f1 100644
+index bf2e79c50092acd13e97ab6e32471a9c527a524e..6c2d4d6f3a36ab452dfd3c33f66e54f152906639 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-@@ -116,6 +116,7 @@ public abstract class Projectile extends Entity implements TraceableEntity {
+@@ -134,6 +134,7 @@ public abstract class Projectile extends Entity implements TraceableEntity {
      protected void readAdditionalSaveData(CompoundTag nbt) {
          if (nbt.hasUUID("Owner")) {
              this.setOwnerThroughUUID(nbt.getUUID("Owner"));
-+            if (this instanceof ThrownEnderpearl && this.level() != null && this.level().paperConfig().fixes.disableUnloadedChunkEnderpearlExploit) { this.ownerUUID = null; } // Paper - Reset pearls when they stop being ticked; Don't store shooter name for pearls to block enderpearl travel exploit
++            if (this instanceof ThrownEnderpearl && this.level() != null && this.level().paperConfig().fixes.disableUnloadedChunkEnderpearlExploit && this.level().paperConfig().misc.legacyEnderPearlBehavior) { this.ownerUUID = null; } // Paper - Reset pearls when they stop being ticked; Don't store shooter name for pearls to block enderpearl travel exploit
          }
  
          this.leftOwner = nbt.getBoolean("LeftOwner");


### PR DESCRIPTION
When enabled, ender pearls will not load chunks and will save to the world instead of the player.

Also changes the exploit config to be default false, as it only makes sense when legacy behavior is enabled.
I didn't bother with a config migration since it won't do anything without legacy behavior enabled.