### PR TITLE
 Added PlayerUseBowWithoutProjectileEvent #11668 

### DIFF
--- a/patches/api/0501-Added-PlayerUseBowWithoutProjectileEvent.patch
+++ b/patches/api/0501-Added-PlayerUseBowWithoutProjectileEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Added PlayerUseBowWithoutProjectileEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9ddb8900f33063b4e93cda38b2fb760f1ce50eaf
+index 0000000000000000000000000000000000000000..dbc2fd3a33d528789fdd39a1c98c656ae4c7be5d
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java
-@@ -0,0 +1,53 @@
+@@ -0,0 +1,54 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Player;
@@ -32,6 +32,7 @@ index 0000000000000000000000000000000000000000..9ddb8900f33063b4e93cda38b2fb760f
 +    @ApiStatus.Internal
 +    public PlayerUseBowWithoutProjectileEvent(final Player player) {
 +        super(player);
++        this.projectile = ItemStack.empty();
 +    }
 +
 +    /**
@@ -40,18 +41,18 @@ index 0000000000000000000000000000000000000000..9ddb8900f33063b4e93cda38b2fb760f
 +     * @return the projectile
 +     */
 +    public ItemStack getProjectile() {
-+        return projectile.copy();
++        return projectile.clone();
 +    }
 +
 +    /**
-+     * Sets the projectile that should used
++     * Sets the projectile that should be used
 +     * <p>
 +     * Note: setting this to {@link ItemStack#empty()} will prevent the player from using the bow/crossbow
 +     * 
 +     * @param projectile the projectile
 +     */
 +    public void setProjectile(ItemStack projectile) {
-+        this.projectile = projectile.copy();
++        this.projectile = projectile.clone();
 +    }
 +
 +    @Override

--- a/patches/api/0501-Added-PlayerUseBowWithoutProjectileEvent.patch
+++ b/patches/api/0501-Added-PlayerUseBowWithoutProjectileEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Added PlayerUseBowWithoutProjectileEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..dbc2fd3a33d528789fdd39a1c98c656ae4c7be5d
+index 0000000000000000000000000000000000000000..59e432878c2619d559eac2855fffe3b73c1f05c0
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,65 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Player;
@@ -27,12 +27,23 @@ index 0000000000000000000000000000000000000000..dbc2fd3a33d528789fdd39a1c98c656a
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
++    private final ItemStack item;
 +    private ItemStack projectile;
 +
 +    @ApiStatus.Internal
