### PR TITLE
Fix painting variant builder

### DIFF
--- a/patches/api/0472-Introduce-registry-entry-and-builders.patch
+++ b/patches/api/0472-Introduce-registry-entry-and-builders.patch
@@ -24,10 +24,10 @@ index 647f6a1ec1f9d3c203b41f90a99bfd415bf67366..9b39e33514b15a9d07104e2ad826d0da
       * Built-in registry for cat variants.
 diff --git a/src/main/java/io/papermc/paper/registry/data/EnchantmentRegistryEntry.java b/src/main/java/io/papermc/paper/registry/data/EnchantmentRegistryEntry.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a428bdc5ad9
+index 0000000000000000000000000000000000000000..f092077453cb13dd8d849550896c2ef1cfa81b7a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/data/EnchantmentRegistryEntry.java
-@@ -0,0 +1,332 @@
+@@ -0,0 +1,331 @@
 +package io.papermc.paper.registry.data;
 +
 +import io.papermc.paper.registry.RegistryBuilder;
@@ -177,7 +177,7 @@ index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a42
 +         * sharpness enchantment.
 +         *
 +         * @param description the description component.
-+         * @return this builder.
++         * @return this builder instance.
 +         */
 +        @Contract(value = "_ -> this", mutates = "this")
 +        Builder description(Component description);
@@ -191,7 +191,7 @@ index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a42
 +         * {@link io.papermc.paper.registry.keys.tags.ItemTypeTagKeys#ENCHANTABLE_SWORD}.
 +         *
 +         * @param supportedItems the registry key set representing the supported items.
-+         * @return this builder.
++         * @return this builder instance.
 +         * @see RegistrySet#keySet(RegistryKey, TypedKey[])
 +         * @see io.papermc.paper.registry.event.RegistryFreezeEvent#getOrCreateTag(TagKey)
 +         */
@@ -212,7 +212,7 @@ index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a42
 +         * which enchantments can even show up in an enchantment table.
 +         *
 +         * @param primaryItems the registry key set representing the primary items.
-+         * @return this builder.
++         * @return this builder instance.
 +         * @see RegistrySet#keySet(RegistryKey, TypedKey[])
 +         * @see io.papermc.paper.registry.event.RegistryFreezeEvent#getOrCreateTag(TagKey)
 +         */
@@ -223,7 +223,7 @@ index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a42
 +         * Configures the weight of this enchantment used by the weighted random when selecting enchantments.
 +         *
 +         * @param weight the weight value.
-+         * @return this builder.
++         * @return this builder instance.
 +         * @see <a href="https://minecraft.wiki/w/Enchanting">https://minecraft.wiki/w/Enchanting</a> for examplary weights.
 +         */
 +        @Contract(value = "_ -> this", mutates = "this")
@@ -233,7 +233,7 @@ index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a42
 +         * Configures the maximum level this enchantment can have when applied.
 +         *
 +         * @param maxLevel the maximum level.
-+         * @return this builder.
++         * @return this builder instance.
 +         */
 +        @Contract(value = "_ -> this", mutates = "this")
 +        Builder maxLevel(@Range(from = 1, to = 255) int maxLevel);
@@ -244,7 +244,7 @@ index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a42
 +         * Note that a cost is not directly related to the consumed xp.
 +         *
 +         * @param minimumCost the enchantment cost.
-+         * @return this builder.
++         * @return this builder instance.
 +         * @see <a href="https://minecraft.wiki/w/Enchanting/Levels">https://minecraft.wiki/w/Enchanting/Levels</a> for
 +         * examplary costs.
 +         */
@@ -257,7 +257,7 @@ index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a42
 +         * Note that a cost is not directly related to the consumed xp.
 +         *
 +         * @param maximumCost the enchantment cost.
-+         * @return this builder.
++         * @return this builder instance.
 +         * @see <a href="https://minecraft.wiki/w/Enchanting/Levels">https://minecraft.wiki/w/Enchanting/Levels</a> for
 +         * examplary costs.
 +         */
@@ -272,7 +272,7 @@ index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a42
 +         * </p>
 +         *
 +         * @param anvilCost the anvil cost of this enchantment
-+         * @return this builder.
++         * @return this builder instance.
 +         * @see Enchantment#getAnvilCost()
 +         */
 +        @Contract(value = "_ -> this", mutates = "this")
@@ -285,7 +285,7 @@ index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a42
 +         * groups, the enchantment's effects, like attribute modifiers, will not activate.
 +         *
 +         * @param activeSlots a list of equipment slot groups.
-+         * @return this builder.
++         * @return this builder instance.
 +         * @see Enchantment#getActiveSlotGroups()
 +         */
 +        @Contract(value = "_ -> this", mutates = "this")
@@ -300,7 +300,7 @@ index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a42
 +         * groups, the enchantment's effects, like attribute modifiers, will not activate.
 +         *
 +         * @param activeSlots a list of equipment slot groups.
-+         * @return this builder.
++         * @return this builder instance.
 +         * @see Enchantment#getActiveSlotGroups()
 +         */
 +        @Contract(value = "_ -> this", mutates = "this")
@@ -315,7 +315,7 @@ index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a42
 +         * Defaults to an empty set allowing this enchantment to be applied regardless of other enchantments.
 +         *
 +         * @param exclusiveWith a registry set of enchantments exclusive to this one.
-+         * @return this builder.
++         * @return this builder instance.
 +         * @see RegistrySet#keySet(RegistryKey, TypedKey[])
 +         * @see io.papermc.paper.registry.event.RegistryFreezeEvent#getOrCreateTag(TagKey)
 +         */
@@ -358,7 +358,6 @@ index 0000000000000000000000000000000000000000..d0d19a4bb2ba0e92710861b106777a42
 +            return new Impl(baseCost, additionalPerLevelCost);
 +        }
 +    }
