### PR TITLE
Only expose velocity relative tp flags to API

### DIFF
--- a/patches/api/0353-More-Teleport-API.patch
+++ b/patches/api/0353-More-Teleport-API.patch
@@ -36,10 +36,10 @@ index 0000000000000000000000000000000000000000..544eec787ea837f7d29df6519255840d
 +}
 diff --git a/src/main/java/io/papermc/paper/entity/TeleportFlag.java b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7a1821367d0c6b5135786755c750dc421111e0b7
+index 0000000000000000000000000000000000000000..c00c4c467f08bd93410f31554d2763e26b154c16
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,113 @@
 +package io.papermc.paper.entity;
 +
 +import org.bukkit.Location;
@@ -67,35 +67,59 @@ index 0000000000000000000000000000000000000000..7a1821367d0c6b5135786755c750dc42
 +        /**
 +         * Configures the player to not loose velocity in their x axis during the teleport.
 +         */
-+        X,
++        VELOCITY_X,
 +        /**
 +         * Configures the player to not loose velocity in their y axis during the teleport.
 +         */
-+        Y,
++        VELOCITY_Y,
 +        /**
 +         * Configures the player to not loose velocity in their z axis during the teleport.
 +         */
-+        Z,
++        VELOCITY_Z,
 +        /**
 +         * Configures the player to not loose velocity in their current rotation during the teleport.
 +         */
-+        ROTATION;
++        VELOCITY_ROTATION;
++        /**
++         * Configures the player to not loose velocity in their x axis during the teleport.
++         * @deprecated Since 1.21.3, vanilla split up the relative teleport flags into velocity and position related
++         * ones. As the API does not deal with position relative flags, this name is no longer applicable.
++         * Use {@link #VELOCITY_X} instead.
++         */
++        @Deprecated(since = "1.21.3")
++        public static final Relative X = VELOCITY_X;
++        /**
++         * Configures the player to not loose velocity in their y axis during the teleport.
++         * @deprecated Since 1.21.3, vanilla split up the relative teleport flags into velocity and position related
++         * ones. As the API does not deal with position relative flags, this name is no longer applicable.
++         * Use {@link #VELOCITY_Y} instead.
++         */
++        @Deprecated(since = "1.21.3")
++        public static final Relative Y = VELOCITY_Y;
++        /**
++         * Configures the player to not loose velocity in their z axis during the teleport.
++         * @deprecated Since 1.21.3, vanilla split up the relative teleport flags into velocity and position related
++         * ones. As the API does not deal with position relative flags, this name is no longer applicable.
++         * Use {@link #VELOCITY_Z} instead.
++         */
++        @Deprecated(since = "1.21.3")
++        public static final Relative Z = VELOCITY_Z;
 +        /**
 +         * Represents the player's yaw
 +         *
 +         * @deprecated relative velocity flags now allow for the whole rotation to be relative, instead of the yaw and
-+         * pitch having individual options. Use {@link #ROTATION} instead.
++         * pitch having individual options. Use {@link #VELOCITY_ROTATION} instead.
 +         */
 +        @Deprecated(since = "1.21.3")
-+        public static final Relative YAW = ROTATION;
++        public static final Relative YAW = VELOCITY_ROTATION;
 +        /**
 +         * Represents the player's pitch
 +         *
 +         * @deprecated relative velocity flags now allow for the whole rotation to be relative, instead of the yaw and
-+         * pitch having individual options. Use {@link #ROTATION} instead.
++         * pitch having individual options. Use {@link #VELOCITY_ROTATION} instead.
 +         */
 +        @Deprecated(since = "1.21.3")
-+        public static final Relative PITCH = ROTATION;
++        public static final Relative PITCH = VELOCITY_ROTATION;
 +    }
 +
 +    /**

--- a/patches/api/0353-More-Teleport-API.patch
+++ b/patches/api/0353-More-Teleport-API.patch
@@ -36,10 +36,10 @@ index 0000000000000000000000000000000000000000..544eec787ea837f7d29df6519255840d
 +}
 diff --git a/src/main/java/io/papermc/paper/entity/TeleportFlag.java b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c8b5b570d44da9524bfc59c7e11b2ae59d4b79b9
+index 0000000000000000000000000000000000000000..7a1821367d0c6b5135786755c750dc421111e0b7
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
-@@ -0,0 +1,79 @@
+@@ -0,0 +1,89 @@
 +package io.papermc.paper.entity;
 +
 +import org.bukkit.Location;
@@ -57,35 +57,45 @@ index 0000000000000000000000000000000000000000..c8b5b570d44da9524bfc59c7e11b2ae5
 +    /**
 +     * Note: These flags only work on {@link org.bukkit.entity.Player} entities.
 +     * <p>
-+     * Represents coordinates in a teleportation that should be handled relatively.
-+     * <p>
-+     * Coordinates of the location that the client should handle as relative teleportation
-+     * Relative teleportation flags are only used client side, and cause the player to not lose velocity in that
-+     * specific coordinate. The location of the teleportation will not change.
++     * Relative flags enable a player to not loose their velocity in the flag-specific axis/context when teleporting.
 +     *
++     * @apiNote The relative flags exposed in the API do *not* mirror all flags known to vanilla, as relative flags concerning
++     * the position are non-applicable given teleports always expect an absolute location.
 +     * @see org.bukkit.entity.Player#teleport(Location, PlayerTeleportEvent.TeleportCause, TeleportFlag...)
 +     */
 +    enum Relative implements TeleportFlag {
 +        /**
-+         * Represents the player's X coordinate
++         * Configures the player to not loose velocity in their x axis during the teleport.
 +         */
 +        X,
 +        /**
-+         * Represents the player's Y coordinate
++         * Configures the player to not loose velocity in their y axis during the teleport.
 +         */
 +        Y,
 +        /**
-+         * Represents the player's Z coordinate
++         * Configures the player to not loose velocity in their z axis during the teleport.
 +         */
 +        Z,
 +        /**
-+         * Represents the player's yaw
++         * Configures the player to not loose velocity in their current rotation during the teleport.
 +         */
-+        YAW,
++        ROTATION;
++        /**
++         * Represents the player's yaw
++         *
++         * @deprecated relative velocity flags now allow for the whole rotation to be relative, instead of the yaw and
++         * pitch having individual options. Use {@link #ROTATION} instead.
++         */
++        @Deprecated(since = "1.21.3")
++        public static final Relative YAW = ROTATION;
 +        /**
 +         * Represents the player's pitch
++         *
++         * @deprecated relative velocity flags now allow for the whole rotation to be relative, instead of the yaw and
++         * pitch having individual options. Use {@link #ROTATION} instead.
 +         */
-+        PITCH;
++        @Deprecated(since = "1.21.3")
++        public static final Relative PITCH = ROTATION;
 +    }
 +
 +    /**

--- a/patches/api/0353-More-Teleport-API.patch
+++ b/patches/api/0353-More-Teleport-API.patch
@@ -36,7 +36,7 @@ index 0000000000000000000000000000000000000000..544eec787ea837f7d29df6519255840d
 +}
 diff --git a/src/main/java/io/papermc/paper/entity/TeleportFlag.java b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c00c4c467f08bd93410f31554d2763e26b154c16
+index 0000000000000000000000000000000000000000..bbc006152ac7885e1ffd05e84073ac1af45cc1a3
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
 @@ -0,0 +1,113 @@
@@ -86,7 +86,7 @@ index 0000000000000000000000000000000000000000..c00c4c467f08bd93410f31554d2763e2
 +         * ones. As the API does not deal with position relative flags, this name is no longer applicable.
 +         * Use {@link #VELOCITY_X} instead.
 +         */
-+        @Deprecated(since = "1.21.3")
++        @Deprecated(since = "1.21.3", forRemoval = true)
 +        public static final Relative X = VELOCITY_X;
 +        /**
 +         * Configures the player to not loose velocity in their y axis during the teleport.
@@ -94,7 +94,7 @@ index 0000000000000000000000000000000000000000..c00c4c467f08bd93410f31554d2763e2
 +         * ones. As the API does not deal with position relative flags, this name is no longer applicable.
 +         * Use {@link #VELOCITY_Y} instead.
 +         */
-+        @Deprecated(since = "1.21.3")
++        @Deprecated(since = "1.21.3", forRemoval = true)
 +        public static final Relative Y = VELOCITY_Y;
 +        /**
 +         * Configures the player to not loose velocity in their z axis during the teleport.
@@ -102,7 +102,7 @@ index 0000000000000000000000000000000000000000..c00c4c467f08bd93410f31554d2763e2
 +         * ones. As the API does not deal with position relative flags, this name is no longer applicable.
 +         * Use {@link #VELOCITY_Z} instead.
 +         */
