### PR TITLE
Decrease dead entity teleport warning

### DIFF
--- a/patches/server/0344-Fix-item-duplication-and-teleport-issues.patch
+++ b/patches/server/0344-Fix-item-duplication-and-teleport-issues.patch
@@ -16,7 +16,7 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5b8e264098f1b713de15f714bae59d3efda365cf..d5f96ed753e8298085e40c6181285cd6ea838ca2 100644
+index 5b8e264098f1b713de15f714bae59d3efda365cf..e3228ad3825adedbd1a8326ac3bea329b539b18f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2630,11 +2630,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -39,7 +39,7 @@ index 5b8e264098f1b713de15f714bae59d3efda365cf..d5f96ed753e8298085e40c6181285cd6
          Level world = this.level();
  
 +        // Paper start - Fix item duplication and teleport issues
-+        if (!this.isAlive() || !this.valid) {
++        if ((!this.isAlive() || !this.valid) && (teleportTarget.newLevel() != world)) {
 +            LOGGER.warn("Illegal Entity Teleport " + this + " to " + teleportTarget.newLevel() + ":" + teleportTarget.position(), new Throwable());
 +            return null;
 +        }
@@ -123,7 +123,7 @@ index e20565cf256aacd012a1722c5ebbf9016bc82e42..59fbfe8de2dc5ec020dd61a5e446b0b6
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0627e3be754dbf8201f3212cf823e2f8cb77cdeb..6b094f8bdf1f25d5c2e108eb88d95aed4a41f6f3 100644
+index 74f33aeb6193080446ebbcc5242d95c3b1c97823..f482fc14e171129f9fa60113b1223b2db79ec6ec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -903,6 +903,11 @@ public class CraftEventFactory {


### PR DESCRIPTION
Decreases the warning back to its 1.21.1 level where only teleports of
dead/invalid entities across dimensions were logged.
