### PR TITLE
Correctly damage tick wolf after armor block

### DIFF
--- a/patches/server/0948-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
+++ b/patches/server/0948-Revert-to-vanilla-handling-of-LivingEntity-actuallyH.patch
@@ -48,3 +48,16 @@ index d08eec460a67fbd0b2ed2e0dd6d557dc629f4dfe..555d1b05ef6278567de598488b9486db
      }
  
      public CombatTracker getCombatTracker() {
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Wolf.java b/src/main/java/net/minecraft/world/entity/animal/Wolf.java
+index fc19bd326f00d1e8bd08ef6cc430c555337a6e3d..fb84ee1225cd762ef306d1fc3e1baed42c034a3c 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Wolf.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Wolf.java
+@@ -388,7 +388,7 @@ public class Wolf extends TamableAnimal implements NeutralMob, VariantHolder<Hol
+             }
+ 
+         }
+-        return false; // CraftBukkit
++        return true; // CraftBukkit // Paper - return false ONLY if event was cancelled
+     }
+ 
+     private boolean canArmorAbsorb(DamageSource source) {


### PR DESCRIPTION
Spigot incorrectly returns false in Wolf#actuallyHurt if the armor
absorbed the damage causing the entity to not get damage invuln ticks.
Resolve this by correctly reverting to the "always true" return value as
the event is not cancelled.

Resolves: #11650
