### PR TITLE
Call CraftPlayer#onEntityRemove for all online players

### DIFF
--- a/patches/server/1060-Call-CraftPlayer-onEntityRemove-for-all-online-playe.patch
+++ b/patches/server/1060-Call-CraftPlayer-onEntityRemove-for-all-online-playe.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gero <gecam59@gmail.com>
+Date: Sat, 9 Nov 2024 22:27:58 +0100
+Subject: [PATCH] Call CraftPlayer#onEntityRemove for all online players
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 5964d601c05176f48167cc92057a59e52a4da92b..3204497dea30365d7d23bb877af811248168afbf 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -2780,7 +2780,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+             // CraftBukkit start
+             entity.valid = false;
+             if (!(entity instanceof ServerPlayer)) {
+-                for (ServerPlayer player : ServerLevel.this.players) {
++                for (ServerPlayer player : server.getPlayerList().players) {
+                     player.getBukkitEntity().onEntityRemove(entity);
+                 }
+             }


### PR DESCRIPTION
This caused leaking of UUIDs in CraftPlayer#invertedVisibilityEntities