### PR TITLE
Add EntityEquipmentChangeEvent

### DIFF
--- a/patches/api/0071-Add-PlayerArmorChangeEvent.patch
+++ b/patches/api/0071-Add-PlayerArmorChangeEvent.patch
@@ -6,17 +6,17 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c7cc612ec81b0c7da6ee6676167e047e69347966
+index 0000000000000000000000000000000000000000..b11c8f5abc6110e20538e2ebadd162666e039cc8
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java
-@@ -0,0 +1,120 @@
+@@ -0,0 +1,96 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import java.util.Set;
++import io.papermc.paper.event.entity.EntityEquipmentChangeEvent;
 +import org.bukkit.Material;
 +import org.bukkit.entity.Player;
-+import org.bukkit.event.HandlerList;
-+import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.inventory.EquipmentSlot;
 +import org.bukkit.inventory.ItemStack;
 +import org.jetbrains.annotations.ApiStatus;
 +import org.jspecify.annotations.NullMarked;
@@ -30,20 +30,23 @@ index 0000000000000000000000000000000000000000..c7cc612ec81b0c7da6ee6676167e047e
 + * Not currently called for environmental factors though it <strong>MAY BE IN THE FUTURE</strong>
 + */
 +@NullMarked
-+public class PlayerArmorChangeEvent extends PlayerEvent {
-+
-+    private static final HandlerList HANDLER_LIST = new HandlerList();
++public class PlayerArmorChangeEvent extends EntityEquipmentChangeEvent {
 +
 +    private final SlotType slotType;
-+    private final ItemStack oldItem;
-+    private final ItemStack newItem;
 +
 +    @ApiStatus.Internal
-+    public PlayerArmorChangeEvent(final Player player, final SlotType slotType, final ItemStack oldItem, final ItemStack newItem) {
-+        super(player);
-+        this.slotType = slotType;
-+        this.oldItem = oldItem;
-+        this.newItem = newItem;
++    public PlayerArmorChangeEvent(final Player player, final EquipmentSlot equipmentSlot, final ItemStack oldItem, final ItemStack newItem) {
++        super(player, equipmentSlot, oldItem, newItem);
++        this.slotType = SlotType.valueOf(equipmentSlot.name());
++    }
++
++    @Override
++    public Player getEntity() {
++        return (Player) entity;
++    }
++
++    public Player getPlayer() {
++        return (Player) entity;
 +    }
 +
 +    /**
@@ -53,33 +56,6 @@ index 0000000000000000000000000000000000000000..c7cc612ec81b0c7da6ee6676167e047e
 +     */
 +    public SlotType getSlotType() {
 +        return this.slotType;
-+    }
-+
-+    /**
-+     * Gets the existing item that's being replaced
-+     *
-+     * @return old item
-+     */
-+    public ItemStack getOldItem() {
-+        return this.oldItem;
-+    }
-+
-+    /**
-+     * Gets the new item that's replacing the old
-+     *
-+     * @return new item
-+     */
-+    public ItemStack getNewItem() {
-+        return this.newItem;
-+    }
-+
-+    @Override
-+    public HandlerList getHandlers() {
-+        return HANDLER_LIST;
-+    }
-+
-+    public static HandlerList getHandlerList() {
-+        return HANDLER_LIST;
 +    }
 +
 +    public enum SlotType {
@@ -129,4 +105,82 @@ index 0000000000000000000000000000000000000000..c7cc612ec81b0c7da6ee6676167e047e
 +            return getByMaterial(material) != null;
 +        }
 +    }
++}
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityEquipmentChangeEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityEquipmentChangeEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..f737c4bddd8f6bcfb5d4935fc68b55c36aabd9a8
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityEquipmentChangeEvent.java
+@@ -0,0 +1,72 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.bukkit.inventory.EquipmentSlot;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
++import org.jspecify.annotations.NullMarked;
++
++/**
++ * Called when an entities' equipment changes.
++ */
++@NullMarked
++public class EntityEquipmentChangeEvent extends EntityEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private final EquipmentSlot equipmentSlot;
++    private final ItemStack oldItem;
++    private final ItemStack newItem;
++
++    @ApiStatus.Internal
++    public EntityEquipmentChangeEvent(final LivingEntity entity, final EquipmentSlot equipmentSlot, final ItemStack oldItem, final ItemStack newItem) {
++        super(entity);
++        this.equipmentSlot = equipmentSlot;
++        this.oldItem = oldItem;
++        this.newItem = newItem;
++    }
++
++    @Override
++    public LivingEntity getEntity() {
++        return (LivingEntity) entity;
++    }
++
++    /**
++     * Gets the equipment slot of the item that is being replaced.
++     *
++     * @return the old item
++     */
++    public EquipmentSlot getEquipmentSlot() {
++        return equipmentSlot;
++    }
++
++    /**
++     * Gets the existing item that is being replaced.
++     *
++     * @return the old item
++     */
++    public ItemStack getOldItem() {
++        return oldItem;
++    }
++
++    /**
++     * Gets the new item that is replacing the old item.
++     *
++     * @return the new item
++     */
++    public ItemStack getNewItem() {
++        return newItem;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
 +}

--- a/patches/server/0156-Add-PlayerArmorChangeEvent.patch
+++ b/patches/server/0156-Add-PlayerArmorChangeEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 009539fa39c81c610ac34747cc09082a0756c79d..a03583daf6cac850c154e0e89dc3fa00a844903f 100644
+index 009539fa39c81c610ac34747cc09082a0756c79d..bcbbb0eb7fea095269e93ad5ada5f9b27aa57dd4 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3280,10 +3280,17 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3280,10 +3280,19 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      throw new MatchException((String) null, (Throwable) null);
              }
  
