### PR TITLE
Fix below-zero-generation-in-existing-chunks

### DIFF
--- a/patches/server/1060-Fix-belowZeroGenerationInExistingChunks.patch
+++ b/patches/server/1060-Fix-belowZeroGenerationInExistingChunks.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tamion <70228790+notTamion@users.noreply.github.com>
+Date: Sun, 3 Nov 2024 11:26:10 +0100
+Subject: [PATCH] Fix belowZeroGenerationInExistingChunks
+
+
+diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkStorage.java b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkStorage.java
+index 46f4b6706a1ca24ff6fc28960ad01a067109819f..44669ff294abed89aa39b33427eb5414e49df6e3 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkStorage.java
++++ b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkStorage.java
+@@ -123,7 +123,10 @@ public class ChunkStorage implements AutoCloseable, ca.spottedleaf.moonrise.patc
+                 boolean belowZeroGenerationInExistingChunks = (generatoraccess != null) ? ((ServerLevel) generatoraccess).spigotConfig.belowZeroGenerationInExistingChunks : org.spigotmc.SpigotConfig.belowZeroGenerationInExistingChunks;
+ 
+                 if (i <= 2730 && !belowZeroGenerationInExistingChunks) {
+-                    stopBelowZero = "full".equals(nbttagcompound.getCompound("Level").getString("Status"));
++                    // Paper start - Fix belowZeroGenerationInExistingChunks
++                    String status = nbttagcompound.getCompound("Level").getString("Status");
++                    stopBelowZero = "full".equals(status) || "mobs_spawned".equals(status);
++                    // Paper end - Fix belowZeroGenerationInExistingChunks
+                 }
+                 // Spigot end
+ 


### PR DESCRIPTION
fixes #11531 
i am not entirely sure what exactly is happening here. my best guess is that the chunk status "full" didn't yet exist in older versions and fully generated chunks were just left on "mobs_spawned".