-+        @Deprecated(since = "1.21.3")
++        @Deprecated(since = "1.21.3", forRemoval = true)
 +        public static final Relative Z = VELOCITY_Z;
 +        /**
 +         * Represents the player's yaw
@@ -110,7 +110,7 @@ index 0000000000000000000000000000000000000000..c00c4c467f08bd93410f31554d2763e2
 +         * @deprecated relative velocity flags now allow for the whole rotation to be relative, instead of the yaw and
 +         * pitch having individual options. Use {@link #VELOCITY_ROTATION} instead.
 +         */
-+        @Deprecated(since = "1.21.3")
++        @Deprecated(since = "1.21.3", forRemoval = true)
 +        public static final Relative YAW = VELOCITY_ROTATION;
 +        /**
 +         * Represents the player's pitch
@@ -118,7 +118,7 @@ index 0000000000000000000000000000000000000000..c00c4c467f08bd93410f31554d2763e2
 +         * @deprecated relative velocity flags now allow for the whole rotation to be relative, instead of the yaw and
 +         * pitch having individual options. Use {@link #VELOCITY_ROTATION} instead.
 +         */
-+        @Deprecated(since = "1.21.3")
++        @Deprecated(since = "1.21.3", forRemoval = true)
 +        public static final Relative PITCH = VELOCITY_ROTATION;
 +    }
 +

--- a/patches/server/0715-More-Teleport-API.patch
+++ b/patches/server/0715-More-Teleport-API.patch
@@ -113,7 +113,7 @@ index 4e6afa243d6108cb946a8a7cf96c4036a3c2ac0c..a314e401ee8a306dc12a2d98a3d400ae
      private final org.bukkit.entity.Entity.Spigot spigot = new org.bukkit.entity.Entity.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fe0c355f8203c9bfa30d2ec48392a5a1a3d616ae..71315f8916dd9c90f18d0778776657a049a74955 100644
+index fe0c355f8203c9bfa30d2ec48392a5a1a3d616ae..59a95187d04d3f1578e05a7f9d18f617eac95278 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1303,13 +1303,94 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -159,19 +159,19 @@ index fe0c355f8203c9bfa30d2ec48392a5a1a3d616ae..71315f8916dd9c90f18d0778776657a0
 +
 +    public static net.minecraft.world.entity.Relative deltaRelativeToNMS(io.papermc.paper.entity.TeleportFlag.Relative apiFlag) {
 +        return switch (apiFlag) {
-+            case X -> net.minecraft.world.entity.Relative.DELTA_X;
-+            case Y -> net.minecraft.world.entity.Relative.DELTA_Y;
-+            case Z -> net.minecraft.world.entity.Relative.DELTA_Z;
-+            case ROTATION -> net.minecraft.world.entity.Relative.ROTATE_DELTA;
++            case VELOCITY_X -> net.minecraft.world.entity.Relative.DELTA_X;
++            case VELOCITY_Y -> net.minecraft.world.entity.Relative.DELTA_Y;
++            case VELOCITY_Z -> net.minecraft.world.entity.Relative.DELTA_Z;
++            case VELOCITY_ROTATION -> net.minecraft.world.entity.Relative.ROTATE_DELTA;
 +        };
 +    }
 +
 +    public static @org.jetbrains.annotations.Nullable io.papermc.paper.entity.TeleportFlag.Relative deltaRelativeToAPI(net.minecraft.world.entity.Relative nmsFlag) {
 +        return switch (nmsFlag) {
-+            case DELTA_X -> io.papermc.paper.entity.TeleportFlag.Relative.X;
-+            case DELTA_Y -> io.papermc.paper.entity.TeleportFlag.Relative.Y;
-+            case DELTA_Z -> io.papermc.paper.entity.TeleportFlag.Relative.Z;
-+            case ROTATE_DELTA -> io.papermc.paper.entity.TeleportFlag.Relative.ROTATION;
++            case DELTA_X -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_X;
++            case DELTA_Y -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_Y;
++            case DELTA_Z -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_Z;
++            case ROTATE_DELTA -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_ROTATION;
 +            default -> null;
 +        };
 +    }

--- a/patches/server/0715-More-Teleport-API.patch
+++ b/patches/server/0715-More-Teleport-API.patch
@@ -5,18 +5,19 @@ Subject: [PATCH] More Teleport API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index bc8f9bd50de3894e6262e13ed55252c98f22ed8a..4d64eedfbe5b967572b7140ddfb55efa1ccc3650 100644
+index bc8f9bd50de3894e6262e13ed55252c98f22ed8a..10f7e45f192ef50b9d9bf5fc83a8090efb2b1042 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1585,11 +1585,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1585,11 +1585,18 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              return true; // CraftBukkit - Return event status
          }
  
 -        PlayerTeleportEvent event = new PlayerTeleportEvent(player, from.clone(), to.clone(), cause);
 +        // Paper start - Teleport API
-+        Set<io.papermc.paper.entity.TeleportFlag.Relative> relativeFlags = java.util.EnumSet.noneOf(io.papermc.paper.entity.TeleportFlag.Relative.class);
-+        for (Relative relativeArgument : set) {
-+            relativeFlags.add(org.bukkit.craftbukkit.entity.CraftPlayer.toApiRelativeFlag(relativeArgument));
++        final Set<io.papermc.paper.entity.TeleportFlag.Relative> relativeFlags = java.util.EnumSet.noneOf(io.papermc.paper.entity.TeleportFlag.Relative.class);
++        for (final Relative relativeArgument : set) {
++            final io.papermc.paper.entity.TeleportFlag.Relative flag = org.bukkit.craftbukkit.entity.CraftPlayer.deltaRelativeToAPI(relativeArgument);
++            if (flag != null) relativeFlags.add(flag);
 +        }
 +        PlayerTeleportEvent event = new PlayerTeleportEvent(player, from.clone(), to.clone(), cause, java.util.Set.copyOf(relativeFlags));
 +        // Paper end - Teleport API
@@ -112,10 +113,10 @@ index 4e6afa243d6108cb946a8a7cf96c4036a3c2ac0c..a314e401ee8a306dc12a2d98a3d400ae
      private final org.bukkit.entity.Entity.Spigot spigot = new org.bukkit.entity.Entity.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fe0c355f8203c9bfa30d2ec48392a5a1a3d616ae..4c4b8c14b41816173466232113252ef1ba2bb2ee 100644
+index fe0c355f8203c9bfa30d2ec48392a5a1a3d616ae..71315f8916dd9c90f18d0778776657a049a74955 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1303,13 +1303,96 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1303,13 +1303,94 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setRotation(float yaw, float pitch) {
@@ -156,24 +157,22 @@ index fe0c355f8203c9bfa30d2ec48392a5a1a3d616ae..4c4b8c14b41816173466232113252ef1
 +        };
 +    }
 +
-+    public static net.minecraft.world.entity.Relative toNmsRelativeFlag(io.papermc.paper.entity.TeleportFlag.Relative apiFlag) {
++    public static net.minecraft.world.entity.Relative deltaRelativeToNMS(io.papermc.paper.entity.TeleportFlag.Relative apiFlag) {
 +        return switch (apiFlag) {
-+            case X -> net.minecraft.world.entity.Relative.X;
-+            case Y -> net.minecraft.world.entity.Relative.Y;
-+            case Z -> net.minecraft.world.entity.Relative.Z;
-+            case PITCH -> net.minecraft.world.entity.Relative.X_ROT;
-+            case YAW -> net.minecraft.world.entity.Relative.Y_ROT;
++            case X -> net.minecraft.world.entity.Relative.DELTA_X;
++            case Y -> net.minecraft.world.entity.Relative.DELTA_Y;
++            case Z -> net.minecraft.world.entity.Relative.DELTA_Z;
++            case ROTATION -> net.minecraft.world.entity.Relative.ROTATE_DELTA;
 +        };
 +    }
 +
-+    public static io.papermc.paper.entity.TeleportFlag.Relative toApiRelativeFlag(net.minecraft.world.entity.Relative nmsFlag) {
++    public static @org.jetbrains.annotations.Nullable io.papermc.paper.entity.TeleportFlag.Relative deltaRelativeToAPI(net.minecraft.world.entity.Relative nmsFlag) {
 +        return switch (nmsFlag) {
-+            case X -> io.papermc.paper.entity.TeleportFlag.Relative.X;
-+            case Y -> io.papermc.paper.entity.TeleportFlag.Relative.Y;
-+            case Z -> io.papermc.paper.entity.TeleportFlag.Relative.Z;
-+            case X_ROT -> io.papermc.paper.entity.TeleportFlag.Relative.PITCH;
-+            case Y_ROT -> io.papermc.paper.entity.TeleportFlag.Relative.YAW;
-+            default -> throw new RuntimeException("not yet"); // TODO figure out what to do with new flags
++            case DELTA_X -> io.papermc.paper.entity.TeleportFlag.Relative.X;
++            case DELTA_Y -> io.papermc.paper.entity.TeleportFlag.Relative.Y;
++            case DELTA_Z -> io.papermc.paper.entity.TeleportFlag.Relative.Z;
++            case ROTATE_DELTA -> io.papermc.paper.entity.TeleportFlag.Relative.ROTATION;
++            default -> null;
 +        };
 +    }
 +
@@ -213,7 +212,7 @@ index fe0c355f8203c9bfa30d2ec48392a5a1a3d616ae..4c4b8c14b41816173466232113252ef1
          location.checkFinite();
  
          ServerPlayer entity = this.getHandle();
-@@ -1322,7 +1405,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1322,7 +1403,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              return false;
          }
  
@@ -222,7 +221,7 @@ index fe0c355f8203c9bfa30d2ec48392a5a1a3d616ae..4c4b8c14b41816173466232113252ef1
              return false;
          }
  
