### PR TITLE
Remove leftover missed timings calls

### DIFF
--- a/patches/server/0956-Brigadier-based-command-API.patch
+++ b/patches/server/0956-Brigadier-based-command-API.patch
@@ -1858,13 +1858,12 @@ index 0000000000000000000000000000000000000000..5eef7ae5197bd395fbd6800530ffe34d
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a286db0e356d95a52ed8738c00c112e64c959875
+index 0000000000000000000000000000000000000000..1814cd072aaca3e72249f0509a9c3b3cb154eaba
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
-@@ -0,0 +1,141 @@
+@@ -0,0 +1,138 @@
 +package io.papermc.paper.command.brigadier.bukkit;
 +
-+import co.aikar.timings.Timing;
 +import com.mojang.brigadier.arguments.StringArgumentType;
 +import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 +import com.mojang.brigadier.context.CommandContext;
@@ -1875,7 +1874,6 @@ index 0000000000000000000000000000000000000000..a286db0e356d95a52ed8738c00c112e6
 +import com.mojang.brigadier.tree.LiteralCommandNode;
 +import io.papermc.paper.command.brigadier.CommandSourceStack;
 +import java.util.ArrayList;
-+import java.util.Collections;
 +import net.minecraft.commands.CommandSource;
 +import org.bukkit.Bukkit;
 +import org.bukkit.ChatColor;
@@ -1888,7 +1886,6 @@ index 0000000000000000000000000000000000000000..a286db0e356d95a52ed8738c00c112e6
 +import java.util.List;
 +import java.util.concurrent.CompletableFuture;
 +import java.util.logging.Level;
-+import org.bukkit.entity.Entity;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.server.TabCompleteEvent;
 +

--- a/patches/server/0956-Brigadier-based-command-API.patch
+++ b/patches/server/0956-Brigadier-based-command-API.patch
@@ -1858,10 +1858,10 @@ index 0000000000000000000000000000000000000000..5eef7ae5197bd395fbd6800530ffe34d
 +}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0c3c82b28e581286b798ee58ca4193efc2faff4a
+index 0000000000000000000000000000000000000000..a286db0e356d95a52ed8738c00c112e64c959875
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
-@@ -0,0 +1,148 @@
+@@ -0,0 +1,141 @@
 +package io.papermc.paper.command.brigadier.bukkit;
 +
 +import co.aikar.timings.Timing;
@@ -1942,18 +1942,11 @@ index 0000000000000000000000000000000000000000..0c3c82b28e581286b798ee58ca4193ef
 +        public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
 +            CommandSender sender = context.getSource().getSender();
 +
-+            // Plugins do weird things to workaround normal registration
-+            if (this.command.timings == null) {
-+                this.command.timings = co.aikar.timings.TimingsManager.getCommandTiming(null, this.command);
-+            }
-+
 +            String content = context.getRange().get(context.getInput());
 +            String[] args = org.apache.commons.lang3.StringUtils.split(content, ' '); // fix adjacent spaces (from console/plugins) causing empty array elements
 +
-+            try (Timing ignored = this.command.timings.startTiming()) {
-+                // Note: we don't return the result of target.execute as thats success / failure, we return handled (true) or not handled (false)
-+                this.command.execute(sender, this.literal, Arrays.copyOfRange(args, 1, args.length));
-+            }
++            // Note: we don't return the result of target.execute as thats success / failure, we return handled (true) or not handled (false)
++            this.command.execute(sender, this.literal, Arrays.copyOfRange(args, 1, args.length));
 +
 +            // return true as command was handled
 +            return 1;


### PR DESCRIPTION
When updating Purpur to the latest `dev/1.21.2` commit, there was still some leftover timings calls that were not removed. This PR removes them.