### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/PaintingVariantKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/PaintingVariantKeys.java
@@ -1,0 +1,392 @@
+package io.papermc.paper.registry.keys;
+
+import static net.kyori.adventure.key.Key.key;
+
+import io.papermc.paper.generated.GeneratedFrom;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.TypedKey;
+import net.kyori.adventure.key.Key;
+import org.bukkit.Art;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Vanilla keys for {@link RegistryKey#PAINTING_VARIANT}.
+ *
+ * @apiNote The fields provided here are a direct representation of
+ * what is available from the vanilla game source. They may be
+ * changed (including removals) on any Minecraft version
+ * bump, so cross-version compatibility is not provided on the
+ * same level as it is on most of the other API.
+ */
+@SuppressWarnings({
+        "unused",
+        "SpellCheckingInspection"
+})
+@GeneratedFrom("1.21.3")
+@ApiStatus.Experimental
+public final class PaintingVariantKeys {
+    /**
+     * {@code minecraft:alban}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> ALBAN = create(key("alban"));
+
+    /**
+     * {@code minecraft:aztec}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> AZTEC = create(key("aztec"));
+
+    /**
+     * {@code minecraft:aztec2}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> AZTEC2 = create(key("aztec2"));
+
+    /**
+     * {@code minecraft:backyard}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> BACKYARD = create(key("backyard"));
+
+    /**
+     * {@code minecraft:baroque}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> BAROQUE = create(key("baroque"));
+
+    /**
+     * {@code minecraft:bomb}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> BOMB = create(key("bomb"));
+
+    /**
+     * {@code minecraft:bouquet}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> BOUQUET = create(key("bouquet"));
+
+    /**
+     * {@code minecraft:burning_skull}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> BURNING_SKULL = create(key("burning_skull"));
+
+    /**
+     * {@code minecraft:bust}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> BUST = create(key("bust"));
+
+    /**
+     * {@code minecraft:cavebird}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> CAVEBIRD = create(key("cavebird"));
+
+    /**
+     * {@code minecraft:changing}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> CHANGING = create(key("changing"));
+
+    /**
+     * {@code minecraft:cotan}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> COTAN = create(key("cotan"));
+
+    /**
+     * {@code minecraft:courbet}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> COURBET = create(key("courbet"));
+
+    /**
+     * {@code minecraft:creebet}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> CREEBET = create(key("creebet"));
+
+    /**
+     * {@code minecraft:donkey_kong}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> DONKEY_KONG = create(key("donkey_kong"));
+
+    /**
+     * {@code minecraft:earth}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> EARTH = create(key("earth"));
+
+    /**
+     * {@code minecraft:endboss}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> ENDBOSS = create(key("endboss"));
+
+    /**
+     * {@code minecraft:fern}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> FERN = create(key("fern"));
+
+    /**
+     * {@code minecraft:fighters}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> FIGHTERS = create(key("fighters"));
+
+    /**
+     * {@code minecraft:finding}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> FINDING = create(key("finding"));
+
+    /**
+     * {@code minecraft:fire}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> FIRE = create(key("fire"));
+
+    /**
+     * {@code minecraft:graham}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> GRAHAM = create(key("graham"));
+
+    /**
+     * {@code minecraft:humble}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> HUMBLE = create(key("humble"));
+
+    /**
+     * {@code minecraft:kebab}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> KEBAB = create(key("kebab"));
+
+    /**
+     * {@code minecraft:lowmist}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> LOWMIST = create(key("lowmist"));
+
+    /**
+     * {@code minecraft:match}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> MATCH = create(key("match"));
+
+    /**
+     * {@code minecraft:meditative}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> MEDITATIVE = create(key("meditative"));
+
+    /**
+     * {@code minecraft:orb}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> ORB = create(key("orb"));
+
+    /**
+     * {@code minecraft:owlemons}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> OWLEMONS = create(key("owlemons"));
+
+    /**
+     * {@code minecraft:passage}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> PASSAGE = create(key("passage"));
+
+    /**
+     * {@code minecraft:pigscene}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> PIGSCENE = create(key("pigscene"));
+
+    /**
+     * {@code minecraft:plant}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> PLANT = create(key("plant"));
+
+    /**
+     * {@code minecraft:pointer}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> POINTER = create(key("pointer"));
+
+    /**
+     * {@code minecraft:pond}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> POND = create(key("pond"));
+
+    /**
+     * {@code minecraft:pool}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> POOL = create(key("pool"));
+
+    /**
+     * {@code minecraft:prairie_ride}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> PRAIRIE_RIDE = create(key("prairie_ride"));
+
+    /**
+     * {@code minecraft:sea}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> SEA = create(key("sea"));
+
+    /**
+     * {@code minecraft:skeleton}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> SKELETON = create(key("skeleton"));
+
+    /**
+     * {@code minecraft:skull_and_roses}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> SKULL_AND_ROSES = create(key("skull_and_roses"));
+
+    /**
+     * {@code minecraft:stage}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> STAGE = create(key("stage"));
+
+    /**
+     * {@code minecraft:sunflowers}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> SUNFLOWERS = create(key("sunflowers"));
+
+    /**
+     * {@code minecraft:sunset}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> SUNSET = create(key("sunset"));
+
+    /**
+     * {@code minecraft:tides}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> TIDES = create(key("tides"));
+
+    /**
+     * {@code minecraft:unpacked}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> UNPACKED = create(key("unpacked"));
+
+    /**
+     * {@code minecraft:void}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> VOID = create(key("void"));
+
+    /**
+     * {@code minecraft:wanderer}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> WANDERER = create(key("wanderer"));
+
+    /**
+     * {@code minecraft:wasteland}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> WASTELAND = create(key("wasteland"));
+
+    /**
+     * {@code minecraft:water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> WATER = create(key("water"));
+
+    /**
+     * {@code minecraft:wind}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> WIND = create(key("wind"));
+
+    /**
+     * {@code minecraft:wither}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Art> WITHER = create(key("wither"));
+
+    private PaintingVariantKeys() {
+    }
+
+    /**
+     * Creates a key for {@link Art} in the registry {@code minecraft:painting_variant}.
+     *
+     * @param key the value's key in the registry
+     * @return a new typed key
+     */
+    @ApiStatus.Experimental
+    public static @NonNull TypedKey<Art> create(final @NonNull Key key) {
+        return TypedKey.create(RegistryKey.PAINTING_VARIANT, key);
+    }
+}

--- a/paper-api-generator/generated/io/papermc/paper/registry/keys/SoundEventKeys.java
+++ b/paper-api-generator/generated/io/papermc/paper/registry/keys/SoundEventKeys.java
@@ -1,0 +1,11487 @@
+package io.papermc.paper.registry.keys;
+
+import static net.kyori.adventure.key.Key.key;
+
+import io.papermc.paper.generated.GeneratedFrom;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.TypedKey;
+import net.kyori.adventure.key.Key;
+import org.bukkit.Sound;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Vanilla keys for {@link RegistryKey#SOUND_EVENT}.
+ *
+ * @apiNote The fields provided here are a direct representation of
+ * what is available from the vanilla game source. They may be
+ * changed (including removals) on any Minecraft version
+ * bump, so cross-version compatibility is not provided on the
+ * same level as it is on most of the other API.
+ */
+@SuppressWarnings({
+        "unused",
+        "SpellCheckingInspection"
+})
+@GeneratedFrom("1.21.3")
+@ApiStatus.Experimental
+public final class SoundEventKeys {
+    /**
+     * {@code minecraft:ambient.basalt_deltas.additions}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_BASALT_DELTAS_ADDITIONS = create(key("ambient.basalt_deltas.additions"));
+
+    /**
+     * {@code minecraft:ambient.basalt_deltas.loop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_BASALT_DELTAS_LOOP = create(key("ambient.basalt_deltas.loop"));
+
+    /**
+     * {@code minecraft:ambient.basalt_deltas.mood}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_BASALT_DELTAS_MOOD = create(key("ambient.basalt_deltas.mood"));
+
+    /**
+     * {@code minecraft:ambient.cave}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_CAVE = create(key("ambient.cave"));
+
+    /**
+     * {@code minecraft:ambient.crimson_forest.additions}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_CRIMSON_FOREST_ADDITIONS = create(key("ambient.crimson_forest.additions"));
+
+    /**
+     * {@code minecraft:ambient.crimson_forest.loop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_CRIMSON_FOREST_LOOP = create(key("ambient.crimson_forest.loop"));
+
+    /**
+     * {@code minecraft:ambient.crimson_forest.mood}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_CRIMSON_FOREST_MOOD = create(key("ambient.crimson_forest.mood"));
+
+    /**
+     * {@code minecraft:ambient.nether_wastes.additions}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_NETHER_WASTES_ADDITIONS = create(key("ambient.nether_wastes.additions"));
+
+    /**
+     * {@code minecraft:ambient.nether_wastes.loop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_NETHER_WASTES_LOOP = create(key("ambient.nether_wastes.loop"));
+
+    /**
+     * {@code minecraft:ambient.nether_wastes.mood}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_NETHER_WASTES_MOOD = create(key("ambient.nether_wastes.mood"));
+
+    /**
+     * {@code minecraft:ambient.soul_sand_valley.additions}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_SOUL_SAND_VALLEY_ADDITIONS = create(key("ambient.soul_sand_valley.additions"));
+
+    /**
+     * {@code minecraft:ambient.soul_sand_valley.loop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_SOUL_SAND_VALLEY_LOOP = create(key("ambient.soul_sand_valley.loop"));
+
+    /**
+     * {@code minecraft:ambient.soul_sand_valley.mood}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_SOUL_SAND_VALLEY_MOOD = create(key("ambient.soul_sand_valley.mood"));
+
+    /**
+     * {@code minecraft:ambient.underwater.enter}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_UNDERWATER_ENTER = create(key("ambient.underwater.enter"));
+
+    /**
+     * {@code minecraft:ambient.underwater.exit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_UNDERWATER_EXIT = create(key("ambient.underwater.exit"));
+
+    /**
+     * {@code minecraft:ambient.underwater.loop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_UNDERWATER_LOOP = create(key("ambient.underwater.loop"));
+
+    /**
+     * {@code minecraft:ambient.underwater.loop.additions}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_UNDERWATER_LOOP_ADDITIONS = create(key("ambient.underwater.loop.additions"));
+
+    /**
+     * {@code minecraft:ambient.underwater.loop.additions.rare}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_UNDERWATER_LOOP_ADDITIONS_RARE = create(key("ambient.underwater.loop.additions.rare"));
+
+    /**
+     * {@code minecraft:ambient.underwater.loop.additions.ultra_rare}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_UNDERWATER_LOOP_ADDITIONS_ULTRA_RARE = create(key("ambient.underwater.loop.additions.ultra_rare"));
+
+    /**
+     * {@code minecraft:ambient.warped_forest.additions}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_WARPED_FOREST_ADDITIONS = create(key("ambient.warped_forest.additions"));
+
+    /**
+     * {@code minecraft:ambient.warped_forest.loop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_WARPED_FOREST_LOOP = create(key("ambient.warped_forest.loop"));
+
+    /**
+     * {@code minecraft:ambient.warped_forest.mood}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> AMBIENT_WARPED_FOREST_MOOD = create(key("ambient.warped_forest.mood"));
+
+    /**
+     * {@code minecraft:block.amethyst_block.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AMETHYST_BLOCK_BREAK = create(key("block.amethyst_block.break"));
+
+    /**
+     * {@code minecraft:block.amethyst_block.chime}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AMETHYST_BLOCK_CHIME = create(key("block.amethyst_block.chime"));
+
+    /**
+     * {@code minecraft:block.amethyst_block.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AMETHYST_BLOCK_FALL = create(key("block.amethyst_block.fall"));
+
+    /**
+     * {@code minecraft:block.amethyst_block.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AMETHYST_BLOCK_HIT = create(key("block.amethyst_block.hit"));
+
+    /**
+     * {@code minecraft:block.amethyst_block.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AMETHYST_BLOCK_PLACE = create(key("block.amethyst_block.place"));
+
+    /**
+     * {@code minecraft:block.amethyst_block.resonate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AMETHYST_BLOCK_RESONATE = create(key("block.amethyst_block.resonate"));
+
+    /**
+     * {@code minecraft:block.amethyst_block.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AMETHYST_BLOCK_STEP = create(key("block.amethyst_block.step"));
+
+    /**
+     * {@code minecraft:block.amethyst_cluster.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AMETHYST_CLUSTER_BREAK = create(key("block.amethyst_cluster.break"));
+
+    /**
+     * {@code minecraft:block.amethyst_cluster.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AMETHYST_CLUSTER_FALL = create(key("block.amethyst_cluster.fall"));
+
+    /**
+     * {@code minecraft:block.amethyst_cluster.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AMETHYST_CLUSTER_HIT = create(key("block.amethyst_cluster.hit"));
+
+    /**
+     * {@code minecraft:block.amethyst_cluster.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AMETHYST_CLUSTER_PLACE = create(key("block.amethyst_cluster.place"));
+
+    /**
+     * {@code minecraft:block.amethyst_cluster.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AMETHYST_CLUSTER_STEP = create(key("block.amethyst_cluster.step"));
+
+    /**
+     * {@code minecraft:block.ancient_debris.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANCIENT_DEBRIS_BREAK = create(key("block.ancient_debris.break"));
+
+    /**
+     * {@code minecraft:block.ancient_debris.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANCIENT_DEBRIS_FALL = create(key("block.ancient_debris.fall"));
+
+    /**
+     * {@code minecraft:block.ancient_debris.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANCIENT_DEBRIS_HIT = create(key("block.ancient_debris.hit"));
+
+    /**
+     * {@code minecraft:block.ancient_debris.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANCIENT_DEBRIS_PLACE = create(key("block.ancient_debris.place"));
+
+    /**
+     * {@code minecraft:block.ancient_debris.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANCIENT_DEBRIS_STEP = create(key("block.ancient_debris.step"));
+
+    /**
+     * {@code minecraft:block.anvil.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANVIL_BREAK = create(key("block.anvil.break"));
+
+    /**
+     * {@code minecraft:block.anvil.destroy}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANVIL_DESTROY = create(key("block.anvil.destroy"));
+
+    /**
+     * {@code minecraft:block.anvil.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANVIL_FALL = create(key("block.anvil.fall"));
+
+    /**
+     * {@code minecraft:block.anvil.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANVIL_HIT = create(key("block.anvil.hit"));
+
+    /**
+     * {@code minecraft:block.anvil.land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANVIL_LAND = create(key("block.anvil.land"));
+
+    /**
+     * {@code minecraft:block.anvil.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANVIL_PLACE = create(key("block.anvil.place"));
+
+    /**
+     * {@code minecraft:block.anvil.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANVIL_STEP = create(key("block.anvil.step"));
+
+    /**
+     * {@code minecraft:block.anvil.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ANVIL_USE = create(key("block.anvil.use"));
+
+    /**
+     * {@code minecraft:block.azalea.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AZALEA_BREAK = create(key("block.azalea.break"));
+
+    /**
+     * {@code minecraft:block.azalea.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AZALEA_FALL = create(key("block.azalea.fall"));
+
+    /**
+     * {@code minecraft:block.azalea.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AZALEA_HIT = create(key("block.azalea.hit"));
+
+    /**
+     * {@code minecraft:block.azalea.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AZALEA_PLACE = create(key("block.azalea.place"));
+
+    /**
+     * {@code minecraft:block.azalea.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AZALEA_STEP = create(key("block.azalea.step"));
+
+    /**
+     * {@code minecraft:block.azalea_leaves.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AZALEA_LEAVES_BREAK = create(key("block.azalea_leaves.break"));
+
+    /**
+     * {@code minecraft:block.azalea_leaves.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AZALEA_LEAVES_FALL = create(key("block.azalea_leaves.fall"));
+
+    /**
+     * {@code minecraft:block.azalea_leaves.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AZALEA_LEAVES_HIT = create(key("block.azalea_leaves.hit"));
+
+    /**
+     * {@code minecraft:block.azalea_leaves.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AZALEA_LEAVES_PLACE = create(key("block.azalea_leaves.place"));
+
+    /**
+     * {@code minecraft:block.azalea_leaves.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_AZALEA_LEAVES_STEP = create(key("block.azalea_leaves.step"));
+
+    /**
+     * {@code minecraft:block.bamboo.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_BREAK = create(key("block.bamboo.break"));
+
+    /**
+     * {@code minecraft:block.bamboo.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_FALL = create(key("block.bamboo.fall"));
+
+    /**
+     * {@code minecraft:block.bamboo.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_HIT = create(key("block.bamboo.hit"));
+
+    /**
+     * {@code minecraft:block.bamboo.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_PLACE = create(key("block.bamboo.place"));
+
+    /**
+     * {@code minecraft:block.bamboo.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_STEP = create(key("block.bamboo.step"));
+
+    /**
+     * {@code minecraft:block.bamboo_sapling.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_SAPLING_BREAK = create(key("block.bamboo_sapling.break"));
+
+    /**
+     * {@code minecraft:block.bamboo_sapling.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_SAPLING_HIT = create(key("block.bamboo_sapling.hit"));
+
+    /**
+     * {@code minecraft:block.bamboo_sapling.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_SAPLING_PLACE = create(key("block.bamboo_sapling.place"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_BREAK = create(key("block.bamboo_wood.break"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_FALL = create(key("block.bamboo_wood.fall"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_HIT = create(key("block.bamboo_wood.hit"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_PLACE = create(key("block.bamboo_wood.place"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_STEP = create(key("block.bamboo_wood.step"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_button.click_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_BUTTON_CLICK_OFF = create(key("block.bamboo_wood_button.click_off"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_button.click_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_BUTTON_CLICK_ON = create(key("block.bamboo_wood_button.click_on"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_door.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_DOOR_CLOSE = create(key("block.bamboo_wood_door.close"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_door.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_DOOR_OPEN = create(key("block.bamboo_wood_door.open"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_fence_gate.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_FENCE_GATE_CLOSE = create(key("block.bamboo_wood_fence_gate.close"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_fence_gate.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_FENCE_GATE_OPEN = create(key("block.bamboo_wood_fence_gate.open"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_hanging_sign.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_HANGING_SIGN_BREAK = create(key("block.bamboo_wood_hanging_sign.break"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_hanging_sign.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_HANGING_SIGN_FALL = create(key("block.bamboo_wood_hanging_sign.fall"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_hanging_sign.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_HANGING_SIGN_HIT = create(key("block.bamboo_wood_hanging_sign.hit"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_hanging_sign.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_HANGING_SIGN_PLACE = create(key("block.bamboo_wood_hanging_sign.place"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_hanging_sign.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_HANGING_SIGN_STEP = create(key("block.bamboo_wood_hanging_sign.step"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_pressure_plate.click_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_PRESSURE_PLATE_CLICK_OFF = create(key("block.bamboo_wood_pressure_plate.click_off"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_pressure_plate.click_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_PRESSURE_PLATE_CLICK_ON = create(key("block.bamboo_wood_pressure_plate.click_on"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_trapdoor.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_TRAPDOOR_CLOSE = create(key("block.bamboo_wood_trapdoor.close"));
+
+    /**
+     * {@code minecraft:block.bamboo_wood_trapdoor.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BAMBOO_WOOD_TRAPDOOR_OPEN = create(key("block.bamboo_wood_trapdoor.open"));
+
+    /**
+     * {@code minecraft:block.barrel.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BARREL_CLOSE = create(key("block.barrel.close"));
+
+    /**
+     * {@code minecraft:block.barrel.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BARREL_OPEN = create(key("block.barrel.open"));
+
+    /**
+     * {@code minecraft:block.basalt.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BASALT_BREAK = create(key("block.basalt.break"));
+
+    /**
+     * {@code minecraft:block.basalt.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BASALT_FALL = create(key("block.basalt.fall"));
+
+    /**
+     * {@code minecraft:block.basalt.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BASALT_HIT = create(key("block.basalt.hit"));
+
+    /**
+     * {@code minecraft:block.basalt.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BASALT_PLACE = create(key("block.basalt.place"));
+
+    /**
+     * {@code minecraft:block.basalt.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BASALT_STEP = create(key("block.basalt.step"));
+
+    /**
+     * {@code minecraft:block.beacon.activate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BEACON_ACTIVATE = create(key("block.beacon.activate"));
+
+    /**
+     * {@code minecraft:block.beacon.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BEACON_AMBIENT = create(key("block.beacon.ambient"));
+
+    /**
+     * {@code minecraft:block.beacon.deactivate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BEACON_DEACTIVATE = create(key("block.beacon.deactivate"));
+
+    /**
+     * {@code minecraft:block.beacon.power_select}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BEACON_POWER_SELECT = create(key("block.beacon.power_select"));
+
+    /**
+     * {@code minecraft:block.beehive.drip}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BEEHIVE_DRIP = create(key("block.beehive.drip"));
+
+    /**
+     * {@code minecraft:block.beehive.enter}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BEEHIVE_ENTER = create(key("block.beehive.enter"));
+
+    /**
+     * {@code minecraft:block.beehive.exit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BEEHIVE_EXIT = create(key("block.beehive.exit"));
+
+    /**
+     * {@code minecraft:block.beehive.shear}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BEEHIVE_SHEAR = create(key("block.beehive.shear"));
+
+    /**
+     * {@code minecraft:block.beehive.work}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BEEHIVE_WORK = create(key("block.beehive.work"));
+
+    /**
+     * {@code minecraft:block.bell.resonate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BELL_RESONATE = create(key("block.bell.resonate"));
+
+    /**
+     * {@code minecraft:block.bell.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BELL_USE = create(key("block.bell.use"));
+
+    /**
+     * {@code minecraft:block.big_dripleaf.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BIG_DRIPLEAF_BREAK = create(key("block.big_dripleaf.break"));
+
+    /**
+     * {@code minecraft:block.big_dripleaf.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BIG_DRIPLEAF_FALL = create(key("block.big_dripleaf.fall"));
+
+    /**
+     * {@code minecraft:block.big_dripleaf.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BIG_DRIPLEAF_HIT = create(key("block.big_dripleaf.hit"));
+
+    /**
+     * {@code minecraft:block.big_dripleaf.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BIG_DRIPLEAF_PLACE = create(key("block.big_dripleaf.place"));
+
+    /**
+     * {@code minecraft:block.big_dripleaf.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BIG_DRIPLEAF_STEP = create(key("block.big_dripleaf.step"));
+
+    /**
+     * {@code minecraft:block.big_dripleaf.tilt_down}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BIG_DRIPLEAF_TILT_DOWN = create(key("block.big_dripleaf.tilt_down"));
+
+    /**
+     * {@code minecraft:block.big_dripleaf.tilt_up}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BIG_DRIPLEAF_TILT_UP = create(key("block.big_dripleaf.tilt_up"));
+
+    /**
+     * {@code minecraft:block.blastfurnace.fire_crackle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BLASTFURNACE_FIRE_CRACKLE = create(key("block.blastfurnace.fire_crackle"));
+
+    /**
+     * {@code minecraft:block.bone_block.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BONE_BLOCK_BREAK = create(key("block.bone_block.break"));
+
+    /**
+     * {@code minecraft:block.bone_block.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BONE_BLOCK_FALL = create(key("block.bone_block.fall"));
+
+    /**
+     * {@code minecraft:block.bone_block.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BONE_BLOCK_HIT = create(key("block.bone_block.hit"));
+
+    /**
+     * {@code minecraft:block.bone_block.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BONE_BLOCK_PLACE = create(key("block.bone_block.place"));
+
+    /**
+     * {@code minecraft:block.bone_block.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BONE_BLOCK_STEP = create(key("block.bone_block.step"));
+
+    /**
+     * {@code minecraft:block.brewing_stand.brew}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BREWING_STAND_BREW = create(key("block.brewing_stand.brew"));
+
+    /**
+     * {@code minecraft:block.bubble_column.bubble_pop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BUBBLE_COLUMN_BUBBLE_POP = create(key("block.bubble_column.bubble_pop"));
+
+    /**
+     * {@code minecraft:block.bubble_column.upwards_ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BUBBLE_COLUMN_UPWARDS_AMBIENT = create(key("block.bubble_column.upwards_ambient"));
+
+    /**
+     * {@code minecraft:block.bubble_column.upwards_inside}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BUBBLE_COLUMN_UPWARDS_INSIDE = create(key("block.bubble_column.upwards_inside"));
+
+    /**
+     * {@code minecraft:block.bubble_column.whirlpool_ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BUBBLE_COLUMN_WHIRLPOOL_AMBIENT = create(key("block.bubble_column.whirlpool_ambient"));
+
+    /**
+     * {@code minecraft:block.bubble_column.whirlpool_inside}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_BUBBLE_COLUMN_WHIRLPOOL_INSIDE = create(key("block.bubble_column.whirlpool_inside"));
+
+    /**
+     * {@code minecraft:block.cake.add_candle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CAKE_ADD_CANDLE = create(key("block.cake.add_candle"));
+
+    /**
+     * {@code minecraft:block.calcite.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CALCITE_BREAK = create(key("block.calcite.break"));
+
+    /**
+     * {@code minecraft:block.calcite.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CALCITE_FALL = create(key("block.calcite.fall"));
+
+    /**
+     * {@code minecraft:block.calcite.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CALCITE_HIT = create(key("block.calcite.hit"));
+
+    /**
+     * {@code minecraft:block.calcite.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CALCITE_PLACE = create(key("block.calcite.place"));
+
+    /**
+     * {@code minecraft:block.calcite.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CALCITE_STEP = create(key("block.calcite.step"));
+
+    /**
+     * {@code minecraft:block.campfire.crackle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CAMPFIRE_CRACKLE = create(key("block.campfire.crackle"));
+
+    /**
+     * {@code minecraft:block.candle.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CANDLE_AMBIENT = create(key("block.candle.ambient"));
+
+    /**
+     * {@code minecraft:block.candle.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CANDLE_BREAK = create(key("block.candle.break"));
+
+    /**
+     * {@code minecraft:block.candle.extinguish}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CANDLE_EXTINGUISH = create(key("block.candle.extinguish"));
+
+    /**
+     * {@code minecraft:block.candle.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CANDLE_FALL = create(key("block.candle.fall"));
+
+    /**
+     * {@code minecraft:block.candle.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CANDLE_HIT = create(key("block.candle.hit"));
+
+    /**
+     * {@code minecraft:block.candle.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CANDLE_PLACE = create(key("block.candle.place"));
+
+    /**
+     * {@code minecraft:block.candle.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CANDLE_STEP = create(key("block.candle.step"));
+
+    /**
+     * {@code minecraft:block.cave_vines.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CAVE_VINES_BREAK = create(key("block.cave_vines.break"));
+
+    /**
+     * {@code minecraft:block.cave_vines.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CAVE_VINES_FALL = create(key("block.cave_vines.fall"));
+
+    /**
+     * {@code minecraft:block.cave_vines.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CAVE_VINES_HIT = create(key("block.cave_vines.hit"));
+
+    /**
+     * {@code minecraft:block.cave_vines.pick_berries}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CAVE_VINES_PICK_BERRIES = create(key("block.cave_vines.pick_berries"));
+
+    /**
+     * {@code minecraft:block.cave_vines.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CAVE_VINES_PLACE = create(key("block.cave_vines.place"));
+
+    /**
+     * {@code minecraft:block.cave_vines.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CAVE_VINES_STEP = create(key("block.cave_vines.step"));
+
+    /**
+     * {@code minecraft:block.chain.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHAIN_BREAK = create(key("block.chain.break"));
+
+    /**
+     * {@code minecraft:block.chain.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHAIN_FALL = create(key("block.chain.fall"));
+
+    /**
+     * {@code minecraft:block.chain.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHAIN_HIT = create(key("block.chain.hit"));
+
+    /**
+     * {@code minecraft:block.chain.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHAIN_PLACE = create(key("block.chain.place"));
+
+    /**
+     * {@code minecraft:block.chain.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHAIN_STEP = create(key("block.chain.step"));
+
+    /**
+     * {@code minecraft:block.cherry_leaves.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_LEAVES_BREAK = create(key("block.cherry_leaves.break"));
+
+    /**
+     * {@code minecraft:block.cherry_leaves.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_LEAVES_FALL = create(key("block.cherry_leaves.fall"));
+
+    /**
+     * {@code minecraft:block.cherry_leaves.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_LEAVES_HIT = create(key("block.cherry_leaves.hit"));
+
+    /**
+     * {@code minecraft:block.cherry_leaves.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_LEAVES_PLACE = create(key("block.cherry_leaves.place"));
+
+    /**
+     * {@code minecraft:block.cherry_leaves.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_LEAVES_STEP = create(key("block.cherry_leaves.step"));
+
+    /**
+     * {@code minecraft:block.cherry_sapling.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_SAPLING_BREAK = create(key("block.cherry_sapling.break"));
+
+    /**
+     * {@code minecraft:block.cherry_sapling.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_SAPLING_FALL = create(key("block.cherry_sapling.fall"));
+
+    /**
+     * {@code minecraft:block.cherry_sapling.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_SAPLING_HIT = create(key("block.cherry_sapling.hit"));
+
+    /**
+     * {@code minecraft:block.cherry_sapling.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_SAPLING_PLACE = create(key("block.cherry_sapling.place"));
+
+    /**
+     * {@code minecraft:block.cherry_sapling.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_SAPLING_STEP = create(key("block.cherry_sapling.step"));
+
+    /**
+     * {@code minecraft:block.cherry_wood.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_BREAK = create(key("block.cherry_wood.break"));
+
+    /**
+     * {@code minecraft:block.cherry_wood.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_FALL = create(key("block.cherry_wood.fall"));
+
+    /**
+     * {@code minecraft:block.cherry_wood.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_HIT = create(key("block.cherry_wood.hit"));
+
+    /**
+     * {@code minecraft:block.cherry_wood.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_PLACE = create(key("block.cherry_wood.place"));
+
+    /**
+     * {@code minecraft:block.cherry_wood.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_STEP = create(key("block.cherry_wood.step"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_button.click_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_BUTTON_CLICK_OFF = create(key("block.cherry_wood_button.click_off"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_button.click_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_BUTTON_CLICK_ON = create(key("block.cherry_wood_button.click_on"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_door.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_DOOR_CLOSE = create(key("block.cherry_wood_door.close"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_door.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_DOOR_OPEN = create(key("block.cherry_wood_door.open"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_fence_gate.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_FENCE_GATE_CLOSE = create(key("block.cherry_wood_fence_gate.close"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_fence_gate.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_FENCE_GATE_OPEN = create(key("block.cherry_wood_fence_gate.open"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_hanging_sign.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_HANGING_SIGN_BREAK = create(key("block.cherry_wood_hanging_sign.break"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_hanging_sign.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_HANGING_SIGN_FALL = create(key("block.cherry_wood_hanging_sign.fall"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_hanging_sign.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_HANGING_SIGN_HIT = create(key("block.cherry_wood_hanging_sign.hit"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_hanging_sign.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_HANGING_SIGN_PLACE = create(key("block.cherry_wood_hanging_sign.place"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_hanging_sign.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_HANGING_SIGN_STEP = create(key("block.cherry_wood_hanging_sign.step"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_pressure_plate.click_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_PRESSURE_PLATE_CLICK_OFF = create(key("block.cherry_wood_pressure_plate.click_off"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_pressure_plate.click_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_PRESSURE_PLATE_CLICK_ON = create(key("block.cherry_wood_pressure_plate.click_on"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_trapdoor.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_TRAPDOOR_CLOSE = create(key("block.cherry_wood_trapdoor.close"));
+
+    /**
+     * {@code minecraft:block.cherry_wood_trapdoor.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHERRY_WOOD_TRAPDOOR_OPEN = create(key("block.cherry_wood_trapdoor.open"));
+
+    /**
+     * {@code minecraft:block.chest.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHEST_CLOSE = create(key("block.chest.close"));
+
+    /**
+     * {@code minecraft:block.chest.locked}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHEST_LOCKED = create(key("block.chest.locked"));
+
+    /**
+     * {@code minecraft:block.chest.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHEST_OPEN = create(key("block.chest.open"));
+
+    /**
+     * {@code minecraft:block.chiseled_bookshelf.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHISELED_BOOKSHELF_BREAK = create(key("block.chiseled_bookshelf.break"));
+
+    /**
+     * {@code minecraft:block.chiseled_bookshelf.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHISELED_BOOKSHELF_FALL = create(key("block.chiseled_bookshelf.fall"));
+
+    /**
+     * {@code minecraft:block.chiseled_bookshelf.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHISELED_BOOKSHELF_HIT = create(key("block.chiseled_bookshelf.hit"));
+
+    /**
+     * {@code minecraft:block.chiseled_bookshelf.insert}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHISELED_BOOKSHELF_INSERT = create(key("block.chiseled_bookshelf.insert"));
+
+    /**
+     * {@code minecraft:block.chiseled_bookshelf.insert.enchanted}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHISELED_BOOKSHELF_INSERT_ENCHANTED = create(key("block.chiseled_bookshelf.insert.enchanted"));
+
+    /**
+     * {@code minecraft:block.chiseled_bookshelf.pickup}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHISELED_BOOKSHELF_PICKUP = create(key("block.chiseled_bookshelf.pickup"));
+
+    /**
+     * {@code minecraft:block.chiseled_bookshelf.pickup.enchanted}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHISELED_BOOKSHELF_PICKUP_ENCHANTED = create(key("block.chiseled_bookshelf.pickup.enchanted"));
+
+    /**
+     * {@code minecraft:block.chiseled_bookshelf.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHISELED_BOOKSHELF_PLACE = create(key("block.chiseled_bookshelf.place"));
+
+    /**
+     * {@code minecraft:block.chiseled_bookshelf.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHISELED_BOOKSHELF_STEP = create(key("block.chiseled_bookshelf.step"));
+
+    /**
+     * {@code minecraft:block.chorus_flower.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHORUS_FLOWER_DEATH = create(key("block.chorus_flower.death"));
+
+    /**
+     * {@code minecraft:block.chorus_flower.grow}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CHORUS_FLOWER_GROW = create(key("block.chorus_flower.grow"));
+
+    /**
+     * {@code minecraft:block.cobweb.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COBWEB_BREAK = create(key("block.cobweb.break"));
+
+    /**
+     * {@code minecraft:block.cobweb.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COBWEB_FALL = create(key("block.cobweb.fall"));
+
+    /**
+     * {@code minecraft:block.cobweb.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COBWEB_HIT = create(key("block.cobweb.hit"));
+
+    /**
+     * {@code minecraft:block.cobweb.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COBWEB_PLACE = create(key("block.cobweb.place"));
+
+    /**
+     * {@code minecraft:block.cobweb.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COBWEB_STEP = create(key("block.cobweb.step"));
+
+    /**
+     * {@code minecraft:block.comparator.click}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COMPARATOR_CLICK = create(key("block.comparator.click"));
+
+    /**
+     * {@code minecraft:block.composter.empty}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COMPOSTER_EMPTY = create(key("block.composter.empty"));
+
+    /**
+     * {@code minecraft:block.composter.fill}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COMPOSTER_FILL = create(key("block.composter.fill"));
+
+    /**
+     * {@code minecraft:block.composter.fill_success}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COMPOSTER_FILL_SUCCESS = create(key("block.composter.fill_success"));
+
+    /**
+     * {@code minecraft:block.composter.ready}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COMPOSTER_READY = create(key("block.composter.ready"));
+
+    /**
+     * {@code minecraft:block.conduit.activate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CONDUIT_ACTIVATE = create(key("block.conduit.activate"));
+
+    /**
+     * {@code minecraft:block.conduit.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CONDUIT_AMBIENT = create(key("block.conduit.ambient"));
+
+    /**
+     * {@code minecraft:block.conduit.ambient.short}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CONDUIT_AMBIENT_SHORT = create(key("block.conduit.ambient.short"));
+
+    /**
+     * {@code minecraft:block.conduit.attack.target}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CONDUIT_ATTACK_TARGET = create(key("block.conduit.attack.target"));
+
+    /**
+     * {@code minecraft:block.conduit.deactivate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CONDUIT_DEACTIVATE = create(key("block.conduit.deactivate"));
+
+    /**
+     * {@code minecraft:block.copper.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_BREAK = create(key("block.copper.break"));
+
+    /**
+     * {@code minecraft:block.copper.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_FALL = create(key("block.copper.fall"));
+
+    /**
+     * {@code minecraft:block.copper.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_HIT = create(key("block.copper.hit"));
+
+    /**
+     * {@code minecraft:block.copper.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_PLACE = create(key("block.copper.place"));
+
+    /**
+     * {@code minecraft:block.copper.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_STEP = create(key("block.copper.step"));
+
+    /**
+     * {@code minecraft:block.copper_bulb.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_BULB_BREAK = create(key("block.copper_bulb.break"));
+
+    /**
+     * {@code minecraft:block.copper_bulb.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_BULB_FALL = create(key("block.copper_bulb.fall"));
+
+    /**
+     * {@code minecraft:block.copper_bulb.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_BULB_HIT = create(key("block.copper_bulb.hit"));
+
+    /**
+     * {@code minecraft:block.copper_bulb.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_BULB_PLACE = create(key("block.copper_bulb.place"));
+
+    /**
+     * {@code minecraft:block.copper_bulb.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_BULB_STEP = create(key("block.copper_bulb.step"));
+
+    /**
+     * {@code minecraft:block.copper_bulb.turn_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_BULB_TURN_OFF = create(key("block.copper_bulb.turn_off"));
+
+    /**
+     * {@code minecraft:block.copper_bulb.turn_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_BULB_TURN_ON = create(key("block.copper_bulb.turn_on"));
+
+    /**
+     * {@code minecraft:block.copper_door.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_DOOR_CLOSE = create(key("block.copper_door.close"));
+
+    /**
+     * {@code minecraft:block.copper_door.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_DOOR_OPEN = create(key("block.copper_door.open"));
+
+    /**
+     * {@code minecraft:block.copper_grate.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_GRATE_BREAK = create(key("block.copper_grate.break"));
+
+    /**
+     * {@code minecraft:block.copper_grate.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_GRATE_FALL = create(key("block.copper_grate.fall"));
+
+    /**
+     * {@code minecraft:block.copper_grate.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_GRATE_HIT = create(key("block.copper_grate.hit"));
+
+    /**
+     * {@code minecraft:block.copper_grate.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_GRATE_PLACE = create(key("block.copper_grate.place"));
+
+    /**
+     * {@code minecraft:block.copper_grate.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_GRATE_STEP = create(key("block.copper_grate.step"));
+
+    /**
+     * {@code minecraft:block.copper_trapdoor.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_TRAPDOOR_CLOSE = create(key("block.copper_trapdoor.close"));
+
+    /**
+     * {@code minecraft:block.copper_trapdoor.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_COPPER_TRAPDOOR_OPEN = create(key("block.copper_trapdoor.open"));
+
+    /**
+     * {@code minecraft:block.coral_block.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CORAL_BLOCK_BREAK = create(key("block.coral_block.break"));
+
+    /**
+     * {@code minecraft:block.coral_block.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CORAL_BLOCK_FALL = create(key("block.coral_block.fall"));
+
+    /**
+     * {@code minecraft:block.coral_block.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CORAL_BLOCK_HIT = create(key("block.coral_block.hit"));
+
+    /**
+     * {@code minecraft:block.coral_block.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CORAL_BLOCK_PLACE = create(key("block.coral_block.place"));
+
+    /**
+     * {@code minecraft:block.coral_block.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CORAL_BLOCK_STEP = create(key("block.coral_block.step"));
+
+    /**
+     * {@code minecraft:block.crafter.craft}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CRAFTER_CRAFT = create(key("block.crafter.craft"));
+
+    /**
+     * {@code minecraft:block.crafter.fail}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CRAFTER_FAIL = create(key("block.crafter.fail"));
+
+    /**
+     * {@code minecraft:block.creaking_heart.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CREAKING_HEART_BREAK = create(key("block.creaking_heart.break"));
+
+    /**
+     * {@code minecraft:block.creaking_heart.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CREAKING_HEART_FALL = create(key("block.creaking_heart.fall"));
+
+    /**
+     * {@code minecraft:block.creaking_heart.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CREAKING_HEART_HIT = create(key("block.creaking_heart.hit"));
+
+    /**
+     * {@code minecraft:block.creaking_heart.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CREAKING_HEART_HURT = create(key("block.creaking_heart.hurt"));
+
+    /**
+     * {@code minecraft:block.creaking_heart.idle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CREAKING_HEART_IDLE = create(key("block.creaking_heart.idle"));
+
+    /**
+     * {@code minecraft:block.creaking_heart.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CREAKING_HEART_PLACE = create(key("block.creaking_heart.place"));
+
+    /**
+     * {@code minecraft:block.creaking_heart.spawn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CREAKING_HEART_SPAWN = create(key("block.creaking_heart.spawn"));
+
+    /**
+     * {@code minecraft:block.creaking_heart.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CREAKING_HEART_STEP = create(key("block.creaking_heart.step"));
+
+    /**
+     * {@code minecraft:block.crop.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_CROP_BREAK = create(key("block.crop.break"));
+
+    /**
+     * {@code minecraft:block.decorated_pot.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DECORATED_POT_BREAK = create(key("block.decorated_pot.break"));
+
+    /**
+     * {@code minecraft:block.decorated_pot.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DECORATED_POT_FALL = create(key("block.decorated_pot.fall"));
+
+    /**
+     * {@code minecraft:block.decorated_pot.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DECORATED_POT_HIT = create(key("block.decorated_pot.hit"));
+
+    /**
+     * {@code minecraft:block.decorated_pot.insert}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DECORATED_POT_INSERT = create(key("block.decorated_pot.insert"));
+
+    /**
+     * {@code minecraft:block.decorated_pot.insert_fail}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DECORATED_POT_INSERT_FAIL = create(key("block.decorated_pot.insert_fail"));
+
+    /**
+     * {@code minecraft:block.decorated_pot.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DECORATED_POT_PLACE = create(key("block.decorated_pot.place"));
+
+    /**
+     * {@code minecraft:block.decorated_pot.shatter}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DECORATED_POT_SHATTER = create(key("block.decorated_pot.shatter"));
+
+    /**
+     * {@code minecraft:block.decorated_pot.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DECORATED_POT_STEP = create(key("block.decorated_pot.step"));
+
+    /**
+     * {@code minecraft:block.deepslate.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_BREAK = create(key("block.deepslate.break"));
+
+    /**
+     * {@code minecraft:block.deepslate.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_FALL = create(key("block.deepslate.fall"));
+
+    /**
+     * {@code minecraft:block.deepslate.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_HIT = create(key("block.deepslate.hit"));
+
+    /**
+     * {@code minecraft:block.deepslate.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_PLACE = create(key("block.deepslate.place"));
+
+    /**
+     * {@code minecraft:block.deepslate.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_STEP = create(key("block.deepslate.step"));
+
+    /**
+     * {@code minecraft:block.deepslate_bricks.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_BRICKS_BREAK = create(key("block.deepslate_bricks.break"));
+
+    /**
+     * {@code minecraft:block.deepslate_bricks.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_BRICKS_FALL = create(key("block.deepslate_bricks.fall"));
+
+    /**
+     * {@code minecraft:block.deepslate_bricks.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_BRICKS_HIT = create(key("block.deepslate_bricks.hit"));
+
+    /**
+     * {@code minecraft:block.deepslate_bricks.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_BRICKS_PLACE = create(key("block.deepslate_bricks.place"));
+
+    /**
+     * {@code minecraft:block.deepslate_bricks.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_BRICKS_STEP = create(key("block.deepslate_bricks.step"));
+
+    /**
+     * {@code minecraft:block.deepslate_tiles.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_TILES_BREAK = create(key("block.deepslate_tiles.break"));
+
+    /**
+     * {@code minecraft:block.deepslate_tiles.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_TILES_FALL = create(key("block.deepslate_tiles.fall"));
+
+    /**
+     * {@code minecraft:block.deepslate_tiles.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_TILES_HIT = create(key("block.deepslate_tiles.hit"));
+
+    /**
+     * {@code minecraft:block.deepslate_tiles.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_TILES_PLACE = create(key("block.deepslate_tiles.place"));
+
+    /**
+     * {@code minecraft:block.deepslate_tiles.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DEEPSLATE_TILES_STEP = create(key("block.deepslate_tiles.step"));
+
+    /**
+     * {@code minecraft:block.dispenser.dispense}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DISPENSER_DISPENSE = create(key("block.dispenser.dispense"));
+
+    /**
+     * {@code minecraft:block.dispenser.fail}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DISPENSER_FAIL = create(key("block.dispenser.fail"));
+
+    /**
+     * {@code minecraft:block.dispenser.launch}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DISPENSER_LAUNCH = create(key("block.dispenser.launch"));
+
+    /**
+     * {@code minecraft:block.dripstone_block.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DRIPSTONE_BLOCK_BREAK = create(key("block.dripstone_block.break"));
+
+    /**
+     * {@code minecraft:block.dripstone_block.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DRIPSTONE_BLOCK_FALL = create(key("block.dripstone_block.fall"));
+
+    /**
+     * {@code minecraft:block.dripstone_block.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DRIPSTONE_BLOCK_HIT = create(key("block.dripstone_block.hit"));
+
+    /**
+     * {@code minecraft:block.dripstone_block.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DRIPSTONE_BLOCK_PLACE = create(key("block.dripstone_block.place"));
+
+    /**
+     * {@code minecraft:block.dripstone_block.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_DRIPSTONE_BLOCK_STEP = create(key("block.dripstone_block.step"));
+
+    /**
+     * {@code minecraft:block.enchantment_table.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ENCHANTMENT_TABLE_USE = create(key("block.enchantment_table.use"));
+
+    /**
+     * {@code minecraft:block.end_gateway.spawn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_END_GATEWAY_SPAWN = create(key("block.end_gateway.spawn"));
+
+    /**
+     * {@code minecraft:block.end_portal.spawn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_END_PORTAL_SPAWN = create(key("block.end_portal.spawn"));
+
+    /**
+     * {@code minecraft:block.end_portal_frame.fill}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_END_PORTAL_FRAME_FILL = create(key("block.end_portal_frame.fill"));
+
+    /**
+     * {@code minecraft:block.ender_chest.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ENDER_CHEST_CLOSE = create(key("block.ender_chest.close"));
+
+    /**
+     * {@code minecraft:block.ender_chest.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ENDER_CHEST_OPEN = create(key("block.ender_chest.open"));
+
+    /**
+     * {@code minecraft:block.fence_gate.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FENCE_GATE_CLOSE = create(key("block.fence_gate.close"));
+
+    /**
+     * {@code minecraft:block.fence_gate.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FENCE_GATE_OPEN = create(key("block.fence_gate.open"));
+
+    /**
+     * {@code minecraft:block.fire.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FIRE_AMBIENT = create(key("block.fire.ambient"));
+
+    /**
+     * {@code minecraft:block.fire.extinguish}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FIRE_EXTINGUISH = create(key("block.fire.extinguish"));
+
+    /**
+     * {@code minecraft:block.flowering_azalea.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FLOWERING_AZALEA_BREAK = create(key("block.flowering_azalea.break"));
+
+    /**
+     * {@code minecraft:block.flowering_azalea.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FLOWERING_AZALEA_FALL = create(key("block.flowering_azalea.fall"));
+
+    /**
+     * {@code minecraft:block.flowering_azalea.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FLOWERING_AZALEA_HIT = create(key("block.flowering_azalea.hit"));
+
+    /**
+     * {@code minecraft:block.flowering_azalea.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FLOWERING_AZALEA_PLACE = create(key("block.flowering_azalea.place"));
+
+    /**
+     * {@code minecraft:block.flowering_azalea.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FLOWERING_AZALEA_STEP = create(key("block.flowering_azalea.step"));
+
+    /**
+     * {@code minecraft:block.froglight.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FROGLIGHT_BREAK = create(key("block.froglight.break"));
+
+    /**
+     * {@code minecraft:block.froglight.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FROGLIGHT_FALL = create(key("block.froglight.fall"));
+
+    /**
+     * {@code minecraft:block.froglight.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FROGLIGHT_HIT = create(key("block.froglight.hit"));
+
+    /**
+     * {@code minecraft:block.froglight.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FROGLIGHT_PLACE = create(key("block.froglight.place"));
+
+    /**
+     * {@code minecraft:block.froglight.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FROGLIGHT_STEP = create(key("block.froglight.step"));
+
+    /**
+     * {@code minecraft:block.frogspawn.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FROGSPAWN_BREAK = create(key("block.frogspawn.break"));
+
+    /**
+     * {@code minecraft:block.frogspawn.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FROGSPAWN_FALL = create(key("block.frogspawn.fall"));
+
+    /**
+     * {@code minecraft:block.frogspawn.hatch}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FROGSPAWN_HATCH = create(key("block.frogspawn.hatch"));
+
+    /**
+     * {@code minecraft:block.frogspawn.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FROGSPAWN_HIT = create(key("block.frogspawn.hit"));
+
+    /**
+     * {@code minecraft:block.frogspawn.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FROGSPAWN_PLACE = create(key("block.frogspawn.place"));
+
+    /**
+     * {@code minecraft:block.frogspawn.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FROGSPAWN_STEP = create(key("block.frogspawn.step"));
+
+    /**
+     * {@code minecraft:block.fungus.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FUNGUS_BREAK = create(key("block.fungus.break"));
+
+    /**
+     * {@code minecraft:block.fungus.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FUNGUS_FALL = create(key("block.fungus.fall"));
+
+    /**
+     * {@code minecraft:block.fungus.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FUNGUS_HIT = create(key("block.fungus.hit"));
+
+    /**
+     * {@code minecraft:block.fungus.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FUNGUS_PLACE = create(key("block.fungus.place"));
+
+    /**
+     * {@code minecraft:block.fungus.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FUNGUS_STEP = create(key("block.fungus.step"));
+
+    /**
+     * {@code minecraft:block.furnace.fire_crackle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_FURNACE_FIRE_CRACKLE = create(key("block.furnace.fire_crackle"));
+
+    /**
+     * {@code minecraft:block.gilded_blackstone.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GILDED_BLACKSTONE_BREAK = create(key("block.gilded_blackstone.break"));
+
+    /**
+     * {@code minecraft:block.gilded_blackstone.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GILDED_BLACKSTONE_FALL = create(key("block.gilded_blackstone.fall"));
+
+    /**
+     * {@code minecraft:block.gilded_blackstone.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GILDED_BLACKSTONE_HIT = create(key("block.gilded_blackstone.hit"));
+
+    /**
+     * {@code minecraft:block.gilded_blackstone.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GILDED_BLACKSTONE_PLACE = create(key("block.gilded_blackstone.place"));
+
+    /**
+     * {@code minecraft:block.gilded_blackstone.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GILDED_BLACKSTONE_STEP = create(key("block.gilded_blackstone.step"));
+
+    /**
+     * {@code minecraft:block.glass.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GLASS_BREAK = create(key("block.glass.break"));
+
+    /**
+     * {@code minecraft:block.glass.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GLASS_FALL = create(key("block.glass.fall"));
+
+    /**
+     * {@code minecraft:block.glass.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GLASS_HIT = create(key("block.glass.hit"));
+
+    /**
+     * {@code minecraft:block.glass.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GLASS_PLACE = create(key("block.glass.place"));
+
+    /**
+     * {@code minecraft:block.glass.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GLASS_STEP = create(key("block.glass.step"));
+
+    /**
+     * {@code minecraft:block.grass.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GRASS_BREAK = create(key("block.grass.break"));
+
+    /**
+     * {@code minecraft:block.grass.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GRASS_FALL = create(key("block.grass.fall"));
+
+    /**
+     * {@code minecraft:block.grass.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GRASS_HIT = create(key("block.grass.hit"));
+
+    /**
+     * {@code minecraft:block.grass.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GRASS_PLACE = create(key("block.grass.place"));
+
+    /**
+     * {@code minecraft:block.grass.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GRASS_STEP = create(key("block.grass.step"));
+
+    /**
+     * {@code minecraft:block.gravel.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GRAVEL_BREAK = create(key("block.gravel.break"));
+
+    /**
+     * {@code minecraft:block.gravel.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GRAVEL_FALL = create(key("block.gravel.fall"));
+
+    /**
+     * {@code minecraft:block.gravel.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GRAVEL_HIT = create(key("block.gravel.hit"));
+
+    /**
+     * {@code minecraft:block.gravel.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GRAVEL_PLACE = create(key("block.gravel.place"));
+
+    /**
+     * {@code minecraft:block.gravel.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GRAVEL_STEP = create(key("block.gravel.step"));
+
+    /**
+     * {@code minecraft:block.grindstone.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GRINDSTONE_USE = create(key("block.grindstone.use"));
+
+    /**
+     * {@code minecraft:block.growing_plant.crop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_GROWING_PLANT_CROP = create(key("block.growing_plant.crop"));
+
+    /**
+     * {@code minecraft:block.hanging_roots.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HANGING_ROOTS_BREAK = create(key("block.hanging_roots.break"));
+
+    /**
+     * {@code minecraft:block.hanging_roots.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HANGING_ROOTS_FALL = create(key("block.hanging_roots.fall"));
+
+    /**
+     * {@code minecraft:block.hanging_roots.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HANGING_ROOTS_HIT = create(key("block.hanging_roots.hit"));
+
+    /**
+     * {@code minecraft:block.hanging_roots.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HANGING_ROOTS_PLACE = create(key("block.hanging_roots.place"));
+
+    /**
+     * {@code minecraft:block.hanging_roots.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HANGING_ROOTS_STEP = create(key("block.hanging_roots.step"));
+
+    /**
+     * {@code minecraft:block.hanging_sign.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HANGING_SIGN_BREAK = create(key("block.hanging_sign.break"));
+
+    /**
+     * {@code minecraft:block.hanging_sign.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HANGING_SIGN_FALL = create(key("block.hanging_sign.fall"));
+
+    /**
+     * {@code minecraft:block.hanging_sign.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HANGING_SIGN_HIT = create(key("block.hanging_sign.hit"));
+
+    /**
+     * {@code minecraft:block.hanging_sign.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HANGING_SIGN_PLACE = create(key("block.hanging_sign.place"));
+
+    /**
+     * {@code minecraft:block.hanging_sign.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HANGING_SIGN_STEP = create(key("block.hanging_sign.step"));
+
+    /**
+     * {@code minecraft:block.hanging_sign.waxed_interact_fail}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HANGING_SIGN_WAXED_INTERACT_FAIL = create(key("block.hanging_sign.waxed_interact_fail"));
+
+    /**
+     * {@code minecraft:block.heavy_core.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HEAVY_CORE_BREAK = create(key("block.heavy_core.break"));
+
+    /**
+     * {@code minecraft:block.heavy_core.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HEAVY_CORE_FALL = create(key("block.heavy_core.fall"));
+
+    /**
+     * {@code minecraft:block.heavy_core.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HEAVY_CORE_HIT = create(key("block.heavy_core.hit"));
+
+    /**
+     * {@code minecraft:block.heavy_core.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HEAVY_CORE_PLACE = create(key("block.heavy_core.place"));
+
+    /**
+     * {@code minecraft:block.heavy_core.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HEAVY_CORE_STEP = create(key("block.heavy_core.step"));
+
+    /**
+     * {@code minecraft:block.honey_block.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HONEY_BLOCK_BREAK = create(key("block.honey_block.break"));
+
+    /**
+     * {@code minecraft:block.honey_block.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HONEY_BLOCK_FALL = create(key("block.honey_block.fall"));
+
+    /**
+     * {@code minecraft:block.honey_block.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HONEY_BLOCK_HIT = create(key("block.honey_block.hit"));
+
+    /**
+     * {@code minecraft:block.honey_block.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HONEY_BLOCK_PLACE = create(key("block.honey_block.place"));
+
+    /**
+     * {@code minecraft:block.honey_block.slide}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HONEY_BLOCK_SLIDE = create(key("block.honey_block.slide"));
+
+    /**
+     * {@code minecraft:block.honey_block.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_HONEY_BLOCK_STEP = create(key("block.honey_block.step"));
+
+    /**
+     * {@code minecraft:block.iron_door.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_IRON_DOOR_CLOSE = create(key("block.iron_door.close"));
+
+    /**
+     * {@code minecraft:block.iron_door.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_IRON_DOOR_OPEN = create(key("block.iron_door.open"));
+
+    /**
+     * {@code minecraft:block.iron_trapdoor.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_IRON_TRAPDOOR_CLOSE = create(key("block.iron_trapdoor.close"));
+
+    /**
+     * {@code minecraft:block.iron_trapdoor.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_IRON_TRAPDOOR_OPEN = create(key("block.iron_trapdoor.open"));
+
+    /**
+     * {@code minecraft:block.ladder.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LADDER_BREAK = create(key("block.ladder.break"));
+
+    /**
+     * {@code minecraft:block.ladder.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LADDER_FALL = create(key("block.ladder.fall"));
+
+    /**
+     * {@code minecraft:block.ladder.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LADDER_HIT = create(key("block.ladder.hit"));
+
+    /**
+     * {@code minecraft:block.ladder.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LADDER_PLACE = create(key("block.ladder.place"));
+
+    /**
+     * {@code minecraft:block.ladder.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LADDER_STEP = create(key("block.ladder.step"));
+
+    /**
+     * {@code minecraft:block.lantern.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LANTERN_BREAK = create(key("block.lantern.break"));
+
+    /**
+     * {@code minecraft:block.lantern.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LANTERN_FALL = create(key("block.lantern.fall"));
+
+    /**
+     * {@code minecraft:block.lantern.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LANTERN_HIT = create(key("block.lantern.hit"));
+
+    /**
+     * {@code minecraft:block.lantern.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LANTERN_PLACE = create(key("block.lantern.place"));
+
+    /**
+     * {@code minecraft:block.lantern.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LANTERN_STEP = create(key("block.lantern.step"));
+
+    /**
+     * {@code minecraft:block.large_amethyst_bud.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LARGE_AMETHYST_BUD_BREAK = create(key("block.large_amethyst_bud.break"));
+
+    /**
+     * {@code minecraft:block.large_amethyst_bud.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LARGE_AMETHYST_BUD_PLACE = create(key("block.large_amethyst_bud.place"));
+
+    /**
+     * {@code minecraft:block.lava.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LAVA_AMBIENT = create(key("block.lava.ambient"));
+
+    /**
+     * {@code minecraft:block.lava.extinguish}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LAVA_EXTINGUISH = create(key("block.lava.extinguish"));
+
+    /**
+     * {@code minecraft:block.lava.pop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LAVA_POP = create(key("block.lava.pop"));
+
+    /**
+     * {@code minecraft:block.lever.click}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LEVER_CLICK = create(key("block.lever.click"));
+
+    /**
+     * {@code minecraft:block.lily_pad.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LILY_PAD_PLACE = create(key("block.lily_pad.place"));
+
+    /**
+     * {@code minecraft:block.lodestone.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LODESTONE_BREAK = create(key("block.lodestone.break"));
+
+    /**
+     * {@code minecraft:block.lodestone.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LODESTONE_FALL = create(key("block.lodestone.fall"));
+
+    /**
+     * {@code minecraft:block.lodestone.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LODESTONE_HIT = create(key("block.lodestone.hit"));
+
+    /**
+     * {@code minecraft:block.lodestone.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LODESTONE_PLACE = create(key("block.lodestone.place"));
+
+    /**
+     * {@code minecraft:block.lodestone.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_LODESTONE_STEP = create(key("block.lodestone.step"));
+
+    /**
+     * {@code minecraft:block.mangrove_roots.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MANGROVE_ROOTS_BREAK = create(key("block.mangrove_roots.break"));
+
+    /**
+     * {@code minecraft:block.mangrove_roots.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MANGROVE_ROOTS_FALL = create(key("block.mangrove_roots.fall"));
+
+    /**
+     * {@code minecraft:block.mangrove_roots.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MANGROVE_ROOTS_HIT = create(key("block.mangrove_roots.hit"));
+
+    /**
+     * {@code minecraft:block.mangrove_roots.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MANGROVE_ROOTS_PLACE = create(key("block.mangrove_roots.place"));
+
+    /**
+     * {@code minecraft:block.mangrove_roots.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MANGROVE_ROOTS_STEP = create(key("block.mangrove_roots.step"));
+
+    /**
+     * {@code minecraft:block.medium_amethyst_bud.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MEDIUM_AMETHYST_BUD_BREAK = create(key("block.medium_amethyst_bud.break"));
+
+    /**
+     * {@code minecraft:block.medium_amethyst_bud.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MEDIUM_AMETHYST_BUD_PLACE = create(key("block.medium_amethyst_bud.place"));
+
+    /**
+     * {@code minecraft:block.metal.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_METAL_BREAK = create(key("block.metal.break"));
+
+    /**
+     * {@code minecraft:block.metal.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_METAL_FALL = create(key("block.metal.fall"));
+
+    /**
+     * {@code minecraft:block.metal.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_METAL_HIT = create(key("block.metal.hit"));
+
+    /**
+     * {@code minecraft:block.metal.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_METAL_PLACE = create(key("block.metal.place"));
+
+    /**
+     * {@code minecraft:block.metal.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_METAL_STEP = create(key("block.metal.step"));
+
+    /**
+     * {@code minecraft:block.metal_pressure_plate.click_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_METAL_PRESSURE_PLATE_CLICK_OFF = create(key("block.metal_pressure_plate.click_off"));
+
+    /**
+     * {@code minecraft:block.metal_pressure_plate.click_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_METAL_PRESSURE_PLATE_CLICK_ON = create(key("block.metal_pressure_plate.click_on"));
+
+    /**
+     * {@code minecraft:block.moss.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MOSS_BREAK = create(key("block.moss.break"));
+
+    /**
+     * {@code minecraft:block.moss.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MOSS_FALL = create(key("block.moss.fall"));
+
+    /**
+     * {@code minecraft:block.moss.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MOSS_HIT = create(key("block.moss.hit"));
+
+    /**
+     * {@code minecraft:block.moss.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MOSS_PLACE = create(key("block.moss.place"));
+
+    /**
+     * {@code minecraft:block.moss.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MOSS_STEP = create(key("block.moss.step"));
+
+    /**
+     * {@code minecraft:block.moss_carpet.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MOSS_CARPET_BREAK = create(key("block.moss_carpet.break"));
+
+    /**
+     * {@code minecraft:block.moss_carpet.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MOSS_CARPET_FALL = create(key("block.moss_carpet.fall"));
+
+    /**
+     * {@code minecraft:block.moss_carpet.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MOSS_CARPET_HIT = create(key("block.moss_carpet.hit"));
+
+    /**
+     * {@code minecraft:block.moss_carpet.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MOSS_CARPET_PLACE = create(key("block.moss_carpet.place"));
+
+    /**
+     * {@code minecraft:block.moss_carpet.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MOSS_CARPET_STEP = create(key("block.moss_carpet.step"));
+
+    /**
+     * {@code minecraft:block.mud.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUD_BREAK = create(key("block.mud.break"));
+
+    /**
+     * {@code minecraft:block.mud.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUD_FALL = create(key("block.mud.fall"));
+
+    /**
+     * {@code minecraft:block.mud.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUD_HIT = create(key("block.mud.hit"));
+
+    /**
+     * {@code minecraft:block.mud.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUD_PLACE = create(key("block.mud.place"));
+
+    /**
+     * {@code minecraft:block.mud.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUD_STEP = create(key("block.mud.step"));
+
+    /**
+     * {@code minecraft:block.mud_bricks.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUD_BRICKS_BREAK = create(key("block.mud_bricks.break"));
+
+    /**
+     * {@code minecraft:block.mud_bricks.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUD_BRICKS_FALL = create(key("block.mud_bricks.fall"));
+
+    /**
+     * {@code minecraft:block.mud_bricks.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUD_BRICKS_HIT = create(key("block.mud_bricks.hit"));
+
+    /**
+     * {@code minecraft:block.mud_bricks.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUD_BRICKS_PLACE = create(key("block.mud_bricks.place"));
+
+    /**
+     * {@code minecraft:block.mud_bricks.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUD_BRICKS_STEP = create(key("block.mud_bricks.step"));
+
+    /**
+     * {@code minecraft:block.muddy_mangrove_roots.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUDDY_MANGROVE_ROOTS_BREAK = create(key("block.muddy_mangrove_roots.break"));
+
+    /**
+     * {@code minecraft:block.muddy_mangrove_roots.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUDDY_MANGROVE_ROOTS_FALL = create(key("block.muddy_mangrove_roots.fall"));
+
+    /**
+     * {@code minecraft:block.muddy_mangrove_roots.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUDDY_MANGROVE_ROOTS_HIT = create(key("block.muddy_mangrove_roots.hit"));
+
+    /**
+     * {@code minecraft:block.muddy_mangrove_roots.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUDDY_MANGROVE_ROOTS_PLACE = create(key("block.muddy_mangrove_roots.place"));
+
+    /**
+     * {@code minecraft:block.muddy_mangrove_roots.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_MUDDY_MANGROVE_ROOTS_STEP = create(key("block.muddy_mangrove_roots.step"));
+
+    /**
+     * {@code minecraft:block.nether_bricks.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_BRICKS_BREAK = create(key("block.nether_bricks.break"));
+
+    /**
+     * {@code minecraft:block.nether_bricks.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_BRICKS_FALL = create(key("block.nether_bricks.fall"));
+
+    /**
+     * {@code minecraft:block.nether_bricks.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_BRICKS_HIT = create(key("block.nether_bricks.hit"));
+
+    /**
+     * {@code minecraft:block.nether_bricks.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_BRICKS_PLACE = create(key("block.nether_bricks.place"));
+
+    /**
+     * {@code minecraft:block.nether_bricks.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_BRICKS_STEP = create(key("block.nether_bricks.step"));
+
+    /**
+     * {@code minecraft:block.nether_gold_ore.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_GOLD_ORE_BREAK = create(key("block.nether_gold_ore.break"));
+
+    /**
+     * {@code minecraft:block.nether_gold_ore.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_GOLD_ORE_FALL = create(key("block.nether_gold_ore.fall"));
+
+    /**
+     * {@code minecraft:block.nether_gold_ore.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_GOLD_ORE_HIT = create(key("block.nether_gold_ore.hit"));
+
+    /**
+     * {@code minecraft:block.nether_gold_ore.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_GOLD_ORE_PLACE = create(key("block.nether_gold_ore.place"));
+
+    /**
+     * {@code minecraft:block.nether_gold_ore.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_GOLD_ORE_STEP = create(key("block.nether_gold_ore.step"));
+
+    /**
+     * {@code minecraft:block.nether_ore.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_ORE_BREAK = create(key("block.nether_ore.break"));
+
+    /**
+     * {@code minecraft:block.nether_ore.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_ORE_FALL = create(key("block.nether_ore.fall"));
+
+    /**
+     * {@code minecraft:block.nether_ore.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_ORE_HIT = create(key("block.nether_ore.hit"));
+
+    /**
+     * {@code minecraft:block.nether_ore.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_ORE_PLACE = create(key("block.nether_ore.place"));
+
+    /**
+     * {@code minecraft:block.nether_ore.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_ORE_STEP = create(key("block.nether_ore.step"));
+
+    /**
+     * {@code minecraft:block.nether_sprouts.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_SPROUTS_BREAK = create(key("block.nether_sprouts.break"));
+
+    /**
+     * {@code minecraft:block.nether_sprouts.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_SPROUTS_FALL = create(key("block.nether_sprouts.fall"));
+
+    /**
+     * {@code minecraft:block.nether_sprouts.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_SPROUTS_HIT = create(key("block.nether_sprouts.hit"));
+
+    /**
+     * {@code minecraft:block.nether_sprouts.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_SPROUTS_PLACE = create(key("block.nether_sprouts.place"));
+
+    /**
+     * {@code minecraft:block.nether_sprouts.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_SPROUTS_STEP = create(key("block.nether_sprouts.step"));
+
+    /**
+     * {@code minecraft:block.nether_wart.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WART_BREAK = create(key("block.nether_wart.break"));
+
+    /**
+     * {@code minecraft:block.nether_wood.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_BREAK = create(key("block.nether_wood.break"));
+
+    /**
+     * {@code minecraft:block.nether_wood.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_FALL = create(key("block.nether_wood.fall"));
+
+    /**
+     * {@code minecraft:block.nether_wood.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_HIT = create(key("block.nether_wood.hit"));
+
+    /**
+     * {@code minecraft:block.nether_wood.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_PLACE = create(key("block.nether_wood.place"));
+
+    /**
+     * {@code minecraft:block.nether_wood.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_STEP = create(key("block.nether_wood.step"));
+
+    /**
+     * {@code minecraft:block.nether_wood_button.click_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_BUTTON_CLICK_OFF = create(key("block.nether_wood_button.click_off"));
+
+    /**
+     * {@code minecraft:block.nether_wood_button.click_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_BUTTON_CLICK_ON = create(key("block.nether_wood_button.click_on"));
+
+    /**
+     * {@code minecraft:block.nether_wood_door.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_DOOR_CLOSE = create(key("block.nether_wood_door.close"));
+
+    /**
+     * {@code minecraft:block.nether_wood_door.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_DOOR_OPEN = create(key("block.nether_wood_door.open"));
+
+    /**
+     * {@code minecraft:block.nether_wood_fence_gate.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_FENCE_GATE_CLOSE = create(key("block.nether_wood_fence_gate.close"));
+
+    /**
+     * {@code minecraft:block.nether_wood_fence_gate.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_FENCE_GATE_OPEN = create(key("block.nether_wood_fence_gate.open"));
+
+    /**
+     * {@code minecraft:block.nether_wood_hanging_sign.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_HANGING_SIGN_BREAK = create(key("block.nether_wood_hanging_sign.break"));
+
+    /**
+     * {@code minecraft:block.nether_wood_hanging_sign.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_HANGING_SIGN_FALL = create(key("block.nether_wood_hanging_sign.fall"));
+
+    /**
+     * {@code minecraft:block.nether_wood_hanging_sign.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_HANGING_SIGN_HIT = create(key("block.nether_wood_hanging_sign.hit"));
+
+    /**
+     * {@code minecraft:block.nether_wood_hanging_sign.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_HANGING_SIGN_PLACE = create(key("block.nether_wood_hanging_sign.place"));
+
+    /**
+     * {@code minecraft:block.nether_wood_hanging_sign.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_HANGING_SIGN_STEP = create(key("block.nether_wood_hanging_sign.step"));
+
+    /**
+     * {@code minecraft:block.nether_wood_pressure_plate.click_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_PRESSURE_PLATE_CLICK_OFF = create(key("block.nether_wood_pressure_plate.click_off"));
+
+    /**
+     * {@code minecraft:block.nether_wood_pressure_plate.click_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_PRESSURE_PLATE_CLICK_ON = create(key("block.nether_wood_pressure_plate.click_on"));
+
+    /**
+     * {@code minecraft:block.nether_wood_trapdoor.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_TRAPDOOR_CLOSE = create(key("block.nether_wood_trapdoor.close"));
+
+    /**
+     * {@code minecraft:block.nether_wood_trapdoor.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHER_WOOD_TRAPDOOR_OPEN = create(key("block.nether_wood_trapdoor.open"));
+
+    /**
+     * {@code minecraft:block.netherite_block.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHERITE_BLOCK_BREAK = create(key("block.netherite_block.break"));
+
+    /**
+     * {@code minecraft:block.netherite_block.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHERITE_BLOCK_FALL = create(key("block.netherite_block.fall"));
+
+    /**
+     * {@code minecraft:block.netherite_block.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHERITE_BLOCK_HIT = create(key("block.netherite_block.hit"));
+
+    /**
+     * {@code minecraft:block.netherite_block.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHERITE_BLOCK_PLACE = create(key("block.netherite_block.place"));
+
+    /**
+     * {@code minecraft:block.netherite_block.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHERITE_BLOCK_STEP = create(key("block.netherite_block.step"));
+
+    /**
+     * {@code minecraft:block.netherrack.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHERRACK_BREAK = create(key("block.netherrack.break"));
+
+    /**
+     * {@code minecraft:block.netherrack.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHERRACK_FALL = create(key("block.netherrack.fall"));
+
+    /**
+     * {@code minecraft:block.netherrack.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHERRACK_HIT = create(key("block.netherrack.hit"));
+
+    /**
+     * {@code minecraft:block.netherrack.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHERRACK_PLACE = create(key("block.netherrack.place"));
+
+    /**
+     * {@code minecraft:block.netherrack.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NETHERRACK_STEP = create(key("block.netherrack.step"));
+
+    /**
+     * {@code minecraft:block.note_block.banjo}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_BANJO = create(key("block.note_block.banjo"));
+
+    /**
+     * {@code minecraft:block.note_block.basedrum}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_BASEDRUM = create(key("block.note_block.basedrum"));
+
+    /**
+     * {@code minecraft:block.note_block.bass}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_BASS = create(key("block.note_block.bass"));
+
+    /**
+     * {@code minecraft:block.note_block.bell}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_BELL = create(key("block.note_block.bell"));
+
+    /**
+     * {@code minecraft:block.note_block.bit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_BIT = create(key("block.note_block.bit"));
+
+    /**
+     * {@code minecraft:block.note_block.chime}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_CHIME = create(key("block.note_block.chime"));
+
+    /**
+     * {@code minecraft:block.note_block.cow_bell}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_COW_BELL = create(key("block.note_block.cow_bell"));
+
+    /**
+     * {@code minecraft:block.note_block.didgeridoo}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_DIDGERIDOO = create(key("block.note_block.didgeridoo"));
+
+    /**
+     * {@code minecraft:block.note_block.flute}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_FLUTE = create(key("block.note_block.flute"));
+
+    /**
+     * {@code minecraft:block.note_block.guitar}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_GUITAR = create(key("block.note_block.guitar"));
+
+    /**
+     * {@code minecraft:block.note_block.harp}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_HARP = create(key("block.note_block.harp"));
+
+    /**
+     * {@code minecraft:block.note_block.hat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_HAT = create(key("block.note_block.hat"));
+
+    /**
+     * {@code minecraft:block.note_block.imitate.creeper}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_IMITATE_CREEPER = create(key("block.note_block.imitate.creeper"));
+
+    /**
+     * {@code minecraft:block.note_block.imitate.ender_dragon}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_IMITATE_ENDER_DRAGON = create(key("block.note_block.imitate.ender_dragon"));
+
+    /**
+     * {@code minecraft:block.note_block.imitate.piglin}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_IMITATE_PIGLIN = create(key("block.note_block.imitate.piglin"));
+
+    /**
+     * {@code minecraft:block.note_block.imitate.skeleton}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_IMITATE_SKELETON = create(key("block.note_block.imitate.skeleton"));
+
+    /**
+     * {@code minecraft:block.note_block.imitate.wither_skeleton}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_IMITATE_WITHER_SKELETON = create(key("block.note_block.imitate.wither_skeleton"));
+
+    /**
+     * {@code minecraft:block.note_block.imitate.zombie}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_IMITATE_ZOMBIE = create(key("block.note_block.imitate.zombie"));
+
+    /**
+     * {@code minecraft:block.note_block.iron_xylophone}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_IRON_XYLOPHONE = create(key("block.note_block.iron_xylophone"));
+
+    /**
+     * {@code minecraft:block.note_block.pling}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_PLING = create(key("block.note_block.pling"));
+
+    /**
+     * {@code minecraft:block.note_block.snare}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_SNARE = create(key("block.note_block.snare"));
+
+    /**
+     * {@code minecraft:block.note_block.xylophone}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NOTE_BLOCK_XYLOPHONE = create(key("block.note_block.xylophone"));
+
+    /**
+     * {@code minecraft:block.nylium.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NYLIUM_BREAK = create(key("block.nylium.break"));
+
+    /**
+     * {@code minecraft:block.nylium.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NYLIUM_FALL = create(key("block.nylium.fall"));
+
+    /**
+     * {@code minecraft:block.nylium.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NYLIUM_HIT = create(key("block.nylium.hit"));
+
+    /**
+     * {@code minecraft:block.nylium.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NYLIUM_PLACE = create(key("block.nylium.place"));
+
+    /**
+     * {@code minecraft:block.nylium.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_NYLIUM_STEP = create(key("block.nylium.step"));
+
+    /**
+     * {@code minecraft:block.packed_mud.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PACKED_MUD_BREAK = create(key("block.packed_mud.break"));
+
+    /**
+     * {@code minecraft:block.packed_mud.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PACKED_MUD_FALL = create(key("block.packed_mud.fall"));
+
+    /**
+     * {@code minecraft:block.packed_mud.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PACKED_MUD_HIT = create(key("block.packed_mud.hit"));
+
+    /**
+     * {@code minecraft:block.packed_mud.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PACKED_MUD_PLACE = create(key("block.packed_mud.place"));
+
+    /**
+     * {@code minecraft:block.packed_mud.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PACKED_MUD_STEP = create(key("block.packed_mud.step"));
+
+    /**
+     * {@code minecraft:block.pale_hanging_moss.idle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PALE_HANGING_MOSS_IDLE = create(key("block.pale_hanging_moss.idle"));
+
+    /**
+     * {@code minecraft:block.pink_petals.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PINK_PETALS_BREAK = create(key("block.pink_petals.break"));
+
+    /**
+     * {@code minecraft:block.pink_petals.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PINK_PETALS_FALL = create(key("block.pink_petals.fall"));
+
+    /**
+     * {@code minecraft:block.pink_petals.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PINK_PETALS_HIT = create(key("block.pink_petals.hit"));
+
+    /**
+     * {@code minecraft:block.pink_petals.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PINK_PETALS_PLACE = create(key("block.pink_petals.place"));
+
+    /**
+     * {@code minecraft:block.pink_petals.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PINK_PETALS_STEP = create(key("block.pink_petals.step"));
+
+    /**
+     * {@code minecraft:block.piston.contract}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PISTON_CONTRACT = create(key("block.piston.contract"));
+
+    /**
+     * {@code minecraft:block.piston.extend}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PISTON_EXTEND = create(key("block.piston.extend"));
+
+    /**
+     * {@code minecraft:block.pointed_dripstone.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POINTED_DRIPSTONE_BREAK = create(key("block.pointed_dripstone.break"));
+
+    /**
+     * {@code minecraft:block.pointed_dripstone.drip_lava}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POINTED_DRIPSTONE_DRIP_LAVA = create(key("block.pointed_dripstone.drip_lava"));
+
+    /**
+     * {@code minecraft:block.pointed_dripstone.drip_lava_into_cauldron}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POINTED_DRIPSTONE_DRIP_LAVA_INTO_CAULDRON = create(key("block.pointed_dripstone.drip_lava_into_cauldron"));
+
+    /**
+     * {@code minecraft:block.pointed_dripstone.drip_water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POINTED_DRIPSTONE_DRIP_WATER = create(key("block.pointed_dripstone.drip_water"));
+
+    /**
+     * {@code minecraft:block.pointed_dripstone.drip_water_into_cauldron}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POINTED_DRIPSTONE_DRIP_WATER_INTO_CAULDRON = create(key("block.pointed_dripstone.drip_water_into_cauldron"));
+
+    /**
+     * {@code minecraft:block.pointed_dripstone.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POINTED_DRIPSTONE_FALL = create(key("block.pointed_dripstone.fall"));
+
+    /**
+     * {@code minecraft:block.pointed_dripstone.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POINTED_DRIPSTONE_HIT = create(key("block.pointed_dripstone.hit"));
+
+    /**
+     * {@code minecraft:block.pointed_dripstone.land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POINTED_DRIPSTONE_LAND = create(key("block.pointed_dripstone.land"));
+
+    /**
+     * {@code minecraft:block.pointed_dripstone.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POINTED_DRIPSTONE_PLACE = create(key("block.pointed_dripstone.place"));
+
+    /**
+     * {@code minecraft:block.pointed_dripstone.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POINTED_DRIPSTONE_STEP = create(key("block.pointed_dripstone.step"));
+
+    /**
+     * {@code minecraft:block.polished_deepslate.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POLISHED_DEEPSLATE_BREAK = create(key("block.polished_deepslate.break"));
+
+    /**
+     * {@code minecraft:block.polished_deepslate.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POLISHED_DEEPSLATE_FALL = create(key("block.polished_deepslate.fall"));
+
+    /**
+     * {@code minecraft:block.polished_deepslate.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POLISHED_DEEPSLATE_HIT = create(key("block.polished_deepslate.hit"));
+
+    /**
+     * {@code minecraft:block.polished_deepslate.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POLISHED_DEEPSLATE_PLACE = create(key("block.polished_deepslate.place"));
+
+    /**
+     * {@code minecraft:block.polished_deepslate.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POLISHED_DEEPSLATE_STEP = create(key("block.polished_deepslate.step"));
+
+    /**
+     * {@code minecraft:block.polished_tuff.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POLISHED_TUFF_BREAK = create(key("block.polished_tuff.break"));
+
+    /**
+     * {@code minecraft:block.polished_tuff.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POLISHED_TUFF_FALL = create(key("block.polished_tuff.fall"));
+
+    /**
+     * {@code minecraft:block.polished_tuff.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POLISHED_TUFF_HIT = create(key("block.polished_tuff.hit"));
+
+    /**
+     * {@code minecraft:block.polished_tuff.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POLISHED_TUFF_PLACE = create(key("block.polished_tuff.place"));
+
+    /**
+     * {@code minecraft:block.polished_tuff.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POLISHED_TUFF_STEP = create(key("block.polished_tuff.step"));
+
+    /**
+     * {@code minecraft:block.portal.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PORTAL_AMBIENT = create(key("block.portal.ambient"));
+
+    /**
+     * {@code minecraft:block.portal.travel}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PORTAL_TRAVEL = create(key("block.portal.travel"));
+
+    /**
+     * {@code minecraft:block.portal.trigger}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PORTAL_TRIGGER = create(key("block.portal.trigger"));
+
+    /**
+     * {@code minecraft:block.powder_snow.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POWDER_SNOW_BREAK = create(key("block.powder_snow.break"));
+
+    /**
+     * {@code minecraft:block.powder_snow.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POWDER_SNOW_FALL = create(key("block.powder_snow.fall"));
+
+    /**
+     * {@code minecraft:block.powder_snow.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POWDER_SNOW_HIT = create(key("block.powder_snow.hit"));
+
+    /**
+     * {@code minecraft:block.powder_snow.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POWDER_SNOW_PLACE = create(key("block.powder_snow.place"));
+
+    /**
+     * {@code minecraft:block.powder_snow.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_POWDER_SNOW_STEP = create(key("block.powder_snow.step"));
+
+    /**
+     * {@code minecraft:block.pumpkin.carve}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_PUMPKIN_CARVE = create(key("block.pumpkin.carve"));
+
+    /**
+     * {@code minecraft:block.redstone_torch.burnout}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_REDSTONE_TORCH_BURNOUT = create(key("block.redstone_torch.burnout"));
+
+    /**
+     * {@code minecraft:block.respawn_anchor.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_RESPAWN_ANCHOR_AMBIENT = create(key("block.respawn_anchor.ambient"));
+
+    /**
+     * {@code minecraft:block.respawn_anchor.charge}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_RESPAWN_ANCHOR_CHARGE = create(key("block.respawn_anchor.charge"));
+
+    /**
+     * {@code minecraft:block.respawn_anchor.deplete}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_RESPAWN_ANCHOR_DEPLETE = create(key("block.respawn_anchor.deplete"));
+
+    /**
+     * {@code minecraft:block.respawn_anchor.set_spawn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_RESPAWN_ANCHOR_SET_SPAWN = create(key("block.respawn_anchor.set_spawn"));
+
+    /**
+     * {@code minecraft:block.rooted_dirt.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ROOTED_DIRT_BREAK = create(key("block.rooted_dirt.break"));
+
+    /**
+     * {@code minecraft:block.rooted_dirt.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ROOTED_DIRT_FALL = create(key("block.rooted_dirt.fall"));
+
+    /**
+     * {@code minecraft:block.rooted_dirt.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ROOTED_DIRT_HIT = create(key("block.rooted_dirt.hit"));
+
+    /**
+     * {@code minecraft:block.rooted_dirt.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ROOTED_DIRT_PLACE = create(key("block.rooted_dirt.place"));
+
+    /**
+     * {@code minecraft:block.rooted_dirt.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ROOTED_DIRT_STEP = create(key("block.rooted_dirt.step"));
+
+    /**
+     * {@code minecraft:block.roots.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ROOTS_BREAK = create(key("block.roots.break"));
+
+    /**
+     * {@code minecraft:block.roots.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ROOTS_FALL = create(key("block.roots.fall"));
+
+    /**
+     * {@code minecraft:block.roots.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ROOTS_HIT = create(key("block.roots.hit"));
+
+    /**
+     * {@code minecraft:block.roots.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ROOTS_PLACE = create(key("block.roots.place"));
+
+    /**
+     * {@code minecraft:block.roots.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_ROOTS_STEP = create(key("block.roots.step"));
+
+    /**
+     * {@code minecraft:block.sand.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SAND_BREAK = create(key("block.sand.break"));
+
+    /**
+     * {@code minecraft:block.sand.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SAND_FALL = create(key("block.sand.fall"));
+
+    /**
+     * {@code minecraft:block.sand.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SAND_HIT = create(key("block.sand.hit"));
+
+    /**
+     * {@code minecraft:block.sand.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SAND_PLACE = create(key("block.sand.place"));
+
+    /**
+     * {@code minecraft:block.sand.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SAND_STEP = create(key("block.sand.step"));
+
+    /**
+     * {@code minecraft:block.scaffolding.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCAFFOLDING_BREAK = create(key("block.scaffolding.break"));
+
+    /**
+     * {@code minecraft:block.scaffolding.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCAFFOLDING_FALL = create(key("block.scaffolding.fall"));
+
+    /**
+     * {@code minecraft:block.scaffolding.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCAFFOLDING_HIT = create(key("block.scaffolding.hit"));
+
+    /**
+     * {@code minecraft:block.scaffolding.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCAFFOLDING_PLACE = create(key("block.scaffolding.place"));
+
+    /**
+     * {@code minecraft:block.scaffolding.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCAFFOLDING_STEP = create(key("block.scaffolding.step"));
+
+    /**
+     * {@code minecraft:block.sculk.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_BREAK = create(key("block.sculk.break"));
+
+    /**
+     * {@code minecraft:block.sculk.charge}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_CHARGE = create(key("block.sculk.charge"));
+
+    /**
+     * {@code minecraft:block.sculk.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_FALL = create(key("block.sculk.fall"));
+
+    /**
+     * {@code minecraft:block.sculk.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_HIT = create(key("block.sculk.hit"));
+
+    /**
+     * {@code minecraft:block.sculk.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_PLACE = create(key("block.sculk.place"));
+
+    /**
+     * {@code minecraft:block.sculk.spread}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SPREAD = create(key("block.sculk.spread"));
+
+    /**
+     * {@code minecraft:block.sculk.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_STEP = create(key("block.sculk.step"));
+
+    /**
+     * {@code minecraft:block.sculk_catalyst.bloom}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_CATALYST_BLOOM = create(key("block.sculk_catalyst.bloom"));
+
+    /**
+     * {@code minecraft:block.sculk_catalyst.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_CATALYST_BREAK = create(key("block.sculk_catalyst.break"));
+
+    /**
+     * {@code minecraft:block.sculk_catalyst.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_CATALYST_FALL = create(key("block.sculk_catalyst.fall"));
+
+    /**
+     * {@code minecraft:block.sculk_catalyst.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_CATALYST_HIT = create(key("block.sculk_catalyst.hit"));
+
+    /**
+     * {@code minecraft:block.sculk_catalyst.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_CATALYST_PLACE = create(key("block.sculk_catalyst.place"));
+
+    /**
+     * {@code minecraft:block.sculk_catalyst.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_CATALYST_STEP = create(key("block.sculk_catalyst.step"));
+
+    /**
+     * {@code minecraft:block.sculk_sensor.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SENSOR_BREAK = create(key("block.sculk_sensor.break"));
+
+    /**
+     * {@code minecraft:block.sculk_sensor.clicking}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SENSOR_CLICKING = create(key("block.sculk_sensor.clicking"));
+
+    /**
+     * {@code minecraft:block.sculk_sensor.clicking_stop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SENSOR_CLICKING_STOP = create(key("block.sculk_sensor.clicking_stop"));
+
+    /**
+     * {@code minecraft:block.sculk_sensor.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SENSOR_FALL = create(key("block.sculk_sensor.fall"));
+
+    /**
+     * {@code minecraft:block.sculk_sensor.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SENSOR_HIT = create(key("block.sculk_sensor.hit"));
+
+    /**
+     * {@code minecraft:block.sculk_sensor.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SENSOR_PLACE = create(key("block.sculk_sensor.place"));
+
+    /**
+     * {@code minecraft:block.sculk_sensor.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SENSOR_STEP = create(key("block.sculk_sensor.step"));
+
+    /**
+     * {@code minecraft:block.sculk_shrieker.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SHRIEKER_BREAK = create(key("block.sculk_shrieker.break"));
+
+    /**
+     * {@code minecraft:block.sculk_shrieker.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SHRIEKER_FALL = create(key("block.sculk_shrieker.fall"));
+
+    /**
+     * {@code minecraft:block.sculk_shrieker.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SHRIEKER_HIT = create(key("block.sculk_shrieker.hit"));
+
+    /**
+     * {@code minecraft:block.sculk_shrieker.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SHRIEKER_PLACE = create(key("block.sculk_shrieker.place"));
+
+    /**
+     * {@code minecraft:block.sculk_shrieker.shriek}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SHRIEKER_SHRIEK = create(key("block.sculk_shrieker.shriek"));
+
+    /**
+     * {@code minecraft:block.sculk_shrieker.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_SHRIEKER_STEP = create(key("block.sculk_shrieker.step"));
+
+    /**
+     * {@code minecraft:block.sculk_vein.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_VEIN_BREAK = create(key("block.sculk_vein.break"));
+
+    /**
+     * {@code minecraft:block.sculk_vein.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_VEIN_FALL = create(key("block.sculk_vein.fall"));
+
+    /**
+     * {@code minecraft:block.sculk_vein.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_VEIN_HIT = create(key("block.sculk_vein.hit"));
+
+    /**
+     * {@code minecraft:block.sculk_vein.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_VEIN_PLACE = create(key("block.sculk_vein.place"));
+
+    /**
+     * {@code minecraft:block.sculk_vein.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SCULK_VEIN_STEP = create(key("block.sculk_vein.step"));
+
+    /**
+     * {@code minecraft:block.shroomlight.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SHROOMLIGHT_BREAK = create(key("block.shroomlight.break"));
+
+    /**
+     * {@code minecraft:block.shroomlight.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SHROOMLIGHT_FALL = create(key("block.shroomlight.fall"));
+
+    /**
+     * {@code minecraft:block.shroomlight.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SHROOMLIGHT_HIT = create(key("block.shroomlight.hit"));
+
+    /**
+     * {@code minecraft:block.shroomlight.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SHROOMLIGHT_PLACE = create(key("block.shroomlight.place"));
+
+    /**
+     * {@code minecraft:block.shroomlight.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SHROOMLIGHT_STEP = create(key("block.shroomlight.step"));
+
+    /**
+     * {@code minecraft:block.shulker_box.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SHULKER_BOX_CLOSE = create(key("block.shulker_box.close"));
+
+    /**
+     * {@code minecraft:block.shulker_box.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SHULKER_BOX_OPEN = create(key("block.shulker_box.open"));
+
+    /**
+     * {@code minecraft:block.sign.waxed_interact_fail}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SIGN_WAXED_INTERACT_FAIL = create(key("block.sign.waxed_interact_fail"));
+
+    /**
+     * {@code minecraft:block.slime_block.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SLIME_BLOCK_BREAK = create(key("block.slime_block.break"));
+
+    /**
+     * {@code minecraft:block.slime_block.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SLIME_BLOCK_FALL = create(key("block.slime_block.fall"));
+
+    /**
+     * {@code minecraft:block.slime_block.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SLIME_BLOCK_HIT = create(key("block.slime_block.hit"));
+
+    /**
+     * {@code minecraft:block.slime_block.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SLIME_BLOCK_PLACE = create(key("block.slime_block.place"));
+
+    /**
+     * {@code minecraft:block.slime_block.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SLIME_BLOCK_STEP = create(key("block.slime_block.step"));
+
+    /**
+     * {@code minecraft:block.small_amethyst_bud.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SMALL_AMETHYST_BUD_BREAK = create(key("block.small_amethyst_bud.break"));
+
+    /**
+     * {@code minecraft:block.small_amethyst_bud.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SMALL_AMETHYST_BUD_PLACE = create(key("block.small_amethyst_bud.place"));
+
+    /**
+     * {@code minecraft:block.small_dripleaf.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SMALL_DRIPLEAF_BREAK = create(key("block.small_dripleaf.break"));
+
+    /**
+     * {@code minecraft:block.small_dripleaf.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SMALL_DRIPLEAF_FALL = create(key("block.small_dripleaf.fall"));
+
+    /**
+     * {@code minecraft:block.small_dripleaf.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SMALL_DRIPLEAF_HIT = create(key("block.small_dripleaf.hit"));
+
+    /**
+     * {@code minecraft:block.small_dripleaf.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SMALL_DRIPLEAF_PLACE = create(key("block.small_dripleaf.place"));
+
+    /**
+     * {@code minecraft:block.small_dripleaf.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SMALL_DRIPLEAF_STEP = create(key("block.small_dripleaf.step"));
+
+    /**
+     * {@code minecraft:block.smithing_table.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SMITHING_TABLE_USE = create(key("block.smithing_table.use"));
+
+    /**
+     * {@code minecraft:block.smoker.smoke}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SMOKER_SMOKE = create(key("block.smoker.smoke"));
+
+    /**
+     * {@code minecraft:block.sniffer_egg.crack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SNIFFER_EGG_CRACK = create(key("block.sniffer_egg.crack"));
+
+    /**
+     * {@code minecraft:block.sniffer_egg.hatch}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SNIFFER_EGG_HATCH = create(key("block.sniffer_egg.hatch"));
+
+    /**
+     * {@code minecraft:block.sniffer_egg.plop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SNIFFER_EGG_PLOP = create(key("block.sniffer_egg.plop"));
+
+    /**
+     * {@code minecraft:block.snow.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SNOW_BREAK = create(key("block.snow.break"));
+
+    /**
+     * {@code minecraft:block.snow.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SNOW_FALL = create(key("block.snow.fall"));
+
+    /**
+     * {@code minecraft:block.snow.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SNOW_HIT = create(key("block.snow.hit"));
+
+    /**
+     * {@code minecraft:block.snow.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SNOW_PLACE = create(key("block.snow.place"));
+
+    /**
+     * {@code minecraft:block.snow.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SNOW_STEP = create(key("block.snow.step"));
+
+    /**
+     * {@code minecraft:block.soul_sand.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SOUL_SAND_BREAK = create(key("block.soul_sand.break"));
+
+    /**
+     * {@code minecraft:block.soul_sand.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SOUL_SAND_FALL = create(key("block.soul_sand.fall"));
+
+    /**
+     * {@code minecraft:block.soul_sand.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SOUL_SAND_HIT = create(key("block.soul_sand.hit"));
+
+    /**
+     * {@code minecraft:block.soul_sand.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SOUL_SAND_PLACE = create(key("block.soul_sand.place"));
+
+    /**
+     * {@code minecraft:block.soul_sand.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SOUL_SAND_STEP = create(key("block.soul_sand.step"));
+
+    /**
+     * {@code minecraft:block.soul_soil.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SOUL_SOIL_BREAK = create(key("block.soul_soil.break"));
+
+    /**
+     * {@code minecraft:block.soul_soil.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SOUL_SOIL_FALL = create(key("block.soul_soil.fall"));
+
+    /**
+     * {@code minecraft:block.soul_soil.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SOUL_SOIL_HIT = create(key("block.soul_soil.hit"));
+
+    /**
+     * {@code minecraft:block.soul_soil.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SOUL_SOIL_PLACE = create(key("block.soul_soil.place"));
+
+    /**
+     * {@code minecraft:block.soul_soil.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SOUL_SOIL_STEP = create(key("block.soul_soil.step"));
+
+    /**
+     * {@code minecraft:block.spawner.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPAWNER_BREAK = create(key("block.spawner.break"));
+
+    /**
+     * {@code minecraft:block.spawner.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPAWNER_FALL = create(key("block.spawner.fall"));
+
+    /**
+     * {@code minecraft:block.spawner.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPAWNER_HIT = create(key("block.spawner.hit"));
+
+    /**
+     * {@code minecraft:block.spawner.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPAWNER_PLACE = create(key("block.spawner.place"));
+
+    /**
+     * {@code minecraft:block.spawner.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPAWNER_STEP = create(key("block.spawner.step"));
+
+    /**
+     * {@code minecraft:block.sponge.absorb}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPONGE_ABSORB = create(key("block.sponge.absorb"));
+
+    /**
+     * {@code minecraft:block.sponge.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPONGE_BREAK = create(key("block.sponge.break"));
+
+    /**
+     * {@code minecraft:block.sponge.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPONGE_FALL = create(key("block.sponge.fall"));
+
+    /**
+     * {@code minecraft:block.sponge.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPONGE_HIT = create(key("block.sponge.hit"));
+
+    /**
+     * {@code minecraft:block.sponge.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPONGE_PLACE = create(key("block.sponge.place"));
+
+    /**
+     * {@code minecraft:block.sponge.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPONGE_STEP = create(key("block.sponge.step"));
+
+    /**
+     * {@code minecraft:block.spore_blossom.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPORE_BLOSSOM_BREAK = create(key("block.spore_blossom.break"));
+
+    /**
+     * {@code minecraft:block.spore_blossom.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPORE_BLOSSOM_FALL = create(key("block.spore_blossom.fall"));
+
+    /**
+     * {@code minecraft:block.spore_blossom.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPORE_BLOSSOM_HIT = create(key("block.spore_blossom.hit"));
+
+    /**
+     * {@code minecraft:block.spore_blossom.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPORE_BLOSSOM_PLACE = create(key("block.spore_blossom.place"));
+
+    /**
+     * {@code minecraft:block.spore_blossom.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SPORE_BLOSSOM_STEP = create(key("block.spore_blossom.step"));
+
+    /**
+     * {@code minecraft:block.stem.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STEM_BREAK = create(key("block.stem.break"));
+
+    /**
+     * {@code minecraft:block.stem.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STEM_FALL = create(key("block.stem.fall"));
+
+    /**
+     * {@code minecraft:block.stem.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STEM_HIT = create(key("block.stem.hit"));
+
+    /**
+     * {@code minecraft:block.stem.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STEM_PLACE = create(key("block.stem.place"));
+
+    /**
+     * {@code minecraft:block.stem.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STEM_STEP = create(key("block.stem.step"));
+
+    /**
+     * {@code minecraft:block.stone.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STONE_BREAK = create(key("block.stone.break"));
+
+    /**
+     * {@code minecraft:block.stone.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STONE_FALL = create(key("block.stone.fall"));
+
+    /**
+     * {@code minecraft:block.stone.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STONE_HIT = create(key("block.stone.hit"));
+
+    /**
+     * {@code minecraft:block.stone.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STONE_PLACE = create(key("block.stone.place"));
+
+    /**
+     * {@code minecraft:block.stone.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STONE_STEP = create(key("block.stone.step"));
+
+    /**
+     * {@code minecraft:block.stone_button.click_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STONE_BUTTON_CLICK_OFF = create(key("block.stone_button.click_off"));
+
+    /**
+     * {@code minecraft:block.stone_button.click_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STONE_BUTTON_CLICK_ON = create(key("block.stone_button.click_on"));
+
+    /**
+     * {@code minecraft:block.stone_pressure_plate.click_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STONE_PRESSURE_PLATE_CLICK_OFF = create(key("block.stone_pressure_plate.click_off"));
+
+    /**
+     * {@code minecraft:block.stone_pressure_plate.click_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_STONE_PRESSURE_PLATE_CLICK_ON = create(key("block.stone_pressure_plate.click_on"));
+
+    /**
+     * {@code minecraft:block.suspicious_gravel.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SUSPICIOUS_GRAVEL_BREAK = create(key("block.suspicious_gravel.break"));
+
+    /**
+     * {@code minecraft:block.suspicious_gravel.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SUSPICIOUS_GRAVEL_FALL = create(key("block.suspicious_gravel.fall"));
+
+    /**
+     * {@code minecraft:block.suspicious_gravel.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SUSPICIOUS_GRAVEL_HIT = create(key("block.suspicious_gravel.hit"));
+
+    /**
+     * {@code minecraft:block.suspicious_gravel.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SUSPICIOUS_GRAVEL_PLACE = create(key("block.suspicious_gravel.place"));
+
+    /**
+     * {@code minecraft:block.suspicious_gravel.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SUSPICIOUS_GRAVEL_STEP = create(key("block.suspicious_gravel.step"));
+
+    /**
+     * {@code minecraft:block.suspicious_sand.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SUSPICIOUS_SAND_BREAK = create(key("block.suspicious_sand.break"));
+
+    /**
+     * {@code minecraft:block.suspicious_sand.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SUSPICIOUS_SAND_FALL = create(key("block.suspicious_sand.fall"));
+
+    /**
+     * {@code minecraft:block.suspicious_sand.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SUSPICIOUS_SAND_HIT = create(key("block.suspicious_sand.hit"));
+
+    /**
+     * {@code minecraft:block.suspicious_sand.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SUSPICIOUS_SAND_PLACE = create(key("block.suspicious_sand.place"));
+
+    /**
+     * {@code minecraft:block.suspicious_sand.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SUSPICIOUS_SAND_STEP = create(key("block.suspicious_sand.step"));
+
+    /**
+     * {@code minecraft:block.sweet_berry_bush.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SWEET_BERRY_BUSH_BREAK = create(key("block.sweet_berry_bush.break"));
+
+    /**
+     * {@code minecraft:block.sweet_berry_bush.pick_berries}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SWEET_BERRY_BUSH_PICK_BERRIES = create(key("block.sweet_berry_bush.pick_berries"));
+
+    /**
+     * {@code minecraft:block.sweet_berry_bush.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_SWEET_BERRY_BUSH_PLACE = create(key("block.sweet_berry_bush.place"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.about_to_spawn_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_ABOUT_TO_SPAWN_ITEM = create(key("block.trial_spawner.about_to_spawn_item"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_AMBIENT = create(key("block.trial_spawner.ambient"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.ambient_ominous}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_AMBIENT_OMINOUS = create(key("block.trial_spawner.ambient_ominous"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_BREAK = create(key("block.trial_spawner.break"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.close_shutter}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_CLOSE_SHUTTER = create(key("block.trial_spawner.close_shutter"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.detect_player}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_DETECT_PLAYER = create(key("block.trial_spawner.detect_player"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.eject_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_EJECT_ITEM = create(key("block.trial_spawner.eject_item"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_FALL = create(key("block.trial_spawner.fall"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_HIT = create(key("block.trial_spawner.hit"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.ominous_activate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_OMINOUS_ACTIVATE = create(key("block.trial_spawner.ominous_activate"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.open_shutter}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_OPEN_SHUTTER = create(key("block.trial_spawner.open_shutter"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_PLACE = create(key("block.trial_spawner.place"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.spawn_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_SPAWN_ITEM = create(key("block.trial_spawner.spawn_item"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.spawn_item_begin}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_SPAWN_ITEM_BEGIN = create(key("block.trial_spawner.spawn_item_begin"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.spawn_mob}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_SPAWN_MOB = create(key("block.trial_spawner.spawn_mob"));
+
+    /**
+     * {@code minecraft:block.trial_spawner.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIAL_SPAWNER_STEP = create(key("block.trial_spawner.step"));
+
+    /**
+     * {@code minecraft:block.tripwire.attach}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIPWIRE_ATTACH = create(key("block.tripwire.attach"));
+
+    /**
+     * {@code minecraft:block.tripwire.click_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIPWIRE_CLICK_OFF = create(key("block.tripwire.click_off"));
+
+    /**
+     * {@code minecraft:block.tripwire.click_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIPWIRE_CLICK_ON = create(key("block.tripwire.click_on"));
+
+    /**
+     * {@code minecraft:block.tripwire.detach}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TRIPWIRE_DETACH = create(key("block.tripwire.detach"));
+
+    /**
+     * {@code minecraft:block.tuff.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TUFF_BREAK = create(key("block.tuff.break"));
+
+    /**
+     * {@code minecraft:block.tuff.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TUFF_FALL = create(key("block.tuff.fall"));
+
+    /**
+     * {@code minecraft:block.tuff.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TUFF_HIT = create(key("block.tuff.hit"));
+
+    /**
+     * {@code minecraft:block.tuff.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TUFF_PLACE = create(key("block.tuff.place"));
+
+    /**
+     * {@code minecraft:block.tuff.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TUFF_STEP = create(key("block.tuff.step"));
+
+    /**
+     * {@code minecraft:block.tuff_bricks.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TUFF_BRICKS_BREAK = create(key("block.tuff_bricks.break"));
+
+    /**
+     * {@code minecraft:block.tuff_bricks.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TUFF_BRICKS_FALL = create(key("block.tuff_bricks.fall"));
+
+    /**
+     * {@code minecraft:block.tuff_bricks.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TUFF_BRICKS_HIT = create(key("block.tuff_bricks.hit"));
+
+    /**
+     * {@code minecraft:block.tuff_bricks.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TUFF_BRICKS_PLACE = create(key("block.tuff_bricks.place"));
+
+    /**
+     * {@code minecraft:block.tuff_bricks.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_TUFF_BRICKS_STEP = create(key("block.tuff_bricks.step"));
+
+    /**
+     * {@code minecraft:block.vault.activate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_ACTIVATE = create(key("block.vault.activate"));
+
+    /**
+     * {@code minecraft:block.vault.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_AMBIENT = create(key("block.vault.ambient"));
+
+    /**
+     * {@code minecraft:block.vault.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_BREAK = create(key("block.vault.break"));
+
+    /**
+     * {@code minecraft:block.vault.close_shutter}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_CLOSE_SHUTTER = create(key("block.vault.close_shutter"));
+
+    /**
+     * {@code minecraft:block.vault.deactivate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_DEACTIVATE = create(key("block.vault.deactivate"));
+
+    /**
+     * {@code minecraft:block.vault.eject_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_EJECT_ITEM = create(key("block.vault.eject_item"));
+
+    /**
+     * {@code minecraft:block.vault.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_FALL = create(key("block.vault.fall"));
+
+    /**
+     * {@code minecraft:block.vault.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_HIT = create(key("block.vault.hit"));
+
+    /**
+     * {@code minecraft:block.vault.insert_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_INSERT_ITEM = create(key("block.vault.insert_item"));
+
+    /**
+     * {@code minecraft:block.vault.insert_item_fail}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_INSERT_ITEM_FAIL = create(key("block.vault.insert_item_fail"));
+
+    /**
+     * {@code minecraft:block.vault.open_shutter}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_OPEN_SHUTTER = create(key("block.vault.open_shutter"));
+
+    /**
+     * {@code minecraft:block.vault.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_PLACE = create(key("block.vault.place"));
+
+    /**
+     * {@code minecraft:block.vault.reject_rewarded_player}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_REJECT_REWARDED_PLAYER = create(key("block.vault.reject_rewarded_player"));
+
+    /**
+     * {@code minecraft:block.vault.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VAULT_STEP = create(key("block.vault.step"));
+
+    /**
+     * {@code minecraft:block.vine.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VINE_BREAK = create(key("block.vine.break"));
+
+    /**
+     * {@code minecraft:block.vine.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VINE_FALL = create(key("block.vine.fall"));
+
+    /**
+     * {@code minecraft:block.vine.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VINE_HIT = create(key("block.vine.hit"));
+
+    /**
+     * {@code minecraft:block.vine.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VINE_PLACE = create(key("block.vine.place"));
+
+    /**
+     * {@code minecraft:block.vine.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_VINE_STEP = create(key("block.vine.step"));
+
+    /**
+     * {@code minecraft:block.wart_block.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WART_BLOCK_BREAK = create(key("block.wart_block.break"));
+
+    /**
+     * {@code minecraft:block.wart_block.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WART_BLOCK_FALL = create(key("block.wart_block.fall"));
+
+    /**
+     * {@code minecraft:block.wart_block.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WART_BLOCK_HIT = create(key("block.wart_block.hit"));
+
+    /**
+     * {@code minecraft:block.wart_block.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WART_BLOCK_PLACE = create(key("block.wart_block.place"));
+
+    /**
+     * {@code minecraft:block.wart_block.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WART_BLOCK_STEP = create(key("block.wart_block.step"));
+
+    /**
+     * {@code minecraft:block.water.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WATER_AMBIENT = create(key("block.water.ambient"));
+
+    /**
+     * {@code minecraft:block.weeping_vines.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WEEPING_VINES_BREAK = create(key("block.weeping_vines.break"));
+
+    /**
+     * {@code minecraft:block.weeping_vines.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WEEPING_VINES_FALL = create(key("block.weeping_vines.fall"));
+
+    /**
+     * {@code minecraft:block.weeping_vines.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WEEPING_VINES_HIT = create(key("block.weeping_vines.hit"));
+
+    /**
+     * {@code minecraft:block.weeping_vines.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WEEPING_VINES_PLACE = create(key("block.weeping_vines.place"));
+
+    /**
+     * {@code minecraft:block.weeping_vines.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WEEPING_VINES_STEP = create(key("block.weeping_vines.step"));
+
+    /**
+     * {@code minecraft:block.wet_grass.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WET_GRASS_BREAK = create(key("block.wet_grass.break"));
+
+    /**
+     * {@code minecraft:block.wet_grass.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WET_GRASS_FALL = create(key("block.wet_grass.fall"));
+
+    /**
+     * {@code minecraft:block.wet_grass.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WET_GRASS_HIT = create(key("block.wet_grass.hit"));
+
+    /**
+     * {@code minecraft:block.wet_grass.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WET_GRASS_PLACE = create(key("block.wet_grass.place"));
+
+    /**
+     * {@code minecraft:block.wet_grass.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WET_GRASS_STEP = create(key("block.wet_grass.step"));
+
+    /**
+     * {@code minecraft:block.wet_sponge.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WET_SPONGE_BREAK = create(key("block.wet_sponge.break"));
+
+    /**
+     * {@code minecraft:block.wet_sponge.dries}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WET_SPONGE_DRIES = create(key("block.wet_sponge.dries"));
+
+    /**
+     * {@code minecraft:block.wet_sponge.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WET_SPONGE_FALL = create(key("block.wet_sponge.fall"));
+
+    /**
+     * {@code minecraft:block.wet_sponge.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WET_SPONGE_HIT = create(key("block.wet_sponge.hit"));
+
+    /**
+     * {@code minecraft:block.wet_sponge.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WET_SPONGE_PLACE = create(key("block.wet_sponge.place"));
+
+    /**
+     * {@code minecraft:block.wet_sponge.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WET_SPONGE_STEP = create(key("block.wet_sponge.step"));
+
+    /**
+     * {@code minecraft:block.wood.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOOD_BREAK = create(key("block.wood.break"));
+
+    /**
+     * {@code minecraft:block.wood.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOOD_FALL = create(key("block.wood.fall"));
+
+    /**
+     * {@code minecraft:block.wood.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOOD_HIT = create(key("block.wood.hit"));
+
+    /**
+     * {@code minecraft:block.wood.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOOD_PLACE = create(key("block.wood.place"));
+
+    /**
+     * {@code minecraft:block.wood.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOOD_STEP = create(key("block.wood.step"));
+
+    /**
+     * {@code minecraft:block.wooden_button.click_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOODEN_BUTTON_CLICK_OFF = create(key("block.wooden_button.click_off"));
+
+    /**
+     * {@code minecraft:block.wooden_button.click_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOODEN_BUTTON_CLICK_ON = create(key("block.wooden_button.click_on"));
+
+    /**
+     * {@code minecraft:block.wooden_door.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOODEN_DOOR_CLOSE = create(key("block.wooden_door.close"));
+
+    /**
+     * {@code minecraft:block.wooden_door.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOODEN_DOOR_OPEN = create(key("block.wooden_door.open"));
+
+    /**
+     * {@code minecraft:block.wooden_pressure_plate.click_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOODEN_PRESSURE_PLATE_CLICK_OFF = create(key("block.wooden_pressure_plate.click_off"));
+
+    /**
+     * {@code minecraft:block.wooden_pressure_plate.click_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOODEN_PRESSURE_PLATE_CLICK_ON = create(key("block.wooden_pressure_plate.click_on"));
+
+    /**
+     * {@code minecraft:block.wooden_trapdoor.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOODEN_TRAPDOOR_CLOSE = create(key("block.wooden_trapdoor.close"));
+
+    /**
+     * {@code minecraft:block.wooden_trapdoor.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOODEN_TRAPDOOR_OPEN = create(key("block.wooden_trapdoor.open"));
+
+    /**
+     * {@code minecraft:block.wool.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOOL_BREAK = create(key("block.wool.break"));
+
+    /**
+     * {@code minecraft:block.wool.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOOL_FALL = create(key("block.wool.fall"));
+
+    /**
+     * {@code minecraft:block.wool.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOOL_HIT = create(key("block.wool.hit"));
+
+    /**
+     * {@code minecraft:block.wool.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOOL_PLACE = create(key("block.wool.place"));
+
+    /**
+     * {@code minecraft:block.wool.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> BLOCK_WOOL_STEP = create(key("block.wool.step"));
+
+    /**
+     * {@code minecraft:enchant.thorns.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENCHANT_THORNS_HIT = create(key("enchant.thorns.hit"));
+
+    /**
+     * {@code minecraft:entity.allay.ambient_with_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ALLAY_AMBIENT_WITH_ITEM = create(key("entity.allay.ambient_with_item"));
+
+    /**
+     * {@code minecraft:entity.allay.ambient_without_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ALLAY_AMBIENT_WITHOUT_ITEM = create(key("entity.allay.ambient_without_item"));
+
+    /**
+     * {@code minecraft:entity.allay.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ALLAY_DEATH = create(key("entity.allay.death"));
+
+    /**
+     * {@code minecraft:entity.allay.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ALLAY_HURT = create(key("entity.allay.hurt"));
+
+    /**
+     * {@code minecraft:entity.allay.item_given}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ALLAY_ITEM_GIVEN = create(key("entity.allay.item_given"));
+
+    /**
+     * {@code minecraft:entity.allay.item_taken}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ALLAY_ITEM_TAKEN = create(key("entity.allay.item_taken"));
+
+    /**
+     * {@code minecraft:entity.allay.item_thrown}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ALLAY_ITEM_THROWN = create(key("entity.allay.item_thrown"));
+
+    /**
+     * {@code minecraft:entity.armadillo.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_AMBIENT = create(key("entity.armadillo.ambient"));
+
+    /**
+     * {@code minecraft:entity.armadillo.brush}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_BRUSH = create(key("entity.armadillo.brush"));
+
+    /**
+     * {@code minecraft:entity.armadillo.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_DEATH = create(key("entity.armadillo.death"));
+
+    /**
+     * {@code minecraft:entity.armadillo.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_EAT = create(key("entity.armadillo.eat"));
+
+    /**
+     * {@code minecraft:entity.armadillo.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_HURT = create(key("entity.armadillo.hurt"));
+
+    /**
+     * {@code minecraft:entity.armadillo.hurt_reduced}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_HURT_REDUCED = create(key("entity.armadillo.hurt_reduced"));
+
+    /**
+     * {@code minecraft:entity.armadillo.land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_LAND = create(key("entity.armadillo.land"));
+
+    /**
+     * {@code minecraft:entity.armadillo.peek}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_PEEK = create(key("entity.armadillo.peek"));
+
+    /**
+     * {@code minecraft:entity.armadillo.roll}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_ROLL = create(key("entity.armadillo.roll"));
+
+    /**
+     * {@code minecraft:entity.armadillo.scute_drop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_SCUTE_DROP = create(key("entity.armadillo.scute_drop"));
+
+    /**
+     * {@code minecraft:entity.armadillo.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_STEP = create(key("entity.armadillo.step"));
+
+    /**
+     * {@code minecraft:entity.armadillo.unroll_finish}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_UNROLL_FINISH = create(key("entity.armadillo.unroll_finish"));
+
+    /**
+     * {@code minecraft:entity.armadillo.unroll_start}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMADILLO_UNROLL_START = create(key("entity.armadillo.unroll_start"));
+
+    /**
+     * {@code minecraft:entity.armor_stand.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMOR_STAND_BREAK = create(key("entity.armor_stand.break"));
+
+    /**
+     * {@code minecraft:entity.armor_stand.fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMOR_STAND_FALL = create(key("entity.armor_stand.fall"));
+
+    /**
+     * {@code minecraft:entity.armor_stand.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMOR_STAND_HIT = create(key("entity.armor_stand.hit"));
+
+    /**
+     * {@code minecraft:entity.armor_stand.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARMOR_STAND_PLACE = create(key("entity.armor_stand.place"));
+
+    /**
+     * {@code minecraft:entity.arrow.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARROW_HIT = create(key("entity.arrow.hit"));
+
+    /**
+     * {@code minecraft:entity.arrow.hit_player}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARROW_HIT_PLAYER = create(key("entity.arrow.hit_player"));
+
+    /**
+     * {@code minecraft:entity.arrow.shoot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ARROW_SHOOT = create(key("entity.arrow.shoot"));
+
+    /**
+     * {@code minecraft:entity.axolotl.attack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_AXOLOTL_ATTACK = create(key("entity.axolotl.attack"));
+
+    /**
+     * {@code minecraft:entity.axolotl.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_AXOLOTL_DEATH = create(key("entity.axolotl.death"));
+
+    /**
+     * {@code minecraft:entity.axolotl.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_AXOLOTL_HURT = create(key("entity.axolotl.hurt"));
+
+    /**
+     * {@code minecraft:entity.axolotl.idle_air}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_AXOLOTL_IDLE_AIR = create(key("entity.axolotl.idle_air"));
+
+    /**
+     * {@code minecraft:entity.axolotl.idle_water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_AXOLOTL_IDLE_WATER = create(key("entity.axolotl.idle_water"));
+
+    /**
+     * {@code minecraft:entity.axolotl.splash}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_AXOLOTL_SPLASH = create(key("entity.axolotl.splash"));
+
+    /**
+     * {@code minecraft:entity.axolotl.swim}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_AXOLOTL_SWIM = create(key("entity.axolotl.swim"));
+
+    /**
+     * {@code minecraft:entity.bat.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BAT_AMBIENT = create(key("entity.bat.ambient"));
+
+    /**
+     * {@code minecraft:entity.bat.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BAT_DEATH = create(key("entity.bat.death"));
+
+    /**
+     * {@code minecraft:entity.bat.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BAT_HURT = create(key("entity.bat.hurt"));
+
+    /**
+     * {@code minecraft:entity.bat.loop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BAT_LOOP = create(key("entity.bat.loop"));
+
+    /**
+     * {@code minecraft:entity.bat.takeoff}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BAT_TAKEOFF = create(key("entity.bat.takeoff"));
+
+    /**
+     * {@code minecraft:entity.bee.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BEE_DEATH = create(key("entity.bee.death"));
+
+    /**
+     * {@code minecraft:entity.bee.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BEE_HURT = create(key("entity.bee.hurt"));
+
+    /**
+     * {@code minecraft:entity.bee.loop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BEE_LOOP = create(key("entity.bee.loop"));
+
+    /**
+     * {@code minecraft:entity.bee.loop_aggressive}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BEE_LOOP_AGGRESSIVE = create(key("entity.bee.loop_aggressive"));
+
+    /**
+     * {@code minecraft:entity.bee.pollinate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BEE_POLLINATE = create(key("entity.bee.pollinate"));
+
+    /**
+     * {@code minecraft:entity.bee.sting}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BEE_STING = create(key("entity.bee.sting"));
+
+    /**
+     * {@code minecraft:entity.blaze.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BLAZE_AMBIENT = create(key("entity.blaze.ambient"));
+
+    /**
+     * {@code minecraft:entity.blaze.burn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BLAZE_BURN = create(key("entity.blaze.burn"));
+
+    /**
+     * {@code minecraft:entity.blaze.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BLAZE_DEATH = create(key("entity.blaze.death"));
+
+    /**
+     * {@code minecraft:entity.blaze.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BLAZE_HURT = create(key("entity.blaze.hurt"));
+
+    /**
+     * {@code minecraft:entity.blaze.shoot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BLAZE_SHOOT = create(key("entity.blaze.shoot"));
+
+    /**
+     * {@code minecraft:entity.boat.paddle_land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BOAT_PADDLE_LAND = create(key("entity.boat.paddle_land"));
+
+    /**
+     * {@code minecraft:entity.boat.paddle_water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BOAT_PADDLE_WATER = create(key("entity.boat.paddle_water"));
+
+    /**
+     * {@code minecraft:entity.bogged.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BOGGED_AMBIENT = create(key("entity.bogged.ambient"));
+
+    /**
+     * {@code minecraft:entity.bogged.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BOGGED_DEATH = create(key("entity.bogged.death"));
+
+    /**
+     * {@code minecraft:entity.bogged.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BOGGED_HURT = create(key("entity.bogged.hurt"));
+
+    /**
+     * {@code minecraft:entity.bogged.shear}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BOGGED_SHEAR = create(key("entity.bogged.shear"));
+
+    /**
+     * {@code minecraft:entity.bogged.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BOGGED_STEP = create(key("entity.bogged.step"));
+
+    /**
+     * {@code minecraft:entity.breeze.charge}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_CHARGE = create(key("entity.breeze.charge"));
+
+    /**
+     * {@code minecraft:entity.breeze.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_DEATH = create(key("entity.breeze.death"));
+
+    /**
+     * {@code minecraft:entity.breeze.deflect}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_DEFLECT = create(key("entity.breeze.deflect"));
+
+    /**
+     * {@code minecraft:entity.breeze.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_HURT = create(key("entity.breeze.hurt"));
+
+    /**
+     * {@code minecraft:entity.breeze.idle_air}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_IDLE_AIR = create(key("entity.breeze.idle_air"));
+
+    /**
+     * {@code minecraft:entity.breeze.idle_ground}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_IDLE_GROUND = create(key("entity.breeze.idle_ground"));
+
+    /**
+     * {@code minecraft:entity.breeze.inhale}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_INHALE = create(key("entity.breeze.inhale"));
+
+    /**
+     * {@code minecraft:entity.breeze.jump}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_JUMP = create(key("entity.breeze.jump"));
+
+    /**
+     * {@code minecraft:entity.breeze.land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_LAND = create(key("entity.breeze.land"));
+
+    /**
+     * {@code minecraft:entity.breeze.shoot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_SHOOT = create(key("entity.breeze.shoot"));
+
+    /**
+     * {@code minecraft:entity.breeze.slide}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_SLIDE = create(key("entity.breeze.slide"));
+
+    /**
+     * {@code minecraft:entity.breeze.whirl}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_WHIRL = create(key("entity.breeze.whirl"));
+
+    /**
+     * {@code minecraft:entity.breeze.wind_burst}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_BREEZE_WIND_BURST = create(key("entity.breeze.wind_burst"));
+
+    /**
+     * {@code minecraft:entity.camel.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAMEL_AMBIENT = create(key("entity.camel.ambient"));
+
+    /**
+     * {@code minecraft:entity.camel.dash}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAMEL_DASH = create(key("entity.camel.dash"));
+
+    /**
+     * {@code minecraft:entity.camel.dash_ready}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAMEL_DASH_READY = create(key("entity.camel.dash_ready"));
+
+    /**
+     * {@code minecraft:entity.camel.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAMEL_DEATH = create(key("entity.camel.death"));
+
+    /**
+     * {@code minecraft:entity.camel.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAMEL_EAT = create(key("entity.camel.eat"));
+
+    /**
+     * {@code minecraft:entity.camel.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAMEL_HURT = create(key("entity.camel.hurt"));
+
+    /**
+     * {@code minecraft:entity.camel.saddle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAMEL_SADDLE = create(key("entity.camel.saddle"));
+
+    /**
+     * {@code minecraft:entity.camel.sit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAMEL_SIT = create(key("entity.camel.sit"));
+
+    /**
+     * {@code minecraft:entity.camel.stand}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAMEL_STAND = create(key("entity.camel.stand"));
+
+    /**
+     * {@code minecraft:entity.camel.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAMEL_STEP = create(key("entity.camel.step"));
+
+    /**
+     * {@code minecraft:entity.camel.step_sand}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAMEL_STEP_SAND = create(key("entity.camel.step_sand"));
+
+    /**
+     * {@code minecraft:entity.cat.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAT_AMBIENT = create(key("entity.cat.ambient"));
+
+    /**
+     * {@code minecraft:entity.cat.beg_for_food}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAT_BEG_FOR_FOOD = create(key("entity.cat.beg_for_food"));
+
+    /**
+     * {@code minecraft:entity.cat.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAT_DEATH = create(key("entity.cat.death"));
+
+    /**
+     * {@code minecraft:entity.cat.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAT_EAT = create(key("entity.cat.eat"));
+
+    /**
+     * {@code minecraft:entity.cat.hiss}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAT_HISS = create(key("entity.cat.hiss"));
+
+    /**
+     * {@code minecraft:entity.cat.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAT_HURT = create(key("entity.cat.hurt"));
+
+    /**
+     * {@code minecraft:entity.cat.purr}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAT_PURR = create(key("entity.cat.purr"));
+
+    /**
+     * {@code minecraft:entity.cat.purreow}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAT_PURREOW = create(key("entity.cat.purreow"));
+
+    /**
+     * {@code minecraft:entity.cat.stray_ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CAT_STRAY_AMBIENT = create(key("entity.cat.stray_ambient"));
+
+    /**
+     * {@code minecraft:entity.chicken.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CHICKEN_AMBIENT = create(key("entity.chicken.ambient"));
+
+    /**
+     * {@code minecraft:entity.chicken.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CHICKEN_DEATH = create(key("entity.chicken.death"));
+
+    /**
+     * {@code minecraft:entity.chicken.egg}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CHICKEN_EGG = create(key("entity.chicken.egg"));
+
+    /**
+     * {@code minecraft:entity.chicken.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CHICKEN_HURT = create(key("entity.chicken.hurt"));
+
+    /**
+     * {@code minecraft:entity.chicken.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CHICKEN_STEP = create(key("entity.chicken.step"));
+
+    /**
+     * {@code minecraft:entity.cod.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_COD_AMBIENT = create(key("entity.cod.ambient"));
+
+    /**
+     * {@code minecraft:entity.cod.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_COD_DEATH = create(key("entity.cod.death"));
+
+    /**
+     * {@code minecraft:entity.cod.flop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_COD_FLOP = create(key("entity.cod.flop"));
+
+    /**
+     * {@code minecraft:entity.cod.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_COD_HURT = create(key("entity.cod.hurt"));
+
+    /**
+     * {@code minecraft:entity.cow.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_COW_AMBIENT = create(key("entity.cow.ambient"));
+
+    /**
+     * {@code minecraft:entity.cow.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_COW_DEATH = create(key("entity.cow.death"));
+
+    /**
+     * {@code minecraft:entity.cow.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_COW_HURT = create(key("entity.cow.hurt"));
+
+    /**
+     * {@code minecraft:entity.cow.milk}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_COW_MILK = create(key("entity.cow.milk"));
+
+    /**
+     * {@code minecraft:entity.cow.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_COW_STEP = create(key("entity.cow.step"));
+
+    /**
+     * {@code minecraft:entity.creaking.activate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREAKING_ACTIVATE = create(key("entity.creaking.activate"));
+
+    /**
+     * {@code minecraft:entity.creaking.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREAKING_AMBIENT = create(key("entity.creaking.ambient"));
+
+    /**
+     * {@code minecraft:entity.creaking.attack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREAKING_ATTACK = create(key("entity.creaking.attack"));
+
+    /**
+     * {@code minecraft:entity.creaking.deactivate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREAKING_DEACTIVATE = create(key("entity.creaking.deactivate"));
+
+    /**
+     * {@code minecraft:entity.creaking.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREAKING_DEATH = create(key("entity.creaking.death"));
+
+    /**
+     * {@code minecraft:entity.creaking.freeze}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREAKING_FREEZE = create(key("entity.creaking.freeze"));
+
+    /**
+     * {@code minecraft:entity.creaking.spawn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREAKING_SPAWN = create(key("entity.creaking.spawn"));
+
+    /**
+     * {@code minecraft:entity.creaking.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREAKING_STEP = create(key("entity.creaking.step"));
+
+    /**
+     * {@code minecraft:entity.creaking.sway}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREAKING_SWAY = create(key("entity.creaking.sway"));
+
+    /**
+     * {@code minecraft:entity.creaking.unfreeze}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREAKING_UNFREEZE = create(key("entity.creaking.unfreeze"));
+
+    /**
+     * {@code minecraft:entity.creeper.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREEPER_DEATH = create(key("entity.creeper.death"));
+
+    /**
+     * {@code minecraft:entity.creeper.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREEPER_HURT = create(key("entity.creeper.hurt"));
+
+    /**
+     * {@code minecraft:entity.creeper.primed}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_CREEPER_PRIMED = create(key("entity.creeper.primed"));
+
+    /**
+     * {@code minecraft:entity.dolphin.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DOLPHIN_AMBIENT = create(key("entity.dolphin.ambient"));
+
+    /**
+     * {@code minecraft:entity.dolphin.ambient_water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DOLPHIN_AMBIENT_WATER = create(key("entity.dolphin.ambient_water"));
+
+    /**
+     * {@code minecraft:entity.dolphin.attack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DOLPHIN_ATTACK = create(key("entity.dolphin.attack"));
+
+    /**
+     * {@code minecraft:entity.dolphin.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DOLPHIN_DEATH = create(key("entity.dolphin.death"));
+
+    /**
+     * {@code minecraft:entity.dolphin.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DOLPHIN_EAT = create(key("entity.dolphin.eat"));
+
+    /**
+     * {@code minecraft:entity.dolphin.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DOLPHIN_HURT = create(key("entity.dolphin.hurt"));
+
+    /**
+     * {@code minecraft:entity.dolphin.jump}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DOLPHIN_JUMP = create(key("entity.dolphin.jump"));
+
+    /**
+     * {@code minecraft:entity.dolphin.play}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DOLPHIN_PLAY = create(key("entity.dolphin.play"));
+
+    /**
+     * {@code minecraft:entity.dolphin.splash}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DOLPHIN_SPLASH = create(key("entity.dolphin.splash"));
+
+    /**
+     * {@code minecraft:entity.dolphin.swim}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DOLPHIN_SWIM = create(key("entity.dolphin.swim"));
+
+    /**
+     * {@code minecraft:entity.donkey.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DONKEY_AMBIENT = create(key("entity.donkey.ambient"));
+
+    /**
+     * {@code minecraft:entity.donkey.angry}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DONKEY_ANGRY = create(key("entity.donkey.angry"));
+
+    /**
+     * {@code minecraft:entity.donkey.chest}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DONKEY_CHEST = create(key("entity.donkey.chest"));
+
+    /**
+     * {@code minecraft:entity.donkey.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DONKEY_DEATH = create(key("entity.donkey.death"));
+
+    /**
+     * {@code minecraft:entity.donkey.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DONKEY_EAT = create(key("entity.donkey.eat"));
+
+    /**
+     * {@code minecraft:entity.donkey.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DONKEY_HURT = create(key("entity.donkey.hurt"));
+
+    /**
+     * {@code minecraft:entity.donkey.jump}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DONKEY_JUMP = create(key("entity.donkey.jump"));
+
+    /**
+     * {@code minecraft:entity.dragon_fireball.explode}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DRAGON_FIREBALL_EXPLODE = create(key("entity.dragon_fireball.explode"));
+
+    /**
+     * {@code minecraft:entity.drowned.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DROWNED_AMBIENT = create(key("entity.drowned.ambient"));
+
+    /**
+     * {@code minecraft:entity.drowned.ambient_water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DROWNED_AMBIENT_WATER = create(key("entity.drowned.ambient_water"));
+
+    /**
+     * {@code minecraft:entity.drowned.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DROWNED_DEATH = create(key("entity.drowned.death"));
+
+    /**
+     * {@code minecraft:entity.drowned.death_water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DROWNED_DEATH_WATER = create(key("entity.drowned.death_water"));
+
+    /**
+     * {@code minecraft:entity.drowned.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DROWNED_HURT = create(key("entity.drowned.hurt"));
+
+    /**
+     * {@code minecraft:entity.drowned.hurt_water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DROWNED_HURT_WATER = create(key("entity.drowned.hurt_water"));
+
+    /**
+     * {@code minecraft:entity.drowned.shoot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DROWNED_SHOOT = create(key("entity.drowned.shoot"));
+
+    /**
+     * {@code minecraft:entity.drowned.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DROWNED_STEP = create(key("entity.drowned.step"));
+
+    /**
+     * {@code minecraft:entity.drowned.swim}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_DROWNED_SWIM = create(key("entity.drowned.swim"));
+
+    /**
+     * {@code minecraft:entity.egg.throw}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_EGG_THROW = create(key("entity.egg.throw"));
+
+    /**
+     * {@code minecraft:entity.elder_guardian.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ELDER_GUARDIAN_AMBIENT = create(key("entity.elder_guardian.ambient"));
+
+    /**
+     * {@code minecraft:entity.elder_guardian.ambient_land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ELDER_GUARDIAN_AMBIENT_LAND = create(key("entity.elder_guardian.ambient_land"));
+
+    /**
+     * {@code minecraft:entity.elder_guardian.curse}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ELDER_GUARDIAN_CURSE = create(key("entity.elder_guardian.curse"));
+
+    /**
+     * {@code minecraft:entity.elder_guardian.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ELDER_GUARDIAN_DEATH = create(key("entity.elder_guardian.death"));
+
+    /**
+     * {@code minecraft:entity.elder_guardian.death_land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ELDER_GUARDIAN_DEATH_LAND = create(key("entity.elder_guardian.death_land"));
+
+    /**
+     * {@code minecraft:entity.elder_guardian.flop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ELDER_GUARDIAN_FLOP = create(key("entity.elder_guardian.flop"));
+
+    /**
+     * {@code minecraft:entity.elder_guardian.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ELDER_GUARDIAN_HURT = create(key("entity.elder_guardian.hurt"));
+
+    /**
+     * {@code minecraft:entity.elder_guardian.hurt_land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ELDER_GUARDIAN_HURT_LAND = create(key("entity.elder_guardian.hurt_land"));
+
+    /**
+     * {@code minecraft:entity.ender_dragon.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDER_DRAGON_AMBIENT = create(key("entity.ender_dragon.ambient"));
+
+    /**
+     * {@code minecraft:entity.ender_dragon.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDER_DRAGON_DEATH = create(key("entity.ender_dragon.death"));
+
+    /**
+     * {@code minecraft:entity.ender_dragon.flap}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDER_DRAGON_FLAP = create(key("entity.ender_dragon.flap"));
+
+    /**
+     * {@code minecraft:entity.ender_dragon.growl}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDER_DRAGON_GROWL = create(key("entity.ender_dragon.growl"));
+
+    /**
+     * {@code minecraft:entity.ender_dragon.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDER_DRAGON_HURT = create(key("entity.ender_dragon.hurt"));
+
+    /**
+     * {@code minecraft:entity.ender_dragon.shoot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDER_DRAGON_SHOOT = create(key("entity.ender_dragon.shoot"));
+
+    /**
+     * {@code minecraft:entity.ender_eye.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDER_EYE_DEATH = create(key("entity.ender_eye.death"));
+
+    /**
+     * {@code minecraft:entity.ender_eye.launch}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDER_EYE_LAUNCH = create(key("entity.ender_eye.launch"));
+
+    /**
+     * {@code minecraft:entity.ender_pearl.throw}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDER_PEARL_THROW = create(key("entity.ender_pearl.throw"));
+
+    /**
+     * {@code minecraft:entity.enderman.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDERMAN_AMBIENT = create(key("entity.enderman.ambient"));
+
+    /**
+     * {@code minecraft:entity.enderman.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDERMAN_DEATH = create(key("entity.enderman.death"));
+
+    /**
+     * {@code minecraft:entity.enderman.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDERMAN_HURT = create(key("entity.enderman.hurt"));
+
+    /**
+     * {@code minecraft:entity.enderman.scream}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDERMAN_SCREAM = create(key("entity.enderman.scream"));
+
+    /**
+     * {@code minecraft:entity.enderman.stare}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDERMAN_STARE = create(key("entity.enderman.stare"));
+
+    /**
+     * {@code minecraft:entity.enderman.teleport}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDERMAN_TELEPORT = create(key("entity.enderman.teleport"));
+
+    /**
+     * {@code minecraft:entity.endermite.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDERMITE_AMBIENT = create(key("entity.endermite.ambient"));
+
+    /**
+     * {@code minecraft:entity.endermite.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDERMITE_DEATH = create(key("entity.endermite.death"));
+
+    /**
+     * {@code minecraft:entity.endermite.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDERMITE_HURT = create(key("entity.endermite.hurt"));
+
+    /**
+     * {@code minecraft:entity.endermite.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ENDERMITE_STEP = create(key("entity.endermite.step"));
+
+    /**
+     * {@code minecraft:entity.evoker.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_EVOKER_AMBIENT = create(key("entity.evoker.ambient"));
+
+    /**
+     * {@code minecraft:entity.evoker.cast_spell}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_EVOKER_CAST_SPELL = create(key("entity.evoker.cast_spell"));
+
+    /**
+     * {@code minecraft:entity.evoker.celebrate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_EVOKER_CELEBRATE = create(key("entity.evoker.celebrate"));
+
+    /**
+     * {@code minecraft:entity.evoker.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_EVOKER_DEATH = create(key("entity.evoker.death"));
+
+    /**
+     * {@code minecraft:entity.evoker.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_EVOKER_HURT = create(key("entity.evoker.hurt"));
+
+    /**
+     * {@code minecraft:entity.evoker.prepare_attack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_EVOKER_PREPARE_ATTACK = create(key("entity.evoker.prepare_attack"));
+
+    /**
+     * {@code minecraft:entity.evoker.prepare_summon}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_EVOKER_PREPARE_SUMMON = create(key("entity.evoker.prepare_summon"));
+
+    /**
+     * {@code minecraft:entity.evoker.prepare_wololo}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_EVOKER_PREPARE_WOLOLO = create(key("entity.evoker.prepare_wololo"));
+
+    /**
+     * {@code minecraft:entity.evoker_fangs.attack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_EVOKER_FANGS_ATTACK = create(key("entity.evoker_fangs.attack"));
+
+    /**
+     * {@code minecraft:entity.experience_bottle.throw}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_EXPERIENCE_BOTTLE_THROW = create(key("entity.experience_bottle.throw"));
+
+    /**
+     * {@code minecraft:entity.experience_orb.pickup}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_EXPERIENCE_ORB_PICKUP = create(key("entity.experience_orb.pickup"));
+
+    /**
+     * {@code minecraft:entity.firework_rocket.blast}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FIREWORK_ROCKET_BLAST = create(key("entity.firework_rocket.blast"));
+
+    /**
+     * {@code minecraft:entity.firework_rocket.blast_far}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FIREWORK_ROCKET_BLAST_FAR = create(key("entity.firework_rocket.blast_far"));
+
+    /**
+     * {@code minecraft:entity.firework_rocket.large_blast}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FIREWORK_ROCKET_LARGE_BLAST = create(key("entity.firework_rocket.large_blast"));
+
+    /**
+     * {@code minecraft:entity.firework_rocket.large_blast_far}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FIREWORK_ROCKET_LARGE_BLAST_FAR = create(key("entity.firework_rocket.large_blast_far"));
+
+    /**
+     * {@code minecraft:entity.firework_rocket.launch}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FIREWORK_ROCKET_LAUNCH = create(key("entity.firework_rocket.launch"));
+
+    /**
+     * {@code minecraft:entity.firework_rocket.shoot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FIREWORK_ROCKET_SHOOT = create(key("entity.firework_rocket.shoot"));
+
+    /**
+     * {@code minecraft:entity.firework_rocket.twinkle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FIREWORK_ROCKET_TWINKLE = create(key("entity.firework_rocket.twinkle"));
+
+    /**
+     * {@code minecraft:entity.firework_rocket.twinkle_far}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FIREWORK_ROCKET_TWINKLE_FAR = create(key("entity.firework_rocket.twinkle_far"));
+
+    /**
+     * {@code minecraft:entity.fish.swim}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FISH_SWIM = create(key("entity.fish.swim"));
+
+    /**
+     * {@code minecraft:entity.fishing_bobber.retrieve}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FISHING_BOBBER_RETRIEVE = create(key("entity.fishing_bobber.retrieve"));
+
+    /**
+     * {@code minecraft:entity.fishing_bobber.splash}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FISHING_BOBBER_SPLASH = create(key("entity.fishing_bobber.splash"));
+
+    /**
+     * {@code minecraft:entity.fishing_bobber.throw}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FISHING_BOBBER_THROW = create(key("entity.fishing_bobber.throw"));
+
+    /**
+     * {@code minecraft:entity.fox.aggro}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FOX_AGGRO = create(key("entity.fox.aggro"));
+
+    /**
+     * {@code minecraft:entity.fox.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FOX_AMBIENT = create(key("entity.fox.ambient"));
+
+    /**
+     * {@code minecraft:entity.fox.bite}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FOX_BITE = create(key("entity.fox.bite"));
+
+    /**
+     * {@code minecraft:entity.fox.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FOX_DEATH = create(key("entity.fox.death"));
+
+    /**
+     * {@code minecraft:entity.fox.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FOX_EAT = create(key("entity.fox.eat"));
+
+    /**
+     * {@code minecraft:entity.fox.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FOX_HURT = create(key("entity.fox.hurt"));
+
+    /**
+     * {@code minecraft:entity.fox.screech}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FOX_SCREECH = create(key("entity.fox.screech"));
+
+    /**
+     * {@code minecraft:entity.fox.sleep}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FOX_SLEEP = create(key("entity.fox.sleep"));
+
+    /**
+     * {@code minecraft:entity.fox.sniff}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FOX_SNIFF = create(key("entity.fox.sniff"));
+
+    /**
+     * {@code minecraft:entity.fox.spit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FOX_SPIT = create(key("entity.fox.spit"));
+
+    /**
+     * {@code minecraft:entity.fox.teleport}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FOX_TELEPORT = create(key("entity.fox.teleport"));
+
+    /**
+     * {@code minecraft:entity.frog.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FROG_AMBIENT = create(key("entity.frog.ambient"));
+
+    /**
+     * {@code minecraft:entity.frog.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FROG_DEATH = create(key("entity.frog.death"));
+
+    /**
+     * {@code minecraft:entity.frog.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FROG_EAT = create(key("entity.frog.eat"));
+
+    /**
+     * {@code minecraft:entity.frog.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FROG_HURT = create(key("entity.frog.hurt"));
+
+    /**
+     * {@code minecraft:entity.frog.lay_spawn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FROG_LAY_SPAWN = create(key("entity.frog.lay_spawn"));
+
+    /**
+     * {@code minecraft:entity.frog.long_jump}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FROG_LONG_JUMP = create(key("entity.frog.long_jump"));
+
+    /**
+     * {@code minecraft:entity.frog.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FROG_STEP = create(key("entity.frog.step"));
+
+    /**
+     * {@code minecraft:entity.frog.tongue}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_FROG_TONGUE = create(key("entity.frog.tongue"));
+
+    /**
+     * {@code minecraft:entity.generic.big_fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GENERIC_BIG_FALL = create(key("entity.generic.big_fall"));
+
+    /**
+     * {@code minecraft:entity.generic.burn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GENERIC_BURN = create(key("entity.generic.burn"));
+
+    /**
+     * {@code minecraft:entity.generic.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GENERIC_DEATH = create(key("entity.generic.death"));
+
+    /**
+     * {@code minecraft:entity.generic.drink}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GENERIC_DRINK = create(key("entity.generic.drink"));
+
+    /**
+     * {@code minecraft:entity.generic.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GENERIC_EAT = create(key("entity.generic.eat"));
+
+    /**
+     * {@code minecraft:entity.generic.explode}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GENERIC_EXPLODE = create(key("entity.generic.explode"));
+
+    /**
+     * {@code minecraft:entity.generic.extinguish_fire}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GENERIC_EXTINGUISH_FIRE = create(key("entity.generic.extinguish_fire"));
+
+    /**
+     * {@code minecraft:entity.generic.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GENERIC_HURT = create(key("entity.generic.hurt"));
+
+    /**
+     * {@code minecraft:entity.generic.small_fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GENERIC_SMALL_FALL = create(key("entity.generic.small_fall"));
+
+    /**
+     * {@code minecraft:entity.generic.splash}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GENERIC_SPLASH = create(key("entity.generic.splash"));
+
+    /**
+     * {@code minecraft:entity.generic.swim}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GENERIC_SWIM = create(key("entity.generic.swim"));
+
+    /**
+     * {@code minecraft:entity.ghast.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GHAST_AMBIENT = create(key("entity.ghast.ambient"));
+
+    /**
+     * {@code minecraft:entity.ghast.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GHAST_DEATH = create(key("entity.ghast.death"));
+
+    /**
+     * {@code minecraft:entity.ghast.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GHAST_HURT = create(key("entity.ghast.hurt"));
+
+    /**
+     * {@code minecraft:entity.ghast.scream}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GHAST_SCREAM = create(key("entity.ghast.scream"));
+
+    /**
+     * {@code minecraft:entity.ghast.shoot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GHAST_SHOOT = create(key("entity.ghast.shoot"));
+
+    /**
+     * {@code minecraft:entity.ghast.warn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GHAST_WARN = create(key("entity.ghast.warn"));
+
+    /**
+     * {@code minecraft:entity.glow_item_frame.add_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GLOW_ITEM_FRAME_ADD_ITEM = create(key("entity.glow_item_frame.add_item"));
+
+    /**
+     * {@code minecraft:entity.glow_item_frame.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GLOW_ITEM_FRAME_BREAK = create(key("entity.glow_item_frame.break"));
+
+    /**
+     * {@code minecraft:entity.glow_item_frame.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GLOW_ITEM_FRAME_PLACE = create(key("entity.glow_item_frame.place"));
+
+    /**
+     * {@code minecraft:entity.glow_item_frame.remove_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GLOW_ITEM_FRAME_REMOVE_ITEM = create(key("entity.glow_item_frame.remove_item"));
+
+    /**
+     * {@code minecraft:entity.glow_item_frame.rotate_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GLOW_ITEM_FRAME_ROTATE_ITEM = create(key("entity.glow_item_frame.rotate_item"));
+
+    /**
+     * {@code minecraft:entity.glow_squid.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GLOW_SQUID_AMBIENT = create(key("entity.glow_squid.ambient"));
+
+    /**
+     * {@code minecraft:entity.glow_squid.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GLOW_SQUID_DEATH = create(key("entity.glow_squid.death"));
+
+    /**
+     * {@code minecraft:entity.glow_squid.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GLOW_SQUID_HURT = create(key("entity.glow_squid.hurt"));
+
+    /**
+     * {@code minecraft:entity.glow_squid.squirt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GLOW_SQUID_SQUIRT = create(key("entity.glow_squid.squirt"));
+
+    /**
+     * {@code minecraft:entity.goat.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_AMBIENT = create(key("entity.goat.ambient"));
+
+    /**
+     * {@code minecraft:entity.goat.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_DEATH = create(key("entity.goat.death"));
+
+    /**
+     * {@code minecraft:entity.goat.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_EAT = create(key("entity.goat.eat"));
+
+    /**
+     * {@code minecraft:entity.goat.horn_break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_HORN_BREAK = create(key("entity.goat.horn_break"));
+
+    /**
+     * {@code minecraft:entity.goat.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_HURT = create(key("entity.goat.hurt"));
+
+    /**
+     * {@code minecraft:entity.goat.long_jump}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_LONG_JUMP = create(key("entity.goat.long_jump"));
+
+    /**
+     * {@code minecraft:entity.goat.milk}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_MILK = create(key("entity.goat.milk"));
+
+    /**
+     * {@code minecraft:entity.goat.prepare_ram}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_PREPARE_RAM = create(key("entity.goat.prepare_ram"));
+
+    /**
+     * {@code minecraft:entity.goat.ram_impact}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_RAM_IMPACT = create(key("entity.goat.ram_impact"));
+
+    /**
+     * {@code minecraft:entity.goat.screaming.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_SCREAMING_AMBIENT = create(key("entity.goat.screaming.ambient"));
+
+    /**
+     * {@code minecraft:entity.goat.screaming.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_SCREAMING_DEATH = create(key("entity.goat.screaming.death"));
+
+    /**
+     * {@code minecraft:entity.goat.screaming.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_SCREAMING_EAT = create(key("entity.goat.screaming.eat"));
+
+    /**
+     * {@code minecraft:entity.goat.screaming.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_SCREAMING_HURT = create(key("entity.goat.screaming.hurt"));
+
+    /**
+     * {@code minecraft:entity.goat.screaming.long_jump}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_SCREAMING_LONG_JUMP = create(key("entity.goat.screaming.long_jump"));
+
+    /**
+     * {@code minecraft:entity.goat.screaming.milk}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_SCREAMING_MILK = create(key("entity.goat.screaming.milk"));
+
+    /**
+     * {@code minecraft:entity.goat.screaming.prepare_ram}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_SCREAMING_PREPARE_RAM = create(key("entity.goat.screaming.prepare_ram"));
+
+    /**
+     * {@code minecraft:entity.goat.screaming.ram_impact}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_SCREAMING_RAM_IMPACT = create(key("entity.goat.screaming.ram_impact"));
+
+    /**
+     * {@code minecraft:entity.goat.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GOAT_STEP = create(key("entity.goat.step"));
+
+    /**
+     * {@code minecraft:entity.guardian.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GUARDIAN_AMBIENT = create(key("entity.guardian.ambient"));
+
+    /**
+     * {@code minecraft:entity.guardian.ambient_land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GUARDIAN_AMBIENT_LAND = create(key("entity.guardian.ambient_land"));
+
+    /**
+     * {@code minecraft:entity.guardian.attack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GUARDIAN_ATTACK = create(key("entity.guardian.attack"));
+
+    /**
+     * {@code minecraft:entity.guardian.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GUARDIAN_DEATH = create(key("entity.guardian.death"));
+
+    /**
+     * {@code minecraft:entity.guardian.death_land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GUARDIAN_DEATH_LAND = create(key("entity.guardian.death_land"));
+
+    /**
+     * {@code minecraft:entity.guardian.flop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GUARDIAN_FLOP = create(key("entity.guardian.flop"));
+
+    /**
+     * {@code minecraft:entity.guardian.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GUARDIAN_HURT = create(key("entity.guardian.hurt"));
+
+    /**
+     * {@code minecraft:entity.guardian.hurt_land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_GUARDIAN_HURT_LAND = create(key("entity.guardian.hurt_land"));
+
+    /**
+     * {@code minecraft:entity.hoglin.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOGLIN_AMBIENT = create(key("entity.hoglin.ambient"));
+
+    /**
+     * {@code minecraft:entity.hoglin.angry}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOGLIN_ANGRY = create(key("entity.hoglin.angry"));
+
+    /**
+     * {@code minecraft:entity.hoglin.attack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOGLIN_ATTACK = create(key("entity.hoglin.attack"));
+
+    /**
+     * {@code minecraft:entity.hoglin.converted_to_zombified}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOGLIN_CONVERTED_TO_ZOMBIFIED = create(key("entity.hoglin.converted_to_zombified"));
+
+    /**
+     * {@code minecraft:entity.hoglin.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOGLIN_DEATH = create(key("entity.hoglin.death"));
+
+    /**
+     * {@code minecraft:entity.hoglin.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOGLIN_HURT = create(key("entity.hoglin.hurt"));
+
+    /**
+     * {@code minecraft:entity.hoglin.retreat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOGLIN_RETREAT = create(key("entity.hoglin.retreat"));
+
+    /**
+     * {@code minecraft:entity.hoglin.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOGLIN_STEP = create(key("entity.hoglin.step"));
+
+    /**
+     * {@code minecraft:entity.horse.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_AMBIENT = create(key("entity.horse.ambient"));
+
+    /**
+     * {@code minecraft:entity.horse.angry}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_ANGRY = create(key("entity.horse.angry"));
+
+    /**
+     * {@code minecraft:entity.horse.armor}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_ARMOR = create(key("entity.horse.armor"));
+
+    /**
+     * {@code minecraft:entity.horse.breathe}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_BREATHE = create(key("entity.horse.breathe"));
+
+    /**
+     * {@code minecraft:entity.horse.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_DEATH = create(key("entity.horse.death"));
+
+    /**
+     * {@code minecraft:entity.horse.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_EAT = create(key("entity.horse.eat"));
+
+    /**
+     * {@code minecraft:entity.horse.gallop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_GALLOP = create(key("entity.horse.gallop"));
+
+    /**
+     * {@code minecraft:entity.horse.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_HURT = create(key("entity.horse.hurt"));
+
+    /**
+     * {@code minecraft:entity.horse.jump}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_JUMP = create(key("entity.horse.jump"));
+
+    /**
+     * {@code minecraft:entity.horse.land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_LAND = create(key("entity.horse.land"));
+
+    /**
+     * {@code minecraft:entity.horse.saddle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_SADDLE = create(key("entity.horse.saddle"));
+
+    /**
+     * {@code minecraft:entity.horse.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_STEP = create(key("entity.horse.step"));
+
+    /**
+     * {@code minecraft:entity.horse.step_wood}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HORSE_STEP_WOOD = create(key("entity.horse.step_wood"));
+
+    /**
+     * {@code minecraft:entity.hostile.big_fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOSTILE_BIG_FALL = create(key("entity.hostile.big_fall"));
+
+    /**
+     * {@code minecraft:entity.hostile.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOSTILE_DEATH = create(key("entity.hostile.death"));
+
+    /**
+     * {@code minecraft:entity.hostile.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOSTILE_HURT = create(key("entity.hostile.hurt"));
+
+    /**
+     * {@code minecraft:entity.hostile.small_fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOSTILE_SMALL_FALL = create(key("entity.hostile.small_fall"));
+
+    /**
+     * {@code minecraft:entity.hostile.splash}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOSTILE_SPLASH = create(key("entity.hostile.splash"));
+
+    /**
+     * {@code minecraft:entity.hostile.swim}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HOSTILE_SWIM = create(key("entity.hostile.swim"));
+
+    /**
+     * {@code minecraft:entity.husk.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HUSK_AMBIENT = create(key("entity.husk.ambient"));
+
+    /**
+     * {@code minecraft:entity.husk.converted_to_zombie}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HUSK_CONVERTED_TO_ZOMBIE = create(key("entity.husk.converted_to_zombie"));
+
+    /**
+     * {@code minecraft:entity.husk.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HUSK_DEATH = create(key("entity.husk.death"));
+
+    /**
+     * {@code minecraft:entity.husk.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HUSK_HURT = create(key("entity.husk.hurt"));
+
+    /**
+     * {@code minecraft:entity.husk.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_HUSK_STEP = create(key("entity.husk.step"));
+
+    /**
+     * {@code minecraft:entity.illusioner.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ILLUSIONER_AMBIENT = create(key("entity.illusioner.ambient"));
+
+    /**
+     * {@code minecraft:entity.illusioner.cast_spell}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ILLUSIONER_CAST_SPELL = create(key("entity.illusioner.cast_spell"));
+
+    /**
+     * {@code minecraft:entity.illusioner.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ILLUSIONER_DEATH = create(key("entity.illusioner.death"));
+
+    /**
+     * {@code minecraft:entity.illusioner.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ILLUSIONER_HURT = create(key("entity.illusioner.hurt"));
+
+    /**
+     * {@code minecraft:entity.illusioner.mirror_move}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ILLUSIONER_MIRROR_MOVE = create(key("entity.illusioner.mirror_move"));
+
+    /**
+     * {@code minecraft:entity.illusioner.prepare_blindness}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ILLUSIONER_PREPARE_BLINDNESS = create(key("entity.illusioner.prepare_blindness"));
+
+    /**
+     * {@code minecraft:entity.illusioner.prepare_mirror}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ILLUSIONER_PREPARE_MIRROR = create(key("entity.illusioner.prepare_mirror"));
+
+    /**
+     * {@code minecraft:entity.iron_golem.attack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_IRON_GOLEM_ATTACK = create(key("entity.iron_golem.attack"));
+
+    /**
+     * {@code minecraft:entity.iron_golem.damage}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_IRON_GOLEM_DAMAGE = create(key("entity.iron_golem.damage"));
+
+    /**
+     * {@code minecraft:entity.iron_golem.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_IRON_GOLEM_DEATH = create(key("entity.iron_golem.death"));
+
+    /**
+     * {@code minecraft:entity.iron_golem.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_IRON_GOLEM_HURT = create(key("entity.iron_golem.hurt"));
+
+    /**
+     * {@code minecraft:entity.iron_golem.repair}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_IRON_GOLEM_REPAIR = create(key("entity.iron_golem.repair"));
+
+    /**
+     * {@code minecraft:entity.iron_golem.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_IRON_GOLEM_STEP = create(key("entity.iron_golem.step"));
+
+    /**
+     * {@code minecraft:entity.item.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ITEM_BREAK = create(key("entity.item.break"));
+
+    /**
+     * {@code minecraft:entity.item.pickup}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ITEM_PICKUP = create(key("entity.item.pickup"));
+
+    /**
+     * {@code minecraft:entity.item_frame.add_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ITEM_FRAME_ADD_ITEM = create(key("entity.item_frame.add_item"));
+
+    /**
+     * {@code minecraft:entity.item_frame.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ITEM_FRAME_BREAK = create(key("entity.item_frame.break"));
+
+    /**
+     * {@code minecraft:entity.item_frame.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ITEM_FRAME_PLACE = create(key("entity.item_frame.place"));
+
+    /**
+     * {@code minecraft:entity.item_frame.remove_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ITEM_FRAME_REMOVE_ITEM = create(key("entity.item_frame.remove_item"));
+
+    /**
+     * {@code minecraft:entity.item_frame.rotate_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ITEM_FRAME_ROTATE_ITEM = create(key("entity.item_frame.rotate_item"));
+
+    /**
+     * {@code minecraft:entity.leash_knot.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LEASH_KNOT_BREAK = create(key("entity.leash_knot.break"));
+
+    /**
+     * {@code minecraft:entity.leash_knot.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LEASH_KNOT_PLACE = create(key("entity.leash_knot.place"));
+
+    /**
+     * {@code minecraft:entity.lightning_bolt.impact}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LIGHTNING_BOLT_IMPACT = create(key("entity.lightning_bolt.impact"));
+
+    /**
+     * {@code minecraft:entity.lightning_bolt.thunder}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LIGHTNING_BOLT_THUNDER = create(key("entity.lightning_bolt.thunder"));
+
+    /**
+     * {@code minecraft:entity.lingering_potion.throw}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LINGERING_POTION_THROW = create(key("entity.lingering_potion.throw"));
+
+    /**
+     * {@code minecraft:entity.llama.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LLAMA_AMBIENT = create(key("entity.llama.ambient"));
+
+    /**
+     * {@code minecraft:entity.llama.angry}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LLAMA_ANGRY = create(key("entity.llama.angry"));
+
+    /**
+     * {@code minecraft:entity.llama.chest}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LLAMA_CHEST = create(key("entity.llama.chest"));
+
+    /**
+     * {@code minecraft:entity.llama.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LLAMA_DEATH = create(key("entity.llama.death"));
+
+    /**
+     * {@code minecraft:entity.llama.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LLAMA_EAT = create(key("entity.llama.eat"));
+
+    /**
+     * {@code minecraft:entity.llama.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LLAMA_HURT = create(key("entity.llama.hurt"));
+
+    /**
+     * {@code minecraft:entity.llama.spit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LLAMA_SPIT = create(key("entity.llama.spit"));
+
+    /**
+     * {@code minecraft:entity.llama.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LLAMA_STEP = create(key("entity.llama.step"));
+
+    /**
+     * {@code minecraft:entity.llama.swag}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_LLAMA_SWAG = create(key("entity.llama.swag"));
+
+    /**
+     * {@code minecraft:entity.magma_cube.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MAGMA_CUBE_DEATH = create(key("entity.magma_cube.death"));
+
+    /**
+     * {@code minecraft:entity.magma_cube.death_small}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MAGMA_CUBE_DEATH_SMALL = create(key("entity.magma_cube.death_small"));
+
+    /**
+     * {@code minecraft:entity.magma_cube.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MAGMA_CUBE_HURT = create(key("entity.magma_cube.hurt"));
+
+    /**
+     * {@code minecraft:entity.magma_cube.hurt_small}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MAGMA_CUBE_HURT_SMALL = create(key("entity.magma_cube.hurt_small"));
+
+    /**
+     * {@code minecraft:entity.magma_cube.jump}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MAGMA_CUBE_JUMP = create(key("entity.magma_cube.jump"));
+
+    /**
+     * {@code minecraft:entity.magma_cube.squish}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MAGMA_CUBE_SQUISH = create(key("entity.magma_cube.squish"));
+
+    /**
+     * {@code minecraft:entity.magma_cube.squish_small}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MAGMA_CUBE_SQUISH_SMALL = create(key("entity.magma_cube.squish_small"));
+
+    /**
+     * {@code minecraft:entity.minecart.inside}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MINECART_INSIDE = create(key("entity.minecart.inside"));
+
+    /**
+     * {@code minecraft:entity.minecart.inside.underwater}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MINECART_INSIDE_UNDERWATER = create(key("entity.minecart.inside.underwater"));
+
+    /**
+     * {@code minecraft:entity.minecart.riding}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MINECART_RIDING = create(key("entity.minecart.riding"));
+
+    /**
+     * {@code minecraft:entity.mooshroom.convert}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MOOSHROOM_CONVERT = create(key("entity.mooshroom.convert"));
+
+    /**
+     * {@code minecraft:entity.mooshroom.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MOOSHROOM_EAT = create(key("entity.mooshroom.eat"));
+
+    /**
+     * {@code minecraft:entity.mooshroom.milk}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MOOSHROOM_MILK = create(key("entity.mooshroom.milk"));
+
+    /**
+     * {@code minecraft:entity.mooshroom.shear}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MOOSHROOM_SHEAR = create(key("entity.mooshroom.shear"));
+
+    /**
+     * {@code minecraft:entity.mooshroom.suspicious_milk}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MOOSHROOM_SUSPICIOUS_MILK = create(key("entity.mooshroom.suspicious_milk"));
+
+    /**
+     * {@code minecraft:entity.mule.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MULE_AMBIENT = create(key("entity.mule.ambient"));
+
+    /**
+     * {@code minecraft:entity.mule.angry}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MULE_ANGRY = create(key("entity.mule.angry"));
+
+    /**
+     * {@code minecraft:entity.mule.chest}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MULE_CHEST = create(key("entity.mule.chest"));
+
+    /**
+     * {@code minecraft:entity.mule.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MULE_DEATH = create(key("entity.mule.death"));
+
+    /**
+     * {@code minecraft:entity.mule.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MULE_EAT = create(key("entity.mule.eat"));
+
+    /**
+     * {@code minecraft:entity.mule.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MULE_HURT = create(key("entity.mule.hurt"));
+
+    /**
+     * {@code minecraft:entity.mule.jump}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_MULE_JUMP = create(key("entity.mule.jump"));
+
+    /**
+     * {@code minecraft:entity.ocelot.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_OCELOT_AMBIENT = create(key("entity.ocelot.ambient"));
+
+    /**
+     * {@code minecraft:entity.ocelot.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_OCELOT_DEATH = create(key("entity.ocelot.death"));
+
+    /**
+     * {@code minecraft:entity.ocelot.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_OCELOT_HURT = create(key("entity.ocelot.hurt"));
+
+    /**
+     * {@code minecraft:entity.painting.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PAINTING_BREAK = create(key("entity.painting.break"));
+
+    /**
+     * {@code minecraft:entity.painting.place}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PAINTING_PLACE = create(key("entity.painting.place"));
+
+    /**
+     * {@code minecraft:entity.panda.aggressive_ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PANDA_AGGRESSIVE_AMBIENT = create(key("entity.panda.aggressive_ambient"));
+
+    /**
+     * {@code minecraft:entity.panda.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PANDA_AMBIENT = create(key("entity.panda.ambient"));
+
+    /**
+     * {@code minecraft:entity.panda.bite}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PANDA_BITE = create(key("entity.panda.bite"));
+
+    /**
+     * {@code minecraft:entity.panda.cant_breed}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PANDA_CANT_BREED = create(key("entity.panda.cant_breed"));
+
+    /**
+     * {@code minecraft:entity.panda.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PANDA_DEATH = create(key("entity.panda.death"));
+
+    /**
+     * {@code minecraft:entity.panda.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PANDA_EAT = create(key("entity.panda.eat"));
+
+    /**
+     * {@code minecraft:entity.panda.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PANDA_HURT = create(key("entity.panda.hurt"));
+
+    /**
+     * {@code minecraft:entity.panda.pre_sneeze}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PANDA_PRE_SNEEZE = create(key("entity.panda.pre_sneeze"));
+
+    /**
+     * {@code minecraft:entity.panda.sneeze}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PANDA_SNEEZE = create(key("entity.panda.sneeze"));
+
+    /**
+     * {@code minecraft:entity.panda.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PANDA_STEP = create(key("entity.panda.step"));
+
+    /**
+     * {@code minecraft:entity.panda.worried_ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PANDA_WORRIED_AMBIENT = create(key("entity.panda.worried_ambient"));
+
+    /**
+     * {@code minecraft:entity.parrot.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_AMBIENT = create(key("entity.parrot.ambient"));
+
+    /**
+     * {@code minecraft:entity.parrot.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_DEATH = create(key("entity.parrot.death"));
+
+    /**
+     * {@code minecraft:entity.parrot.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_EAT = create(key("entity.parrot.eat"));
+
+    /**
+     * {@code minecraft:entity.parrot.fly}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_FLY = create(key("entity.parrot.fly"));
+
+    /**
+     * {@code minecraft:entity.parrot.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_HURT = create(key("entity.parrot.hurt"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.blaze}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_BLAZE = create(key("entity.parrot.imitate.blaze"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.bogged}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_BOGGED = create(key("entity.parrot.imitate.bogged"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.breeze}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_BREEZE = create(key("entity.parrot.imitate.breeze"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.creaking}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_CREAKING = create(key("entity.parrot.imitate.creaking"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.creeper}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_CREEPER = create(key("entity.parrot.imitate.creeper"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.drowned}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_DROWNED = create(key("entity.parrot.imitate.drowned"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.elder_guardian}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_ELDER_GUARDIAN = create(key("entity.parrot.imitate.elder_guardian"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.ender_dragon}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_ENDER_DRAGON = create(key("entity.parrot.imitate.ender_dragon"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.endermite}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_ENDERMITE = create(key("entity.parrot.imitate.endermite"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.evoker}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_EVOKER = create(key("entity.parrot.imitate.evoker"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.ghast}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_GHAST = create(key("entity.parrot.imitate.ghast"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.guardian}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_GUARDIAN = create(key("entity.parrot.imitate.guardian"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.hoglin}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_HOGLIN = create(key("entity.parrot.imitate.hoglin"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.husk}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_HUSK = create(key("entity.parrot.imitate.husk"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.illusioner}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_ILLUSIONER = create(key("entity.parrot.imitate.illusioner"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.magma_cube}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_MAGMA_CUBE = create(key("entity.parrot.imitate.magma_cube"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.phantom}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_PHANTOM = create(key("entity.parrot.imitate.phantom"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.piglin}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_PIGLIN = create(key("entity.parrot.imitate.piglin"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.piglin_brute}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_PIGLIN_BRUTE = create(key("entity.parrot.imitate.piglin_brute"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.pillager}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_PILLAGER = create(key("entity.parrot.imitate.pillager"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.ravager}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_RAVAGER = create(key("entity.parrot.imitate.ravager"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.shulker}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_SHULKER = create(key("entity.parrot.imitate.shulker"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.silverfish}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_SILVERFISH = create(key("entity.parrot.imitate.silverfish"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.skeleton}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_SKELETON = create(key("entity.parrot.imitate.skeleton"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.slime}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_SLIME = create(key("entity.parrot.imitate.slime"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.spider}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_SPIDER = create(key("entity.parrot.imitate.spider"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.stray}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_STRAY = create(key("entity.parrot.imitate.stray"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.vex}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_VEX = create(key("entity.parrot.imitate.vex"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.vindicator}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_VINDICATOR = create(key("entity.parrot.imitate.vindicator"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.warden}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_WARDEN = create(key("entity.parrot.imitate.warden"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.witch}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_WITCH = create(key("entity.parrot.imitate.witch"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.wither}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_WITHER = create(key("entity.parrot.imitate.wither"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.wither_skeleton}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_WITHER_SKELETON = create(key("entity.parrot.imitate.wither_skeleton"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.zoglin}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_ZOGLIN = create(key("entity.parrot.imitate.zoglin"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.zombie}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_ZOMBIE = create(key("entity.parrot.imitate.zombie"));
+
+    /**
+     * {@code minecraft:entity.parrot.imitate.zombie_villager}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_IMITATE_ZOMBIE_VILLAGER = create(key("entity.parrot.imitate.zombie_villager"));
+
+    /**
+     * {@code minecraft:entity.parrot.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PARROT_STEP = create(key("entity.parrot.step"));
+
+    /**
+     * {@code minecraft:entity.phantom.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PHANTOM_AMBIENT = create(key("entity.phantom.ambient"));
+
+    /**
+     * {@code minecraft:entity.phantom.bite}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PHANTOM_BITE = create(key("entity.phantom.bite"));
+
+    /**
+     * {@code minecraft:entity.phantom.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PHANTOM_DEATH = create(key("entity.phantom.death"));
+
+    /**
+     * {@code minecraft:entity.phantom.flap}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PHANTOM_FLAP = create(key("entity.phantom.flap"));
+
+    /**
+     * {@code minecraft:entity.phantom.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PHANTOM_HURT = create(key("entity.phantom.hurt"));
+
+    /**
+     * {@code minecraft:entity.phantom.swoop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PHANTOM_SWOOP = create(key("entity.phantom.swoop"));
+
+    /**
+     * {@code minecraft:entity.pig.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIG_AMBIENT = create(key("entity.pig.ambient"));
+
+    /**
+     * {@code minecraft:entity.pig.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIG_DEATH = create(key("entity.pig.death"));
+
+    /**
+     * {@code minecraft:entity.pig.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIG_HURT = create(key("entity.pig.hurt"));
+
+    /**
+     * {@code minecraft:entity.pig.saddle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIG_SADDLE = create(key("entity.pig.saddle"));
+
+    /**
+     * {@code minecraft:entity.pig.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIG_STEP = create(key("entity.pig.step"));
+
+    /**
+     * {@code minecraft:entity.piglin.admiring_item}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_ADMIRING_ITEM = create(key("entity.piglin.admiring_item"));
+
+    /**
+     * {@code minecraft:entity.piglin.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_AMBIENT = create(key("entity.piglin.ambient"));
+
+    /**
+     * {@code minecraft:entity.piglin.angry}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_ANGRY = create(key("entity.piglin.angry"));
+
+    /**
+     * {@code minecraft:entity.piglin.celebrate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_CELEBRATE = create(key("entity.piglin.celebrate"));
+
+    /**
+     * {@code minecraft:entity.piglin.converted_to_zombified}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_CONVERTED_TO_ZOMBIFIED = create(key("entity.piglin.converted_to_zombified"));
+
+    /**
+     * {@code minecraft:entity.piglin.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_DEATH = create(key("entity.piglin.death"));
+
+    /**
+     * {@code minecraft:entity.piglin.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_HURT = create(key("entity.piglin.hurt"));
+
+    /**
+     * {@code minecraft:entity.piglin.jealous}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_JEALOUS = create(key("entity.piglin.jealous"));
+
+    /**
+     * {@code minecraft:entity.piglin.retreat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_RETREAT = create(key("entity.piglin.retreat"));
+
+    /**
+     * {@code minecraft:entity.piglin.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_STEP = create(key("entity.piglin.step"));
+
+    /**
+     * {@code minecraft:entity.piglin_brute.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_BRUTE_AMBIENT = create(key("entity.piglin_brute.ambient"));
+
+    /**
+     * {@code minecraft:entity.piglin_brute.angry}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_BRUTE_ANGRY = create(key("entity.piglin_brute.angry"));
+
+    /**
+     * {@code minecraft:entity.piglin_brute.converted_to_zombified}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_BRUTE_CONVERTED_TO_ZOMBIFIED = create(key("entity.piglin_brute.converted_to_zombified"));
+
+    /**
+     * {@code minecraft:entity.piglin_brute.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_BRUTE_DEATH = create(key("entity.piglin_brute.death"));
+
+    /**
+     * {@code minecraft:entity.piglin_brute.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_BRUTE_HURT = create(key("entity.piglin_brute.hurt"));
+
+    /**
+     * {@code minecraft:entity.piglin_brute.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PIGLIN_BRUTE_STEP = create(key("entity.piglin_brute.step"));
+
+    /**
+     * {@code minecraft:entity.pillager.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PILLAGER_AMBIENT = create(key("entity.pillager.ambient"));
+
+    /**
+     * {@code minecraft:entity.pillager.celebrate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PILLAGER_CELEBRATE = create(key("entity.pillager.celebrate"));
+
+    /**
+     * {@code minecraft:entity.pillager.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PILLAGER_DEATH = create(key("entity.pillager.death"));
+
+    /**
+     * {@code minecraft:entity.pillager.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PILLAGER_HURT = create(key("entity.pillager.hurt"));
+
+    /**
+     * {@code minecraft:entity.player.attack.crit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_ATTACK_CRIT = create(key("entity.player.attack.crit"));
+
+    /**
+     * {@code minecraft:entity.player.attack.knockback}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_ATTACK_KNOCKBACK = create(key("entity.player.attack.knockback"));
+
+    /**
+     * {@code minecraft:entity.player.attack.nodamage}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_ATTACK_NODAMAGE = create(key("entity.player.attack.nodamage"));
+
+    /**
+     * {@code minecraft:entity.player.attack.strong}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_ATTACK_STRONG = create(key("entity.player.attack.strong"));
+
+    /**
+     * {@code minecraft:entity.player.attack.sweep}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_ATTACK_SWEEP = create(key("entity.player.attack.sweep"));
+
+    /**
+     * {@code minecraft:entity.player.attack.weak}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_ATTACK_WEAK = create(key("entity.player.attack.weak"));
+
+    /**
+     * {@code minecraft:entity.player.big_fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_BIG_FALL = create(key("entity.player.big_fall"));
+
+    /**
+     * {@code minecraft:entity.player.breath}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_BREATH = create(key("entity.player.breath"));
+
+    /**
+     * {@code minecraft:entity.player.burp}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_BURP = create(key("entity.player.burp"));
+
+    /**
+     * {@code minecraft:entity.player.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_DEATH = create(key("entity.player.death"));
+
+    /**
+     * {@code minecraft:entity.player.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_HURT = create(key("entity.player.hurt"));
+
+    /**
+     * {@code minecraft:entity.player.hurt_drown}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_HURT_DROWN = create(key("entity.player.hurt_drown"));
+
+    /**
+     * {@code minecraft:entity.player.hurt_freeze}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_HURT_FREEZE = create(key("entity.player.hurt_freeze"));
+
+    /**
+     * {@code minecraft:entity.player.hurt_on_fire}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_HURT_ON_FIRE = create(key("entity.player.hurt_on_fire"));
+
+    /**
+     * {@code minecraft:entity.player.hurt_sweet_berry_bush}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_HURT_SWEET_BERRY_BUSH = create(key("entity.player.hurt_sweet_berry_bush"));
+
+    /**
+     * {@code minecraft:entity.player.levelup}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_LEVELUP = create(key("entity.player.levelup"));
+
+    /**
+     * {@code minecraft:entity.player.small_fall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_SMALL_FALL = create(key("entity.player.small_fall"));
+
+    /**
+     * {@code minecraft:entity.player.splash}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_SPLASH = create(key("entity.player.splash"));
+
+    /**
+     * {@code minecraft:entity.player.splash.high_speed}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_SPLASH_HIGH_SPEED = create(key("entity.player.splash.high_speed"));
+
+    /**
+     * {@code minecraft:entity.player.swim}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_SWIM = create(key("entity.player.swim"));
+
+    /**
+     * {@code minecraft:entity.player.teleport}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PLAYER_TELEPORT = create(key("entity.player.teleport"));
+
+    /**
+     * {@code minecraft:entity.polar_bear.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_POLAR_BEAR_AMBIENT = create(key("entity.polar_bear.ambient"));
+
+    /**
+     * {@code minecraft:entity.polar_bear.ambient_baby}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_POLAR_BEAR_AMBIENT_BABY = create(key("entity.polar_bear.ambient_baby"));
+
+    /**
+     * {@code minecraft:entity.polar_bear.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_POLAR_BEAR_DEATH = create(key("entity.polar_bear.death"));
+
+    /**
+     * {@code minecraft:entity.polar_bear.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_POLAR_BEAR_HURT = create(key("entity.polar_bear.hurt"));
+
+    /**
+     * {@code minecraft:entity.polar_bear.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_POLAR_BEAR_STEP = create(key("entity.polar_bear.step"));
+
+    /**
+     * {@code minecraft:entity.polar_bear.warning}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_POLAR_BEAR_WARNING = create(key("entity.polar_bear.warning"));
+
+    /**
+     * {@code minecraft:entity.puffer_fish.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PUFFER_FISH_AMBIENT = create(key("entity.puffer_fish.ambient"));
+
+    /**
+     * {@code minecraft:entity.puffer_fish.blow_out}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PUFFER_FISH_BLOW_OUT = create(key("entity.puffer_fish.blow_out"));
+
+    /**
+     * {@code minecraft:entity.puffer_fish.blow_up}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PUFFER_FISH_BLOW_UP = create(key("entity.puffer_fish.blow_up"));
+
+    /**
+     * {@code minecraft:entity.puffer_fish.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PUFFER_FISH_DEATH = create(key("entity.puffer_fish.death"));
+
+    /**
+     * {@code minecraft:entity.puffer_fish.flop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PUFFER_FISH_FLOP = create(key("entity.puffer_fish.flop"));
+
+    /**
+     * {@code minecraft:entity.puffer_fish.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PUFFER_FISH_HURT = create(key("entity.puffer_fish.hurt"));
+
+    /**
+     * {@code minecraft:entity.puffer_fish.sting}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_PUFFER_FISH_STING = create(key("entity.puffer_fish.sting"));
+
+    /**
+     * {@code minecraft:entity.rabbit.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RABBIT_AMBIENT = create(key("entity.rabbit.ambient"));
+
+    /**
+     * {@code minecraft:entity.rabbit.attack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RABBIT_ATTACK = create(key("entity.rabbit.attack"));
+
+    /**
+     * {@code minecraft:entity.rabbit.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RABBIT_DEATH = create(key("entity.rabbit.death"));
+
+    /**
+     * {@code minecraft:entity.rabbit.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RABBIT_HURT = create(key("entity.rabbit.hurt"));
+
+    /**
+     * {@code minecraft:entity.rabbit.jump}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RABBIT_JUMP = create(key("entity.rabbit.jump"));
+
+    /**
+     * {@code minecraft:entity.ravager.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RAVAGER_AMBIENT = create(key("entity.ravager.ambient"));
+
+    /**
+     * {@code minecraft:entity.ravager.attack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RAVAGER_ATTACK = create(key("entity.ravager.attack"));
+
+    /**
+     * {@code minecraft:entity.ravager.celebrate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RAVAGER_CELEBRATE = create(key("entity.ravager.celebrate"));
+
+    /**
+     * {@code minecraft:entity.ravager.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RAVAGER_DEATH = create(key("entity.ravager.death"));
+
+    /**
+     * {@code minecraft:entity.ravager.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RAVAGER_HURT = create(key("entity.ravager.hurt"));
+
+    /**
+     * {@code minecraft:entity.ravager.roar}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RAVAGER_ROAR = create(key("entity.ravager.roar"));
+
+    /**
+     * {@code minecraft:entity.ravager.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RAVAGER_STEP = create(key("entity.ravager.step"));
+
+    /**
+     * {@code minecraft:entity.ravager.stunned}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_RAVAGER_STUNNED = create(key("entity.ravager.stunned"));
+
+    /**
+     * {@code minecraft:entity.salmon.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SALMON_AMBIENT = create(key("entity.salmon.ambient"));
+
+    /**
+     * {@code minecraft:entity.salmon.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SALMON_DEATH = create(key("entity.salmon.death"));
+
+    /**
+     * {@code minecraft:entity.salmon.flop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SALMON_FLOP = create(key("entity.salmon.flop"));
+
+    /**
+     * {@code minecraft:entity.salmon.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SALMON_HURT = create(key("entity.salmon.hurt"));
+
+    /**
+     * {@code minecraft:entity.sheep.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHEEP_AMBIENT = create(key("entity.sheep.ambient"));
+
+    /**
+     * {@code minecraft:entity.sheep.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHEEP_DEATH = create(key("entity.sheep.death"));
+
+    /**
+     * {@code minecraft:entity.sheep.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHEEP_HURT = create(key("entity.sheep.hurt"));
+
+    /**
+     * {@code minecraft:entity.sheep.shear}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHEEP_SHEAR = create(key("entity.sheep.shear"));
+
+    /**
+     * {@code minecraft:entity.sheep.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHEEP_STEP = create(key("entity.sheep.step"));
+
+    /**
+     * {@code minecraft:entity.shulker.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHULKER_AMBIENT = create(key("entity.shulker.ambient"));
+
+    /**
+     * {@code minecraft:entity.shulker.close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHULKER_CLOSE = create(key("entity.shulker.close"));
+
+    /**
+     * {@code minecraft:entity.shulker.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHULKER_DEATH = create(key("entity.shulker.death"));
+
+    /**
+     * {@code minecraft:entity.shulker.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHULKER_HURT = create(key("entity.shulker.hurt"));
+
+    /**
+     * {@code minecraft:entity.shulker.hurt_closed}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHULKER_HURT_CLOSED = create(key("entity.shulker.hurt_closed"));
+
+    /**
+     * {@code minecraft:entity.shulker.open}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHULKER_OPEN = create(key("entity.shulker.open"));
+
+    /**
+     * {@code minecraft:entity.shulker.shoot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHULKER_SHOOT = create(key("entity.shulker.shoot"));
+
+    /**
+     * {@code minecraft:entity.shulker.teleport}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHULKER_TELEPORT = create(key("entity.shulker.teleport"));
+
+    /**
+     * {@code minecraft:entity.shulker_bullet.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHULKER_BULLET_HIT = create(key("entity.shulker_bullet.hit"));
+
+    /**
+     * {@code minecraft:entity.shulker_bullet.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SHULKER_BULLET_HURT = create(key("entity.shulker_bullet.hurt"));
+
+    /**
+     * {@code minecraft:entity.silverfish.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SILVERFISH_AMBIENT = create(key("entity.silverfish.ambient"));
+
+    /**
+     * {@code minecraft:entity.silverfish.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SILVERFISH_DEATH = create(key("entity.silverfish.death"));
+
+    /**
+     * {@code minecraft:entity.silverfish.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SILVERFISH_HURT = create(key("entity.silverfish.hurt"));
+
+    /**
+     * {@code minecraft:entity.silverfish.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SILVERFISH_STEP = create(key("entity.silverfish.step"));
+
+    /**
+     * {@code minecraft:entity.skeleton.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_AMBIENT = create(key("entity.skeleton.ambient"));
+
+    /**
+     * {@code minecraft:entity.skeleton.converted_to_stray}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_CONVERTED_TO_STRAY = create(key("entity.skeleton.converted_to_stray"));
+
+    /**
+     * {@code minecraft:entity.skeleton.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_DEATH = create(key("entity.skeleton.death"));
+
+    /**
+     * {@code minecraft:entity.skeleton.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_HURT = create(key("entity.skeleton.hurt"));
+
+    /**
+     * {@code minecraft:entity.skeleton.shoot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_SHOOT = create(key("entity.skeleton.shoot"));
+
+    /**
+     * {@code minecraft:entity.skeleton.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_STEP = create(key("entity.skeleton.step"));
+
+    /**
+     * {@code minecraft:entity.skeleton_horse.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_HORSE_AMBIENT = create(key("entity.skeleton_horse.ambient"));
+
+    /**
+     * {@code minecraft:entity.skeleton_horse.ambient_water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_HORSE_AMBIENT_WATER = create(key("entity.skeleton_horse.ambient_water"));
+
+    /**
+     * {@code minecraft:entity.skeleton_horse.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_HORSE_DEATH = create(key("entity.skeleton_horse.death"));
+
+    /**
+     * {@code minecraft:entity.skeleton_horse.gallop_water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_HORSE_GALLOP_WATER = create(key("entity.skeleton_horse.gallop_water"));
+
+    /**
+     * {@code minecraft:entity.skeleton_horse.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_HORSE_HURT = create(key("entity.skeleton_horse.hurt"));
+
+    /**
+     * {@code minecraft:entity.skeleton_horse.jump_water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_HORSE_JUMP_WATER = create(key("entity.skeleton_horse.jump_water"));
+
+    /**
+     * {@code minecraft:entity.skeleton_horse.step_water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_HORSE_STEP_WATER = create(key("entity.skeleton_horse.step_water"));
+
+    /**
+     * {@code minecraft:entity.skeleton_horse.swim}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SKELETON_HORSE_SWIM = create(key("entity.skeleton_horse.swim"));
+
+    /**
+     * {@code minecraft:entity.slime.attack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SLIME_ATTACK = create(key("entity.slime.attack"));
+
+    /**
+     * {@code minecraft:entity.slime.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SLIME_DEATH = create(key("entity.slime.death"));
+
+    /**
+     * {@code minecraft:entity.slime.death_small}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SLIME_DEATH_SMALL = create(key("entity.slime.death_small"));
+
+    /**
+     * {@code minecraft:entity.slime.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SLIME_HURT = create(key("entity.slime.hurt"));
+
+    /**
+     * {@code minecraft:entity.slime.hurt_small}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SLIME_HURT_SMALL = create(key("entity.slime.hurt_small"));
+
+    /**
+     * {@code minecraft:entity.slime.jump}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SLIME_JUMP = create(key("entity.slime.jump"));
+
+    /**
+     * {@code minecraft:entity.slime.jump_small}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SLIME_JUMP_SMALL = create(key("entity.slime.jump_small"));
+
+    /**
+     * {@code minecraft:entity.slime.squish}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SLIME_SQUISH = create(key("entity.slime.squish"));
+
+    /**
+     * {@code minecraft:entity.slime.squish_small}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SLIME_SQUISH_SMALL = create(key("entity.slime.squish_small"));
+
+    /**
+     * {@code minecraft:entity.sniffer.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNIFFER_DEATH = create(key("entity.sniffer.death"));
+
+    /**
+     * {@code minecraft:entity.sniffer.digging}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNIFFER_DIGGING = create(key("entity.sniffer.digging"));
+
+    /**
+     * {@code minecraft:entity.sniffer.digging_stop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNIFFER_DIGGING_STOP = create(key("entity.sniffer.digging_stop"));
+
+    /**
+     * {@code minecraft:entity.sniffer.drop_seed}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNIFFER_DROP_SEED = create(key("entity.sniffer.drop_seed"));
+
+    /**
+     * {@code minecraft:entity.sniffer.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNIFFER_EAT = create(key("entity.sniffer.eat"));
+
+    /**
+     * {@code minecraft:entity.sniffer.happy}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNIFFER_HAPPY = create(key("entity.sniffer.happy"));
+
+    /**
+     * {@code minecraft:entity.sniffer.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNIFFER_HURT = create(key("entity.sniffer.hurt"));
+
+    /**
+     * {@code minecraft:entity.sniffer.idle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNIFFER_IDLE = create(key("entity.sniffer.idle"));
+
+    /**
+     * {@code minecraft:entity.sniffer.scenting}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNIFFER_SCENTING = create(key("entity.sniffer.scenting"));
+
+    /**
+     * {@code minecraft:entity.sniffer.searching}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNIFFER_SEARCHING = create(key("entity.sniffer.searching"));
+
+    /**
+     * {@code minecraft:entity.sniffer.sniffing}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNIFFER_SNIFFING = create(key("entity.sniffer.sniffing"));
+
+    /**
+     * {@code minecraft:entity.sniffer.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNIFFER_STEP = create(key("entity.sniffer.step"));
+
+    /**
+     * {@code minecraft:entity.snow_golem.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNOW_GOLEM_AMBIENT = create(key("entity.snow_golem.ambient"));
+
+    /**
+     * {@code minecraft:entity.snow_golem.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNOW_GOLEM_DEATH = create(key("entity.snow_golem.death"));
+
+    /**
+     * {@code minecraft:entity.snow_golem.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNOW_GOLEM_HURT = create(key("entity.snow_golem.hurt"));
+
+    /**
+     * {@code minecraft:entity.snow_golem.shear}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNOW_GOLEM_SHEAR = create(key("entity.snow_golem.shear"));
+
+    /**
+     * {@code minecraft:entity.snow_golem.shoot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNOW_GOLEM_SHOOT = create(key("entity.snow_golem.shoot"));
+
+    /**
+     * {@code minecraft:entity.snowball.throw}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SNOWBALL_THROW = create(key("entity.snowball.throw"));
+
+    /**
+     * {@code minecraft:entity.spider.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SPIDER_AMBIENT = create(key("entity.spider.ambient"));
+
+    /**
+     * {@code minecraft:entity.spider.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SPIDER_DEATH = create(key("entity.spider.death"));
+
+    /**
+     * {@code minecraft:entity.spider.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SPIDER_HURT = create(key("entity.spider.hurt"));
+
+    /**
+     * {@code minecraft:entity.spider.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SPIDER_STEP = create(key("entity.spider.step"));
+
+    /**
+     * {@code minecraft:entity.splash_potion.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SPLASH_POTION_BREAK = create(key("entity.splash_potion.break"));
+
+    /**
+     * {@code minecraft:entity.splash_potion.throw}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SPLASH_POTION_THROW = create(key("entity.splash_potion.throw"));
+
+    /**
+     * {@code minecraft:entity.squid.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SQUID_AMBIENT = create(key("entity.squid.ambient"));
+
+    /**
+     * {@code minecraft:entity.squid.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SQUID_DEATH = create(key("entity.squid.death"));
+
+    /**
+     * {@code minecraft:entity.squid.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SQUID_HURT = create(key("entity.squid.hurt"));
+
+    /**
+     * {@code minecraft:entity.squid.squirt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_SQUID_SQUIRT = create(key("entity.squid.squirt"));
+
+    /**
+     * {@code minecraft:entity.stray.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRAY_AMBIENT = create(key("entity.stray.ambient"));
+
+    /**
+     * {@code minecraft:entity.stray.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRAY_DEATH = create(key("entity.stray.death"));
+
+    /**
+     * {@code minecraft:entity.stray.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRAY_HURT = create(key("entity.stray.hurt"));
+
+    /**
+     * {@code minecraft:entity.stray.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRAY_STEP = create(key("entity.stray.step"));
+
+    /**
+     * {@code minecraft:entity.strider.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRIDER_AMBIENT = create(key("entity.strider.ambient"));
+
+    /**
+     * {@code minecraft:entity.strider.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRIDER_DEATH = create(key("entity.strider.death"));
+
+    /**
+     * {@code minecraft:entity.strider.eat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRIDER_EAT = create(key("entity.strider.eat"));
+
+    /**
+     * {@code minecraft:entity.strider.happy}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRIDER_HAPPY = create(key("entity.strider.happy"));
+
+    /**
+     * {@code minecraft:entity.strider.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRIDER_HURT = create(key("entity.strider.hurt"));
+
+    /**
+     * {@code minecraft:entity.strider.retreat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRIDER_RETREAT = create(key("entity.strider.retreat"));
+
+    /**
+     * {@code minecraft:entity.strider.saddle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRIDER_SADDLE = create(key("entity.strider.saddle"));
+
+    /**
+     * {@code minecraft:entity.strider.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRIDER_STEP = create(key("entity.strider.step"));
+
+    /**
+     * {@code minecraft:entity.strider.step_lava}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_STRIDER_STEP_LAVA = create(key("entity.strider.step_lava"));
+
+    /**
+     * {@code minecraft:entity.tadpole.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TADPOLE_DEATH = create(key("entity.tadpole.death"));
+
+    /**
+     * {@code minecraft:entity.tadpole.flop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TADPOLE_FLOP = create(key("entity.tadpole.flop"));
+
+    /**
+     * {@code minecraft:entity.tadpole.grow_up}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TADPOLE_GROW_UP = create(key("entity.tadpole.grow_up"));
+
+    /**
+     * {@code minecraft:entity.tadpole.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TADPOLE_HURT = create(key("entity.tadpole.hurt"));
+
+    /**
+     * {@code minecraft:entity.tnt.primed}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TNT_PRIMED = create(key("entity.tnt.primed"));
+
+    /**
+     * {@code minecraft:entity.tropical_fish.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TROPICAL_FISH_AMBIENT = create(key("entity.tropical_fish.ambient"));
+
+    /**
+     * {@code minecraft:entity.tropical_fish.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TROPICAL_FISH_DEATH = create(key("entity.tropical_fish.death"));
+
+    /**
+     * {@code minecraft:entity.tropical_fish.flop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TROPICAL_FISH_FLOP = create(key("entity.tropical_fish.flop"));
+
+    /**
+     * {@code minecraft:entity.tropical_fish.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TROPICAL_FISH_HURT = create(key("entity.tropical_fish.hurt"));
+
+    /**
+     * {@code minecraft:entity.turtle.ambient_land}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TURTLE_AMBIENT_LAND = create(key("entity.turtle.ambient_land"));
+
+    /**
+     * {@code minecraft:entity.turtle.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TURTLE_DEATH = create(key("entity.turtle.death"));
+
+    /**
+     * {@code minecraft:entity.turtle.death_baby}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TURTLE_DEATH_BABY = create(key("entity.turtle.death_baby"));
+
+    /**
+     * {@code minecraft:entity.turtle.egg_break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TURTLE_EGG_BREAK = create(key("entity.turtle.egg_break"));
+
+    /**
+     * {@code minecraft:entity.turtle.egg_crack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TURTLE_EGG_CRACK = create(key("entity.turtle.egg_crack"));
+
+    /**
+     * {@code minecraft:entity.turtle.egg_hatch}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TURTLE_EGG_HATCH = create(key("entity.turtle.egg_hatch"));
+
+    /**
+     * {@code minecraft:entity.turtle.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TURTLE_HURT = create(key("entity.turtle.hurt"));
+
+    /**
+     * {@code minecraft:entity.turtle.hurt_baby}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TURTLE_HURT_BABY = create(key("entity.turtle.hurt_baby"));
+
+    /**
+     * {@code minecraft:entity.turtle.lay_egg}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TURTLE_LAY_EGG = create(key("entity.turtle.lay_egg"));
+
+    /**
+     * {@code minecraft:entity.turtle.shamble}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TURTLE_SHAMBLE = create(key("entity.turtle.shamble"));
+
+    /**
+     * {@code minecraft:entity.turtle.shamble_baby}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TURTLE_SHAMBLE_BABY = create(key("entity.turtle.shamble_baby"));
+
+    /**
+     * {@code minecraft:entity.turtle.swim}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_TURTLE_SWIM = create(key("entity.turtle.swim"));
+
+    /**
+     * {@code minecraft:entity.vex.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VEX_AMBIENT = create(key("entity.vex.ambient"));
+
+    /**
+     * {@code minecraft:entity.vex.charge}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VEX_CHARGE = create(key("entity.vex.charge"));
+
+    /**
+     * {@code minecraft:entity.vex.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VEX_DEATH = create(key("entity.vex.death"));
+
+    /**
+     * {@code minecraft:entity.vex.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VEX_HURT = create(key("entity.vex.hurt"));
+
+    /**
+     * {@code minecraft:entity.villager.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_AMBIENT = create(key("entity.villager.ambient"));
+
+    /**
+     * {@code minecraft:entity.villager.celebrate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_CELEBRATE = create(key("entity.villager.celebrate"));
+
+    /**
+     * {@code minecraft:entity.villager.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_DEATH = create(key("entity.villager.death"));
+
+    /**
+     * {@code minecraft:entity.villager.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_HURT = create(key("entity.villager.hurt"));
+
+    /**
+     * {@code minecraft:entity.villager.no}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_NO = create(key("entity.villager.no"));
+
+    /**
+     * {@code minecraft:entity.villager.trade}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_TRADE = create(key("entity.villager.trade"));
+
+    /**
+     * {@code minecraft:entity.villager.work_armorer}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_ARMORER = create(key("entity.villager.work_armorer"));
+
+    /**
+     * {@code minecraft:entity.villager.work_butcher}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_BUTCHER = create(key("entity.villager.work_butcher"));
+
+    /**
+     * {@code minecraft:entity.villager.work_cartographer}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_CARTOGRAPHER = create(key("entity.villager.work_cartographer"));
+
+    /**
+     * {@code minecraft:entity.villager.work_cleric}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_CLERIC = create(key("entity.villager.work_cleric"));
+
+    /**
+     * {@code minecraft:entity.villager.work_farmer}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_FARMER = create(key("entity.villager.work_farmer"));
+
+    /**
+     * {@code minecraft:entity.villager.work_fisherman}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_FISHERMAN = create(key("entity.villager.work_fisherman"));
+
+    /**
+     * {@code minecraft:entity.villager.work_fletcher}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_FLETCHER = create(key("entity.villager.work_fletcher"));
+
+    /**
+     * {@code minecraft:entity.villager.work_leatherworker}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_LEATHERWORKER = create(key("entity.villager.work_leatherworker"));
+
+    /**
+     * {@code minecraft:entity.villager.work_librarian}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_LIBRARIAN = create(key("entity.villager.work_librarian"));
+
+    /**
+     * {@code minecraft:entity.villager.work_mason}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_MASON = create(key("entity.villager.work_mason"));
+
+    /**
+     * {@code minecraft:entity.villager.work_shepherd}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_SHEPHERD = create(key("entity.villager.work_shepherd"));
+
+    /**
+     * {@code minecraft:entity.villager.work_toolsmith}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_TOOLSMITH = create(key("entity.villager.work_toolsmith"));
+
+    /**
+     * {@code minecraft:entity.villager.work_weaponsmith}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_WORK_WEAPONSMITH = create(key("entity.villager.work_weaponsmith"));
+
+    /**
+     * {@code minecraft:entity.villager.yes}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VILLAGER_YES = create(key("entity.villager.yes"));
+
+    /**
+     * {@code minecraft:entity.vindicator.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VINDICATOR_AMBIENT = create(key("entity.vindicator.ambient"));
+
+    /**
+     * {@code minecraft:entity.vindicator.celebrate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VINDICATOR_CELEBRATE = create(key("entity.vindicator.celebrate"));
+
+    /**
+     * {@code minecraft:entity.vindicator.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VINDICATOR_DEATH = create(key("entity.vindicator.death"));
+
+    /**
+     * {@code minecraft:entity.vindicator.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_VINDICATOR_HURT = create(key("entity.vindicator.hurt"));
+
+    /**
+     * {@code minecraft:entity.wandering_trader.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WANDERING_TRADER_AMBIENT = create(key("entity.wandering_trader.ambient"));
+
+    /**
+     * {@code minecraft:entity.wandering_trader.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WANDERING_TRADER_DEATH = create(key("entity.wandering_trader.death"));
+
+    /**
+     * {@code minecraft:entity.wandering_trader.disappeared}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WANDERING_TRADER_DISAPPEARED = create(key("entity.wandering_trader.disappeared"));
+
+    /**
+     * {@code minecraft:entity.wandering_trader.drink_milk}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WANDERING_TRADER_DRINK_MILK = create(key("entity.wandering_trader.drink_milk"));
+
+    /**
+     * {@code minecraft:entity.wandering_trader.drink_potion}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WANDERING_TRADER_DRINK_POTION = create(key("entity.wandering_trader.drink_potion"));
+
+    /**
+     * {@code minecraft:entity.wandering_trader.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WANDERING_TRADER_HURT = create(key("entity.wandering_trader.hurt"));
+
+    /**
+     * {@code minecraft:entity.wandering_trader.no}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WANDERING_TRADER_NO = create(key("entity.wandering_trader.no"));
+
+    /**
+     * {@code minecraft:entity.wandering_trader.reappeared}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WANDERING_TRADER_REAPPEARED = create(key("entity.wandering_trader.reappeared"));
+
+    /**
+     * {@code minecraft:entity.wandering_trader.trade}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WANDERING_TRADER_TRADE = create(key("entity.wandering_trader.trade"));
+
+    /**
+     * {@code minecraft:entity.wandering_trader.yes}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WANDERING_TRADER_YES = create(key("entity.wandering_trader.yes"));
+
+    /**
+     * {@code minecraft:entity.warden.agitated}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_AGITATED = create(key("entity.warden.agitated"));
+
+    /**
+     * {@code minecraft:entity.warden.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_AMBIENT = create(key("entity.warden.ambient"));
+
+    /**
+     * {@code minecraft:entity.warden.angry}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_ANGRY = create(key("entity.warden.angry"));
+
+    /**
+     * {@code minecraft:entity.warden.attack_impact}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_ATTACK_IMPACT = create(key("entity.warden.attack_impact"));
+
+    /**
+     * {@code minecraft:entity.warden.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_DEATH = create(key("entity.warden.death"));
+
+    /**
+     * {@code minecraft:entity.warden.dig}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_DIG = create(key("entity.warden.dig"));
+
+    /**
+     * {@code minecraft:entity.warden.emerge}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_EMERGE = create(key("entity.warden.emerge"));
+
+    /**
+     * {@code minecraft:entity.warden.heartbeat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_HEARTBEAT = create(key("entity.warden.heartbeat"));
+
+    /**
+     * {@code minecraft:entity.warden.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_HURT = create(key("entity.warden.hurt"));
+
+    /**
+     * {@code minecraft:entity.warden.listening}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_LISTENING = create(key("entity.warden.listening"));
+
+    /**
+     * {@code minecraft:entity.warden.listening_angry}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_LISTENING_ANGRY = create(key("entity.warden.listening_angry"));
+
+    /**
+     * {@code minecraft:entity.warden.nearby_close}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_NEARBY_CLOSE = create(key("entity.warden.nearby_close"));
+
+    /**
+     * {@code minecraft:entity.warden.nearby_closer}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_NEARBY_CLOSER = create(key("entity.warden.nearby_closer"));
+
+    /**
+     * {@code minecraft:entity.warden.nearby_closest}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_NEARBY_CLOSEST = create(key("entity.warden.nearby_closest"));
+
+    /**
+     * {@code minecraft:entity.warden.roar}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_ROAR = create(key("entity.warden.roar"));
+
+    /**
+     * {@code minecraft:entity.warden.sniff}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_SNIFF = create(key("entity.warden.sniff"));
+
+    /**
+     * {@code minecraft:entity.warden.sonic_boom}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_SONIC_BOOM = create(key("entity.warden.sonic_boom"));
+
+    /**
+     * {@code minecraft:entity.warden.sonic_charge}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_SONIC_CHARGE = create(key("entity.warden.sonic_charge"));
+
+    /**
+     * {@code minecraft:entity.warden.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_STEP = create(key("entity.warden.step"));
+
+    /**
+     * {@code minecraft:entity.warden.tendril_clicks}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WARDEN_TENDRIL_CLICKS = create(key("entity.warden.tendril_clicks"));
+
+    /**
+     * {@code minecraft:entity.wind_charge.throw}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WIND_CHARGE_THROW = create(key("entity.wind_charge.throw"));
+
+    /**
+     * {@code minecraft:entity.wind_charge.wind_burst}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WIND_CHARGE_WIND_BURST = create(key("entity.wind_charge.wind_burst"));
+
+    /**
+     * {@code minecraft:entity.witch.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITCH_AMBIENT = create(key("entity.witch.ambient"));
+
+    /**
+     * {@code minecraft:entity.witch.celebrate}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITCH_CELEBRATE = create(key("entity.witch.celebrate"));
+
+    /**
+     * {@code minecraft:entity.witch.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITCH_DEATH = create(key("entity.witch.death"));
+
+    /**
+     * {@code minecraft:entity.witch.drink}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITCH_DRINK = create(key("entity.witch.drink"));
+
+    /**
+     * {@code minecraft:entity.witch.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITCH_HURT = create(key("entity.witch.hurt"));
+
+    /**
+     * {@code minecraft:entity.witch.throw}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITCH_THROW = create(key("entity.witch.throw"));
+
+    /**
+     * {@code minecraft:entity.wither.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITHER_AMBIENT = create(key("entity.wither.ambient"));
+
+    /**
+     * {@code minecraft:entity.wither.break_block}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITHER_BREAK_BLOCK = create(key("entity.wither.break_block"));
+
+    /**
+     * {@code minecraft:entity.wither.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITHER_DEATH = create(key("entity.wither.death"));
+
+    /**
+     * {@code minecraft:entity.wither.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITHER_HURT = create(key("entity.wither.hurt"));
+
+    /**
+     * {@code minecraft:entity.wither.shoot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITHER_SHOOT = create(key("entity.wither.shoot"));
+
+    /**
+     * {@code minecraft:entity.wither.spawn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITHER_SPAWN = create(key("entity.wither.spawn"));
+
+    /**
+     * {@code minecraft:entity.wither_skeleton.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITHER_SKELETON_AMBIENT = create(key("entity.wither_skeleton.ambient"));
+
+    /**
+     * {@code minecraft:entity.wither_skeleton.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITHER_SKELETON_DEATH = create(key("entity.wither_skeleton.death"));
+
+    /**
+     * {@code minecraft:entity.wither_skeleton.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITHER_SKELETON_HURT = create(key("entity.wither_skeleton.hurt"));
+
+    /**
+     * {@code minecraft:entity.wither_skeleton.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WITHER_SKELETON_STEP = create(key("entity.wither_skeleton.step"));
+
+    /**
+     * {@code minecraft:entity.wolf.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WOLF_AMBIENT = create(key("entity.wolf.ambient"));
+
+    /**
+     * {@code minecraft:entity.wolf.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WOLF_DEATH = create(key("entity.wolf.death"));
+
+    /**
+     * {@code minecraft:entity.wolf.growl}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WOLF_GROWL = create(key("entity.wolf.growl"));
+
+    /**
+     * {@code minecraft:entity.wolf.howl}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WOLF_HOWL = create(key("entity.wolf.howl"));
+
+    /**
+     * {@code minecraft:entity.wolf.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WOLF_HURT = create(key("entity.wolf.hurt"));
+
+    /**
+     * {@code minecraft:entity.wolf.pant}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WOLF_PANT = create(key("entity.wolf.pant"));
+
+    /**
+     * {@code minecraft:entity.wolf.shake}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WOLF_SHAKE = create(key("entity.wolf.shake"));
+
+    /**
+     * {@code minecraft:entity.wolf.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WOLF_STEP = create(key("entity.wolf.step"));
+
+    /**
+     * {@code minecraft:entity.wolf.whine}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_WOLF_WHINE = create(key("entity.wolf.whine"));
+
+    /**
+     * {@code minecraft:entity.zoglin.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOGLIN_AMBIENT = create(key("entity.zoglin.ambient"));
+
+    /**
+     * {@code minecraft:entity.zoglin.angry}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOGLIN_ANGRY = create(key("entity.zoglin.angry"));
+
+    /**
+     * {@code minecraft:entity.zoglin.attack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOGLIN_ATTACK = create(key("entity.zoglin.attack"));
+
+    /**
+     * {@code minecraft:entity.zoglin.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOGLIN_DEATH = create(key("entity.zoglin.death"));
+
+    /**
+     * {@code minecraft:entity.zoglin.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOGLIN_HURT = create(key("entity.zoglin.hurt"));
+
+    /**
+     * {@code minecraft:entity.zoglin.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOGLIN_STEP = create(key("entity.zoglin.step"));
+
+    /**
+     * {@code minecraft:entity.zombie.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_AMBIENT = create(key("entity.zombie.ambient"));
+
+    /**
+     * {@code minecraft:entity.zombie.attack_iron_door}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_ATTACK_IRON_DOOR = create(key("entity.zombie.attack_iron_door"));
+
+    /**
+     * {@code minecraft:entity.zombie.attack_wooden_door}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_ATTACK_WOODEN_DOOR = create(key("entity.zombie.attack_wooden_door"));
+
+    /**
+     * {@code minecraft:entity.zombie.break_wooden_door}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_BREAK_WOODEN_DOOR = create(key("entity.zombie.break_wooden_door"));
+
+    /**
+     * {@code minecraft:entity.zombie.converted_to_drowned}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_CONVERTED_TO_DROWNED = create(key("entity.zombie.converted_to_drowned"));
+
+    /**
+     * {@code minecraft:entity.zombie.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_DEATH = create(key("entity.zombie.death"));
+
+    /**
+     * {@code minecraft:entity.zombie.destroy_egg}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_DESTROY_EGG = create(key("entity.zombie.destroy_egg"));
+
+    /**
+     * {@code minecraft:entity.zombie.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_HURT = create(key("entity.zombie.hurt"));
+
+    /**
+     * {@code minecraft:entity.zombie.infect}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_INFECT = create(key("entity.zombie.infect"));
+
+    /**
+     * {@code minecraft:entity.zombie.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_STEP = create(key("entity.zombie.step"));
+
+    /**
+     * {@code minecraft:entity.zombie_horse.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_HORSE_AMBIENT = create(key("entity.zombie_horse.ambient"));
+
+    /**
+     * {@code minecraft:entity.zombie_horse.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_HORSE_DEATH = create(key("entity.zombie_horse.death"));
+
+    /**
+     * {@code minecraft:entity.zombie_horse.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_HORSE_HURT = create(key("entity.zombie_horse.hurt"));
+
+    /**
+     * {@code minecraft:entity.zombie_villager.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_VILLAGER_AMBIENT = create(key("entity.zombie_villager.ambient"));
+
+    /**
+     * {@code minecraft:entity.zombie_villager.converted}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_VILLAGER_CONVERTED = create(key("entity.zombie_villager.converted"));
+
+    /**
+     * {@code minecraft:entity.zombie_villager.cure}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_VILLAGER_CURE = create(key("entity.zombie_villager.cure"));
+
+    /**
+     * {@code minecraft:entity.zombie_villager.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_VILLAGER_DEATH = create(key("entity.zombie_villager.death"));
+
+    /**
+     * {@code minecraft:entity.zombie_villager.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_VILLAGER_HURT = create(key("entity.zombie_villager.hurt"));
+
+    /**
+     * {@code minecraft:entity.zombie_villager.step}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIE_VILLAGER_STEP = create(key("entity.zombie_villager.step"));
+
+    /**
+     * {@code minecraft:entity.zombified_piglin.ambient}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIFIED_PIGLIN_AMBIENT = create(key("entity.zombified_piglin.ambient"));
+
+    /**
+     * {@code minecraft:entity.zombified_piglin.angry}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIFIED_PIGLIN_ANGRY = create(key("entity.zombified_piglin.angry"));
+
+    /**
+     * {@code minecraft:entity.zombified_piglin.death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIFIED_PIGLIN_DEATH = create(key("entity.zombified_piglin.death"));
+
+    /**
+     * {@code minecraft:entity.zombified_piglin.hurt}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ENTITY_ZOMBIFIED_PIGLIN_HURT = create(key("entity.zombified_piglin.hurt"));
+
+    /**
+     * {@code minecraft:event.mob_effect.bad_omen}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> EVENT_MOB_EFFECT_BAD_OMEN = create(key("event.mob_effect.bad_omen"));
+
+    /**
+     * {@code minecraft:event.mob_effect.raid_omen}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> EVENT_MOB_EFFECT_RAID_OMEN = create(key("event.mob_effect.raid_omen"));
+
+    /**
+     * {@code minecraft:event.mob_effect.trial_omen}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> EVENT_MOB_EFFECT_TRIAL_OMEN = create(key("event.mob_effect.trial_omen"));
+
+    /**
+     * {@code minecraft:event.raid.horn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> EVENT_RAID_HORN = create(key("event.raid.horn"));
+
+    /**
+     * {@code minecraft:intentionally_empty}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> INTENTIONALLY_EMPTY = create(key("intentionally_empty"));
+
+    /**
+     * {@code minecraft:item.armor.equip_chain}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_ARMOR_EQUIP_CHAIN = create(key("item.armor.equip_chain"));
+
+    /**
+     * {@code minecraft:item.armor.equip_diamond}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_ARMOR_EQUIP_DIAMOND = create(key("item.armor.equip_diamond"));
+
+    /**
+     * {@code minecraft:item.armor.equip_elytra}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_ARMOR_EQUIP_ELYTRA = create(key("item.armor.equip_elytra"));
+
+    /**
+     * {@code minecraft:item.armor.equip_generic}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_ARMOR_EQUIP_GENERIC = create(key("item.armor.equip_generic"));
+
+    /**
+     * {@code minecraft:item.armor.equip_gold}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_ARMOR_EQUIP_GOLD = create(key("item.armor.equip_gold"));
+
+    /**
+     * {@code minecraft:item.armor.equip_iron}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_ARMOR_EQUIP_IRON = create(key("item.armor.equip_iron"));
+
+    /**
+     * {@code minecraft:item.armor.equip_leather}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_ARMOR_EQUIP_LEATHER = create(key("item.armor.equip_leather"));
+
+    /**
+     * {@code minecraft:item.armor.equip_netherite}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_ARMOR_EQUIP_NETHERITE = create(key("item.armor.equip_netherite"));
+
+    /**
+     * {@code minecraft:item.armor.equip_turtle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_ARMOR_EQUIP_TURTLE = create(key("item.armor.equip_turtle"));
+
+    /**
+     * {@code minecraft:item.armor.equip_wolf}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_ARMOR_EQUIP_WOLF = create(key("item.armor.equip_wolf"));
+
+    /**
+     * {@code minecraft:item.armor.unequip_wolf}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_ARMOR_UNEQUIP_WOLF = create(key("item.armor.unequip_wolf"));
+
+    /**
+     * {@code minecraft:item.axe.scrape}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_AXE_SCRAPE = create(key("item.axe.scrape"));
+
+    /**
+     * {@code minecraft:item.axe.strip}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_AXE_STRIP = create(key("item.axe.strip"));
+
+    /**
+     * {@code minecraft:item.axe.wax_off}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_AXE_WAX_OFF = create(key("item.axe.wax_off"));
+
+    /**
+     * {@code minecraft:item.bone_meal.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BONE_MEAL_USE = create(key("item.bone_meal.use"));
+
+    /**
+     * {@code minecraft:item.book.page_turn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BOOK_PAGE_TURN = create(key("item.book.page_turn"));
+
+    /**
+     * {@code minecraft:item.book.put}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BOOK_PUT = create(key("item.book.put"));
+
+    /**
+     * {@code minecraft:item.bottle.empty}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BOTTLE_EMPTY = create(key("item.bottle.empty"));
+
+    /**
+     * {@code minecraft:item.bottle.fill}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BOTTLE_FILL = create(key("item.bottle.fill"));
+
+    /**
+     * {@code minecraft:item.bottle.fill_dragonbreath}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BOTTLE_FILL_DRAGONBREATH = create(key("item.bottle.fill_dragonbreath"));
+
+    /**
+     * {@code minecraft:item.brush.brushing.generic}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BRUSH_BRUSHING_GENERIC = create(key("item.brush.brushing.generic"));
+
+    /**
+     * {@code minecraft:item.brush.brushing.gravel}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BRUSH_BRUSHING_GRAVEL = create(key("item.brush.brushing.gravel"));
+
+    /**
+     * {@code minecraft:item.brush.brushing.gravel.complete}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BRUSH_BRUSHING_GRAVEL_COMPLETE = create(key("item.brush.brushing.gravel.complete"));
+
+    /**
+     * {@code minecraft:item.brush.brushing.sand}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BRUSH_BRUSHING_SAND = create(key("item.brush.brushing.sand"));
+
+    /**
+     * {@code minecraft:item.brush.brushing.sand.complete}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BRUSH_BRUSHING_SAND_COMPLETE = create(key("item.brush.brushing.sand.complete"));
+
+    /**
+     * {@code minecraft:item.bucket.empty}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUCKET_EMPTY = create(key("item.bucket.empty"));
+
+    /**
+     * {@code minecraft:item.bucket.empty_axolotl}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUCKET_EMPTY_AXOLOTL = create(key("item.bucket.empty_axolotl"));
+
+    /**
+     * {@code minecraft:item.bucket.empty_fish}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUCKET_EMPTY_FISH = create(key("item.bucket.empty_fish"));
+
+    /**
+     * {@code minecraft:item.bucket.empty_lava}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUCKET_EMPTY_LAVA = create(key("item.bucket.empty_lava"));
+
+    /**
+     * {@code minecraft:item.bucket.empty_powder_snow}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUCKET_EMPTY_POWDER_SNOW = create(key("item.bucket.empty_powder_snow"));
+
+    /**
+     * {@code minecraft:item.bucket.empty_tadpole}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUCKET_EMPTY_TADPOLE = create(key("item.bucket.empty_tadpole"));
+
+    /**
+     * {@code minecraft:item.bucket.fill}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUCKET_FILL = create(key("item.bucket.fill"));
+
+    /**
+     * {@code minecraft:item.bucket.fill_axolotl}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUCKET_FILL_AXOLOTL = create(key("item.bucket.fill_axolotl"));
+
+    /**
+     * {@code minecraft:item.bucket.fill_fish}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUCKET_FILL_FISH = create(key("item.bucket.fill_fish"));
+
+    /**
+     * {@code minecraft:item.bucket.fill_lava}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUCKET_FILL_LAVA = create(key("item.bucket.fill_lava"));
+
+    /**
+     * {@code minecraft:item.bucket.fill_powder_snow}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUCKET_FILL_POWDER_SNOW = create(key("item.bucket.fill_powder_snow"));
+
+    /**
+     * {@code minecraft:item.bucket.fill_tadpole}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUCKET_FILL_TADPOLE = create(key("item.bucket.fill_tadpole"));
+
+    /**
+     * {@code minecraft:item.bundle.drop_contents}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUNDLE_DROP_CONTENTS = create(key("item.bundle.drop_contents"));
+
+    /**
+     * {@code minecraft:item.bundle.insert}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUNDLE_INSERT = create(key("item.bundle.insert"));
+
+    /**
+     * {@code minecraft:item.bundle.insert_fail}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUNDLE_INSERT_FAIL = create(key("item.bundle.insert_fail"));
+
+    /**
+     * {@code minecraft:item.bundle.remove_one}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_BUNDLE_REMOVE_ONE = create(key("item.bundle.remove_one"));
+
+    /**
+     * {@code minecraft:item.chorus_fruit.teleport}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_CHORUS_FRUIT_TELEPORT = create(key("item.chorus_fruit.teleport"));
+
+    /**
+     * {@code minecraft:item.crop.plant}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_CROP_PLANT = create(key("item.crop.plant"));
+
+    /**
+     * {@code minecraft:item.crossbow.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_CROSSBOW_HIT = create(key("item.crossbow.hit"));
+
+    /**
+     * {@code minecraft:item.crossbow.loading_end}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_CROSSBOW_LOADING_END = create(key("item.crossbow.loading_end"));
+
+    /**
+     * {@code minecraft:item.crossbow.loading_middle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_CROSSBOW_LOADING_MIDDLE = create(key("item.crossbow.loading_middle"));
+
+    /**
+     * {@code minecraft:item.crossbow.loading_start}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_CROSSBOW_LOADING_START = create(key("item.crossbow.loading_start"));
+
+    /**
+     * {@code minecraft:item.crossbow.quick_charge_1}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_CROSSBOW_QUICK_CHARGE_1 = create(key("item.crossbow.quick_charge_1"));
+
+    /**
+     * {@code minecraft:item.crossbow.quick_charge_2}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_CROSSBOW_QUICK_CHARGE_2 = create(key("item.crossbow.quick_charge_2"));
+
+    /**
+     * {@code minecraft:item.crossbow.quick_charge_3}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_CROSSBOW_QUICK_CHARGE_3 = create(key("item.crossbow.quick_charge_3"));
+
+    /**
+     * {@code minecraft:item.crossbow.shoot}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_CROSSBOW_SHOOT = create(key("item.crossbow.shoot"));
+
+    /**
+     * {@code minecraft:item.dye.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_DYE_USE = create(key("item.dye.use"));
+
+    /**
+     * {@code minecraft:item.elytra.flying}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_ELYTRA_FLYING = create(key("item.elytra.flying"));
+
+    /**
+     * {@code minecraft:item.firecharge.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_FIRECHARGE_USE = create(key("item.firecharge.use"));
+
+    /**
+     * {@code minecraft:item.flintandsteel.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_FLINTANDSTEEL_USE = create(key("item.flintandsteel.use"));
+
+    /**
+     * {@code minecraft:item.glow_ink_sac.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_GLOW_INK_SAC_USE = create(key("item.glow_ink_sac.use"));
+
+    /**
+     * {@code minecraft:item.goat_horn.sound.0}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_GOAT_HORN_SOUND_0 = create(key("item.goat_horn.sound.0"));
+
+    /**
+     * {@code minecraft:item.goat_horn.sound.1}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_GOAT_HORN_SOUND_1 = create(key("item.goat_horn.sound.1"));
+
+    /**
+     * {@code minecraft:item.goat_horn.sound.2}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_GOAT_HORN_SOUND_2 = create(key("item.goat_horn.sound.2"));
+
+    /**
+     * {@code minecraft:item.goat_horn.sound.3}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_GOAT_HORN_SOUND_3 = create(key("item.goat_horn.sound.3"));
+
+    /**
+     * {@code minecraft:item.goat_horn.sound.4}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_GOAT_HORN_SOUND_4 = create(key("item.goat_horn.sound.4"));
+
+    /**
+     * {@code minecraft:item.goat_horn.sound.5}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_GOAT_HORN_SOUND_5 = create(key("item.goat_horn.sound.5"));
+
+    /**
+     * {@code minecraft:item.goat_horn.sound.6}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_GOAT_HORN_SOUND_6 = create(key("item.goat_horn.sound.6"));
+
+    /**
+     * {@code minecraft:item.goat_horn.sound.7}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_GOAT_HORN_SOUND_7 = create(key("item.goat_horn.sound.7"));
+
+    /**
+     * {@code minecraft:item.hoe.till}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_HOE_TILL = create(key("item.hoe.till"));
+
+    /**
+     * {@code minecraft:item.honey_bottle.drink}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_HONEY_BOTTLE_DRINK = create(key("item.honey_bottle.drink"));
+
+    /**
+     * {@code minecraft:item.honeycomb.wax_on}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_HONEYCOMB_WAX_ON = create(key("item.honeycomb.wax_on"));
+
+    /**
+     * {@code minecraft:item.ink_sac.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_INK_SAC_USE = create(key("item.ink_sac.use"));
+
+    /**
+     * {@code minecraft:item.lodestone_compass.lock}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_LODESTONE_COMPASS_LOCK = create(key("item.lodestone_compass.lock"));
+
+    /**
+     * {@code minecraft:item.mace.smash_air}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_MACE_SMASH_AIR = create(key("item.mace.smash_air"));
+
+    /**
+     * {@code minecraft:item.mace.smash_ground}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_MACE_SMASH_GROUND = create(key("item.mace.smash_ground"));
+
+    /**
+     * {@code minecraft:item.mace.smash_ground_heavy}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_MACE_SMASH_GROUND_HEAVY = create(key("item.mace.smash_ground_heavy"));
+
+    /**
+     * {@code minecraft:item.nether_wart.plant}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_NETHER_WART_PLANT = create(key("item.nether_wart.plant"));
+
+    /**
+     * {@code minecraft:item.ominous_bottle.dispose}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_OMINOUS_BOTTLE_DISPOSE = create(key("item.ominous_bottle.dispose"));
+
+    /**
+     * {@code minecraft:item.shield.block}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_SHIELD_BLOCK = create(key("item.shield.block"));
+
+    /**
+     * {@code minecraft:item.shield.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_SHIELD_BREAK = create(key("item.shield.break"));
+
+    /**
+     * {@code minecraft:item.shovel.flatten}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_SHOVEL_FLATTEN = create(key("item.shovel.flatten"));
+
+    /**
+     * {@code minecraft:item.spyglass.stop_using}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_SPYGLASS_STOP_USING = create(key("item.spyglass.stop_using"));
+
+    /**
+     * {@code minecraft:item.spyglass.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_SPYGLASS_USE = create(key("item.spyglass.use"));
+
+    /**
+     * {@code minecraft:item.totem.use}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_TOTEM_USE = create(key("item.totem.use"));
+
+    /**
+     * {@code minecraft:item.trident.hit}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_TRIDENT_HIT = create(key("item.trident.hit"));
+
+    /**
+     * {@code minecraft:item.trident.hit_ground}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_TRIDENT_HIT_GROUND = create(key("item.trident.hit_ground"));
+
+    /**
+     * {@code minecraft:item.trident.return}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_TRIDENT_RETURN = create(key("item.trident.return"));
+
+    /**
+     * {@code minecraft:item.trident.riptide_1}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_TRIDENT_RIPTIDE_1 = create(key("item.trident.riptide_1"));
+
+    /**
+     * {@code minecraft:item.trident.riptide_2}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_TRIDENT_RIPTIDE_2 = create(key("item.trident.riptide_2"));
+
+    /**
+     * {@code minecraft:item.trident.riptide_3}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_TRIDENT_RIPTIDE_3 = create(key("item.trident.riptide_3"));
+
+    /**
+     * {@code minecraft:item.trident.throw}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_TRIDENT_THROW = create(key("item.trident.throw"));
+
+    /**
+     * {@code minecraft:item.trident.thunder}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_TRIDENT_THUNDER = create(key("item.trident.thunder"));
+
+    /**
+     * {@code minecraft:item.wolf_armor.break}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_WOLF_ARMOR_BREAK = create(key("item.wolf_armor.break"));
+
+    /**
+     * {@code minecraft:item.wolf_armor.crack}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_WOLF_ARMOR_CRACK = create(key("item.wolf_armor.crack"));
+
+    /**
+     * {@code minecraft:item.wolf_armor.damage}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_WOLF_ARMOR_DAMAGE = create(key("item.wolf_armor.damage"));
+
+    /**
+     * {@code minecraft:item.wolf_armor.repair}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> ITEM_WOLF_ARMOR_REPAIR = create(key("item.wolf_armor.repair"));
+
+    /**
+     * {@code minecraft:music.creative}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_CREATIVE = create(key("music.creative"));
+
+    /**
+     * {@code minecraft:music.credits}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_CREDITS = create(key("music.credits"));
+
+    /**
+     * {@code minecraft:music.dragon}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DRAGON = create(key("music.dragon"));
+
+    /**
+     * {@code minecraft:music.end}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_END = create(key("music.end"));
+
+    /**
+     * {@code minecraft:music.game}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_GAME = create(key("music.game"));
+
+    /**
+     * {@code minecraft:music.menu}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_MENU = create(key("music.menu"));
+
+    /**
+     * {@code minecraft:music.nether.basalt_deltas}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_NETHER_BASALT_DELTAS = create(key("music.nether.basalt_deltas"));
+
+    /**
+     * {@code minecraft:music.nether.crimson_forest}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_NETHER_CRIMSON_FOREST = create(key("music.nether.crimson_forest"));
+
+    /**
+     * {@code minecraft:music.nether.nether_wastes}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_NETHER_NETHER_WASTES = create(key("music.nether.nether_wastes"));
+
+    /**
+     * {@code minecraft:music.nether.soul_sand_valley}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_NETHER_SOUL_SAND_VALLEY = create(key("music.nether.soul_sand_valley"));
+
+    /**
+     * {@code minecraft:music.nether.warped_forest}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_NETHER_WARPED_FOREST = create(key("music.nether.warped_forest"));
+
+    /**
+     * {@code minecraft:music.overworld.badlands}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_BADLANDS = create(key("music.overworld.badlands"));
+
+    /**
+     * {@code minecraft:music.overworld.bamboo_jungle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_BAMBOO_JUNGLE = create(key("music.overworld.bamboo_jungle"));
+
+    /**
+     * {@code minecraft:music.overworld.cherry_grove}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_CHERRY_GROVE = create(key("music.overworld.cherry_grove"));
+
+    /**
+     * {@code minecraft:music.overworld.deep_dark}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_DEEP_DARK = create(key("music.overworld.deep_dark"));
+
+    /**
+     * {@code minecraft:music.overworld.desert}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_DESERT = create(key("music.overworld.desert"));
+
+    /**
+     * {@code minecraft:music.overworld.dripstone_caves}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_DRIPSTONE_CAVES = create(key("music.overworld.dripstone_caves"));
+
+    /**
+     * {@code minecraft:music.overworld.flower_forest}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_FLOWER_FOREST = create(key("music.overworld.flower_forest"));
+
+    /**
+     * {@code minecraft:music.overworld.forest}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_FOREST = create(key("music.overworld.forest"));
+
+    /**
+     * {@code minecraft:music.overworld.frozen_peaks}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_FROZEN_PEAKS = create(key("music.overworld.frozen_peaks"));
+
+    /**
+     * {@code minecraft:music.overworld.grove}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_GROVE = create(key("music.overworld.grove"));
+
+    /**
+     * {@code minecraft:music.overworld.jagged_peaks}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_JAGGED_PEAKS = create(key("music.overworld.jagged_peaks"));
+
+    /**
+     * {@code minecraft:music.overworld.jungle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_JUNGLE = create(key("music.overworld.jungle"));
+
+    /**
+     * {@code minecraft:music.overworld.lush_caves}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_LUSH_CAVES = create(key("music.overworld.lush_caves"));
+
+    /**
+     * {@code minecraft:music.overworld.meadow}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_MEADOW = create(key("music.overworld.meadow"));
+
+    /**
+     * {@code minecraft:music.overworld.old_growth_taiga}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_OLD_GROWTH_TAIGA = create(key("music.overworld.old_growth_taiga"));
+
+    /**
+     * {@code minecraft:music.overworld.snowy_slopes}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_SNOWY_SLOPES = create(key("music.overworld.snowy_slopes"));
+
+    /**
+     * {@code minecraft:music.overworld.sparse_jungle}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_SPARSE_JUNGLE = create(key("music.overworld.sparse_jungle"));
+
+    /**
+     * {@code minecraft:music.overworld.stony_peaks}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_STONY_PEAKS = create(key("music.overworld.stony_peaks"));
+
+    /**
+     * {@code minecraft:music.overworld.swamp}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_OVERWORLD_SWAMP = create(key("music.overworld.swamp"));
+
+    /**
+     * {@code minecraft:music.under_water}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_UNDER_WATER = create(key("music.under_water"));
+
+    /**
+     * {@code minecraft:music_disc.11}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_11 = create(key("music_disc.11"));
+
+    /**
+     * {@code minecraft:music_disc.13}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_13 = create(key("music_disc.13"));
+
+    /**
+     * {@code minecraft:music_disc.5}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_5 = create(key("music_disc.5"));
+
+    /**
+     * {@code minecraft:music_disc.blocks}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_BLOCKS = create(key("music_disc.blocks"));
+
+    /**
+     * {@code minecraft:music_disc.cat}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_CAT = create(key("music_disc.cat"));
+
+    /**
+     * {@code minecraft:music_disc.chirp}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_CHIRP = create(key("music_disc.chirp"));
+
+    /**
+     * {@code minecraft:music_disc.creator}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_CREATOR = create(key("music_disc.creator"));
+
+    /**
+     * {@code minecraft:music_disc.creator_music_box}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_CREATOR_MUSIC_BOX = create(key("music_disc.creator_music_box"));
+
+    /**
+     * {@code minecraft:music_disc.far}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_FAR = create(key("music_disc.far"));
+
+    /**
+     * {@code minecraft:music_disc.mall}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_MALL = create(key("music_disc.mall"));
+
+    /**
+     * {@code minecraft:music_disc.mellohi}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_MELLOHI = create(key("music_disc.mellohi"));
+
+    /**
+     * {@code minecraft:music_disc.otherside}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_OTHERSIDE = create(key("music_disc.otherside"));
+
+    /**
+     * {@code minecraft:music_disc.pigstep}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_PIGSTEP = create(key("music_disc.pigstep"));
+
+    /**
+     * {@code minecraft:music_disc.precipice}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_PRECIPICE = create(key("music_disc.precipice"));
+
+    /**
+     * {@code minecraft:music_disc.relic}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_RELIC = create(key("music_disc.relic"));
+
+    /**
+     * {@code minecraft:music_disc.stal}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_STAL = create(key("music_disc.stal"));
+
+    /**
+     * {@code minecraft:music_disc.strad}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_STRAD = create(key("music_disc.strad"));
+
+    /**
+     * {@code minecraft:music_disc.wait}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_WAIT = create(key("music_disc.wait"));
+
+    /**
+     * {@code minecraft:music_disc.ward}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> MUSIC_DISC_WARD = create(key("music_disc.ward"));
+
+    /**
+     * {@code minecraft:particle.soul_escape}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> PARTICLE_SOUL_ESCAPE = create(key("particle.soul_escape"));
+
+    /**
+     * {@code minecraft:ui.button.click}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> UI_BUTTON_CLICK = create(key("ui.button.click"));
+
+    /**
+     * {@code minecraft:ui.cartography_table.take_result}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> UI_CARTOGRAPHY_TABLE_TAKE_RESULT = create(key("ui.cartography_table.take_result"));
+
+    /**
+     * {@code minecraft:ui.hud.bubble_pop}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> UI_HUD_BUBBLE_POP = create(key("ui.hud.bubble_pop"));
+
+    /**
+     * {@code minecraft:ui.loom.select_pattern}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> UI_LOOM_SELECT_PATTERN = create(key("ui.loom.select_pattern"));
+
+    /**
+     * {@code minecraft:ui.loom.take_result}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> UI_LOOM_TAKE_RESULT = create(key("ui.loom.take_result"));
+
+    /**
+     * {@code minecraft:ui.stonecutter.select_recipe}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> UI_STONECUTTER_SELECT_RECIPE = create(key("ui.stonecutter.select_recipe"));
+
+    /**
+     * {@code minecraft:ui.stonecutter.take_result}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> UI_STONECUTTER_TAKE_RESULT = create(key("ui.stonecutter.take_result"));
+
+    /**
+     * {@code minecraft:ui.toast.challenge_complete}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> UI_TOAST_CHALLENGE_COMPLETE = create(key("ui.toast.challenge_complete"));
+
+    /**
+     * {@code minecraft:ui.toast.in}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> UI_TOAST_IN = create(key("ui.toast.in"));
+
+    /**
+     * {@code minecraft:ui.toast.out}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> UI_TOAST_OUT = create(key("ui.toast.out"));
+
+    /**
+     * {@code minecraft:weather.rain}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> WEATHER_RAIN = create(key("weather.rain"));
+
+    /**
+     * {@code minecraft:weather.rain.above}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<Sound> WEATHER_RAIN_ABOVE = create(key("weather.rain.above"));
+
+    private SoundEventKeys() {
+    }
+
+    private static @NonNull TypedKey<Sound> create(final @NonNull Key key) {
+        return TypedKey.create(RegistryKey.SOUND_EVENT, key);
+    }
+}

--- a/paper-api-generator/src/main/java/io/papermc/generator/Generators.java
+++ b/paper-api-generator/src/main/java/io/papermc/generator/Generators.java
@@ -8,10 +8,12 @@ import io.papermc.paper.registry.RegistryKey;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
+import org.bukkit.Art;
 import org.bukkit.Fluid;
 import org.bukkit.GameEvent;
 import org.bukkit.JukeboxSong;
 import org.bukkit.MusicInstrument;
+import org.bukkit.Sound;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.block.Biome;
 import org.bukkit.block.BlockType;
@@ -49,6 +51,7 @@ public interface Generators {
         simpleKey("MenuTypeKeys", MenuType.class, Registries.MENU, RegistryKey.MENU, false),
         simpleKey("AttributeKeys", Attribute.class, Registries.ATTRIBUTE, RegistryKey.ATTRIBUTE, false),
         simpleKey("FluidKeys", Fluid.class, Registries.FLUID, RegistryKey.FLUID, false),
+        simpleKey("SoundEventKeys", Sound.class, Registries.SOUND_EVENT, RegistryKey.SOUND_EVENT, false),
 
         // data-driven
         simpleKey("BiomeKeys", Biome.class, Registries.BIOME, RegistryKey.BIOME, true),
@@ -60,6 +63,7 @@ public interface Generators {
         simpleKey("EnchantmentKeys", Enchantment.class, Registries.ENCHANTMENT, RegistryKey.ENCHANTMENT, false),
         simpleKey("JukeboxSongKeys", JukeboxSong.class, Registries.JUKEBOX_SONG, RegistryKey.JUKEBOX_SONG, true),
         simpleKey("BannerPatternKeys", PatternType.class, Registries.BANNER_PATTERN, RegistryKey.BANNER_PATTERN, true),
+        simpleKey("PaintingVariantKeys", Art.class, Registries.PAINTING_VARIANT, RegistryKey.PAINTING_VARIANT, true),
 
         // tags
         simpleTagKey("EnchantmentTagKeys", Enchantment.class, Registries.ENCHANTMENT, RegistryKey.ENCHANTMENT),

--- a/patches/api/0004-Code-Generation.patch
+++ b/patches/api/0004-Code-Generation.patch
@@ -85,10 +85,10 @@ index 0000000000000000000000000000000000000000..2512dba27edfdccbc4430815b6cba048
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/RegistryKey.java b/src/main/java/io/papermc/paper/registry/RegistryKey.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..fdef87eec3765523b00c987d4c1ccc289882e95d
+index 0000000000000000000000000000000000000000..d895b36e14f7fab6e3e78160dfa559d2c5331601
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/RegistryKey.java
-@@ -0,0 +1,188 @@
+@@ -0,0 +1,196 @@
 +package io.papermc.paper.registry;
 +
 +import net.kyori.adventure.key.Keyed;
@@ -214,6 +214,11 @@ index 0000000000000000000000000000000000000000..fdef87eec3765523b00c987d4c1ccc28
 +     * @see io.papermc.paper.registry.keys.FluidKeys
 +     */
 +    RegistryKey<Fluid> FLUID = create("fluid");
++    /**
++     * Built-in registry for sound events.
++     * @see io.papermc.paper.registry.keys.SoundEventKeys
++     */
++    RegistryKey<Sound> SOUND_EVENT = create("sound_event");
 +
 +
 +
@@ -265,16 +270,19 @@ index 0000000000000000000000000000000000000000..fdef87eec3765523b00c987d4c1ccc28
 +     * @see io.papermc.paper.registry.keys.BannerPatternKeys
 +     */
 +    RegistryKey<PatternType> BANNER_PATTERN = create("banner_pattern");
++    /**
++     * Data-driven registry for painting variants.
++     * @see io.papermc.paper.registry.keys.PaintingVariantKeys
++     */
++    RegistryKey<Art> PAINTING_VARIANT = create("painting_variant");
 +
 +
 +    /* ******************* *
 +     * API-only Registries *
 +     * ******************* */
-+    RegistryKey<Art> PAINTING_VARIANT = create("painting_variant");
 +    RegistryKey<EntityType> ENTITY_TYPE = create("entity_type");
 +    RegistryKey<Particle> PARTICLE_TYPE = create("particle_type");
 +    RegistryKey<PotionType> POTION = create("potion");
-+    RegistryKey<Sound> SOUND_EVENT = create("sound_event");
 +    RegistryKey<MemoryKey<?>> MEMORY_MODULE_TYPE = create("memory_module_type");
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/RegistryKeyImpl.java b/src/main/java/io/papermc/paper/registry/RegistryKeyImpl.java

--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -1494,27 +1494,27 @@ index 18a53194483410c4d5ad35f901c90d44efaeef60..aff43d77f31d81b82e5fc5fea6272dda
          String getDisplayName();
  
 diff --git a/src/main/java/org/bukkit/Sound.java b/src/main/java/org/bukkit/Sound.java
-index 8824e83039195882fa9c2a854460b0aeedfb7d21..cf17af024b1953b6f21f18885411ea6a0baa1d4c 100644
+index 4204a7dac18c60f177a5f70693388cd4ddc3bc0c..04e890be72b18259f1af2833879b4d9af51b1f02 100644
 --- a/src/main/java/org/bukkit/Sound.java
 +++ b/src/main/java/org/bukkit/Sound.java
-@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
-  * guarantee values will not be removed from this Enum. As such, you should not
+@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
+  * guarantee values will not be removed from this interface. As such, you should not
   * depend on the ordinal values of this class.
   */
--public enum Sound implements Keyed {
-+public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Paper - implement Sound.Type
+-public interface Sound extends OldEnum<Sound>, Keyed {
++public interface Sound extends OldEnum<Sound>, Keyed, net.kyori.adventure.sound.Sound.Type { // Paper - implement Sound.Type
  
-     AMBIENT_BASALT_DELTAS_ADDITIONS("ambient.basalt_deltas.additions"),
-     AMBIENT_BASALT_DELTAS_LOOP("ambient.basalt_deltas.loop"),
-@@ -1660,4 +1660,11 @@ public enum Sound implements Keyed {
-     public NamespacedKey getKey() {
-         return key;
+     Sound AMBIENT_BASALT_DELTAS_ADDITIONS = getSound("ambient.basalt_deltas.additions");
+     Sound AMBIENT_BASALT_DELTAS_LOOP = getSound("ambient.basalt_deltas.loop");
+@@ -1698,4 +1698,11 @@ public interface Sound extends OldEnum<Sound>, Keyed {
+     static Sound[] values() {
+         return Lists.newArrayList(Registry.SOUNDS).toArray(new Sound[0]);
      }
 +
 +    // Paper start
 +    @Override
-+    public net.kyori.adventure.key.@NotNull Key key() {
-+        return this.key;
++    default net.kyori.adventure.key.@NotNull Key key() {
++        return this.getKey();
 +    }
 +    // Paper end
  }

--- a/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
@@ -11,34 +11,6 @@ that continues to have use (internally).
 
 These do not help plugin developers if they bring moise noise than value.
 
-diff --git a/src/main/java/org/bukkit/Art.java b/src/main/java/org/bukkit/Art.java
-index dadff073abb2dec39111e677ec77ffdb2b7ff9a9..042d1d932a33022e4fc873652f70dc6ed342d46a 100644
---- a/src/main/java/org/bukkit/Art.java
-+++ b/src/main/java/org/bukkit/Art.java
-@@ -96,9 +96,9 @@ public enum Art implements Keyed {
-      * Get the ID of this painting.
-      *
-      * @return The ID of this painting
--     * @deprecated Magic value
-+     * @apiNote Internal Use Only
-      */
--    @Deprecated
-+    @org.jetbrains.annotations.ApiStatus.Internal // Paper
-     public int getId() {
-         return id;
-     }
-@@ -114,9 +114,9 @@ public enum Art implements Keyed {
-      *
-      * @param id The ID
-      * @return The painting
--     * @deprecated Magic value
-+     * @apiNote Internal Use Only
-      */
--    @Deprecated
-+    @org.jetbrains.annotations.ApiStatus.Internal // Paper
-     @Nullable
-     public static Art getById(int id) {
-         return BY_ID.get(id);
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
 index 577b4b89b50441572f0edd9325047c38e25e782e..949ffc320502e46493183cc3ef621d9c4edbe7d6 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
@@ -453,7 +425,7 @@ index 48aecc9421c500137bbef1dfe3bec8de277c3ff9..aff858346776386f1288b648b221404f
          return note;
      }
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 774f9bd0ef95d385dc3f715753c83e05fcc2bdff..26399345dd02031712994da1553417186b8c7370 100644
+index f0e806865910578110f4794f7ebe93640516e7c1..b4f297f90e3c1deaa1fc3f4418418588ab19b6c5 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
 @@ -248,14 +248,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {

--- a/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
@@ -904,10 +904,10 @@ index 9e0137ea412ec8c65b2903a76499ba8222446ea3..db7dafba43b50146a32d749ec043c5d5
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Minecart.java b/src/main/java/org/bukkit/entity/Minecart.java
-index 4910075d0fb21b4dc4fab57894f9c7cca3093e3b..9125cc9f60258938946ee30932f0299edcd9573b 100644
+index e5c43a80375624b11653b0693a7883a490d73c6d..d9ad5fd48eec569eb4aef2aaf527ba24d2db3254 100644
 --- a/src/main/java/org/bukkit/entity/Minecart.java
 +++ b/src/main/java/org/bukkit/entity/Minecart.java
-@@ -106,7 +106,9 @@ public interface Minecart extends Vehicle {
+@@ -102,7 +102,9 @@ public interface Minecart extends Vehicle {
       * Passing a null value will set the minecart to have no display block.
       *
       * @param material the material to set as display block.
@@ -917,7 +917,7 @@ index 4910075d0fb21b4dc4fab57894f9c7cca3093e3b..9125cc9f60258938946ee30932f0299e
      public void setDisplayBlock(@Nullable MaterialData material);
  
      /**
-@@ -114,8 +116,10 @@ public interface Minecart extends Vehicle {
+@@ -110,8 +112,10 @@ public interface Minecart extends Vehicle {
       * This function will return the type AIR if none is set.
       *
       * @return the block displayed by this minecart.

--- a/patches/api/0225-Add-API-to-get-Material-from-Boats-and-Minecarts.patch
+++ b/patches/api/0225-Add-API-to-get-Material-from-Boats-and-Minecarts.patch
@@ -24,7 +24,7 @@ index dbdd2c1ad74a4d56e282736cd06d6937701f2e5c..a0fb3c44405f6362f8a1613661d507e4
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Minecart.java b/src/main/java/org/bukkit/entity/Minecart.java
-index 9125cc9f60258938946ee30932f0299edcd9573b..148d8cddba48a886eddef72a3de63d5eaa15949f 100644
+index d9ad5fd48eec569eb4aef2aaf527ba24d2db3254..c3c94a5694f1e8d79e5acc45af1cd2e0fa6a621f 100644
 --- a/src/main/java/org/bukkit/entity/Minecart.java
 +++ b/src/main/java/org/bukkit/entity/Minecart.java
 @@ -1,6 +1,7 @@
@@ -35,7 +35,7 @@ index 9125cc9f60258938946ee30932f0299edcd9573b..148d8cddba48a886eddef72a3de63d5e
  import org.bukkit.block.data.BlockData;
  import org.bukkit.material.MaterialData;
  import org.bukkit.util.Vector;
-@@ -152,4 +153,14 @@ public interface Minecart extends Vehicle {
+@@ -148,4 +149,14 @@ public interface Minecart extends Vehicle {
       * @return the current block offset for this minecart.
       */
      public int getDisplayBlockOffset();

--- a/patches/api/0236-Add-RegistryAccess-for-managing-registries.patch
+++ b/patches/api/0236-Add-RegistryAccess-for-managing-registries.patch
@@ -207,10 +207,19 @@ index e0f652117e585882693736de8165ae9c689e1d68..fbe14c327ee9c1ac07893853ca7c699e
          return server.getRegistry(tClass);
      }
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 26399345dd02031712994da1553417186b8c7370..759925decc0b66e8f5861f3f8bd9bee0ed66181e 100644
+index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..099c8acc0338dc0e6ac81f77d99cd2a02a630535 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -92,20 +92,26 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -86,26 +86,34 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      * Server art.
+      *
+      * @see Art
++     * @deprecated use {@link io.papermc.paper.registry.RegistryAccess#getRegistry(io.papermc.paper.registry.RegistryKey)} with {@link io.papermc.paper.registry.RegistryKey#PAINTING_VARIANT}
+      */
+-    Registry<Art> ART = Objects.requireNonNull(Bukkit.getRegistry(Art.class), "No registry present for Art. This is a bug.");
++    @Deprecated(since = "1.21.3") // Paper
++    Registry<Art> ART = Objects.requireNonNull(io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(Art.class), "No registry present for Art. This is a bug.");
+     /**
       * Attribute.
       *
       * @see Attribute
@@ -240,7 +249,7 @@ index 26399345dd02031712994da1553417186b8c7370..759925decc0b66e8f5861f3f8bd9bee0
      /**
       * Server block types.
       *
-@@ -113,7 +119,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -113,7 +121,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * @apiNote BlockType is not ready for public usage yet
       */
      @ApiStatus.Internal
@@ -249,7 +258,7 @@ index 26399345dd02031712994da1553417186b8c7370..759925decc0b66e8f5861f3f8bd9bee0
      /**
       * Custom boss bars.
       *
-@@ -155,13 +161,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -155,13 +163,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @see Cat.Type
       */
@@ -267,7 +276,7 @@ index 26399345dd02031712994da1553417186b8c7370..759925decc0b66e8f5861f3f8bd9bee0
      /**
       * Server entity types.
       *
-@@ -173,7 +181,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -173,7 +183,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @see MusicInstrument
       */
@@ -276,7 +285,7 @@ index 26399345dd02031712994da1553417186b8c7370..759925decc0b66e8f5861f3f8bd9bee0
      /**
       * Server item types.
       *
-@@ -181,7 +189,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -181,7 +191,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * @apiNote ItemType is not ready for public usage yet
       */
      @ApiStatus.Internal
@@ -285,7 +294,7 @@ index 26399345dd02031712994da1553417186b8c7370..759925decc0b66e8f5861f3f8bd9bee0
      /**
       * Default server loot tables.
       *
-@@ -200,13 +208,13 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -200,13 +210,13 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * @see MenuType
       */
      @ApiStatus.Experimental
@@ -301,7 +310,7 @@ index 26399345dd02031712994da1553417186b8c7370..759925decc0b66e8f5861f3f8bd9bee0
      /**
       * Server particles.
       *
-@@ -229,14 +237,16 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -229,58 +239,67 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * Server structures.
       *
       * @see Structure
@@ -320,7 +329,11 @@ index 26399345dd02031712994da1553417186b8c7370..759925decc0b66e8f5861f3f8bd9bee0
      /**
       * Sound keys.
       *
-@@ -247,40 +257,47 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      * @see Sound
+      */
+-    Registry<Sound> SOUNDS = Objects.requireNonNull(Bukkit.getRegistry(Sound.class), "No registry present for Sound. This is a bug.");
++    Registry<Sound> SOUNDS = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.SOUND_EVENT); // Paper
+     /**
       * Trim materials.
       *
       * @see TrimMaterial
@@ -375,7 +388,7 @@ index 26399345dd02031712994da1553417186b8c7370..759925decc0b66e8f5861f3f8bd9bee0
      /**
       * Memory Keys.
       *
-@@ -320,32 +337,36 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -320,32 +339,36 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * Server fluids.
       *
       * @see Fluid

--- a/patches/api/0329-More-PotionEffectType-API.patch
+++ b/patches/api/0329-More-PotionEffectType-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More PotionEffectType API
 
 
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 759925decc0b66e8f5861f3f8bd9bee0ed66181e..833eea6ee8c7fd8ccb3f2eed4285a3eb8311448c 100644
+index 099c8acc0338dc0e6ac81f77d99cd2a02a630535..a5db0a013921423f87abb14dc08b24f47d4093f6 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -367,6 +367,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -369,6 +369,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * @see GameEvent
       */
      Registry<GameEvent> GAME_EVENT = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.GAME_EVENT); // Paper

--- a/patches/api/0378-fix-Instruments.patch
+++ b/patches/api/0378-fix-Instruments.patch
@@ -99,10 +99,10 @@ index 032d7b812ddc0a85e316882c8f7de0c5a0a4fd30..8df26e0d7bea77bb257cddbc2ab9e969
      public static Instrument getByType(final byte type) {
          return BY_DATA.get(type);
 diff --git a/src/test/java/org/bukkit/InstrumentTest.java b/src/test/java/org/bukkit/InstrumentTest.java
-index 8c1d88885de7d56c1b7c78d2e6e059b0648c982a..b177a47a5bda05bfe3598ec5e6771b92a73f0edf 100644
+index 6f27b260d9dbe76da733459c8341282e23440b8a..4dc36cef270f09f98e99f66bab592b45013452e6 100644
 --- a/src/test/java/org/bukkit/InstrumentTest.java
 +++ b/src/test/java/org/bukkit/InstrumentTest.java
-@@ -8,9 +8,7 @@ public class InstrumentTest {
+@@ -9,9 +9,7 @@ public class InstrumentTest extends AbstractTestingBase {
      @Test
      public void getByType() {
          for (Instrument instrument : Instrument.values()) {

--- a/patches/api/0378-fix-Instruments.patch
+++ b/patches/api/0378-fix-Instruments.patch
@@ -99,17 +99,27 @@ index 032d7b812ddc0a85e316882c8f7de0c5a0a4fd30..8df26e0d7bea77bb257cddbc2ab9e969
      public static Instrument getByType(final byte type) {
          return BY_DATA.get(type);
 diff --git a/src/test/java/org/bukkit/InstrumentTest.java b/src/test/java/org/bukkit/InstrumentTest.java
-index 6f27b260d9dbe76da733459c8341282e23440b8a..4dc36cef270f09f98e99f66bab592b45013452e6 100644
+deleted file mode 100644
+index 6f27b260d9dbe76da733459c8341282e23440b8a..0000000000000000000000000000000000000000
 --- a/src/test/java/org/bukkit/InstrumentTest.java
-+++ b/src/test/java/org/bukkit/InstrumentTest.java
-@@ -9,9 +9,7 @@ public class InstrumentTest extends AbstractTestingBase {
-     @Test
-     public void getByType() {
-         for (Instrument instrument : Instrument.values()) {
++++ /dev/null
+@@ -1,19 +0,0 @@
+-package org.bukkit;
+-
+-import static org.bukkit.support.MatcherAssert.*;
+-import static org.hamcrest.CoreMatchers.*;
+-import org.bukkit.support.AbstractTestingBase;
+-import org.junit.jupiter.api.Test;
+-
+-public class InstrumentTest extends AbstractTestingBase {
+-    @Test
+-    public void getByType() {
+-        for (Instrument instrument : Instrument.values()) {
 -            if (instrument.getType() < 0) {
 -                continue;
 -            }
-+            // Paper - byte magic values are still used
- 
-             assertThat(Instrument.getByType(instrument.getType()), is(instrument));
-         }
+-
+-            assertThat(Instrument.getByType(instrument.getType()), is(instrument));
+-        }
+-    }
+-}

--- a/patches/api/0429-Improve-Registry.patch
+++ b/patches/api/0429-Improve-Registry.patch
@@ -10,12 +10,12 @@ getKey() methods on Keyed objects that have a registry
 are marked as Deprecated or Obsolete.
 
 diff --git a/src/main/java/org/bukkit/Art.java b/src/main/java/org/bukkit/Art.java
-index 042d1d932a33022e4fc873652f70dc6ed342d46a..e57e34064262b90221b0621f1d13e9705e68421a 100644
+index d24bf449f58fd7c1b8ffab8dbc42f9f1fef8c4ef..00a290f1bf58cdc2238c13fd5a6048a26b7871da 100644
 --- a/src/main/java/org/bukkit/Art.java
 +++ b/src/main/java/org/bukkit/Art.java
-@@ -103,6 +103,13 @@ public enum Art implements Keyed {
-         return id;
-     }
+@@ -97,6 +97,16 @@ public interface Art extends OldEnum<Art>, Keyed {
+     @Deprecated(since = "1.6.2")
+     int getId();
  
 +    // Paper start - deprecate getKey
 +    /**
@@ -23,10 +23,13 @@ index 042d1d932a33022e4fc873652f70dc6ed342d46a..e57e34064262b90221b0621f1d13e970
 +     * and {@link io.papermc.paper.registry.RegistryKey#PAINTING_VARIANT}. Painting variants can exist without a key.
 +     */
 +    @Deprecated(since = "1.21")
++    @Override
++    @NotNull NamespacedKey getKey();
 +    // Paper end - deprecate getKey
-     @NotNull
-     @Override
-     public NamespacedKey getKey() {
++
+     /**
+      * Get a painting by its numeric ID
+      *
 diff --git a/src/main/java/org/bukkit/MusicInstrument.java b/src/main/java/org/bukkit/MusicInstrument.java
 index c9f02466a04d20579fe2258bb02acf98e163ca81..bffd4ab2d08e5c3f83a49a31e1e55cc1eab7b319 100644
 --- a/src/main/java/org/bukkit/MusicInstrument.java
@@ -49,10 +52,10 @@ index c9f02466a04d20579fe2258bb02acf98e163ca81..bffd4ab2d08e5c3f83a49a31e1e55cc1
      @Override
      public @NotNull String translationKey() {
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 833eea6ee8c7fd8ccb3f2eed4285a3eb8311448c..e4d4ac6436f341f5d9de95e1ab56461fd68a3dc2 100644
+index a5db0a013921423f87abb14dc08b24f47d4093f6..9ed61b649d7e7056bd9ebcbb77f17c6c5798bf2d 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -385,6 +385,79 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -387,6 +387,79 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      @Nullable
      T get(@NotNull NamespacedKey key);
  
@@ -132,7 +135,7 @@ index 833eea6ee8c7fd8ccb3f2eed4285a3eb8311448c..e4d4ac6436f341f5d9de95e1ab56461f
      /**
       * Get the object by its key.
       *
-@@ -481,5 +554,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -483,5 +556,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
          public Class<T> getType() {
              return this.type;
          }
@@ -146,11 +149,11 @@ index 833eea6ee8c7fd8ccb3f2eed4285a3eb8311448c..e4d4ac6436f341f5d9de95e1ab56461f
      }
  }
 diff --git a/src/main/java/org/bukkit/Sound.java b/src/main/java/org/bukkit/Sound.java
-index cf17af024b1953b6f21f18885411ea6a0baa1d4c..f32a035317f3f8e200bb8076e6a326cb1e87cfe1 100644
+index 04e890be72b18259f1af2833879b4d9af51b1f02..97c4fc9615e28c7268cd8340b50029c8f7de56b7 100644
 --- a/src/main/java/org/bukkit/Sound.java
 +++ b/src/main/java/org/bukkit/Sound.java
-@@ -1655,6 +1655,13 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
-         this.key = NamespacedKey.minecraft(key);
+@@ -1689,6 +1689,16 @@ public interface Sound extends OldEnum<Sound>, Keyed, net.kyori.adventure.sound.
+         return sound;
      }
  
 +    // Paper start - deprecate getKey
@@ -159,10 +162,13 @@ index cf17af024b1953b6f21f18885411ea6a0baa1d4c..f32a035317f3f8e200bb8076e6a326cb
 +     * can exist without a key.
 +     */
 +    @Deprecated(since = "1.20.5")
++    @Override
++    @NotNull NamespacedKey getKey();
 +    // Paper end - deprecate getKey
-     @NotNull
-     @Override
-     public NamespacedKey getKey() {
++
+     /**
+      * @return an array of all known sounds.
+      * @deprecated use {@link Registry#iterator()}.
 diff --git a/src/main/java/org/bukkit/block/banner/PatternType.java b/src/main/java/org/bukkit/block/banner/PatternType.java
 index eaf6cd758344eeba29f00f822a50c93704af8bda..eb192030832e1741850871bec9bf999f014b6fc1 100644
 --- a/src/main/java/org/bukkit/block/banner/PatternType.java

--- a/patches/api/0471-Registry-Modification-API.patch
+++ b/patches/api/0471-Registry-Modification-API.patch
@@ -809,10 +809,10 @@ index 0000000000000000000000000000000000000000..bf49125acc8a0508bf59674bba3ed350
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index e4d4ac6436f341f5d9de95e1ab56461fd68a3dc2..b56e8fc3fba40637396abef27c08806f5157b3b4 100644
+index 9ed61b649d7e7056bd9ebcbb77f17c6c5798bf2d..16bef936a9aef957a73c33e45be7573584943a6b 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -384,6 +384,27 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -386,6 +386,27 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       */
      @Nullable
      T get(@NotNull NamespacedKey key);
@@ -840,7 +840,7 @@ index e4d4ac6436f341f5d9de95e1ab56461fd68a3dc2..b56e8fc3fba40637396abef27c08806f
  
      // Paper start - improve Registry
      /**
-@@ -458,6 +479,34 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -460,6 +481,34 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      }
      // Paper end - improve Registry
  
@@ -875,7 +875,7 @@ index e4d4ac6436f341f5d9de95e1ab56461fd68a3dc2..b56e8fc3fba40637396abef27c08806f
      /**
       * Get the object by its key.
       *
-@@ -561,5 +610,23 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -563,5 +612,23 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
              return value.getKey();
          }
          // Paper end - improve Registry

--- a/patches/server/0004-Test-changes.patch
+++ b/patches/server/0004-Test-changes.patch
@@ -452,3 +452,81 @@ index 5781c2fab2d407b4a22d5fc80e1c03e907617316..68ae998b30bbcacae3604fb6581ceca3
          RegistryHelper.registry = layers.compositeAccess().freeze();
          // Register vanilla pack
          RegistryHelper.dataPack = ReloadableServerResources.loadResources(ireloadableresourcemanager, layers, list, featureFlagSet, Commands.CommandSelection.DEDICATED, 0, MoreExecutors.directExecutor(), MoreExecutors.directExecutor()).join();
+diff --git a/src/test/java/org/bukkit/support/suite/AllFeaturesTestSuite.java b/src/test/java/org/bukkit/support/suite/AllFeaturesTestSuite.java
+index d78661198815b78d041288eb62076514926428ad..2d268498b545db48efa106d2c7afca7f7b74c76d 100644
+--- a/src/test/java/org/bukkit/support/suite/AllFeaturesTestSuite.java
++++ b/src/test/java/org/bukkit/support/suite/AllFeaturesTestSuite.java
+@@ -14,7 +14,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
+ @Suite(failIfNoTests = false)
+ @SuiteDisplayName("Test suite for test which need registry values present, with all feature flags set")
+ @IncludeTags("AllFeatures")
+-@SelectPackages("org.bukkit")
++@SelectPackages({"org.bukkit", "io.papermc"})
+ @SelectClasses({RegistryClassTest.class, PerRegistryTest.class, RegistryConversionTest.class}) // Make sure general registry tests are run first
+ @ExcludeClassNamePatterns("org.bukkit.craftbukkit.inventory.ItemStack.*Test")
+ @ConfigurationParameter(key = "TestSuite", value = "AllFeatures")
+diff --git a/src/test/java/org/bukkit/support/suite/BundleFeatureTestSuite.java b/src/test/java/org/bukkit/support/suite/BundleFeatureTestSuite.java
+index 8faaffd16fb05bd3d976b6a63835cfa547ec2445..c1ee709083276acb14b474993800dd4894febc47 100644
+--- a/src/test/java/org/bukkit/support/suite/BundleFeatureTestSuite.java
++++ b/src/test/java/org/bukkit/support/suite/BundleFeatureTestSuite.java
+@@ -9,7 +9,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
+ @Suite(failIfNoTests = false)
+ @SuiteDisplayName("Test suite for test which need registry values present, with the bundle feature flag set")
+ @IncludeTags("BundleFeature")
+-@SelectPackages("org.bukkit")
++@SelectPackages({"org.bukkit", "io.papermc"})
+ @ConfigurationParameter(key = "TestSuite", value = "BundleFeature")
+ public class BundleFeatureTestSuite {
+ }
+diff --git a/src/test/java/org/bukkit/support/suite/LegacyTestSuite.java b/src/test/java/org/bukkit/support/suite/LegacyTestSuite.java
+index 576c35e086345c96325628cf1a048599f9ed6950..ac3c1c88ce5de4b623d17ab0af11a7d04caec869 100644
+--- a/src/test/java/org/bukkit/support/suite/LegacyTestSuite.java
++++ b/src/test/java/org/bukkit/support/suite/LegacyTestSuite.java
+@@ -9,7 +9,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
+ @Suite(failIfNoTests = false)
+ @SuiteDisplayName("Test suite for legacy tests")
+ @IncludeTags("Legacy")
+-@SelectPackages("org.bukkit")
++@SelectPackages({"org.bukkit", "io.papermc"})
+ @ConfigurationParameter(key = "TestSuite", value = "Legacy")
+ public class LegacyTestSuite {
+ }
+diff --git a/src/test/java/org/bukkit/support/suite/NormalTestSuite.java b/src/test/java/org/bukkit/support/suite/NormalTestSuite.java
+index 661c49c83b9a81512cf181b50f6353dc76e9f0bc..76f61fb60612160477b7da0b095f1c7e4822d4fb 100644
+--- a/src/test/java/org/bukkit/support/suite/NormalTestSuite.java
++++ b/src/test/java/org/bukkit/support/suite/NormalTestSuite.java
+@@ -9,7 +9,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
+ @Suite(failIfNoTests = false)
+ @SuiteDisplayName("Test suite for standalone tests, which don't need any registry values present")
+ @IncludeTags("Normal")
+-@SelectPackages("org.bukkit")
++@SelectPackages({"org.bukkit", "io.papermc"})
+ @ConfigurationParameter(key = "TestSuite", value = "Normal")
+ public class NormalTestSuite {
+ }
+diff --git a/src/test/java/org/bukkit/support/suite/SlowTestSuite.java b/src/test/java/org/bukkit/support/suite/SlowTestSuite.java
+index f95ff2e9930f4fd0ff284f714fc39afb6b7789ca..60be4c20101bbae8cf027270ff0e1e138d2fe9d2 100644
+--- a/src/test/java/org/bukkit/support/suite/SlowTestSuite.java
++++ b/src/test/java/org/bukkit/support/suite/SlowTestSuite.java
+@@ -9,7 +9,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
+ @Suite(failIfNoTests = false)
+ @SuiteDisplayName("Test suite for slow tests, which don't need to run every time")
+ @IncludeTags("Slow")
+-@SelectPackages("org.bukkit")
++@SelectPackages({"org.bukkit", "io.papermc"})
+ @ConfigurationParameter(key = "TestSuite", value = "Slow")
+ public class SlowTestSuite {
+ }
+diff --git a/src/test/java/org/bukkit/support/suite/VanillaFeatureTestSuite.java b/src/test/java/org/bukkit/support/suite/VanillaFeatureTestSuite.java
+index 5ee48e92d2b5134a4ba15802087f6afe58c1cb8d..d0e2eacfcd487e2852eff4b1828031dd3649e41a 100644
+--- a/src/test/java/org/bukkit/support/suite/VanillaFeatureTestSuite.java
++++ b/src/test/java/org/bukkit/support/suite/VanillaFeatureTestSuite.java
+@@ -9,7 +9,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
+ @Suite(failIfNoTests = false)
+ @SuiteDisplayName("Test suite for test which need vanilla registry values present")
+ @IncludeTags("VanillaFeature")
+-@SelectPackages("org.bukkit")
++@SelectPackages({"org.bukkit", "io.papermc"})
+ @ConfigurationParameter(key = "TestSuite", value = "VanillaFeature")
+ public class VanillaFeatureTestSuite {
+ }

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -5624,10 +5624,10 @@ index ae25aec117a7272735c824a00c1ed117fa52a921..d6e942aca1bcc769c390504a4119d661
      @Override
      public void schedule(R runnable) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1631ea62aab53d6e5e0ae44f63367416ac424410..c010d18061f58a583c69e85fc29305497523f569 100644
+index 4c9ff26332e2f5224d0308e4cb64b7b6c474fb3f..0fa9bcd7e7f1c4d1c8c57a061f0a782de1bfbf8b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -342,6 +342,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -343,6 +343,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return this.level.hasChunk((int) Math.floor(this.getX()) >> 4, (int) Math.floor(this.getZ()) >> 4);
      }
      // CraftBukkit end

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -5594,7 +5594,7 @@ index a1f4ebcd0877a6d0c41493eff5d70a408bf98e59..f1725ef766c35aa623ace58fe8bf31fc
      public BlockState getBlockState(BlockPos pos) {
          return this.getChunk(SectionPos.blockToSectionCoord(pos.getX()), SectionPos.blockToSectionCoord(pos.getZ())).getBlockState(pos);
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 23a611c9a83d1cea5ab2f64cdbd696c39872477d..bf660a057d135563b47e7b74d927a82a20b8ef75 100644
+index d7095aab94a9f3b9f06a033ba4d414dfae42f620..7bb87d2bdf0ead0fdca38a9685e2e15b249ec2cb 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -181,6 +181,7 @@ public abstract class PlayerList {
@@ -5640,7 +5640,7 @@ index 1631ea62aab53d6e5e0ae44f63367416ac424410..c010d18061f58a583c69e85fc2930549
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 47712d062ece9914de058153272ab1fa535af372..9aa4e70f1d1c4de2138d31701dceaed25062e69c 100644
+index 17f706d401154035a7f1ed47b04a38e4eef24263..1d7af970b8f5eaa46fe4cd2b7d076f3cdd371216 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -296,6 +296,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -6162,7 +6162,7 @@ index 34933c5324126f9afdc5cba9dea997ace8f01806..4eb0b0969325f39a7ae65492cccd4825
              return false;
          } else {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3882ae04173cd125fe490692a6bc2b4d8b20ff7b..eb61712ea067b277e7f32f887e3528faca275450 100644
+index 6c8a69b7c1b45549b2c388a8df2258184c587309..49102177454765b8e53d0d7f47fe4bf4a33549af 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2617,4 +2617,9 @@ public final class CraftServer implements Server {
@@ -6386,10 +6386,10 @@ index e837d76e833d73d888bc1dad3515c2b82bc0e437..4705aed1dd98378c146bf9e346df1a17
      public WorldBorder getWorldBorder() {
          throw new UnsupportedOperationException("Not supported yet.");
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 1bf87b4915edf341ad55f8274cef324e0bc28547..3591b79481ac17bd02e59ac3c623d1c6991abd84 100644
+index fb83cadf384712e2dff1cb001bdbeec8f5e89ada..5baf68732cb0e5ecab9d809df54a42e8252f1624 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -34,6 +34,9 @@ public class ActivationRange
+@@ -35,6 +35,9 @@ public class ActivationRange
  
      public enum ActivationType
      {

--- a/patches/server/0021-Hook-into-CB-plugin-rewrites.patch
+++ b/patches/server/0021-Hook-into-CB-plugin-rewrites.patch
@@ -8,7 +8,7 @@ our own relocation. Also lets us rewrite NMS calls for when we're
 debugging in an IDE pre-relocate.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 79b386af9eb2450b0a8abe3342bc53d3f0b86fd9..58df23162aed12f3058b5e0921a9e30b89f56a10 100644
+index 40fbbff1df7e65ca01bb82e213eeefbb38c85a7a..7d2d5c4ee244e7118a4c38628e2e69c79b11b98d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 @@ -12,6 +12,7 @@ import java.util.Arrays;
@@ -27,7 +27,7 @@ index 79b386af9eb2450b0a8abe3342bc53d3f0b86fd9..58df23162aed12f3058b5e0921a9e30b
  import joptsimple.OptionParser;
  import joptsimple.OptionSet;
  import joptsimple.OptionSpec;
-@@ -126,6 +128,40 @@ public class Commodore {
+@@ -128,6 +130,40 @@ public class Commodore {
          return this.reroutes;
      }
  
@@ -68,7 +68,7 @@ index 79b386af9eb2450b0a8abe3342bc53d3f0b86fd9..58df23162aed12f3058b5e0921a9e30b
      public static void main(String[] args) {
          OptionParser parser = new OptionParser();
          OptionSpec<File> inputFlag = parser.acceptsAll(Arrays.asList("i", "input")).withRequiredArg().ofType(File.class).required();
-@@ -281,9 +317,49 @@ public class Commodore {
+@@ -283,9 +319,49 @@ public class Commodore {
                  }
  
                  return new MethodVisitor(this.api, super.visitMethod(access, name, desc, signature, exceptions)) {
@@ -118,7 +118,7 @@ index 79b386af9eb2450b0a8abe3342bc53d3f0b86fd9..58df23162aed12f3058b5e0921a9e30b
                          name = FieldRename.rename(pluginVersion, owner, name);
  
                          if (modern) {
-@@ -396,6 +472,13 @@ public class Commodore {
+@@ -398,6 +474,13 @@ public class Commodore {
                              return;
                          }
  
@@ -132,7 +132,7 @@ index 79b386af9eb2450b0a8abe3342bc53d3f0b86fd9..58df23162aed12f3058b5e0921a9e30b
                          if (modern) {
                              if (owner.equals("org/bukkit/Material") || (instantiatedMethodType != null && instantiatedMethodType.getDescriptor().startsWith("(Lorg/bukkit/Material;)"))) {
                                  switch (name) {
-@@ -492,6 +575,13 @@ public class Commodore {
+@@ -494,6 +577,13 @@ public class Commodore {
  
                      @Override
                      public void visitLdcInsn(Object value) {
@@ -146,7 +146,7 @@ index 79b386af9eb2450b0a8abe3342bc53d3f0b86fd9..58df23162aed12f3058b5e0921a9e30b
                          if (value instanceof String && ((String) value).equals("com.mysql.jdbc.Driver")) {
                              super.visitLdcInsn("com.mysql.cj.jdbc.Driver");
                              return;
-@@ -502,6 +592,14 @@ public class Commodore {
+@@ -504,6 +594,14 @@ public class Commodore {
  
                      @Override
                      public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
@@ -161,7 +161,7 @@ index 79b386af9eb2450b0a8abe3342bc53d3f0b86fd9..58df23162aed12f3058b5e0921a9e30b
                          if (bootstrapMethodHandle.getOwner().equals("java/lang/invoke/LambdaMetafactory")
                                  && bootstrapMethodHandle.getName().equals("metafactory") && bootstrapMethodArguments.length == 3) {
                              Type samMethodType = (Type) bootstrapMethodArguments[0];
-@@ -518,7 +616,7 @@ public class Commodore {
+@@ -520,7 +618,7 @@ public class Commodore {
                                  methodArgs.add(new Handle(newOpcode, newOwner, newName, newDescription, newItf));
                                  methodArgs.add(newInstantiated);
  
@@ -170,7 +170,7 @@ index 79b386af9eb2450b0a8abe3342bc53d3f0b86fd9..58df23162aed12f3058b5e0921a9e30b
                              }, implMethod.getTag(), implMethod.getOwner(), implMethod.getName(), implMethod.getDesc(), implMethod.isInterface(), samMethodType, instantiatedMethodType);
                              return;
                          }
-@@ -569,6 +667,12 @@ public class Commodore {
+@@ -571,6 +669,12 @@ public class Commodore {
  
              @Override
              public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {

--- a/patches/server/0022-Remap-reflection-calls-in-plugins-using-internals.patch
+++ b/patches/server/0022-Remap-reflection-calls-in-plugins-using-internals.patch
@@ -645,10 +645,10 @@ index 242811578a786e3807a1a7019d472d5a68f87116..0b65fdf53124f3dd042b2363b1b8df8e
              return traceElements;
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 58df23162aed12f3058b5e0921a9e30b89f56a10..ba104635c7713b04ce624bc4c7bd390462bc0edb 100644
+index 7d2d5c4ee244e7118a4c38628e2e69c79b11b98d..371d31266a532e59c49dbb106e354296b119fa5e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -129,36 +129,26 @@ public class Commodore {
+@@ -131,36 +131,26 @@ public class Commodore {
      }
  
      // Paper start - Plugin rewrites
@@ -696,7 +696,7 @@ index 58df23162aed12f3058b5e0921a9e30b89f56a10..ba104635c7713b04ce624bc4c7bd3904
      }
      // Paper end - Plugin rewrites
  
-@@ -243,6 +233,7 @@ public class Commodore {
+@@ -245,6 +235,7 @@ public class Commodore {
              visitor = new LimitedClassRemapper(cw, new SimpleRemapper(Commodore.ENUM_RENAMES));
          }
  

--- a/patches/server/0024-Remove-Spigot-timings.patch
+++ b/patches/server/0024-Remove-Spigot-timings.patch
@@ -330,10 +330,10 @@ index 18d56058073b6cc4f9020f0a6137e4ac26eed0b2..fddc6b5abbad66ebe556ff8565c38c60
      }
      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c010d18061f58a583c69e85fc29305497523f569..c8b8102d84119dfb6093f4b79aa3124c594f9a88 100644
+index 0fa9bcd7e7f1c4d1c8c57a061f0a782de1bfbf8b..aba3e1b5d86940f91034ee6415c909529503a184 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -148,7 +148,6 @@ import org.bukkit.command.CommandSender;
+@@ -149,7 +149,6 @@ import org.bukkit.command.CommandSender;
  import org.bukkit.entity.Hanging;
  import org.bukkit.entity.LivingEntity;
  import org.bukkit.entity.Vehicle;
@@ -341,7 +341,7 @@ index c010d18061f58a583c69e85fc29305497523f569..c8b8102d84119dfb6093f4b79aa3124c
  import org.bukkit.event.entity.EntityCombustByEntityEvent;
  import org.bukkit.event.hanging.HangingBreakByEntityEvent;
  import org.bukkit.event.vehicle.VehicleBlockCollisionEvent;
-@@ -326,7 +325,6 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -327,7 +326,6 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      // Marks an entity, that it was removed by a plugin via Entity#remove
      // Main use case currently is for SPIGOT-7487, preventing dropping of leash when leash is removed
      public boolean pluginRemoved = false;
@@ -349,7 +349,7 @@ index c010d18061f58a583c69e85fc29305497523f569..c8b8102d84119dfb6093f4b79aa3124c
      // Spigot start
      public final org.spigotmc.ActivationRange.ActivationType activationType = org.spigotmc.ActivationRange.initializeEntityActivationType(this);
      public final boolean defaultActivationState;
-@@ -866,7 +864,6 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -867,7 +865,6 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void move(MoverType type, Vec3 movement) {
@@ -357,7 +357,7 @@ index c010d18061f58a583c69e85fc29305497523f569..c8b8102d84119dfb6093f4b79aa3124c
          if (this.noPhysics) {
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
          } else {
-@@ -978,7 +975,6 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -979,7 +976,6 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  gameprofilerfiller.pop();
              }
          }

--- a/patches/server/0024-Remove-Spigot-timings.patch
+++ b/patches/server/0024-Remove-Spigot-timings.patch
@@ -366,7 +366,7 @@ index c010d18061f58a583c69e85fc29305497523f569..c8b8102d84119dfb6093f4b79aa3124c
  
      private void applyMovementEmissionAndPlaySound(Entity.MovementEmission moveEffect, Vec3 movement, BlockPos landingPos, BlockState landingState) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9aa4e70f1d1c4de2138d31701dceaed25062e69c..6dba567e9f7a197af16598647f216b5323d1b601 100644
+index 1d7af970b8f5eaa46fe4cd2b7d076f3cdd371216..900ab23f587e9d990afe29492058390dc1c13f2d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -162,8 +162,6 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -378,7 +378,7 @@ index 9aa4e70f1d1c4de2138d31701dceaed25062e69c..6dba567e9f7a197af16598647f216b53
  public abstract class LivingEntity extends Entity implements Attackable {
  
      private static final Logger LOGGER = LogUtils.getLogger();
-@@ -3090,7 +3088,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3091,7 +3089,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      @Override
      public void tick() {
@@ -386,7 +386,7 @@ index 9aa4e70f1d1c4de2138d31701dceaed25062e69c..6dba567e9f7a197af16598647f216b53
          super.tick();
          this.updatingUsingItem();
          this.updateSwimAmount();
-@@ -3132,9 +3129,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3133,9 +3130,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          }
  
          if (!this.isRemoved()) {
@@ -396,7 +396,7 @@ index 9aa4e70f1d1c4de2138d31701dceaed25062e69c..6dba567e9f7a197af16598647f216b53
          }
  
          double d0 = this.getX() - this.xo;
-@@ -3228,7 +3223,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3229,7 +3224,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
          }
  
          this.elytraAnimationState.tick();
@@ -404,7 +404,7 @@ index 9aa4e70f1d1c4de2138d31701dceaed25062e69c..6dba567e9f7a197af16598647f216b53
      }
  
      public void detectEquipmentUpdatesPublic() { // CraftBukkit
-@@ -3435,7 +3429,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3436,7 +3430,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
          ProfilerFiller gameprofilerfiller = Profiler.get();
  
          gameprofilerfiller.push("ai");
@@ -412,7 +412,7 @@ index 9aa4e70f1d1c4de2138d31701dceaed25062e69c..6dba567e9f7a197af16598647f216b53
          if (this.isImmobile()) {
              this.jumping = false;
              this.xxa = 0.0F;
-@@ -3445,7 +3438,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3446,7 +3439,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.serverAiStep();
              gameprofilerfiller.pop();
          }
@@ -420,7 +420,7 @@ index 9aa4e70f1d1c4de2138d31701dceaed25062e69c..6dba567e9f7a197af16598647f216b53
  
          gameprofilerfiller.pop();
          gameprofilerfiller.push("jump");
-@@ -3488,7 +3480,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3489,7 +3481,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.resetFallDistance();
          }
  
@@ -428,7 +428,7 @@ index 9aa4e70f1d1c4de2138d31701dceaed25062e69c..6dba567e9f7a197af16598647f216b53
          label112:
          {
              LivingEntity entityliving = this.getControllingPassenger();
-@@ -3502,7 +3493,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3503,7 +3494,6 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
              this.travel(vec3d1);
          }
@@ -436,7 +436,7 @@ index 9aa4e70f1d1c4de2138d31701dceaed25062e69c..6dba567e9f7a197af16598647f216b53
  
          if (!this.level().isClientSide() || this.isControlledByLocalInstance()) {
              this.applyEffectsFromBlocks();
-@@ -3538,9 +3528,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3539,9 +3529,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.checkAutoSpinAttack(axisalignedbb, this.getBoundingBox());
          }
  
@@ -595,7 +595,7 @@ index d1b82dec25069a7027aaf53086b1829e511fc301..4367ccc628bb4f404d6a081083002518
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7c5b0db8115dc4032a3a364299ca06c88efd9a26..5650b4cfcd4008ac7f351d5bfb1fb8cc81da4caa 100644
+index f3bc8196b43bfdfdd85e03769c4d109c2fe1930c..f401fb3261a883019083f3c6c145d0ff74f149f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -379,7 +379,6 @@ public final class CraftServer implements Server {
@@ -919,10 +919,10 @@ index f97eccb6a17c7876e1e002d798eb67bbe80571a0..dba31a2cbcfebe1f28883545ce4a70fc
 +    }
  }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 3591b79481ac17bd02e59ac3c623d1c6991abd84..263df52c7f5e172a6b9118b4bc4672e443adedba 100644
+index 5baf68732cb0e5ecab9d809df54a42e8252f1624..0338ceaddc1a0921f5f8796d5eac75c301bafac2 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -27,7 +27,6 @@ import net.minecraft.world.entity.projectile.ThrownTrident;
+@@ -28,7 +28,6 @@ import net.minecraft.world.entity.projectile.ThrownTrident;
  import net.minecraft.world.entity.raid.Raider;
  import net.minecraft.world.level.Level;
  import net.minecraft.world.phys.AABB;
@@ -930,7 +930,7 @@ index 3591b79481ac17bd02e59ac3c623d1c6991abd84..263df52c7f5e172a6b9118b4bc4672e4
  
  public class ActivationRange
  {
-@@ -110,7 +109,6 @@ public class ActivationRange
+@@ -111,7 +110,6 @@ public class ActivationRange
       */
      public static void activateEntities(Level world)
      {
@@ -938,7 +938,7 @@ index 3591b79481ac17bd02e59ac3c623d1c6991abd84..263df52c7f5e172a6b9118b4bc4672e4
          final int miscActivationRange = world.spigotConfig.miscActivationRange;
          final int raiderActivationRange = world.spigotConfig.raiderActivationRange;
          final int animalActivationRange = world.spigotConfig.animalActivationRange;
-@@ -137,7 +135,6 @@ public class ActivationRange
+@@ -138,7 +136,6 @@ public class ActivationRange
  
              world.getEntities().get(ActivationRange.maxBB, ActivationRange::activateEntity);
          }
@@ -946,18 +946,18 @@ index 3591b79481ac17bd02e59ac3c623d1c6991abd84..263df52c7f5e172a6b9118b4bc4672e4
      }
  
      /**
-@@ -232,10 +229,8 @@ public class ActivationRange
+@@ -233,10 +230,8 @@ public class ActivationRange
       */
      public static boolean checkIfActive(Entity entity)
      {
 -        SpigotTimings.checkIfActiveTimer.startTiming();
-         // Never safe to skip fireworks or entities not yet added to chunk
-         if ( entity instanceof FireworkRocketEntity ) {
+         // Never safe to skip fireworks or item gravity
+         if (entity instanceof FireworkRocketEntity || (entity instanceof ItemEntity && (entity.tickCount + entity.getId() + 1) % 4 == 0)) {
 -            SpigotTimings.checkIfActiveTimer.stopTiming();
              return true;
          }
  
-@@ -259,7 +254,6 @@ public class ActivationRange
+@@ -260,7 +255,6 @@ public class ActivationRange
          {
              isActive = false;
          }

--- a/patches/server/0036-Entity-Origin-API.patch
+++ b/patches/server/0036-Entity-Origin-API.patch
@@ -25,10 +25,10 @@ index f3633da64f990972cddc03f2fcfd34ced2955a7a..025363e6b51ff8aa089715b1ec2a0fa1
  
          public void onTrackingEnd(Entity entity) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c8b8102d84119dfb6093f4b79aa3124c594f9a88..e97853cbfa6da8ecdb4c92cf634831492e1fc7e3 100644
+index aba3e1b5d86940f91034ee6415c909529503a184..57960530e15f0e4b8fb40b725ff03aaf8ce6ffac 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -331,7 +331,27 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -332,7 +332,27 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public long activatedTick = Integer.MIN_VALUE;
      public void inactiveTick() { }
      // Spigot end
@@ -56,7 +56,7 @@ index c8b8102d84119dfb6093f4b79aa3124c594f9a88..e97853cbfa6da8ecdb4c92cf63483149
      public float getBukkitYaw() {
          return this.yRot;
      }
-@@ -2269,6 +2289,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2270,6 +2290,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  this.bukkitEntity.storeBukkitValues(nbttagcompound);
              }
              // CraftBukkit end
@@ -72,7 +72,7 @@ index c8b8102d84119dfb6093f4b79aa3124c594f9a88..e97853cbfa6da8ecdb4c92cf63483149
              return nbttagcompound;
          } catch (Throwable throwable) {
              CrashReport crashreport = CrashReport.forThrowable(throwable, "Saving entity NBT");
-@@ -2397,6 +2426,20 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2398,6 +2427,20 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              }
              // CraftBukkit end
  

--- a/patches/server/0038-Configurable-top-of-nether-void-damage.patch
+++ b/patches/server/0038-Configurable-top-of-nether-void-damage.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable top of nether void damage
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e97853cbfa6da8ecdb4c92cf634831492e1fc7e3..49df5f4b09926556986e3a45d52ff299b878af76 100644
+index 57960530e15f0e4b8fb40b725ff03aaf8ce6ffac..2828ef013fe2c35292990cccd824a76a5551c952 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -720,7 +720,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -721,7 +721,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void checkBelowWorld() {

--- a/patches/server/0040-Add-more-entities-to-activation-range-ignore-list.patch
+++ b/patches/server/0040-Add-more-entities-to-activation-range-ignore-list.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add more entities to activation range ignore list
 
 
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 263df52c7f5e172a6b9118b4bc4672e443adedba..dd1c5bc7522a4710cbfdd4764f6431e1e28d63cc 100644
+index 0338ceaddc1a0921f5f8796d5eac75c301bafac2..bd522080d17b5b470ec3ab42aa4ecc3082248c8a 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -91,6 +91,9 @@ public class ActivationRange
+@@ -92,6 +92,9 @@ public class ActivationRange
                  || entity instanceof AbstractHurtingProjectile
                  || entity instanceof LightningBolt
                  || entity instanceof PrimedTnt

--- a/patches/server/0063-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/patches/server/0063-Disable-Scoreboards-for-non-players-by-default.patch
@@ -11,10 +11,10 @@ So avoid looking up scoreboards and short circuit to the "not on a team"
 logic which is most likely to be true.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 49df5f4b09926556986e3a45d52ff299b878af76..8a61ca3cba2888e03e440519714705fe50b81267 100644
+index 2828ef013fe2c35292990cccd824a76a5551c952..0c2389e73e98ec48ed636f616a36e6e1cefa7b93 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3057,6 +3057,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3058,6 +3058,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Nullable
      public PlayerTeam getTeam() {
@@ -23,7 +23,7 @@ index 49df5f4b09926556986e3a45d52ff299b878af76..8a61ca3cba2888e03e440519714705fe
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 6dba567e9f7a197af16598647f216b5323d1b601..47403887721914b632565947efae0dfa7c841588 100644
+index 900ab23f587e9d990afe29492058390dc1c13f2d..c177e3ba30b8807eb41ad7741706d9a017ab9717 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -871,6 +871,7 @@ public abstract class LivingEntity extends Entity implements Attackable {

--- a/patches/server/0073-Custom-replacement-for-eaten-items.patch
+++ b/patches/server/0073-Custom-replacement-for-eaten-items.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom replacement for eaten items
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 47403887721914b632565947efae0dfa7c841588..031b7f51959d1b8ca30e4a9fda0a2832516c9c0c 100644
+index c177e3ba30b8807eb41ad7741706d9a017ab9717..21a356b3c7d3dec73e5c8feaa4afda479a7ec1a2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3982,10 +3982,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3983,10 +3983,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  if (!this.useItem.isEmpty() && this.isUsingItem()) {
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
@@ -21,7 +21,7 @@ index 47403887721914b632565947efae0dfa7c841588..031b7f51959d1b8ca30e4a9fda0a2832
                          this.level().getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {
-@@ -4003,6 +4004,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4004,6 +4005,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      } else {
                          itemstack = this.useItem.finishUsingItem(this.level(), this);
                      }
@@ -34,7 +34,7 @@ index 47403887721914b632565947efae0dfa7c841588..031b7f51959d1b8ca30e4a9fda0a2832
                      // CraftBukkit end
  
                      if (itemstack != this.useItem) {
-@@ -4010,6 +4017,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4011,6 +4018,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0074-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0074-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] handle NaN health/absorb values and repair bad data
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 031b7f51959d1b8ca30e4a9fda0a2832516c9c0c..e5d1877f570b302f0b193e77ff5fdd7e89532513 100644
+index 21a356b3c7d3dec73e5c8feaa4afda479a7ec1a2..cd7837935003775688281882b19f0808512a2e0d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -831,7 +831,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -34,7 +34,7 @@ index 031b7f51959d1b8ca30e4a9fda0a2832516c9c0c..e5d1877f570b302f0b193e77ff5fdd7e
          // CraftBukkit start - Handle scaled health
          if (this instanceof ServerPlayer) {
              org.bukkit.craftbukkit.entity.CraftPlayer player = ((ServerPlayer) this).getBukkitEntity();
-@@ -3839,7 +3849,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3840,7 +3850,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public final void setAbsorptionAmount(float absorptionAmount) {

--- a/patches/server/0075-Use-a-Shared-Random-for-Entities.patch
+++ b/patches/server/0075-Use-a-Shared-Random-for-Entities.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Use a Shared Random for Entities
 Reduces memory usage and provides ensures more randomness, Especially since a lot of garbage entity objects get created.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8a61ca3cba2888e03e440519714705fe50b81267..847fd720f11e89d906430c820bc92afe0454761d 100644
+index 0c2389e73e98ec48ed636f616a36e6e1cefa7b93..27a0f0651ac961c06626df1e4beb5525b4dacd48 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -183,6 +183,79 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -184,6 +184,79 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return tag.contains("Bukkit.updateLevel") && tag.getInt("Bukkit.updateLevel") >= level;
      }
  
@@ -89,7 +89,7 @@ index 8a61ca3cba2888e03e440519714705fe50b81267..847fd720f11e89d906430c820bc92afe
      private CraftEntity bukkitEntity;
  
      public CraftEntity getBukkitEntity() {
-@@ -373,7 +446,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -374,7 +447,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.bb = Entity.INITIAL_AABB;
          this.stuckSpeedMultiplier = Vec3.ZERO;
          this.nextStep = 1.0F;

--- a/patches/server/0126-Cap-Entity-Collisions.patch
+++ b/patches/server/0126-Cap-Entity-Collisions.patch
@@ -24,10 +24,10 @@ index 847fd720f11e89d906430c820bc92afe0454761d..b1b26e7c0f66f0697bcfe9eb045d45f3
      @javax.annotation.Nullable
      private org.bukkit.util.Vector origin;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 7a648a8c3f25397e1c883a42648b21a05901513f..bcc0137fec45406e70231b4e2a5bd69dc08ffb5a 100644
+index 6c29a05e91a6bac634ca3e5394b90112b65cdbd6..009539fa39c81c610ac34747cc09082a0756c79d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3640,10 +3640,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3641,10 +3641,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  }
  
                  Iterator iterator1 = list.iterator();

--- a/patches/server/0126-Cap-Entity-Collisions.patch
+++ b/patches/server/0126-Cap-Entity-Collisions.patch
@@ -12,10 +12,10 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 847fd720f11e89d906430c820bc92afe0454761d..b1b26e7c0f66f0697bcfe9eb045d45f31cd9ab06 100644
+index 27a0f0651ac961c06626df1e4beb5525b4dacd48..2b5d1bc6d3b3fd04bcbf4984035a00b9151cf2ee 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -404,6 +404,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -405,6 +405,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public long activatedTick = Integer.MIN_VALUE;
      public void inactiveTick() { }
      // Spigot end

--- a/patches/server/0141-Entity-fromMobSpawner.patch
+++ b/patches/server/0141-Entity-fromMobSpawner.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b1b26e7c0f66f0697bcfe9eb045d45f31cd9ab06..99794276626d26849150d4956abbbc2296543907 100644
+index 2b5d1bc6d3b3fd04bcbf4984035a00b9151cf2ee..aa70b6437cabdd875cec446db4bcf2422ab2cbc6 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -405,6 +405,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -406,6 +406,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public void inactiveTick() { }
      // Spigot end
      protected int numCollisions = 0; // Paper - Cap entity collisions
@@ -16,7 +16,7 @@ index b1b26e7c0f66f0697bcfe9eb045d45f31cd9ab06..99794276626d26849150d4956abbbc22
      // Paper start - Entity origin API
      @javax.annotation.Nullable
      private org.bukkit.util.Vector origin;
-@@ -2375,6 +2376,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2376,6 +2377,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  }
                  nbttagcompound.put("Paper.Origin", this.newDoubleList(origin.getX(), origin.getY(), origin.getZ()));
              }
@@ -27,7 +27,7 @@ index b1b26e7c0f66f0697bcfe9eb045d45f31cd9ab06..99794276626d26849150d4956abbbc22
              // Paper end
              return nbttagcompound;
          } catch (Throwable throwable) {
-@@ -2516,6 +2521,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2517,6 +2522,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  this.originWorld = originWorld;
                  origin = new org.bukkit.util.Vector(originTag.getDouble(0), originTag.getDouble(1), originTag.getDouble(2));
              }

--- a/patches/server/0156-Add-PlayerArmorChangeEvent.patch
+++ b/patches/server/0156-Add-PlayerArmorChangeEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index bcc0137fec45406e70231b4e2a5bd69dc08ffb5a..84e11e2c62e643f959f1a570a27f6ad07df165d4 100644
+index 009539fa39c81c610ac34747cc09082a0756c79d..08322f6147b78d140a2e0d6c3189ee95270c3c71 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3283,6 +3283,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3284,6 +3284,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
              itemstack = this.getItemBySlot(enumitemslot);
              if (this.equipmentHasChanged(itemstack2, itemstack)) {

--- a/patches/server/0176-Player.setPlayerProfile-API.patch
+++ b/patches/server/0176-Player.setPlayerProfile-API.patch
@@ -207,10 +207,10 @@ index 128fcd537783986d816dae6d1ce2afb7af07d45a..32eeca2467189c6c97f7da5529d4fe93
      public void onEntityRemove(Entity entity) {
          this.invertedVisibilityEntities.remove(entity.getUUID());
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index ba104635c7713b04ce624bc4c7bd390462bc0edb..9a6857f325d72c1b5ce403c3240e0b1a3f43bc38 100644
+index 371d31266a532e59c49dbb106e354296b119fa5e..61d617d4abb9c9cf5c711459aa98c8b173597a9a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -470,6 +470,13 @@ public class Commodore {
+@@ -472,6 +472,13 @@ public class Commodore {
                          }
                          // Paper end - Rewrite plugins
  

--- a/patches/server/0193-Add-EntityTeleportEndGatewayEvent.patch
+++ b/patches/server/0193-Add-EntityTeleportEndGatewayEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add EntityTeleportEndGatewayEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 99794276626d26849150d4956abbbc2296543907..087f030985180b91a809fb45244e23106da62e34 100644
+index aa70b6437cabdd875cec446db4bcf2422ab2cbc6..46cb5722be10182af7af41f733405ab5fe137576 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3429,8 +3429,16 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3430,8 +3430,16 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  // CraftBukkit start
                  PositionMoveRotation absolutePosition = PositionMoveRotation.calculateAbsolute(PositionMoveRotation.of(this), PositionMoveRotation.of(teleportTarget), teleportTarget.relatives());
                  Location to = CraftLocation.toBukkit(absolutePosition.position(), teleportTarget.newLevel().getWorld(), absolutePosition.yRot(), absolutePosition.xRot());

--- a/patches/server/0198-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0198-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 84e11e2c62e643f959f1a570a27f6ad07df165d4..08a2fbca50e26938e46e49dae7b101cfc375b02e 100644
+index 08322f6147b78d140a2e0d6c3189ee95270c3c71..9e21f77689eb246ad72cdbd7ee19211dcb2ed738 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4101,12 +4101,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4102,12 +4102,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (this.isUsingItem() && !this.useItem.isEmpty()) {
              Item item = this.useItem.getItem();
  

--- a/patches/server/0201-Add-entity-knockback-events.patch
+++ b/patches/server/0201-Add-entity-knockback-events.patch
@@ -11,10 +11,10 @@ Co-authored-by: aerulion <aerulion@gmail.com>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 087f030985180b91a809fb45244e23106da62e34..011006bc2e88a9fec98796f939c07d884b92126b 100644
+index 46cb5722be10182af7af41f733405ab5fe137576..ab7740d1753cd8540189c77053e5ca1f71c1b024 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2050,7 +2050,21 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2051,7 +2051,21 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void push(double deltaX, double deltaY, double deltaZ) {
@@ -38,7 +38,7 @@ index 087f030985180b91a809fb45244e23106da62e34..011006bc2e88a9fec98796f939c07d88
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 08a2fbca50e26938e46e49dae7b101cfc375b02e..cfff596d720efe5f5ee4ad1990c3ee0fd6e4e836 100644
+index 9e21f77689eb246ad72cdbd7ee19211dcb2ed738..61124dfec84792fa23ce1b0f03cbd97b1a6bde5b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1563,7 +1563,7 @@ public abstract class LivingEntity extends Entity implements Attackable {

--- a/patches/server/0209-add-more-information-to-Entity.toString.patch
+++ b/patches/server/0209-add-more-information-to-Entity.toString.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add more information to Entity.toString()
 UUID, ticks lived, valid, dead
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 011006bc2e88a9fec98796f939c07d884b92126b..79a3d586ddf404c449b7c0aa1996e9b9897b2383 100644
+index ab7740d1753cd8540189c77053e5ca1f71c1b024..659ed49cebb8ed2a6e1c88fb1e4d95f0520820d4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3406,7 +3406,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3407,7 +3407,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public String toString() {
          String s = this.level() == null ? "~NULL~" : this.level().toString();
  

--- a/patches/server/0239-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/patches/server/0239-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ray tracing methods to LivingEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cfff596d720efe5f5ee4ad1990c3ee0fd6e4e836..5b8e0931be2acb1eb4ac6f399ecc0a5ebc5db586 100644
+index 61124dfec84792fa23ce1b0f03cbd97b1a6bde5b..30343efb680edf3dc355498b04c5db9ebecbf270 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4112,6 +4112,19 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4113,6 +4113,19 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      // Paper start - Make shield blocking delay configurable

--- a/patches/server/0251-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0251-Add-LivingEntity-getTargetEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 7a89c25fcd1c76e4b176c257600db89788aa0f21..3bcf2ba5f065d946ded4020b9882bc4e19af0e08 100644
+index 781568c0aef7556fd4422574d31c0ad790f0afa7..8f6f73fd6f1fce3b78e472f454e0a34043a00125 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4176,6 +4176,38 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4177,6 +4177,38 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return this.level().clip(raytrace);
      }
  

--- a/patches/server/0266-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0266-force-entity-dismount-during-teleportation.patch
@@ -106,10 +106,10 @@ index 79a3d586ddf404c449b7c0aa1996e9b9897b2383..5d551a50e1043e369ebf3ddfe181be1e
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3bcf2ba5f065d946ded4020b9882bc4e19af0e08..63d1c5e8441eb5a32fc298ff2d2f3157cbd19557 100644
+index 8f6f73fd6f1fce3b78e472f454e0a34043a00125..7e684a7df64b64e25ba602c39488712eefdfbcfa 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3756,9 +3756,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3757,9 +3757,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      @Override
      public void stopRiding() {

--- a/patches/server/0266-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0266-force-entity-dismount-during-teleportation.patch
@@ -41,10 +41,10 @@ index cef054ba95ed7d2b0e2ee575edae3e94b77f58b6..8d958ac09bd9484d879eee6acb6aaea2
              Iterator iterator = entityliving.getActiveEffects().iterator();
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 79a3d586ddf404c449b7c0aa1996e9b9897b2383..5d551a50e1043e369ebf3ddfe181be1e24cfd068 100644
+index 659ed49cebb8ed2a6e1c88fb1e4d95f0520820d4..2e1628a9b5507ff6b1f00ac83247fc033b2db1c4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2821,17 +2821,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2822,17 +2822,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void removeVehicle() {
@@ -75,7 +75,7 @@ index 79a3d586ddf404c449b7c0aa1996e9b9897b2383..5d551a50e1043e369ebf3ddfe181be1e
      }
  
      protected void addPassenger(Entity passenger) {
-@@ -2856,7 +2867,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2857,7 +2868,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          }
      }
  
@@ -87,7 +87,7 @@ index 79a3d586ddf404c449b7c0aa1996e9b9897b2383..5d551a50e1043e369ebf3ddfe181be1e
          if (entity.getVehicle() == this) {
              throw new IllegalStateException("Use x.stopRiding(y), not y.removePassenger(x)");
          } else {
-@@ -2866,7 +2880,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2867,7 +2881,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              if (this.getBukkitEntity() instanceof Vehicle && entity.getBukkitEntity() instanceof LivingEntity) {
                  VehicleExitEvent event = new VehicleExitEvent(
                          (Vehicle) this.getBukkitEntity(),
@@ -96,7 +96,7 @@ index 79a3d586ddf404c449b7c0aa1996e9b9897b2383..5d551a50e1043e369ebf3ddfe181be1e
                  );
                  // Suppress during worldgen
                  if (this.valid) {
-@@ -2879,7 +2893,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2880,7 +2894,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  }
              }
  

--- a/patches/server/0278-Fixes-and-additions-to-the-spawn-reason-API.patch
+++ b/patches/server/0278-Fixes-and-additions-to-the-spawn-reason-API.patch
@@ -51,7 +51,7 @@ index 9cfd0b457f6c462921667b9439a7b3e32d019758..62412b37d4f7d37b3fec0966ab700c2a
  
                  if (entity == null) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c75bc7427bd818e9d23ca0af2b08cb160f3c432e..fd1fe9a72a1d4e87b97a34fc79ab1429d31207e5 100644
+index 97b48186a48ca037645d4a5ae84e3a95fd413a33..a04cfa09d9f8594a7ad3120855efe1641abb7a47 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -223,6 +223,11 @@ public abstract class PlayerList {
@@ -67,10 +67,10 @@ index c75bc7427bd818e9d23ca0af2b08cb160f3c432e..fd1fe9a72a1d4e87b97a34fc79ab1429
          String s1 = connection.getLoggableAddress(this.server.logIPs());
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5d551a50e1043e369ebf3ddfe181be1e24cfd068..463d34e7b54efd503c4879d1386b2439474863dd 100644
+index 2e1628a9b5507ff6b1f00ac83247fc033b2db1c4..e7b4809aa7220597ae92cf8f941f61e874d45d46 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -255,6 +255,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -256,6 +256,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          }
      }
      // Paper end - Share random for entities to make them more random
@@ -78,7 +78,7 @@ index 5d551a50e1043e369ebf3ddfe181be1e24cfd068..463d34e7b54efd503c4879d1386b2439
  
      private CraftEntity bukkitEntity;
  
-@@ -2390,6 +2391,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2391,6 +2392,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  }
                  nbttagcompound.put("Paper.Origin", this.newDoubleList(origin.getX(), origin.getY(), origin.getZ()));
              }
@@ -88,7 +88,7 @@ index 5d551a50e1043e369ebf3ddfe181be1e24cfd068..463d34e7b54efd503c4879d1386b2439
              // Save entity's from mob spawner status
              if (spawnedViaMobSpawner) {
                  nbttagcompound.putBoolean("Paper.FromMobSpawner", true);
-@@ -2537,6 +2541,26 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2538,6 +2542,26 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0293-Prevent-consuming-the-wrong-itemstack.patch
+++ b/patches/server/0293-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 63d1c5e8441eb5a32fc298ff2d2f3157cbd19557..ebfea3adbedd2695f645421019a276efbc73ee63 100644
+index 7e684a7df64b64e25ba602c39488712eefdfbcfa..ba78e8b73793292830f3260f9a12c50c698bb881 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3993,9 +3993,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3994,9 +3994,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public void startUsingItem(InteractionHand hand) {
@@ -24,7 +24,7 @@ index 63d1c5e8441eb5a32fc298ff2d2f3157cbd19557..ebfea3adbedd2695f645421019a276ef
              this.useItem = itemstack;
              this.useItemRemaining = itemstack.getUseDuration(this);
              if (!this.level().isClientSide) {
-@@ -4066,6 +4071,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4067,6 +4072,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  this.releaseUsingItem();
              } else {
                  if (!this.useItem.isEmpty() && this.isUsingItem()) {
@@ -32,7 +32,7 @@ index 63d1c5e8441eb5a32fc298ff2d2f3157cbd19557..ebfea3adbedd2695f645421019a276ef
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
                      PlayerItemConsumeEvent event = null; // Paper
-@@ -4103,8 +4109,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4104,8 +4110,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0302-Fix-item-EAR-ticks.patch
+++ b/patches/server/0302-Fix-item-EAR-ticks.patch
@@ -21,15 +21,12 @@ index 75ebf09777e19645eee296a9edabac39c858ffb9..c21fa55c62d97d9511e41a1e313e9043
                  this.applyEffectsFromBlocks();
                  float f = 0.98F;
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index dd1c5bc7522a4710cbfdd4764f6431e1e28d63cc..05ad15fc40ccb7feed5c51ad0ad0a98bd0d02af6 100644
+index bd522080d17b5b470ec3ab42aa4ecc3082248c8a..964e3e81ab522ceebfceb651dfe3309d7b87c688 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -251,12 +251,11 @@ public class ActivationRange
-                     entity.activatedTick = MinecraftServer.currentTick + 20;
+@@ -253,11 +253,8 @@ public class ActivationRange
                  }
                  isActive = true;
-+            } else if (entity instanceof net.minecraft.world.entity.item.ItemEntity && (entity.tickCount + entity.getId()) % 4 == 0) { // Paper - Needed for item gravity, see ItemEntity tick
-+                isActive = true;
              }
 -            // Add a little performance juice to active entities. Skip 1/4 if not immune.
 -        } else if ( !entity.defaultActivationState && entity.tickCount % 4 == 0 && !ActivationRange.checkEntityImmunities( entity ) )

--- a/patches/server/0313-Entity-Jump-API.patch
+++ b/patches/server/0313-Entity-Jump-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Entity Jump API
 public net.minecraft.world.entity.LivingEntity jumping
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ebfea3adbedd2695f645421019a276efbc73ee63..724fe482f1711008dc43fef96c4512a18ed54a48 100644
+index ba78e8b73793292830f3260f9a12c50c698bb881..a874913997c80c8f47f395e2ef4bb959aaa3e76d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3537,8 +3537,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3538,8 +3538,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
              } else if (this.isInLava() && (!this.onGround() || d3 > d4)) {
                  this.jumpInLiquid(FluidTags.LAVA);
              } else if ((this.onGround() || flag && d3 <= d4) && this.noJumpDelay == 0) {

--- a/patches/server/0314-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0314-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 463d34e7b54efd503c4879d1386b2439474863dd..fa80b6220aba144521dc0a2a35914c10046c1963 100644
+index e7b4809aa7220597ae92cf8f941f61e874d45d46..01ea0f81aecbf642d238e6cf6409df2cc83000f3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -406,6 +406,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -407,6 +407,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public void inactiveTick() { }
      // Spigot end
      protected int numCollisions = 0; // Paper - Cap entity collisions
@@ -16,7 +16,7 @@ index 463d34e7b54efd503c4879d1386b2439474863dd..fa80b6220aba144521dc0a2a35914c10
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      // Paper start - Entity origin API
      @javax.annotation.Nullable
-@@ -2398,6 +2399,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2399,6 +2400,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              if (spawnedViaMobSpawner) {
                  nbttagcompound.putBoolean("Paper.FromMobSpawner", true);
              }
@@ -26,7 +26,7 @@ index 463d34e7b54efd503c4879d1386b2439474863dd..fa80b6220aba144521dc0a2a35914c10
              // Paper end
              return nbttagcompound;
          } catch (Throwable throwable) {
-@@ -2541,6 +2545,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2542,6 +2546,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0336-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0336-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -12,10 +12,10 @@ The entity's current team collision rule causes them to NEVER collide.
 Co-authored-by: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 724fe482f1711008dc43fef96c4512a18ed54a48..4fb99e3ee14d2e7fe2720e25af1c890004b0c250 100644
+index a874913997c80c8f47f395e2ef4bb959aaa3e76d..b01e472a8a5f05e586bfa35e33abfd3875518ab3 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3681,10 +3681,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3682,10 +3682,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (!(world instanceof ServerLevel worldserver)) {
              this.level().getEntities(EntityTypeTest.forClass(net.minecraft.world.entity.player.Player.class), this.getBoundingBox(), EntitySelector.pushableBy(this)).forEach(this::doPush);
          } else {

--- a/patches/server/0340-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
+++ b/patches/server/0340-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
@@ -10,7 +10,7 @@ Co-authored-by: Wyatt Childers <wchilders@nearce.com>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4ff14dc6996634b0fcd365f76055023601ad2be0..530369764cad77466995f8f65070eec6a5de74f2 100644
+index ac5725230b04bc1a333863e251fe86580f909ea9..54de4e701adea123c0fdfb5787e951699305bb81 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -197,6 +197,7 @@ public abstract class PlayerList {
@@ -84,10 +84,10 @@ index 4ff14dc6996634b0fcd365f76055023601ad2be0..530369764cad77466995f8f65070eec6
          }
          // Paper end - Entity#getEntitySpawnReason
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fa80b6220aba144521dc0a2a35914c10046c1963..5b8e264098f1b713de15f714bae59d3efda365cf 100644
+index 01ea0f81aecbf642d238e6cf6409df2cc83000f3..416e76f2124aba0c9ad6e6ecb052e73a8b743f37 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2502,27 +2502,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2503,27 +2503,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              }
              // CraftBukkit end
  

--- a/patches/server/0341-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/patches/server/0341-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4fb99e3ee14d2e7fe2720e25af1c890004b0c250..25a2085ed68d393afbb658b63a1cd39af98f39fa 100644
+index b01e472a8a5f05e586bfa35e33abfd3875518ab3..33d969e09372930e740a8a4a84e5503284df9c28 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2352,7 +2352,17 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2353,7 +2353,17 @@ public abstract class LivingEntity extends Entity implements Attackable {
              }
  
              if (damagesource.getEntity() instanceof net.minecraft.world.entity.player.Player) {

--- a/patches/server/0344-Fix-item-duplication-and-teleport-issues.patch
+++ b/patches/server/0344-Fix-item-duplication-and-teleport-issues.patch
@@ -16,10 +16,10 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5b8e264098f1b713de15f714bae59d3efda365cf..e3228ad3825adedbd1a8326ac3bea329b539b18f 100644
+index 416e76f2124aba0c9ad6e6ecb052e73a8b743f37..8b4ded85500379bd7dafba51a91732dc56b815e6 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2630,11 +2630,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2631,11 +2631,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          } else {
              // CraftBukkit start - Capture drops for death event
              if (this instanceof net.minecraft.world.entity.LivingEntity && !((net.minecraft.world.entity.LivingEntity) this).forceDrops) {
@@ -34,7 +34,7 @@ index 5b8e264098f1b713de15f714bae59d3efda365cf..e3228ad3825adedbd1a8326ac3bea329
  
              entityitem.setDefaultPickUpDelay();
              // CraftBukkit start
-@@ -3462,6 +3463,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3463,6 +3464,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public Entity teleport(TeleportTransition teleportTarget) {
          Level world = this.level();
  
@@ -47,7 +47,7 @@ index 5b8e264098f1b713de15f714bae59d3efda365cf..e3228ad3825adedbd1a8326ac3bea329
          if (world instanceof ServerLevel worldserver) {
              if (!this.isRemoved()) {
                  // CraftBukkit start
-@@ -3550,6 +3557,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3551,6 +3558,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              gameprofilerfiller.pop();
              return null;
          } else {
@@ -59,7 +59,7 @@ index 5b8e264098f1b713de15f714bae59d3efda365cf..e3228ad3825adedbd1a8326ac3bea329
              entity.restoreFrom(this);
              this.removeAfterChangingDimensions();
              // CraftBukkit start - Forward the CraftEntity to the new entity
-@@ -3662,6 +3674,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3663,6 +3675,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean canTeleport(Level from, Level to) {
@@ -68,7 +68,7 @@ index 5b8e264098f1b713de15f714bae59d3efda365cf..e3228ad3825adedbd1a8326ac3bea329
              Iterator iterator = this.getPassengers().iterator();
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 25a2085ed68d393afbb658b63a1cd39af98f39fa..718ccabb46d4520ba363d21a33e06eb2c9ff62ee 100644
+index 33d969e09372930e740a8a4a84e5503284df9c28..4d39aa2fdc311acb34d7b674365141b995c324b7 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1765,9 +1765,9 @@ public abstract class LivingEntity extends Entity implements Attackable {

--- a/patches/server/0369-Ensure-Entity-position-and-AABB-are-never-invalid.patch
+++ b/patches/server/0369-Ensure-Entity-position-and-AABB-are-never-invalid.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Ensure Entity position and AABB are never invalid
 Co-authored-by: Spottedleaf <Spottedleaf@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d5f96ed753e8298085e40c6181285cd6ea838ca2..8993c16254ac05d509bd8ac1cd21e7cc7c4097b8 100644
+index 8b4ded85500379bd7dafba51a91732dc56b815e6..65144603a545903b8f11ee1b2b1ac2795af81381 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -677,8 +677,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -678,8 +678,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void setPos(double x, double y, double z) {
@@ -20,7 +20,7 @@ index d5f96ed753e8298085e40c6181285cd6ea838ca2..8993c16254ac05d509bd8ac1cd21e7cc
      }
  
      protected AABB makeBoundingBox() {
-@@ -4412,7 +4412,29 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4442,7 +4442,29 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return this.getZ((2.0D * this.random.nextDouble() - 1.0D) * widthScale);
      }
  
@@ -50,7 +50,7 @@ index d5f96ed753e8298085e40c6181285cd6ea838ca2..8993c16254ac05d509bd8ac1cd21e7cc
          if (this.position.x != x || this.position.y != y || this.position.z != z) {
              this.position = new Vec3(x, y, z);
              int i = Mth.floor(x);
-@@ -4430,6 +4452,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4460,6 +4482,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              this.levelCallback.onMove();
          }
  

--- a/patches/server/0380-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/patches/server/0380-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 718ccabb46d4520ba363d21a33e06eb2c9ff62ee..7e3670bee52407d768d1f7c0be66d7c0d0f72c46 100644
+index 4d39aa2fdc311acb34d7b674365141b995c324b7..6a2f54a70b484effb903f084a5a109981ef38114 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3796,7 +3796,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3797,7 +3797,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          Entity entity = this.getVehicle();
  
          super.stopRiding(suppressCancellation); // Paper - Force entity dismount during teleportation

--- a/patches/server/0404-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0404-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -22,10 +22,10 @@ index 00ce20359f6d73acf3f1016806e5f4f3b6d01bcd..1754e413dc1b7a18b3fc0b981eae1128
              this.lastGoodY = this.awaitingPositionFromClient.y;
              this.lastGoodZ = this.awaitingPositionFromClient.z;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8993c16254ac05d509bd8ac1cd21e7cc7c4097b8..2c9e57436469f94beb45f656a1df71aba7b1e408 100644
+index 65144603a545903b8f11ee1b2b1ac2795af81381..906a5cc5671b707ef90d1f25d8ba5642c7a483bc 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -179,6 +179,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -180,6 +180,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      // CraftBukkit start
      private static final int CURRENT_LEVEL = 2;
@@ -33,7 +33,7 @@ index 8993c16254ac05d509bd8ac1cd21e7cc7c4097b8..2c9e57436469f94beb45f656a1df71ab
      static boolean isLevelAtLeast(CompoundTag tag, int level) {
          return tag.contains("Bukkit.updateLevel") && tag.getInt("Bukkit.updateLevel") >= level;
      }
-@@ -1943,6 +1944,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1944,6 +1945,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void moveTo(double x, double y, double z, float yaw, float pitch) {

--- a/patches/server/0408-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0408-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2c9e57436469f94beb45f656a1df71aba7b1e408..c3e28cc070993be5afe9323c2c2d54ffc81d82f3 100644
+index 906a5cc5671b707ef90d1f25d8ba5642c7a483bc..3f0a44db707176c25e306f55fa63da9314d682a1 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4704,4 +4704,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4734,4 +4734,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0410-Entity-isTicking.patch
+++ b/patches/server/0410-Entity-isTicking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c3e28cc070993be5afe9323c2c2d54ffc81d82f3..6cefe8e0de375d3b192cc8be2b553a2dcbe098f5 100644
+index 3f0a44db707176c25e306f55fa63da9314d682a1..4a26795d22c0276980f4d0ad266861389d8471a8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4709,5 +4709,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4739,5 +4739,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0435-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0435-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6cefe8e0de375d3b192cc8be2b553a2dcbe098f5..7feed6383fdc367796ccb943bd086814ec989e6d 100644
+index 07255e610e88dd0d2a1e659388d06d86152297a6..d19a53c25774aad64dafda2f187a0ee3ce0d6ca2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2195,6 +2195,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -44,10 +44,10 @@ index b8d57e25851dd7da905100dfd4022e4b99fd7f02..721321a19ce056f82de2bef44a8791dc
              } else if (entity1 instanceof Player && entity instanceof Player && !io.papermc.paper.configuration.GlobalConfiguration.get().collisions.enablePlayerCollisions) { // Paper - Configurable player collision
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 7e3670bee52407d768d1f7c0be66d7c0d0f72c46..d361e39ba50958e7bdaea0b95c37d13f48a89771 100644
+index 6a2f54a70b484effb903f084a5a109981ef38114..499e4fbb919ae3875aaa371d6ee206b8b144387b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3710,7 +3710,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3711,7 +3711,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  return;
              }
              // Paper end - don't run getEntities if we're not going to use its result
@@ -56,7 +56,7 @@ index 7e3670bee52407d768d1f7c0be66d7c0d0f72c46..d361e39ba50958e7bdaea0b95c37d13f
  
              if (!list.isEmpty()) {
                  // Paper - don't run getEntities if we're not going to use its result; moved up
-@@ -3915,9 +3915,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3916,9 +3916,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return !this.isRemoved() && this.collides; // CraftBukkit
      }
  

--- a/patches/server/0435-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0435-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 07255e610e88dd0d2a1e659388d06d86152297a6..d19a53c25774aad64dafda2f187a0ee3ce0d6ca2 100644
+index 4a26795d22c0276980f4d0ad266861389d8471a8..9ebce90de425989014466d2c5ce68fce505d1dcd 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2195,6 +2195,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2196,6 +2196,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean isPushable() {
@@ -142,7 +142,7 @@ index b0373df16a3e6910fb5f4a2ab7ca2523ced84a22..a9661ab34bc98c19d525eb4b60b1f0d0
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java
-index a8fc89f78181abf9963bd1523f3bbefa911847d8..50c0055d80735313c280821991bd2a76e427f082 100644
+index a4ab0e50a245790b1767047c384859f06c3f9526..fb9f0a62201dfeccd0eec9bb399f9edc6a01f1f0 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java
 @@ -161,7 +161,7 @@ public abstract class AbstractMinecart extends VehicleEntity {

--- a/patches/server/0436-Add-missing-default-perms-for-commands.patch
+++ b/patches/server/0436-Add-missing-default-perms-for-commands.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add missing default perms for commands
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/permissions/CommandPermissions.java b/src/main/java/org/bukkit/craftbukkit/util/permissions/CommandPermissions.java
-index a9ea2e38e4673686c9994a58c94ad19e59fd423c..52649f82351ab4f675c3cc3cd6640956b0f76b91 100644
+index a9ea2e38e4673686c9994a58c94ad19e59fd423c..b3169c551b8410f5861f9db0543c785439ecba7c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/permissions/CommandPermissions.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/permissions/CommandPermissions.java
-@@ -24,13 +24,75 @@ public final class CommandPermissions {
+@@ -24,13 +24,76 @@ public final class CommandPermissions {
          DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "stop", "Allows the user to stop the server", PermissionDefault.OP, commands);
          DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "list", "Allows the user to list all online players", PermissionDefault.OP, commands);
          DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "gamemode", "Allows the user to change the gamemode of another player", PermissionDefault.OP, commands);
@@ -82,6 +82,7 @@ index a9ea2e38e4673686c9994a58c94ad19e59fd423c..52649f82351ab4f675c3cc3cd6640956
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "place", "Allows the user to place features and structures", PermissionDefault.OP, commands);
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "return", "Allows the user to use the /return command", PermissionDefault.OP, commands);
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "random", "Allows the user to generate a random number", PermissionDefault.OP, commands);
++        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "rotate", "Allows the user to change the rotation of entities", PermissionDefault.OP, commands);
 +        // Paper end
  
          DefaultPermissions.registerPermission("minecraft.admin.command_feedback", "Receive command broadcasts when sendCommandFeedback is true", PermissionDefault.OP, commands);

--- a/patches/server/0439-Fix-CraftSound-backwards-compatibility.patch
+++ b/patches/server/0439-Fix-CraftSound-backwards-compatibility.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Fix CraftSound backwards compatibility
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftSound.java b/src/main/java/org/bukkit/craftbukkit/CraftSound.java
-index 260a738d5d61cf931b939502ea9c66451855b91e..dce716b6ac407d1e1ae07272ee5c8b14f891f5fa 100644
+index e53d6d33bfe9ed14fce0f5df0ab7648f18489c39..5b6e6902db19b078bb8598014a87c06f1267acc4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftSound.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftSound.java
-@@ -40,4 +40,10 @@ public class CraftSound {
-         throw new IllegalArgumentException("No Reference holder found for " + bukkit
-                 + ", this can happen if a plugin creates its own sound effect with out properly registering it.");
+@@ -106,4 +106,10 @@ public class CraftSound implements Sound, Handleable<SoundEvent> {
+     public int hashCode() {
+         return this.getKey().hashCode();
      }
 +
 +    // Paper start

--- a/patches/server/0446-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0446-MC-4-Fix-item-position-desync.patch
@@ -28,10 +28,10 @@ index 488ebd443903af812913437f1ade3002093f2470..a043ac10834562d357ef0b5aded2e916
  
      public Vec3 decode(long x, long y, long z) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7feed6383fdc367796ccb943bd086814ec989e6d..7c07ffaabce7a3964114b0859ad0028d52c662cc 100644
+index 9ebce90de425989014466d2c5ce68fce505d1dcd..282863951033f7e036b0e58393651e1a22fada23 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4449,6 +4449,16 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4479,6 +4479,16 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              return;
          }
          // Paper end - Block invalid positions and bounding box

--- a/patches/server/0448-API-to-get-Material-from-Boats-and-Minecarts.patch
+++ b/patches/server/0448-API-to-get-Material-from-Boats-and-Minecarts.patch
@@ -25,10 +25,10 @@ index c101d01b55472efc9fc2829b8c17db5377ed57ff..5d51a49228eaee94f91cd04843e27c79
      public Status getStatus() {
          return CraftBoat.boatStatusFromNms(this.getHandle().status);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java
-index ee010d53f8c671d17d68f3f43dca9978e23ac8ab..d35c1a10e58932b19c8053c5dacdc25fd7f22e8c 100644
+index c4db7c00c66e064993b8b2158f226d063eea798c..8192ccb01ed4efe9e987cab94952c172ed876581 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java
-@@ -3,6 +3,7 @@ package org.bukkit.craftbukkit.entity;
+@@ -4,6 +4,7 @@ import net.minecraft.server.level.ServerLevel;
  import net.minecraft.world.entity.vehicle.AbstractMinecart;
  import net.minecraft.world.level.block.Blocks;
  import net.minecraft.world.level.block.state.BlockState;
@@ -36,7 +36,7 @@ index ee010d53f8c671d17d68f3f43dca9978e23ac8ab..d35c1a10e58932b19c8053c5dacdc25f
  import org.bukkit.block.data.BlockData;
  import org.bukkit.craftbukkit.CraftServer;
  import org.bukkit.craftbukkit.block.data.CraftBlockData;
-@@ -68,6 +69,24 @@ public abstract class CraftMinecart extends CraftVehicle implements Minecart {
+@@ -69,6 +70,24 @@ public abstract class CraftMinecart extends CraftVehicle implements Minecart {
          this.getHandle().setDerailedVelocityMod(derailed);
      }
  

--- a/patches/server/0467-Add-RegistryAccess-for-managing-Registries.patch
+++ b/patches/server/0467-Add-RegistryAccess-for-managing-Registries.patch
@@ -12,10 +12,10 @@ public net.minecraft.server.RegistryLayer STATIC_ACCESS
 
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9657c35ffbcc12061b394b97c97224e699c99b4f
+index 0000000000000000000000000000000000000000..39120c63ed25d45a4083523fbfe79d871f4d892e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-@@ -0,0 +1,152 @@
+@@ -0,0 +1,156 @@
 +package io.papermc.paper.registry;
 +
 +import io.papermc.paper.adventure.PaperAdventure;
@@ -28,19 +28,23 @@ index 0000000000000000000000000000000000000000..9657c35ffbcc12061b394b97c97224e6
 +import net.minecraft.core.Registry;
 +import net.minecraft.core.registries.Registries;
 +import net.minecraft.resources.ResourceKey;
++import org.bukkit.Art;
 +import org.bukkit.Fluid;
 +import org.bukkit.GameEvent;
 +import org.bukkit.JukeboxSong;
 +import org.bukkit.Keyed;
 +import org.bukkit.MusicInstrument;
++import org.bukkit.Sound;
 +import org.bukkit.attribute.Attribute;
 +import org.bukkit.block.Biome;
 +import org.bukkit.block.BlockType;
 +import org.bukkit.block.banner.PatternType;
++import org.bukkit.craftbukkit.CraftArt;
 +import org.bukkit.craftbukkit.CraftFluid;
 +import org.bukkit.craftbukkit.CraftGameEvent;
 +import org.bukkit.craftbukkit.CraftJukeboxSong;
 +import org.bukkit.craftbukkit.CraftMusicInstrument;
++import org.bukkit.craftbukkit.CraftSound;
 +import org.bukkit.craftbukkit.attribute.CraftAttribute;
 +import org.bukkit.craftbukkit.block.CraftBiome;
 +import org.bukkit.craftbukkit.block.CraftBlockType;
@@ -106,6 +110,7 @@ index 0000000000000000000000000000000000000000..9657c35ffbcc12061b394b97c97224e6
 +            entry(Registries.MENU, RegistryKey.MENU, MenuType.class, CraftMenuType::new),
 +            entry(Registries.ATTRIBUTE, RegistryKey.ATTRIBUTE, Attribute.class, CraftAttribute::new),
 +            entry(Registries.FLUID, RegistryKey.FLUID, Fluid.class, CraftFluid::new),
++            entry(Registries.SOUND_EVENT, RegistryKey.SOUND_EVENT, Sound.class, CraftSound::new),
 +
 +            // data-drivens
 +            entry(Registries.BIOME, RegistryKey.BIOME, Biome.class, CraftBiome::new).delayed(),
@@ -117,13 +122,12 @@ index 0000000000000000000000000000000000000000..9657c35ffbcc12061b394b97c97224e6
 +            entry(Registries.ENCHANTMENT, RegistryKey.ENCHANTMENT, Enchantment.class, CraftEnchantment::new).withSerializationUpdater(FieldRename.ENCHANTMENT_RENAME).delayed(),
 +            entry(Registries.JUKEBOX_SONG, RegistryKey.JUKEBOX_SONG, JukeboxSong.class, CraftJukeboxSong::new).delayed(),
 +            entry(Registries.BANNER_PATTERN, RegistryKey.BANNER_PATTERN, PatternType.class, CraftPatternType::new).delayed(),
++            entry(Registries.PAINTING_VARIANT, RegistryKey.PAINTING_VARIANT, Art.class, CraftArt::new).delayed(),
 +
 +            // api-only
-+            apiOnly(Registries.PAINTING_VARIANT, RegistryKey.PAINTING_VARIANT, () -> org.bukkit.Registry.ART),
 +            apiOnly(Registries.ENTITY_TYPE, RegistryKey.ENTITY_TYPE, () -> org.bukkit.Registry.ENTITY_TYPE),
 +            apiOnly(Registries.PARTICLE_TYPE, RegistryKey.PARTICLE_TYPE, () -> org.bukkit.Registry.PARTICLE_TYPE),
 +            apiOnly(Registries.POTION, RegistryKey.POTION, () -> org.bukkit.Registry.POTION),
-+            apiOnly(Registries.SOUND_EVENT, RegistryKey.SOUND_EVENT, () -> org.bukkit.Registry.SOUNDS),
 +            apiOnly(Registries.MEMORY_MODULE_TYPE, RegistryKey.MEMORY_MODULE_TYPE, () -> (org.bukkit.Registry<MemoryKey<?>>) (org.bukkit.Registry) org.bukkit.Registry.MEMORY_MODULE_TYPE)
 +        );
 +        final Map<RegistryKey<?>, RegistryEntry<?, ?>> byRegistryKey = new IdentityHashMap<>(REGISTRY_ENTRIES.size());
@@ -749,10 +753,10 @@ index 8e8d6214adbd21a221147f0fc0d91cd9c06a080c..6fddef967b6314ca0158f5bd4b889867
              String string = Registries.elementsDirPath(type.registryKey());
              SimpleJsonResourceReloadListener.scanDirectory(resourceManager, string, ops, type.codec(), map);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-index d7e3371ebc08b5534c259ea45d89a969dfbe491a..16985dc1f54d64c44f96b045012612f16ba9ae8a 100644
+index 0d091c7b328fb70a82f5b5ded7dec61b7cd3d59a..249f0dcad04a35244da6dab837a461bb42aad00a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-@@ -125,90 +125,12 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -127,96 +127,12 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
                  + ", this can happen if a plugin creates its own registry entry with out properly registering it.");
      }
  
@@ -764,6 +768,9 @@ index d7e3371ebc08b5534c259ea45d89a969dfbe491a..16985dc1f54d64c44f96b045012612f1
 -     * @return the bukkit registry of the provided class
 -     */
 -    public static <B extends Keyed> Registry<?> createRegistry(Class<? super B> bukkitClass, RegistryAccess registryHolder) {
+-        if (bukkitClass == Art.class) {
+-            return new CraftRegistry<>(Art.class, registryHolder.lookupOrThrow(Registries.PAINTING_VARIANT), CraftArt::new, FieldRename.NONE);
+-        }
 -        if (bukkitClass == Attribute.class) {
 -            return new CraftRegistry<>(Attribute.class, registryHolder.lookupOrThrow(Registries.ATTRIBUTE), CraftAttribute::new, FieldRename.ATTRIBUTE_RENAME);
 -        }
@@ -787,6 +794,9 @@ index d7e3371ebc08b5534c259ea45d89a969dfbe491a..16985dc1f54d64c44f96b045012612f1
 -        }
 -        if (bukkitClass == PotionEffectType.class) {
 -            return new CraftRegistry<>(PotionEffectType.class, registryHolder.lookupOrThrow(Registries.MOB_EFFECT), CraftPotionEffectType::new, FieldRename.NONE);
+-        }
+-        if (bukkitClass == Sound.class) {
+-            return new CraftRegistry<>(Sound.class, registryHolder.lookupOrThrow(Registries.SOUND_EVENT), CraftSound::new, FieldRename.NONE);
 -        }
 -        if (bukkitClass == Structure.class) {
 -            return new CraftRegistry<>(Structure.class, registryHolder.lookupOrThrow(Registries.STRUCTURE), CraftStructure::new, FieldRename.NONE);
@@ -846,7 +856,7 @@ index d7e3371ebc08b5534c259ea45d89a969dfbe491a..16985dc1f54d64c44f96b045012612f1
          }
  
          if (bukkit instanceof Registry.SimpleRegistry<?> simple) {
-@@ -226,23 +148,21 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -234,23 +150,21 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
          return bukkit.get(namespacedKey);
      }
  
@@ -930,10 +940,10 @@ index 091e11934bddb180f0b2e51efb3921c62275d41d..12fe2f8d0dcb715545e071023490a321
      // PatternType
      private static final FieldRenameData PATTERN_TYPE_DATA = FieldRenameData.Builder.newBuilder()
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 9a6857f325d72c1b5ce403c3240e0b1a3f43bc38..e4b79d92a8c41eb37d989248425b1e5a963b476c 100644
+index 61d617d4abb9c9cf5c711459aa98c8b173597a9a..c9b789c2a904c2caff516ee9aeff4a6b368766f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -218,20 +218,10 @@ public class Commodore {
+@@ -220,20 +220,10 @@ public class Commodore {
  
      public byte[] convert(byte[] b, final String pluginName, final ApiVersion pluginVersion, final Set<String> activeCompatibilities) {
          final boolean modern = pluginVersion.isNewerThanOrSameAs(ApiVersion.FLATTENING);
@@ -954,7 +964,7 @@ index 9a6857f325d72c1b5ce403c3240e0b1a3f43bc38..e4b79d92a8c41eb37d989248425b1e5a
  
          visitor = io.papermc.paper.pluginremap.reflect.ReflectionRemapper.visitor(visitor); // Paper
          cr.accept(new ClassRemapper(new ClassVisitor(Opcodes.ASM9, visitor) {
-@@ -298,15 +288,6 @@ public class Commodore {
+@@ -300,15 +290,6 @@ public class Commodore {
  
              @Override
              public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
@@ -1259,7 +1269,7 @@ index bbd5dd5b27937ddc3d8c57f2b604331495b0f311..626c3033e36897846fe84a77d05e2e91
          CraftRegistry.setMinecraftRegistry(RegistryHelper.getRegistry());
      }
 diff --git a/src/test/java/org/bukkit/support/provider/RegistriesArgumentProvider.java b/src/test/java/org/bukkit/support/provider/RegistriesArgumentProvider.java
-index c0e02198200c93e3d0ff2461d267e856db087532..bbabfad54c58f74cb5d70cbce4d140ad69a56abb 100644
+index bfec6280e8b753a29ad2d9eb88808beb79ec65ea..b717a5ffa567781b0687bbe238b62844214db284 100644
 --- a/src/test/java/org/bukkit/support/provider/RegistriesArgumentProvider.java
 +++ b/src/test/java/org/bukkit/support/provider/RegistriesArgumentProvider.java
 @@ -1,6 +1,7 @@
@@ -1270,11 +1280,12 @@ index c0e02198200c93e3d0ff2461d267e856db087532..bbabfad54c58f74cb5d70cbce4d140ad
  import java.util.List;
  import java.util.stream.Stream;
  import net.minecraft.core.registries.Registries;
-@@ -67,39 +68,38 @@ public class RegistriesArgumentProvider implements ArgumentsProvider {
+@@ -73,41 +74,40 @@ public class RegistriesArgumentProvider implements ArgumentsProvider {
      private static final List<Arguments> DATA = Lists.newArrayList();
  
      static {
 -        // Order: Bukkit class, Minecraft Registry key, CraftBukkit class, Minecraft class
+-        register(Art.class, Registries.PAINTING_VARIANT, CraftArt.class, PaintingVariant.class);
 -        register(Attribute.class, Registries.ATTRIBUTE, CraftAttribute.class, net.minecraft.world.entity.ai.attributes.Attribute.class);
 -        register(Biome.class, Registries.BIOME, CraftBiome.class, net.minecraft.world.level.biome.Biome.class);
 -        register(Enchantment.class, Registries.ENCHANTMENT, CraftEnchantment.class, net.minecraft.world.item.enchantment.Enchantment.class);
@@ -1283,6 +1294,7 @@ index c0e02198200c93e3d0ff2461d267e856db087532..bbabfad54c58f74cb5d70cbce4d140ad
 -        register(MusicInstrument.class, Registries.INSTRUMENT, CraftMusicInstrument.class, Instrument.class);
 -        register(MenuType.class, Registries.MENU, CraftMenuType.class, net.minecraft.world.inventory.MenuType.class);
 -        register(PotionEffectType.class, Registries.MOB_EFFECT, CraftPotionEffectType.class, MobEffect.class);
+-        register(Sound.class, Registries.SOUND_EVENT, CraftSound.class, SoundEvent.class);
 -        register(Structure.class, Registries.STRUCTURE, CraftStructure.class, net.minecraft.world.level.levelgen.structure.Structure.class);
 -        register(StructureType.class, Registries.STRUCTURE_TYPE, CraftStructureType.class, net.minecraft.world.level.levelgen.structure.StructureType.class);
 -        register(Villager.Type.class, Registries.VILLAGER_TYPE, CraftVillager.CraftType.class, VillagerType.class);
@@ -1300,6 +1312,7 @@ index c0e02198200c93e3d0ff2461d267e856db087532..bbabfad54c58f74cb5d70cbce4d140ad
 -        register(PatternType.class, Registries.BANNER_PATTERN, CraftPatternType.class, BannerPattern.class);
 -
 +        // Order: RegistryKey, Bukkit class, Minecraft Registry key, CraftBukkit class, Minecraft class
++        register(RegistryKey.PAINTING_VARIANT, Art.class, Registries.PAINTING_VARIANT, CraftArt.class, PaintingVariant.class);
 +        register(RegistryKey.ATTRIBUTE, Attribute.class, Registries.ATTRIBUTE, CraftAttribute.class, net.minecraft.world.entity.ai.attributes.Attribute.class);
 +        register(RegistryKey.BIOME, Biome.class, Registries.BIOME, CraftBiome.class, net.minecraft.world.level.biome.Biome.class);
 +        register(RegistryKey.ENCHANTMENT, Enchantment.class, Registries.ENCHANTMENT, CraftEnchantment.class, net.minecraft.world.item.enchantment.Enchantment.class);
@@ -1307,6 +1320,7 @@ index c0e02198200c93e3d0ff2461d267e856db087532..bbabfad54c58f74cb5d70cbce4d140ad
 +        register(RegistryKey.GAME_EVENT, GameEvent.class, Registries.GAME_EVENT, CraftGameEvent.class, net.minecraft.world.level.gameevent.GameEvent.class);
 +        register(RegistryKey.INSTRUMENT, MusicInstrument.class, Registries.INSTRUMENT, CraftMusicInstrument.class, Instrument.class);
 +        register(RegistryKey.MOB_EFFECT, PotionEffectType.class, Registries.MOB_EFFECT, CraftPotionEffectType.class, MobEffect.class);
++        register(RegistryKey.SOUND_EVENT, Sound.class, Registries.SOUND_EVENT, CraftSound.class, SoundEvent.class);
 +        register(RegistryKey.STRUCTURE, Structure.class, Registries.STRUCTURE, CraftStructure.class, net.minecraft.world.level.levelgen.structure.Structure.class);
 +        register(RegistryKey.STRUCTURE_TYPE, StructureType.class, Registries.STRUCTURE_TYPE, CraftStructureType.class, net.minecraft.world.level.levelgen.structure.StructureType.class);
 +        register(RegistryKey.VILLAGER_TYPE, Villager.Type.class, Registries.VILLAGER_TYPE, CraftVillager.CraftType.class, VillagerType.class);

--- a/patches/server/0469-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0469-Collision-option-for-requiring-a-player-participant.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Collision option for requiring a player participant
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7c07ffaabce7a3964114b0859ad0028d52c662cc..0d10abc918e31bf8a529706b3350c80dec11b313 100644
+index 282863951033f7e036b0e58393651e1a22fada23..fa070c7243a4d800edc7bde2905773022788fa14 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2024,6 +2024,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2025,6 +2025,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public void push(Entity entity) {
          if (!this.isPassengerOfSameVehicle(entity)) {
              if (!entity.noPhysics && !this.noPhysics) {
@@ -29,7 +29,7 @@ index a9661ab34bc98c19d525eb4b60b1f0d05d73241e..3590f4bc1af829cdb6e0cfdc8fa68571
              if (entity.getBoundingBox().minY < this.getBoundingBox().maxY) {
                  // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java
-index 50c0055d80735313c280821991bd2a76e427f082..ee7350e19a86ffa115e4bce6b186a2422951e89b 100644
+index fb9f0a62201dfeccd0eec9bb399f9edc6a01f1f0..9a864b4bacc5e180f36a6af2a0d63dc6d10ab0e5 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java
 @@ -562,6 +562,7 @@ public abstract class AbstractMinecart extends VehicleEntity {

--- a/patches/server/0477-Expand-EntityUnleashEvent.patch
+++ b/patches/server/0477-Expand-EntityUnleashEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expand EntityUnleashEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0d10abc918e31bf8a529706b3350c80dec11b313..3479b7c89741ba93e49e7e51fe4b45bb14fbc419 100644
+index fa070c7243a4d800edc7bde2905773022788fa14..963c190e4c445131659cc9e2e72b0272324666e2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2689,12 +2689,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2690,12 +2690,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              if (leashable.getLeashHolder() == player) {
                  if (!this.level().isClientSide()) {
                      // CraftBukkit start - fire PlayerUnleashEntityEvent
@@ -26,7 +26,7 @@ index 0d10abc918e31bf8a529706b3350c80dec11b313..3479b7c89741ba93e49e7e51fe4b45bb
                      this.gameEvent(GameEvent.ENTITY_INTERACT, player);
                  }
  
-@@ -3659,9 +3662,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3660,9 +3663,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      protected void removeAfterChangingDimensions() {
          this.setRemoved(Entity.RemovalReason.CHANGED_DIMENSION, null); // CraftBukkit - add Bukkit remove cause
@@ -140,7 +140,7 @@ index 4b44830ef5d08887274ebb39e2780606fe3a76b4..d3a7953a3f42a0020342845e9107c699
                              flag1 = true;
                          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a25e814978a2f19fa6fe74aaa5c529a524240d71..5064dd8c97f45f0c4e2d1402500e7cf67a263dfa 100644
+index 6d1d3451054af05e2381d70d71b99869f37c0901..697c69b60aa45b6a229f3bec77dc728e50a895ce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1596,8 +1596,10 @@ public class CraftEventFactory {

--- a/patches/server/0480-Add-EntityMoveEvent.patch
+++ b/patches/server/0480-Add-EntityMoveEvent.patch
@@ -29,10 +29,10 @@ index 0e984f3521b578779dd9d0142bce7db433b78f07..1c3f41d7ed7320342fe68c5ab6eb57db
      public LevelChunk getChunkIfLoaded(int x, int z) {
          return this.chunkSource.getChunk(x, z, false);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index d361e39ba50958e7bdaea0b95c37d13f48a89771..ce9369e730ba8862cd1e6e26f8825c35b16fcfb9 100644
+index 499e4fbb919ae3875aaa371d6ee206b8b144387b..a0b90b18e8f8970e722ebd0e78113f55ff54a55b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3626,6 +3626,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3627,6 +3627,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
          this.pushEntities();
          gameprofilerfiller.pop();

--- a/patches/server/0503-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0503-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,10 +9,10 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ce9369e730ba8862cd1e6e26f8825c35b16fcfb9..502a5455533113ef580cd23399dc1dcad530b0ae 100644
+index a0b90b18e8f8970e722ebd0e78113f55ff54a55b..6eda6f62e54eefddad51033e7d69c76ffc110a6d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4141,6 +4141,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4142,6 +4142,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                              }
                              entityPlayer.getBukkitEntity().updateInventory();
                              entityPlayer.getBukkitEntity().updateScaledHealth();

--- a/patches/server/0548-Line-Of-Sight-Changes.patch
+++ b/patches/server/0548-Line-Of-Sight-Changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Line Of Sight Changes
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 502a5455533113ef580cd23399dc1dcad530b0ae..83557da78340e3327f8c9a3050662413ecc3fc17 100644
+index 6eda6f62e54eefddad51033e7d69c76ffc110a6d..5415cade10ab36709f722cabc20ea3f1b9c285d9 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3905,7 +3905,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3906,7 +3906,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
              Vec3 vec3d = new Vec3(this.getX(), this.getEyeY(), this.getZ());
              Vec3 vec3d1 = new Vec3(entity.getX(), entityY.getAsDouble(), entity.getZ());
  

--- a/patches/server/0571-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0571-Optimize-indirect-passenger-iteration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3479b7c89741ba93e49e7e51fe4b45bb14fbc419..fe9cdd104d6203233a90068b55e0876be4964afe 100644
+index 963c190e4c445131659cc9e2e72b0272324666e2..5ddab7fde91ab1089c9ea35f441a21dfd5df2ef8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4087,20 +4087,34 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4088,20 +4088,34 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      private Stream<Entity> getIndirectPassengersStream() {
@@ -43,7 +43,7 @@ index 3479b7c89741ba93e49e7e51fe4b45bb14fbc419..fe9cdd104d6203233a90068b55e0876b
          return () -> {
              return this.getIndirectPassengersStream().iterator();
          };
-@@ -4113,6 +4127,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4114,6 +4128,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean hasExactlyOnePlayerPassenger() {

--- a/patches/server/0578-Add-back-EntityPortalExitEvent.patch
+++ b/patches/server/0578-Add-back-EntityPortalExitEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add back EntityPortalExitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fe9cdd104d6203233a90068b55e0876be4964afe..88d3b1997bba632c5746d295bb39095f5d328369 100644
+index 5ddab7fde91ab1089c9ea35f441a21dfd5df2ef8..3d9bf236eb1535cc2547f1421ee2a09b2c44fc52 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3491,6 +3491,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3492,6 +3492,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              if (!this.isRemoved()) {
                  // CraftBukkit start
                  PositionMoveRotation absolutePosition = PositionMoveRotation.calculateAbsolute(PositionMoveRotation.of(this), PositionMoveRotation.of(teleportTarget), teleportTarget.relatives());
@@ -16,7 +16,7 @@ index fe9cdd104d6203233a90068b55e0876be4964afe..88d3b1997bba632c5746d295bb39095f
                  Location to = CraftLocation.toBukkit(absolutePosition.position(), teleportTarget.newLevel().getWorld(), absolutePosition.yRot(), absolutePosition.xRot());
                  // Paper start - gateway-specific teleport event
                  final EntityTeleportEvent teleEvent;
-@@ -3507,7 +3508,29 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3508,7 +3509,29 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  if (!to.equals(teleEvent.getTo())) {
                      to = teleEvent.getTo();
                      teleportTarget = new TeleportTransition(((CraftWorld) to.getWorld()).getHandle(), CraftLocation.toVec3D(to), Vec3.ZERO, to.getYaw(), to.getPitch(), teleportTarget.missingRespawnBlock(), teleportTarget.asPassenger(), Set.of(), teleportTarget.postTeleportTransition(), teleportTarget.cause());

--- a/patches/server/0582-Add-more-advancement-API.patch
+++ b/patches/server/0582-Add-more-advancement-API.patch
@@ -164,10 +164,10 @@ index 8ca86852319d7463f60832bc98b825b0b4325995..62ada73302c6b3ce3fb2dcc8c31a1d9c
  
      private final DisplayInfo handle;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index e4b79d92a8c41eb37d989248425b1e5a963b476c..1f25fa2b2ce8fae5bce29232cbb51966b86dae85 100644
+index c9b789c2a904c2caff516ee9aeff4a6b368766f4..52a507ff2770bd46494e805956b4569f0d4d21ee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -456,6 +456,11 @@ public class Commodore {
+@@ -458,6 +458,11 @@ public class Commodore {
                              super.visitMethodInsn(opcode, owner, name, "()Lcom/destroystokyo/paper/profile/PlayerProfile;", itf);
                              return;
                          }

--- a/patches/server/0583-Add-ItemFactory-getSpawnEgg-API.patch
+++ b/patches/server/0583-Add-ItemFactory-getSpawnEgg-API.patch
@@ -37,10 +37,10 @@ index cab7a3d21699605cb7fc480830d7529f70e69e88..ad86ee4372e55c82968fd4fc6a65deba
 +    // Paper end - old getSpawnEgg API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 1f25fa2b2ce8fae5bce29232cbb51966b86dae85..f10e7a847e9f57d2a987b118215c0ceab251a5b0 100644
+index 52a507ff2770bd46494e805956b4569f0d4d21ee..5a7aa491e0846ca8133bc4bb6e74b93cff85fb17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -463,6 +463,15 @@ public class Commodore {
+@@ -465,6 +465,15 @@ public class Commodore {
                          }
                          // Paper end
  

--- a/patches/server/0589-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0589-Add-Raw-Byte-Entity-Serialization.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 public net.minecraft.world.entity.Entity setLevel(Lnet/minecraft/world/level/Level;)V
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 88d3b1997bba632c5746d295bb39095f5d328369..900765b0129e8bf485aca93af6f523c9948e288b 100644
+index 3d9bf236eb1535cc2547f1421ee2a09b2c44fc52..9755d8a40a5a5b4863ce057f576f393773cee3e4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2260,6 +2260,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2261,6 +2261,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          }
      }
  

--- a/patches/server/0590-Vanilla-command-permission-fixes.patch
+++ b/patches/server/0590-Vanilla-command-permission-fixes.patch
@@ -51,10 +51,10 @@ index 7acd7f60327106d55e8f48247650bc0064dd1b58..bee79fab7f8195e14f6bd22d9cd59bfc
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
-index 87c93ee9bbbfff785b7b6a1f0c4b932e36362943..4e81c26fdbd089961b2577168c716bf29d504d40 100644
+index 71bc74071e7bbce1d6aa5b0f0fb244c93dae168e..732655bf8dd279167f799e01b1516b4dd5fa7464 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
-@@ -86,7 +86,21 @@ public final class VanillaCommandWrapper extends BukkitCommand {
+@@ -91,7 +91,21 @@ public final class VanillaCommandWrapper extends BukkitCommand {
      }
  
      public static String getPermission(CommandNode<CommandSourceStack> vanillaCommand) {

--- a/patches/server/0615-Update-head-rotation-in-missing-places.patch
+++ b/patches/server/0615-Update-head-rotation-in-missing-places.patch
@@ -8,10 +8,10 @@ This is because bukkit uses a separate head rotation field for yaw.
 This issue only applies to players.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 900765b0129e8bf485aca93af6f523c9948e288b..3903bbc53d541e66d9362eea27029ed320a74772 100644
+index 9755d8a40a5a5b4863ce057f576f393773cee3e4..2ab2cfddae9f1bb3a1ca3c3bfd0916a14409b205 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1914,6 +1914,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1915,6 +1915,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.setXRot(Mth.clamp(pitch, -90.0F, 90.0F) % 360.0F);
          this.yRotO = this.getYRot();
          this.xRotO = this.getXRot();
@@ -19,7 +19,7 @@ index 900765b0129e8bf485aca93af6f523c9948e288b..3903bbc53d541e66d9362eea27029ed3
      }
  
      public void absMoveTo(double x, double y, double z) {
-@@ -1956,6 +1957,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1957,6 +1958,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.setXRot(pitch);
          this.setOldPosAndRot();
          this.reapplyPosition();

--- a/patches/server/0621-don-t-attempt-to-teleport-dead-entities.patch
+++ b/patches/server/0621-don-t-attempt-to-teleport-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] don't attempt to teleport dead entities
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3903bbc53d541e66d9362eea27029ed320a74772..d6bbefe3d3b21c6fc9be3cfe3ba304226bab6883 100644
+index 2ab2cfddae9f1bb3a1ca3c3bfd0916a14409b205..d05fd90a000c723e9c3bef0fde1b59aea2367f7f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -713,7 +713,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -714,7 +714,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      // CraftBukkit start
      public void postTick() {
          // No clean way to break out of ticking once the entity has been copied to a new world, so instead we move the portalling later in the tick cycle

--- a/patches/server/0622-Prevent-excessive-velocity-through-repeated-crits.patch
+++ b/patches/server/0622-Prevent-excessive-velocity-through-repeated-crits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent excessive velocity through repeated crits
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4f13d792a2cc504f174766d4c0d924d9ca51df9c..2ae65d0303a01536bae6ef8f900b23b94d72dc22 100644
+index 924db96764ef1d0b9596be01f344065f8e1a721e..f06fe310e8dd950fa68ed3b7a7ba5e43a23b9316 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2863,17 +2863,29 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2864,17 +2864,29 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return this.hasEffect(MobEffects.JUMP) ? 0.1F * ((float) this.getEffect(MobEffects.JUMP).getAmplifier() + 1.0F) : 0.0F;
      }
  

--- a/patches/server/0631-Forward-CraftEntity-in-teleport-command.patch
+++ b/patches/server/0631-Forward-CraftEntity-in-teleport-command.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Forward CraftEntity in teleport command
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d6bbefe3d3b21c6fc9be3cfe3ba304226bab6883..06d7aed2539a0f38fabe5b10c91d8da10c43605f 100644
+index d05fd90a000c723e9c3bef0fde1b59aea2367f7f..0eda06b3919e0cc4ddaec4b644c17011a01ccdeb 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3480,6 +3480,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3481,6 +3481,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void restoreFrom(Entity original) {
@@ -22,7 +22,7 @@ index d6bbefe3d3b21c6fc9be3cfe3ba304226bab6883..06d7aed2539a0f38fabe5b10c91d8da1
          CompoundTag nbttagcompound = original.saveWithoutId(new CompoundTag());
  
          nbttagcompound.remove("Dimension");
-@@ -3617,8 +3624,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3618,8 +3625,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              entity.restoreFrom(this);
              this.removeAfterChangingDimensions();
              // CraftBukkit start - Forward the CraftEntity to the new entity

--- a/patches/server/0650-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0650-Freeze-Tick-Lock-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Freeze Tick Lock API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 06d7aed2539a0f38fabe5b10c91d8da10c43605f..4b0b768a4563281ec4ef1a16a3a21c24a1272849 100644
+index 0c8f0f009eb835b8b1eeb7366c2fb6f50fc0ccf0..ba0c6c51c68c346d145ffac056c2e6e73d92980f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -414,6 +414,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -46,10 +46,10 @@ index 06d7aed2539a0f38fabe5b10c91d8da10c43605f..4b0b768a4563281ec4ef1a16a3a21c24
  
          } catch (Throwable throwable) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2ae65d0303a01536bae6ef8f900b23b94d72dc22..f0a3a1342610966f954d8f25fd38281b2af80f06 100644
+index f06fe310e8dd950fa68ed3b7a7ba5e43a23b9316..36277d10822a4fd19b6159a90a455c237b5b177f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3609,7 +3609,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3610,7 +3610,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          this.calculateEntityAnimation(this instanceof FlyingAnimal);
          gameprofilerfiller.pop();
          gameprofilerfiller.push("freezing");

--- a/patches/server/0650-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0650-Freeze-Tick-Lock-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Freeze Tick Lock API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0c8f0f009eb835b8b1eeb7366c2fb6f50fc0ccf0..ba0c6c51c68c346d145ffac056c2e6e73d92980f 100644
+index 0eda06b3919e0cc4ddaec4b644c17011a01ccdeb..a390e1791b4fb3eae5555fc9b760588e410be900 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -414,6 +414,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -415,6 +415,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      private org.bukkit.util.Vector origin;
      @javax.annotation.Nullable
      private UUID originWorld;
@@ -16,7 +16,7 @@ index 0c8f0f009eb835b8b1eeb7366c2fb6f50fc0ccf0..ba0c6c51c68c346d145ffac056c2e6e7
  
      public void setOrigin(@javax.annotation.Nonnull Location location) {
          this.origin = location.toVector();
-@@ -759,7 +760,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -760,7 +761,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                      this.setRemainingFireTicks(this.remainingFireTicks - 1);
                  }
  
@@ -25,7 +25,7 @@ index 0c8f0f009eb835b8b1eeb7366c2fb6f50fc0ccf0..ba0c6c51c68c346d145ffac056c2e6e7
                      this.setTicksFrozen(0);
                      this.level().levelEvent((Player) null, 1009, this.blockPosition, 1);
                  }
-@@ -2428,6 +2429,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2429,6 +2430,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              if (fromNetherPortal) {
                  nbttagcompound.putBoolean("Paper.FromNetherPortal", true);
              }
@@ -35,7 +35,7 @@ index 0c8f0f009eb835b8b1eeb7366c2fb6f50fc0ccf0..ba0c6c51c68c346d145ffac056c2e6e7
              // Paper end
              return nbttagcompound;
          } catch (Throwable throwable) {
-@@ -2573,6 +2577,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2574,6 +2578,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              if (spawnReason == null) {
                  spawnReason = org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT;
              }

--- a/patches/server/0653-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0653-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -122,7 +122,7 @@ index 0000000000000000000000000000000000000000..e3a5f1ec376319bdfda87fa27ae217bf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6d32505266fef119289bcf6761c1948368238eb9..9de7978c7383f8364feba82e9cd3efbfcce00e3c 100644
+index 23b2233f7435f03902e640152cc6fe1501fb3820..c89aee30e4a4f4eec48e23b04e0558e17d95587c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2165,6 +2165,13 @@ public final class CraftServer implements Server {
@@ -153,10 +153,10 @@ index 7f22950ae61436e91a59cd29a345809c42bbe739..1e3091687735b461d3b6a313ab876112
  
      protected ServerCommandSender() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
-index 4e81c26fdbd089961b2577168c716bf29d504d40..a35e2d2f53e8308d51e5a07b34c56d05a707bc14 100644
+index 732655bf8dd279167f799e01b1516b4dd5fa7464..4d4a1ac9d75908bbd105a1e5756d2c0932b2d238 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
-@@ -81,6 +81,11 @@ public final class VanillaCommandWrapper extends BukkitCommand {
+@@ -86,6 +86,11 @@ public final class VanillaCommandWrapper extends BukkitCommand {
          if (sender instanceof ProxiedCommandSender) {
              return ((ProxiedNativeCommandSender) sender).getHandle();
          }

--- a/patches/server/0680-Ensure-entity-passenger-world-matches-ridden-entity.patch
+++ b/patches/server/0680-Ensure-entity-passenger-world-matches-ridden-entity.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Ensure entity passenger world matches ridden entity
 Bad plugins doing this would cause some obvious problems...
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4b0b768a4563281ec4ef1a16a3a21c24a1272849..dcd6cb204d5d19da17664e446da7f3edef104b80 100644
+index a390e1791b4fb3eae5555fc9b760588e410be900..612abe47627f0e7c69aa8bfaeee1de4fda528a57 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2802,7 +2802,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2803,7 +2803,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean startRiding(Entity entity, boolean force) {

--- a/patches/server/0693-Add-PlayerStopUsingItemEvent.patch
+++ b/patches/server/0693-Add-PlayerStopUsingItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerStopUsingItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f0a3a1342610966f954d8f25fd38281b2af80f06..94cc2bc2f5e6ed32173f675c3b27ab602dbcd7f8 100644
+index 36277d10822a4fd19b6159a90a455c237b5b177f..aef73b8ebc6b7784dea32a70e972fa9adb7d303e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4202,6 +4202,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4203,6 +4203,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      public void releaseUsingItem() {
          if (!this.useItem.isEmpty()) {

--- a/patches/server/0701-Prevent-entity-loading-causing-async-lookups.patch
+++ b/patches/server/0701-Prevent-entity-loading-causing-async-lookups.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent entity loading causing async lookups
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index dcd6cb204d5d19da17664e446da7f3edef104b80..736b8bb59631a4e6f8639d84715a7d8cf9dbb775 100644
+index 612abe47627f0e7c69aa8bfaeee1de4fda528a57..828535741f9e39693fe9055ae1f5af2258668ae3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -724,6 +724,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -725,6 +725,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          ProfilerFiller gameprofilerfiller = Profiler.get();
  
          gameprofilerfiller.push("entityBaseTick");

--- a/patches/server/0713-Add-various-missing-EntityDropItemEvent-calls.patch
+++ b/patches/server/0713-Add-various-missing-EntityDropItemEvent-calls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add various missing EntityDropItemEvent calls
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 736b8bb59631a4e6f8639d84715a7d8cf9dbb775..0de6c90c195439564810036c90f31e8296538666 100644
+index 828535741f9e39693fe9055ae1f5af2258668ae3..7d4817cf9d2783f7be5882748323391a8cae5673 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2672,6 +2672,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2673,6 +2673,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              stack.setCount(0); // Paper - destroy this item - if this ever leaks due to game bugs, ensure it doesn't dupe
  
              entityitem.setDefaultPickUpDelay();

--- a/patches/server/0728-Stop-large-look-changes-from-crashing-the-server.patch
+++ b/patches/server/0728-Stop-large-look-changes-from-crashing-the-server.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Stop large look changes from crashing the server
 Co-authored-by: Jaren Knodel <Jaren@Knodel.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 94cc2bc2f5e6ed32173f675c3b27ab602dbcd7f8..079e6224c56128c0a0fc0643eeec49f2475937ea 100644
+index aef73b8ebc6b7784dea32a70e972fa9adb7d303e..5986af338ffadbfae32783178dfe0b145c875b73 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3270,37 +3270,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3271,37 +3271,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
          gameprofilerfiller.pop();
          gameprofilerfiller.push("rangeChecks");
  

--- a/patches/server/0735-Mitigate-effects-of-WorldCreator-keepSpawnLoaded-ret.patch
+++ b/patches/server/0735-Mitigate-effects-of-WorldCreator-keepSpawnLoaded-ret.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Mitigate effects of WorldCreator#keepSpawnLoaded ret type
 TODO: Remove in 1.21?
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index f10e7a847e9f57d2a987b118215c0ceab251a5b0..015a2cf3e969e938158f27a04e172c837068437d 100644
+index 5a7aa491e0846ca8133bc4bb6e74b93cff85fb17..2a2e37a7c67cac657712fc20746a892097a3c4be 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -461,6 +461,12 @@ public class Commodore {
+@@ -463,6 +463,12 @@ public class Commodore {
                              super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, runtimeCbPkgPrefix() + "advancement/CraftAdvancement", "getDisplay0", desc, false);
                              return;
                          }

--- a/patches/server/0754-Fix-EntityCombustEvent-cancellation-cant-fully-preve.patch
+++ b/patches/server/0754-Fix-EntityCombustEvent-cancellation-cant-fully-preve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix EntityCombustEvent cancellation cant fully prevent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0de6c90c195439564810036c90f31e8296538666..8b2b0cf8318f06f0fef59908ece650fb54b6a6b3 100644
+index 7d4817cf9d2783f7be5882748323391a8cae5673..9b5af1041410be058afde31d2630d8dcb3b25179 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3320,6 +3320,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3321,6 +3321,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              pluginManager.callEvent(entityCombustEvent);
              if (!entityCombustEvent.isCancelled()) {
                  this.igniteForSeconds(entityCombustEvent.getDuration(), false);

--- a/patches/server/0760-check-global-player-list-where-appropriate.patch
+++ b/patches/server/0760-check-global-player-list-where-appropriate.patch
@@ -24,10 +24,10 @@ index 45e61a08152517a61260e662764d8bb0335537e3..b81d814619e4175f42aee397811b07ca
 +    // Paper end - check global player list where appropriate
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 079e6224c56128c0a0fc0643eeec49f2475937ea..0e2b5e1dbdf671da0a4edfa77f7fb759732674cb 100644
+index 5986af338ffadbfae32783178dfe0b145c875b73..d121b28c8a79b6f5b690c53ae4fef7cd304afdaa 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3865,7 +3865,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3866,7 +3866,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public void onItemPickup(ItemEntity item) {

--- a/patches/server/0763-Friction-API.patch
+++ b/patches/server/0763-Friction-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Friction API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 0e2b5e1dbdf671da0a4edfa77f7fb759732674cb..076c7828fdfa53c7453406beb937700e12b137d2 100644
+index d121b28c8a79b6f5b690c53ae4fef7cd304afdaa..29c3db84b55e82e25d60c99c87f3472b30fc9239 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -296,6 +296,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -110,12 +110,12 @@ index d555fd0b200c012f30ed0c0ec09a37b25a737b76..7a6d51020d9c6be33b4c34c0d6085595
              this.discard(null); // CraftBukkit - add Bukkit remove cause
          }
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java
-index d8fcd6d1edec1f31a861fab4b86cbeb15ddc799d..d277f56fef882313d6d21f636fafae2f26630ad7 100644
+index 1fdf2179eb768575fa49c019fb6d81f466892f98..ce91809d66007def728a127a0a9d33f6235cc94d 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java
 @@ -93,6 +93,7 @@ public abstract class AbstractMinecart extends VehicleEntity {
      private double flyingZ = 0.95;
-     public double maxSpeed = 0.4D;
+     public Double maxSpeed;
      // CraftBukkit end
 +    public net.kyori.adventure.util.TriState frictionState = net.kyori.adventure.util.TriState.NOT_SET; // Paper - Friction API
  
@@ -152,10 +152,10 @@ index d8fcd6d1edec1f31a861fab4b86cbeb15ddc799d..d277f56fef882313d6d21f636fafae2f
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/NewMinecartBehavior.java b/src/main/java/net/minecraft/world/entity/vehicle/NewMinecartBehavior.java
-index 00b0004940339dc105fb95f813bd35b16f7a9fb4..a8718ee94cd6b9a20bd1e9a49d58d39e6f3f2a7a 100644
+index 60b8d8c1ccfe7f9d1a327d1a361493e97ca9ad4c..f43439b31a14b9db4744512465d81134ebe5b3e1 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/NewMinecartBehavior.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/NewMinecartBehavior.java
-@@ -548,6 +548,7 @@ public class NewMinecartBehavior extends MinecartBehavior {
+@@ -554,6 +554,7 @@ public class NewMinecartBehavior extends MinecartBehavior {
  
      @Override
      public double getSlowdownFactor() {
@@ -164,10 +164,10 @@ index 00b0004940339dc105fb95f813bd35b16f7a9fb4..a8718ee94cd6b9a20bd1e9a49d58d39e
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/OldMinecartBehavior.java b/src/main/java/net/minecraft/world/entity/vehicle/OldMinecartBehavior.java
-index cf871c174091139c8ad1affb84f98fcd74b60dee..23cbafcc12f6e5f5755215a72879a6cab306ad18 100644
+index 62ae79808aba4112ea845311080bb496174a68d2..04a622f52353ebcc21f41c233f5a0fd67690cf4a 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/OldMinecartBehavior.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/OldMinecartBehavior.java
-@@ -522,6 +522,7 @@ public class OldMinecartBehavior extends MinecartBehavior {
+@@ -528,6 +528,7 @@ public class OldMinecartBehavior extends MinecartBehavior {
  
      @Override
      public double getSlowdownFactor() {
@@ -221,10 +221,10 @@ index 1ceaa081231a617bd87331b308c24d9c7a8dcf2b..2fd4a3068d86a37cc18c9203448823c5
 +    // Paper end - friction API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java
-index d35c1a10e58932b19c8053c5dacdc25fd7f22e8c..ab9d06a9a4951a5b8aa14d47818a3850433e92b8 100644
+index 8192ccb01ed4efe9e987cab94952c172ed876581..5791f9936532899b337b149a109781fba0819657 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java
-@@ -137,4 +137,18 @@ public abstract class CraftMinecart extends CraftVehicle implements Minecart {
+@@ -138,4 +138,18 @@ public abstract class CraftMinecart extends CraftVehicle implements Minecart {
      public int getDisplayBlockOffset() {
          return this.getHandle().getDisplayOffset();
      }

--- a/patches/server/0767-Player-Entity-Tracking-Events.patch
+++ b/patches/server/0767-Player-Entity-Tracking-Events.patch
@@ -21,10 +21,10 @@ index 51a6735b35e73175680e61c2d67d4adbedf305c9..8b5d11aceb77135c917c3581f4db792e
                  } else if (this.seenBy.remove(player.connection)) {
                      this.serverEntity.removePairing(player);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8b2b0cf8318f06f0fef59908ece650fb54b6a6b3..429cdb83252b417c810d529125fc7343dca7990d 100644
+index 9b5af1041410be058afde31d2630d8dcb3b25179..a361480801d113b9619f7cd93b0da2332ca089dd 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4071,7 +4071,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4072,7 +4072,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      public void startSeenByPlayer(ServerPlayer player) {}
  

--- a/patches/server/0769-fix-Instruments.patch
+++ b/patches/server/0769-fix-Instruments.patch
@@ -55,3 +55,29 @@ index 0000000000000000000000000000000000000000..cd718ed01ba5d448cdf0a2b6a39dc7ef
 +        assertEquals(nms.getSoundEvent(), CraftSound.bukkitToMinecraftHolder(bukkit.getSound()));
 +    }
 +}
+diff --git a/src/test/java/org/bukkit/InstrumentTest.java b/src/test/java/org/bukkit/InstrumentTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..5da6b5c996c9a4077f309e923731e3f148e91c19
+--- /dev/null
++++ b/src/test/java/org/bukkit/InstrumentTest.java
+@@ -0,0 +1,20 @@
++package org.bukkit;
++
++import org.bukkit.support.environment.AllFeatures;
++import org.junit.jupiter.api.Test;
++
++import static org.bukkit.support.MatcherAssert.assertThat;
++import static org.hamcrest.CoreMatchers.is;
++
++@AllFeatures
++public class InstrumentTest { // Paper - moved to internals as this test now access the sound registry.
++
++    @Test
++    public void getByType() {
++        for (Instrument instrument : Instrument.values()) {
++            // Paper - byte magic values are still used
++
++            assertThat(Instrument.getByType(instrument.getType()), is(instrument));
++        }
++    }
++}

--- a/patches/server/0774-Improve-PortalEvents.patch
+++ b/patches/server/0774-Improve-PortalEvents.patch
@@ -18,10 +18,10 @@ index 25b1e8bec23465f0e9a17f156bdff7fe716db84c..f05a9fd321a4af28e9771bbf39d73f80
              // Paper start - gateway-specific teleport event
              if (this.portalProcess != null && this.portalProcess.isSamePortal(((net.minecraft.world.level.block.EndGatewayBlock) net.minecraft.world.level.block.Blocks.END_GATEWAY)) && this.serverLevel().getBlockEntity(this.portalProcess.getEntryPosition()) instanceof net.minecraft.world.level.block.entity.TheEndGatewayBlockEntity theEndGatewayBlockEntity) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 429cdb83252b417c810d529125fc7343dca7990d..411ffaf842841709eaef48776e2c6ce4f524af05 100644
+index a361480801d113b9619f7cd93b0da2332ca089dd..4d9680748a00df783e9611a90c31e2665ce3d736 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3742,7 +3742,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3743,7 +3743,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          org.bukkit.entity.Entity bukkitEntity = entity.getBukkitEntity();
          Location enter = bukkitEntity.getLocation();
  

--- a/patches/server/0779-Expose-pre-collision-moving-velocity-to-VehicleBlock.patch
+++ b/patches/server/0779-Expose-pre-collision-moving-velocity-to-VehicleBlock.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose pre-collision moving velocity to
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 411ffaf842841709eaef48776e2c6ce4f524af05..5340d6d911a7e586468f2b7e2e74b3386d1dc72d 100644
+index 4d9680748a00df783e9611a90c31e2665ce3d736..798fd11e76326ace74035cf782be9f4218fe5edc 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -968,6 +968,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -969,6 +969,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void move(MoverType type, Vec3 movement) {
@@ -17,7 +17,7 @@ index 411ffaf842841709eaef48776e2c6ce4f524af05..5340d6d911a7e586468f2b7e2e74b338
          if (this.noPhysics) {
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
          } else {
-@@ -1059,7 +1060,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1060,7 +1061,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                      }
  
                      if (!bl.getType().isAir()) {

--- a/patches/server/0792-Fix-advancement-triggers-for-entity-damage.patch
+++ b/patches/server/0792-Fix-advancement-triggers-for-entity-damage.patch
@@ -23,10 +23,10 @@ index 821bb93e1b055ba38fafe3b7079d79aa062ebe8a..221d73676fe2fd240a47cf312c1179e0
  
              return !this.getResponse();
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 879ac6ec0b429ddb89ede2d51c8ccee9090fdc49..2a587683463fb0a0770ab54125868e82c0694ca6 100644
+index 0f20301c8194dcf9f3b42429437552ca0a613b13..c6fa51118232e5875779482ed1d694b7b9c7b861 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2463,7 +2463,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2464,7 +2464,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  // Duplicate triggers if blocking
                  if (event.getDamage(DamageModifier.BLOCKING) < 0) {
                      if (this instanceof ServerPlayer) {
@@ -35,7 +35,7 @@ index 879ac6ec0b429ddb89ede2d51c8ccee9090fdc49..2a587683463fb0a0770ab54125868e82
                          f2 = (float) -event.getDamage(DamageModifier.BLOCKING);
                          if (f2 > 0.0F && f2 < 3.4028235E37F) {
                              ((ServerPlayer) this).awardStat(Stats.DAMAGE_BLOCKED_BY_SHIELD, Math.round(originalDamage * 10.0F));
-@@ -2471,7 +2471,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2472,7 +2472,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      }
  
                      if (damagesource.getEntity() instanceof ServerPlayer) {

--- a/patches/server/0809-Refresh-ProjectileSource-for-projectiles.patch
+++ b/patches/server/0809-Refresh-ProjectileSource-for-projectiles.patch
@@ -14,10 +14,10 @@ clearing the owner.
 Co-authored-by: Warrior <50800980+Warriorrrr@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5340d6d911a7e586468f2b7e2e74b3386d1dc72d..90b47da5c6df05565b522636e08c4ebb7165c351 100644
+index 798fd11e76326ace74035cf782be9f4218fe5edc..3d4d5d23623dccb8a5be85c2205dae11509a7119 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -393,6 +393,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -394,6 +394,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public boolean inWorld = false;
      public boolean generation;
      public int maxAirTicks = this.getDefaultMaxAirSupply(); // CraftBukkit - SPIGOT-6907: re-implement LivingEntity#setMaximumAir()

--- a/patches/server/0823-Don-t-load-chunks-for-supporting-block-checks.patch
+++ b/patches/server/0823-Don-t-load-chunks-for-supporting-block-checks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't load chunks for supporting block checks
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 90b47da5c6df05565b522636e08c4ebb7165c351..a8bb9caaf0db01d8b7cfb18e5f162c6eeada5d6a 100644
+index 3d4d5d23623dccb8a5be85c2205dae11509a7119..c26c814e9a3a54fb7b46b0e5f51843621f179d3d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1228,7 +1228,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1229,7 +1229,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      protected BlockPos getOnPos(float offset) {

--- a/patches/server/0829-Fix-possible-NPE-on-painting-creation.patch
+++ b/patches/server/0829-Fix-possible-NPE-on-painting-creation.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix possible NPE on painting creation
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
-index 39ea25d2145acaa7c7b458800adc674a3e73e7c1..8715d8e790b6735610e2f880f8c1f88a89967f21 100644
+index 0b9c4f9b61651660e821735f18b4f3cc7cfd164c..e31aa2a499e894847f19800b6bceb17aba38a1c0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
 @@ -361,8 +361,13 @@ public final class CraftEntityTypes {
@@ -24,7 +24,7 @@ index 39ea25d2145acaa7c7b458800adc674a3e73e7c1..8715d8e790b6735610e2f880f8c1f88a
                          net.minecraft.world.entity.decoration.Painting entity = new net.minecraft.world.entity.decoration.Painting(net.minecraft.world.entity.EntityType.PAINTING, spawnData.minecraftWorld());
                          entity.absMoveTo(spawnData.x(), spawnData.y(), spawnData.z(), spawnData.yaw(), spawnData.pitch());
                          entity.setDirection(hangingData.direction());
-@@ -523,6 +528,7 @@ public final class CraftEntityTypes {
+@@ -529,6 +534,7 @@ public final class CraftEntityTypes {
                      AABB bb = (ItemFrame.class.isAssignableFrom(clazz))
                              ? net.minecraft.world.entity.decoration.ItemFrame.calculateBoundingBoxStatic(pos, CraftBlock.blockFaceToNotch(dir).getOpposite())
                              : net.minecraft.world.entity.decoration.Painting.calculateBoundingBoxStatic(pos, CraftBlock.blockFaceToNotch(dir).getOpposite(), width, height);

--- a/patches/server/0835-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/server/0835-Folia-scheduler-and-owned-region-API.patch
@@ -1173,7 +1173,7 @@ index 741b5ba321d9bd854afb9b54f0e23c739c7f929c..9312279f8f958cd1fd13e8333ca47680
          gameprofilerfiller.push("commandFunctions");
          this.getFunctions().tick();
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index cbba549176b3acfc25ec42c2935b31ab2176e0fa..4ac0bb0ec3222ebdd3fa386696dcb0723dc162a4 100644
+index 7da3e315de67f3273997ce9160995183a3a1ce71..3a6e918e9db6397b6f1cff531041655298ce087d 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -597,6 +597,7 @@ public abstract class PlayerList {
@@ -1185,10 +1185,10 @@ index cbba549176b3acfc25ec42c2935b31ab2176e0fa..4ac0bb0ec3222ebdd3fa386696dcb072
          this.players.remove(entityplayer);
          this.playersByName.remove(entityplayer.getScoreboardName().toLowerCase(java.util.Locale.ROOT)); // Spigot
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a8bb9caaf0db01d8b7cfb18e5f162c6eeada5d6a..cc4906ed08e84beaca0ba93200693a0a3730fb4c 100644
+index c26c814e9a3a54fb7b46b0e5f51843621f179d3d..638b202519b0cca5ca7ba406e6f92c51a0ef990e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -262,10 +262,21 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -263,10 +263,21 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      public CraftEntity getBukkitEntity() {
          if (this.bukkitEntity == null) {
@@ -1211,7 +1211,7 @@ index a8bb9caaf0db01d8b7cfb18e5f162c6eeada5d6a..cc4906ed08e84beaca0ba93200693a0a
  
      // CraftBukkit - SPIGOT-6907: re-implement LivingEntity#setMaximumAir()
      public int getDefaultMaxAirSupply() {
-@@ -4676,6 +4687,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4706,6 +4717,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public final void setRemoved(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
          CraftEventFactory.callEntityRemoveEvent(this, cause);
          // CraftBukkit end
@@ -1219,7 +1219,7 @@ index a8bb9caaf0db01d8b7cfb18e5f162c6eeada5d6a..cc4906ed08e84beaca0ba93200693a0a
          if (this.removalReason == null) {
              this.removalReason = entity_removalreason;
          }
-@@ -4687,12 +4699,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4717,12 +4729,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.getPassengers().forEach(Entity::stopRiding);
          this.levelCallback.onRemove(entity_removalreason);
          this.onRemoval(entity_removalreason);
@@ -1249,7 +1249,7 @@ index a8bb9caaf0db01d8b7cfb18e5f162c6eeada5d6a..cc4906ed08e84beaca0ba93200693a0a
      public void setLevelCallback(EntityInLevelCallback changeListener) {
          this.levelCallback = changeListener;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a7b79c9ec51f037287fad609c29b240e2071f2f8..46807d5d94a0f90b230dfaf4d37378a3bfa21414 100644
+index b59dc253a086374e07338b989ba5835d138e5d72..190529d8f96b2cb4096a454aec37775388650af2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -313,6 +313,76 @@ public final class CraftServer implements Server {

--- a/patches/server/0844-API-for-updating-recipes-on-clients.patch
+++ b/patches/server/0844-API-for-updating-recipes-on-clients.patch
@@ -38,7 +38,7 @@ index 3a6e918e9db6397b6f1cff531041655298ce087d..efc12d629b71ba1da664d9ecfd4575be
  
      public void reloadRecipes() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 87bc228c121077815bdad7942df1c9576edac21b..6cd8464636099bd8eac5245569f01907ca523365 100644
+index 87bc228c121077815bdad7942df1c9576edac21b..a618258fde1226588ea447522ba4177aa9cf9016 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1178,6 +1178,18 @@ public final class CraftServer implements Server {
@@ -53,7 +53,7 @@ index 87bc228c121077815bdad7942df1c9576edac21b..6cd8464636099bd8eac5245569f01907
 +
 +    @Override
 +    public void updateRecipes() {
-+        this.playerList.reloadRecipeData();
++        this.playerList.reloadRecipes();
 +    }
 +    // Paper end - API for updating recipes on clients
 +
@@ -80,7 +80,7 @@ index 87bc228c121077815bdad7942df1c9576edac21b..6cd8464636099bd8eac5245569f01907
          toAdd.addToCraftingManager();
 +        // Paper start - API for updating recipes on clients
 +        if (true || resendRecipes) { // Always needs to be resent now... TODO
-+            this.playerList.reloadRecipeData();
++            this.playerList.reloadRecipes();
 +        }
 +        // Paper end - API for updating recipes on clients
          return true;
@@ -104,7 +104,7 @@ index 87bc228c121077815bdad7942df1c9576edac21b..6cd8464636099bd8eac5245569f01907
 +        final ResourceKey<net.minecraft.world.item.crafting.Recipe<?>> minecraftKey = CraftRecipe.toMinecraft(recipeKey);
 +        final boolean removed = this.getServer().getRecipeManager().removeRecipe(minecraftKey);
 +        if (removed/* && resendRecipes*/) { // TODO Always need to resend them rn - deprecate this method?
-+            this.playerList.reloadRecipeData();
++            this.playerList.reloadRecipes();
 +        }
 +        return removed;
 +        // Paper end - resend recipes on successful removal

--- a/patches/server/0844-API-for-updating-recipes-on-clients.patch
+++ b/patches/server/0844-API-for-updating-recipes-on-clients.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] API for updating recipes on clients
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4ac0bb0ec3222ebdd3fa386696dcb0723dc162a4..d92fb522d88a790d9cea2e6c4edad30bb73298fc 100644
+index 3a6e918e9db6397b6f1cff531041655298ce087d..efc12d629b71ba1da664d9ecfd4575bee9b45dc3 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1448,6 +1448,13 @@ public abstract class PlayerList {
@@ -15,14 +15,14 @@ index 4ac0bb0ec3222ebdd3fa386696dcb0723dc162a4..d92fb522d88a790d9cea2e6c4edad30b
 +        // Paper start - API for updating recipes on clients
 +        this.reloadAdvancementData();
 +        this.reloadTagData();
-+        this.reloadRecipeData();
++        this.reloadRecipes();
 +    }
 +    public void reloadAdvancementData() {
 +        // Paper end - API for updating recipes on clients
          // CraftBukkit start
          /*Iterator iterator = this.advancements.values().iterator();
  
-@@ -1463,7 +1470,13 @@ public abstract class PlayerList {
+@@ -1463,9 +1470,13 @@ public abstract class PlayerList {
          }
          // CraftBukkit end
  
@@ -30,14 +30,15 @@ index 4ac0bb0ec3222ebdd3fa386696dcb0723dc162a4..d92fb522d88a790d9cea2e6c4edad30b
 +    }
 +    public void reloadTagData() {
          this.broadcastAll(new ClientboundUpdateTagsPacket(TagNetworkSerialization.serializeTagsToNetwork(this.registries)));
-+    }
-+    public void reloadRecipeData() {
+         // CraftBukkit start
+-        this.reloadRecipes();
++        // this.reloadRecipes(); // Paper - do not reload recipes just because tag data was reloaded
 +        // Paper end - API for updating recipes on clients
-         RecipeManager craftingmanager = this.server.getRecipeManager();
-         ClientboundUpdateRecipesPacket packetplayoutrecipeupdate = new ClientboundUpdateRecipesPacket(craftingmanager.getSynchronizedItemProperties(), craftingmanager.getSynchronizedStonecutterRecipes());
-         Iterator iterator1 = this.players.iterator();
+     }
+ 
+     public void reloadRecipes() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index da3819f49b105bd98ce94b5abdf1c7652ff625a4..fa505c0714bb95b2ab08b4bbb9ea79ce98898f4b 100644
+index 87bc228c121077815bdad7942df1c9576edac21b..6cd8464636099bd8eac5245569f01907ca523365 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1178,6 +1178,18 @@ public final class CraftServer implements Server {

--- a/patches/server/0858-Expand-Pose-API.patch
+++ b/patches/server/0858-Expand-Pose-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expand Pose API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index cc4906ed08e84beaca0ba93200693a0a3730fb4c..67dda7d37cc4af2f09734da5653e8fa33098c7db 100644
+index 638b202519b0cca5ca7ba406e6f92c51a0ef990e..8a0b26533e6bbabe829efbf5afcef1a79cdf0adb 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -427,6 +427,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -428,6 +428,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      @javax.annotation.Nullable
      private UUID originWorld;
      public boolean freezeLocked = false; // Paper - Freeze Tick Lock API
@@ -16,7 +16,7 @@ index cc4906ed08e84beaca0ba93200693a0a3730fb4c..67dda7d37cc4af2f09734da5653e8fa3
  
      public void setOrigin(@javax.annotation.Nonnull Location location) {
          this.origin = location.toVector();
-@@ -625,6 +626,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -626,6 +627,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public void onRemoval(Entity.RemovalReason reason) {}
  
      public void setPose(net.minecraft.world.entity.Pose pose) {

--- a/patches/server/0865-Fix-slot-desync.patch
+++ b/patches/server/0865-Fix-slot-desync.patch
@@ -40,10 +40,10 @@ index 38730e11118bf71d167a18b807e06c20ea0d63d0..5be7304c8417e2987837d1c6ce8b8023
  
                              if (event.isCancelled()) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 67dda7d37cc4af2f09734da5653e8fa33098c7db..56f2ac87f42572556646eb62f16274726e7ae455 100644
+index 8a0b26533e6bbabe829efbf5afcef1a79cdf0adb..4cd07d9a90885b59ef1b2be7562386d5e8c7b2ae 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2752,8 +2752,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2753,8 +2753,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  if (!this.level().isClientSide()) {
                      // CraftBukkit start - fire PlayerLeashEntityEvent
                      if (CraftEventFactory.callPlayerLeashEntityEvent(this, player, player, hand).isCancelled()) {

--- a/patches/server/0891-Broadcast-take-item-packets-with-collector-as-source.patch
+++ b/patches/server/0891-Broadcast-take-item-packets-with-collector-as-source.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Broadcast take item packets with collector as source
 This fixes players (which can't view the collector) seeing item pickups with themselves as the target.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2a587683463fb0a0770ab54125868e82c0694ca6..375280dd829eb2f6b98a95228250a3d87a7872cf 100644
+index c6fa51118232e5875779482ed1d694b7b9c7b861..2bff94cef4fef66b81508a2ef4b5613e76044832 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3891,7 +3891,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3892,7 +3892,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      public void take(Entity item, int count) {
          if (!item.isRemoved() && !this.level().isClientSide && (item instanceof ItemEntity || item instanceof AbstractArrow || item instanceof ExperienceOrb)) {

--- a/patches/server/0899-Don-t-fire-sync-events-during-worldgen.patch
+++ b/patches/server/0899-Don-t-fire-sync-events-during-worldgen.patch
@@ -31,10 +31,10 @@ index 7cecbac43f1cd2d9516034ea9d2633c0c76e61f4..7a985c30a973efacf3e8b70e7163c550
          if (entity.valid) {
              MinecraftServer.LOGGER.error("Attempted Double World add on {}", entity, new Throwable());
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 56f2ac87f42572556646eb62f16274726e7ae455..5c7df0efee4a0aa078e36d3e262cd0b48a27cf47 100644
+index 4cd07d9a90885b59ef1b2be7562386d5e8c7b2ae..7657888bab53428fda9d3d10ac35bfddc5c16266 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -631,7 +631,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -632,7 +632,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          if (pose == this.getPose()) {
              return;
          }
@@ -68,7 +68,7 @@ index 64dc0bd1900575e40ac72a98c6df371223bd244c..c2693d530be00af16b2aa4ca4afd1d13
          }, () -> {
              EntityType.LOGGER.warn("Skipping Entity with id {}", nbt.getString("id"));
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 375280dd829eb2f6b98a95228250a3d87a7872cf..e8749957c39abcd922b734a87df95b815012737a 100644
+index 2bff94cef4fef66b81508a2ef4b5613e76044832..22c565fd6b14ae018f4526b174388ed5247600f6 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1159,6 +1159,11 @@ public abstract class LivingEntity extends Entity implements Attackable {

--- a/patches/server/0902-Restore-vanilla-entity-drops-behavior.patch
+++ b/patches/server/0902-Restore-vanilla-entity-drops-behavior.patch
@@ -37,10 +37,10 @@ index 419fcb4cd97cf10a2601e02024b999a51a0ff952..df21cd1bd2a3dda7169edbea18bbfdf0
          loot.addAll(this.drops);
          this.drops.clear(); // SPIGOT-5188: make sure to clear
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5c7df0efee4a0aa078e36d3e262cd0b48a27cf47..b78395ab8f393a0f6551951731ddce7a5228b44c 100644
+index 7657888bab53428fda9d3d10ac35bfddc5c16266..b7594a0fd6fe7e25d13202c95b2c39a04e84abde 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2678,19 +2678,45 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2679,19 +2679,45 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Nullable
      public ItemEntity spawnAtLocation(ServerLevel world, ItemStack stack, float yOffset) {
@@ -89,7 +89,7 @@ index 5c7df0efee4a0aa078e36d3e262cd0b48a27cf47..b78395ab8f393a0f6551951731ddce7a
              return this.spawnAtLocation(world, entityitem);
          }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e8749957c39abcd922b734a87df95b815012737a..9e105732fb765258af9154b84534234fd84eb24f 100644
+index 22c565fd6b14ae018f4526b174388ed5247600f6..8c3ec957210a259e26253dbb3a4191702ce6699c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -289,7 +289,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -150,7 +150,7 @@ index 2bb2b36f793d25b6e49d1a72bb665cfa9f212730..63f02cdc67d9e88cc6998d0ae9d139c8
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index dbef230ae88ee1bfbc20ba53b534434c3ccac985..a0455f590d549343d6d8fd7991ba1b87a87acdb8 100644
+index b6c30bb70fb4746da024bc4d80b71aeb3558f101..1c87019f5eb8e51accef3dc7ee949cdf2bec8f72 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -973,19 +973,25 @@ public class CraftEventFactory {

--- a/patches/server/0905-Improve-Registry.patch
+++ b/patches/server/0905-Improve-Registry.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Improve Registry
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-index 16985dc1f54d64c44f96b045012612f16ba9ae8a..002a3475c6e062071845399ed723754ce4ce9e95 100644
+index 249f0dcad04a35244da6dab837a461bb42aad00a..273844c9071b8d5cf6009c6c94a6c47a9d0cc700 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-@@ -150,6 +150,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -152,6 +152,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
  
      private final Class<?> bukkitClass; // Paper - relax preload class
      private final Map<NamespacedKey, B> cache = new HashMap<>();
@@ -16,7 +16,7 @@ index 16985dc1f54d64c44f96b045012612f16ba9ae8a..002a3475c6e062071845399ed723754c
      private final net.minecraft.core.Registry<M> minecraftRegistry;
      private final BiFunction<NamespacedKey, M, B> minecraftToBukkit;
      private final BiFunction<NamespacedKey, ApiVersion, NamespacedKey> serializationUpdater; // Paper - rename to make it *clear* what it is *only* for
-@@ -198,6 +199,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -200,6 +201,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
          }
  
          this.cache.put(namespacedKey, bukkit);
@@ -24,7 +24,7 @@ index 16985dc1f54d64c44f96b045012612f16ba9ae8a..002a3475c6e062071845399ed723754c
  
          return bukkit;
      }
-@@ -230,4 +232,11 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -232,4 +234,11 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
  
          return this.minecraftToBukkit.apply(namespacedKey, minecraft);
      }

--- a/patches/server/0906-Fix-NPE-on-null-loc-for-EntityTeleportEvent.patch
+++ b/patches/server/0906-Fix-NPE-on-null-loc-for-EntityTeleportEvent.patch
@@ -26,10 +26,10 @@ index c6dcc37ac5fcf50bcb246f533b99983dfc5c19c2..c13b6f14c3061710c2b27034db240cc9
                  d3 = to.getX();
                  d4 = to.getY();
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9e105732fb765258af9154b84534234fd84eb24f..97a524db692b7367f22a373439c1233b143f4a17 100644
+index 8c3ec957210a259e26253dbb3a4191702ce6699c..0557a182a17a2891f2a9e0e4367d5102674e3b42 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4363,7 +4363,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4364,7 +4364,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      if (!(this instanceof ServerPlayer)) {
                          EntityTeleportEvent teleport = new EntityTeleportEvent(this.getBukkitEntity(), new Location(this.level().getWorld(), d3, d4, d5), new Location(this.level().getWorld(), d0, d6, d2));
                          this.level().getCraftServer().getPluginManager().callEvent(teleport);

--- a/patches/server/0912-Fixup-NamespacedKey-handling.patch
+++ b/patches/server/0912-Fixup-NamespacedKey-handling.patch
@@ -18,10 +18,10 @@ index 90b82ad996b2b85628c9a5ddeef9410150b7f70c..5fd22a80e9d05afbea273471cee99173
  
      public static NamespacedKey minecraftToBukkitKey(ResourceKey<LootTable> minecraft) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-index 002a3475c6e062071845399ed723754ce4ce9e95..9245f6de141384bfc12e8dd81ce1df366c6a62aa 100644
+index 273844c9071b8d5cf6009c6c94a6c47a9d0cc700..45c78c113e881b277e1216293ad918ee40b44325 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-@@ -125,6 +125,16 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -127,6 +127,16 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
                  + ", this can happen if a plugin creates its own registry entry with out properly registering it.");
      }
  

--- a/patches/server/0912-Fixup-NamespacedKey-handling.patch
+++ b/patches/server/0912-Fixup-NamespacedKey-handling.patch
@@ -68,7 +68,7 @@ index afed8bdb9bd6a135e9b5f7bd9bfc61964cb240f7..bb2d1dddca6bfe719b28df136e80a7c5
          }
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
-index bcac1359c667ef1ee46384f9c7a5adf4010d2b08..98a4463c9f194f33f4f85d95a0b9fa061cf6faaf 100644
+index bcac1359c667ef1ee46384f9c7a5adf4010d2b08..b1b139b773b37e6ec2afea85c500387d6ba9800e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
 @@ -16,7 +16,7 @@ public class CraftPainting extends CraftHanging implements Painting {
@@ -76,7 +76,7 @@ index bcac1359c667ef1ee46384f9c7a5adf4010d2b08..98a4463c9f194f33f4f85d95a0b9fa06
      @Override
      public Art getArt() {
 -        return CraftArt.minecraftHolderToBukkit(this.getHandle().getVariant());
-+        return org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.ART, this.getHandle().getVariant()).orElseThrow(() -> new IllegalStateException("Inlined/custom painting variants are not supported yet in the API!")); // Paper
++        return org.bukkit.craftbukkit.CraftRegistry.unwrapAndConvertHolder(org.bukkit.Registry.ART, this.getHandle().getVariant()).orElseThrow(() -> new IllegalStateException("Inlined painting variants are not supported yet in the API!")); // Paper
      }
  
      @Override

--- a/patches/server/0934-Fix-DamageSource-API.patch
+++ b/patches/server/0934-Fix-DamageSource-API.patch
@@ -84,10 +84,10 @@ index fddbdb7322a2063996a28c5c3d93c265188b1256..be87cb3cfa15a7d889118cdc4b87232e
  
      public DamageSource sonicBoom(Entity attacker) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b78395ab8f393a0f6551951731ddce7a5228b44c..e2322f361271712aca31c95b8b79cdf1c04945f2 100644
+index b7594a0fd6fe7e25d13202c95b2c39a04e84abde..6ebd653ea3c302f26d02f81b6718924708148e4c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3388,7 +3388,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3389,7 +3389,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              return;
          }
  
@@ -220,7 +220,7 @@ index 4c6e15535fa40aad8cf1920f392589404f9ba79c..35eb95ef6fb6a0f7ea63351e90741c48
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e7749a3ef6289d73379649f2f76f4e4fdfac7a8b..96b901d07718d8926a2175925e867b4417c3947c 100644
+index ea4e1bf4bfe003c102ecce5958131aa86ec83864..937ed4e77739ff02ff1e4405047f15eac40906fe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1092,7 +1092,7 @@ public class CraftEventFactory {

--- a/patches/server/0945-Fix-shield-disable-inconsistency.patch
+++ b/patches/server/0945-Fix-shield-disable-inconsistency.patch
@@ -8,10 +8,10 @@ it will not disable the shield if the attacker is holding
 an axe item.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2fa73a9f444628a5e0df9f54e9bcd453973f0029..e2a069d15d355e985bd80e27023c53b8ef72e0e9 100644
+index 9154f43b578176e13604a7cbd8c210ff3b0ecce9..241c0b1d509bf60104820914a32b81edfdbb33c4 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2424,7 +2424,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2425,7 +2425,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  this.hurtCurrentlyUsedShield((float) -event.getDamage(DamageModifier.BLOCKING));
                  Entity entity = damagesource.getDirectEntity();
  

--- a/patches/server/0949-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
+++ b/patches/server/0949-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Revert to vanilla handling of LivingEntity#actuallyHurt
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e2a069d15d355e985bd80e27023c53b8ef72e0e9..ea423fd53150b4a530de673359bfcadc432e9501 100644
+index 241c0b1d509bf60104820914a32b81edfdbb33c4..fe545447bdb982355491ec83c14993325dcc799d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1455,7 +1455,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -33,7 +33,7 @@ index e2a069d15d355e985bd80e27023c53b8ef72e0e9..ea423fd53150b4a530de673359bfcadc
                  this.lastHurt = amount;
                  this.invulnerableTime = this.invulnerableDuration; // CraftBukkit - restore use of maxNoDamageTicks
                  // this.actuallyHurt(worldserver, damagesource, f);
-@@ -2486,12 +2488,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2487,12 +2489,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
                      return true;
                  } else {

--- a/patches/server/0956-Brigadier-based-command-API.patch
+++ b/patches/server/0956-Brigadier-based-command-API.patch
@@ -2376,7 +2376,7 @@ index c4ffa8519b520e0793af90e149518951d7ffb65b..688916c8fef40d4c81379ad38609a979
      // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6136037d3d096300d93b9710dd854224b30e0738..694eacb7d3ffd28fe7684139554113e58be1ebfa 100644
+index b8c2df77ee339c0f711eb767c00cd262c0b84ff3..91ede397a5de5582fcff9d18d1d1b2be9f0909cf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -275,11 +275,11 @@ public final class CraftServer implements Server {
@@ -2559,10 +2559,10 @@ index 4b1ac1fe7ea07f419ae2818251900e7ba434ee16..90ed57a7fbcd0625b64084347460e986
  
      public Map<String, Command> getKnownCommands() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
-index a35e2d2f53e8308d51e5a07b34c56d05a707bc14..945878e989f136ac516eb1c539c0626547c465fb 100644
+index 4d4a1ac9d75908bbd105a1e5756d2c0932b2d238..7b9f95802071e009412c4a3e6427e34f0b4d468c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
-@@ -23,14 +23,26 @@ import org.bukkit.craftbukkit.entity.CraftEntity;
+@@ -24,14 +24,26 @@ import org.bukkit.craftbukkit.entity.CraftEntity;
  import org.bukkit.craftbukkit.entity.CraftMinecartCommand;
  import org.bukkit.entity.minecart.CommandMinecart;
  
@@ -2592,7 +2592,7 @@ index a35e2d2f53e8308d51e5a07b34c56d05a707bc14..945878e989f136ac516eb1c539c06265
          this.vanillaCommand = vanillaCommand;
          this.setPermission(VanillaCommandWrapper.getPermission(vanillaCommand));
      }
-@@ -40,7 +52,7 @@ public final class VanillaCommandWrapper extends BukkitCommand {
+@@ -41,7 +53,7 @@ public final class VanillaCommandWrapper extends BukkitCommand {
          if (!this.testPermission(sender)) return true;
  
          CommandSourceStack icommandlistener = VanillaCommandWrapper.getListener(sender);
@@ -2601,7 +2601,7 @@ index a35e2d2f53e8308d51e5a07b34c56d05a707bc14..945878e989f136ac516eb1c539c06265
          return true;
      }
  
-@@ -51,10 +63,10 @@ public final class VanillaCommandWrapper extends BukkitCommand {
+@@ -52,10 +64,10 @@ public final class VanillaCommandWrapper extends BukkitCommand {
          Preconditions.checkArgument(alias != null, "Alias cannot be null");
  
          CommandSourceStack icommandlistener = VanillaCommandWrapper.getListener(sender);
@@ -2614,7 +2614,7 @@ index a35e2d2f53e8308d51e5a07b34c56d05a707bc14..945878e989f136ac516eb1c539c06265
              suggestions.getList().forEach((s) -> results.add(s.getText()));
          });
  
-@@ -111,4 +123,15 @@ public final class VanillaCommandWrapper extends BukkitCommand {
+@@ -116,4 +128,15 @@ public final class VanillaCommandWrapper extends BukkitCommand {
      private String toDispatcher(String[] args, String name) {
          return name + ((args.length > 0) ? " " + Joiner.on(' ').join(args) : "");
      }

--- a/patches/server/0960-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0960-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -222,10 +222,10 @@ index 688916c8fef40d4c81379ad38609a97993b4b702..6cf3b28749d92b4e33e2f88c6335c9a6
  
                                  ServerGamePacketListenerImpl.this.player.containerMenu.sendAllDataToRemote(); // Paper - fix slot desync - always refresh player inventory
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ea423fd53150b4a530de673359bfcadc432e9501..ce686e5a98aea61979b842637ed6ebb97e64d2e1 100644
+index fe545447bdb982355491ec83c14993325dcc799d..6feab3d1b85857ab2c5b2228f2b0d5e6c2a5518d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3460,7 +3460,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3461,7 +3461,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              }
  
          });

--- a/patches/server/0970-Configurable-damage-tick-when-blocking-with-shield.patch
+++ b/patches/server/0970-Configurable-damage-tick-when-blocking-with-shield.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable damage tick when blocking with shield
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ce686e5a98aea61979b842637ed6ebb97e64d2e1..cebb05310502cd1e2277896e75fddab268a3fdf1 100644
+index 6feab3d1b85857ab2c5b2228f2b0d5e6c2a5518d..ff7616e1d6d6c821a75649812ec69e0dc6a8e378 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2486,7 +2486,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2487,7 +2487,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                          CriteriaTriggers.PLAYER_HURT_ENTITY.trigger((ServerPlayer) damagesource.getEntity(), this, damagesource, originalDamage, f, true); // Paper - fix taken/dealt param order
                      }
  

--- a/patches/server/0978-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0978-Entity-Activation-Range-2.0.patch
@@ -87,10 +87,10 @@ index ce148cf5930cdcf0163c7f6416cbbd89e4d22720..cd00b534e4c527e0b4a5ad78cde87c22
  
              }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8f5a5d996ec55da00b843abde9ed3eb0438caa16..51b6642d0a0f1bf921cb895cf09ea64fddfc0da7 100644
+index 6ebd653ea3c302f26d02f81b6718924708148e4c..72dbee3795eb634b3ff3f063a226a1965bc988fb 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -420,6 +420,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -421,6 +421,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      // Spigot end
      protected int numCollisions = 0; // Paper - Cap entity collisions
      public boolean fromNetherPortal; // Paper - Add option to nerf pigmen from nether portals
@@ -99,7 +99,7 @@ index 8f5a5d996ec55da00b843abde9ed3eb0438caa16..51b6642d0a0f1bf921cb895cf09ea64f
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      // Paper start - Entity origin API
      @javax.annotation.Nullable
-@@ -992,6 +994,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -993,6 +995,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          } else {
              this.wasOnFire = this.isOnFire();
              if (type == MoverType.PISTON) {
@@ -108,7 +108,7 @@ index 8f5a5d996ec55da00b843abde9ed3eb0438caa16..51b6642d0a0f1bf921cb895cf09ea64f
                  movement = this.limitPistonMovement(movement);
                  if (movement.equals(Vec3.ZERO)) {
                      return;
-@@ -1006,6 +1010,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1007,6 +1011,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  this.stuckSpeedMultiplier = Vec3.ZERO;
                  this.setDeltaMovement(Vec3.ZERO);
              }

--- a/patches/server/0978-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0978-Entity-Activation-Range-2.0.patch
@@ -87,7 +87,7 @@ index ce148cf5930cdcf0163c7f6416cbbd89e4d22720..cd00b534e4c527e0b4a5ad78cde87c22
  
              }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e2322f361271712aca31c95b8b79cdf1c04945f2..4c76002af5eee553b92a026688c83ab36429fe4f 100644
+index 8f5a5d996ec55da00b843abde9ed3eb0438caa16..51b6642d0a0f1bf921cb895cf09ea64fddfc0da7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -420,6 +420,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -349,10 +349,10 @@ index 46afba838cf12eeb1bbccaa260131a76f090364b..e1c9a961064887070b29207efd7af478
                              }
                          }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 05ad15fc40ccb7feed5c51ad0ad0a98bd0d02af6..133bcf639a45bd7fa1a2d02410ea3e8568265007 100644
+index 964e3e81ab522ceebfceb651dfe3309d7b87c688..c1f753f7c4530a772fb408db83fc8c78675cbec2 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -1,26 +1,35 @@
+@@ -1,14 +1,22 @@
  package org.spigotmc;
  
 +import net.minecraft.core.BlockPos;
@@ -375,7 +375,8 @@ index 05ad15fc40ccb7feed5c51ad0ad0a98bd0d02af6..133bcf639a45bd7fa1a2d02410ea3e85
  import net.minecraft.world.entity.boss.EnderDragonPart;
  import net.minecraft.world.entity.boss.enderdragon.EndCrystal;
  import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
- import net.minecraft.world.entity.boss.wither.WitherBoss;
+@@ -16,12 +24,13 @@ import net.minecraft.world.entity.boss.wither.WitherBoss;
+ import net.minecraft.world.entity.item.ItemEntity;
  import net.minecraft.world.entity.item.PrimedTnt;
  import net.minecraft.world.entity.monster.Creeper;
 -import net.minecraft.world.entity.monster.Monster;
@@ -390,7 +391,7 @@ index 05ad15fc40ccb7feed5c51ad0ad0a98bd0d02af6..133bcf639a45bd7fa1a2d02410ea3e85
  import net.minecraft.world.entity.projectile.FireworkRocketEntity;
  import net.minecraft.world.entity.projectile.ThrowableProjectile;
  import net.minecraft.world.entity.projectile.ThrownTrident;
-@@ -43,6 +52,43 @@ public class ActivationRange
+@@ -44,6 +53,43 @@ public class ActivationRange
  
          AABB boundingBox = new AABB( 0, 0, 0, 0, 0, 0 );
      }
@@ -434,7 +435,7 @@ index 05ad15fc40ccb7feed5c51ad0ad0a98bd0d02af6..133bcf639a45bd7fa1a2d02410ea3e85
  
      static AABB maxBB = new AABB( 0, 0, 0, 0, 0, 0 );
  
-@@ -55,10 +101,13 @@ public class ActivationRange
+@@ -56,10 +102,13 @@ public class ActivationRange
       */
      public static ActivationType initializeEntityActivationType(Entity entity)
      {
@@ -449,7 +450,7 @@ index 05ad15fc40ccb7feed5c51ad0ad0a98bd0d02af6..133bcf639a45bd7fa1a2d02410ea3e85
          {
              return ActivationType.MONSTER;
          } else if ( entity instanceof PathfinderMob || entity instanceof AmbientCreature )
-@@ -79,10 +128,14 @@ public class ActivationRange
+@@ -80,10 +129,14 @@ public class ActivationRange
       */
      public static boolean initializeEntityActivationState(Entity entity, SpigotWorldConfig config)
      {
@@ -468,7 +469,7 @@ index 05ad15fc40ccb7feed5c51ad0ad0a98bd0d02af6..133bcf639a45bd7fa1a2d02410ea3e85
                  || entity instanceof Player
                  || entity instanceof ThrowableProjectile
                  || entity instanceof EnderDragon
-@@ -116,10 +169,25 @@ public class ActivationRange
+@@ -117,10 +170,25 @@ public class ActivationRange
          final int raiderActivationRange = world.spigotConfig.raiderActivationRange;
          final int animalActivationRange = world.spigotConfig.animalActivationRange;
          final int monsterActivationRange = world.spigotConfig.monsterActivationRange;
@@ -494,7 +495,7 @@ index 05ad15fc40ccb7feed5c51ad0ad0a98bd0d02af6..133bcf639a45bd7fa1a2d02410ea3e85
          maxRange = Math.min( ( world.spigotConfig.simulationDistance << 4 ) - 8, maxRange );
  
          for ( Player player : world.players() )
-@@ -130,13 +198,30 @@ public class ActivationRange
+@@ -131,13 +199,30 @@ public class ActivationRange
                  continue;
              }
  
@@ -531,7 +532,7 @@ index 05ad15fc40ccb7feed5c51ad0ad0a98bd0d02af6..133bcf639a45bd7fa1a2d02410ea3e85
          }
      }
  
-@@ -168,60 +253,118 @@ public class ActivationRange
+@@ -169,60 +254,118 @@ public class ActivationRange
       * @param entity
       * @return
       */
@@ -667,8 +668,8 @@ index 05ad15fc40ccb7feed5c51ad0ad0a98bd0d02af6..133bcf639a45bd7fa1a2d02410ea3e85
      }
  
      /**
-@@ -236,8 +379,19 @@ public class ActivationRange
-         if ( entity instanceof FireworkRocketEntity ) {
+@@ -237,8 +380,19 @@ public class ActivationRange
+         if (entity instanceof FireworkRocketEntity || (entity instanceof ItemEntity && (entity.tickCount + entity.getId() + 1) % 4 == 0)) {
              return true;
          }
 +        // Paper start - special case always immunities
@@ -688,7 +689,7 @@ index 05ad15fc40ccb7feed5c51ad0ad0a98bd0d02af6..133bcf639a45bd7fa1a2d02410ea3e85
  
          // Should this entity tick?
          if ( !isActive )
-@@ -245,11 +399,14 @@ public class ActivationRange
+@@ -246,11 +400,14 @@ public class ActivationRange
              if ( ( MinecraftServer.currentTick - entity.activatedTick - 1 ) % 20 == 0 )
              {
                  // Check immunities every 20 ticks.
@@ -705,8 +706,8 @@ index 05ad15fc40ccb7feed5c51ad0ad0a98bd0d02af6..133bcf639a45bd7fa1a2d02410ea3e85
                  }
 +                // Paper end
                  isActive = true;
-             } else if (entity instanceof net.minecraft.world.entity.item.ItemEntity && (entity.tickCount + entity.getId()) % 4 == 0) { // Paper - Needed for item gravity, see ItemEntity tick
-                 isActive = true;
+             }
+         }
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 index 2b263246135c85aa225120519e9702a628773935..2c408fa4abcbe1171c58aee8799c8cf7867d0f0a 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java

--- a/patches/server/0981-Optimize-Collision-to-not-load-chunks.patch
+++ b/patches/server/0981-Optimize-Collision-to-not-load-chunks.patch
@@ -14,7 +14,7 @@ movement will load only the chunk the player enters anyways and avoids loading
 massive amounts of surrounding chunks due to large AABB lookups.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 7097d87dead028c8dd44cefc97694bada93f608b..751fc4b0fe60c6d26ea0f768f3d66031a4bad963 100644
+index 3e03d65ac4ef267de67684d24c6f9c303b1a0bf0..b451842d6848af883cc3abf200f03c9a4680106c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -826,6 +826,7 @@ public abstract class PlayerList {
@@ -26,10 +26,10 @@ index 7097d87dead028c8dd44cefc97694bada93f608b..751fc4b0fe60c6d26ea0f768f3d66031
          if (teleporttransition.missingRespawnBlock()) {
              entityplayer1.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.NO_RESPAWN_BLOCK_AVAILABLE, 0.0F));
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4c76002af5eee553b92a026688c83ab36429fe4f..7fbaaed892b39ca920b15e08d6c44943a69a35d7 100644
+index 72dbee3795eb634b3ff3f063a226a1965bc988fb..430addbb5c3d84f4354a89a9ec8fa15bca4d2a60 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -258,6 +258,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -259,6 +259,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      // Paper end - Share random for entities to make them more random
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason; // Paper - Entity#getEntitySpawnReason
  

--- a/patches/server/0990-Check-distance-in-entity-interactions.patch
+++ b/patches/server/0990-Check-distance-in-entity-interactions.patch
@@ -17,7 +17,7 @@ index 57223285860f61119b6cf348aa78e59384a04e22..ccfe9ef24dce9f34613692adb13738d3
      };
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cebb05310502cd1e2277896e75fddab268a3fdf1..40697022b64100fcf7f5c079c6863cd0eabfb0b8 100644
+index ff7616e1d6d6c821a75649812ec69e0dc6a8e378..bd34c878d8ca6fb4e4f526761fd657b250c26d80 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1467,7 +1467,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -44,7 +44,7 @@ index cebb05310502cd1e2277896e75fddab268a3fdf1..40697022b64100fcf7f5c079c6863cd0
  
                      this.knockback(0.4000000059604645D, d0, d1, entity1, entity1 == null ? io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.DAMAGE : io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.ENTITY_ATTACK); // CraftBukkit // Paper - knockback events
                      if (!flag) {
-@@ -2426,7 +2434,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2427,7 +2435,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  this.hurtCurrentlyUsedShield((float) -event.getDamage(DamageModifier.BLOCKING));
                  Entity entity = damagesource.getDirectEntity();
  

--- a/patches/server/0992-Properly-resend-entities.patch
+++ b/patches/server/0992-Properly-resend-entities.patch
@@ -134,10 +134,10 @@ index b451842d6848af883cc3abf200f03c9a4680106c..88299abf563a041ade1683b66b43103b
  
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 87155c6536e5d4c6f1c4e6a74609314dac2777e9..99a09fcbf5dde07d484d6193434017ef17e8c11a 100644
+index 430addbb5c3d84f4354a89a9ec8fa15bca4d2a60..7093a7383c93f172fb7674799d7efe4c563fc99c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -598,13 +598,45 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -599,13 +599,45 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      // CraftBukkit start
      public void refreshEntityData(ServerPlayer to) {

--- a/patches/server/0992-Properly-resend-entities.patch
+++ b/patches/server/0992-Properly-resend-entities.patch
@@ -102,7 +102,7 @@ index da719576b2c7e992b74266c7fbe5c9728d238dcf..c93aa97abd46b3ad87e284feac51487e
                              }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 751fc4b0fe60c6d26ea0f768f3d66031a4bad963..700ab5ef2f8ab1466c4f659cd34679dc809efbaf 100644
+index b451842d6848af883cc3abf200f03c9a4680106c..88299abf563a041ade1683b66b43103b0eeeea0d 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -396,7 +396,7 @@ public abstract class PlayerList {
@@ -134,7 +134,7 @@ index 751fc4b0fe60c6d26ea0f768f3d66031a4bad963..700ab5ef2f8ab1466c4f659cd34679dc
  
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7fbaaed892b39ca920b15e08d6c44943a69a35d7..ddfc4818f091802e5999c6b99e5bc57c6f370648 100644
+index 87155c6536e5d4c6f1c4e6a74609314dac2777e9..99a09fcbf5dde07d484d6193434017ef17e8c11a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -598,13 +598,45 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -186,10 +186,10 @@ index 7fbaaed892b39ca920b15e08d6c44943a69a35d7..ddfc4818f091802e5999c6b99e5bc57c
      public boolean equals(Object object) {
          return object instanceof Entity ? ((Entity) object).id == this.id : false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 40697022b64100fcf7f5c079c6863cd0eabfb0b8..61d4515cce2b5ed73a2202d43b8f96bb63b9a459 100644
+index bd34c878d8ca6fb4e4f526761fd657b250c26d80..016be3addd3bf0ae3dd5f6094de3902206c5b43a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4029,6 +4029,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4030,6 +4030,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 2) > 0 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
      }
  

--- a/patches/server/0993-Registry-Modification-API.patch
+++ b/patches/server/0993-Registry-Modification-API.patch
@@ -9,7 +9,7 @@ public net.minecraft.resources.RegistryOps lookupProvider
 public net.minecraft.resources.RegistryOps$HolderLookupAdapter
 
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-index b5df90b500a64ee3ba1026fa3449ca6441293367..36bc8d005de14622eb8a0bf4736d964276c95344 100644
+index 39120c63ed25d45a4083523fbfe79d871f4d892e..f563e6e7a558d22f571154640e99cc86718c89f5 100644
 --- a/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 @@ -2,6 +2,7 @@ package io.papermc.paper.registry;
@@ -20,7 +20,7 @@ index b5df90b500a64ee3ba1026fa3449ca6441293367..36bc8d005de14622eb8a0bf4736d9642
  import java.util.Collections;
  import java.util.IdentityHashMap;
  import java.util.List;
-@@ -64,6 +65,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
+@@ -68,6 +69,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
  
  import static io.papermc.paper.registry.entry.RegistryEntry.apiOnly;
  import static io.papermc.paper.registry.entry.RegistryEntry.entry;
@@ -28,7 +28,7 @@ index b5df90b500a64ee3ba1026fa3449ca6441293367..36bc8d005de14622eb8a0bf4736d9642
  
  @DefaultQualifier(NonNull.class)
  public final class PaperRegistries {
-@@ -147,6 +149,15 @@ public final class PaperRegistries {
+@@ -151,6 +153,15 @@ public final class PaperRegistries {
          return ResourceKey.create((ResourceKey<? extends Registry<M>>) PaperRegistries.registryToNms(typedKey.registryKey()), PaperAdventure.asVanilla(typedKey.key()));
      }
  
@@ -1323,10 +1323,10 @@ index 6fddef967b6314ca0158f5bd4b8898670ea5e9ec..b5ca1a0acb16d0cd8dccc854f309d425
              return writableRegistry;
          }, prepareExecutor);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-index 9245f6de141384bfc12e8dd81ce1df366c6a62aa..d97ddbcb5efdae5f848c77bee52058b16316b3dc 100644
+index 45c78c113e881b277e1216293ad918ee40b44325..8314059455d91f01b986c5c0a239f41817834bd6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
-@@ -162,11 +162,11 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -164,11 +164,11 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
      private final Map<NamespacedKey, B> cache = new HashMap<>();
      private final Map<B, NamespacedKey> byValue = new java.util.IdentityHashMap<>(); // Paper - improve Registry
      private final net.minecraft.core.Registry<M> minecraftRegistry;
@@ -1340,7 +1340,7 @@ index 9245f6de141384bfc12e8dd81ce1df366c6a62aa..d97ddbcb5efdae5f848c77bee52058b1
          this.bukkitClass = bukkitClass;
          this.minecraftRegistry = minecraftRegistry;
          this.minecraftToBukkit = minecraftToBukkit;
-@@ -249,4 +249,17 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+@@ -251,4 +251,17 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
          return this.byValue.get(value);
      }
      // Paper end - improve Registry

--- a/patches/server/0994-Add-registry-entry-and-builders.patch
+++ b/patches/server/0994-Add-registry-entry-and-builders.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add registry entry and builders
 
 
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-index 3c48848a2628d07c470425d1c70d10b45db346a1..97fceb4de04d6756bd9b18b650e3325f21854f40 100644
+index f563e6e7a558d22f571154640e99cc86718c89f5..a2d26151b5d1ae413e1e588520ecf13fe479de94 100644
 --- a/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 @@ -1,6 +1,8 @@
@@ -17,7 +17,7 @@ index 3c48848a2628d07c470425d1c70d10b45db346a1..97fceb4de04d6756bd9b18b650e3325f
  import io.papermc.paper.registry.entry.RegistryEntry;
  import io.papermc.paper.registry.tag.TagKey;
  import java.util.Collections;
-@@ -76,7 +78,7 @@ public final class PaperRegistries {
+@@ -80,7 +82,7 @@ public final class PaperRegistries {
      static {
          REGISTRY_ENTRIES = List.of(
              // built-ins
@@ -26,7 +26,7 @@ index 3c48848a2628d07c470425d1c70d10b45db346a1..97fceb4de04d6756bd9b18b650e3325f
              entry(Registries.STRUCTURE_TYPE, RegistryKey.STRUCTURE_TYPE, StructureType.class, CraftStructureType::new),
              entry(Registries.INSTRUMENT, RegistryKey.INSTRUMENT, MusicInstrument.class, CraftMusicInstrument::new),
              entry(Registries.MOB_EFFECT, RegistryKey.MOB_EFFECT, PotionEffectType.class, CraftPotionEffectType::new),
-@@ -98,7 +100,7 @@ public final class PaperRegistries {
+@@ -103,7 +105,7 @@ public final class PaperRegistries {
              entry(Registries.TRIM_PATTERN, RegistryKey.TRIM_PATTERN, TrimPattern.class, CraftTrimPattern::new).delayed(),
              entry(Registries.DAMAGE_TYPE, RegistryKey.DAMAGE_TYPE, DamageType.class, CraftDamageType::new).delayed(),
              entry(Registries.WOLF_VARIANT, RegistryKey.WOLF_VARIANT, Wolf.Variant.class, CraftWolf.CraftVariant::new).delayed(),
@@ -34,7 +34,7 @@ index 3c48848a2628d07c470425d1c70d10b45db346a1..97fceb4de04d6756bd9b18b650e3325f
 +            writable(Registries.ENCHANTMENT, RegistryKey.ENCHANTMENT, Enchantment.class, CraftEnchantment::new, PaperEnchantmentRegistryEntry.PaperBuilder::new).withSerializationUpdater(FieldRename.ENCHANTMENT_RENAME).delayed(),
              entry(Registries.JUKEBOX_SONG, RegistryKey.JUKEBOX_SONG, JukeboxSong.class, CraftJukeboxSong::new).delayed(),
              entry(Registries.BANNER_PATTERN, RegistryKey.BANNER_PATTERN, PatternType.class, CraftPatternType::new).delayed(),
- 
+             entry(Registries.PAINTING_VARIANT, RegistryKey.PAINTING_VARIANT, Art.class, CraftArt::new).delayed(),
 diff --git a/src/main/java/io/papermc/paper/registry/data/PaperEnchantmentRegistryEntry.java b/src/main/java/io/papermc/paper/registry/data/PaperEnchantmentRegistryEntry.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..481f5f0cfae1fada3bc3f873fb7e04c3086ea9bf

--- a/patches/server/1032-Void-damage-configuration-API.patch
+++ b/patches/server/1032-Void-damage-configuration-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Void damage configuration API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 99a09fcbf5dde07d484d6193434017ef17e8c11a..0b7aea178cd6097a7dfefd1435b70333c6a2e0ff 100644
+index 7093a7383c93f172fb7674799d7efe4c563fc99c..ed276c599890d9db11130d8ae0844ca364a824a6 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -853,8 +853,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -854,8 +854,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void checkBelowWorld() {

--- a/patches/server/1032-Void-damage-configuration-API.patch
+++ b/patches/server/1032-Void-damage-configuration-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Void damage configuration API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ddfc4818f091802e5999c6b99e5bc57c6f370648..e5466be840ef32e4fa17c0e9446c4d0b30a56e26 100644
+index 99a09fcbf5dde07d484d6193434017ef17e8c11a..0b7aea178cd6097a7dfefd1435b70333c6a2e0ff 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -853,8 +853,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -20,10 +20,10 @@ index ddfc4818f091802e5999c6b99e5bc57c6f370648..e5466be840ef32e4fa17c0e9446c4d0b
              && (!(this instanceof Player player) || !player.getAbilities().invulnerable))) {
              // Paper end - Configurable nether ceiling damage
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4d75ce205d5a0d61780936aa522710f5f753b271..22bb0aaf3aebdc60a8894dc473cbeb0e58ca37b8 100644
+index 99c98a91fe7471791fca8233acf6eeba516b10ed..4836b01323abb125289982ef3ceca09d6a9cfc3b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2700,7 +2700,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2701,7 +2701,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      @Override
      protected void onBelowWorld() {

--- a/patches/server/1038-Moonrise-optimisation-patches.patch
+++ b/patches/server/1038-Moonrise-optimisation-patches.patch
@@ -28026,7 +28026,7 @@ index b7d29389a357f142237cecd75f8ca91cf1eb6b5b..e4b0dc3121101d54394a0c3a413dabf8
          this.generatingStep = generationStep;
          this.cache = chunks;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 700ab5ef2f8ab1466c4f659cd34679dc809efbaf..b28b23c69512b054e856388f2f94d27d35347b8c 100644
+index 88299abf563a041ade1683b66b43103b0eeeea0d..61f3ee42aaad1641c92df3eb60d699b9dd5679e3 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1420,7 +1420,7 @@ public abstract class PlayerList {
@@ -28416,10 +28416,10 @@ index 50040c497a819cd1229042ab3cb057d34a32cacc..1f9c436a632e4f110be61cf76fcfc3b7
 +    // Paper end - block counting
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0b7aea178cd6097a7dfefd1435b70333c6a2e0ff..6cdb0460c2d232f022ee6ea8dcbe4dcb69b63c75 100644
+index ed276c599890d9db11130d8ae0844ca364a824a6..86e3d37ac9b4d5efe240c07289f88a070543b30d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -175,7 +175,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;
+@@ -176,7 +176,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;
  import org.bukkit.plugin.PluginManager;
  // CraftBukkit end
  
@@ -28428,7 +28428,7 @@ index 0b7aea178cd6097a7dfefd1435b70333c6a2e0ff..6cdb0460c2d232f022ee6ea8dcbe4dcb
  
      // CraftBukkit start
      private static final int CURRENT_LEVEL = 2;
-@@ -460,6 +460,156 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -461,6 +461,156 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return this.dimensions.makeBoundingBox(x, y, z);
      }
      // Paper end
@@ -28585,7 +28585,7 @@ index 0b7aea178cd6097a7dfefd1435b70333c6a2e0ff..6cdb0460c2d232f022ee6ea8dcbe4dcb
  
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
-@@ -1365,41 +1515,76 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1366,41 +1516,76 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      private Vec3 collide(Vec3 movement) {
@@ -28690,7 +28690,7 @@ index 0b7aea178cd6097a7dfefd1435b70333c6a2e0ff..6cdb0460c2d232f022ee6ea8dcbe4dcb
      }
  
      private static float[] collectCandidateStepUpHeights(AABB collisionBox, List<VoxelShape> collisions, float f, float stepHeight) {
-@@ -2787,18 +2972,110 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2788,18 +2973,110 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean isInWall() {
@@ -28808,7 +28808,7 @@ index 0b7aea178cd6097a7dfefd1435b70333c6a2e0ff..6cdb0460c2d232f022ee6ea8dcbe4dcb
      }
  
      public InteractionResult interact(Player player, InteractionHand hand) {
-@@ -4271,14 +4548,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4272,14 +4549,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public Iterable<Entity> getIndirectPassengers() {
@@ -28833,7 +28833,7 @@ index 0b7aea178cd6097a7dfefd1435b70333c6a2e0ff..6cdb0460c2d232f022ee6ea8dcbe4dcb
      }
      private Iterable<Entity> getIndirectPassengers_old() {
          // Paper end - Optimize indirect passenger iteration
-@@ -4407,82 +4687,136 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4437,82 +4717,136 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return Mth.lerp(delta, this.yRotO, this.yRot);
      }
  
@@ -29028,7 +29028,7 @@ index 0b7aea178cd6097a7dfefd1435b70333c6a2e0ff..6cdb0460c2d232f022ee6ea8dcbe4dcb
  
      public boolean touchingUnloadedChunk() {
          AABB axisalignedbb = this.getBoundingBox().inflate(1.0D);
-@@ -4634,6 +4968,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4664,6 +4998,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.setPosRaw(x, y, z, false);
      }
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
@@ -29044,7 +29044,7 @@ index 0b7aea178cd6097a7dfefd1435b70333c6a2e0ff..6cdb0460c2d232f022ee6ea8dcbe4dcb
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4763,6 +5106,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4793,6 +5136,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
      public final void setRemoved(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
@@ -29057,7 +29057,7 @@ index 0b7aea178cd6097a7dfefd1435b70333c6a2e0ff..6cdb0460c2d232f022ee6ea8dcbe4dcb
          CraftEventFactory.callEntityRemoveEvent(this, cause);
          // CraftBukkit end
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
-@@ -4774,7 +5123,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4804,7 +5153,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              this.stopRiding();
          }
  
@@ -29066,7 +29066,7 @@ index 0b7aea178cd6097a7dfefd1435b70333c6a2e0ff..6cdb0460c2d232f022ee6ea8dcbe4dcb
          this.levelCallback.onRemove(entity_removalreason);
          this.onRemoval(entity_removalreason);
          // Paper start - Folia schedulers
-@@ -4806,7 +5155,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4836,7 +5185,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
      public boolean shouldBeSaved() {
@@ -36006,7 +36006,7 @@ index f65cc95ab28e8a3b21eac2b16bd9ebe97e56e571..0074bc0e7147dc3a8c538e796f14ac9b
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 02ee599dff305d63b44c724a2f6807d91362f675..97ebe3852f34b88e727083b539d94de62dc1ca80 100644
+index 4a1fa5b7597a06e57619bbc336d8ca117bc6f5b2..c814b68933155fe7391b325260052d9affb6841c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1432,7 +1432,7 @@ public final class CraftServer implements Server {

--- a/patches/server/1043-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/1043-Detail-more-information-in-watchdog-dumps.patch
@@ -121,10 +121,10 @@ index 70efc63102b3d3727be376d42f1bef70174468a3..7b936a01888d71fe305863054471b6b4
  
      private void tickPassenger(Entity vehicle, Entity passenger, boolean isActive) { // Paper - EAR 2
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 88543de6e51acbe76b89aef4a84de20337d616e4..6574219da33a7b9a4906883e65b78d7806f6e67b 100644
+index 86e3d37ac9b4d5efe240c07289f88a070543b30d..a0876d3f88620bb24ef69101fc67b0dcd5dca0d2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1171,8 +1171,43 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1172,8 +1172,43 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return this.onGround;
      }
  
@@ -168,7 +168,7 @@ index 88543de6e51acbe76b89aef4a84de20337d616e4..6574219da33a7b9a4906883e65b78d78
          if (this.noPhysics) {
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
          } else {
-@@ -1293,6 +1328,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1294,6 +1329,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  gameprofilerfiller.pop();
              }
          }
@@ -182,7 +182,7 @@ index 88543de6e51acbe76b89aef4a84de20337d616e4..6574219da33a7b9a4906883e65b78d78
      }
  
      private void applyMovementEmissionAndPlaySound(Entity.MovementEmission moveEffect, Vec3 movement, BlockPos landingPos, BlockState landingState) {
-@@ -4886,7 +4928,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4916,7 +4958,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void setDeltaMovement(Vec3 velocity) {
@@ -192,7 +192,7 @@ index 88543de6e51acbe76b89aef4a84de20337d616e4..6574219da33a7b9a4906883e65b78d78
      }
  
      public void addDeltaMovement(Vec3 velocity) {
-@@ -4992,7 +5036,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -5022,7 +5066,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          }
          // Paper end - Fix MC-4
          if (this.position.x != x || this.position.y != y || this.position.z != z) {

--- a/patches/server/1051-Lag-compensation-ticks.patch
+++ b/patches/server/1051-Lag-compensation-ticks.patch
@@ -8,7 +8,7 @@ Areas affected by lag comepnsation:
  - Eating food items
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 196d7ffb8b362873f93224ccdd37e7efc656fd78..9dfa6bb83469620a446509656ea1ad140b2e683f 100644
+index b33b68649e67de08719b30e98650c84f4c3c18d6..e636a96ea6220fda671a31d3d9cdea468a558768 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -331,6 +331,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -63,10 +63,10 @@ index 504c996220b278c194c93e001a3b326d549868ec..a96f859a5d0c6ec692d4627a69f3c9ee
  
          if (this.hasDelayedDestroy) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 22bb0aaf3aebdc60a8894dc473cbeb0e58ca37b8..9c61225a728a2ca91a1c71dead75fc7cd93668b6 100644
+index 4836b01323abb125289982ef3ceca09d6a9cfc3b..e86314de8d908a0c3e9f17d3e163c11180cf3f59 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4050,6 +4050,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4051,6 +4051,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
          this.resendPossiblyDesyncedDataValues(java.util.List.of(DATA_LIVING_ENTITY_FLAGS), serverPlayer);
      }
      // Paper end - Properly cancel usable items
@@ -77,7 +77,7 @@ index 22bb0aaf3aebdc60a8894dc473cbeb0e58ca37b8..9c61225a728a2ca91a1c71dead75fc7c
      private void updatingUsingItem() {
          if (this.isUsingItem()) {
              if (ItemStack.isSameItem(this.getItemInHand(this.getUsedItemHand()), this.useItem)) {
-@@ -4064,7 +4068,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4065,7 +4069,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      protected void updateUsingItem(ItemStack stack) {
          stack.onUseTick(this.level(), this, this.getUseItemRemainingTicks());
@@ -91,7 +91,7 @@ index 22bb0aaf3aebdc60a8894dc473cbeb0e58ca37b8..9c61225a728a2ca91a1c71dead75fc7c
              this.completeUsingItem();
          }
  
-@@ -4102,7 +4111,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4103,7 +4112,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
          if (!itemstack.isEmpty() && !this.isUsingItem() || forceUpdate) { // Paper - Prevent consuming the wrong itemstack
              this.useItem = itemstack;
@@ -103,7 +103,7 @@ index 22bb0aaf3aebdc60a8894dc473cbeb0e58ca37b8..9c61225a728a2ca91a1c71dead75fc7c
              if (!this.level().isClientSide) {
                  this.setLivingEntityFlag(1, true);
                  this.setLivingEntityFlag(2, hand == InteractionHand.OFF_HAND);
-@@ -4127,7 +4139,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4128,7 +4140,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  }
              } else if (!this.isUsingItem() && !this.useItem.isEmpty()) {
                  this.useItem = ItemStack.EMPTY;
@@ -115,7 +115,7 @@ index 22bb0aaf3aebdc60a8894dc473cbeb0e58ca37b8..9c61225a728a2ca91a1c71dead75fc7c
              }
          }
  
-@@ -4258,7 +4273,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4259,7 +4274,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
          }
  
          this.useItem = ItemStack.EMPTY;


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
fc496179 Fix InstrumentTest
7c0ec598 PR-1075: Make Art an interface
c389f5a4 PR-1074: Make Sound an interface

CraftBukkit Changes:
a0f3d4e50 SPIGOT-7940: Recipe book errors after reload
9e0618ec2 SPIGOT-7937: Cannot spawn minecart during world generation with minecart_improvements enabled
1eb4d28da SPIGOT-7941: Fix resistance over 4 amplify causing issues in damage
52b99158a PR-1504: Make Art an interface
e18ae35f1 PR-1502: Make Sound an interface

Spigot Changes:
e65d67a7 SPIGOT-7934: Item entities start "bouncing" under certain conditions