-@@ -1331,7 +1414,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1331,7 +1412,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // To = Players new Location if Teleport is Successful
          Location to = location;
          // Create & Call the Teleport Event.
@@ -231,7 +230,7 @@ index fe0c355f8203c9bfa30d2ec48392a5a1a3d616ae..4c4b8c14b41816173466232113252ef1
          this.server.getPluginManager().callEvent(event);
  
          // Return False to inform the Plugin that the Teleport was unsuccessful/cancelled.
-@@ -1340,7 +1423,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1340,7 +1421,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          // If this player is riding another entity, we must dismount before teleporting.
@@ -240,7 +239,7 @@ index fe0c355f8203c9bfa30d2ec48392a5a1a3d616ae..4c4b8c14b41816173466232113252ef1
  
          // SPIGOT-5509: Wakeup, similar to riding
          if (this.isSleeping()) {
-@@ -1356,13 +1439,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1356,13 +1437,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          ServerLevel toWorld = ((CraftWorld) to.getWorld()).getHandle();
  
          // Close any foreign inventory
@@ -255,7 +254,7 @@ index fe0c355f8203c9bfa30d2ec48392a5a1a3d616ae..4c4b8c14b41816173466232113252ef1
 +            // Paper start - Teleport API
 +            final Set<net.minecraft.world.entity.Relative> nms = java.util.EnumSet.noneOf(net.minecraft.world.entity.Relative.class);
 +            for (final io.papermc.paper.entity.TeleportFlag.Relative bukkit : relativeArguments) {
-+                nms.add(toNmsRelativeFlag(bukkit));
++                nms.add(deltaRelativeToNMS(bukkit));
 +            }
 +            entity.connection.internalTeleport(new net.minecraft.world.entity.PositionMoveRotation(
 +                io.papermc.paper.util.MCUtil.toVec3(to), net.minecraft.world.phys.Vec3.ZERO, to.getYaw(), to.getPitch()

--- a/patches/server/0718-Send-block-entities-after-destroy-prediction.patch
+++ b/patches/server/0718-Send-block-entities-after-destroy-prediction.patch
@@ -57,10 +57,10 @@ index 5c3e5c348e6fececccd8097355f423b9e7ad982b..064a7a3e1c4d192010e072a5e985a541
              }
          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4d64eedfbe5b967572b7140ddfb55efa1ccc3650..b48966424fb8e937552c0e7bffaedaefc63ef77f 100644
+index 10f7e45f192ef50b9d9bf5fc83a8090efb2b1042..51ee01dfe5e144cb881c9376e586b95790a9ab98 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1723,8 +1723,28 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1724,8 +1724,28 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      return;
                  }
                  // Paper end - Don't allow digging into unloaded chunks

--- a/patches/server/0720-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/server/0720-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4c4b8c14b41816173466232113252ef1ba2bb2ee..2aaf9e87a7322392d713bd869b0bdddae88db7ff 100644
+index 71315f8916dd9c90f18d0778776657a049a74955..a4f82a09100f321bfc01a716172cad60c2c20374 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -708,6 +708,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0720-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/server/0720-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 71315f8916dd9c90f18d0778776657a049a74955..a4f82a09100f321bfc01a716172cad60c2c20374 100644
+index 59a95187d04d3f1578e05a7f9d18f617eac95278..bdb4c337265f70d97f8e17f1509c1fee91a7bf6f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -708,6 +708,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0739-Fix-a-bunch-of-vanilla-bugs.patch
+++ b/patches/server/0739-Fix-a-bunch-of-vanilla-bugs.patch
@@ -115,10 +115,10 @@ index 064a7a3e1c4d192010e072a5e985a54135748d87..a706f0855fdf88cc9aece3ba00ef574b
              this.player.server.getPlayerList().broadcastAll(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE, this.player), this.player); // CraftBukkit
              this.level.updateSleepingPlayerList();
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b48966424fb8e937552c0e7bffaedaefc63ef77f..79eceb995f92b3f3d7b695dc6d2a0a4a824ce871 100644
+index 51ee01dfe5e144cb881c9376e586b95790a9ab98..f5e05a34afee8f5750b3a7871083968c5d75d2e7 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1831,7 +1831,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1832,7 +1832,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                      this.player.swing(enumhand, true);
                                  }
                              }

--- a/patches/server/0745-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0745-Elder-Guardian-appearance-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a4f82a09100f321bfc01a716172cad60c2c20374..bc8d2dab3e4a64852490ef46ad0d4e7bc6d23dde 100644
+index bdb4c337265f70d97f8e17f1509c1fee91a7bf6f..b6c8eb48c78ae40ab8ea5af3339086d1d300cf93 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -3320,6 +3320,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0745-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0745-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2aaf9e87a7322392d713bd869b0bdddae88db7ff..dc09ddfb8e695606fe4dfd2594d75ab312ee9b78 100644
+index a4f82a09100f321bfc01a716172cad60c2c20374..bc8d2dab3e4a64852490ef46ad0d4e7bc6d23dde 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3322,6 +3322,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3320,6 +3320,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0757-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0757-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index dc09ddfb8e695606fe4dfd2594d75ab312ee9b78..9f31ea3cb0b5dac2c50be0f51ad002e593d6fb5c 100644
+index bc8d2dab3e4a64852490ef46ad0d4e7bc6d23dde..b691d64886d4c81d8b41d7fd85cdd7640c0e676c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3327,6 +3327,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3325,6 +3325,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }

--- a/patches/server/0757-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0757-Add-Player-Warden-Warning-API.patch
@@ -10,7 +10,7 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index bc8d2dab3e4a64852490ef46ad0d4e7bc6d23dde..b691d64886d4c81d8b41d7fd85cdd7640c0e676c 100644
+index b6c8eb48c78ae40ab8ea5af3339086d1d300cf93..b4191c1a54666b82c4da14f06343dae581f9f7f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -3325,6 +3325,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0769-fix-Instruments.patch
+++ b/patches/server/0769-fix-Instruments.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] fix Instruments
 properly handle Player#playNote
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b691d64886d4c81d8b41d7fd85cdd7640c0e676c..5e041d52f09d8b1e952c257d92af13b6d49cd663 100644
+index b4191c1a54666b82c4da14f06343dae581f9f7f7..1cbb5b0b53d9c8f0bee82d4f4ee2cfd5caf835db 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -785,7 +785,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0769-fix-Instruments.patch
+++ b/patches/server/0769-fix-Instruments.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] fix Instruments
 properly handle Player#playNote
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9f31ea3cb0b5dac2c50be0f51ad002e593d6fb5c..f41d97bdb046747a6540dc22cbdc322d764f1e0a 100644
+index b691d64886d4c81d8b41d7fd85cdd7640c0e676c..5e041d52f09d8b1e952c257d92af13b6d49cd663 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -785,7 +785,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0773-Improve-logging-and-errors.patch
+++ b/patches/server/0773-Improve-logging-and-errors.patch
@@ -52,10 +52,10 @@ index 4e47611f85f3db6a638d0fc6a0dd712b245cf229..ebe6a002d883721d80cbfcc004064e8a
          }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 79eceb995f92b3f3d7b695dc6d2a0a4a824ce871..345d5069d0ebb8ad74158334fd230d0ea64b909d 100644
