### PR TITLE
fix: move to jline-terminal-ffm on java 22+ and fall back to jni on 21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ import kotlin.io.path.*
 plugins {
     java
     `maven-publish`
-    id("io.papermc.paperweight.core") version "1.7.4"
+    id("io.papermc.paperweight.core") version "1.7.5"
 }
 
 allprojects {

--- a/patches/server/0011-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0011-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -25,7 +25,7 @@ Other changes:
 Co-Authored-By: Emilia Kond <emilia@rymiel.space>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 220d2696bf40d1657c87d049f563ccfffed2e8ad..c808f36b30d0f8edb8365875039fd20b8c20007d 100644
+index 220d2696bf40d1657c87d049f563ccfffed2e8ad..99e44684a3f6340ed3c0f73c690a9d4d51872f0d 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -5,6 +5,12 @@ plugins {
@@ -41,13 +41,14 @@ index 220d2696bf40d1657c87d049f563ccfffed2e8ad..c808f36b30d0f8edb8365875039fd20b
  // Paper start - configure mockito agent that is needed in newer java versions
  val mockitoAgent = configurations.register("mockitoAgent")
  abstract class MockitoAgentProvider : CommandLineArgumentProvider {
-@@ -19,7 +25,21 @@ abstract class MockitoAgentProvider : CommandLineArgumentProvider {
+@@ -19,7 +25,22 @@ abstract class MockitoAgentProvider : CommandLineArgumentProvider {
  
  dependencies {
      implementation(project(":paper-api"))
 -    implementation("jline:jline:2.12.1")
 +    // Paper start
-+    implementation("org.jline:jline-terminal-jansi:3.21.0")
++    implementation("org.jline:jline-terminal-ffm:3.27.1") // use ffm on java 22+
++    implementation("org.jline:jline-terminal-jni:3.27.1") // fall back to jni on java 21
 +    implementation("net.minecrell:terminalconsoleappender:1.3.0")
 +    implementation("net.kyori:adventure-text-serializer-ansi:4.17.0") // Keep in sync with adventureVersion from Paper-API build file
 +    /*
@@ -64,7 +65,7 @@ index 220d2696bf40d1657c87d049f563ccfffed2e8ad..c808f36b30d0f8edb8365875039fd20b
      implementation("org.apache.logging.log4j:log4j-iostreams:2.22.1") // Paper - remove exclusion
      implementation("org.ow2.asm:asm-commons:9.7.1")
      implementation("org.spongepowered:configurate-yaml:4.2.0-SNAPSHOT") // Paper - config files
-@@ -92,6 +112,19 @@ tasks.check {
+@@ -92,6 +113,19 @@ tasks.check {
      dependsOn(scanJar)
  }
  // Paper end
@@ -401,7 +402,7 @@ index 1333daa8666fe2ec4033a2f57ba6b716fcdd5343..8daa027a94602d7d556cf4fbfc8fcd97
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c3fc8b1abe843a19347509947f4b864c1b417800..e497da2dba83779c4ad1c45cea133bddadf61446 100644
+index c3774d9a253d4fda80f63d4040722ab5c1c94be4..41aa22f431c989d60dde5c85ca2821d5bcf613af 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -43,7 +43,7 @@ import java.util.logging.Level;
@@ -428,7 +429,7 @@ index c3fc8b1abe843a19347509947f4b864c1b417800..e497da2dba83779c4ad1c45cea133bdd
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 2e33acc428dbfd3e123dfd6ef90bc020b8a08daf..4a99cf5a146abe0d2b40ffc1189fdc5540f14d55 100644
+index 41ceea1093edbf777f9ebe252114be7f75438420..b6e449c2f29b0a201e5e7495de81d21a19f67a25 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -13,7 +13,6 @@ import java.util.logging.Logger;
@@ -467,11 +468,12 @@ index 2e33acc428dbfd3e123dfd6ef90bc020b8a08daf..4a99cf5a146abe0d2b40ffc1189fdc55
                  }
  
                  if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
-@@ -231,6 +241,7 @@ public class Main {
+@@ -231,6 +241,8 @@ public class Main {
                      }
                  }
  
 +                System.setProperty("library.jansi.version", "Paper"); // Paper - set meaningless jansi version to prevent git builds from crashing on Windows
++                System.setProperty("jdk.console", "java.base"); // Paper - revert default console provider back to java.base so we can have our own jline
                  System.out.println("Loading libraries, please wait...");
                  net.minecraft.server.Main.main(options);
              } catch (Throwable t) {

--- a/patches/server/0012-Handle-plugin-prefixes-using-Log4J-configuration.patch
+++ b/patches/server/0012-Handle-plugin-prefixes-using-Log4J-configuration.patch
@@ -15,10 +15,10 @@ This may cause additional prefixes to be disabled for plugins bypassing
 the plugin logger.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index c808f36b30d0f8edb8365875039fd20b8c20007d..59f52f56dd9dc80a929f1ae754138e4ca2ecf493 100644
+index ad49cd6db794dc42dda6f72204d5f232aafde797..ec71e5a0fa0190b54828da9688281e72b21f733e 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -35,7 +35,7 @@ dependencies {
+@@ -36,7 +36,7 @@ dependencies {
            all its classes to check if they are plugins.
            Scanning takes about 1-2 seconds so adding this speeds up the server start.
       */

--- a/patches/server/0014-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
+++ b/patches/server/0014-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use AsyncAppender to keep logging IO off main thread
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 59f52f56dd9dc80a929f1ae754138e4ca2ecf493..dde8718b8c0dab4b8bcd44de33117c48dc3ead0a 100644
+index ec71e5a0fa0190b54828da9688281e72b21f733e..3fb47580cd8de02574905384e455d87224864407 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -46,6 +46,7 @@ dependencies {
+@@ -47,6 +47,7 @@ dependencies {
      implementation("commons-lang:commons-lang:2.6")
      runtimeOnly("org.xerial:sqlite-jdbc:3.46.1.3")
      runtimeOnly("com.mysql:mysql-connector-j:9.1.0")

--- a/patches/server/0015-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0015-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Deobfuscate stacktraces in log messages, crash reports, and
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index dde8718b8c0dab4b8bcd44de33117c48dc3ead0a..429fcd5927cf3259e8cdc83fadf78b41a38eb3bf 100644
+index 3fb47580cd8de02574905384e455d87224864407..653b48c1bc28af6f88ec3bdd11b2d1a683dd3465 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -59,6 +59,7 @@ dependencies {
+@@ -60,6 +60,7 @@ dependencies {
      mockitoAgent("org.mockito:mockito-core:5.14.1") { isTransitive = false } // Paper - configure mockito agent that is needed in newer java versions
      testImplementation("org.ow2.asm:asm-tree:9.7.1")
      testImplementation("org.junit-pioneer:junit-pioneer:2.2.0") // Paper - CartesianTest

--- a/patches/server/0020-Plugin-remapping.patch
+++ b/patches/server/0020-Plugin-remapping.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Plugin remapping
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 429fcd5927cf3259e8cdc83fadf78b41a38eb3bf..fa3476acb77ce5d1247244808ead5b2a994e5fc7 100644
+index dd7900a126ab35ed00af5653a35d361d175f6f76..8678e5bd59a7e085cb1b4e38f29e06ce36d2c1de 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -60,6 +60,7 @@ dependencies {
+@@ -61,6 +61,7 @@ dependencies {
      testImplementation("org.ow2.asm:asm-tree:9.7.1")
      testImplementation("org.junit-pioneer:junit-pioneer:2.2.0") // Paper - CartesianTest
      implementation("net.neoforged:srgutils:1.0.9") // Paper - mappings handling
@@ -17,7 +17,7 @@ index 429fcd5927cf3259e8cdc83fadf78b41a38eb3bf..fa3476acb77ce5d1247244808ead5b2a
  }
  
  paperweight {
-@@ -187,20 +188,41 @@ val runtimeClasspathWithoutVanillaServer = configurations.runtimeClasspath.flatM
+@@ -188,20 +189,41 @@ val runtimeClasspathWithoutVanillaServer = configurations.runtimeClasspath.flatM
          runtime.filterNot { it.asFile.absolutePath == vanilla }
      }
  
@@ -1904,7 +1904,7 @@ index 0000000000000000000000000000000000000000..73b20a92f330311e3fef8f03b51a0985
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 600e865688b423d9bb4338f413dc28418ba37748..ad699a4ad555a4d7c85727bd835ebacd24d02c2b 100644
+index 542ff64ce0cb93a9f996fa0a65e8dde7ed39c3a9..5c54c5c525c86bb8037982435b8769ec2ca2c6cb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1005,6 +1005,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0022-Remap-reflection-calls-in-plugins-using-internals.patch
+++ b/patches/server/0022-Remap-reflection-calls-in-plugins-using-internals.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Remap reflection calls in plugins using internals
 Co-authored-by: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index fa3476acb77ce5d1247244808ead5b2a994e5fc7..47df5ac22b0fc97381364eb4d16e33768ff9794c 100644
+index 24f3d0c96fe9d70b1a7cf528e09ebfc4366577ed..7aee6d9849f0a9c64db0368d2faa03c0633a72a4 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -61,6 +61,12 @@ dependencies {
+@@ -62,6 +62,12 @@ dependencies {
      testImplementation("org.junit-pioneer:junit-pioneer:2.2.0") // Paper - CartesianTest
      implementation("net.neoforged:srgutils:1.0.9") // Paper - mappings handling
      implementation("net.neoforged:AutoRenamingTool:2.0.3") // Paper - remap plugins

--- a/patches/server/0033-Expose-server-build-information.patch
+++ b/patches/server/0033-Expose-server-build-information.patch
@@ -11,7 +11,7 @@ Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 Co-authored-by: masmc05 <masmc05@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 47df5ac22b0fc97381364eb4d16e33768ff9794c..dfc9ca34656cb48462354e7d35dee5ad54096c39 100644
+index 7aee6d9849f0a9c64db0368d2faa03c0633a72a4..40afa9e2cfb4518e9050ccac739aec3215f95d56 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -1,4 +1,5 @@
@@ -20,7 +20,7 @@ index 47df5ac22b0fc97381364eb4d16e33768ff9794c..dfc9ca34656cb48462354e7d35dee5ad
  
  plugins {
      java
-@@ -78,18 +79,24 @@ tasks.jar {
+@@ -79,18 +80,24 @@ tasks.jar {
  
      manifest {
          val git = Git(rootProject.layout.projectDirectory.path)
@@ -659,7 +659,7 @@ index 16d2b3e59b8a6ef65b411afb9d94c61e6d797e36..e4335bfc98272c5499651977625e1f0c
      public List<CraftPlayer> getOnlinePlayers() {
          return this.playerView;
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 6a3331eb45fdd2199fe41ab624d6dbb85bc04711..15ea3363127f315dc3aeb1482dd8a8637cc1a9e0 100644
+index 99bc6e3d472edc0a0182e7b53286cb6a0170ae80..44b6fd8a64e7d7756eb62cd3816b1c4dcc5c5927 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -15,6 +15,7 @@ import joptsimple.OptionSet;
@@ -670,7 +670,7 @@ index 6a3331eb45fdd2199fe41ab624d6dbb85bc04711..15ea3363127f315dc3aeb1482dd8a863
      public static boolean useJline = true;
      public static boolean useConsole = true;
  
-@@ -241,15 +242,17 @@ public class Main {
+@@ -241,7 +242,7 @@ public class Main {
                      deadline.add(Calendar.DAY_OF_YEAR, -14);
                      if (buildDate.before(deadline.getTime())) {
                          System.err.println("*** Error, this build is outdated ***");
@@ -679,12 +679,12 @@ index 6a3331eb45fdd2199fe41ab624d6dbb85bc04711..15ea3363127f315dc3aeb1482dd8a863
                          System.err.println("*** Server will start in 20 seconds ***");
                          Thread.sleep(TimeUnit.SECONDS.toMillis(20));
                      }
-                 }
+@@ -249,8 +250,9 @@ public class Main {
  
                  System.setProperty("library.jansi.version", "Paper"); // Paper - set meaningless jansi version to prevent git builds from crashing on Windows
+                 System.setProperty("jdk.console", "java.base"); // Paper - revert default console provider back to java.base so we can have our own jline
 -                System.out.println("Loading libraries, please wait...");
 -                net.minecraft.server.Main.main(options);
-+
 +                //System.out.println("Loading libraries, please wait...");
 +                //net.minecraft.server.Main.main(options);
 +                io.papermc.paper.PaperBootstrap.boot(options);

--- a/patches/server/0350-Implement-Mob-Goal-API.patch
+++ b/patches/server/0350-Implement-Mob-Goal-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Mob Goal API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index dfc9ca34656cb48462354e7d35dee5ad54096c39..92c1fe881f3bfedc2d773b1812772f16555a09d3 100644
+index 40afa9e2cfb4518e9050ccac739aec3215f95d56..fd687af4923208272b01fc03fe9b65867e49dd6e 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -53,6 +53,7 @@ dependencies {
+@@ -54,6 +54,7 @@ dependencies {
      runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.9.18")
      runtimeOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.9.18")
  

--- a/patches/server/0696-Add-support-for-Proxy-Protocol.patch
+++ b/patches/server/0696-Add-support-for-Proxy-Protocol.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add support for Proxy Protocol
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 92c1fe881f3bfedc2d773b1812772f16555a09d3..c2cd0db92d7f73c6b256440aa8f11e7bcc19e5b7 100644
+index fd687af4923208272b01fc03fe9b65867e49dd6e..c8f3c53a84451cc19c958c1468cf1520f9d3347a 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -40,6 +40,7 @@ dependencies {
+@@ -41,6 +41,7 @@ dependencies {
      log4jPlugins.annotationProcessorConfigurationName("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - Needed to generate meta for our Log4j plugins
      runtimeOnly(log4jPlugins.output)
      alsoShade(log4jPlugins.output)

--- a/patches/server/0980-Use-Velocity-compression-and-cipher-natives.patch
+++ b/patches/server/0980-Use-Velocity-compression-and-cipher-natives.patch
@@ -9,10 +9,10 @@ Feature patch
 private-f net.minecraft.network.CompressionDecoder inflater
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index c2cd0db92d7f73c6b256440aa8f11e7bcc19e5b7..a6ae4494ab5970447625d332ef15a76baac9666e 100644
+index c8f3c53a84451cc19c958c1468cf1520f9d3347a..3288d59c9635819aef0bd864c64cb80e339c050f 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -49,6 +49,11 @@ dependencies {
+@@ -50,6 +50,11 @@ dependencies {
      runtimeOnly("org.xerial:sqlite-jdbc:3.46.1.3")
      runtimeOnly("com.mysql:mysql-connector-j:9.1.0")
      runtimeOnly("com.lmax:disruptor:3.4.4") // Paper

--- a/patches/server/1046-Bundle-spark.patch
+++ b/patches/server/1046-Bundle-spark.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Bundle spark
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index a6ae4494ab5970447625d332ef15a76baac9666e..c209eb393670fd8d6c97ca65a801c8032b582a35 100644
+index 3288d59c9635819aef0bd864c64cb80e339c050f..f5104c3232b4ad1bc486490d17a8877d603c7d8d 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -75,6 +75,10 @@ dependencies {
+@@ -76,6 +76,10 @@ dependencies {
      implementation("io.papermc:reflection-rewriter-runtime:$reflectionRewriterVersion")
      implementation("io.papermc:reflection-rewriter-proxy-generator:$reflectionRewriterVersion")
      // Paper end - Remap reflection
@@ -364,7 +364,7 @@ index c06863578c5d654706d93e73059d89c12ae502a5..17a158ff6ce6520b69a5a0032ba4c054
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // Paper - load version history now
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c814b68933155fe7391b325260052d9affb6841c..e80439a0d17adaab7b782626fd2ee9ce1669058c 100644
+index 34eb7ede1d9f8cbd94660144fc5ef77669ea8afa..dfddcfb1fe1679adaecf75375757dca720e76ce1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -312,6 +312,7 @@ public final class CraftServer implements Server {


### PR DESCRIPTION
ffm requires 1) native access allowed (the jdk cracks down on undocumented native access in 22) and 2) reverting the default console back to java.base, so the internal jline doesnt take over

tested on windows 11, windows terminal cmd/ps java 21/22/23 and cmd/ps java 21/22/23 without windows terminal.

(Closes #10674)
(Closes #10405)
(Replaces #10675)
(Requires https://github.com/PaperMC/paperweight/pull/263)