-+    public PlayerUseBowWithoutProjectileEvent(final Player player) {
++    public PlayerUseBowWithoutProjectileEvent(final Player player, final ItemStack item) {
 +        super(player);
++        this.item = item;
 +        this.projectile = ItemStack.empty();
++    }
++
++    /**
++     *  Gets the item which the player tries to use
++     *
++     * @return the item
++     */
++    public ItemStack getItem() {
++        return item.clone();
 +    }
 +
 +    /**

--- a/patches/api/0501-Added-PlayerUseBowWithoutProjectileEvent.patch
+++ b/patches/api/0501-Added-PlayerUseBowWithoutProjectileEvent.patch
@@ -6,34 +6,52 @@ Subject: [PATCH] Added PlayerUseBowWithoutProjectileEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7ea392d6accb967a545a720718e33ddbb13023c9
+index 0000000000000000000000000000000000000000..9ddb8900f33063b4e93cda38b2fb760f1ce50eaf
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,53 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.ItemStack;
-+import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.ApiStatus;
++import org.jspecify.annotations.NullMarked;
 +
++/**
++ * Called when a player tries to draw a bow or load a crossbow without having a suitable projectile in their inventory
++ */
++@NullMarked
 +public class PlayerUseBowWithoutProjectileEvent extends PlayerEvent {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    private ItemStack projectile;
 +
-+    public PlayerUseBowWithoutProjectileEvent(@NotNull final Player player) {
++    @ApiStatus.Internal
++    public PlayerUseBowWithoutProjectileEvent(final Player player) {
 +        super(player);
 +    }
 +
++    /**
++     * Gets the projectile that should be used
++     * 
++     * @return the projectile
++     */
 +    public ItemStack getProjectile() {
-+        return projectile;
++        return projectile.copy();
 +    }
 +
++    /**
++     * Sets the projectile that should used
++     * <p>
++     * Note: setting this to {@link ItemStack#empty()} will prevent the player from using the bow/crossbow
++     * 
++     * @param projectile the projectile
++     */
 +    public void setProjectile(ItemStack projectile) {
-+        this.projectile = projectile;
++        this.projectile = projectile.copy();
 +    }
 +
 +    @Override

--- a/patches/api/0501-Added-PlayerUseBowWithoutProjectileEvent.patch
+++ b/patches/api/0501-Added-PlayerUseBowWithoutProjectileEvent.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chaosdave34 <david.emanuel@gmx.de>
+Date: Tue, 26 Nov 2024 17:10:15 +0100
+Subject: [PATCH] Added PlayerUseBowWithoutProjectileEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..7ea392d6accb967a545a720718e33ddbb13023c9
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/player/PlayerUseBowWithoutProjectileEvent.java
+@@ -0,0 +1,35 @@
++package io.papermc.paper.event.player;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++
++public class PlayerUseBowWithoutProjectileEvent extends PlayerEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private ItemStack projectile;
++
++    public PlayerUseBowWithoutProjectileEvent(@NotNull final Player player) {
++        super(player);
++    }
++
++    public ItemStack getProjectile() {
++        return projectile;
++    }
++
++    public void setProjectile(ItemStack projectile) {
++        this.projectile = projectile;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}

--- a/patches/server/1073-Call-PlayerUseBowWithoutProjectileEvent-in-Player-ge.patch
+++ b/patches/server/1073-Call-PlayerUseBowWithoutProjectileEvent-in-Player-ge.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chaosdave34 <david.emanuel@gmx.de>
+Date: Tue, 26 Nov 2024 17:11:23 +0100
+Subject: [PATCH] Call PlayerUseBowWithoutProjectileEvent in
+ Player#getProjectile
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
+index 61d412c4f1ebd55661cc3f0260468e3ac0efe0bb..f793e41ed4f202e2f3d1257c1d9768d28da05e83 100644
+--- a/src/main/java/net/minecraft/world/entity/player/Player.java
++++ b/src/main/java/net/minecraft/world/entity/player/Player.java
+@@ -2266,7 +2266,15 @@ public abstract class Player extends LivingEntity {
+                     }
+                 }
+ 
+-                return this.abilities.instabuild ? new ItemStack(Items.ARROW) : ItemStack.EMPTY;
++                // Paper start - Call PlayerUseProjectileWeaponWithoutProjectileEvent in Player#getProjectile
++                if (this.abilities.instabuild) {
++                    return new ItemStack(Items.ARROW);
++                } else {
++                    io.papermc.paper.event.player.PlayerUseBowWithoutProjectileEvent event = new io.papermc.paper.event.player.PlayerUseBowWithoutProjectileEvent((org.bukkit.entity.Player) getBukkitEntity());
++                    event.callEvent();
++                    return org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getProjectile());
++                }
++                // Paper end - Call PlayerUseProjectileWeaponWithoutProjectileEvent in Player#getProjectile
+             }
+         }
+     }

--- a/patches/server/1073-Call-PlayerUseBowWithoutProjectileEvent-in-Player-ge.patch
+++ b/patches/server/1073-Call-PlayerUseBowWithoutProjectileEvent-in-Player-ge.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Call PlayerUseBowWithoutProjectileEvent in
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 61d412c4f1ebd55661cc3f0260468e3ac0efe0bb..f793e41ed4f202e2f3d1257c1d9768d28da05e83 100644
+index 61d412c4f1ebd55661cc3f0260468e3ac0efe0bb..6cf27e4e95b6b73212236ce739dc2514ea8dbab4 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -2266,7 +2266,15 @@ public abstract class Player extends LivingEntity {
@@ -14,15 +14,15 @@ index 61d412c4f1ebd55661cc3f0260468e3ac0efe0bb..f793e41ed4f202e2f3d1257c1d9768d2
                  }
  
 -                return this.abilities.instabuild ? new ItemStack(Items.ARROW) : ItemStack.EMPTY;
-+                // Paper start - Call PlayerUseProjectileWeaponWithoutProjectileEvent in Player#getProjectile
++                // Paper start - Call PlayerUseBowWithoutProjectileEvent in Player#getProjectile
 +                if (this.abilities.instabuild) {
 +                    return new ItemStack(Items.ARROW);
 +                } else {
-+                    io.papermc.paper.event.player.PlayerUseBowWithoutProjectileEvent event = new io.papermc.paper.event.player.PlayerUseBowWithoutProjectileEvent((org.bukkit.entity.Player) getBukkitEntity());
++                    io.papermc.paper.event.player.PlayerUseBowWithoutProjectileEvent event = new io.papermc.paper.event.player.PlayerUseBowWithoutProjectileEvent((org.bukkit.entity.Player) getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(stack));
 +                    event.callEvent();
 +                    return org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getProjectile());
 +                }
-+                // Paper end - Call PlayerUseProjectileWeaponWithoutProjectileEvent in Player#getProjectile
++                // Paper end - Call PlayerUseBowWithoutProjectileEvent in Player#getProjectile
              }
          }
      }


### PR DESCRIPTION
Added PlayerUseBowWithoutProjectileEvent when a player tries to load a crossbow or draw a bow without having a suitable projectile in their inventory. Makes it possible to set a projectile and enable the player to use the weapon nevertheless.