-+
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/data/GameEventRegistryEntry.java b/src/main/java/io/papermc/paper/registry/data/GameEventRegistryEntry.java
 new file mode 100644
@@ -417,10 +416,10 @@ index 0000000000000000000000000000000000000000..980fe12b75258b51cc2498590cadb9de
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/data/PaintingVariantRegistryEntry.java b/src/main/java/io/papermc/paper/registry/data/PaintingVariantRegistryEntry.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b8d133afa82da1b5b9e7a18e1c332ae3aefea50d
+index 0000000000000000000000000000000000000000..4e2c99acd7dc307981ba8e33a62835f0f29fd73e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/data/PaintingVariantRegistryEntry.java
-@@ -0,0 +1,135 @@
+@@ -0,0 +1,131 @@
 +package io.papermc.paper.registry.data;
 +
 +import io.papermc.paper.registry.RegistryBuilder;
@@ -443,27 +442,25 @@ index 0000000000000000000000000000000000000000..b8d133afa82da1b5b9e7a18e1c332ae3
 +public interface PaintingVariantRegistryEntry {
 +
 +    /**
-+     * Provides the width of this variant in blocks.
++     * Provides the width of this painting in blocks.
 +     *
-+     * @return the width
++     * @return the width.
 +     * @see Art#getBlockWidth()
 +     */
-+    @Range(from = 1, to = 16)
-+    int width();
++    @Range(from = 1, to = 16) int width();
 +
 +    /**
-+     * Provides the height of this variant in blocks.
++     * Provides the height of this painting in blocks.
 +     *
-+     * @return the height
++     * @return the height.
 +     * @see Art#getBlockHeight()
 +     */
-+    @Range(from = 1, to = 16)
-+    int height();
++    @Range(from = 1, to = 16) int height();
 +
 +    /**
 +     * Provides the title of the painting visible in the creative inventory.
 +     *
-+     * @return the title
++     * @return the title.
 +     * @see Art#title()
 +     */
 +    @Nullable Component title();
@@ -471,15 +468,15 @@ index 0000000000000000000000000000000000000000..b8d133afa82da1b5b9e7a18e1c332ae3
 +    /**
 +     * Provides the author of the painting visible in the creative inventory.
 +     *
-+     * @return the author
++     * @return the author.
 +     * @see Art#author()
 +     */
 +    @Nullable Component author();
 +
 +    /**
-+     * Provides the assetId of the variant, which is the location of the sprite to use.
++     * Provides the asset id of the painting, which is the location of the sprite to use.
 +     *
-+     * @return the asset id
++     * @return the asset id.
 +     * @see Art#assetId()
 +     */
 +    Key assetId();
@@ -501,30 +498,30 @@ index 0000000000000000000000000000000000000000..b8d133afa82da1b5b9e7a18e1c332ae3
 +        /**
 +         * Sets the width of the painting in blocks.
 +         *
-+         * @param width the width in blocks
-+         * @return this builder instance
++         * @param width the width in blocks.
++         * @return this builder instance.
 +         * @see PaintingVariantRegistryEntry#width()
 +         * @see Art#getBlockWidth()
 +         */
 +        @Contract(value = "_ -> this", mutates = "this")
-+        Builder width(@Range(from = 0, to = 16) int width);
++        Builder width(@Range(from = 1, to = 16) int width);
 +
 +        /**
 +         * Sets the height of the painting in blocks.
 +         *
-+         * @param height the height in blocks
-+         * @return this builder instance
++         * @param height the height in blocks.
++         * @return this builder instance.
 +         * @see PaintingVariantRegistryEntry#height()
 +         * @see Art#getBlockHeight()
 +         */
 +        @Contract(value = "_ -> this", mutates = "this")
-+        Builder height(@Range(from = 0, to = 16) int height);
++        Builder height(@Range(from = 1, to = 16) int height);
 +
 +        /**
 +         * Sets the title of the painting.
 +         *
-+         * @param title the title
-+         * @return this builder instance
++         * @param title the title.
++         * @return this builder instance.
 +         * @see PaintingVariantRegistryEntry#title()
 +         * @see Art#title()
 +         */
@@ -534,8 +531,8 @@ index 0000000000000000000000000000000000000000..b8d133afa82da1b5b9e7a18e1c332ae3
 +        /**
 +         * Sets the author of the painting.
 +         *
-+         * @param author the author
-+         * @return this builder instance
++         * @param author the author.
++         * @return this builder instance.
 +         * @see PaintingVariantRegistryEntry#author()
 +         * @see Art#author()
 +         */
@@ -543,18 +540,16 @@ index 0000000000000000000000000000000000000000..b8d133afa82da1b5b9e7a18e1c332ae3
 +        Builder author(@Nullable Component author);
 +
 +        /**
-+         * Sets the assetId of the variant, which is the location of the sprite to use.
++         * Sets the asset id of the painting, which is the location of the sprite to use.
 +         *
-+         * @param assetId the asset id
-+         * @return this builder instance
++         * @param assetId the asset id.
++         * @return this builder instance.
 +         * @see PaintingVariantRegistryEntry#assetId()
 +         * @see Art#assetId()
 +         */
 +        @Contract(value = "_ -> this", mutates = "this")
 +        Builder assetId(Key assetId);
-+
 +    }
