### PR TITLE
Fix and optimize getChunkCount

### DIFF
--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -5344,21 +5344,24 @@ index 019228b1809e3816b0b4dfb9f19b8d42876cc240..6c2339d6a93172e25040c4868a3a4747
  
          while (objectiterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 9cdcab885a915990a679f3fc9ae6885f7d125bfd..a970ceab0176d97f9d274ed257c2f86f3b63e430 100644
+index 9cdcab885a915990a679f3fc9ae6885f7d125bfd..3e35a64b4b92ec25789e85c7445375dd899e1805 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -74,6 +74,10 @@ public class ServerChunkCache extends ChunkSource {
+@@ -74,6 +74,13 @@ public class ServerChunkCache extends ChunkSource {
      @Nullable
      @VisibleForDebug
      private NaturalSpawner.SpawnState lastSpawnState;
 +    // Paper start
 +    private final ca.spottedleaf.concurrentutil.map.ConcurrentLong2ReferenceChainedHashTable<net.minecraft.world.level.chunk.LevelChunk> fullChunks = new ca.spottedleaf.concurrentutil.map.ConcurrentLong2ReferenceChainedHashTable<>();
++    public int getFullChunksCount() {
++        return this.fullChunks.size();
++    }
 +    long chunkFutureAwaitCounter;
 +    // Paper end
  
      public ServerChunkCache(ServerLevel world, LevelStorageSource.LevelStorageAccess session, DataFixer dataFixer, StructureTemplateManager structureTemplateManager, Executor workerExecutor, ChunkGenerator chunkGenerator, int viewDistance, int simulationDistance, boolean dsync, ChunkProgressListener worldGenerationProgressListener, ChunkStatusUpdateListener chunkStatusChangeListener, Supplier<DimensionDataStorage> persistentStateManagerFactory) {
          this.level = world;
-@@ -104,6 +108,54 @@ public class ServerChunkCache extends ChunkSource {
+@@ -104,6 +111,54 @@ public class ServerChunkCache extends ChunkSource {
          return chunk.getFullChunkNow() != null;
      }
      // CraftBukkit end
@@ -5413,7 +5416,7 @@ index 9cdcab885a915990a679f3fc9ae6885f7d125bfd..a970ceab0176d97f9d274ed257c2f86f
  
      @Override
      public ThreadedLevelLightEngine getLightEngine() {
-@@ -299,7 +351,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -299,7 +354,7 @@ public class ServerChunkCache extends ChunkSource {
          return this.mainThreadProcessor.pollTask();
      }
  

--- a/patches/server/0024-Remove-Spigot-timings.patch
+++ b/patches/server/0024-Remove-Spigot-timings.patch
@@ -153,10 +153,10 @@ index 9d6be455c3bbcdbcb9d3d24b0bad79f46ba6a8cb..a129ddfe7b00d6abab94437806a5cfb9
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index a970ceab0176d97f9d274ed257c2f86f3b63e430..4a0fedff38f12ec87905558a100f1772cee03dd4 100644
+index 3e35a64b4b92ec25789e85c7445375dd899e1805..2e2976efcf99de269f67dec2c87cb910ff280562 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -207,13 +207,11 @@ public class ServerChunkCache extends ChunkSource {
+@@ -210,13 +210,11 @@ public class ServerChunkCache extends ChunkSource {
              }
  
              gameprofilerfiller.incrementCounter("getChunkCacheMiss");
@@ -170,7 +170,7 @@ index a970ceab0176d97f9d274ed257c2f86f3b63e430..4a0fedff38f12ec87905558a100f1772
              ChunkResult<ChunkAccess> chunkresult = (ChunkResult) completablefuture.join();
              ChunkAccess ichunkaccess1 = (ChunkAccess) chunkresult.orElse(null); // CraftBukkit - decompile error
  
-@@ -414,25 +412,19 @@ public class ServerChunkCache extends ChunkSource {
+@@ -417,25 +415,19 @@ public class ServerChunkCache extends ChunkSource {
          ProfilerFiller gameprofilerfiller = Profiler.get();
  
          gameprofilerfiller.push("purge");
@@ -196,7 +196,7 @@ index a970ceab0176d97f9d274ed257c2f86f3b63e430..4a0fedff38f12ec87905558a100f1772
          gameprofilerfiller.pop();
          this.clearCache();
      }
-@@ -525,9 +517,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -528,9 +520,7 @@ public class ServerChunkCache extends ChunkSource {
              }
  
              if (this.level.shouldTickBlocksAt(chunkcoordintpair.toLong())) {

--- a/patches/server/0123-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/server/0123-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -20,10 +20,10 @@ index 943c14b26cf5b1c9f9ea1acec058cecac3b93bf7..e5eac1977f77b7ce1112bfe7ac1b77d9
      private final List<TickingBlockEntity> pendingBlockEntityTickers = Lists.newArrayList();
      private boolean tickingBlockEntities;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9a79b948264150d0f7a843a8ddd2ea9245ae66f3..9389c0ebdcaba5022bdae47b2b2ff06b40406127 100644
+index 9a79b948264150d0f7a843a8ddd2ea9245ae66f3..44ecb821c528d10f38c8c85298c8257e92e3c41c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -168,6 +168,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -168,6 +168,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftWorld.DATA_TYPE_REGISTRY);
      private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
  
@@ -60,15 +60,7 @@ index 9a79b948264150d0f7a843a8ddd2ea9245ae66f3..9389c0ebdcaba5022bdae47b2b2ff06b
 +
 +    @Override
 +    public int getChunkCount() {
-+        int ret = 0;
-+
-+        for (ChunkHolder chunkHolder : ca.spottedleaf.moonrise.common.util.ChunkSystem.getVisibleChunkHolders(this.world)) {
-+            if (chunkHolder.getTickingChunk() != null) {
-+                ++ret;
-+            }
-+        }
-+
-+        return ret;
++        return this.world.getChunkSource().getFullChunksCount();
 +    }
 +
 +    @Override

--- a/patches/server/0164-PlayerNaturallySpawnCreaturesEvent.patch
+++ b/patches/server/0164-PlayerNaturallySpawnCreaturesEvent.patch
@@ -40,10 +40,10 @@ index 261943f1f188643793a72bd239dfc5fe604e3b99..985ba48a5ac027d3c3dcd9b710b53748
  
          return true;
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 4a0fedff38f12ec87905558a100f1772cee03dd4..c9efcb6170e9ecc615ab70594954fae24ba46ac4 100644
+index 2e2976efcf99de269f67dec2c87cb910ff280562..5749698b0c9647295e0be6f7d532d39c18432539 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -498,6 +498,15 @@ public class ServerChunkCache extends ChunkSource {
+@@ -501,6 +501,15 @@ public class ServerChunkCache extends ChunkSource {
          List list1;
  
          if (flag && (this.spawnEnemies || this.spawnFriendlies)) {

--- a/patches/server/0186-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0186-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -34,10 +34,10 @@ index 88c93a2e67c8d1bc227c7fa35bb919a40009f931..0c0d19708832a49734ea08ae05696e0c
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9389c0ebdcaba5022bdae47b2b2ff06b40406127..5231548e886e884f565ff6cc5d45518141fbab2d 100644
+index 44ecb821c528d10f38c8c85298c8257e92e3c41c..aa82637098072b9371a1815d6c05887e19f1424e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1992,8 +1992,19 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1984,8 +1984,19 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0202-Expand-Explosions-API.patch
+++ b/patches/server/0202-Expand-Explosions-API.patch
@@ -54,10 +54,10 @@ index 9f37d7284c81d529551107e2836627977efabd65..d1878f597c3d8119e9b248f4fe8af435
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5231548e886e884f565ff6cc5d45518141fbab2d..e285c8486c36e8d2bc4ddc43e0029943ea5c7fe7 100644
+index aa82637098072b9371a1815d6c05887e19f1424e..a4f140fefaac7e74b6c9834e6b532f20e80b9ab9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -784,6 +784,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -776,6 +776,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks, Entity source) {
@@ -69,7 +69,7 @@ index 5231548e886e884f565ff6cc5d45518141fbab2d..e285c8486c36e8d2bc4ddc43e0029943
          net.minecraft.world.level.Level.ExplosionInteraction explosionType;
          if (!breakBlocks) {
              explosionType = net.minecraft.world.level.Level.ExplosionInteraction.NONE; // Don't break blocks
-@@ -794,8 +799,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -786,8 +791,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
  
          net.minecraft.world.entity.Entity entity = (source == null) ? null : ((CraftEntity) source).getHandle();

--- a/patches/server/0206-Implement-World.getEntity-UUID-API.patch
+++ b/patches/server/0206-Implement-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e285c8486c36e8d2bc4ddc43e0029943ea5c7fe7..e9840a1159419593145d166b54e523fd3e6684f0 100644
+index a4f140fefaac7e74b6c9834e6b532f20e80b9ab9..0f8a5ad8853052c51989570df10a75bb5b3a1f68 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1137,6 +1137,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1129,6 +1129,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return list;
      }
  

--- a/patches/server/0238-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/patches/server/0238-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e9840a1159419593145d166b54e523fd3e6684f0..a8e738941d8cd6373eb0ae5259da8e763a695657 100644
+index 0f8a5ad8853052c51989570df10a75bb5b3a1f68..58bece6427afd9e0341e2cf065adc0b04cd8a0e2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -438,7 +438,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -430,7 +430,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0252-Add-sun-related-API.patch
+++ b/patches/server/0252-Add-sun-related-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add sun related API
 public net.minecraft.world.entity.Mob isSunBurnTick()Z
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a8e738941d8cd6373eb0ae5259da8e763a695657..d5f8c07480b1dc6b6f97e8ebc74b50493f011f45 100644
+index 58bece6427afd9e0341e2cf065adc0b04cd8a0e2..e6a7359d120b2361669a407b92357ea1a6b9a2a8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -762,6 +762,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -754,6 +754,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
      }
  

--- a/patches/server/0309-Optimise-getChunkAt-calls-for-loaded-chunks.patch
+++ b/patches/server/0309-Optimise-getChunkAt-calls-for-loaded-chunks.patch
@@ -7,10 +7,10 @@ bypass the need to get a player chunk, then get the either,
 then unwrap it...
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index d4eb7608a3e40d2da4c427e9b3a2ce916be86df1..43e01db5314452c194d2809fdc6a71c6fb42d8d2 100644
+index 5749698b0c9647295e0be6f7d532d39c18432539..758b874424b1fed90893132e5455a683b789ebf2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -191,6 +191,12 @@ public class ServerChunkCache extends ChunkSource {
+@@ -194,6 +194,12 @@ public class ServerChunkCache extends ChunkSource {
                  return this.getChunk(x, z, leastStatus, create);
              }, this.mainThreadProcessor).join();
          } else {
@@ -23,7 +23,7 @@ index d4eb7608a3e40d2da4c427e9b3a2ce916be86df1..43e01db5314452c194d2809fdc6a71c6
              ProfilerFiller gameprofilerfiller = Profiler.get();
  
              gameprofilerfiller.incrementCounter("getChunk");
-@@ -230,33 +236,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -233,33 +239,7 @@ public class ServerChunkCache extends ChunkSource {
          if (Thread.currentThread() != this.mainThread) {
              return null;
          } else {

--- a/patches/server/0310-Add-debug-for-sync-chunk-loads.patch
+++ b/patches/server/0310-Add-debug-for-sync-chunk-loads.patch
@@ -302,10 +302,10 @@ index 0000000000000000000000000000000000000000..95d6022c9cfb2e36ec5a71be6e343540
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 43e01db5314452c194d2809fdc6a71c6fb42d8d2..76cb7ffad02dcc27966ca13da6552edbb696e41f 100644
+index 758b874424b1fed90893132e5455a683b789ebf2..0a895055ec7f61d3cb52d303bbe3f89486a322e7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -218,6 +218,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -221,6 +221,7 @@ public class ServerChunkCache extends ChunkSource {
  
              Objects.requireNonNull(completablefuture);
              chunkproviderserver_b.managedBlock(completablefuture::isDone);

--- a/patches/server/0370-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0370-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -89,7 +89,7 @@ index 0884f71d3264c2a09d2a0958d4751962e4156526..8bb1b0e7caa938170169379ce22f21c1
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d1be64bec1985ff04bf61ed65f18b043e771657c..c52d550ebc7eb9aca2c2e109b2982cad7cb9ac4f 100644
+index ca8eb3216c4331a95ab44f923f6b49641662505f..9905555f249db72649bde8401835dd816ed7b428 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1000,8 +1000,8 @@ public final class CraftServer implements Server {
@@ -104,10 +104,10 @@ index d1be64bec1985ff04bf61ed65f18b043e771657c..c52d550ebc7eb9aca2c2e109b2982cad
              for (SpawnCategory spawnCategory : SpawnCategory.values()) {
                  if (CraftSpawnCategory.isValidForLimits(spawnCategory)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d5f8c07480b1dc6b6f97e8ebc74b50493f011f45..84028e959f697fade97640b9b35e5433fcf894ce 100644
+index e6a7359d120b2361669a407b92357ea1a6b9a2a8..93d1c641a6fa063f3c5a4b9b2d9a15071ae7de01 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1177,7 +1177,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1169,7 +1169,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setDifficulty(Difficulty difficulty) {

--- a/patches/server/0373-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0373-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,7 +22,7 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c52d550ebc7eb9aca2c2e109b2982cad7cb9ac4f..134cd194962be898253e034b19524fad0d48ada5 100644
+index 9905555f249db72649bde8401835dd816ed7b428..972e3a1de1d289f82156097a9bf0faf03cb4ff42 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -382,7 +382,7 @@ public final class CraftServer implements Server {
@@ -44,10 +44,10 @@ index c52d550ebc7eb9aca2c2e109b2982cad7cb9ac4f..134cd194962be898253e034b19524fad
          this.printSaveWarning = false;
          this.console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 84028e959f697fade97640b9b35e5433fcf894ce..55daddd0d80a18a3c044f48a47a0a13ef3a68943 100644
+index 93d1c641a6fa063f3c5a4b9b2d9a15071ae7de01..5ca7db643a1616df57be114faf9ce2e33e8d4eb8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -270,7 +270,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -262,7 +262,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk getChunkAt(int x, int z) {
@@ -62,7 +62,7 @@ index 84028e959f697fade97640b9b35e5433fcf894ce..55daddd0d80a18a3c044f48a47a0a13e
          return new CraftChunk(chunk);
      }
  
-@@ -284,6 +290,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -276,6 +282,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return new CraftChunk(this.getHandle(), x, z);
      }
  
@@ -75,7 +75,7 @@ index 84028e959f697fade97640b9b35e5433fcf894ce..55daddd0d80a18a3c044f48a47a0a13e
      @Override
      public Chunk getChunkAt(Block block) {
          Preconditions.checkArgument(block != null, "null block");
-@@ -335,7 +347,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -327,7 +339,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean unloadChunkRequest(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk unload"); // Spigot
          if (this.isChunkLoaded(x, z)) {
@@ -84,7 +84,7 @@ index 84028e959f697fade97640b9b35e5433fcf894ce..55daddd0d80a18a3c044f48a47a0a13e
          }
  
          return true;
-@@ -447,7 +459,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -439,7 +451,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
  
          if (chunk instanceof net.minecraft.world.level.chunk.LevelChunk) {
@@ -93,7 +93,7 @@ index 84028e959f697fade97640b9b35e5433fcf894ce..55daddd0d80a18a3c044f48a47a0a13e
              return true;
          }
  
-@@ -2256,6 +2268,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2248,6 +2260,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          ca.spottedleaf.moonrise.common.util.ChunkSystem.scheduleChunkLoad(this.getHandle(), x, z, gen, ChunkStatus.FULL, true, priority, (c) -> {
              net.minecraft.server.MinecraftServer.getServer().scheduleOnMain(() -> {
                  net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk)c;

--- a/patches/server/0392-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0392-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -19,10 +19,10 @@ index 0995a3a274df988a5c63c813de8213019a7c47c4..17725a575a29aa8076582e1b8c644ffd
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 55daddd0d80a18a3c044f48a47a0a13ef3a68943..b0fbb828306194fd91f0e62244d5db6404b4f10a 100644
+index 5ca7db643a1616df57be114faf9ce2e33e8d4eb8..3ff0a43907cbe2cb4e54c57d9ac735dc0dd7f8f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -250,12 +250,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -242,12 +242,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean setSpawnLocation(int x, int y, int z, float angle) {
          try {

--- a/patches/server/0456-Add-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0456-Add-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 7ea92a0b0f5d4eb6bd873e61c42bc0499d5d2028..09299e45552eb998fd02123c3921c065
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b0fbb828306194fd91f0e62244d5db6404b4f10a..e19e5f1223f8b4fae9292a936dd05b9170610134 100644
+index 3ff0a43907cbe2cb4e54c57d9ac735dc0dd7f8f4..bacc00be9466d5253df668336bb83542b759f9d2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1899,9 +1899,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1891,9 +1891,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          if (rule == null || value == null) return false;
  
          if (!this.isGameRule(rule)) return false;
@@ -83,7 +83,7 @@ index b0fbb828306194fd91f0e62244d5db6404b4f10a..e19e5f1223f8b4fae9292a936dd05b91
          handle.onChanged(this.getHandle());
          return true;
      }
-@@ -1936,9 +1941,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1928,9 +1933,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Preconditions.checkArgument(newValue != null, "GameRule value cannot be null");
  
          if (!this.isGameRule(rule.getName())) return false;

--- a/patches/server/0512-More-World-API.patch
+++ b/patches/server/0512-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e19e5f1223f8b4fae9292a936dd05b9170610134..e44a78a34aa572b10deb3f343c238cad1c521ab4 100644
+index bacc00be9466d5253df668336bb83542b759f9d2..5cbb66ad1eb2e54a4c6eb8ec9ff1c09d13d5e796 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2145,6 +2145,28 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2137,6 +2137,28 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return new CraftStructureSearchResult(CraftStructure.minecraftToBukkit(found.getSecond().value()), CraftLocation.toBukkit(found.getFirst(), this));
      }
  

--- a/patches/server/0536-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0536-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -95,10 +95,10 @@ index 6a3959095e57f76b3a092b32d26ff91cf1c5e068..0fa16ff37f09ecfda104b751e48bf246
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e44a78a34aa572b10deb3f343c238cad1c521ab4..07986523451a755515c912e5cab5172195b929de 100644
+index 5cbb66ad1eb2e54a4c6eb8ec9ff1c09d13d5e796..eaba5097bb8e0048c85ee1b3651644ef06efdc7d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1220,7 +1220,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1212,7 +1212,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -107,7 +107,7 @@ index e44a78a34aa572b10deb3f343c238cad1c521ab4..07986523451a755515c912e5cab51721
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1242,7 +1242,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1234,7 +1234,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0549-add-per-world-spawn-limits.patch
+++ b/patches/server/0549-add-per-world-spawn-limits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add per world spawn limits
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 07986523451a755515c912e5cab5172195b929de..9e0f2900dea70c471ea73b190b8aa2d9abd37ee6 100644
+index eaba5097bb8e0048c85ee1b3651644ef06efdc7d..336daaaf9a8e1cfbc2682c2932add78db11afad3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -226,6 +226,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -218,6 +218,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          this.biomeProvider = biomeProvider;
  
          this.environment = env;

--- a/patches/server/0579-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0579-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -31,10 +31,10 @@ index 91fb83761885752743adb53cc9ed30ddc879263d..3c281cdd24acbc9484c968c07f737d50
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9e0f2900dea70c471ea73b190b8aa2d9abd37ee6..06ccf20081ecd2b56f9e5aeef988804fef10df73 100644
+index 336daaaf9a8e1cfbc2682c2932add78db11afad3..bb61295b8ae44eee9d0c7b12152a7d93d191bdfa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -695,6 +695,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -687,6 +687,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  

--- a/patches/server/0593-Improve-and-expand-AsyncCatcher.patch
+++ b/patches/server/0593-Improve-and-expand-AsyncCatcher.patch
@@ -29,7 +29,7 @@ index 70b891bd018029eda8cda4fb9f919e77524dbc5e..a4abcbc69ccd023a936d02d359ba4c08
          if (player.isRemoved()) {
              LOGGER.info("Attempt to teleport removed player {} restricted", player.getScoreboardName());
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 83557da78340e3327f8c9a3050662413ecc3fc17..4f13d792a2cc504f174766d4c0d924d9ca51df9c 100644
+index 5415cade10ab36709f722cabc20ea3f1b9c285d9..924db96764ef1d0b9596be01f344065f8e1a721e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1143,7 +1143,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -166,10 +166,10 @@ index 4eb0b0969325f39a7ae65492cccd482515a50142..5aa74c00a61282830d82359eae2b114e
                  PersistentEntitySectionManager.LOGGER.warn("Entity {} wasn't found in section {} (destroying due to {})", new Object[]{this.entity, SectionPos.of(this.currentSectionKey), reason});
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 06ccf20081ecd2b56f9e5aeef988804fef10df73..f10b9898f180b231ce793cc03488df5a359b0ac0 100644
+index bb61295b8ae44eee9d0c7b12152a7d93d191bdfa..38febc623ee84d7eeeb7359c299ad0dbd5086e5b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1770,6 +1770,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1762,6 +1762,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void playSound(Location loc, Sound sound, org.bukkit.SoundCategory category, float volume, float pitch, long seed) {
@@ -177,7 +177,7 @@ index 06ccf20081ecd2b56f9e5aeef988804fef10df73..f10b9898f180b231ce793cc03488df5a
          if (loc == null || sound == null || category == null) return;
  
          double x = loc.getX();
-@@ -1781,6 +1782,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1773,6 +1774,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void playSound(Location loc, String sound, org.bukkit.SoundCategory category, float volume, float pitch, long seed) {
@@ -185,7 +185,7 @@ index 06ccf20081ecd2b56f9e5aeef988804fef10df73..f10b9898f180b231ce793cc03488df5a
          if (loc == null || sound == null || category == null) return;
  
          double x = loc.getX();
-@@ -1813,6 +1815,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1805,6 +1807,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void playSound(Entity entity, Sound sound, org.bukkit.SoundCategory category, float volume, float pitch, long seed) {
@@ -193,7 +193,7 @@ index 06ccf20081ecd2b56f9e5aeef988804fef10df73..f10b9898f180b231ce793cc03488df5a
          if (!(entity instanceof CraftEntity craftEntity) || entity.getWorld() != this || sound == null || category == null) return;
  
          ClientboundSoundEntityPacket packet = new ClientboundSoundEntityPacket(CraftSound.bukkitToMinecraftHolder(sound), net.minecraft.sounds.SoundSource.valueOf(category.name()), craftEntity.getHandle(), volume, pitch, seed);
-@@ -1833,6 +1836,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1825,6 +1828,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void playSound(Entity entity, String sound, org.bukkit.SoundCategory category, float volume, float pitch, long seed) {

--- a/patches/server/0594-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0594-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -278,7 +278,7 @@ index 606a60fe273974b71ed2bd40be819d848627e777..bf943feca387b77a3154773a59da7190
          BlockPos blockposition = NaturalSpawner.getRandomPosWithin(world, chunk);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ecf7ee1ca39d58f1780580bd24366fc8037df34a..1c72862b3167acc05f06b44cd9a0929ad8d2b9c8 100644
+index 0c6fbba9d4c27d05c0a7ff0ba1f735abb6d1e6ed..9ee5c98af55e93e304c157d63f6ef4e5ebdc7fc3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2334,6 +2334,11 @@ public final class CraftServer implements Server {
@@ -294,10 +294,10 @@ index ecf7ee1ca39d58f1780580bd24366fc8037df34a..1c72862b3167acc05f06b44cd9a0929a
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f10b9898f180b231ce793cc03488df5a359b0ac0..5050c9a9d5369a829f5b47a56b7621de05c9a6de 100644
+index 38febc623ee84d7eeeb7359c299ad0dbd5086e5b..d3722ffa822f5716ba46dc620a36ab8b0cd7cafe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1728,9 +1728,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1720,9 +1720,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Preconditions.checkArgument(spawnCategory != null, "SpawnCategory cannot be null");
          Preconditions.checkArgument(CraftSpawnCategory.isValidForLimits(spawnCategory), "SpawnCategory.%s are not supported", spawnCategory);
  

--- a/patches/server/0641-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0641-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -31,7 +31,7 @@ index 3b3024fcf39266cc6ae61fb77dbffb391dc96c92..2d77e9526917a83987ae0486a669538d
                  chunkgenerator = new NoiseBasedChunkGenerator(worldChunkManager, cga.settings);
              } else if (chunkgenerator instanceof FlatLevelSource cpf) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1c72862b3167acc05f06b44cd9a0929ad8d2b9c8..6d32505266fef119289bcf6761c1948368238eb9 100644
+index 9ee5c98af55e93e304c157d63f6ef4e5ebdc7fc3..0939d4f1297296efdcc083b2a2b0aa987141d42f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1310,7 +1310,7 @@ public final class CraftServer implements Server {
@@ -44,10 +44,10 @@ index 1c72862b3167acc05f06b44cd9a0929ad8d2b9c8..6d32505266fef119289bcf6761c19483
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5050c9a9d5369a829f5b47a56b7621de05c9a6de..0ff12d4e74c14b2b0ecf06d720c5e06edb35fcdb 100644
+index d3722ffa822f5716ba46dc620a36ab8b0cd7cafe..f544aa7ce6ab98581c4dacf2a79b05ce80131729 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -216,6 +216,39 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -208,6 +208,39 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getPlayerCount() {
          return world.players().size();
      }

--- a/patches/server/0666-Fix-falling-block-spawn-methods.patch
+++ b/patches/server/0666-Fix-falling-block-spawn-methods.patch
@@ -11,10 +11,10 @@ Restores the API behavior from previous versions of the server
 public net.minecraft.world.entity.item.FallingBlockEntity <init>(Lnet/minecraft/world/level/Level;DDDLnet/minecraft/world/level/block/state/BlockState;)V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0ff12d4e74c14b2b0ecf06d720c5e06edb35fcdb..9240460b9ec582ac01d3074c9bc923191bf0ad95 100644
+index f544aa7ce6ab98581c4dacf2a79b05ce80131729..f67fee006578719262e2e32b38e023acff63fd7d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1405,7 +1405,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1397,7 +1397,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Preconditions.checkArgument(material != null, "Material cannot be null");
          Preconditions.checkArgument(material.isBlock(), "Material.%s must be a block", material);
  
@@ -28,7 +28,7 @@ index 0ff12d4e74c14b2b0ecf06d720c5e06edb35fcdb..9240460b9ec582ac01d3074c9bc92319
          return (FallingBlock) entity.getBukkitEntity();
      }
  
-@@ -1414,7 +1419,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1406,7 +1411,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Preconditions.checkArgument(location != null, "Location cannot be null");
          Preconditions.checkArgument(data != null, "BlockData cannot be null");
  
@@ -43,7 +43,7 @@ index 0ff12d4e74c14b2b0ecf06d720c5e06edb35fcdb..9240460b9ec582ac01d3074c9bc92319
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
-index 42ecef3dbb888ba716b6f63335efca6fb0f27457..b79e72a77178f755957ef391b6444a357bdefbd0 100644
+index f8ce309c6ec8c294378d2cd9bc542e43338f8376..0bafd3b1a55154c8e9eb37c96df9f5985640a675 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntityTypes.java
 @@ -440,7 +440,7 @@ public final class CraftEntityTypes {

--- a/patches/server/0719-Warn-on-plugins-accessing-faraway-chunks.patch
+++ b/patches/server/0719-Warn-on-plugins-accessing-faraway-chunks.patch
@@ -18,10 +18,10 @@ index 9afc0eaaca5ab7b6445d90ce53e31a6ae76f8848..f0c2187a92de633a1d4cc7e71ff62cbe
  
      private static boolean isOutsideSpawnableHeight(int y) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9240460b9ec582ac01d3074c9bc923191bf0ad95..c0f5e4497e1ffc93f56fc2b5748bcf76569e8c3a 100644
+index f67fee006578719262e2e32b38e023acff63fd7d..df0f83941215a098014936f22e1ba353b69204a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -309,9 +309,24 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -301,9 +301,24 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean setSpawnLocation(int x, int y, int z) {
          return this.setSpawnLocation(x, y, z, 0.0F);
      }
@@ -46,7 +46,7 @@ index 9240460b9ec582ac01d3074c9bc923191bf0ad95..c0f5e4497e1ffc93f56fc2b5748bcf76
          // Paper start - add ticket to hold chunk for a little while longer if plugin accesses it
          net.minecraft.world.level.chunk.LevelChunk chunk = this.world.getChunkSource().getChunkAtIfLoadedImmediately(x, z);
          if (chunk == null) {
-@@ -419,6 +434,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -411,6 +426,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          if (!unloadChunk0(x, z, false)) {
              return false;
          }
@@ -54,7 +54,7 @@ index 9240460b9ec582ac01d3074c9bc923191bf0ad95..c0f5e4497e1ffc93f56fc2b5748bcf76
  
          final long chunkKey = ChunkCoordIntPair.pair(x, z);
          world.getChunkProvider().unloadQueue.remove(chunkKey);
-@@ -492,6 +508,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -484,6 +500,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
@@ -62,7 +62,7 @@ index 9240460b9ec582ac01d3074c9bc923191bf0ad95..c0f5e4497e1ffc93f56fc2b5748bcf76
          ChunkAccess chunk = this.world.getChunkSource().getChunk(x, z, generate || isChunkGenerated(x, z) ? ChunkStatus.FULL : ChunkStatus.EMPTY, true); // Paper
  
          // If generate = false, but the chunk already exists, we will get this back.
-@@ -524,6 +541,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -516,6 +533,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean addPluginChunkTicket(int x, int z, Plugin plugin) {
@@ -70,7 +70,7 @@ index 9240460b9ec582ac01d3074c9bc923191bf0ad95..c0f5e4497e1ffc93f56fc2b5748bcf76
          Preconditions.checkArgument(plugin != null, "null plugin");
          Preconditions.checkArgument(plugin.isEnabled(), "plugin is not enabled");
  
-@@ -624,6 +642,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -616,6 +634,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setChunkForceLoaded(int x, int z, boolean forced) {
@@ -78,7 +78,7 @@ index 9240460b9ec582ac01d3074c9bc923191bf0ad95..c0f5e4497e1ffc93f56fc2b5748bcf76
          this.getHandle().setChunkForced(x, z, forced);
      }
  
-@@ -958,6 +977,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -950,6 +969,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public int getHighestBlockYAt(int x, int z, org.bukkit.HeightMap heightMap) {
@@ -86,7 +86,7 @@ index 9240460b9ec582ac01d3074c9bc923191bf0ad95..c0f5e4497e1ffc93f56fc2b5748bcf76
          // Transient load for this tick
          return this.world.getChunk(x >> 4, z >> 4).getHeight(CraftHeightMap.toNMS(heightMap), x, z);
      }
-@@ -2358,6 +2378,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2350,6 +2370,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot end
      // Paper start
      public java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent) {

--- a/patches/server/0846-Bandaid-fix-for-Effect.patch
+++ b/patches/server/0846-Bandaid-fix-for-Effect.patch
@@ -68,10 +68,10 @@ index 71733f918ed84b9879ac1b142ef6205c5e768a9c..c856384019eff2f2d0bb831ebe1ccb0f
              break;
          case BONE_MEAL_USE:
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c0f5e4497e1ffc93f56fc2b5748bcf76569e8c3a..188bd33f46b6baaa3fc21c9da6fa9a9d004e899e 100644
+index df0f83941215a098014936f22e1ba353b69204a7..bfe7d57310f822edaa4ddb3ebddb2086ffee8a4a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1382,7 +1382,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1374,7 +1374,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public <T> void playEffect(Location loc, Effect effect, T data, int radius) {
          if (data != null) {
              Preconditions.checkArgument(effect.getData() != null, "Effect.%s does not have a valid Data", effect);
@@ -81,7 +81,7 @@ index c0f5e4497e1ffc93f56fc2b5748bcf76569e8c3a..188bd33f46b6baaa3fc21c9da6fa9a9d
              // Special case: the axis is optional for ELECTRIC_SPARK
              Preconditions.checkArgument(effect.getData() == null || effect == Effect.ELECTRIC_SPARK, "Wrong kind of data for the %s effect", effect);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 796a1540239362aec90f0a136bf7c28d282d5274..d903b9f1d62a826378b6d4b8458e5f675536fef2 100644
+index b0b417d916c6c3099157f8279c346bc6670c0012..b397f784510d832d300a777b4c4a4de03c904b72 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -922,7 +922,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0890-Add-predicate-for-blocks-when-raytracing.patch
+++ b/patches/server/0890-Add-predicate-for-blocks-when-raytracing.patch
@@ -47,10 +47,10 @@ index 7e1a332168357b9af14dbe3299549c2c93903fa6..93738c7dea1ea3d19013a47380391274
              Vec3 vec3d = raytrace1.getFrom().subtract(raytrace1.getTo());
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 188bd33f46b6baaa3fc21c9da6fa9a9d004e899e..041a6042a91f2a8933d7f9bcb44bb78894ffd405 100644
+index bfe7d57310f822edaa4ddb3ebddb2086ffee8a4a..acb9da6f6560f6cb4ac38c07aca449110d0e2e76 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1116,9 +1116,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1108,9 +1108,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public RayTraceResult rayTraceEntities(Location start, Vector direction, double maxDistance, double raySize, Predicate<? super Entity> filter) {
@@ -68,7 +68,7 @@ index 188bd33f46b6baaa3fc21c9da6fa9a9d004e899e..041a6042a91f2a8933d7f9bcb44bb788
  
          Preconditions.checkArgument(direction != null, "Vector direction cannot be null");
          direction.checkFinite();
-@@ -1168,9 +1174,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1160,9 +1166,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks) {
@@ -87,7 +87,7 @@ index 188bd33f46b6baaa3fc21c9da6fa9a9d004e899e..041a6042a91f2a8933d7f9bcb44bb788
  
          Preconditions.checkArgument(direction != null, "Vector direction cannot be null");
          direction.checkFinite();
-@@ -1183,16 +1196,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1175,16 +1188,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
  
          Vector dir = direction.clone().normalize().multiply(maxDistance);

--- a/patches/server/0893-Fix-strikeLightningEffect-powers-lightning-rods-and-.patch
+++ b/patches/server/0893-Fix-strikeLightningEffect-powers-lightning-rods-and-.patch
@@ -45,10 +45,10 @@ index 152ecd38814089333b8d61538297ce720756d2c3..12127b14babf646711d3a118416453c4
  
              if (world instanceof ServerLevel) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 041a6042a91f2a8933d7f9bcb44bb78894ffd405..b1ad6c47d3d42c93411753d4505ac9142b1697d3 100644
+index acb9da6f6560f6cb4ac38c07aca449110d0e2e76..305e1dc2d727841cd6dd23ec5ec0289e102552f8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -742,7 +742,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -734,7 +734,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          LightningBolt lightning = EntityType.LIGHTNING_BOLT.create(this.world, EntitySpawnReason.COMMAND);
          lightning.moveTo(loc.getX(), loc.getY(), loc.getZ());

--- a/patches/server/0900-Add-Structure-check-API.patch
+++ b/patches/server/0900-Add-Structure-check-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Structure check API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b1ad6c47d3d42c93411753d4505ac9142b1697d3..34e8afae13085f0a9ce0c916d911c88c395418e0 100644
+index 305e1dc2d727841cd6dd23ec5ec0289e102552f8..e8b1d8fb12280f733b3d96a78991b14dcb4484c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -250,6 +250,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -242,6 +242,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          };
      }
      // Paper end

--- a/patches/server/0928-More-Raid-API.patch
+++ b/patches/server/0928-More-Raid-API.patch
@@ -86,10 +86,10 @@ index b8ce1c1c2447f9cff1717bfcfd6eb911ade0d4b3..51f21af9d75769abdcba713b9aa33392
 +    // Paper end - more Raid API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 34e8afae13085f0a9ce0c916d911c88c395418e0..406a3b4a6e213879a9b262d2ffa9ba404cf31cc1 100644
+index e8b1d8fb12280f733b3d96a78991b14dcb4484c4..86d653da7e0ed8123e769eb48c6de2e1396e4fe0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2326,6 +2326,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2318,6 +2318,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (raid == null) ? null : new CraftRaid(raid);
      }
  

--- a/patches/server/0979-Anti-Xray.patch
+++ b/patches/server/0979-Anti-Xray.patch
@@ -1612,10 +1612,10 @@ index 0289bd3e047847a1ecd66ca30863bd0408645667..a3c6ad1a53bdfd9bd928951983a503af
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 406a3b4a6e213879a9b262d2ffa9ba404cf31cc1..367e662c2ca370f569fc65e3f74ec322140630db 100644
+index 86d653da7e0ed8123e769eb48c6de2e1396e4fe0..d7726177e6085faa1169767835d5cb666e4a67bc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -472,11 +472,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -464,11 +464,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  List<ServerPlayer> playersInRange = playerChunk.playerProvider.getPlayers(playerChunk.getPos(), false);
                  if (playersInRange.isEmpty()) return;
  

--- a/patches/server/1020-Add-FeatureFlag-API.patch
+++ b/patches/server/1020-Add-FeatureFlag-API.patch
@@ -162,10 +162,10 @@ index f0bd7d01f56bb792886354ca4f199e46c2cf7503..adc6741e0e017660fbd39a62b69be1e6
 +    // Paper end - feature flag API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 367e662c2ca370f569fc65e3f74ec322140630db..7d360620bd78f28f366815a019c57e5058d9f2a3 100644
+index d7726177e6085faa1169767835d5cb666e4a67bc..0437eee2b34b2ad5799892390726ff79635b6baf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2379,10 +2379,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2371,10 +2371,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.persistentDataContainer;
      }
  
@@ -284,7 +284,7 @@ index 6cf790c9fa23ea313423fdaeb7c181bf530828c6..0bcb9df1103050441f8922a688b163dc
      public static PotionEffectType minecraftHolderToBukkit(Holder<MobEffect> minecraft) {
          return CraftPotionEffectType.minecraftToBukkit(minecraft.value());
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 3bd77074da98bcfe3677995038642c4e9cdb86b8..83835e41034e79442177f19dcb18e7df5b0e296e 100644
+index 8af9ac9e22a15457da12f0746d0e411942c278fb..f4ccdd848dd64e97796ef952d2aeacb3219da1bd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -48,7 +48,7 @@ import org.bukkit.attribute.Attribute;

--- a/patches/server/1032-Void-damage-configuration-API.patch
+++ b/patches/server/1032-Void-damage-configuration-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Void damage configuration API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7093a7383c93f172fb7674799d7efe4c563fc99c..ed276c599890d9db11130d8ae0844ca364a824a6 100644
+index 20fcfb7d7d2541731452454d78f6967215c4fcd7..5949cbccb569ab1d518508d200e69ad9d7d0ba9a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -854,8 +854,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -33,7 +33,7 @@ index 99c98a91fe7471791fca8233acf6eeba516b10ed..4836b01323abb125289982ef3ceca09d
  
      protected void updateSwingTime() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7d360620bd78f28f366815a019c57e5058d9f2a3..6dc3fc701d1e16a51d99f934ea3dc192363a6762 100644
+index 0437eee2b34b2ad5799892390726ff79635b6baf..30dc6ac6c7da7397a113da2994b16ef375b067fa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -167,6 +167,41 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -78,7 +78,7 @@ index 7d360620bd78f28f366815a019c57e5058d9f2a3..6dc3fc701d1e16a51d99f934ea3dc192
  
      // Paper start - Provide fast information methods
      @Override
-@@ -275,6 +310,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -267,6 +302,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              }
          }
          // Paper end - per world spawn limits

--- a/patches/server/1038-Moonrise-optimisation-patches.patch
+++ b/patches/server/1038-Moonrise-optimisation-patches.patch
@@ -26268,7 +26268,7 @@ index 65206fdfa5b94eaca139e433b4865c16b16641f3..bf4463bcb5dc439ac5a3fa08dd60845a
      }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ece660a5cd 100644
+index 0a895055ec7f61d3cb52d303bbe3f89486a322e7..38ac7fd8e68f535a5e9bdd816997e865b7694af1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -52,7 +52,7 @@ import net.minecraft.world.level.storage.DimensionDataStorage;
@@ -26280,8 +26280,8 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
  
      private static final Logger LOGGER = LogUtils.getLogger();
      private final DistanceManager distanceManager;
-@@ -78,6 +78,100 @@ public class ServerChunkCache extends ChunkSource {
-     private final ca.spottedleaf.concurrentutil.map.ConcurrentLong2ReferenceChainedHashTable<net.minecraft.world.level.chunk.LevelChunk> fullChunks = new ca.spottedleaf.concurrentutil.map.ConcurrentLong2ReferenceChainedHashTable<>();
+@@ -81,6 +81,100 @@ public class ServerChunkCache extends ChunkSource {
+     }
      long chunkFutureAwaitCounter;
      // Paper end
 +    // Paper start - rewrite chunk system
@@ -26381,7 +26381,7 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
  
      public ServerChunkCache(ServerLevel world, LevelStorageSource.LevelStorageAccess session, DataFixer dataFixer, StructureTemplateManager structureTemplateManager, Executor workerExecutor, ChunkGenerator chunkGenerator, int viewDistance, int simulationDistance, boolean dsync, ChunkProgressListener worldGenerationProgressListener, ChunkStatusUpdateListener chunkStatusChangeListener, Supplier<DimensionDataStorage> persistentStateManagerFactory) {
          this.level = world;
-@@ -109,13 +203,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -112,13 +206,7 @@ public class ServerChunkCache extends ChunkSource {
      }
      // CraftBukkit end
      // Paper start
@@ -26396,7 +26396,7 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
  
      @Nullable
      public ChunkAccess getChunkAtImmediately(int x, int z) {
-@@ -186,59 +274,42 @@ public class ServerChunkCache extends ChunkSource {
+@@ -189,59 +277,42 @@ public class ServerChunkCache extends ChunkSource {
      @Nullable
      @Override
      public ChunkAccess getChunk(int x, int z, ChunkStatus leastStatus, boolean create) {
@@ -26482,7 +26482,7 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
      }
  
      private void clearCache() {
-@@ -269,56 +340,59 @@ public class ServerChunkCache extends ChunkSource {
+@@ -272,56 +343,59 @@ public class ServerChunkCache extends ChunkSource {
      }
  
      private CompletableFuture<ChunkResult<ChunkAccess>> getChunkFutureMainThread(int chunkX, int chunkZ, ChunkStatus leastStatus, boolean create) {
@@ -26580,7 +26580,7 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
      }
  
      @Override
-@@ -331,30 +405,18 @@ public class ServerChunkCache extends ChunkSource {
+@@ -334,30 +408,18 @@ public class ServerChunkCache extends ChunkSource {
      }
  
      public boolean runDistanceManagerUpdates() { // Paper - public
@@ -26617,7 +26617,7 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
          this.chunkMap.saveAllChunks(flush);
      }
  
-@@ -365,17 +427,15 @@ public class ServerChunkCache extends ChunkSource {
+@@ -368,17 +430,15 @@ public class ServerChunkCache extends ChunkSource {
      }
  
      public void close(boolean save) throws IOException {
@@ -26638,7 +26638,7 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
          ProfilerFiller gameprofilerfiller = Profiler.get();
  
          gameprofilerfiller.push("purge");
-@@ -400,6 +460,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -403,6 +463,7 @@ public class ServerChunkCache extends ChunkSource {
          this.runDistanceManagerUpdates();
          gameprofilerfiller.popPush("chunks");
          if (tickChunks) {
@@ -26646,7 +26646,7 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
              this.tickChunks();
              this.chunkMap.tick();
          }
-@@ -426,7 +487,10 @@ public class ServerChunkCache extends ChunkSource {
+@@ -429,7 +490,10 @@ public class ServerChunkCache extends ChunkSource {
                      gameprofilerfiller.push("filteringTickingChunks");
                      this.collectTickingChunks(list);
                      gameprofilerfiller.popPush("shuffleChunks");
@@ -26658,7 +26658,7 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
                      this.tickChunks(gameprofilerfiller, j, list);
                      gameprofilerfiller.pop();
                  } finally {
-@@ -457,14 +521,26 @@ public class ServerChunkCache extends ChunkSource {
+@@ -460,14 +524,26 @@ public class ServerChunkCache extends ChunkSource {
      }
  
      private void collectTickingChunks(List<LevelChunk> chunks) {
@@ -26690,7 +26690,7 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
      }
  
      private void tickChunks(ProfilerFiller profiler, long timeDelta, List<LevelChunk> chunks) {
-@@ -506,7 +582,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -509,7 +585,7 @@ public class ServerChunkCache extends ChunkSource {
                  NaturalSpawner.spawnForChunk(this.level, chunk, spawnercreature_d, list1);
              }
  
@@ -26699,7 +26699,7 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
                  this.level.tickChunk(chunk, k);
              }
          }
-@@ -519,11 +595,13 @@ public class ServerChunkCache extends ChunkSource {
+@@ -522,11 +598,13 @@ public class ServerChunkCache extends ChunkSource {
      }
  
      private void getFullChunk(long pos, Consumer<LevelChunk> chunkConsumer) {
@@ -26717,7 +26717,7 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
  
      }
  
-@@ -617,6 +695,12 @@ public class ServerChunkCache extends ChunkSource {
+@@ -620,6 +698,12 @@ public class ServerChunkCache extends ChunkSource {
          this.chunkMap.setServerViewDistance(watchDistance);
      }
  
@@ -26730,7 +26730,7 @@ index ea0e972122abd08c2f822f6ff039ac89994e8c20..1d75ad42bfe9324baafb5d60e2fd44ec
      public void setSimulationDistance(int simulationDistance) {
          this.distanceManager.updateSimulationDistance(simulationDistance);
      }
-@@ -708,21 +792,19 @@ public class ServerChunkCache extends ChunkSource {
+@@ -711,21 +795,19 @@ public class ServerChunkCache extends ChunkSource {
          @Override
          // CraftBukkit start - process pending Chunk loadCallback() and unloadCallback() after each run task
          public boolean pollTask() {
@@ -36033,10 +36033,10 @@ index a3c6ad1a53bdfd9bd928951983a503afba9eedc3..34eb7ede1d9f8cbd94660144fc5ef776
  
      // Paper start - Adventure
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6dc3fc701d1e16a51d99f934ea3dc192363a6762..2058671a77cac4cfa6494461a5142abae14402b6 100644
+index 30dc6ac6c7da7397a113da2994b16ef375b067fa..18e6c9fb355614de40999310f47502e2847e626b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -508,10 +508,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -500,10 +500,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          ChunkHolder playerChunk = this.world.getChunkSource().chunkMap.getVisibleChunkIfPresent(ChunkPos.asLong(x, z));
          if (playerChunk == null) return false;
  
@@ -36054,7 +36054,7 @@ index 6dc3fc701d1e16a51d99f934ea3dc192363a6762..2058671a77cac4cfa6494461a5142aba
  
                  // Paper start - Anti-Xray bypass
                  final Map<Object, ClientboundLevelChunkWithLightPacket> refreshPackets = new HashMap<>();
-@@ -524,8 +528,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -516,8 +520,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                      }));
                      // Paper end - Anti-Xray bypass
                  }
@@ -36064,7 +36064,7 @@ index 6dc3fc701d1e16a51d99f934ea3dc192363a6762..2058671a77cac4cfa6494461a5142aba
  
          return true;
      }
-@@ -629,20 +632,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -621,20 +624,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public Collection<Plugin> getPluginChunkTickets(int x, int z) {
          DistanceManager chunkDistanceManager = this.world.getChunkSource().chunkMap.distanceManager;
@@ -36086,7 +36086,7 @@ index 6dc3fc701d1e16a51d99f934ea3dc192363a6762..2058671a77cac4cfa6494461a5142aba
      }
  
      @Override
-@@ -650,7 +641,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -642,7 +633,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Map<Plugin, ImmutableList.Builder<Chunk>> ret = new HashMap<>();
          DistanceManager chunkDistanceManager = this.world.getChunkSource().chunkMap.distanceManager;
  
@@ -36095,7 +36095,7 @@ index 6dc3fc701d1e16a51d99f934ea3dc192363a6762..2058671a77cac4cfa6494461a5142aba
              long chunkKey = chunkTickets.getLongKey();
              SortedArraySet<Ticket<?>> tickets = chunkTickets.getValue();
  
-@@ -1353,12 +1344,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1345,12 +1336,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public int getViewDistance() {
@@ -36110,7 +36110,7 @@ index 6dc3fc701d1e16a51d99f934ea3dc192363a6762..2058671a77cac4cfa6494461a5142aba
      }
  
      public BlockMetadataStore getBlockMetadata() {
-@@ -2496,17 +2487,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2488,17 +2479,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setSimulationDistance(final int simulationDistance) {
@@ -36135,7 +36135,7 @@ index 6dc3fc701d1e16a51d99f934ea3dc192363a6762..2058671a77cac4cfa6494461a5142aba
  
      // Paper start - implement pointers
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 55fa71403c6fe1fa1ffd00d9cecb6b67bd66e174..73ee1ba0b70859cc9c012ab32ad04e8ae2a73e30 100644
+index 0d3d565db8fdc30e44966492f2c30171b4dac7ec..4f1b3b38d1eec331ab67307eb0e9e62621ce3cd5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -3511,7 +3511,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/1040-Fix-CraftWorld-isChunkGenerated.patch
+++ b/patches/server/1040-Fix-CraftWorld-isChunkGenerated.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix CraftWorld#isChunkGenerated
 The upstream implementation is returning true for non-full chunks.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2058671a77cac4cfa6494461a5142abae14402b6..d41c81158c00931e6b11093cce141f6a3085ba05 100644
+index 18e6c9fb355614de40999310f47502e2847e626b..3134fab97260897601d7c8e2810f11b8be86dbec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -417,11 +417,28 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -409,11 +409,28 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {

--- a/patches/server/1053-Optional-per-player-mob-spawns.patch
+++ b/patches/server/1053-Optional-per-player-mob-spawns.patch
@@ -38,10 +38,10 @@ index f1999729cd1c00071c5e1835ee49ea5fcafa7b05..4896c3ba81ead769972fa9efdbe563d4
      // Paper end
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 1d75ad42bfe9324baafb5d60e2fd44ece660a5cd..6a59b3b98c99e5b1d8a2d4f5970fc782bdd0b29c 100644
+index 38ac7fd8e68f535a5e9bdd816997e865b7694af1..b1ecc218034944533967375d11297705c3fc01a3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -489,7 +489,7 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+@@ -492,7 +492,7 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
                      gameprofilerfiller.popPush("shuffleChunks");
                      // Paper start - chunk tick iteration optimisation
                      this.shuffleRandom.setSeed(this.level.random.nextLong());
@@ -50,7 +50,7 @@ index 1d75ad42bfe9324baafb5d60e2fd44ece660a5cd..6a59b3b98c99e5b1d8a2d4f5970fc782
                      // Paper end - chunk tick iteration optimisation
                      this.tickChunks(gameprofilerfiller, j, list);
                      gameprofilerfiller.pop();
-@@ -546,7 +546,19 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+@@ -549,7 +549,19 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
      private void tickChunks(ProfilerFiller profiler, long timeDelta, List<LevelChunk> chunks) {
          profiler.popPush("naturalSpawnCount");
          int j = this.distanceManager.getNaturalSpawnChunkCount();

--- a/patches/server/1054-Improve-cancelling-PreCreatureSpawnEvent-with-per-pl.patch
+++ b/patches/server/1054-Improve-cancelling-PreCreatureSpawnEvent-with-per-pl.patch
@@ -37,10 +37,10 @@ index 4896c3ba81ead769972fa9efdbe563d4006e4401..5b3a886c624b36557cbfaccdc3fb05a4
      }
      // Paper end
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 6a59b3b98c99e5b1d8a2d4f5970fc782bdd0b29c..381b2535d598094990af532b72b15eadc13208ad 100644
+index b1ecc218034944533967375d11297705c3fc01a3..aaaadb7be8abf867624a1ca83371595bef4ab633 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -552,7 +552,17 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+@@ -555,7 +555,17 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
          if ((this.spawnFriendlies || this.spawnEnemies) && this.level.paperConfig().entities.spawning.perPlayerMobSpawns) { // don't count mobs when animals and monsters are disabled
              // re-set mob counts
              for (ServerPlayer player : this.level.players) {


### PR DESCRIPTION
It was returning ticking chunk count instead of the intended full chunk count. We can also directly use the size of the fullChunks collection instead of iterating all chunks.