### PR TITLE
Call ProjectileHitEvent for entity hits

### DIFF
--- a/patches/server/1071-Call-ProjectileHitEvent-for-entity-hits.patch
+++ b/patches/server/1071-Call-ProjectileHitEvent-for-entity-hits.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <git@lynxplay.dev>
+Date: Sat, 23 Nov 2024 22:48:26 +0100
+Subject: [PATCH] Call ProjectileHitEvent for entity hits
+
+A simple bugfix replacing a new vanilla call to
+Projectile#hitTargetOrDeflectSelf with the bukkit replacement to call
+the event.
+
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
+index accc246f441c8bf5e1a755cfc0db8f97c0c01c6b..571f0699772eecbe02d71845da82a142321f2142 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
+@@ -309,7 +309,7 @@ public abstract class AbstractArrow extends Projectile {
+                         continue;
+                     }
+ 
+-                    ProjectileDeflection projectiledeflection = this.hitTargetOrDeflectSelf(movingobjectpositionentity);
++                    ProjectileDeflection projectiledeflection = this.preHitTargetOrDeflectSelf(movingobjectpositionentity); // Paper - also call projectile hit event
+ 
+                     this.hasImpulse = true;
+                     if (this.getPierceLevel() > 0 && projectiledeflection == ProjectileDeflection.NONE) {


### PR DESCRIPTION
A simple bugfix replacing a new vanilla call to
Projectile#hitTargetOrDeflectSelf with the bukkit replacement to call
the event.

Resolves: #11645
