### PR TITLE
Optimize Player#canSee

### DIFF
--- a/patches/server/1060-Optimize-Player-canSee.patch
+++ b/patches/server/1060-Optimize-Player-canSee.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Luedtke <david@ldtke.de>
+Date: Fri, 8 Nov 2024 20:23:41 +0100
+Subject: [PATCH] Optimize Player#canSee
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 2c7ec674f55b3178b9dcba7f2bc1ff5efccb50ea..d40dde6516ff9aff6f08ddd6ec6a118ab095689b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -205,7 +205,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     private boolean hasPlayedBefore = false;
+     private final ConversationTracker conversationTracker = new ConversationTracker();
+     private final Set<String> channels = new HashSet<String>();
+-    private final Map<UUID, Set<WeakReference<Plugin>>> invertedVisibilityEntities = new HashMap<>();
++    private final Map<UUID, Set<WeakReference<Plugin>>> invertedVisibilityEntities = new it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap<>(); // Paper - Perf: Replace HashMap with Object2ObjectOpenHashMap
+     private final Set<UUID> unlistedEntities = new HashSet<>(); // Paper - Add Listing API for Player
+     private static final WeakHashMap<Plugin, WeakReference<Plugin>> pluginWeakReferences = new WeakHashMap<>();
+     private int hash = 0;


### PR DESCRIPTION
Replaces the `invertedVisibilityEntities` HashMap with an `OpenHashMap` for better performance in `Player#canSee`.