### PR TITLE
Support tags for more SimpleRegistry

### DIFF
--- a/patches/api/0236-Add-RegistryAccess-for-managing-registries.patch
+++ b/patches/api/0236-Add-RegistryAccess-for-managing-registries.patch
@@ -206,8 +206,45 @@ index 3470755c65a2db38e679adc35d3d43f7fef5468d..1fe3a5e2f5c15fddfbcd503a061ebf75
      public static <T extends Keyed> Registry<T> getRegistry(@NotNull Class<T> tClass) {
          return server.getRegistry(tClass);
      }
+diff --git a/src/main/java/org/bukkit/Particle.java b/src/main/java/org/bukkit/Particle.java
+index 37e7862be843da4f48ac061fb1625854fd671b2a..cdc09d18088af3100cb731702edb7e6bffdeb502 100644
+--- a/src/main/java/org/bukkit/Particle.java
++++ b/src/main/java/org/bukkit/Particle.java
+@@ -162,28 +162,23 @@ public enum Particle implements Keyed {
+ 
+     private final NamespacedKey key;
+     private final Class<?> dataType;
+-    final boolean register;
++    // Paper - all particles are registered
+ 
+     Particle(String key) {
+         this(key, Void.class);
+     }
+ 
+-    Particle(String key, boolean register) {
+-        this(key, Void.class, register);
+-    }
++    // Paper - all particles are registered
+ 
+     Particle(String key, /*@NotNull*/ Class<?> data) {
+-        this(key, data, true);
+-    }
+-
+-    Particle(String key, /*@NotNull*/ Class<?> data, boolean register) {
++        // Paper - all particles are registered
+         if (key != null) {
+             this.key = NamespacedKey.minecraft(key);
+         } else {
+             this.key = null;
+         }
+         dataType = data;
+-        this.register = register;
++        // Paper - all particles are registered
+     }
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..46dce7c2a543f6b165975565ea9d40654a132b9b 100644
+index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..d03bdf6617ce66950e335f0afb52c19b2e2a14e2 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
 @@ -86,26 +86,32 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
@@ -256,7 +293,7 @@ index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..46dce7c2a543f6b165975565ea9d4065
      /**
       * Custom boss bars.
       *
-@@ -155,13 +161,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -155,25 +161,29 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @see Cat.Type
       */
@@ -274,7 +311,11 @@ index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..46dce7c2a543f6b165975565ea9d4065
      /**
       * Server entity types.
       *
-@@ -172,8 +180,10 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      * @see EntityType
+      */
+-    Registry<EntityType> ENTITY_TYPE = new SimpleRegistry<>(EntityType.class, (entity) -> entity != EntityType.UNKNOWN);
++    Registry<EntityType> ENTITY_TYPE = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.ENTITY_TYPE); // Paper
+     /**
       * Server instruments.
       *
       * @see MusicInstrument
@@ -295,7 +336,7 @@ index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..46dce7c2a543f6b165975565ea9d4065
      /**
       * Default server loot tables.
       *
-@@ -200,13 +210,13 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -200,25 +210,25 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * @see MenuType
       */
      @ApiStatus.Experimental
