### PR TITLE
Remove string dupe exploit setting

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -485,10 +485,10 @@ index 0000000000000000000000000000000000000000..007e01d329a31acf7f4ed4c6dc4de7ad
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0ea9eba1367858dfa5284524a8dd2f79daf6fc69
+index 0000000000000000000000000000000000000000..87da4ff63294735bfcbfa8442fb8ae7196b0f197
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,330 @@
+@@ -0,0 +1,328 @@
 +package io.papermc.paper.configuration;
 +
 +import com.mojang.logging.LogUtils;
@@ -653,8 +653,6 @@ index 0000000000000000000000000000000000000000..0ea9eba1367858dfa5284524a8dd2f79
 +    public UnsupportedSettings unsupportedSettings;
 +
 +    public class UnsupportedSettings extends ConfigurationPart {
-+        @Comment("This setting controls if the broken behavior of disarmed tripwires not breaking should be allowed. This also allows for dupes")
-+        public boolean allowTripwireDisarmingExploits = false;
 +        @Comment("This setting allows for exploits related to end portals, for example sand duping")
 +        public boolean allowUnsafeEndPortalTeleportation = false;
 +        @Comment("This setting controls if players should be able to break bedrock, end portals and other intended to be permanent blocks.")
@@ -1334,10 +1332,10 @@ index 0000000000000000000000000000000000000000..c5644d8d64f12073e39bc6ed79c8714f
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/RemovedConfigurations.java b/src/main/java/io/papermc/paper/configuration/RemovedConfigurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..279b24c689b9979884b65df7eb1f059024f0feac
+index 0000000000000000000000000000000000000000..f9a4bb664409a6c691c4dc901afe0bde75813636
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/RemovedConfigurations.java
-@@ -0,0 +1,83 @@
+@@ -0,0 +1,84 @@
 +package io.papermc.paper.configuration;
 +
 +import org.spongepowered.configurate.NodePath;
@@ -1417,7 +1415,8 @@ index 0000000000000000000000000000000000000000..279b24c689b9979884b65df7eb1f0590
 +        path("limit-player-interactions"),
 +        path("warnWhenSettingExcessiveVelocity"),
 +        path("logging", "use-rgb-for-named-text-colors"),
-+        path("unsupported-settings", "allow-grindstone-overstacking")
++        path("unsupported-settings", "allow-grindstone-overstacking"),
++        path("unsupported-settings", "allow-tripwire-disarming-exploits")
 +    };
 +
 +}

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -4698,7 +4698,7 @@ diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.ja
 index 0ea9eba1367858dfa5284524a8dd2f79daf6fc69..18b64c00fa73e233bf41f519db54a1d43c2a8b1f 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -217,7 +217,7 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -215,7 +215,7 @@ public class GlobalConfiguration extends ConfigurationPart {
  
          @PostProcess
          private void postProcess() {

--- a/patches/server/0733-Configurable-chat-thread-limit.patch
+++ b/patches/server/0733-Configurable-chat-thread-limit.patch
@@ -22,10 +22,10 @@ is actually processed, this is honestly really just exposed for the misnomers or
 who just wanna ensure that this won't grow over a specific size if chat gets stupidly active
 
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index c3fe4481dd35f80815716e48beeeb07b1f51e30b..56798215644d8bca1695856b3a941e8089f49e48 100644
+index 2eb155d3df2e34c050fd28c5a64015e6e1232851..d8db428f06606c16466d39cceb2a5e02eb3d3b24 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -302,7 +302,18 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -300,7 +300,18 @@ public class GlobalConfiguration extends ConfigurationPart {
  
              @PostProcess
              private void postProcess() {

--- a/patches/server/1038-Moonrise-optimisation-patches.patch
+++ b/patches/server/1038-Moonrise-optimisation-patches.patch
@@ -23220,10 +23220,10 @@ index 0000000000000000000000000000000000000000..85950a1aa732ab8c01ad28bec9e0de14
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 5e9c471ab20b0391e7e41351c65d96745fc8ce4a..9221ce36355eaf8d4456209c57b68486d587c255 100644
+index 2d2ff826354670fef356e241d939080c9ed3fd4a..17e23ca4dd2bbfba49ea00aa2b719a95feb931be 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -219,6 +219,23 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -217,6 +217,23 @@ public class GlobalConfiguration extends ConfigurationPart {
          @PostProcess
          private void postProcess() {
              ca.spottedleaf.moonrise.common.util.MoonriseCommon.adjustWorkerThreads(this.workerThreads, this.ioThreads);


### PR DESCRIPTION
Removes the unused config option that enabled string duping. 