### PR TITLE
Fix getMaxHeight to be exclusive instead of inclusive to match docs

### DIFF
--- a/patches/server/1073-Fix-getMaxHeight-to-be-exclusive-instead-of-inclusiv.patch
+++ b/patches/server/1073-Fix-getMaxHeight-to-be-exclusive-instead-of-inclusiv.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MrPowerGamerBR <git@mrpowergamerbr.com>
+Date: Wed, 27 Nov 2024 02:26:32 -0300
+Subject: [PATCH] Fix getMaxHeight to be exclusive instead of inclusive to
+ match docs
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 8f234b46c24a0ae08aa5f8190c5b27e1f62dfbab..372581a1a44870c53afa5ecd456b1b09ea77b2ae 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -1538,7 +1538,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+ 
+     @Override
+     public int getMaxHeight() {
+-        return this.world.getMaxY();
++        return this.world.getMaxY() + 1; // Paper - Fix getMaxHeight to be exclusive instead of inclusive
+     }
+ 
+     @Override


### PR DESCRIPTION
The `getMaxHeight` docs says that the value is exclusive, not inclusive. This has changed in 1.21.3 and since 1.21.3 the value is now inclusive due to Mojang changes. This patch changes the value to be exclusive by +1 the returned value from NMS.

Worth noting that this needs to be tested! I haven't tested it yet, and I seen that there are some CraftBukkit code that does call `getMaxHeight` (`setBiome`)

Fixes #11674