### PR TITLE
Only attempt to find spawn position if there isn't a fixed spawn position set

### DIFF
--- a/patches/server/1073-Only-attempt-to-find-spawn-position-if-there-isn-t-a.patch
+++ b/patches/server/1073-Only-attempt-to-find-spawn-position-if-there-isn-t-a.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MrPowerGamerBR <git@mrpowergamerbr.com>
+Date: Thu, 28 Nov 2024 15:20:25 -0300
+Subject: [PATCH] Only attempt to find spawn position if there isn't a fixed
+ spawn position set
+
+
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index c26e3a239441376f2694782d4f07943538677c71..566d8014865695d3180c8b94195d71bd2bf8e7cc 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -816,7 +816,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+             worldProperties.setSpawn(BlockPos.ZERO.above(80), 0.0F);
+         } else {
+             ServerChunkCache chunkproviderserver = world.getChunkSource();
+-            ChunkPos chunkcoordintpair = new ChunkPos(chunkproviderserver.randomState().sampler().findSpawnPosition());
++            // ChunkPos chunkcoordintpair = new ChunkPos(chunkproviderserver.randomState().sampler().findSpawnPosition()); // Paper - Move down, don't attempt to find spawn position if there isn't a fixed spawn position set
+             // CraftBukkit start
+             if (world.generator != null) {
+                 Random rand = new Random(world.getSeed());
+@@ -832,6 +832,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+                 }
+             }
+             // CraftBukkit end
++            ChunkPos chunkcoordintpair = new ChunkPos(chunkproviderserver.randomState().sampler().findSpawnPosition()); // Paper - Only attempt to find spawn position if there isn't a fixed spawn position set
+             int i = chunkproviderserver.getGenerator().getSpawnHeight(world);
+ 
+             if (i < world.getMinY()) {

--- a/patches/server/1073-Only-attempt-to-find-spawn-position-if-there-isn-t-a.patch
+++ b/patches/server/1073-Only-attempt-to-find-spawn-position-if-there-isn-t-a.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Only attempt to find spawn position if there isn't a fixed
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c26e3a239441376f2694782d4f07943538677c71..566d8014865695d3180c8b94195d71bd2bf8e7cc 100644
+index c26e3a239441376f2694782d4f07943538677c71..4acdef7a20b0625fc348e5592edd64868b73dd82 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -816,7 +816,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -14,7 +14,7 @@ index c26e3a239441376f2694782d4f07943538677c71..566d8014865695d3180c8b94195d71bd
          } else {
              ServerChunkCache chunkproviderserver = world.getChunkSource();
 -            ChunkPos chunkcoordintpair = new ChunkPos(chunkproviderserver.randomState().sampler().findSpawnPosition());
-+            // ChunkPos chunkcoordintpair = new ChunkPos(chunkproviderserver.randomState().sampler().findSpawnPosition()); // Paper - Move down, don't attempt to find spawn position if there isn't a fixed spawn position set
++            // ChunkPos chunkcoordintpair = new ChunkPos(chunkproviderserver.randomState().sampler().findSpawnPosition()); // Paper - Move down, only attempt to find spawn position if there isn't a fixed spawn position set
              // CraftBukkit start
              if (world.generator != null) {
                  Random rand = new Random(world.getSeed());


### PR DESCRIPTION
Fixes #11630

This only improves performance when creating fresh worlds, not worlds loaded from a file.