@@ -310,6 +351,20 @@ index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..46dce7c2a543f6b165975565ea9d4065
 +    Registry<PotionEffectType> EFFECT = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.MOB_EFFECT); // Paper
      /**
       * Server particles.
+      *
+      * @see Particle
+      */
+-    Registry<Particle> PARTICLE_TYPE = new SimpleRegistry<>(Particle.class, (par) -> par.register);
++    Registry<Particle> PARTICLE_TYPE = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.PARTICLE_TYPE); // Paper
+     /**
+      * Server potions.
+      *
+      * @see PotionType
+      */
+-    Registry<PotionType> POTION = new SimpleRegistry<>(PotionType.class);
++    Registry<PotionType> POTION = io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(io.papermc.paper.registry.RegistryKey.POTION); // Paper
+     /**
+      * Server statistics.
       *
 @@ -229,58 +239,67 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * Server structures.
@@ -428,6 +483,15 @@ index b4f297f90e3c1deaa1fc3f4418418588ab19b6c5..46dce7c2a543f6b165975565ea9d4065
      /**
       * Get the object by its key.
       *
+@@ -396,7 +417,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+         return (namespacedKey != null) ? get(namespacedKey) : null;
+     }
+ 
+-    static final class SimpleRegistry<T extends Enum<T> & Keyed> implements Registry<T> {
++    class SimpleRegistry<T extends Enum<T> & Keyed> implements Registry<T> { // Paper - remove final
+ 
+         private final Class<T> type;
+         private final Map<NamespacedKey, T> map;
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
 index 6bc43f3a5748a1b83aa4c4d462df3cbc9220c267..cad9c18dbe56ffcef377f0b1162bc880fc56aa6c 100644
 --- a/src/main/java/org/bukkit/Server.java

--- a/patches/api/0471-Registry-Modification-API.patch
+++ b/patches/api/0471-Registry-Modification-API.patch
@@ -809,7 +809,7 @@ index 0000000000000000000000000000000000000000..bf49125acc8a0508bf59674bba3ed350
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 67b9ab322baecf5b2453df4795106514cb073108..7cf7c6d05aa6cbf3f0c8612831404552c6a7b84a 100644
+index c3d49f9c640eb390f507f9521a389cb7c172983a..87907918c42b11780b285b6d82e7297628a07376 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
 @@ -384,6 +384,27 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
@@ -875,38 +875,3 @@ index 67b9ab322baecf5b2453df4795106514cb073108..7cf7c6d05aa6cbf3f0c8612831404552
      /**
       * Get the object by its key.
       *
-@@ -561,5 +610,23 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
-             return value.getKey();
-         }
-         // Paper end - improve Registry
-+
-+        // Paper start - RegistrySet API
-+        @SuppressWarnings("deprecation")
-+        @Override
-+        public boolean hasTag(final io.papermc.paper.registry.tag.@NotNull TagKey<T> key) {
-+            return Bukkit.getUnsafe().getTag(key) != null;
-+        }
-+
-+        @SuppressWarnings("deprecation")
-+        @Override
-+        public io.papermc.paper.registry.tag.@NotNull Tag<T> getTag(final io.papermc.paper.registry.tag.@NotNull TagKey<T> key) {
-+            final io.papermc.paper.registry.tag.Tag<T> tag = Bukkit.getUnsafe().getTag(key);
-+            if (tag == null) {
-+                throw new java.util.NoSuchElementException("No tag " + key + " found");
-+            }
-+            return tag;
-+        }
-+        // Paper end - RegistrySet API
-     }
- }
-diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index b503b5e13c51580367d53939ad4c19a7718c22ce..5b13617e497e847ef66214f9140aea0cd41f4c4f 100644
---- a/src/main/java/org/bukkit/UnsafeValues.java
-+++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -281,4 +281,6 @@ public interface UnsafeValues {
-     // Paper end - lifecycle event API
- 
-     @NotNull java.util.List<net.kyori.adventure.text.Component> computeTooltipLines(@NotNull ItemStack itemStack, @NotNull io.papermc.paper.inventory.tooltip.TooltipContext tooltipContext, @Nullable org.bukkit.entity.Player player); // Paper - expose itemstack tooltip lines
-+
-+    <A extends Keyed, M> io.papermc.paper.registry.tag.@Nullable Tag<A> getTag(io.papermc.paper.registry.tag.@NotNull TagKey<A> tagKey); // Paper - hack to get tags for non-server backed registries
- }

--- a/patches/api/0473-Proxy-ItemStack-to-CraftItemStack.patch
+++ b/patches/api/0473-Proxy-ItemStack-to-CraftItemStack.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Proxy ItemStack to CraftItemStack
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 5b13617e497e847ef66214f9140aea0cd41f4c4f..56d16c887b7663aab7db2f7be532d9912aeb3570 100644
+index b503b5e13c51580367d53939ad4c19a7718c22ce..307439827b401acb96f0df1cf4ef31835bd1d513 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -283,4 +283,6 @@ public interface UnsafeValues {
-     @NotNull java.util.List<net.kyori.adventure.text.Component> computeTooltipLines(@NotNull ItemStack itemStack, @NotNull io.papermc.paper.inventory.tooltip.TooltipContext tooltipContext, @Nullable org.bukkit.entity.Player player); // Paper - expose itemstack tooltip lines
+@@ -281,4 +281,6 @@ public interface UnsafeValues {
+     // Paper end - lifecycle event API
  
-     <A extends Keyed, M> io.papermc.paper.registry.tag.@Nullable Tag<A> getTag(io.papermc.paper.registry.tag.@NotNull TagKey<A> tagKey); // Paper - hack to get tags for non-server backed registries
+     @NotNull java.util.List<net.kyori.adventure.text.Component> computeTooltipLines(@NotNull ItemStack itemStack, @NotNull io.papermc.paper.inventory.tooltip.TooltipContext tooltipContext, @Nullable org.bukkit.entity.Player player); // Paper - expose itemstack tooltip lines
 +
 +    ItemStack createEmptyStack(); // Paper - proxy ItemStack
  }

--- a/patches/server/0466-Add-RegistryAccess-for-managing-Registries.patch
+++ b/patches/server/0466-Add-RegistryAccess-for-managing-Registries.patch
@@ -12,12 +12,13 @@ public net.minecraft.server.RegistryLayer STATIC_ACCESS
 
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c6969f968b45eff2aeb44e647712abda10c7c113
+index 0000000000000000000000000000000000000000..2f22f46f80b80be43a2cc1cd8afb51f4d1fd0e91
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-@@ -0,0 +1,156 @@
+@@ -0,0 +1,157 @@
 +package io.papermc.paper.registry;
 +
++import com.google.common.base.Preconditions;
 +import io.papermc.paper.adventure.PaperAdventure;
 +import io.papermc.paper.registry.entry.RegistryEntry;
 +import java.util.Collections;
@@ -125,16 +126,16 @@ index 0000000000000000000000000000000000000000..c6969f968b45eff2aeb44e647712abda
 +            entry(Registries.INSTRUMENT, RegistryKey.INSTRUMENT, MusicInstrument.class, CraftMusicInstrument::new).delayed(),
 +
 +            // api-only
-+            apiOnly(Registries.ENTITY_TYPE, RegistryKey.ENTITY_TYPE, () -> org.bukkit.Registry.ENTITY_TYPE),
-+            apiOnly(Registries.PARTICLE_TYPE, RegistryKey.PARTICLE_TYPE, () -> org.bukkit.Registry.PARTICLE_TYPE),
-+            apiOnly(Registries.POTION, RegistryKey.POTION, () -> org.bukkit.Registry.POTION),
++            apiOnly(Registries.ENTITY_TYPE, RegistryKey.ENTITY_TYPE, PaperSimpleRegistry::entityType),
++            apiOnly(Registries.PARTICLE_TYPE, RegistryKey.PARTICLE_TYPE, PaperSimpleRegistry::particleType),
++            apiOnly(Registries.POTION, RegistryKey.POTION, PaperSimpleRegistry::potion),
 +            apiOnly(Registries.MEMORY_MODULE_TYPE, RegistryKey.MEMORY_MODULE_TYPE, () -> (org.bukkit.Registry<MemoryKey<?>>) (org.bukkit.Registry) org.bukkit.Registry.MEMORY_MODULE_TYPE)
 +        );
 +        final Map<RegistryKey<?>, RegistryEntry<?, ?>> byRegistryKey = new IdentityHashMap<>(REGISTRY_ENTRIES.size());
 +        final Map<ResourceKey<?>, RegistryEntry<?, ?>> byResourceKey = new IdentityHashMap<>(REGISTRY_ENTRIES.size());
 +        for (final RegistryEntry<?, ?> entry : REGISTRY_ENTRIES) {
-+            byRegistryKey.put(entry.apiKey(), entry);
-+            byResourceKey.put(entry.mcKey(), entry);
++            Preconditions.checkState(byRegistryKey.put(entry.apiKey(), entry) == null, "Duplicate api registry key: %s", entry.apiKey());
++            Preconditions.checkState(byResourceKey.put(entry.mcKey(), entry) == null, "Duplicate mc registry key: %s", entry.mcKey());
 +        }
 +        BY_REGISTRY_KEY = Collections.unmodifiableMap(byRegistryKey);
 +        BY_RESOURCE_KEY = Collections.unmodifiableMap(byResourceKey);
@@ -303,6 +304,50 @@ index 0000000000000000000000000000000000000000..35b6a7c5bac9640332a833bd3627f2bc
 +    @VisibleForTesting
 +    public static <T extends Keyed> @Nullable RegistryKey<T> byType(final Class<T> type) {
 +        return (RegistryKey<T>) LegacyRegistryIdentifiers.CLASS_TO_KEY_MAP.get(type);
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/registry/PaperSimpleRegistry.java b/src/main/java/io/papermc/paper/registry/PaperSimpleRegistry.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..6d134ace042758da722960cbcb48e52508dafd61
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/registry/PaperSimpleRegistry.java
+@@ -0,0 +1,38 @@
++package io.papermc.paper.registry;
++
++import java.util.function.Predicate;
++import net.minecraft.core.registries.BuiltInRegistries;
++import org.bukkit.Keyed;
++import org.bukkit.Particle;
++import org.bukkit.Registry;
++import org.bukkit.entity.EntityType;
++import org.bukkit.potion.PotionType;
++import org.jspecify.annotations.NullMarked;
++
++@NullMarked
++public class PaperSimpleRegistry<T extends Enum<T> & Keyed, M> extends Registry.SimpleRegistry<T> {
++
++    static Registry<EntityType> entityType() {
++        return new PaperSimpleRegistry<>(EntityType.class, entity -> entity != EntityType.UNKNOWN, BuiltInRegistries.ENTITY_TYPE);
++    }
++
++    static Registry<Particle> particleType() {
++        return new PaperSimpleRegistry<>(Particle.class, BuiltInRegistries.PARTICLE_TYPE);
++    }
++
++    static Registry<PotionType> potion() {
++        return new PaperSimpleRegistry<>(PotionType.class, BuiltInRegistries.POTION);
++    }
++
++    private final net.minecraft.core.Registry<M> nmsRegistry;
++
++    protected PaperSimpleRegistry(final Class<T> type, final net.minecraft.core.Registry<M> nmsRegistry) {
++        super(type);
++        this.nmsRegistry = nmsRegistry;
++    }
++
++    public PaperSimpleRegistry(final Class<T> type, final Predicate<T> predicate, final net.minecraft.core.Registry<M> nmsRegistry) {
++        super(type, predicate);
++        this.nmsRegistry = nmsRegistry;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/RegistryHolder.java b/src/main/java/io/papermc/paper/registry/RegistryHolder.java

--- a/patches/server/0992-Registry-Modification-API.patch
+++ b/patches/server/0992-Registry-Modification-API.patch
@@ -14,15 +14,15 @@ diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/
 index c6969f968b45eff2aeb44e647712abda10c7c113..d34ffad8a36abbb215491d74ae8d9b490a0bc64f 100644
 --- a/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-@@ -2,6 +2,7 @@ package io.papermc.paper.registry;
- 
+@@ -3,6 +3,7 @@ package io.papermc.paper.registry;
+ import com.google.common.base.Preconditions;
  import io.papermc.paper.adventure.PaperAdventure;
  import io.papermc.paper.registry.entry.RegistryEntry;
 +import io.papermc.paper.registry.tag.TagKey;
  import java.util.Collections;
  import java.util.IdentityHashMap;
  import java.util.List;
-@@ -68,6 +69,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
+@@ -69,6 +70,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
  
  import static io.papermc.paper.registry.entry.RegistryEntry.apiOnly;
  import static io.papermc.paper.registry.entry.RegistryEntry.entry;
@@ -30,7 +30,7 @@ index c6969f968b45eff2aeb44e647712abda10c7c113..d34ffad8a36abbb215491d74ae8d9b49
  
  @DefaultQualifier(NonNull.class)
  public final class PaperRegistries {
-@@ -151,6 +153,15 @@ public final class PaperRegistries {
+@@ -152,6 +154,15 @@ public final class PaperRegistries {
          return ResourceKey.create((ResourceKey<? extends Registry<M>>) PaperRegistries.registryToNms(typedKey.registryKey()), PaperAdventure.asVanilla(typedKey.key()));
      }
  
@@ -286,6 +286,38 @@ index 0000000000000000000000000000000000000000..69e946173407eb05b18a2b19b0d45cbb
 +        return this.freezeEventTypes.getOrCreate(type.registryKey(), RegistryLifecycleEventType::new);
 +    }
 +}
+diff --git a/src/main/java/io/papermc/paper/registry/PaperSimpleRegistry.java b/src/main/java/io/papermc/paper/registry/PaperSimpleRegistry.java
+index 6d134ace042758da722960cbcb48e52508dafd61..cc39bc68d29055ef6429f08f975412bd9fe68dbc 100644
+--- a/src/main/java/io/papermc/paper/registry/PaperSimpleRegistry.java
++++ b/src/main/java/io/papermc/paper/registry/PaperSimpleRegistry.java
+@@ -1,6 +1,10 @@
+ package io.papermc.paper.registry;
+ 
++import io.papermc.paper.registry.set.NamedRegistryKeySetImpl;
++import io.papermc.paper.registry.tag.Tag;
++import io.papermc.paper.registry.tag.TagKey;
+ import java.util.function.Predicate;
++import net.minecraft.core.HolderSet;
+ import net.minecraft.core.registries.BuiltInRegistries;
+ import org.bukkit.Keyed;
+ import org.bukkit.Particle;
+@@ -35,4 +39,16 @@ public class PaperSimpleRegistry<T extends Enum<T> & Keyed, M> extends Registry.
+         super(type, predicate);
+         this.nmsRegistry = nmsRegistry;
+     }
++
++    @Override
++    public boolean hasTag(final TagKey<T> key) {
++        final net.minecraft.tags.TagKey<M> nmsKey = PaperRegistries.toNms(key);
++        return this.nmsRegistry.get(nmsKey).isPresent();
++    }
++
++    @Override
++    public Tag<T> getTag(final TagKey<T> key) {
++        final HolderSet.Named<M> namedHolderSet = this.nmsRegistry.get(PaperRegistries.toNms(key)).orElseThrow();
++        return new NamedRegistryKeySetImpl<>(key, namedHolderSet);
++    }
+ }
 diff --git a/src/main/java/io/papermc/paper/registry/WritableCraftRegistry.java b/src/main/java/io/papermc/paper/registry/WritableCraftRegistry.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..78317c7ab42a666f19634593a8f3b696700764c8
@@ -1365,32 +1397,6 @@ index 45c78c113e881b277e1216293ad918ee40b44325..8314059455d91f01b986c5c0a239f418
 +    }
 +    // Paper end - RegistrySet API
  }
-diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index f0556a207f6d9d1766ef0d9753355f7fa5052dc1..f55733b7a56ac21cb297971b9e854ef54001ca26 100644
---- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-+++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -666,6 +666,21 @@ public final class CraftMagicNumbers implements UnsafeValues {
-     }
-     // Paper end - lifecycle event API
- 
-+    // Paper start - hack to get tags for non server-backed registries
-+    @Override
-+    public <A extends Keyed, M> io.papermc.paper.registry.tag.Tag<A> getTag(final io.papermc.paper.registry.tag.TagKey<A> tagKey) { // TODO remove Keyed
-+        if (tagKey.registryKey() != io.papermc.paper.registry.RegistryKey.ENTITY_TYPE && tagKey.registryKey() != io.papermc.paper.registry.RegistryKey.FLUID) {
-+            throw new UnsupportedOperationException(tagKey.registryKey() + " doesn't have tags");
-+        }
-+        final net.minecraft.resources.ResourceKey<? extends net.minecraft.core.Registry<M>> nmsKey = io.papermc.paper.registry.PaperRegistries.registryToNms(tagKey.registryKey());
-+        final net.minecraft.core.Registry<M> nmsRegistry = org.bukkit.craftbukkit.CraftRegistry.getMinecraftRegistry().lookupOrThrow(nmsKey);
-+        return nmsRegistry
-+            .get(io.papermc.paper.registry.PaperRegistries.toNms(tagKey))
-+            .map(named -> new io.papermc.paper.registry.set.NamedRegistryKeySetImpl<>(tagKey, named))
-+            .orElse(null);
-+    }
-+    // Paper end - hack to get tags for non server-backed registries
-+
-     /**
-      * This helper class represents the different NBT Tags.
-      * <p>
 diff --git a/src/main/resources/META-INF/services/io.papermc.paper.registry.event.RegistryEventTypeProvider b/src/main/resources/META-INF/services/io.papermc.paper.registry.event.RegistryEventTypeProvider
 new file mode 100644
 index 0000000000000000000000000000000000000000..8bee1a5ed877a04e4d027593df1f42cefdd824e7

--- a/patches/server/0993-Add-registry-entry-and-builders.patch
+++ b/patches/server/0993-Add-registry-entry-and-builders.patch
@@ -6,19 +6,19 @@ Subject: [PATCH] Add registry entry and builders
 Feature patch
 
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-index d34ffad8a36abbb215491d74ae8d9b490a0bc64f..f8c6da955e4bd0e480c7b581d2a4325738f9dd6f 100644
+index 3ec2aa5da045b62809afd2c13fc9ae74189dbdad..82fc79fb78be6e5d77060717e28d75cb9e8c388b 100644
 --- a/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-@@ -1,6 +1,8 @@
- package io.papermc.paper.registry;
+@@ -2,6 +2,8 @@ package io.papermc.paper.registry;
  
+ import com.google.common.base.Preconditions;
  import io.papermc.paper.adventure.PaperAdventure;
 +import io.papermc.paper.registry.data.PaperEnchantmentRegistryEntry;
 +import io.papermc.paper.registry.data.PaperGameEventRegistryEntry;
  import io.papermc.paper.registry.entry.RegistryEntry;
  import io.papermc.paper.registry.tag.TagKey;
  import java.util.Collections;
-@@ -80,7 +82,7 @@ public final class PaperRegistries {
+@@ -81,7 +83,7 @@ public final class PaperRegistries {
      static {
          REGISTRY_ENTRIES = List.of(
              // built-ins
@@ -27,7 +27,7 @@ index d34ffad8a36abbb215491d74ae8d9b490a0bc64f..f8c6da955e4bd0e480c7b581d2a43257
              entry(Registries.STRUCTURE_TYPE, RegistryKey.STRUCTURE_TYPE, StructureType.class, CraftStructureType::new),
              entry(Registries.MOB_EFFECT, RegistryKey.MOB_EFFECT, PotionEffectType.class, CraftPotionEffectType::new),
              entry(Registries.BLOCK, RegistryKey.BLOCK, BlockType.class, CraftBlockType::new),
-@@ -102,7 +104,7 @@ public final class PaperRegistries {
+@@ -103,7 +105,7 @@ public final class PaperRegistries {
              entry(Registries.TRIM_PATTERN, RegistryKey.TRIM_PATTERN, TrimPattern.class, CraftTrimPattern::new).delayed(),
              entry(Registries.DAMAGE_TYPE, RegistryKey.DAMAGE_TYPE, DamageType.class, CraftDamageType::new).delayed(),
              entry(Registries.WOLF_VARIANT, RegistryKey.WOLF_VARIANT, Wolf.Variant.class, CraftWolf.CraftVariant::new).delayed(),

--- a/patches/server/0994-Proxy-ItemStack-to-CraftItemStack.patch
+++ b/patches/server/0994-Proxy-ItemStack-to-CraftItemStack.patch
@@ -205,12 +205,12 @@ index 6cc9d7a9e6d4bfdc27e52fc581b2bb832616f121..6930d0afb230a88aa813b02e4d55c95d
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index f55733b7a56ac21cb297971b9e854ef54001ca26..8af9ac9e22a15457da12f0746d0e411942c278fb 100644
+index f0556a207f6d9d1766ef0d9753355f7fa5052dc1..2539802c0a02b6a564bdbd58e93ffe5685e775b9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -681,6 +681,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -666,6 +666,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
      }
-     // Paper end - hack to get tags for non server-backed registries
+     // Paper end - lifecycle event API
  
 +    // Paper start - proxy ItemStack
 +    @Override

--- a/patches/server/1035-DataComponent-API.patch
+++ b/patches/server/1035-DataComponent-API.patch
@@ -3589,19 +3589,19 @@ index 0000000000000000000000000000000000000000..62aa1061c35d5358e6dec16a52574b42
 +
 +import org.jspecify.annotations.NullMarked;
 diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-index f8c6da955e4bd0e480c7b581d2a4325738f9dd6f..ee1fce58c6e57dd93a30ee66e7488a92f9da2fe3 100644
+index 82fc79fb78be6e5d77060717e28d75cb9e8c388b..a42e3298cac463a431fea973d2961d98a026c148 100644
 --- a/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-@@ -1,6 +1,8 @@
- package io.papermc.paper.registry;
+@@ -2,6 +2,8 @@ package io.papermc.paper.registry;
  
+ import com.google.common.base.Preconditions;
  import io.papermc.paper.adventure.PaperAdventure;
 +import io.papermc.paper.datacomponent.DataComponentType;
 +import io.papermc.paper.datacomponent.PaperComponentType;
  import io.papermc.paper.registry.data.PaperEnchantmentRegistryEntry;
  import io.papermc.paper.registry.data.PaperGameEventRegistryEntry;
  import io.papermc.paper.registry.entry.RegistryEntry;
-@@ -96,6 +98,7 @@ public final class PaperRegistries {
+@@ -97,6 +99,7 @@ public final class PaperRegistries {
              entry(Registries.ATTRIBUTE, RegistryKey.ATTRIBUTE, Attribute.class, CraftAttribute::new),
              entry(Registries.FLUID, RegistryKey.FLUID, Fluid.class, CraftFluid::new),
              entry(Registries.SOUND_EVENT, RegistryKey.SOUND_EVENT, Sound.class, CraftSound::new),


### PR DESCRIPTION
Better supports getTag/hasTag methods on Registry for SimpleRegistry by making them backed by the server, but only for tag support, it still uses the enum. Just temporary until they all are server-backed.