### PR TITLE
Fix enchantment init

### DIFF
--- a/patches/api/0496-fix-Enchantment-init.patch
+++ b/patches/api/0496-fix-Enchantment-init.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Doc <nachito94@msn.com>
+Date: Sun, 17 Nov 2024 11:28:34 -0300
+Subject: [PATCH] fix Enchantment init
+
+
+diff --git a/src/main/java/org/bukkit/enchantments/Enchantment.java b/src/main/java/org/bukkit/enchantments/Enchantment.java
+index 43e306584988e39a6daca78c621a937acdce48a1..a6c56e0c5b464a03692985d26336d7fa50d7b145 100644
+--- a/src/main/java/org/bukkit/enchantments/Enchantment.java
++++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
+@@ -13,6 +13,8 @@ import org.jetbrains.annotations.Nullable;
+ 
+ /**
+  * The various type of enchantments that may be added to armour or weapons
++ * <br>
++ * <b>Note:</b> Vanilla enchantments can be null or not valid if a datapack just remove them.
+  */
+ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adventure.translation.Translatable { // Paper - Adventure translations
+     /**
+@@ -227,9 +229,9 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
+      */
+     public static final Enchantment SWIFT_SNEAK = getEnchantment("swift_sneak");
+ 
+-    @NotNull
++    @Nullable // Paper - Internal Vanilla enchantments can be Nullables
+     private static Enchantment getEnchantment(@NotNull String key) {
+-        return Registry.ENCHANTMENT.getOrThrow(NamespacedKey.minecraft(key));
++        return Registry.ENCHANTMENT.get(NamespacedKey.minecraft(key)); // Paper - Vanilla enchantments can be null if datapacks remove them
+     }
+ 
+     /**


### PR DESCRIPTION
Fixs #11623 like Tags enchantments (and pretty sure many other Registry things) can be removed by datapacks and how CrafBukkit (for legacy) expects vanilla ever exists can cause issues...
This PR just make the Vanillla Enchantments can be null in the Bukkit Enchantment class also mention in docs about this (more "easy" than add Nullable to all the static instances of Enchantment with the same issue (or maybe this can be better)