@@ -19,10 +19,12 @@ index 009539fa39c81c610ac34747cc09082a0756c79d..a03583daf6cac850c154e0e89dc3fa00
 +            itemstack = this.getItemBySlot(enumitemslot); final ItemStack newEquipment = itemstack;// Paper - PlayerArmorChangeEvent - obfhelper
              if (this.equipmentHasChanged(itemstack2, itemstack)) {
 +                // Paper start - PlayerArmorChangeEvent
++                final org.bukkit.inventory.ItemStack oldItem = CraftItemStack.asBukkitCopy(oldEquipment);
++                final org.bukkit.inventory.ItemStack newItem = CraftItemStack.asBukkitCopy(newEquipment);
 +                if (this instanceof ServerPlayer && enumitemslot.getType() == EquipmentSlot.Type.HUMANOID_ARMOR) {
-+                    final org.bukkit.inventory.ItemStack oldItem = CraftItemStack.asBukkitCopy(oldEquipment);
-+                    final org.bukkit.inventory.ItemStack newItem = CraftItemStack.asBukkitCopy(newEquipment);
-+                    new com.destroystokyo.paper.event.player.PlayerArmorChangeEvent((Player) this.getBukkitEntity(), com.destroystokyo.paper.event.player.PlayerArmorChangeEvent.SlotType.valueOf(enumitemslot.name()), oldItem, newItem).callEvent();
++                    new com.destroystokyo.paper.event.player.PlayerArmorChangeEvent((Player) this.getBukkitEntity(), org.bukkit.craftbukkit.CraftEquipmentSlot.getSlot(enumitemslot), oldItem, newItem).callEvent();
++                } else {
++                    new io.papermc.paper.event.entity.EntityEquipmentChangeEvent(this.getBukkitLivingEntity(), org.bukkit.craftbukkit.CraftEquipmentSlot.getSlot(enumitemslot), oldItem, newItem).callEvent();
 +                }
 +                // Paper end - PlayerArmorChangeEvent
                  if (map == null) {

--- a/patches/server/0198-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0198-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 08322f6147b78d140a2e0d6c3189ee95270c3c71..9e21f77689eb246ad72cdbd7ee19211dcb2ed738 100644
+index bcbbb0eb7fea095269e93ad5ada5f9b27aa57dd4..75a085455cdca59b50d544b4f089c9f0e0088d35 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4102,12 +4102,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4104,12 +4104,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (this.isUsingItem() && !this.useItem.isEmpty()) {
              Item item = this.useItem.getItem();
  

--- a/patches/server/0239-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/patches/server/0239-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ray tracing methods to LivingEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 61124dfec84792fa23ce1b0f03cbd97b1a6bde5b..30343efb680edf3dc355498b04c5db9ebecbf270 100644
+index 93d55414861960782a3bd9cd436a7aa492d19dfe..02b467a4231b39bd497389c03f2bcae1037d2f07 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4113,6 +4113,19 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4115,6 +4115,19 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      // Paper start - Make shield blocking delay configurable

--- a/patches/server/0251-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0251-Add-LivingEntity-getTargetEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 781568c0aef7556fd4422574d31c0ad790f0afa7..8f6f73fd6f1fce3b78e472f454e0a34043a00125 100644
+index bd1f8d001aa665951441520f268af895b73bf53b..6462634a9802766cc26c647764654482ad8f7cb3 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4177,6 +4177,38 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4179,6 +4179,38 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return this.level().clip(raytrace);
      }
  

--- a/patches/server/0266-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0266-force-entity-dismount-during-teleportation.patch
@@ -20,7 +20,7 @@ this is going to be the best soultion all around.
 Improvements/suggestions welcome!
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index cef054ba95ed7d2b0e2ee575edae3e94b77f58b6..8d958ac09bd9484d879eee6acb6aaea20f4f8339 100644
+index c00c0473c83c724e894cbd08d75e476e8599d55c..05f3275e7be6a0dca5cef3124802287790701dcd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -2826,9 +2826,15 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player {
@@ -41,7 +41,7 @@ index cef054ba95ed7d2b0e2ee575edae3e94b77f58b6..8d958ac09bd9484d879eee6acb6aaea2
              Iterator iterator = entityliving.getActiveEffects().iterator();
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 659ed49cebb8ed2a6e1c88fb1e4d95f0520820d4..2e1628a9b5507ff6b1f00ac83247fc033b2db1c4 100644
+index e67d8da5be50e07cb0473b7bfe6d381da044155a..a430a3e2c3b4ae53cad1fbaf4dd71b9e2f24ccf7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2822,17 +2822,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -106,10 +106,10 @@ index 659ed49cebb8ed2a6e1c88fb1e4d95f0520820d4..2e1628a9b5507ff6b1f00ac83247fc03
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8f6f73fd6f1fce3b78e472f454e0a34043a00125..7e684a7df64b64e25ba602c39488712eefdfbcfa 100644
+index 6462634a9802766cc26c647764654482ad8f7cb3..45e6d6ccafffafcf8eff5dc3c0254fc427e94860 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3757,9 +3757,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3759,9 +3759,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      @Override
      public void stopRiding() {

--- a/patches/server/0293-Prevent-consuming-the-wrong-itemstack.patch
+++ b/patches/server/0293-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 7e684a7df64b64e25ba602c39488712eefdfbcfa..ba78e8b73793292830f3260f9a12c50c698bb881 100644
+index 45e6d6ccafffafcf8eff5dc3c0254fc427e94860..e2aebc600a915c308febcc2c05e3fcd5d73ce4af 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3994,9 +3994,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3996,9 +3996,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public void startUsingItem(InteractionHand hand) {
@@ -24,7 +24,7 @@ index 7e684a7df64b64e25ba602c39488712eefdfbcfa..ba78e8b73793292830f3260f9a12c50c
              this.useItem = itemstack;
              this.useItemRemaining = itemstack.getUseDuration(this);
              if (!this.level().isClientSide) {
-@@ -4067,6 +4072,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4069,6 +4074,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  this.releaseUsingItem();
              } else {
                  if (!this.useItem.isEmpty() && this.isUsingItem()) {
@@ -32,7 +32,7 @@ index 7e684a7df64b64e25ba602c39488712eefdfbcfa..ba78e8b73793292830f3260f9a12c50c
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
                      PlayerItemConsumeEvent event = null; // Paper
-@@ -4104,8 +4110,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4106,8 +4112,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0313-Entity-Jump-API.patch
+++ b/patches/server/0313-Entity-Jump-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Entity Jump API
 public net.minecraft.world.entity.LivingEntity jumping
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ba78e8b73793292830f3260f9a12c50c698bb881..a874913997c80c8f47f395e2ef4bb959aaa3e76d 100644
+index e2aebc600a915c308febcc2c05e3fcd5d73ce4af..9cc56273be257451e73a79de7d9f5c47973155be 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3538,8 +3538,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3540,8 +3540,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
              } else if (this.isInLava() && (!this.onGround() || d3 > d4)) {
                  this.jumpInLiquid(FluidTags.LAVA);
              } else if ((this.onGround() || flag && d3 <= d4) && this.noJumpDelay == 0) {

--- a/patches/server/0336-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0336-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -12,10 +12,10 @@ The entity's current team collision rule causes them to NEVER collide.
 Co-authored-by: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a874913997c80c8f47f395e2ef4bb959aaa3e76d..b01e472a8a5f05e586bfa35e33abfd3875518ab3 100644
+index 9cc56273be257451e73a79de7d9f5c47973155be..6b3217179a1705163af27d75ab735aa910f8182a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3682,10 +3682,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3684,10 +3684,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (!(world instanceof ServerLevel worldserver)) {
              this.level().getEntities(EntityTypeTest.forClass(net.minecraft.world.entity.player.Player.class), this.getBoundingBox(), EntitySelector.pushableBy(this)).forEach(this::doPush);
          } else {

--- a/patches/server/0379-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/patches/server/0379-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 911dcfb9b34d94e38db71c17022b8a8c1e707eb7..e3322e8897f361b3fbf8d7188207271906a84c46 100644
+index 7ab69f6d3e5da621ac830561f3aa5ff4abf4d6ac..1417d7795c0edf79b3dc5ad1837db6b560b56537 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3797,7 +3797,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3799,7 +3799,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          Entity entity = this.getVehicle();
  
          super.stopRiding(suppressCancellation); // Paper - Force entity dismount during teleportation

--- a/patches/server/0434-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0434-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -44,10 +44,10 @@ index b8d57e25851dd7da905100dfd4022e4b99fd7f02..721321a19ce056f82de2bef44a8791dc
              } else if (entity1 instanceof Player && entity instanceof Player && !io.papermc.paper.configuration.GlobalConfiguration.get().collisions.enablePlayerCollisions) { // Paper - Configurable player collision
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e3322e8897f361b3fbf8d7188207271906a84c46..b725bd297ed40aa8ccf3ad77f8652b39980efcf2 100644
+index 1417d7795c0edf79b3dc5ad1837db6b560b56537..43f6fec9462fd66877dea551883f9b31779f76fa 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3711,7 +3711,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3713,7 +3713,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  return;
              }
              // Paper end - don't run getEntities if we're not going to use its result
@@ -56,7 +56,7 @@ index e3322e8897f361b3fbf8d7188207271906a84c46..b725bd297ed40aa8ccf3ad77f8652b39
  
              if (!list.isEmpty()) {
                  // Paper - don't run getEntities if we're not going to use its result; moved up
-@@ -3916,9 +3916,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3918,9 +3918,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return !this.isRemoved() && this.collides; // CraftBukkit
      }
  

--- a/patches/server/0479-Add-EntityMoveEvent.patch
+++ b/patches/server/0479-Add-EntityMoveEvent.patch
@@ -29,10 +29,10 @@ index e4710b95685508a54d552cf916cbaa56ee48a11a..9d62a76a82097f1fc934312e6b764c66
      public LevelChunk getChunkIfLoaded(int x, int z) {
          return this.chunkSource.getChunk(x, z, false);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index b725bd297ed40aa8ccf3ad77f8652b39980efcf2..6b5d8328ae9ce819f6ff1b9ba109a67ce8f121e8 100644
+index 43f6fec9462fd66877dea551883f9b31779f76fa..d2d29fd7d7d5783fc39eb2baa5e68c8d59752856 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3627,6 +3627,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3629,6 +3629,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
          this.pushEntities();
          gameprofilerfiller.pop();

--- a/patches/server/0502-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0502-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,10 +9,10 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 6b5d8328ae9ce819f6ff1b9ba109a67ce8f121e8..123f9a7675c1f194273fff0fdd804cb6ab409201 100644
+index d2d29fd7d7d5783fc39eb2baa5e68c8d59752856..3631145ac746a1bcac941c060fb20b8d4f96388c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4142,6 +4142,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4144,6 +4144,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                              }
                              entityPlayer.getBukkitEntity().updateInventory();
                              entityPlayer.getBukkitEntity().updateScaledHealth();

--- a/patches/server/0547-Line-Of-Sight-Changes.patch
+++ b/patches/server/0547-Line-Of-Sight-Changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Line Of Sight Changes
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 123f9a7675c1f194273fff0fdd804cb6ab409201..f240a63f39affc048d1c13eb184f4b07c6c52d3e 100644
+index 3631145ac746a1bcac941c060fb20b8d4f96388c..0c558b5e6a581087eca1973de487eede1011c0fb 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3906,7 +3906,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3908,7 +3908,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
              Vec3 vec3d = new Vec3(this.getX(), this.getEyeY(), this.getZ());
              Vec3 vec3d1 = new Vec3(entity.getX(), entityY.getAsDouble(), entity.getZ());
  

--- a/patches/server/0649-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0649-Freeze-Tick-Lock-API.patch
@@ -46,10 +46,10 @@ index 568e968af99cc97de5c32b432f8c1be9790b0bcd..775243c5a2c44300c00f4f674f40d679
  
          } catch (Throwable throwable) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f714569ebc0e6c43d4d879b2d7bb407b0eed77f6..03285728ca3df70c487cd67e973812f3968218e2 100644
+index 446441ba5c9d68ddf85d7811467a33a764131a3b..b8076d71a2d3e877c458e1b524c26c7d4f5297f8 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3610,7 +3610,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3612,7 +3612,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          this.calculateEntityAnimation(this instanceof FlyingAnimal);
          gameprofilerfiller.pop();
          gameprofilerfiller.push("freezing");

--- a/patches/server/0692-Add-PlayerStopUsingItemEvent.patch
+++ b/patches/server/0692-Add-PlayerStopUsingItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerStopUsingItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 03285728ca3df70c487cd67e973812f3968218e2..d86f10107e5f580fe96ff6a3cd186ca16d24f3f9 100644
+index b8076d71a2d3e877c458e1b524c26c7d4f5297f8..27ce919125d8fe727390cb1b0a7e4e61500b0b21 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4203,6 +4203,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4205,6 +4205,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      public void releaseUsingItem() {
          if (!this.useItem.isEmpty()) {

--- a/patches/server/0759-check-global-player-list-where-appropriate.patch
+++ b/patches/server/0759-check-global-player-list-where-appropriate.patch
@@ -24,10 +24,10 @@ index 6db3418d839c0f4cd75ad822e605dc2105c3df53..77c1ddc6fd14e0b033825909e5c814ab
 +    // Paper end - check global player list where appropriate
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 18c56cef30fca0174703e775b3bbbf6df4272585..d239108bd98fe885eba50a17855f2d62de02c70e 100644
+index 8fe158d1a14c46c9e7793f997f949997c3dde83b..080d66ab8a35e285512bbcf43d8c3697bdc8bcad 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3866,7 +3866,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3868,7 +3868,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public void onItemPickup(ItemEntity item) {

--- a/patches/server/0890-Broadcast-take-item-packets-with-collector-as-source.patch
+++ b/patches/server/0890-Broadcast-take-item-packets-with-collector-as-source.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Broadcast take item packets with collector as source
 This fixes players (which can't view the collector) seeing item pickups with themselves as the target.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 7bce1bd9ff1d76c5a238d03475d8bcdaaca680d3..84623aa24f8c90f0b51094c2d0773ee98c3a8524 100644
+index 816b0a6c25b460f29dd56fbfc310b06b8ca98034..ede805cf95fccc72130aba23815d936b1a5778bd 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3892,7 +3892,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3894,7 +3894,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      public void take(Entity item, int count) {
          if (!item.isRemoved() && !this.level().isClientSide && (item instanceof ItemEntity || item instanceof AbstractArrow || item instanceof ExperienceOrb)) {

--- a/patches/server/0905-Fix-NPE-on-null-loc-for-EntityTeleportEvent.patch
+++ b/patches/server/0905-Fix-NPE-on-null-loc-for-EntityTeleportEvent.patch
@@ -26,10 +26,10 @@ index c6dcc37ac5fcf50bcb246f533b99983dfc5c19c2..c13b6f14c3061710c2b27034db240cc9
                  d3 = to.getX();
                  d4 = to.getY();
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4fbd23d1783642becb39a404b988eb44c418c3b5..bd2df2a70e78b68b5eefd9c0b6fe14f9717fb1d7 100644
+index cbab906077edc4b7bec4b3bbadd1a7ac7369b9c6..64b7a2c1384f5ce5bd793f45dd8e4e37e6389678 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4364,7 +4364,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4366,7 +4366,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      if (!(this instanceof ServerPlayer)) {
                          EntityTeleportEvent teleport = new EntityTeleportEvent(this.getBukkitEntity(), new Location(this.level().getWorld(), d3, d4, d5), new Location(this.level().getWorld(), d0, d6, d2));
                          this.level().getCraftServer().getPluginManager().callEvent(teleport);

--- a/patches/server/0959-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0959-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -222,10 +222,10 @@ index 688916c8fef40d4c81379ad38609a97993b4b702..6cf3b28749d92b4e33e2f88c6335c9a6
  
                                  ServerGamePacketListenerImpl.this.player.containerMenu.sendAllDataToRemote(); // Paper - fix slot desync - always refresh player inventory
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 555d1b05ef6278567de598488b9486db965b8587..e33130ca8f3d2572018dd782b366af2989a95fd6 100644
+index 2837ec29b69f4215cb06bd335d71c3bd5fc83772..91fbad8de23b443d9c50912b52d000f3c603373b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3461,7 +3461,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3463,7 +3463,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              }
  
          });

--- a/patches/server/0991-Properly-resend-entities.patch
+++ b/patches/server/0991-Properly-resend-entities.patch
@@ -188,10 +188,10 @@ index 6a4f52342c5a195206ecf3ac118e8a4df4d2f3d2..20fcfb7d7d2541731452454d78f69672
      public boolean equals(Object object) {
          return object instanceof Entity ? ((Entity) object).id == this.id : false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ed26eb5e8cc9a46e4a4d2c58d587463d5571a8e0..5616391f02f8599f5786a6d8e740a0ed9290627f 100644
+index 170ff32b9cef77dc6ac71fcac7b838bdaee5a22d..1c96ebcafb2b9856bbea734533a38a0243a92f33 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4030,6 +4030,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4032,6 +4032,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 2) > 0 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
      }
  

--- a/patches/server/1051-Lag-compensation-ticks.patch
+++ b/patches/server/1051-Lag-compensation-ticks.patch
@@ -65,10 +65,10 @@ index 504c996220b278c194c93e001a3b326d549868ec..a96f859a5d0c6ec692d4627a69f3c9ee
  
          if (this.hasDelayedDestroy) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 59c992173fda6153c58722caae061b0e6bee86a1..6a3a8f0466998409a01223bc0c16d92b96e50118 100644
+index 5263b9ba38ddce2343f2b4c36f5aa97dbab7e596..6533ca93b26381ec90f61e7be7db6787ad137e2c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4051,6 +4051,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4053,6 +4053,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
          this.resendPossiblyDesyncedDataValues(java.util.List.of(DATA_LIVING_ENTITY_FLAGS), serverPlayer);
      }
      // Paper end - Properly cancel usable items
@@ -79,7 +79,7 @@ index 59c992173fda6153c58722caae061b0e6bee86a1..6a3a8f0466998409a01223bc0c16d92b
      private void updatingUsingItem() {
          if (this.isUsingItem()) {
              if (ItemStack.isSameItem(this.getItemInHand(this.getUsedItemHand()), this.useItem)) {
-@@ -4065,7 +4069,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4067,7 +4071,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      protected void updateUsingItem(ItemStack stack) {
          stack.onUseTick(this.level(), this, this.getUseItemRemainingTicks());
@@ -93,7 +93,7 @@ index 59c992173fda6153c58722caae061b0e6bee86a1..6a3a8f0466998409a01223bc0c16d92b
              this.completeUsingItem();
          }
  
-@@ -4103,7 +4112,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4105,7 +4114,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
          if (!itemstack.isEmpty() && !this.isUsingItem() || forceUpdate) { // Paper - Prevent consuming the wrong itemstack
              this.useItem = itemstack;
@@ -105,7 +105,7 @@ index 59c992173fda6153c58722caae061b0e6bee86a1..6a3a8f0466998409a01223bc0c16d92b
              if (!this.level().isClientSide) {
                  this.setLivingEntityFlag(1, true);
                  this.setLivingEntityFlag(2, hand == InteractionHand.OFF_HAND);
-@@ -4128,7 +4140,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4130,7 +4142,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  }
              } else if (!this.isUsingItem() && !this.useItem.isEmpty()) {
                  this.useItem = ItemStack.EMPTY;
@@ -117,7 +117,7 @@ index 59c992173fda6153c58722caae061b0e6bee86a1..6a3a8f0466998409a01223bc0c16d92b
              }
          }
  
-@@ -4259,7 +4274,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4261,7 +4276,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
          }
  
          this.useItem = ItemStack.EMPTY;


### PR DESCRIPTION
Adds `EntityEquipmentChangeEvent`, a more generic version of `PlayerArmorChangeEvent` that applies to the equipment changes of living entities.

At the moment, the patch changes `PlayerArmorChangeEvent` to extend `EntityEquipmentChangeEvent`. I'm not sure on this, especially since that would make `PlayerArmorChangeEvent` no longer extend `PlayerEvent`.

Another alternative I considered was for the event to instead expose a map of slots -> equipment changes, so that the event is called only once when multiple slots are changed, and avoiding changing the inheritance of `PlayerArmorChangeEvent`.