### PR TITLE
Fix NPE with spark when CraftServer is not init yet

### DIFF
--- a/patches/server/1046-Bundle-spark.patch
+++ b/patches/server/1046-Bundle-spark.patch
@@ -279,7 +279,7 @@ index 6b8ed8a0baaf4a57d20e57cec3400af5561ddd79..48604e7f96adc9e226e034054c5e2bad
      }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b29dbab3c26c078eb993183d808149d958857f3a..db90abc0e081d1d2623e6bfe000bc2694ae84c7a 100644
+index b29dbab3c26c078eb993183d808149d958857f3a..38b5eef0b5ff38f9a8dfa59822d7b41336108f49 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -764,6 +764,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -291,14 +291,14 @@ index b29dbab3c26c078eb993183d808149d958857f3a..db90abc0e081d1d2623e6bfe000bc269
          if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.pluginsEnabled(); // Paper - Remap plugins
          io.papermc.paper.command.brigadier.PaperCommands.INSTANCE.setValid(); // Paper - reset invalid state for event fire below
          io.papermc.paper.plugin.lifecycle.event.LifecycleEventRunner.INSTANCE.callReloadableRegistrarEvent(io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents.COMMANDS, io.papermc.paper.command.brigadier.PaperCommands.INSTANCE, org.bukkit.plugin.Plugin.class, io.papermc.paper.plugin.lifecycle.event.registrar.ReloadableRegistrarEvent.Cause.INITIAL); // Paper - call commands event for regular plugins
-@@ -1049,6 +1051,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
- 
-         MinecraftServer.LOGGER.info("Stopping server");
+@@ -1051,6 +1053,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          Commands.COMMAND_SENDING_POOL.shutdownNow(); // Paper - Perf: Async command map building; Shutdown and don't bother finishing
-+        this.server.spark.disable(); // Paper - spark
          // CraftBukkit start
          if (this.server != null) {
++            this.server.spark.disable(); // Paper - spark
              this.server.disablePlugins();
+             this.server.waitForAsyncTasksShutdown(); // Paper - Wait for Async Tasks during shutdown
+         }
 @@ -1244,6 +1247,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              // tasks are default scheduled at -1 + delay, and first tick will tick at 1
              final long actualDoneTimeMs = System.currentTimeMillis() - org.bukkit.craftbukkit.Main.BOOT_TIME.toEpochMilli(); // Paper - Add total time
@@ -364,7 +364,7 @@ index c06863578c5d654706d93e73059d89c12ae502a5..17a158ff6ce6520b69a5a0032ba4c054
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // Paper - load version history now
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ca92d377a774ee46d13e108c528ce78941f906ec..9f9eefc7346838a9effcda861cecd098092efb0f 100644
+index 97ebe3852f34b88e727083b539d94de62dc1ca80..b185a9b474121b8a4067816b3c3c39270c2a202e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -312,6 +312,7 @@ public final class CraftServer implements Server {


### PR DESCRIPTION
Happens for example when getting a registry in the bootstrap and the server shutdown.