### PR TITLE
Added PlayerUseBowWithoutProjectileEvent

### DIFF
--- a/patches/api/0501-Added-PlayerUseBowWithoutProjectileEvent.patch
+++ b/patches/api/0501-Added-PlayerUseBowWithoutProjectileEvent.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chaosdave34 <david.emanuel@gmx.de>
+Date: Tue, 26 Nov 2024 17:10:15 +0100
+Subject: [PATCH] Added PlayerUseBowWithoutProjectileEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..7ea392d6accb967a545a720718e33ddbb13023c9
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java
+@@ -0,0 +1,35 @@
++package io.papermc.paper.event.player;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++
++public class PlayerUseBowWithoutProjectileEvent extends PlayerEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private ItemStack projectile;
++
++    public PlayerUseBowWithoutProjectileEvent(@NotNull final Player player) {
++        super(player);
++    }
++
++    public ItemStack getProjectile() {
++        return projectile;
++    }
++
++    public void setProjectile(ItemStack projectile) {
++        this.projectile = projectile;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}

--- a/patches/server/1073-Call-PlayerUseBowWithoutProjectileEvent-in-Player-ge.patch
+++ b/patches/server/1073-Call-PlayerUseBowWithoutProjectileEvent-in-Player-ge.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chaosdave34 <david.emanuel@gmx.de>
+Date: Tue, 26 Nov 2024 17:11:23 +0100
+Subject: [PATCH] Call PlayerUseBowWithoutProjectileEvent in
+ Player#getProjectile
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
+index 61d412c4f1ebd55661cc3f0260468e3ac0efe0bb..f793e41ed4f202e2f3d1257c1d9768d28da05e83 100644
+--- a/src/main/java/net/minecraft/world/entity/player/Player.java
++++ b/src/main/java/net/minecraft/world/entity/player/Player.java
+@@ -2266,7 +2266,15 @@ public abstract class Player extends LivingEntity {
+                     }
+                 }
+ 
+-                return this.abilities.instabuild ? new ItemStack(Items.ARROW) : ItemStack.EMPTY;
++                // Paper start - Call PlayerUseProjectileWeaponWithoutProjectileEvent in Player#getProjectile
++                if (this.abilities.instabuild) {
++                    return new ItemStack(Items.ARROW);
++                } else {
++                    io.papermc.paper.event.player.PlayerUseBowWithoutProjectileEvent event = new io.papermc.paper.event.player.PlayerUseBowWithoutProjectileEvent((org.bukkit.entity.Player) getBukkitEntity());
++                    event.callEvent();
++                    return org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getProjectile());
++                }
++                // Paper end - Call PlayerUseProjectileWeaponWithoutProjectileEvent in Player#getProjectile
+             }
+         }
+     }


### PR DESCRIPTION
Added PlayerUseBowWithoutProjectileEvent when a player tries to load a crossbow or draw a bow without having a suitable projectile in their inventory. Makes it possible to set a projectile and enable the player to use the weapon nevertheless.