-+
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/data/package-info.java b/src/main/java/io/papermc/paper/registry/data/package-info.java
 new file mode 100644

--- a/patches/api/0495-DataComponent-API.patch
+++ b/patches/api/0495-DataComponent-API.patch
@@ -3561,7 +3561,7 @@ index 0000000000000000000000000000000000000000..979bc05009b84b6fcdb59938cceace35
 +}
 diff --git a/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumableTypesBridge.java b/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumableTypesBridge.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a845ccfc21f101f0632249745bbd8b334f85e72c
+index 0000000000000000000000000000000000000000..e632221f36d0f355b4750071c7d8ccdd84b040a9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumableTypesBridge.java
 @@ -0,0 +1,32 @@
@@ -3589,7 +3589,7 @@ index 0000000000000000000000000000000000000000..a845ccfc21f101f0632249745bbd8b33
 +
 +    ConsumeEffect.ApplyStatusEffects applyStatusEffects(List<PotionEffect> effectList, float probability);
 +
-+    ConsumeEffect.RemoveStatusEffects removeStatusEffects(RegistryKeySet<PotionEffectType> potionEffectTypeTagKey);
++    ConsumeEffect.RemoveStatusEffects removeStatusEffects(RegistryKeySet<PotionEffectType> effectTypes);
 +
 +    ConsumeEffect.ClearAllStatusEffects clearAllStatusEffects();
 +

--- a/patches/server/0992-Registry-Modification-API.patch
+++ b/patches/server/0992-Registry-Modification-API.patch
@@ -1406,21 +1406,24 @@ index 0000000000000000000000000000000000000000..8bee1a5ed877a04e4d027593df1f42ce
 +io.papermc.paper.registry.event.RegistryEventTypeProviderImpl
 diff --git a/src/test/java/io/papermc/paper/registry/RegistryBuilderTest.java b/src/test/java/io/papermc/paper/registry/RegistryBuilderTest.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ceef7b5864deb1d7c6aa5630febe86ba9427bdc4