+index f5e05a34afee8f5750b3a7871083968c5d75d2e7..7f1fc7523ff98bf932ffc31035c233f6517e5192 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3448,7 +3448,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3449,7 +3449,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                      this.resetPlayerChatState(remotechatsession_a.validate(this.player.getGameProfile(), signaturevalidator));
                  } catch (ProfilePublicKey.ValidationException profilepublickey_b) {

--- a/patches/server/0776-Add-missing-SpigotConfig-logCommands-check.patch
+++ b/patches/server/0776-Add-missing-SpigotConfig-logCommands-check.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing SpigotConfig logCommands check
 Co-authored-by: david <mrminecraft00@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 345d5069d0ebb8ad74158334fd230d0ea64b909d..af8a513c2692b71ad56abce24048b61eb78d41c4 100644
+index 7f1fc7523ff98bf932ffc31035c233f6517e5192..762382b45afbc18810787858539fba62afc3e84c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2078,7 +2078,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2079,7 +2079,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      private void performUnsignedChatCommand(String command) {
          // CraftBukkit start
          String command1 = "/" + command;
@@ -19,7 +19,7 @@ index 345d5069d0ebb8ad74158334fd230d0ea64b909d..af8a513c2692b71ad56abce24048b61e
  
          PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(this.getCraftPlayer(), command1, new LazyPlayerSet(this.server));
          this.cserver.getPluginManager().callEvent(event);
-@@ -2118,7 +2120,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2119,7 +2121,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      private void performSignedChatCommand(ServerboundChatCommandSignedPacket packet, LastSeenMessages lastSeenMessages) {
          // CraftBukkit start
          String command = "/" + packet.command();

--- a/patches/server/0778-Flying-Fall-Damage.patch
+++ b/patches/server/0778-Flying-Fall-Damage.patch
@@ -26,10 +26,10 @@ index 30e0a5fe3f9bd85d2b702c2c877c5682ed35d461..aca888c2f02b09ac6739bdc81b194c45
          } else {
              if (fallDistance >= 2.0F) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f41d97bdb046747a6540dc22cbdc322d764f1e0a..3b6bd9a4b3c9767cdc13cda75e0be6d9aed0b672 100644
+index 5e041d52f09d8b1e952c257d92af13b6d49cd663..80413deb60c39ec1fe3a5bbb7464c2600df68a21 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2605,6 +2605,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2603,6 +2603,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().onUpdateAbilities();
      }
  

--- a/patches/server/0778-Flying-Fall-Damage.patch
+++ b/patches/server/0778-Flying-Fall-Damage.patch
@@ -26,7 +26,7 @@ index 30e0a5fe3f9bd85d2b702c2c877c5682ed35d461..aca888c2f02b09ac6739bdc81b194c45
          } else {
              if (fallDistance >= 2.0F) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5e041d52f09d8b1e952c257d92af13b6d49cd663..80413deb60c39ec1fe3a5bbb7464c2600df68a21 100644
+index 1cbb5b0b53d9c8f0bee82d4f4ee2cfd5caf835db..01062856483557c874f54bc610c3d13fca44ef05 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2603,6 +2603,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0781-Use-single-player-info-update-packet-on-join.patch
+++ b/patches/server/0781-Use-single-player-info-update-packet-on-join.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use single player info update packet on join
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index af8a513c2692b71ad56abce24048b61eb78d41c4..5802bca38fdeccbc1353990ecb425034f86e8332 100644
+index 762382b45afbc18810787858539fba62afc3e84c..66655aecd83138760e5d7601d22b95bb1bf0ec98 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3486,7 +3486,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3487,7 +3487,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          this.signedMessageDecoder = session.createMessageDecoder(this.player.getUUID());
          this.chatMessageChain.append(() -> {
              this.player.setChatSession(session);

--- a/patches/server/0783-Win-Screen-API.patch
+++ b/patches/server/0783-Win-Screen-API.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Win Screen API
 public net.minecraft.server.level.ServerPlayer seenCredits
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 80413deb60c39ec1fe3a5bbb7464c2600df68a21..6b22ddc0c1bec88070d32d5dbaa05f9616f70ae3 100644
+index 01062856483557c874f54bc610c3d13fca44ef05..b6aa646b28aef25e07c6e7fc0dfc2a252671e6c5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1322,6 +1322,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0783-Win-Screen-API.patch
+++ b/patches/server/0783-Win-Screen-API.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Win Screen API
 public net.minecraft.server.level.ServerPlayer seenCredits
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3b6bd9a4b3c9767cdc13cda75e0be6d9aed0b672..3419024a58a3c68b160f16350c72d1250c10d4dd 100644
+index 80413deb60c39ec1fe3a5bbb7464c2600df68a21..6b22ddc0c1bec88070d32d5dbaa05f9616f70ae3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1322,6 +1322,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0798-Treat-sequence-violations-like-they-should-be.patch
+++ b/patches/server/0798-Treat-sequence-violations-like-they-should-be.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Treat sequence violations like they should be
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 5802bca38fdeccbc1353990ecb425034f86e8332..3e9247f662afde4dcca900b69b6a78140f9566fa 100644
+index 66655aecd83138760e5d7601d22b95bb1bf0ec98..2edf9a3c4ce5d2feaac624c969c2711dfc2dc4f7 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1997,6 +1997,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1998,6 +1998,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      public void ackBlockChangesUpTo(int sequence) {
          if (sequence < 0) {

--- a/patches/server/0799-Prevent-causing-expired-keys-from-impacting-new-join.patch
+++ b/patches/server/0799-Prevent-causing-expired-keys-from-impacting-new-join.patch
@@ -26,7 +26,7 @@ index d0b2a8b5ded71a9a41753f4addea1c49826b34a3..29b465fc1dc50e0e84ddb889c5303e80
          UPDATE_GAME_MODE((serialized, buf) -> serialized.gameMode = GameType.byId(buf.readVarInt()), (buf, entry) -> buf.writeVarInt(entry.gameMode().getId())),
          UPDATE_LISTED((serialized, buf) -> serialized.listed = buf.readBoolean(), (buf, entry) -> buf.writeBoolean(entry.listed())),
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3e9247f662afde4dcca900b69b6a78140f9566fa..919b0ffb69720b3edeb9d25c7f41291a09976505 100644
+index 2edf9a3c4ce5d2feaac624c969c2711dfc2dc4f7..e653dc4ac16fd22674a6c1ba402f8913e0fbb336 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -305,6 +305,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -51,7 +51,7 @@ index 3e9247f662afde4dcca900b69b6a78140f9566fa..919b0ffb69720b3edeb9d25c7f41291a
      }
  
      private int getMaximumFlyingTicks(Entity vehicle) {
-@@ -3484,6 +3492,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3485,6 +3493,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      private void resetPlayerChatState(RemoteChatSession session) {
          this.chatSession = session;

--- a/patches/server/0808-Expand-PlayerItemMendEvent.patch
+++ b/patches/server/0808-Expand-PlayerItemMendEvent.patch
@@ -30,10 +30,10 @@ index 3a7af27bb1ce0cbe56bd3760cd400083daf98d4c..bf0838f574fa3fb9654e087d602b8d38
                  if (l > 0) {
                      // this.value = l; // CraftBukkit - update exp value of orb for PlayerItemMendEvent calls // Paper - the value field should not be mutated here because it doesn't take "count" into account
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3419024a58a3c68b160f16350c72d1250c10d4dd..d48a0d67853fb17cc73bba94c9b6660d2689c8fc 100644
+index 6b22ddc0c1bec88070d32d5dbaa05f9616f70ae3..9b5bf841866c0d14f0302aac8519e7463fc80a52 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1877,11 +1877,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1875,11 +1875,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  handle.serverLevel(), itemstack, amount
              );
              int i = Math.min(possibleDurabilityFromXp, itemstack.getDamageValue());

--- a/patches/server/0808-Expand-PlayerItemMendEvent.patch
+++ b/patches/server/0808-Expand-PlayerItemMendEvent.patch
@@ -30,7 +30,7 @@ index 3a7af27bb1ce0cbe56bd3760cd400083daf98d4c..bf0838f574fa3fb9654e087d602b8d38
                  if (l > 0) {
                      // this.value = l; // CraftBukkit - update exp value of orb for PlayerItemMendEvent calls // Paper - the value field should not be mutated here because it doesn't take "count" into account
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6b22ddc0c1bec88070d32d5dbaa05f9616f70ae3..9b5bf841866c0d14f0302aac8519e7463fc80a52 100644
+index b6aa646b28aef25e07c6e7fc0dfc2a252671e6c5..d4cf68ad626e6a7d5facaa0a7474a7d4ad7981db 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1875,11 +1875,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0827-Fix-BanList-API.patch
+++ b/patches/server/0827-Fix-BanList-API.patch
@@ -208,7 +208,7 @@ index 172202accf4448a933fcf1ff820316c7910dd7f7..50ee7656580d386db473c054f5c5ec57
              return null;
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9b5bf841866c0d14f0302aac8519e7463fc80a52..f1690fa4ed3933d96d1fbe1d06aba76bbe3339fd 100644
+index d4cf68ad626e6a7d5facaa0a7474a7d4ad7981db..86af7b3bcefe9201a56868388be8789bfdeaa22b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1769,23 +1769,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0827-Fix-BanList-API.patch
+++ b/patches/server/0827-Fix-BanList-API.patch
@@ -208,10 +208,10 @@ index 172202accf4448a933fcf1ff820316c7910dd7f7..50ee7656580d386db473c054f5c5ec57
              return null;
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d48a0d67853fb17cc73bba94c9b6660d2689c8fc..3ddf3b893605f5763b1f685ad951b1ccdd4a44ce 100644
+index 9b5bf841866c0d14f0302aac8519e7463fc80a52..f1690fa4ed3933d96d1fbe1d06aba76bbe3339fd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1771,23 +1771,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1769,23 +1769,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      @Override
@@ -240,7 +240,7 @@ index d48a0d67853fb17cc73bba94c9b6660d2689c8fc..3ddf3b893605f5763b1f685ad951b1cc
          if (kickPlayer) {
              this.kickPlayer(reason);
          }
-@@ -1795,12 +1795,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1793,12 +1793,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      @Override

--- a/patches/server/0834-Implement-PlayerFailMoveEvent.patch
+++ b/patches/server/0834-Implement-PlayerFailMoveEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement PlayerFailMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 919b0ffb69720b3edeb9d25c7f41291a09976505..134d9fbdb757094a4624325c0ad8f32efadd61b6 100644
+index e653dc4ac16fd22674a6c1ba402f8913e0fbb336..2de655df951199c74758578c7f00fa053851b55e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1271,8 +1271,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -91,7 +91,7 @@ index 919b0ffb69720b3edeb9d25c7f41291a09976505..134d9fbdb757094a4624325c0ad8f32e
                                  this.internalTeleport(d3, d4, d5, f, f1); // CraftBukkit - SPIGOT-1807: Don't call teleport event, when the client thinks the player is falling, because the chunks are not loaded on the client yet.
                                  this.player.doCheckFallDamage(this.player.getX() - d3, this.player.getY() - d4, this.player.getZ() - d5, packet.isOnGround());
                              } else {
-@@ -3534,4 +3564,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3535,4 +3565,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
          InteractionResult run(ServerPlayer player, Entity entity, InteractionHand hand);
      }

--- a/patches/server/0846-Bandaid-fix-for-Effect.patch
+++ b/patches/server/0846-Bandaid-fix-for-Effect.patch
@@ -81,7 +81,7 @@ index c0f5e4497e1ffc93f56fc2b5748bcf76569e8c3a..188bd33f46b6baaa3fc21c9da6fa9a9d
              // Special case: the axis is optional for ELECTRIC_SPARK
              Preconditions.checkArgument(effect.getData() == null || effect == Effect.ELECTRIC_SPARK, "Wrong kind of data for the %s effect", effect);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f1690fa4ed3933d96d1fbe1d06aba76bbe3339fd..1d7243082c6a3187307caf88d345323fb4cd92e3 100644
+index 86af7b3bcefe9201a56868388be8789bfdeaa22b..c582b8f307e6b8fd4991702d92c2e74c3012763a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -934,7 +934,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0846-Bandaid-fix-for-Effect.patch
+++ b/patches/server/0846-Bandaid-fix-for-Effect.patch
@@ -81,7 +81,7 @@ index c0f5e4497e1ffc93f56fc2b5748bcf76569e8c3a..188bd33f46b6baaa3fc21c9da6fa9a9d
              // Special case: the axis is optional for ELECTRIC_SPARK
              Preconditions.checkArgument(effect.getData() == null || effect == Effect.ELECTRIC_SPARK, "Wrong kind of data for the %s effect", effect);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3ddf3b893605f5763b1f685ad951b1ccdd4a44ce..abb0370243ad95260c5c6034e20097a09415fe00 100644
+index f1690fa4ed3933d96d1fbe1d06aba76bbe3339fd..1d7243082c6a3187307caf88d345323fb4cd92e3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -934,7 +934,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0850-Don-t-tab-complete-namespaced-commands-if-send-names.patch
+++ b/patches/server/0850-Don-t-tab-complete-namespaced-commands-if-send-names.patch
@@ -11,7 +11,7 @@ This patch prevents server from sending namespaced commands when player
 requests tab-complete only commands.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 134d9fbdb757094a4624325c0ad8f32efadd61b6..688d6e51bc8b844ba7648cf1aed1bdd9629c1675 100644
+index 2de655df951199c74758578c7f00fa053851b55e..c3a53db9f611f160bd4b8662498f5ac0e988c5d1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -832,6 +832,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl

--- a/patches/server/0854-Add-Listing-API-for-Player.patch
+++ b/patches/server/0854-Add-Listing-API-for-Player.patch
@@ -122,7 +122,7 @@ index d92fb522d88a790d9cea2e6c4edad30bb73298fc..a20e5f896cfbd0a3e60b741562194e30
          // Paper end - Use single player info update packet on join
          player.sentListPacket = true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1d7243082c6a3187307caf88d345323fb4cd92e3..336aa249e0ad49415ed710ead149f32720c4cfb1 100644
+index c582b8f307e6b8fd4991702d92c2e74c3012763a..334303fbb2cf0086ad133bdc07b27e833162f71a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -206,6 +206,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0854-Add-Listing-API-for-Player.patch
+++ b/patches/server/0854-Add-Listing-API-for-Player.patch
@@ -122,7 +122,7 @@ index d92fb522d88a790d9cea2e6c4edad30bb73298fc..a20e5f896cfbd0a3e60b741562194e30
          // Paper end - Use single player info update packet on join
          player.sentListPacket = true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index abb0370243ad95260c5c6034e20097a09415fe00..47180d44b7e168352b17bc295ffb6d3ea6e0a937 100644
+index 1d7243082c6a3187307caf88d345323fb4cd92e3..336aa249e0ad49415ed710ead149f32720c4cfb1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -206,6 +206,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -133,7 +133,7 @@ index abb0370243ad95260c5c6034e20097a09415fe00..47180d44b7e168352b17bc295ffb6d3e
      private static final WeakHashMap<Plugin, WeakReference<Plugin>> pluginWeakReferences = new WeakHashMap<>();
      private int hash = 0;
      private double health = 20;
-@@ -2116,7 +2117,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2114,7 +2115,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  otherPlayer.setUUID(uuidOverride);
              }
              // Paper end
@@ -142,7 +142,7 @@ index abb0370243ad95260c5c6034e20097a09415fe00..47180d44b7e168352b17bc295ffb6d3e
              if (original != null) otherPlayer.setUUID(original); // Paper - uuid override
          }
  
-@@ -2220,6 +2221,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2218,6 +2219,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (entity != null) ? this.canSee(entity) : false; // If we can't find it, we can't see it
      }
  

--- a/patches/server/0860-Add-PlayerPickItemEvent.patch
+++ b/patches/server/0860-Add-PlayerPickItemEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerPickItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 688d6e51bc8b844ba7648cf1aed1bdd9629c1675..b840f7aac9c830b8aa0aa133bf43f87dfc598b2c 100644
+index c3a53db9f611f160bd4b8662498f5ac0e988c5d1..38730e11118bf71d167a18b807e06c20ea0d63d0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -947,7 +947,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl

--- a/patches/server/0864-Implement-OfflinePlayer-isConnected.patch
+++ b/patches/server/0864-Implement-OfflinePlayer-isConnected.patch
@@ -23,7 +23,7 @@ index 2c2c4db31a746b4eb853dc04c6b3e5631bbfa034..4f4e3ee18d586f61706504218cddc06a
      public String getName() {
          Player player = this.getPlayer();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 47180d44b7e168352b17bc295ffb6d3ea6e0a937..96d8bd55ecfb6aca8a6f65bc2a25e5756eecc4d8 100644
+index 336aa249e0ad49415ed710ead149f32720c4cfb1..889cb761df8c8d07788f47cedde0010144e46f00 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -261,6 +261,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0864-Implement-OfflinePlayer-isConnected.patch
+++ b/patches/server/0864-Implement-OfflinePlayer-isConnected.patch
@@ -23,7 +23,7 @@ index 2c2c4db31a746b4eb853dc04c6b3e5631bbfa034..4f4e3ee18d586f61706504218cddc06a
      public String getName() {
          Player player = this.getPlayer();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 336aa249e0ad49415ed710ead149f32720c4cfb1..889cb761df8c8d07788f47cedde0010144e46f00 100644
+index 334303fbb2cf0086ad133bdc07b27e833162f71a..de97ca0a25d70de50dfcc6b092f5e58facfb5a3a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -261,6 +261,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0865-Fix-slot-desync.patch
+++ b/patches/server/0865-Fix-slot-desync.patch
@@ -22,10 +22,10 @@ index f05a9fd321a4af28e9771bbf39d73f80dd4160c9..90aa8e401e1d092a31ff21699409b836
          this.containerMenu.findSlot(this.getInventory(), this.getInventory().selected).ifPresent(s -> {
              this.containerSynchronizer.sendSlotChange(this.containerMenu, s, this.getMainHandItem());
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b840f7aac9c830b8aa0aa133bf43f87dfc598b2c..0cb0d2f863efb86bb589b30bae61ac57bda40fab 100644
+index 38730e11118bf71d167a18b807e06c20ea0d63d0..5be7304c8417e2987837d1c6ce8b80231fd29c51 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2746,10 +2746,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2747,10 +2747,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  // Refresh the current entity metadata
                                  entity.refreshEntityData(ServerGamePacketListenerImpl.this.player);
                                  // SPIGOT-7136 - Allays

--- a/patches/server/0870-Add-slot-sanity-checks-in-container-clicks.patch
+++ b/patches/server/0870-Add-slot-sanity-checks-in-container-clicks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add slot sanity checks in container clicks
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0cb0d2f863efb86bb589b30bae61ac57bda40fab..f92624ccd43f448abdee92c975d613cbcb3457c6 100644
+index 5be7304c8417e2987837d1c6ce8b80231fd29c51..1ef521e4552f8ce48f620d8932d5e9356b14ae57 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3008,6 +3008,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3009,6 +3009,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              break;
                          case SWAP:
                              if ((packet.getButtonNum() >= 0 && packet.getButtonNum() < 9) || packet.getButtonNum() == 40) {

--- a/patches/server/0884-Add-player-idle-duration-API.patch
+++ b/patches/server/0884-Add-player-idle-duration-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 889cb761df8c8d07788f47cedde0010144e46f00..ae43d0dbdad7d5608f52772c4cf589cabaafabb8 100644
+index de97ca0a25d70de50dfcc6b092f5e58facfb5a3a..b4f967c8cc0800d0606e7ad32ff8a350387c6132 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -3441,6 +3441,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0884-Add-player-idle-duration-API.patch
+++ b/patches/server/0884-Add-player-idle-duration-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 96d8bd55ecfb6aca8a6f65bc2a25e5756eecc4d8..fee7f60d457f34dd46756efc51bf21bd5498d854 100644
+index 889cb761df8c8d07788f47cedde0010144e46f00..ae43d0dbdad7d5608f52772c4cf589cabaafabb8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3443,6 +3443,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3441,6 +3441,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0887-Allow-null-itemstack-for-Player-sendEquipmentChange.patch
+++ b/patches/server/0887-Allow-null-itemstack-for-Player-sendEquipmentChange.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow null itemstack for Player#sendEquipmentChange
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fee7f60d457f34dd46756efc51bf21bd5498d854..90df4f4a70b416b2d750f3d2063a68848bd38085 100644
+index ae43d0dbdad7d5608f52772c4cf589cabaafabb8..aae59396799b4d723fc99d25cf3e018ea72d3cd7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1144,7 +1144,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0887-Allow-null-itemstack-for-Player-sendEquipmentChange.patch
+++ b/patches/server/0887-Allow-null-itemstack-for-Player-sendEquipmentChange.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow null itemstack for Player#sendEquipmentChange
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ae43d0dbdad7d5608f52772c4cf589cabaafabb8..aae59396799b4d723fc99d25cf3e018ea72d3cd7 100644
+index b4f967c8cc0800d0606e7ad32ff8a350387c6132..ccc65e07d0d1bb6e94e861e7f50977ba61462ca4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1144,7 +1144,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0907-Add-experience-points-API.patch
+++ b/patches/server/0907-Add-experience-points-API.patch
@@ -18,7 +18,7 @@ index aca888c2f02b09ac6739bdc81b194c4527dd69f5..a19a795deaa7f46c92b97912e2ade006
      // Paper start - send while respecting visibility
      private static void sendSoundEffect(Player fromEntity, double x, double y, double z, SoundEvent soundEffect, SoundSource soundCategory, float volume, float pitch) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index aae59396799b4d723fc99d25cf3e018ea72d3cd7..ea1a0ae187adc9170953b8261fa061ef50a59e67 100644
+index ccc65e07d0d1bb6e94e861e7f50977ba61462ca4..58d12409447903f855baa6beb149aa658bf7b1bb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1943,6 +1943,49 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0907-Add-experience-points-API.patch
+++ b/patches/server/0907-Add-experience-points-API.patch
@@ -18,10 +18,10 @@ index aca888c2f02b09ac6739bdc81b194c4527dd69f5..a19a795deaa7f46c92b97912e2ade006
      // Paper start - send while respecting visibility
      private static void sendSoundEffect(Player fromEntity, double x, double y, double z, SoundEvent soundEffect, SoundSource soundCategory, float volume, float pitch) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 90df4f4a70b416b2d750f3d2063a68848bd38085..933390c4244200dc1be5311a174e5df95f6ac633 100644
+index aae59396799b4d723fc99d25cf3e018ea72d3cd7..ea1a0ae187adc9170953b8261fa061ef50a59e67 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1945,6 +1945,49 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1943,6 +1943,49 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          Preconditions.checkArgument(exp >= 0, "Total experience points must not be negative (%s)", exp);
          this.getHandle().totalExperience = exp;
      }

--- a/patches/server/0927-Add-CartographyItemEvent.patch
+++ b/patches/server/0927-Add-CartographyItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add CartographyItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f92624ccd43f448abdee92c975d613cbcb3457c6..90bed0a36b2d518b56164a414350ec02822ad42a 100644
+index 1ef521e4552f8ce48f620d8932d5e9356b14ae57..bf8355d3b235ce48cbb1011142096d42246a08e2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3130,6 +3130,19 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3131,6 +3131,19 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              }
                          }
  

--- a/patches/server/0937-Improve-tag-parser-handling.patch
+++ b/patches/server/0937-Improve-tag-parser-handling.patch
@@ -252,7 +252,7 @@ index 898b19887ed34c87003fc63cb5905df2ba6234a5..b47eeb23055b135d5567552ba983bfbc
  
      private void write(FriendlyByteBuf buf) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 90bed0a36b2d518b56164a414350ec02822ad42a..0d6c3cdd0c8fa8c6983e8a35bac89ff062e1a97f 100644
+index bf8355d3b235ce48cbb1011142096d42246a08e2..c4ffa8519b520e0793af90e149518951d7ffb65b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -778,6 +778,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl

--- a/patches/server/0952-Added-API-to-get-player-ha-proxy-address.patch
+++ b/patches/server/0952-Added-API-to-get-player-ha-proxy-address.patch
@@ -35,7 +35,7 @@ index c62df32af11636ad408b584fcc590590ce4fb0d0..baed0bb80d44973f9323bbe536551182
                                  } else {
                                      super.channelRead(ctx, msg);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 933390c4244200dc1be5311a174e5df95f6ac633..e1e73e877dfef5bcf30a99b275ececbf42f59c95 100644
+index ea1a0ae187adc9170953b8261fa061ef50a59e67..ecde377d35d7750686b6eccef06a1051d73e961e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -270,7 +270,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0952-Added-API-to-get-player-ha-proxy-address.patch
+++ b/patches/server/0952-Added-API-to-get-player-ha-proxy-address.patch
@@ -35,7 +35,7 @@ index c62df32af11636ad408b584fcc590590ce4fb0d0..baed0bb80d44973f9323bbe536551182
                                  } else {
                                      super.channelRead(ctx, msg);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ea1a0ae187adc9170953b8261fa061ef50a59e67..ecde377d35d7750686b6eccef06a1051d73e961e 100644
+index 58d12409447903f855baa6beb149aa658bf7b1bb..766c1e80997d1bed99f4ebf9499eec60bf70a536 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -270,7 +270,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0956-Brigadier-based-command-API.patch
+++ b/patches/server/0956-Brigadier-based-command-API.patch
@@ -2328,10 +2328,10 @@ index ebe6a002d883721d80cbfcc004064e8a57934a56..cce0e570c8217c8e7cc81642d303e1b9
          this.setPvpAllowed(dedicatedserverproperties.pvp);
          this.setFlightAllowed(dedicatedserverproperties.allowFlight);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0d6c3cdd0c8fa8c6983e8a35bac89ff062e1a97f..af3e0049beb5590520ed84b52d6df85ad22a8f23 100644
+index c4ffa8519b520e0793af90e149518951d7ffb65b..688916c8fef40d4c81379ad38609a97993b4b702 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2429,30 +2429,20 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2430,30 +2430,20 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
      }
  

--- a/patches/server/0960-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0960-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -209,10 +209,10 @@ index f3456aeeab7eee5b6d0383a4bf1338dd8cc95bb3..b2fd3e936559c8fcb8b02ae3ef63c4f3
              ((LivingEntity) this.entity).detectEquipmentUpdatesPublic(); // CraftBukkit - SPIGOT-3789: sync again immediately after sending
          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index af3e0049beb5590520ed84b52d6df85ad22a8f23..b7ff8607cd33d8e6bdab9533792cf43a434210bd 100644
+index 688916c8fef40d4c81379ad38609a97993b4b702..6cf3b28749d92b4e33e2f88c6335c9a663edd534 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2751,7 +2751,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2752,7 +2752,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  entity.refreshEntityData(ServerGamePacketListenerImpl.this.player);
                                  // SPIGOT-7136 - Allays
                                  if (entity instanceof Allay || entity instanceof net.minecraft.world.entity.animal.horse.AbstractHorse) { // Paper - Fix horse armor desync

--- a/patches/server/0964-Deprecate-InvAction-HOTBAR_MOVE_AND_READD.patch
+++ b/patches/server/0964-Deprecate-InvAction-HOTBAR_MOVE_AND_READD.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deprecate InvAction#HOTBAR_MOVE_AND_READD
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b7ff8607cd33d8e6bdab9533792cf43a434210bd..52eafd99ed63f5fc9596225cf45175b1287f20a1 100644
+index 6cf3b28749d92b4e33e2f88c6335c9a663edd534..da719576b2c7e992b74266c7fbe5c9728d238dcf 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3022,14 +3022,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3023,14 +3023,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  Slot clickedSlot = this.player.containerMenu.getSlot(packet.getSlotNum());
                                  if (clickedSlot.mayPickup(this.player)) {
                                      ItemStack hotbar = this.player.getInventory().getItem(packet.getButtonNum());

--- a/patches/server/0992-Properly-resend-entities.patch
+++ b/patches/server/0992-Properly-resend-entities.patch
@@ -81,10 +81,10 @@ index f2dd272a01b4e946a6746865d55ebc9861f8361b..5d189ba60d40f5c42b2dacc339594ed0
              }
          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 52eafd99ed63f5fc9596225cf45175b1287f20a1..e5db85f858ab376b225172e22b92b841f1f9546a 100644
+index da719576b2c7e992b74266c7fbe5c9728d238dcf..c93aa97abd46b3ad87e284feac51487ed50b9f5a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1966,6 +1966,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1967,6 +1967,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              }
  
              if (cancelled) {
@@ -92,7 +92,7 @@ index 52eafd99ed63f5fc9596225cf45175b1287f20a1..e5db85f858ab376b225172e22b92b841
                  this.player.getBukkitEntity().updateInventory(); // SPIGOT-2524
                  return;
              }
-@@ -2737,7 +2738,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2738,7 +2739,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              // Entity in bucket - SPIGOT-4048 and SPIGOT-6859a
                              if ((entity instanceof Bucketable && entity instanceof LivingEntity && origItem != null && origItem.asItem() == Items.WATER_BUCKET) && (event.isCancelled() || ServerGamePacketListenerImpl.this.player.getInventory().getSelected() == null || ServerGamePacketListenerImpl.this.player.getInventory().getSelected().getItem() != origItem)) {

--- a/patches/server/1004-Make-interaction-leniency-distance-configurable.patch
+++ b/patches/server/1004-Make-interaction-leniency-distance-configurable.patch
@@ -12,10 +12,10 @@ This value however may be too low in high latency environments.
 The patch exposes a new configuration option to configure said value.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e5db85f858ab376b225172e22b92b841f1f9546a..293f83f5513d3ab6492f93834229903570009fdb 100644
+index c93aa97abd46b3ad87e284feac51487ed50b9f5a..bb3d444f7bf2b20a557cd39997f9943c90763432 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2722,7 +2722,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2723,7 +2723,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
              AABB axisalignedbb = entity.getBoundingBox();
  

--- a/patches/server/1012-Fix-CraftBukkit-drag-system.patch
+++ b/patches/server/1012-Fix-CraftBukkit-drag-system.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.inventory.AbstractContainerMenu quickcraftType
 public net.minecraft.world.inventory.AbstractContainerMenu resetQuickCraft()V
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 293f83f5513d3ab6492f93834229903570009fdb..654531ada32d3adacca71546480abeebfdad40d3 100644
+index bb3d444f7bf2b20a557cd39997f9943c90763432..65ee382684fe2d8dec621ca709880f7349208eae 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3080,6 +3080,25 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3081,6 +3081,25 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              }
                              break;
                          case QUICK_CRAFT:

--- a/patches/server/1016-Fix-synchronise-sending-chat-to-client-with-updating.patch
+++ b/patches/server/1016-Fix-synchronise-sending-chat-to-client-with-updating.patch
@@ -9,10 +9,10 @@ In the case where multiple messages from different players are being processed i
 This also applies to the last seen state of the server, which becomes inconsistent in the same way as the message signature cache and would cause any messages sent to be rejected by the server too.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 654531ada32d3adacca71546480abeebfdad40d3..b57f9e048581f67ab031731553e82829d7eb7c1d 100644
+index 65ee382684fe2d8dec621ca709880f7349208eae..6a5fc3f92b5d56bedc20054b36f4513fc8bab303 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2663,8 +2663,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2664,8 +2664,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              return;
          }
          // CraftBukkit end

--- a/patches/server/1026-Fix-PlayerCommandPreprocessEvent-on-signed-commands.patch
+++ b/patches/server/1026-Fix-PlayerCommandPreprocessEvent-on-signed-commands.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix PlayerCommandPreprocessEvent on signed commands
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b57f9e048581f67ab031731553e82829d7eb7c1d..bcf6c5ec1cb4be806d49f30f3404498018760f91 100644
+index 6a5fc3f92b5d56bedc20054b36f4513fc8bab303..fc64c09f466e6a0fb3eb6aa47f28f90748e81ce6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2195,24 +2195,32 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2196,24 +2196,32 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
          PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(this.getCraftPlayer(), command, new LazyPlayerSet(this.server));
          this.cserver.getPluginManager().callEvent(event);

--- a/patches/server/1028-Improve-entity-effect-API.patch
+++ b/patches/server/1028-Improve-entity-effect-API.patch
@@ -25,7 +25,7 @@ index b0e49ad831f1ebc6b126bf82c5fddaebffb91312..179886dcbda29c5cdb7dbd43e44951ae
 +    // Paper end - broadcast hurt animation
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ecde377d35d7750686b6eccef06a1051d73e961e..2ca9b03f6d991bdfbb8b72289ea71285e4f9e767 100644
+index 766c1e80997d1bed99f4ebf9499eec60bf70a536..f668359f2fbe765c68fb575c31444bc0404cba0f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1294,6 +1294,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/1028-Improve-entity-effect-API.patch
+++ b/patches/server/1028-Improve-entity-effect-API.patch
@@ -25,7 +25,7 @@ index b0e49ad831f1ebc6b126bf82c5fddaebffb91312..179886dcbda29c5cdb7dbd43e44951ae
 +    // Paper end - broadcast hurt animation
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e1e73e877dfef5bcf30a99b275ececbf42f59c95..4eb2cd3f75e8e727199193dc8b1c01d4c855223c 100644
+index ecde377d35d7750686b6eccef06a1051d73e961e..2ca9b03f6d991bdfbb8b72289ea71285e4f9e767 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1294,6 +1294,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -49,7 +49,7 @@ index e1e73e877dfef5bcf30a99b275ececbf42f59c95..4eb2cd3f75e8e727199193dc8b1c01d4
      }
  
      @Override
-@@ -3542,4 +3547,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3540,4 +3545,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setSendViewDistance(final int viewDistance) {
          throw new UnsupportedOperationException("Not implemented yet");
      }

--- a/patches/server/1035-Add-proper-async-player-disconnections.patch
+++ b/patches/server/1035-Add-proper-async-player-disconnections.patch
@@ -74,7 +74,7 @@ index fc242acade3ff06c9213428cde103cf078216382..b0bc66dc7248aae691dcab68b925b52a
          return this.server.isSingleplayerOwner(this.playerProfile());
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index bcf6c5ec1cb4be806d49f30f3404498018760f91..eef96e946b80064fe211039a65db4192ea7a52d3 100644
+index fc64c09f466e6a0fb3eb6aa47f28f90748e81ce6..e3458038d56b7133f991a5198db26398a299bf30 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -769,7 +769,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -112,7 +112,7 @@ index bcf6c5ec1cb4be806d49f30f3404498018760f91..eef96e946b80064fe211039a65db4192
              return;
          }
          this.lastBookTick = MinecraftServer.currentTick;
-@@ -2304,7 +2304,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2305,7 +2305,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      private void tryHandleChat(String s, Runnable runnable, boolean sync) { // CraftBukkit
          if (ServerGamePacketListenerImpl.isChatMessageIllegal(s)) {
@@ -121,7 +121,7 @@ index bcf6c5ec1cb4be806d49f30f3404498018760f91..eef96e946b80064fe211039a65db4192
          } else if (this.player.isRemoved() || this.player.getChatVisibility() == ChatVisiblity.HIDDEN) { // CraftBukkit - dead men tell no tales
              this.send(new ClientboundSystemChatPacket(Component.translatable("chat.disabled.options").withStyle(ChatFormatting.RED), false));
          } else {
-@@ -2327,7 +2327,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2328,7 +2328,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
              if (optional.isEmpty()) {
                  ServerGamePacketListenerImpl.LOGGER.warn("Failed to validate message acknowledgements from {}", this.player.getName().getString());
@@ -130,7 +130,7 @@ index bcf6c5ec1cb4be806d49f30f3404498018760f91..eef96e946b80064fe211039a65db4192
              }
  
              return optional;
-@@ -2498,7 +2498,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2499,7 +2499,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // this.chatSpamThrottler.increment();
          if (!this.chatSpamThrottler.isIncrementAndUnderThreshold() && !this.server.getPlayerList().isOp(this.player.getGameProfile()) && !this.server.isSingleplayerOwner(this.player.getGameProfile())) {
              // CraftBukkit end
@@ -139,7 +139,7 @@ index bcf6c5ec1cb4be806d49f30f3404498018760f91..eef96e946b80064fe211039a65db4192
          }
  
      }
-@@ -2510,7 +2510,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2511,7 +2511,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          synchronized (this.lastSeenMessages) {
              if (!this.lastSeenMessages.applyOffset(packet.offset())) {
                  ServerGamePacketListenerImpl.LOGGER.warn("Failed to validate message acknowledgements from {}", this.player.getName().getString());
@@ -148,7 +148,7 @@ index bcf6c5ec1cb4be806d49f30f3404498018760f91..eef96e946b80064fe211039a65db4192
              }
  
          }
-@@ -2658,7 +2658,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2659,7 +2659,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              }
  
              if (i > 4096) {
@@ -157,7 +157,7 @@ index bcf6c5ec1cb4be806d49f30f3404498018760f91..eef96e946b80064fe211039a65db4192
              }
  
          }
-@@ -3267,7 +3267,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3268,7 +3268,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // Paper start - auto recipe limit
          if (!org.bukkit.Bukkit.isPrimaryThread()) {
              if (!this.recipeSpamPackets.isIncrementAndUnderThreshold()) {

--- a/patches/server/1038-Moonrise-optimisation-patches.patch
+++ b/patches/server/1038-Moonrise-optimisation-patches.patch
@@ -36127,7 +36127,7 @@ index 6dc3fc701d1e16a51d99f934ea3dc192363a6762..2058671a77cac4cfa6494461a5142aba
  
      // Paper start - implement pointers
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2ca9b03f6d991bdfbb8b72289ea71285e4f9e767..f1f09568f7f168aa0ecbf13f198f87c233c9dae4 100644
+index f668359f2fbe765c68fb575c31444bc0404cba0f..4fe26b5e492b5cc3ee6b99ec6ade4938acfc9ed8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -3523,7 +3523,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/1038-Moonrise-optimisation-patches.patch
+++ b/patches/server/1038-Moonrise-optimisation-patches.patch
@@ -36127,10 +36127,10 @@ index 6dc3fc701d1e16a51d99f934ea3dc192363a6762..2058671a77cac4cfa6494461a5142aba
  
      // Paper start - implement pointers
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4eb2cd3f75e8e727199193dc8b1c01d4c855223c..f071e5cf0bf05e12fb922eb1cd70c7bb4a3cf486 100644
+index 2ca9b03f6d991bdfbb8b72289ea71285e4f9e767..f1f09568f7f168aa0ecbf13f198f87c233c9dae4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3525,7 +3525,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3523,7 +3523,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setViewDistance(final int viewDistance) {
@@ -36141,7 +36141,7 @@ index 4eb2cd3f75e8e727199193dc8b1c01d4c855223c..f071e5cf0bf05e12fb922eb1cd70c7bb
      }
  
      @Override
-@@ -3535,7 +3537,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3533,7 +3535,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setSimulationDistance(final int simulationDistance) {
@@ -36152,7 +36152,7 @@ index 4eb2cd3f75e8e727199193dc8b1c01d4c855223c..f071e5cf0bf05e12fb922eb1cd70c7bb
      }
  
      @Override
-@@ -3545,7 +3549,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3543,7 +3547,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setSendViewDistance(final int viewDistance) {

--- a/patches/server/1039-API-for-checking-sent-chunks.patch
+++ b/patches/server/1039-API-for-checking-sent-chunks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] API for checking sent chunks
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f1f09568f7f168aa0ecbf13f198f87c233c9dae4..4f24d3f415c1bb411d24ad8325c5d3edfd38aac4 100644
+index 4fe26b5e492b5cc3ee6b99ec6ade4938acfc9ed8..2c7ec674f55b3178b9dcba7f2bc1ff5efccb50ea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -3510,6 +3510,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/1039-API-for-checking-sent-chunks.patch
+++ b/patches/server/1039-API-for-checking-sent-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for checking sent chunks
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f071e5cf0bf05e12fb922eb1cd70c7bb4a3cf486..9e4c416ddeccff87ea9ed5b45a2ef04eae2280bf 100644
+index f1f09568f7f168aa0ecbf13f198f87c233c9dae4..4f24d3f415c1bb411d24ad8325c5d3edfd38aac4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3512,6 +3512,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3510,6 +3510,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/1052-Optimise-collision-checking-in-player-move-packet-ha.patch
+++ b/patches/server/1052-Optimise-collision-checking-in-player-move-packet-ha.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Optimise collision checking in player move packet handling
 Move collision logic to just the hasNewCollision call instead of getCubes + hasNewCollision
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index eef96e946b80064fe211039a65db4192ea7a52d3..c4b016a2fb5c79fb3f191e243712bee7cbe5cd2c 100644
+index e3458038d56b7133f991a5198db26398a299bf30..d7ac001d53a083e9881f2320eb7fd5dcbd20416e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -577,7 +577,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl


### PR DESCRIPTION
Since 1.21.2, vanilla split relative teleportation flags into position and delta/velocity flags into separate enum entries. This highlighted a design flaw in the paper api addition for teleport flags, which just simply mirrored internals while also only being able to apply the delta/velocity part of a flag, given the teleport target is always absolute in the API.

This patch proposes to simply no longer expose the non-velocity related flags to the API, instead marking the entire Relative enum as being purely velocity related, as non-velocity related flags are not useful to callers. This was done over simply exposing all internal flags, as another vanilla change to the internal enum would result in the same breakage.

The newly proposed API *only* promises that the passed flags prevent the loss of velocity in the specific axis/context, which should be independent enough of vanillas specific implementation of this feature.