### PR TITLE
Make TypedKey an actual Key

### DIFF
--- a/patches/api/0004-Code-Generation.patch
+++ b/patches/api/0004-Code-Generation.patch
@@ -319,7 +319,7 @@ index 0000000000000000000000000000000000000000..80e3e64f47ac55a4978c9e5b430e2f2d
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/TypedKey.java b/src/main/java/io/papermc/paper/registry/TypedKey.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..cb2e1a4a6d583787573eeefab24e3188c43d148f
+index 0000000000000000000000000000000000000000..81bee5224196008662ddda528b5dcb8dd7cb9f21
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/TypedKey.java
 @@ -0,0 +1,45 @@
@@ -337,7 +337,7 @@ index 0000000000000000000000000000000000000000..cb2e1a4a6d583787573eeefab24e3188
 + */
 +@ApiStatus.Experimental
 +@NullMarked
-+public sealed interface TypedKey<T> extends Keyed permits TypedKeyImpl {
++public sealed interface TypedKey<T> extends Key permits TypedKeyImpl {
 +
 +    /**
 +     * Gets the key for the value in the registry.
@@ -370,10 +370,10 @@ index 0000000000000000000000000000000000000000..cb2e1a4a6d583787573eeefab24e3188
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/TypedKeyImpl.java b/src/main/java/io/papermc/paper/registry/TypedKeyImpl.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..99375deaa6b90b33cd6a77e0df651236d304874e
+index 0000000000000000000000000000000000000000..3e29f7007500582cdc3f84b91f11ebeb58f68bbf
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/TypedKeyImpl.java
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,23 @@
 +package io.papermc.paper.registry;
 +
 +import net.kyori.adventure.key.Key;
@@ -381,6 +381,21 @@ index 0000000000000000000000000000000000000000..99375deaa6b90b33cd6a77e0df651236
 +
 +@NullMarked
 +record TypedKeyImpl<T>(Key key, RegistryKey<T> registryKey) implements TypedKey<T> {
++    // Wrap key methods to make this easier to use
++    @Override
++    public String namespace() {
++        return this.key.namespace();
++    }
++
++    @Override
++    public String value() {
++        return this.key.value();
++    }
++
++    @Override
++    public String asString() {
++        return this.key.asString();
++    }
 +}
 diff --git a/src/main/java/org/bukkit/MinecraftExperimental.java b/src/main/java/org/bukkit/MinecraftExperimental.java
 index b7845523e8587e13b86516c0012fe097d904846c..d92a75f610cb2a95203b3f22dc67bdbfb5c3405a 100644


### PR DESCRIPTION
Take an example from the data component api:
```java
Equippable.Builder equippable = itemStack.getData(DataComponentTypes.EQUIPPABLE).toBuilder()
    .equipSound(Sound.ENTITY_GHAST_HURT.key());
```
For the equipment sound and similar methods taking some kind of key, we have wonderful <X>Key classes that unfortunately aren't actually keys. So `Sound.TYPE.key()` ends up being less annoying to use than `SoundEventKeys.TYPE.key()` (though still annoying). Being able to actually use `SoundEventKeys.TYPE` as an argument makes it more likely for people to prefer it over the enums/enum-like registry values

Key extends Keyed, so this won't break existing plugins