### PR TITLE
Fix NPE with enchantable

### DIFF
--- a/paper-api-generator/generated/com/destroystokyo/paper/entity/ai/VanillaGoal.java
+++ b/paper-api-generator/generated/com/destroystokyo/paper/entity/ai/VanillaGoal.java
@@ -51,7 +51,7 @@ import org.bukkit.entity.WanderingTrader;
 import org.bukkit.entity.Wither;
 import org.bukkit.entity.Wolf;
 import org.bukkit.entity.Zombie;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for Mob Goals.
@@ -67,6 +67,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 public interface VanillaGoal<T extends Mob> extends Goal<T> {
     GoalKey<AbstractHorse> RANDOM_STAND = create("random_stand", AbstractHorse.class);
 
@@ -440,8 +441,7 @@ public interface VanillaGoal<T extends Mob> extends Goal<T> {
 
     GoalKey<Zombie> ZOMBIE_ATTACK_TURTLE_EGG = create("zombie_attack_turtle_egg", Zombie.class);
 
-    private static <T extends Mob> @NonNull GoalKey<T> create(final @NonNull String key,
-            final @NonNull Class<T> type) {
+    private static <T extends Mob> GoalKey<T> create(final String key, final Class<T> type) {
         return GoalKey.of(type, NamespacedKey.minecraft(key));
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/AttributeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/AttributeKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.attribute.Attribute;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#ATTRIBUTE}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class AttributeKeys {
     /**
@@ -253,7 +254,7 @@ public final class AttributeKeys {
     private AttributeKeys() {
     }
 
-    private static @NonNull TypedKey<Attribute> create(final @NonNull Key key) {
+    private static TypedKey<Attribute> create(final Key key) {
         return TypedKey.create(RegistryKey.ATTRIBUTE, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/BannerPatternKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/BannerPatternKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.block.banner.PatternType;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#BANNER_PATTERN}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class BannerPatternKeys {
     /**
@@ -337,7 +338,7 @@ public final class BannerPatternKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NonNull TypedKey<PatternType> create(final @NonNull Key key) {
+    public static TypedKey<PatternType> create(final Key key) {
         return TypedKey.create(RegistryKey.BANNER_PATTERN, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/BiomeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/BiomeKeys.java
@@ -8,8 +8,8 @@ import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.MinecraftExperimental;
 import org.bukkit.block.Biome;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#BIOME}.
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class BiomeKeys {
     /**
@@ -494,7 +495,7 @@ public final class BiomeKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NonNull TypedKey<Biome> create(final @NonNull Key key) {
+    public static TypedKey<Biome> create(final Key key) {
         return TypedKey.create(RegistryKey.BIOME, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/BlockTypeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/BlockTypeKeys.java
@@ -8,8 +8,8 @@ import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.MinecraftExperimental;
 import org.bukkit.block.BlockType;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#BLOCK}.
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class BlockTypeKeys {
     /**
@@ -7666,7 +7667,7 @@ public final class BlockTypeKeys {
     private BlockTypeKeys() {
     }
 
-    private static @NonNull TypedKey<BlockType> create(final @NonNull Key key) {
+    private static TypedKey<BlockType> create(final Key key) {
         return TypedKey.create(RegistryKey.BLOCK, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/CatVariantKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/CatVariantKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.entity.Cat;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#CAT_VARIANT}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class CatVariantKeys {
     /**
@@ -106,7 +107,7 @@ public final class CatVariantKeys {
     private CatVariantKeys() {
     }
 
-    private static @NonNull TypedKey<Cat.Type> create(final @NonNull Key key) {
+    private static TypedKey<Cat.Type> create(final Key key) {
         return TypedKey.create(RegistryKey.CAT_VARIANT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/DamageTypeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/DamageTypeKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.damage.DamageType;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#DAMAGE_TYPE}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class DamageTypeKeys {
     /**
@@ -379,7 +380,7 @@ public final class DamageTypeKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NonNull TypedKey<DamageType> create(final @NonNull Key key) {
+    public static TypedKey<DamageType> create(final Key key) {
         return TypedKey.create(RegistryKey.DAMAGE_TYPE, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/EnchantmentKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/EnchantmentKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.enchantments.Enchantment;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#ENCHANTMENT}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class EnchantmentKeys {
     /**
@@ -323,7 +324,14 @@ public final class EnchantmentKeys {
     private EnchantmentKeys() {
     }
 
-    private static @NonNull TypedKey<Enchantment> create(final @NonNull Key key) {
+    /**
+     * Creates a key for {@link Enchantment} in the registry {@code minecraft:enchantment}.
+     *
+     * @param key the value's key in the registry
+     * @return a new typed key
+     */
+    @ApiStatus.Experimental
+    public static TypedKey<Enchantment> create(final Key key) {
         return TypedKey.create(RegistryKey.ENCHANTMENT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/FluidKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/FluidKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.Fluid;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#FLUID}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class FluidKeys {
     /**
@@ -64,7 +65,7 @@ public final class FluidKeys {
     private FluidKeys() {
     }
 
-    private static @NonNull TypedKey<Fluid> create(final @NonNull Key key) {
+    private static TypedKey<Fluid> create(final Key key) {
         return TypedKey.create(RegistryKey.FLUID, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/FrogVariantKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/FrogVariantKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.entity.Frog;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#FROG_VARIANT}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class FrogVariantKeys {
     /**
@@ -50,7 +51,7 @@ public final class FrogVariantKeys {
     private FrogVariantKeys() {
     }
 
-    private static @NonNull TypedKey<Frog.Variant> create(final @NonNull Key key) {
+    private static TypedKey<Frog.Variant> create(final Key key) {
         return TypedKey.create(RegistryKey.FROG_VARIANT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/GameEventKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/GameEventKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.GameEvent;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#GAME_EVENT}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class GameEventKeys {
     /**
@@ -456,7 +457,7 @@ public final class GameEventKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NonNull TypedKey<GameEvent> create(final @NonNull Key key) {
+    public static TypedKey<GameEvent> create(final Key key) {
         return TypedKey.create(RegistryKey.GAME_EVENT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/InstrumentKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/InstrumentKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.MusicInstrument;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#INSTRUMENT}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class InstrumentKeys {
     /**
@@ -85,7 +86,14 @@ public final class InstrumentKeys {
     private InstrumentKeys() {
     }
 
-    private static @NonNull TypedKey<MusicInstrument> create(final @NonNull Key key) {
+    /**
+     * Creates a key for {@link MusicInstrument} in the registry {@code minecraft:instrument}.
+     *
+     * @param key the value's key in the registry
+     * @return a new typed key
+     */
+    @ApiStatus.Experimental
+    public static TypedKey<MusicInstrument> create(final Key key) {
         return TypedKey.create(RegistryKey.INSTRUMENT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/ItemTypeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/ItemTypeKeys.java
@@ -8,8 +8,8 @@ import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.MinecraftExperimental;
 import org.bukkit.inventory.ItemType;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#ITEM}.
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class ItemTypeKeys {
     /**
@@ -9703,7 +9704,7 @@ public final class ItemTypeKeys {
     private ItemTypeKeys() {
     }
 
-    private static @NonNull TypedKey<ItemType> create(final @NonNull Key key) {
+    private static TypedKey<ItemType> create(final Key key) {
         return TypedKey.create(RegistryKey.ITEM, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/JukeboxSongKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/JukeboxSongKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.JukeboxSong;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#JUKEBOX_SONG}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class JukeboxSongKeys {
     /**
@@ -169,7 +170,7 @@ public final class JukeboxSongKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NonNull TypedKey<JukeboxSong> create(final @NonNull Key key) {
+    public static TypedKey<JukeboxSong> create(final Key key) {
         return TypedKey.create(RegistryKey.JUKEBOX_SONG, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/MapDecorationTypeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/MapDecorationTypeKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.map.MapCursor;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#MAP_DECORATION_TYPE}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class MapDecorationTypeKeys {
     /**
@@ -274,7 +275,7 @@ public final class MapDecorationTypeKeys {
     private MapDecorationTypeKeys() {
     }
 
-    private static @NonNull TypedKey<MapCursor.Type> create(final @NonNull Key key) {
+    private static TypedKey<MapCursor.Type> create(final Key key) {
         return TypedKey.create(RegistryKey.MAP_DECORATION_TYPE, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/MenuTypeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/MenuTypeKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.inventory.MenuType;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#MENU}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class MenuTypeKeys {
     /**
@@ -204,7 +205,7 @@ public final class MenuTypeKeys {
     private MenuTypeKeys() {
     }
 
-    private static @NonNull TypedKey<MenuType> create(final @NonNull Key key) {
+    private static TypedKey<MenuType> create(final Key key) {
         return TypedKey.create(RegistryKey.MENU, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/MobEffectKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/MobEffectKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.potion.PotionEffectType;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#MOB_EFFECT}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class MobEffectKeys {
     /**
@@ -302,7 +303,7 @@ public final class MobEffectKeys {
     private MobEffectKeys() {
     }
 
-    private static @NonNull TypedKey<PotionEffectType> create(final @NonNull Key key) {
+    private static TypedKey<PotionEffectType> create(final Key key) {
         return TypedKey.create(RegistryKey.MOB_EFFECT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/PaintingVariantKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/PaintingVariantKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.Art;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#PAINTING_VARIANT}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class PaintingVariantKeys {
     /**
@@ -386,7 +387,7 @@ public final class PaintingVariantKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NonNull TypedKey<Art> create(final @NonNull Key key) {
+    public static TypedKey<Art> create(final Key key) {
         return TypedKey.create(RegistryKey.PAINTING_VARIANT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/SoundEventKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/SoundEventKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.Sound;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#SOUND_EVENT}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class SoundEventKeys {
     /**
@@ -11481,7 +11482,7 @@ public final class SoundEventKeys {
     private SoundEventKeys() {
     }
 
-    private static @NonNull TypedKey<Sound> create(final @NonNull Key key) {
+    private static TypedKey<Sound> create(final Key key) {
         return TypedKey.create(RegistryKey.SOUND_EVENT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/StructureKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/StructureKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.generator.structure.Structure;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#STRUCTURE}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class StructureKeys {
     /**
@@ -274,7 +275,7 @@ public final class StructureKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NonNull TypedKey<Structure> create(final @NonNull Key key) {
+    public static TypedKey<Structure> create(final Key key) {
         return TypedKey.create(RegistryKey.STRUCTURE, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/StructureTypeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/StructureTypeKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.generator.structure.StructureType;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#STRUCTURE_TYPE}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class StructureTypeKeys {
     /**
@@ -141,7 +142,7 @@ public final class StructureTypeKeys {
     private StructureTypeKeys() {
     }
 
-    private static @NonNull TypedKey<StructureType> create(final @NonNull Key key) {
+    private static TypedKey<StructureType> create(final Key key) {
         return TypedKey.create(RegistryKey.STRUCTURE_TYPE, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/TrimMaterialKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/TrimMaterialKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.inventory.meta.trim.TrimMaterial;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#TRIM_MATERIAL}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class TrimMaterialKeys {
     /**
@@ -106,7 +107,7 @@ public final class TrimMaterialKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NonNull TypedKey<TrimMaterial> create(final @NonNull Key key) {
+    public static TypedKey<TrimMaterial> create(final Key key) {
         return TypedKey.create(RegistryKey.TRIM_MATERIAL, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/TrimPatternKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/TrimPatternKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.inventory.meta.trim.TrimPattern;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#TRIM_PATTERN}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class TrimPatternKeys {
     /**
@@ -162,7 +163,7 @@ public final class TrimPatternKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NonNull TypedKey<TrimPattern> create(final @NonNull Key key) {
+    public static TypedKey<TrimPattern> create(final Key key) {
         return TypedKey.create(RegistryKey.TRIM_PATTERN, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/VillagerProfessionKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/VillagerProfessionKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.entity.Villager;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#VILLAGER_PROFESSION}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class VillagerProfessionKeys {
     /**
@@ -134,7 +135,7 @@ public final class VillagerProfessionKeys {
     private VillagerProfessionKeys() {
     }
 
-    private static @NonNull TypedKey<Villager.Profession> create(final @NonNull Key key) {
+    private static TypedKey<Villager.Profession> create(final Key key) {
         return TypedKey.create(RegistryKey.VILLAGER_PROFESSION, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/VillagerTypeKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/VillagerTypeKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.entity.Villager;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#VILLAGER_TYPE}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class VillagerTypeKeys {
     /**
@@ -78,7 +79,7 @@ public final class VillagerTypeKeys {
     private VillagerTypeKeys() {
     }
 
-    private static @NonNull TypedKey<Villager.Type> create(final @NonNull Key key) {
+    private static TypedKey<Villager.Type> create(final Key key) {
         return TypedKey.create(RegistryKey.VILLAGER_TYPE, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/WolfVariantKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/WolfVariantKeys.java
@@ -7,8 +7,8 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.entity.Wolf;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#WOLF_VARIANT}.
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class WolfVariantKeys {
     /**
@@ -99,7 +100,7 @@ public final class WolfVariantKeys {
      * @return a new typed key
      */
     @ApiStatus.Experimental
-    public static @NonNull TypedKey<Wolf.Variant> create(final @NonNull Key key) {
+    public static TypedKey<Wolf.Variant> create(final Key key) {
         return TypedKey.create(RegistryKey.WOLF_VARIANT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/tags/EnchantmentTagKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/tags/EnchantmentTagKeys.java
@@ -8,8 +8,8 @@ import io.papermc.paper.registry.tag.TagKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.MinecraftExperimental;
 import org.bukkit.enchantments.Enchantment;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#ENCHANTMENT}.
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class EnchantmentTagKeys {
     /**
@@ -317,7 +318,7 @@ public final class EnchantmentTagKeys {
      * @return a new tag key
      */
     @ApiStatus.Experimental
-    public static @NonNull TagKey<Enchantment> create(final @NonNull Key key) {
+    public static TagKey<Enchantment> create(final Key key) {
         return TagKey.create(RegistryKey.ENCHANTMENT, key);
     }
 }

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/tags/ItemTypeTagKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/tags/ItemTypeTagKeys.java
@@ -8,8 +8,8 @@ import io.papermc.paper.registry.tag.TagKey;
 import net.kyori.adventure.key.Key;
 import org.bukkit.MinecraftExperimental;
 import org.bukkit.inventory.ItemType;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Vanilla keys for {@link RegistryKey#ITEM}.
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.ApiStatus;
         "SpellCheckingInspection"
 })
 @GeneratedFrom("1.21.3")
+@NullMarked
 @ApiStatus.Experimental
 public final class ItemTypeTagKeys {
     /**
@@ -1236,7 +1237,7 @@ public final class ItemTypeTagKeys {
      * @return a new tag key
      */
     @ApiStatus.Experimental
-    public static @NonNull TagKey<ItemType> create(final @NonNull Key key) {
+    public static TagKey<ItemType> create(final Key key) {
         return TagKey.create(RegistryKey.ITEM, key);
     }
 }

--- a/paper-api-generator/src/main/java/io/papermc/generator/Generators.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/Generators.java
@@ -39,7 +39,6 @@ public interface Generators {
         // built-ins
         simpleKey("GameEventKeys", GameEvent.class, Registries.GAME_EVENT, RegistryKey.GAME_EVENT, true),
         simpleKey("StructureTypeKeys", StructureType.class, Registries.STRUCTURE_TYPE, RegistryKey.STRUCTURE_TYPE, false),
-        simpleKey("InstrumentKeys", MusicInstrument.class, Registries.INSTRUMENT, RegistryKey.INSTRUMENT, false),
         simpleKey("MobEffectKeys", PotionEffectType.class, Registries.MOB_EFFECT, RegistryKey.MOB_EFFECT, false),
         simpleKey("BlockTypeKeys", BlockType.class, Registries.BLOCK, RegistryKey.BLOCK, false),
         simpleKey("ItemTypeKeys", ItemType.class, Registries.ITEM, RegistryKey.ITEM, false),
@@ -60,10 +59,11 @@ public interface Generators {
         simpleKey("TrimPatternKeys", TrimPattern.class, Registries.TRIM_PATTERN, RegistryKey.TRIM_PATTERN, true),
         simpleKey("DamageTypeKeys", DamageType.class, Registries.DAMAGE_TYPE, RegistryKey.DAMAGE_TYPE, true),
         simpleKey("WolfVariantKeys", Wolf.Variant.class, Registries.WOLF_VARIANT, RegistryKey.WOLF_VARIANT, true),
-        simpleKey("EnchantmentKeys", Enchantment.class, Registries.ENCHANTMENT, RegistryKey.ENCHANTMENT, false),
+        simpleKey("EnchantmentKeys", Enchantment.class, Registries.ENCHANTMENT, RegistryKey.ENCHANTMENT, true),
         simpleKey("JukeboxSongKeys", JukeboxSong.class, Registries.JUKEBOX_SONG, RegistryKey.JUKEBOX_SONG, true),
         simpleKey("BannerPatternKeys", PatternType.class, Registries.BANNER_PATTERN, RegistryKey.BANNER_PATTERN, true),
         simpleKey("PaintingVariantKeys", Art.class, Registries.PAINTING_VARIANT, RegistryKey.PAINTING_VARIANT, true),
+        simpleKey("InstrumentKeys", MusicInstrument.class, Registries.INSTRUMENT, RegistryKey.INSTRUMENT, true),
 
         // tags
         simpleTagKey("EnchantmentTagKeys", Enchantment.class, Registries.ENCHANTMENT, RegistryKey.ENCHANTMENT),

--- a/paper-api-generator/src/main/java/io/papermc/generator/types/GeneratedKeyType.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/types/GeneratedKeyType.java
@@ -42,7 +42,6 @@ import org.checkerframework.framework.qual.DefaultQualifier;
 
 import static com.squareup.javapoet.TypeSpec.classBuilder;
 import static io.papermc.generator.utils.Annotations.EXPERIMENTAL_API_ANNOTATION;
-import static io.papermc.generator.utils.Annotations.NOT_NULL;
 import static io.papermc.generator.utils.Annotations.experimentalAnnotations;
 import static java.util.Objects.requireNonNull;
 import static javax.lang.model.element.Modifier.FINAL;
@@ -96,14 +95,14 @@ public class GeneratedKeyType<T, A> extends SimpleGenerator {
     }
 
     private MethodSpec.Builder createMethod(final TypeName returnType) {
-        final TypeName keyType = TypeName.get(Key.class).annotated(NOT_NULL);
+        final TypeName keyType = TypeName.get(Key.class);
 
         final ParameterSpec keyParam = ParameterSpec.builder(keyType, "key", FINAL).build();
         final MethodSpec.Builder create = MethodSpec.methodBuilder("create")
             .addModifiers(this.publicCreateKeyMethod ? PUBLIC : PRIVATE, STATIC)
             .addParameter(keyParam)
             .addCode("return $T.create($T.$L, $N);", TypedKey.class, RegistryKey.class, requireNonNull(REGISTRY_KEY_FIELD_NAMES.get(this.apiRegistryKey), "Missing field for " + this.apiRegistryKey), keyParam)
-            .returns(returnType.annotated(NOT_NULL));
+            .returns(returnType);
         if (this.publicCreateKeyMethod) {
             create.addAnnotation(EXPERIMENTAL_API_ANNOTATION); // TODO remove once not experimental
             create.addJavadoc(CREATE_JAVADOC, this.apiType, this.registryKey.location().toString());

--- a/paper-api-generator/src/main/java/io/papermc/generator/types/GeneratedTagKeyType.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/types/GeneratedTagKeyType.java
@@ -26,7 +26,6 @@ import org.bukkit.MinecraftExperimental;
 
 import static com.squareup.javapoet.TypeSpec.classBuilder;
 import static io.papermc.generator.utils.Annotations.EXPERIMENTAL_API_ANNOTATION;
-import static io.papermc.generator.utils.Annotations.NOT_NULL;
 import static io.papermc.generator.utils.Annotations.experimentalAnnotations;
 import static java.util.Objects.requireNonNull;
 import static javax.lang.model.element.Modifier.FINAL;
@@ -73,14 +72,14 @@ public class GeneratedTagKeyType<T, A> extends SimpleGenerator {
     }
 
     private MethodSpec.Builder createMethod(final TypeName returnType) {
-        final TypeName keyType = TypeName.get(Key.class).annotated(NOT_NULL);
+        final TypeName keyType = TypeName.get(Key.class);
 
         final ParameterSpec keyParam = ParameterSpec.builder(keyType, "key", FINAL).build();
         final MethodSpec.Builder create = MethodSpec.methodBuilder("create")
             .addModifiers(this.publicCreateKeyMethod ? PUBLIC : PRIVATE, STATIC)
             .addParameter(keyParam)
             .addCode("return $T.create($T.$L, $N);", TagKey.class, RegistryKey.class, requireNonNull(REGISTRY_KEY_FIELD_NAMES.get(this.apiRegistryKey), "Missing field for " + this.apiRegistryKey), keyParam)
-            .returns(returnType.annotated(NOT_NULL));
+            .returns(returnType);
         if (this.publicCreateKeyMethod) {
             create.addAnnotation(EXPERIMENTAL_API_ANNOTATION); // TODO remove once not experimental
             create.addJavadoc(CREATE_JAVADOC, this.apiType, this.registryKey.location().toString());

--- a/paper-api-generator/src/main/java/io/papermc/generator/types/goal/MobGoalGenerator.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/types/goal/MobGoalGenerator.java
@@ -50,10 +50,8 @@ public class MobGoalGenerator extends SimpleGenerator {
             .addAnnotations(Annotations.CLASS_HEADER)
             .addJavadoc(CLASS_HEADER);
 
-        TypeName mobType = ParameterizedTypeName.get(ClassName.get(Class.class), type)
-            .annotated(Annotations.NOT_NULL);
-        TypeName keyType = TypeName.get(String.class)
-            .annotated(Annotations.NOT_NULL);
+        TypeName mobType = ParameterizedTypeName.get(ClassName.get(Class.class), type);
+        TypeName keyType = TypeName.get(String.class);
 
         ParameterSpec keyParam = ParameterSpec.builder(keyType, "key", FINAL).build();
         ParameterSpec typeParam = ParameterSpec.builder(mobType, "type", FINAL).build();
@@ -63,7 +61,7 @@ public class MobGoalGenerator extends SimpleGenerator {
             .addParameter(typeParam)
             .addCode("return $T.of($N, $T.minecraft($N));", GoalKey.class, typeParam, NamespacedKey.class, keyParam)
             .addTypeVariable(type)
-            .returns(ParameterizedTypeName.get(ClassName.get(GoalKey.class), type).annotated(Annotations.NOT_NULL));
+            .returns(ParameterizedTypeName.get(ClassName.get(GoalKey.class), type));
 
         List<Class<Goal>> classes;
         try (ScanResult scanResult = new ClassGraph().enableAllInfo().whitelistPackages("net.minecraft").scan()) {

--- a/paper-api-generator/src/main/java/io/papermc/generator/utils/Annotations.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/utils/Annotations.java
@@ -7,9 +7,9 @@ import java.util.List;
 import io.papermc.paper.generated.GeneratedFrom;
 import net.minecraft.SharedConstants;
 import org.bukkit.MinecraftExperimental;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
 
 public final class Annotations {
 
@@ -46,7 +46,7 @@ public final class Annotations {
 
     @ApiStatus.Experimental
     public static final AnnotationSpec EXPERIMENTAL_API_ANNOTATION = AnnotationSpec.builder(ApiStatus.Experimental.class).build();
-    public static final AnnotationSpec NOT_NULL = AnnotationSpec.builder(NonNull.class).build();
+    public static final AnnotationSpec NULL_MARKED = AnnotationSpec.builder(NullMarked.class).build();
     private static final AnnotationSpec SUPPRESS_WARNINGS = AnnotationSpec.builder(SuppressWarnings.class)
         .addMember("value", "$S", "unused")
         .addMember("value", "$S", "SpellCheckingInspection")
@@ -56,7 +56,8 @@ public final class Annotations {
         .build();
     public static final Iterable<AnnotationSpec> CLASS_HEADER = List.of(
         SUPPRESS_WARNINGS,
-        GENERATED_FROM
+        GENERATED_FROM,
+        NULL_MARKED
     );
 
     private Annotations() {

--- a/patches/api/0004-Code-Generation.patch
+++ b/patches/api/0004-Code-Generation.patch
@@ -85,7 +85,7 @@ index 0000000000000000000000000000000000000000..2512dba27edfdccbc4430815b6cba048
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/RegistryKey.java b/src/main/java/io/papermc/paper/registry/RegistryKey.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d895b36e14f7fab6e3e78160dfa559d2c5331601
+index 0000000000000000000000000000000000000000..647f6a1ec1f9d3c203b41f90a99bfd415bf67366
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/RegistryKey.java
 @@ -0,0 +1,196 @@
@@ -154,11 +154,6 @@ index 0000000000000000000000000000000000000000..d895b36e14f7fab6e3e78160dfa559d2
 +     * @see io.papermc.paper.registry.keys.StructureTypeKeys
 +     */
 +    RegistryKey<StructureType> STRUCTURE_TYPE = create("worldgen/structure_type");
-+    /**
-+     * Built-in registry for instruments.
-+     * @see io.papermc.paper.registry.keys.InstrumentKeys
-+     */
-+    RegistryKey<MusicInstrument> INSTRUMENT = create("instrument");
 +    /**
 +     * Built-in registry for potion effect types (mob effects).
 +     * @see io.papermc.paper.registry.keys.MobEffectKeys
@@ -275,6 +270,11 @@ index 0000000000000000000000000000000000000000..d895b36e14f7fab6e3e78160dfa559d2
 +     * @see io.papermc.paper.registry.keys.PaintingVariantKeys
 +     */
 +    RegistryKey<Art> PAINTING_VARIANT = create("painting_variant");
++    /**
++     * Data-driven registry for instruments.
++     * @see io.papermc.paper.registry.keys.InstrumentKeys
++     */
++    RegistryKey<MusicInstrument> INSTRUMENT = create("instrument");
 +
 +
 +    /* ******************* *

--- a/patches/api/0202-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0202-Add-methods-to-get-translation-keys.patch
@@ -187,7 +187,7 @@ index 309a79cbe65498c90d9e135607bc246688ac6274..8820dd330cee4f8463f2f39f84d4be07
          if (this.isItem()) {
              return asItemType().getTranslationKey();
 diff --git a/src/main/java/org/bukkit/MusicInstrument.java b/src/main/java/org/bukkit/MusicInstrument.java
-index 807e89d026bffae521ead39c514a872ae4d406b3..c9f02466a04d20579fe2258bb02acf98e163ca81 100644
+index 807e89d026bffae521ead39c514a872ae4d406b3..f87364de1bf24ee78e0d823d9081a5f352934405 100644
 --- a/src/main/java/org/bukkit/MusicInstrument.java
 +++ b/src/main/java/org/bukkit/MusicInstrument.java
 @@ -6,7 +6,7 @@ import java.util.Collections;
@@ -199,17 +199,20 @@ index 807e89d026bffae521ead39c514a872ae4d406b3..c9f02466a04d20579fe2258bb02acf98
  
      public static final MusicInstrument PONDER_GOAT_HORN = getInstrument("ponder_goat_horn");
      public static final MusicInstrument SING_GOAT_HORN = getInstrument("sing_goat_horn");
-@@ -46,4 +46,11 @@ public abstract class MusicInstrument implements Keyed {
+@@ -46,4 +46,14 @@ public abstract class MusicInstrument implements Keyed {
      private static MusicInstrument getInstrument(@NotNull String key) {
          return Registry.INSTRUMENT.getOrThrow(NamespacedKey.minecraft(key));
      }
 +
-+    // Paper start - translation key
++    // Paper start - mark translation key as deprecated
++    /**
++     * @deprecated this method assumes that the instrument description
++     * always be a translatable component which is not guaranteed.
++     */
 +    @Override
-+    public @NotNull String translationKey() {
-+        return "instrument.minecraft." + this.getKey().value();
-+    }
-+    // Paper end - translation key
++    @Deprecated(forRemoval = true)
++    public abstract @NotNull String translationKey();
++    // Paper end - mark translation key as deprecated
  }
 diff --git a/src/main/java/org/bukkit/Translatable.java b/src/main/java/org/bukkit/Translatable.java
 index e3faa2c675c85a9cbdbbb1debec0ff81c58a1bbd..fd1629c2d2028a88fb3d56b0aeb833d17235080a 100644

--- a/patches/api/0236-Add-RegistryAccess-for-managing-registries.patch
+++ b/patches/api/0236-Add-RegistryAccess-for-managing-registries.patch
@@ -207,10 +207,10 @@ index e0f652117e585882693736de8165ae9c689e1d68..fbe14c327ee9c1ac07893853ca7c699e
          return server.getRegistry(tClass);
      }
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..099c8acc0338dc0e6ac81f77d99cd2a02a630535 100644
+index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..46dce7c2a543f6b165975565ea9d40654a132b9b 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -86,26 +86,34 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -86,26 +86,32 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * Server art.
       *
       * @see Art
@@ -223,11 +223,9 @@ index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..099c8acc0338dc0e6ac81f77d99cd2a0
       * Attribute.
       *
       * @see Attribute
-+     * @deprecated use {@link io.papermc.paper.registry.RegistryAccess#getRegistry(io.papermc.paper.registry.RegistryKey)} with {@link io.papermc.paper.registry.RegistryKey#ATTRIBUTE}
       */
 -    Registry<Attribute> ATTRIBUTE = Objects.requireNonNull(Bukkit.getRegistry(Attribute.class), "No registry present for Attribute. This is a bug.");
-+    @Deprecated(since = "1.21.3") // Paper
-+    Registry<Attribute> ATTRIBUTE = Objects.requireNonNull(io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(Attribute.class), "No registry present for Attribute. This is a bug.");
++    Registry<Attribute> ATTRIBUTE = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.ATTRIBUTE); // Paper
      /**
       * Server banner patterns.
       *
@@ -249,7 +247,7 @@ index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..099c8acc0338dc0e6ac81f77d99cd2a0
      /**
       * Server block types.
       *
-@@ -113,7 +121,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -113,7 +119,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * @apiNote BlockType is not ready for public usage yet
       */
      @ApiStatus.Internal
@@ -258,7 +256,7 @@ index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..099c8acc0338dc0e6ac81f77d99cd2a0
      /**
       * Custom boss bars.
       *
-@@ -155,13 +163,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -155,13 +161,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @see Cat.Type
       */
@@ -276,12 +274,15 @@ index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..099c8acc0338dc0e6ac81f77d99cd2a0
      /**
       * Server entity types.
       *
-@@ -173,7 +183,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -172,8 +180,10 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      * Server instruments.
       *
       * @see MusicInstrument
++     * @deprecated use {@link io.papermc.paper.registry.RegistryAccess#getRegistry(io.papermc.paper.registry.RegistryKey)} with {@link io.papermc.paper.registry.RegistryKey#INSTRUMENT}
       */
 -    Registry<MusicInstrument> INSTRUMENT = Objects.requireNonNull(Bukkit.getRegistry(MusicInstrument.class), "No registry present for MusicInstrument. This is a bug.");
-+    Registry<MusicInstrument> INSTRUMENT = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.INSTRUMENT); // Paper
++    @Deprecated(since = "1.21.2")
++    Registry<MusicInstrument> INSTRUMENT = Objects.requireNonNull(io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(MusicInstrument.class), "No registry present for Instruments. This is a bug."); // Paper
      /**
       * Server item types.
       *
@@ -388,15 +389,12 @@ index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..099c8acc0338dc0e6ac81f77d99cd2a0
      /**
       * Memory Keys.
       *
-@@ -320,32 +339,36 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
-      * Server fluids.
+@@ -321,31 +340,33 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @see Fluid
-+     * @deprecated use {@link io.papermc.paper.registry.RegistryAccess#getRegistry(io.papermc.paper.registry.RegistryKey)} with {@link io.papermc.paper.registry.RegistryKey#FLUID}
       */
 -    Registry<Fluid> FLUID = Objects.requireNonNull(Bukkit.getRegistry(Fluid.class), "No registry present for Fluid. This is a bug.");
-+    @Deprecated(since = "1.21.3")
-+    Registry<Fluid> FLUID = Objects.requireNonNull(io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(Fluid.class), "No registry present for Fluid. This is a bug.");
++    Registry<Fluid> FLUID = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.FLUID); // Paper
      /**
       * Frog variants.
       *

--- a/patches/api/0329-More-PotionEffectType-API.patch
+++ b/patches/api/0329-More-PotionEffectType-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More PotionEffectType API
 
 
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 099c8acc0338dc0e6ac81f77d99cd2a02a630535..a5db0a013921423f87abb14dc08b24f47d4093f6 100644
+index 46dce7c2a543f6b165975565ea9d40654a132b9b..ae76b0d2b84dda5eefb9ffd9d76383408f67fbe3 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -369,6 +369,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -367,6 +367,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * @see GameEvent
       */
      Registry<GameEvent> GAME_EVENT = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.GAME_EVENT); // Paper

--- a/patches/api/0429-Improve-Registry.patch
+++ b/patches/api/0429-Improve-Registry.patch
@@ -31,7 +31,7 @@ index d24bf449f58fd7c1b8ffab8dbc42f9f1fef8c4ef..00a290f1bf58cdc2238c13fd5a6048a2
       * Get a painting by its numeric ID
       *
 diff --git a/src/main/java/org/bukkit/MusicInstrument.java b/src/main/java/org/bukkit/MusicInstrument.java
-index c9f02466a04d20579fe2258bb02acf98e163ca81..bffd4ab2d08e5c3f83a49a31e1e55cc1eab7b319 100644
+index f87364de1bf24ee78e0d823d9081a5f352934405..84edda17692eca0f21eeb01a9eb94eba81c356ab 100644
 --- a/src/main/java/org/bukkit/MusicInstrument.java
 +++ b/src/main/java/org/bukkit/MusicInstrument.java
 @@ -47,6 +47,16 @@ public abstract class MusicInstrument implements Keyed, net.kyori.adventure.tran
@@ -40,22 +40,22 @@ index c9f02466a04d20579fe2258bb02acf98e163ca81..bffd4ab2d08e5c3f83a49a31e1e55cc1
  
 +    // Paper start - deprecate getKey
 +    /**
-+     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#INSTRUMENT}. MusicInstruments
-+     * can exist without a key.
++     * @deprecated use {@link Registry#getKey(Keyed)}, {@link io.papermc.paper.registry.RegistryAccess#getRegistry(io.papermc.paper.registry.RegistryKey)},
++     * and {@link io.papermc.paper.registry.RegistryKey#INSTRUMENT}. MusicInstruments can exist without a key.
 +     */
 +    @Deprecated(forRemoval = true, since = "1.20.5")
 +    @Override
 +    public abstract @NotNull NamespacedKey getKey();
 +    // Paper end - deprecate getKey
 +
-     // Paper start - translation key
-     @Override
-     public @NotNull String translationKey() {
+     // Paper start - mark translation key as deprecated
+     /**
+      * @deprecated this method assumes that the instrument description
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index a5db0a013921423f87abb14dc08b24f47d4093f6..9ed61b649d7e7056bd9ebcbb77f17c6c5798bf2d 100644
+index ae76b0d2b84dda5eefb9ffd9d76383408f67fbe3..67b9ab322baecf5b2453df4795106514cb073108 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -387,6 +387,79 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -385,6 +385,79 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      @Nullable
      T get(@NotNull NamespacedKey key);
  
@@ -135,7 +135,7 @@ index a5db0a013921423f87abb14dc08b24f47d4093f6..9ed61b649d7e7056bd9ebcbb77f17c6c
      /**
       * Get the object by its key.
       *
-@@ -483,5 +556,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -481,5 +554,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
          public Class<T> getType() {
              return this.type;
          }
@@ -188,7 +188,7 @@ index eaf6cd758344eeba29f00f822a50c93704af8bda..eb192030832e1741850871bec9bf999f
      @NotNull
      public NamespacedKey getKey();
 diff --git a/src/main/java/org/bukkit/generator/structure/Structure.java b/src/main/java/org/bukkit/generator/structure/Structure.java
-index 20a7fd27ba3a029d58dd18ad9b470ffaed8c9578..a773550549b4093a5fb4ef47284c438dcddd99ab 100644
+index 20a7fd27ba3a029d58dd18ad9b470ffaed8c9578..542e3e32e77c0b8dfa707193787516f83b884780 100644
 --- a/src/main/java/org/bukkit/generator/structure/Structure.java
 +++ b/src/main/java/org/bukkit/generator/structure/Structure.java
 @@ -61,4 +61,13 @@ public abstract class Structure implements Keyed {
@@ -197,8 +197,8 @@ index 20a7fd27ba3a029d58dd18ad9b470ffaed8c9578..a773550549b4093a5fb4ef47284c438d
      public abstract StructureType getStructureType();
 +    // Paper start - deprecate getKey
 +    /**
-+     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#STRUCTURE}. Structures
-+     * can exist without a key.
++     * @deprecated use {@link Registry#getKey(Keyed)}, {@link io.papermc.paper.registry.RegistryAccess#getRegistry(io.papermc.paper.registry.RegistryKey)},
++     * and {@link io.papermc.paper.registry.RegistryKey#STRUCTURE}. Structures can exist without a key.
 +     */
 +    @Override
 +    @Deprecated(since = "1.20.4")

--- a/patches/api/0471-Registry-Modification-API.patch
+++ b/patches/api/0471-Registry-Modification-API.patch
@@ -809,10 +809,10 @@ index 0000000000000000000000000000000000000000..bf49125acc8a0508bf59674bba3ed350
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 9ed61b649d7e7056bd9ebcbb77f17c6c5798bf2d..16bef936a9aef957a73c33e45be7573584943a6b 100644
+index 67b9ab322baecf5b2453df4795106514cb073108..7cf7c6d05aa6cbf3f0c8612831404552c6a7b84a 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -386,6 +386,27 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -384,6 +384,27 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       */
      @Nullable
      T get(@NotNull NamespacedKey key);
@@ -840,7 +840,7 @@ index 9ed61b649d7e7056bd9ebcbb77f17c6c5798bf2d..16bef936a9aef957a73c33e45be75735
  
      // Paper start - improve Registry
      /**
-@@ -460,6 +481,34 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -458,6 +479,34 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      }
      // Paper end - improve Registry
  
@@ -875,7 +875,7 @@ index 9ed61b649d7e7056bd9ebcbb77f17c6c5798bf2d..16bef936a9aef957a73c33e45be75735
      /**
       * Get the object by its key.
       *
-@@ -563,5 +612,23 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -561,5 +610,23 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
              return value.getKey();
          }
          // Paper end - improve Registry

--- a/patches/api/0472-Introduce-registry-entry-and-builders.patch
+++ b/patches/api/0472-Introduce-registry-entry-and-builders.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Introduce registry entry and builders
 
 
 diff --git a/src/main/java/io/papermc/paper/registry/RegistryKey.java b/src/main/java/io/papermc/paper/registry/RegistryKey.java
-index 8410d7213370f01cbedbf7fac29bac96f150c49a..d8716f855806471728c35b3ec34efb808a5146cf 100644
+index 647f6a1ec1f9d3c203b41f90a99bfd415bf67366..9b39e33514b15a9d07104e2ad826d0da11f569d6 100644
 --- a/src/main/java/io/papermc/paper/registry/RegistryKey.java
 +++ b/src/main/java/io/papermc/paper/registry/RegistryKey.java
-@@ -79,9 +79,10 @@ public sealed interface RegistryKey<T> extends Keyed permits RegistryKeyImpl {
+@@ -74,9 +74,10 @@ public sealed interface RegistryKey<T> extends Keyed permits RegistryKeyImpl {
      @ApiStatus.Internal
      RegistryKey<BlockType> BLOCK = create("block");
      /**

--- a/patches/server/0401-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0401-Add-methods-to-get-translation-keys.patch
@@ -10,6 +10,27 @@ public org.bukkit.craftbukkit.inventory.CraftMetaFirework getNBT(Lorg/bukkit/Fir
 
 Co-authored-by: MeFisto94 <MeFisto94@users.noreply.github.com>
 
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftMusicInstrument.java b/src/main/java/org/bukkit/craftbukkit/CraftMusicInstrument.java
+index fa0a3f895f12a33938222d354caf13857bdd6955..fb8f68f1aedfb26e4d95fe5bad87f0f2cc91c287 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftMusicInstrument.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftMusicInstrument.java
+@@ -68,6 +68,16 @@ public class CraftMusicInstrument extends MusicInstrument implements Handleable<
+         return this.key;
+     }
+ 
++    // Paper start - add translationKey methods
++    @Override
++    public @NotNull String translationKey() {
++        if (!(this.getHandle().description().getContents() instanceof final net.minecraft.network.chat.contents.TranslatableContents translatableContents)) {
++            throw new UnsupportedOperationException("Description isn't translatable!"); // Paper
++        }
++        return translatableContents.getKey();
++    }
++    // Paper end - add translationKey methods
++
+     @Override
+     public boolean equals(Object other) {
+         if (this == other) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/attribute/CraftAttribute.java b/src/main/java/org/bukkit/craftbukkit/attribute/CraftAttribute.java
 index 8797a47be16b85dc69a28a56bb355bee7d6b1a78..9ab615347e241ac264fb70f43306075907420885 100644
 --- a/src/main/java/org/bukkit/craftbukkit/attribute/CraftAttribute.java
@@ -109,7 +130,7 @@ index 4921fc085c9d60c74028ef390325e26c598e8df1..4941e0afff8df5f10f06c715b54bf58e
              case BALL:
                  return FireworkExplosion.Shape.SMALL_BALL;
 diff --git a/src/test/java/io/papermc/paper/world/TranslationKeyTest.java b/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
-index 7f8b6462d2a1bbd39a870d2543bebc135f7eb45b..e8d5c3eb8ad98b2082bdd33d96bfb1d7124ea186 100644
+index 7f8b6462d2a1bbd39a870d2543bebc135f7eb45b..c843de24f06dcdee474e9a21d0a3dc54b7b3557a 100644
 --- a/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
 +++ b/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
 @@ -1,11 +1,32 @@
@@ -145,7 +166,7 @@ index 7f8b6462d2a1bbd39a870d2543bebc135f7eb45b..e8d5c3eb8ad98b2082bdd33d96bfb1d7
  public class TranslationKeyTest {
  
      @Test
-@@ -15,4 +36,70 @@ public class TranslationKeyTest {
+@@ -15,4 +36,61 @@ public class TranslationKeyTest {
              Assertions.assertEquals(ChatVisiblity.valueOf(chatVisibility.name()).getKey(), chatVisibility.translationKey(), chatVisibility + "'s translation key doesn't match");
          }
      }
@@ -204,15 +225,6 @@ index 7f8b6462d2a1bbd39a870d2543bebc135f7eb45b..e8d5c3eb8ad98b2082bdd33d96bfb1d7
 +        for (Map.Entry<ResourceKey<Biome>, Biome> nms : RegistryHelper.getBiomes().entrySet()) {
 +            org.bukkit.block.Biome bukkit = org.bukkit.block.Biome.valueOf(nms.getKey().location().getPath().toUpperCase(Locale.ROOT));
 +            Assertions.assertEquals(nms.getKey().location().toLanguageKey("biome"), bukkit.translationKey(), "translation key mismatch for " + bukkit);
-+        }
-+    }
-+
-+    @Test
-+    public void testMusicInstrument() {
-+        for (final ResourceLocation nms : RegistryHelper.getRegistry().lookupOrThrow(Registries.INSTRUMENT).keySet()) {
-+            final MusicInstrument bukkit = MusicInstrument.getByKey(CraftNamespacedKey.fromMinecraft(nms));
-+            Assertions.assertNotNull(bukkit, "Missing bukkit instrument for " + nms);
-+            Assertions.assertEquals(nms.toLanguageKey("instrument"), bukkit.translationKey(), "translation key mismatch for " + bukkit);
 +        }
 +    }
  }

--- a/patches/server/0467-Add-RegistryAccess-for-managing-Registries.patch
+++ b/patches/server/0467-Add-RegistryAccess-for-managing-Registries.patch
@@ -12,7 +12,7 @@ public net.minecraft.server.RegistryLayer STATIC_ACCESS
 
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..39120c63ed25d45a4083523fbfe79d871f4d892e
+index 0000000000000000000000000000000000000000..c6969f968b45eff2aeb44e647712abda10c7c113
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 @@ -0,0 +1,156 @@
@@ -98,7 +98,6 @@ index 0000000000000000000000000000000000000000..39120c63ed25d45a4083523fbfe79d87
 +            // built-ins
 +            entry(Registries.GAME_EVENT, RegistryKey.GAME_EVENT, GameEvent.class, CraftGameEvent::new),
 +            entry(Registries.STRUCTURE_TYPE, RegistryKey.STRUCTURE_TYPE, StructureType.class, CraftStructureType::new),
-+            entry(Registries.INSTRUMENT, RegistryKey.INSTRUMENT, MusicInstrument.class, CraftMusicInstrument::new),
 +            entry(Registries.MOB_EFFECT, RegistryKey.MOB_EFFECT, PotionEffectType.class, CraftPotionEffectType::new),
 +            entry(Registries.BLOCK, RegistryKey.BLOCK, BlockType.class, CraftBlockType::new),
 +            entry(Registries.ITEM, RegistryKey.ITEM, ItemType.class, CraftItemType::new),
@@ -123,6 +122,7 @@ index 0000000000000000000000000000000000000000..39120c63ed25d45a4083523fbfe79d87
 +            entry(Registries.JUKEBOX_SONG, RegistryKey.JUKEBOX_SONG, JukeboxSong.class, CraftJukeboxSong::new).delayed(),
 +            entry(Registries.BANNER_PATTERN, RegistryKey.BANNER_PATTERN, PatternType.class, CraftPatternType::new).delayed(),
 +            entry(Registries.PAINTING_VARIANT, RegistryKey.PAINTING_VARIANT, Art.class, CraftArt::new).delayed(),
++            entry(Registries.INSTRUMENT, RegistryKey.INSTRUMENT, MusicInstrument.class, CraftMusicInstrument::new).delayed(),
 +
 +            // api-only
 +            apiOnly(Registries.ENTITY_TYPE, RegistryKey.ENTITY_TYPE, () -> org.bukkit.Registry.ENTITY_TYPE),

--- a/patches/server/0953-General-ItemMeta-fixes.patch
+++ b/patches/server/0953-General-ItemMeta-fixes.patch
@@ -1049,7 +1049,7 @@ index 566d893a413fd04b99e83dc2da8fe958a48492a8..a944803771d514572f94b4e98a6d4435
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 14aab3a2adfde7a236610be2b928651bc01067f5..71d0ade48d450b76be9cb396ac613fa4c783679e 100644
+index 14aab3a2adfde7a236610be2b928651bc01067f5..069c79aecc190f62f2d217b3e9868677845b5dc9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -199,9 +199,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -1181,7 +1181,7 @@ index 14aab3a2adfde7a236610be2b928651bc01067f5..71d0ade48d450b76be9cb396ac613fa4
  
      @Override
      public void setEnchantable(Integer data) {
-+        Preconditions.checkArgument(data > 0, "Enchantability must be > 0");
++        Preconditions.checkArgument(data == null || data > 0, "Enchantability must be positive"); // Paper
          this.enchantableValue = data;
      }
  

--- a/patches/server/0994-Add-registry-entry-and-builders.patch
+++ b/patches/server/0994-Add-registry-entry-and-builders.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add registry entry and builders
 
 
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-index f563e6e7a558d22f571154640e99cc86718c89f5..a2d26151b5d1ae413e1e588520ecf13fe479de94 100644
+index d34ffad8a36abbb215491d74ae8d9b490a0bc64f..f8c6da955e4bd0e480c7b581d2a4325738f9dd6f 100644
 --- a/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 @@ -1,6 +1,8 @@
@@ -24,9 +24,9 @@ index f563e6e7a558d22f571154640e99cc86718c89f5..a2d26151b5d1ae413e1e588520ecf13f
 -            entry(Registries.GAME_EVENT, RegistryKey.GAME_EVENT, GameEvent.class, CraftGameEvent::new),
 +            writable(Registries.GAME_EVENT, RegistryKey.GAME_EVENT, GameEvent.class, CraftGameEvent::new, PaperGameEventRegistryEntry.PaperBuilder::new),
              entry(Registries.STRUCTURE_TYPE, RegistryKey.STRUCTURE_TYPE, StructureType.class, CraftStructureType::new),
-             entry(Registries.INSTRUMENT, RegistryKey.INSTRUMENT, MusicInstrument.class, CraftMusicInstrument::new),
              entry(Registries.MOB_EFFECT, RegistryKey.MOB_EFFECT, PotionEffectType.class, CraftPotionEffectType::new),
-@@ -103,7 +105,7 @@ public final class PaperRegistries {
+             entry(Registries.BLOCK, RegistryKey.BLOCK, BlockType.class, CraftBlockType::new),
+@@ -102,7 +104,7 @@ public final class PaperRegistries {
              entry(Registries.TRIM_PATTERN, RegistryKey.TRIM_PATTERN, TrimPattern.class, CraftTrimPattern::new).delayed(),
              entry(Registries.DAMAGE_TYPE, RegistryKey.DAMAGE_TYPE, DamageType.class, CraftDamageType::new).delayed(),
              entry(Registries.WOLF_VARIANT, RegistryKey.WOLF_VARIANT, Wolf.Variant.class, CraftWolf.CraftVariant::new).delayed(),


### PR DESCRIPTION
ItemMeta#setEnchantable is nullable but yet passing null result in an NPE on Paper.

Also fixes a bunch of leftover during the update:
migrate the generated content to jspecify, make EnchantmentKeys#create public
undeprecate some fields on Registry
register instrument registry as data driven registry