### PR TITLE
Fix drops for sheared mushroom cow

### DIFF
--- a/patches/server/0907-Add-drops-to-shear-events.patch
+++ b/patches/server/0907-Add-drops-to-shear-events.patch
@@ -46,7 +46,7 @@ index 35076593f3ccd651295ae1fc9bcf8256c19672dd..8fda407c9fbfdde623564a7d9607275c
 +    // Paper end - custom shear drops
  }
 diff --git a/src/main/java/net/minecraft/world/entity/animal/MushroomCow.java b/src/main/java/net/minecraft/world/entity/animal/MushroomCow.java
-index d4d343e2d75a3e3ea787c3c68c64970f5b239f81..feeb7bc34ae02e44d7f13f0bae5d175ef924c53a 100644
+index d4d343e2d75a3e3ea787c3c68c64970f5b239f81..eea02ea0d99425a60575f5fa729782494d579080 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/MushroomCow.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/MushroomCow.java
 @@ -46,6 +46,7 @@ import net.minecraft.world.level.storage.loot.BuiltInLootTables;
@@ -79,7 +79,7 @@ index d4d343e2d75a3e3ea787c3c68c64970f5b239f81..feeb7bc34ae02e44d7f13f0bae5d175e
                  this.gameEvent(GameEvent.SHEAR, player);
                  itemstack.hurtAndBreak(1, player, getSlotForHand(hand));
              }
-@@ -168,22 +176,32 @@ public class MushroomCow extends Cow implements Shearable, VariantHolder<Mushroo
+@@ -168,22 +176,30 @@ public class MushroomCow extends Cow implements Shearable, VariantHolder<Mushroo
  
      @Override
      public void shear(ServerLevel world, SoundSource shearedSoundCategory, ItemStack shears) {
@@ -113,19 +113,18 @@ index d4d343e2d75a3e3ea787c3c68c64970f5b239f81..feeb7bc34ae02e44d7f13f0bae5d175e
 -                    }
 -                    worldserver1.addFreshEntity(entityitem);
 -                    // CraftBukkit end
-+            // Paper start - custom shear drops; moved drop generation to separate method
-+            drops.forEach(itemstack1 -> {
-+                for (final ItemStack drop : drops) {
-+                    ItemEntity entityitem = new ItemEntity(this.level(), this.getX(), this.getY(1.0D), this.getZ(), drop);
-+                    this.spawnAtLocation(world, entityitem);
-                 }
+-                }
 -
++            // Paper start - custom shear drops; moved drop generation to separate method
++            drops.forEach(drop -> {
++                ItemEntity entityitem = new ItemEntity(this.level(), this.getX(), this.getY(1.0D), this.getZ(), drop);
++                this.spawnAtLocation(world, entityitem);
 +            // Paper end - custom shear drops; moved drop generation to separate method
              });
          }, EntityTransformEvent.TransformReason.SHEARED, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.SHEARED); // CraftBukkit
      }
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Sheep.java b/src/main/java/net/minecraft/world/entity/animal/Sheep.java
-index 1bc638ab505850bffcbd08025de9664dd27e47c6..432ad1c785e133ef18390108fd342be50ec4dddc 100644
+index 1bc638ab505850bffcbd08025de9664dd27e47c6..0b7f8b8d8cd119d83e67a2cee389bd6117ac4cf7 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Sheep.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Sheep.java
 @@ -173,11 +173,18 @@ public class Sheep extends Animal implements Shearable {
@@ -150,7 +149,7 @@ index 1bc638ab505850bffcbd08025de9664dd27e47c6..432ad1c785e133ef18390108fd342be5
                      this.gameEvent(GameEvent.SHEAR, player);
                      itemstack.hurtAndBreak(1, player, getSlotForHand(hand));
                      return InteractionResult.SUCCESS_SERVER;
-@@ -192,9 +199,26 @@ public class Sheep extends Animal implements Shearable {
+@@ -192,11 +199,28 @@ public class Sheep extends Animal implements Shearable {
  
      @Override
      public void shear(ServerLevel world, SoundSource shearedSoundCategory, ItemStack shears) {
@@ -177,8 +176,11 @@ index 1bc638ab505850bffcbd08025de9664dd27e47c6..432ad1c785e133ef18390108fd342be5
 +        drops.forEach(itemstack1 -> { // Paper - custom drops - loop in generated default drops
 +            if (true) { // Paper - custom drops - loop in generated default drops
                  this.forceDrops = true; // CraftBukkit
-                 ItemEntity entityitem = this.spawnAtLocation(worldserver1, itemstack1.copyWithCount(1), 1.0F);
+-                ItemEntity entityitem = this.spawnAtLocation(worldserver1, itemstack1.copyWithCount(1), 1.0F);
++                ItemEntity entityitem = this.spawnAtLocation(worldserver1, itemstack1, 1.0F); // Paper - custom drops - copy already done above
                  this.forceDrops = false; // CraftBukkit
+ 
+                 if (entityitem != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/animal/SnowGolem.java b/src/main/java/net/minecraft/world/entity/animal/SnowGolem.java
 index 975a9e35303bec29aedfbd554c38e4331cdfb174..fd9f6c17448a4d87f940eb8f544ecb9669068582 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/SnowGolem.java


### PR DESCRIPTION
The loop was nested so the cow could drop more than 5 mushrooms.
Also fix the event setter that always flatten all the item amount to 1 for the sheep.