### PR TITLE
Correctly adopt upstream item EAR fix

### DIFF
--- a/patches/server/0302-Fix-item-EAR-ticks.patch
+++ b/patches/server/0302-Fix-item-EAR-ticks.patch
@@ -21,9 +21,18 @@ index 75ebf09777e19645eee296a9edabac39c858ffb9..c21fa55c62d97d9511e41a1e313e9043
                  this.applyEffectsFromBlocks();
                  float f = 0.98F;
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index bd522080d17b5b470ec3ab42aa4ecc3082248c8a..964e3e81ab522ceebfceb651dfe3309d7b87c688 100644
+index bd522080d17b5b470ec3ab42aa4ecc3082248c8a..84ff1210e944ea9d1ec88874d218458773e341c9 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
+@@ -234,7 +234,7 @@ public class ActivationRange
+     public static boolean checkIfActive(Entity entity)
+     {
+         // Never safe to skip fireworks or item gravity
+-        if (entity instanceof FireworkRocketEntity || (entity instanceof ItemEntity && (entity.tickCount + entity.getId() + 1) % 4 == 0)) {
++        if (entity instanceof FireworkRocketEntity || (entity instanceof ItemEntity && (entity.tickCount + entity.getId()) % 4 == 0)) { // Paper - Needed for item gravity, see ItemEntity tick
+             return true;
+         }
+ 
 @@ -253,11 +253,8 @@ public class ActivationRange
                  }
                  isActive = true;

--- a/patches/server/0978-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0978-Entity-Activation-Range-2.0.patch
@@ -349,7 +349,7 @@ index 46afba838cf12eeb1bbccaa260131a76f090364b..e1c9a961064887070b29207efd7af478
                              }
                          }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 964e3e81ab522ceebfceb651dfe3309d7b87c688..c1f753f7c4530a772fb408db83fc8c78675cbec2 100644
+index 84ff1210e944ea9d1ec88874d218458773e341c9..bd7c37123c70d2afdef252f39548725d4ef318ed 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -1,14 +1,22 @@
@@ -669,7 +669,7 @@ index 964e3e81ab522ceebfceb651dfe3309d7b87c688..c1f753f7c4530a772fb408db83fc8c78
  
      /**
 @@ -237,8 +380,19 @@ public class ActivationRange
-         if (entity instanceof FireworkRocketEntity || (entity instanceof ItemEntity && (entity.tickCount + entity.getId() + 1) % 4 == 0)) {
+         if (entity instanceof FireworkRocketEntity || (entity instanceof ItemEntity && (entity.tickCount + entity.getId()) % 4 == 0)) { // Paper - Needed for item gravity, see ItemEntity tick
              return true;
          }
 +        // Paper start - special case always immunities


### PR DESCRIPTION
EAR 2 evaluates the entities activity on the already incremented entity
tick. This diverges from spigots behaviour and hence needed adoption for
their item ear fix.
