### PR TITLE
only init key-pair if needed

### DIFF
--- a/patches/server/1062-only-init-key-pair-if-needed.patch
+++ b/patches/server/1062-only-init-key-pair-if-needed.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aaron <bauhd@gmx.net>
+Date: Sat, 9 Nov 2024 23:44:47 +0100
+Subject: [PATCH] only init key-pair if needed
+
+
+diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+index 17a158ff6ce6520b69a5a0032ba4c05449dd0cf8..0337754cc88d50edae4c21a833afab9e11826d0a 100644
+--- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -271,7 +271,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         }
+         // Paper end - Unix domain socket support
+ 
+-        this.initializeKeyPair();
++        if (this.usesAuthentication()) this.initializeKeyPair(); // Paper - skip key pair, if not needed
+         DedicatedServer.LOGGER.info("Starting Minecraft server on {}:{}", this.getLocalIp().isEmpty() ? "*" : this.getLocalIp(), this.getPort());
+ 
+         try {


### PR DESCRIPTION
Only init the key-pair if needed, to save up some time and heap space.