### PR TITLE
Brigadier: fix simpleUnwrap not keeping redirect modifier and forks properties from original node

### DIFF
--- a/patches/server/0950-Brigadier-based-command-API.patch
+++ b/patches/server/0950-Brigadier-based-command-API.patch
@@ -10,6 +10,7 @@ public net.minecraft.server.ReloadableServerResources registryLookup
 public net.minecraft.server.ReloadableServerResources
 
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
+Co-authored-by: Marc Baloup <marc.baloup@laposte.net>
 
 diff --git a/src/main/java/com/mojang/brigadier/CommandDispatcher.java b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
 index 4b4f812eb13d5f03bcf3f8724d8aa8dbbc724e8b..a4d5d7017e0be79844b996de85a63cad5f8488bc 100644
@@ -253,7 +254,7 @@ index dd6012b6a097575b2d1471be5069eccee4537c0a..00000000000000000000000000000000
 -}
 diff --git a/src/main/java/io/papermc/paper/command/brigadier/ApiMirrorRootNode.java b/src/main/java/io/papermc/paper/command/brigadier/ApiMirrorRootNode.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..23525592d880f340745a28c956fa38d3e4057231
+index 0000000000000000000000000000000000000000..74d7b19627a127364f3c51700884746d3af1caac
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/brigadier/ApiMirrorRootNode.java
 @@ -0,0 +1,253 @@
@@ -505,7 +506,7 @@ index 0000000000000000000000000000000000000000..23525592d880f340745a28c956fa38d3
 +
 +    private CommandNode<CommandSourceStack> simpleUnwrap(final CommandNode<CommandSourceStack> node) {
 +        return node.createBuilder()
-+            .redirect(node.getRedirect() == null ? null : this.unwrapNode(node.getRedirect()))
++            .forward(node.getRedirect() == null ? null : this.unwrapNode(node.getRedirect()), node.getRedirectModifier(), node.isFork())
 +            .build();
 +    }
 +


### PR DESCRIPTION
In ArgumentBuilder, the `redirect` method resets the values of the properties `modifier` and `forks` to null and false respectively.
This prevented the Brigadier commands registered during the Lifecycle event to use any redirect using the fork method.
This PR changes the use of the `redirect` method by the `forward` method to directly set the 3 forwarding related properties.