+index 0000000000000000000000000000000000000000..f2f1dfe4277ce1e84a9494bee285badc958c8d3f
 --- /dev/null
 +++ b/src/test/java/io/papermc/paper/registry/RegistryBuilderTest.java
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,44 @@
 +package io.papermc.paper.registry;
 +
 +import io.papermc.paper.registry.data.util.Conversions;
-+import java.util.List;
++import io.papermc.paper.registry.entry.RegistryEntry;
++import io.papermc.paper.registry.entry.RegistryEntryInfo;
++import io.papermc.paper.registry.legacy.DelayedRegistryEntry;
 +import java.util.Map;
++import java.util.stream.Stream;
 +import net.minecraft.core.Registry;
 +import net.minecraft.resources.RegistryOps;
 +import net.minecraft.resources.ResourceKey;
++import org.bukkit.Keyed;
 +import org.bukkit.support.RegistryHelper;
 +import org.bukkit.support.environment.AllFeatures;
-+import org.junit.jupiter.api.Disabled;
 +import org.junit.jupiter.params.ParameterizedTest;
 +import org.junit.jupiter.params.provider.Arguments;
 +import org.junit.jupiter.params.provider.MethodSource;
@@ -1430,18 +1433,23 @@ index 0000000000000000000000000000000000000000..ceef7b5864deb1d7c6aa5630febe86ba
 +@AllFeatures
 +class RegistryBuilderTest {
 +
-+    static List<Arguments> registries() {
-+        return List.of(
-+        );
++    static Stream<Arguments> registries() {
++        return PaperRegistries.REGISTRY_ENTRIES.stream()
++            .map(RegistryBuilderTest::possiblyUnwrap)
++            .filter(RegistryEntry.BuilderHolder.class::isInstance)
++            .map(Arguments::arguments);
 +    }
 +
-+    @Disabled
++    private static <M, B extends Keyed> RegistryEntryInfo<M, B> possiblyUnwrap(final RegistryEntryInfo<M, B> entry) {
++        return entry instanceof final DelayedRegistryEntry<M, B> delayed ? delayed.delegate() : entry;
++    }
++
 +    @ParameterizedTest
 +    @MethodSource("registries")
-+    <M, T> void testEquality(final ResourceKey<? extends Registry<M>> resourceKey, final PaperRegistryBuilder.Filler<M, T, ?> filler) {
-+        final Registry<M> registry = RegistryHelper.getRegistry().lookupOrThrow(resourceKey);
++    <M, T> void testEquality(final RegistryEntry.BuilderHolder<M, T, ?> registryEntry) {
++        final Registry<M> registry = RegistryHelper.getRegistry().lookupOrThrow(registryEntry.mcKey());
 +        for (final Map.Entry<ResourceKey<M>, M> entry : registry.entrySet()) {
-+            final M built = filler.fill(new Conversions(new RegistryOps.HolderLookupAdapter(RegistryHelper.getRegistry())), PaperRegistries.fromNms(entry.getKey()), entry.getValue()).build();
++            final M built = registryEntry.fillBuilder(new Conversions(new RegistryOps.HolderLookupAdapter(RegistryHelper.getRegistry())), PaperRegistries.fromNms(entry.getKey()), entry.getValue()).build();
 +            assertEquals(entry.getValue(), built);
 +        }
 +    }

--- a/patches/server/0993-Add-registry-entry-and-builders.patch
+++ b/patches/server/0993-Add-registry-entry-and-builders.patch
@@ -283,7 +283,7 @@ index 0000000000000000000000000000000000000000..481f5f0cfae1fada3bc3f873fb7e04c3
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/data/PaperGameEventRegistryEntry.java b/src/main/java/io/papermc/paper/registry/data/PaperGameEventRegistryEntry.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..18f9463ae23ba2d9c65ffb7531a87c925a5a8d6f
+index 0000000000000000000000000000000000000000..a96609223ed1e0500f8a4b868e309c0fc82bbc31
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/data/PaperGameEventRegistryEntry.java
 @@ -0,0 +1,57 @@
@@ -309,11 +309,11 @@ index 0000000000000000000000000000000000000000..18f9463ae23ba2d9c65ffb7531a87c92
 +    public PaperGameEventRegistryEntry(
 +        final Conversions ignoredConversions,
 +        final io.papermc.paper.registry.TypedKey<org.bukkit.GameEvent> ignoredKey,
-+        final @Nullable GameEvent nms
++        final @Nullable GameEvent internal
 +    ) {
-+        if (nms == null) return;
++        if (internal == null) return;
 +
-+        this.range = OptionalInt.of(nms.notificationRadius());
++        this.range = OptionalInt.of(internal.notificationRadius());
 +    }
 +
 +    @Override
@@ -327,9 +327,9 @@ index 0000000000000000000000000000000000000000..18f9463ae23ba2d9c65ffb7531a87c92
 +        public PaperBuilder(
 +            final Conversions conversions,
 +            final io.papermc.paper.registry.TypedKey<org.bukkit.GameEvent> key,
-+            final @Nullable GameEvent nms
++            final @Nullable GameEvent internal
 +        ) {
-+            super(conversions, key, nms);
++            super(conversions, key, internal);
 +        }
 +
 +        @Override
@@ -346,7 +346,7 @@ index 0000000000000000000000000000000000000000..18f9463ae23ba2d9c65ffb7531a87c92
 +}
 diff --git a/src/main/java/io/papermc/paper/registry/data/PaperPaintingVariantRegistryEntry.java b/src/main/java/io/papermc/paper/registry/data/PaperPaintingVariantRegistryEntry.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..21cb8c28c0027b4b2446279f6cf9dbedfc8945d5
+index 0000000000000000000000000000000000000000..68b3d747f759f615a3c942de3f4d7a0fe856cd84
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/registry/data/PaperPaintingVariantRegistryEntry.java
 @@ -0,0 +1,120 @@
@@ -385,16 +385,16 @@ index 0000000000000000000000000000000000000000..21cb8c28c0027b4b2446279f6cf9dbed
 +    public PaperPaintingVariantRegistryEntry(
 +        final Conversions conversions,
 +        final TypedKey<Art> ignoredKey,
-+        final @Nullable PaintingVariant nms
++        final @Nullable PaintingVariant internal
 +    ) {
 +        this.conversions = conversions;
-+        if(nms == null) return;
++        if (internal == null) return;
 +
-+        this.width = OptionalInt.of(nms.width());
-+        this.height = OptionalInt.of(nms.height());
-+        this.title = nms.title().orElse(null);
-+        this.author = nms.title().orElse(null);
-+        this.assetId = nms.assetId();
++        this.width = OptionalInt.of(internal.width());
++        this.height = OptionalInt.of(internal.height());
++        this.title = internal.title().orElse(null);
++        this.author = internal.author().orElse(null);
++        this.assetId = internal.assetId();
 +    }
 +
 +    @Override
@@ -424,18 +424,18 @@ index 0000000000000000000000000000000000000000..21cb8c28c0027b4b2446279f6cf9dbed
 +
 +    public static final class PaperBuilder extends PaperPaintingVariantRegistryEntry implements PaintingVariantRegistryEntry.Builder, PaperRegistryBuilder<PaintingVariant, Art> {
 +
-+        public PaperBuilder(final Conversions conversions, final TypedKey<Art> key, final @Nullable PaintingVariant nms) {
-+            super(conversions, key, nms);
++        public PaperBuilder(final Conversions conversions, final TypedKey<Art> key, final @Nullable PaintingVariant internal) {
++            super(conversions, key, internal);
 +        }
 +
 +        @Override
-+        public Builder width(@Range(from = 0, to = 16) final int width) {
++        public Builder width(final @Range(from = 1, to = 16) int width) {
 +            this.width = OptionalInt.of(asArgumentRange(width, "width", 1, 16));
 +            return this;
 +        }
 +
 +        @Override
-+        public Builder height(@Range(from = 0, to = 16) final int height) {
++        public Builder height(final @Range(from = 1, to = 16) int height) {
 +            this.height = OptionalInt.of(asArgumentRange(height, "height", 1, 16));
 +            return this;
 +        }
@@ -573,44 +573,3 @@ index ac9b4328cd55a68664a3f71186bc9a7be7cd9658..ea9fe1f8b1a1685ea975eba0ca418a83
      @NotNull
      @Override
      public NamespacedKey getKey() {
-diff --git a/src/test/java/io/papermc/paper/registry/RegistryBuilderTest.java b/src/test/java/io/papermc/paper/registry/RegistryBuilderTest.java
-index ceef7b5864deb1d7c6aa5630febe86ba9427bdc4..4d4632da6bf1bde85115dde2e2f7e353bd392176 100644
---- a/src/test/java/io/papermc/paper/registry/RegistryBuilderTest.java
-+++ b/src/test/java/io/papermc/paper/registry/RegistryBuilderTest.java
-@@ -1,11 +1,16 @@
- package io.papermc.paper.registry;
- 
-+import io.papermc.paper.registry.data.PaperEnchantmentRegistryEntry;
-+import io.papermc.paper.registry.data.PaperGameEventRegistryEntry;
- import io.papermc.paper.registry.data.util.Conversions;
- import java.util.List;
- import java.util.Map;
- import net.minecraft.core.Registry;
-+import net.minecraft.core.registries.Registries;
- import net.minecraft.resources.RegistryOps;
- import net.minecraft.resources.ResourceKey;
-+import net.minecraft.world.item.enchantment.Enchantment;
-+import net.minecraft.world.level.gameevent.GameEvent;
- import org.bukkit.support.RegistryHelper;
- import org.bukkit.support.environment.AllFeatures;
- import org.junit.jupiter.api.Disabled;
-@@ -14,16 +19,18 @@ import org.junit.jupiter.params.provider.Arguments;
- import org.junit.jupiter.params.provider.MethodSource;
- 
- import static org.junit.jupiter.api.Assertions.assertEquals;
-+import static org.junit.jupiter.params.provider.Arguments.arguments;
- 
- @AllFeatures
- class RegistryBuilderTest {
- 
-     static List<Arguments> registries() {
-         return List.of(
-+            arguments(Registries.ENCHANTMENT, (PaperRegistryBuilder.Filler<Enchantment, org.bukkit.enchantments.Enchantment, PaperEnchantmentRegistryEntry.PaperBuilder>) PaperEnchantmentRegistryEntry.PaperBuilder::new),
-+            arguments(Registries.GAME_EVENT, (PaperRegistryBuilder.Filler<GameEvent, org.bukkit.GameEvent, PaperGameEventRegistryEntry.PaperBuilder>) PaperGameEventRegistryEntry.PaperBuilder::new)
-         );
-     }
- 
--    @Disabled
-     @ParameterizedTest
-     @MethodSource("registries")
-     <M, T> void testEquality(final ResourceKey<? extends Registry<M>> resourceKey, final PaperRegistryBuilder.Filler<M, T, ?> filler) {

--- a/patches/server/1035-DataComponent-API.patch
+++ b/patches/server/1035-DataComponent-API.patch
@@ -1484,7 +1484,7 @@ index 0000000000000000000000000000000000000000..2a043bb9001048f66d3a6aa8cb896b35
 +}
 diff --git a/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAdventurePredicate.java b/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAdventurePredicate.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c7e40bd15b7063f155b2065927e8201f80fb6d0e
+index 0000000000000000000000000000000000000000..e6315cd0ebd46f874284c32da9cc03eb77f0677f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAdventurePredicate.java
 @@ -0,0 +1,75 @@
@@ -1533,7 +1533,7 @@ index 0000000000000000000000000000000000000000..c7e40bd15b7063f155b2065927e8201f
 +    static final class BuilderImpl implements ItemAdventurePredicate.Builder {
 +
 +        private final List<net.minecraft.advancements.critereon.BlockPredicate> predicates = new ObjectArrayList<>();
-+        private boolean showInTooltip = net.minecraft.world.item.component.ItemAttributeModifiers.EMPTY.showInTooltip();
++        private boolean showInTooltip = true;
 +
 +        @Override
 +        public ItemAdventurePredicate.Builder addPredicate(final BlockPredicate predicate) {
@@ -3311,7 +3311,7 @@ index 0000000000000000000000000000000000000000..037a6695bdb8ee6e3c119fa79000c4ea
 +}
 diff --git a/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumableTypesBridgeImpl.java b/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumableTypesBridgeImpl.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e11e7b36c0b0b499a6149c44ca2ad9f331d1b863
+index 0000000000000000000000000000000000000000..eab1883d691e0d0034b7959c8130a6240c3f529c
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumableTypesBridgeImpl.java
 @@ -0,0 +1,64 @@
@@ -3349,10 +3349,10 @@ index 0000000000000000000000000000000000000000..e11e7b36c0b0b499a6149c44ca2ad9f3
 +    }
 +
 +    @Override
-+    public ConsumeEffect.RemoveStatusEffects removeStatusEffects(final RegistryKeySet<PotionEffectType> potionEffectTypeTagKey) {
++    public ConsumeEffect.RemoveStatusEffects removeStatusEffects(final RegistryKeySet<PotionEffectType> effectTypes) {
 +        return new PaperRemoveStatusEffects(
 +            new net.minecraft.world.item.consume_effects.RemoveStatusEffectsConsumeEffect(
-+                PaperRegistrySets.convertToNms(Registries.MOB_EFFECT, BuiltInRegistries.BUILT_IN_CONVERSIONS.lookup(), potionEffectTypeTagKey)
++                PaperRegistrySets.convertToNms(Registries.MOB_EFFECT, BuiltInRegistries.BUILT_IN_CONVERSIONS.lookup(), effectTypes)
 +            )
 +        );
 +    }

--- a/patches/server/1071-Expanded-Art-API.patch
+++ b/patches/server/1071-Expanded-Art-API.patch
@@ -5,48 +5,28 @@ Subject: [PATCH] Expanded Art API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftArt.java b/src/main/java/org/bukkit/craftbukkit/CraftArt.java
-index 40af940193d0df66bbcdcf5f46132e304016a4d7..932118f5e5bfc765c852acaf21f9721d8fa5fb6a 100644
+index 40af940193d0df66bbcdcf5f46132e304016a4d7..9d73954282104a6e315c1840feb7d6034d27cfbe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftArt.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftArt.java
-@@ -42,6 +42,9 @@ public class CraftArt implements Art, Handleable<PaintingVariant> {
- 
-     private final NamespacedKey key;
-     private final PaintingVariant paintingVariant;
-+    private final net.kyori.adventure.text.@org.jspecify.annotations.Nullable Component adventureTitle; // Paper - name and author components, assetId key
-+    private final net.kyori.adventure.text.@org.jspecify.annotations.Nullable Component adventureAuthor; // Paper - name and author components, assetId key
-+    private final net.kyori.adventure.key.@org.jspecify.annotations.NonNull Key adventureAssetId; // Paper - name and author components, assetId key
-     private final String name;
-     private final int ordinal;
- 
-@@ -58,6 +61,9 @@ public class CraftArt implements Art, Handleable<PaintingVariant> {
-             this.name = key.toString();
-         }
-         this.ordinal = CraftArt.count++;
-+        this.adventureTitle = paintingVariant.title().map(io.papermc.paper.adventure.PaperAdventure::asAdventure).orElse(null); // Paper - name and author components, assetId key
-+        this.adventureAuthor = paintingVariant.author().map(io.papermc.paper.adventure.PaperAdventure::asAdventure).orElse(null); // Paper - name and author components, assetId key
-+        this.adventureAssetId = io.papermc.paper.adventure.PaperAdventure.asAdventure(paintingVariant.assetId()); // Paper - name and author components, assetId key
-     }
- 
-     @Override
-@@ -75,6 +81,22 @@ public class CraftArt implements Art, Handleable<PaintingVariant> {
+@@ -75,6 +75,22 @@ public class CraftArt implements Art, Handleable<PaintingVariant> {
          return this.paintingVariant.height();
      }
  
-+    // Paper start - name and author components, assetId key
++    // Paper start - Expand Art API
 +    @Override
-+    public net.kyori.adventure.text.@org.jetbrains.annotations.Nullable Component title() {
-+        return this.adventureTitle;
++    public net.kyori.adventure.text.Component title() {
++        return this.paintingVariant.title().map(io.papermc.paper.adventure.PaperAdventure::asAdventure).orElse(null);
 +    }
 +
 +    @Override
-+    public net.kyori.adventure.text.@org.jetbrains.annotations.Nullable Component author() {
-+        return this.adventureAuthor;
++    public net.kyori.adventure.text.Component author() {
++        return this.paintingVariant.author().map(io.papermc.paper.adventure.PaperAdventure::asAdventure).orElse(null);
 +    }
 +
-+    public net.kyori.adventure.key.@org.jspecify.annotations.NonNull Key assetId() {
-+        return this.adventureAssetId;
++    public net.kyori.adventure.key.Key assetId() {
++        return io.papermc.paper.adventure.PaperAdventure.asAdventure(this.paintingVariant.assetId());
 +    }
-+    // Paper end - name and author components, assetId key
++    // Paper end - Expand Art API
 +
      @Override
      public int getId() {


### PR DESCRIPTION
Fixes a typo when a plugin try to change already existing variant where the author of all the other paintings would be set to the title. And generalize the test to avoid that in the future.