### PR TITLE
Add ItemMeta customName methods

### DIFF
--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -4899,10 +4899,10 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/meta/PotionMeta.java b/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
-index b61d2e322f80fcabae5e286cba8df9701ebcf5ea..25904406ce7bf62b22621448ce982473df1d919a 100644
+index b61d2e322f80fcabae5e286cba8df9701ebcf5ea..ada7b3d8f5743fa4dd7809060f1c5a5608b7aec3 100644
 --- a/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
-@@ -149,9 +149,13 @@ public interface PotionMeta extends ItemMeta {
+@@ -149,27 +149,64 @@ public interface PotionMeta extends ItemMeta {
      /**
       * Checks for existence of a custom potion name translation suffix.
       *
@@ -4917,8 +4917,9 @@ index b61d2e322f80fcabae5e286cba8df9701ebcf5ea..25904406ce7bf62b22621448ce982473
  
      /**
       * Gets the potion name translation suffix that is set.
-@@ -159,17 +163,50 @@ public interface PotionMeta extends ItemMeta {
-      * Plugins should check that hasCustomName() returns <code>true</code>
+      * <p>
+-     * Plugins should check that hasCustomName() returns <code>true</code>
++     * Plugins should check that {@link #hasCustomPotionName()} returns {@code true}
       * before calling this method.
       *
 +     * @deprecated conflicting name, use {@link #getCustomPotionName()}
@@ -4953,7 +4954,7 @@ index b61d2e322f80fcabae5e286cba8df9701ebcf5ea..25904406ce7bf62b22621448ce982473
 +    /**
 +     * Gets the potion name translation suffix that is set.
 +     * <p>
-+     * Plugins should check that hasCustomName() returns {@code true}
++     * Plugins should check that {@link #hasCustomPotionName()} returns {@code true}
 +     * before calling this method.
 +     *
 +     * @return the potion name that is set

--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -4713,14 +4713,48 @@ index 9bab73c3c2ca759b8e1c7d07d98cc593c961666a..f0c6943da3f783101ca647b75b3230fa
              throw new UnsupportedOperationException("Not supported yet.");
          }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 69d6de6e9618dd27f5ba73b931f8455912caf060..77f0e0a9e991f65b89909d0307fd93c3ecd9d8ac 100644
+index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45c826908f 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -45,6 +45,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
-      */
-     boolean hasDisplayName();
+@@ -38,12 +38,62 @@ import org.jetbrains.annotations.Nullable;
+  */
+ public interface ItemMeta extends Cloneable, ConfigurationSerializable, PersistentDataHolder {
  
 +    // Paper start
++    /**
++     * Checks for existence of a custom name.
++     *
++     * @return true if this has a custom name
++     */
++    boolean hasCustomName();
++
++    /**
++     * Gets the custom name.
++     *
++     * <p>Plugins should check that {@link #hasCustomName()} returns {@code true} before calling this method.</p>
++     *
++     * @return the custom name
++     */
++    net.kyori.adventure.text.@Nullable Component customName();
++
++    /**
++     * Sets the custom name.
++     *
++     * @param customName the custom name to set
++     */
++    void customName(final net.kyori.adventure.text.@Nullable Component customName);
++
+     /**
+      * Checks for existence of a display name.
+      *
+      * @return true if this has a display name
+      */
+-    boolean hasDisplayName();
++    @ApiStatus.Obsolete(since = "1.21.4")
++    default boolean hasDisplayName() {
++        return this.hasCustomName();
++    }
++
 +    /**
 +     * Gets the display name.
 +     *
@@ -4728,20 +4762,25 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..77f0e0a9e991f65b89909d0307fd93c3
 +     *
 +     * @return the display name
 +     */
-+    net.kyori.adventure.text.@Nullable Component displayName();
++    @ApiStatus.Obsolete(since = "1.21.4")
++    default net.kyori.adventure.text.@Nullable Component displayName() {
++        return this.customName();
++    }
 +
 +    /**
 +     * Sets the display name.
 +     *
 +     * @param displayName the display name to set
 +     */
-+    void displayName(final net.kyori.adventure.text.@Nullable Component displayName);
++    @ApiStatus.Obsolete(since = "1.21.4")
++    default void displayName(final net.kyori.adventure.text.@Nullable Component displayName) {
++        this.customName(displayName);
++    }
 +    // Paper end
-+
+ 
      /**
       * Gets the display name that is set.
-      * <p>
-@@ -52,7 +70,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -52,7 +102,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * before calling this method.
       *
       * @return the display name that is set
@@ -4751,7 +4790,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..77f0e0a9e991f65b89909d0307fd93c3
      @NotNull
      String getDisplayName();
  
-@@ -60,7 +80,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -60,7 +112,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * Sets the display name.
       *
       * @param name the name to set
@@ -4761,7 +4800,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..77f0e0a9e991f65b89909d0307fd93c3
      void setDisplayName(@Nullable String name);
  
      /**
-@@ -73,6 +95,32 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -73,6 +127,32 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       */
      boolean hasItemName();
  
@@ -4794,7 +4833,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..77f0e0a9e991f65b89909d0307fd93c3
      /**
       * Gets the item name that is set.
       * <br>
-@@ -83,7 +131,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -83,7 +163,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * calling this method.
       *
       * @return the item name that is set
@@ -4804,7 +4843,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..77f0e0a9e991f65b89909d0307fd93c3
      @NotNull
      String getItemName();
  
-@@ -94,7 +144,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -94,7 +176,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * anvil, is not styled with italics, and does not show labels.
       *
       * @param name the name to set
@@ -4814,7 +4853,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..77f0e0a9e991f65b89909d0307fd93c3
      void setItemName(@Nullable String name);
  
      /**
-@@ -135,6 +187,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -135,6 +219,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       */
      boolean hasLore();
  
@@ -4839,7 +4878,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..77f0e0a9e991f65b89909d0307fd93c3
      /**
       * Gets the lore that is set.
       * <p>
-@@ -142,7 +212,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -142,7 +244,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * calling this method.
       *
       * @return a list of lore that is set
@@ -4849,7 +4888,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..77f0e0a9e991f65b89909d0307fd93c3
      @Nullable
      List<String> getLore();
  
-@@ -151,7 +223,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -151,7 +255,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * Removes lore when given null.
       *
       * @param lore the lore that will be set
@@ -4859,6 +4898,78 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..77f0e0a9e991f65b89909d0307fd93c3
      void setLore(@Nullable List<String> lore);
  
      /**
+diff --git a/src/main/java/org/bukkit/inventory/meta/PotionMeta.java b/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
+index b61d2e322f80fcabae5e286cba8df9701ebcf5ea..25904406ce7bf62b22621448ce982473df1d919a 100644
+--- a/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
+@@ -149,9 +149,13 @@ public interface PotionMeta extends ItemMeta {
+     /**
+      * Checks for existence of a custom potion name translation suffix.
+      *
++     * @deprecated conflicting name, use {@link #hasCustomPotionName()}
+      * @return true if this has a custom potion name
+      */
+-    boolean hasCustomName();
++    @Deprecated(forRemoval = true, since = "1.21.4")
++    default boolean hasCustomName() {
++        return this.hasCustomPotionName();
++    }
+ 
+     /**
+      * Gets the potion name translation suffix that is set.
+@@ -159,17 +163,50 @@ public interface PotionMeta extends ItemMeta {
+      * Plugins should check that hasCustomName() returns <code>true</code>
+      * before calling this method.
+      *
++     * @deprecated conflicting name, use {@link #getCustomPotionName()}
+      * @return the potion name that is set
+      */
++    @Deprecated(forRemoval = true, since = "1.21.4")
+     @Nullable
+-    String getCustomName();
++    default String getCustomName() {
++        return this.getCustomPotionName();
++    }
+ 
+     /**
+      * Sets the potion name translation suffix.
+      *
++     * @deprecated conflicting name, use {@link #setCustomPotionName(String)}
+      * @param name the name to set
+      */
+-    void setCustomName(@Nullable String name);
++    @Deprecated(forRemoval = true, since = "1.21.4")
++    default void setCustomName(@Nullable String name) {
++        this.setCustomPotionName(name);
++    }
++
++    /**
++     * Checks for existence of a custom potion name translation suffix.
++     *
++     * @return true if this has a custom potion name
++     */
++    boolean hasCustomPotionName();
++
++    /**
++     * Gets the potion name translation suffix that is set.
++     * <p>
++     * Plugins should check that hasCustomName() returns {@code true}
++     * before calling this method.
++     *
++     * @return the potion name that is set
++     */
++    @Nullable
++    String getCustomPotionName();
++
++    /**
++     * Sets the potion name translation suffix.
++     *
++     * @param name the name to set
++     */
++    void setCustomPotionName(@Nullable String name);
+ 
+     @Override
+     PotionMeta clone();
 diff --git a/src/main/java/org/bukkit/inventory/meta/WritableBookMeta.java b/src/main/java/org/bukkit/inventory/meta/WritableBookMeta.java
 index 12595536080ffe09df2b6ecdb83d846f50100d38..9fc47c879ee6b8edf2503f20e4736c2997d2de2e 100644
 --- a/src/main/java/org/bukkit/inventory/meta/WritableBookMeta.java

--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -4713,10 +4713,10 @@ index 9bab73c3c2ca759b8e1c7d07d98cc593c961666a..f0c6943da3f783101ca647b75b3230fa
              throw new UnsupportedOperationException("Not supported yet.");
          }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45c826908f 100644
+index 69d6de6e9618dd27f5ba73b931f8455912caf060..753a756525f6afea981dd0c2984e7a747d4d148b 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -38,12 +38,62 @@ import org.jetbrains.annotations.Nullable;
+@@ -38,12 +38,65 @@ import org.jetbrains.annotations.Nullable;
   */
  public interface ItemMeta extends Cloneable, ConfigurationSerializable, PersistentDataHolder {
  
@@ -4747,6 +4747,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45
      /**
       * Checks for existence of a display name.
       *
++     * @apiNote This method is obsolete, use {@link #hasCustomName()} instead.
       * @return true if this has a display name
       */
 -    boolean hasDisplayName();
@@ -4760,6 +4761,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45
 +     *
 +     * <p>Plugins should check that {@link #hasDisplayName()} returns <code>true</code> before calling this method.</p>
 +     *
++     * @apiNote This method is obsolete, use {@link #customName()} instead.
 +     * @return the display name
 +     */
 +    @ApiStatus.Obsolete(since = "1.21.4")
@@ -4771,6 +4773,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45
 +     * Sets the display name.
 +     *
 +     * @param displayName the display name to set
++     * @apiNote This method is obsolete, use {@link #customName(Component)} instead.
 +     */
 +    @ApiStatus.Obsolete(since = "1.21.4")
 +    default void displayName(final net.kyori.adventure.text.@Nullable Component displayName) {
@@ -4780,7 +4783,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45
  
      /**
       * Gets the display name that is set.
-@@ -52,7 +102,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -52,7 +105,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * before calling this method.
       *
       * @return the display name that is set
@@ -4790,7 +4793,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45
      @NotNull
      String getDisplayName();
  
-@@ -60,7 +112,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -60,7 +115,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * Sets the display name.
       *
       * @param name the name to set
@@ -4800,7 +4803,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45
      void setDisplayName(@Nullable String name);
  
      /**
-@@ -73,6 +127,32 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -73,6 +130,32 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       */
      boolean hasItemName();
  
@@ -4833,7 +4836,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45
      /**
       * Gets the item name that is set.
       * <br>
-@@ -83,7 +163,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -83,7 +166,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * calling this method.
       *
       * @return the item name that is set
@@ -4843,7 +4846,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45
      @NotNull
      String getItemName();
  
-@@ -94,7 +176,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -94,7 +179,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * anvil, is not styled with italics, and does not show labels.
       *
       * @param name the name to set
@@ -4853,7 +4856,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45
      void setItemName(@Nullable String name);
  
      /**
-@@ -135,6 +219,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -135,6 +222,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       */
      boolean hasLore();
  
@@ -4878,7 +4881,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45
      /**
       * Gets the lore that is set.
       * <p>
-@@ -142,7 +244,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -142,7 +247,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * calling this method.
       *
       * @return a list of lore that is set
@@ -4888,7 +4891,7 @@ index 69d6de6e9618dd27f5ba73b931f8455912caf060..1181d62f13ad53a47bf3280f00f7ed45
      @Nullable
      List<String> getLore();
  
-@@ -151,7 +255,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -151,7 +258,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * Removes lore when given null.
       *
       * @param lore the lore that will be set

--- a/patches/api/0053-Fix-upstream-javadocs.patch
+++ b/patches/api/0053-Fix-upstream-javadocs.patch
@@ -1622,10 +1622,10 @@ index 35c6594fd1040a1af1029e7260e5e3a9307b107d..d58719ee75bef8bc265bfc81bc5d88a4
      void addChargedProjectile(@NotNull ItemStack item);
  }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 77f0e0a9e991f65b89909d0307fd93c3ecd9d8ac..66315ae78d6143ac6bde2b3a2b40b617dc4b1aab 100644
+index 1181d62f13ad53a47bf3280f00f7ed45c826908f..93cce20187ae7142977233f5520e672cb554e369 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -293,7 +293,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -325,7 +325,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Gets the enchantable component. Higher values allow higher enchantments.
       *
@@ -1634,7 +1634,7 @@ index 77f0e0a9e991f65b89909d0307fd93c3ecd9d8ac..66315ae78d6143ac6bde2b3a2b40b617
       */
      int getEnchantable();
  
-@@ -626,11 +626,6 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -658,11 +658,6 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
  
      /**
       * Gets the item which this item will convert to when used.
@@ -1646,7 +1646,7 @@ index 77f0e0a9e991f65b89909d0307fd93c3ecd9d8ac..66315ae78d6143ac6bde2b3a2b40b617
       *
       * @return remainder
       */
-@@ -767,7 +762,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -799,7 +794,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * The returned component is a snapshot of its current state and does not
       * reflect a live view of what is on an item. After changing any value on
       * this component, it must be set with
@@ -1655,7 +1655,7 @@ index 77f0e0a9e991f65b89909d0307fd93c3ecd9d8ac..66315ae78d6143ac6bde2b3a2b40b617
       * to apply the changes.
       *
       * @return component
-@@ -776,7 +771,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -808,7 +803,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      JukeboxPlayableComponent getJukeboxPlayable();
  
      /**
@@ -1664,7 +1664,7 @@ index 77f0e0a9e991f65b89909d0307fd93c3ecd9d8ac..66315ae78d6143ac6bde2b3a2b40b617
       *
       * @param jukeboxPlayable new component
       */
-@@ -803,7 +798,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -835,7 +830,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Return an immutable copy of all {@link Attribute}s and their
       * {@link AttributeModifier}s for a given {@link EquipmentSlot}.<br>

--- a/patches/api/0053-Fix-upstream-javadocs.patch
+++ b/patches/api/0053-Fix-upstream-javadocs.patch
@@ -1622,10 +1622,10 @@ index 35c6594fd1040a1af1029e7260e5e3a9307b107d..d58719ee75bef8bc265bfc81bc5d88a4
      void addChargedProjectile(@NotNull ItemStack item);
  }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 1181d62f13ad53a47bf3280f00f7ed45c826908f..93cce20187ae7142977233f5520e672cb554e369 100644
+index 753a756525f6afea981dd0c2984e7a747d4d148b..c083ac4344dd1b2b56cbe103ce80daac945defd5 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -325,7 +325,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -328,7 +328,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Gets the enchantable component. Higher values allow higher enchantments.
       *
@@ -1634,7 +1634,7 @@ index 1181d62f13ad53a47bf3280f00f7ed45c826908f..93cce20187ae7142977233f5520e672c
       */
      int getEnchantable();
  
-@@ -658,11 +658,6 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -661,11 +661,6 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
  
      /**
       * Gets the item which this item will convert to when used.
@@ -1646,7 +1646,7 @@ index 1181d62f13ad53a47bf3280f00f7ed45c826908f..93cce20187ae7142977233f5520e672c
       *
       * @return remainder
       */
-@@ -799,7 +794,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -802,7 +797,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * The returned component is a snapshot of its current state and does not
       * reflect a live view of what is on an item. After changing any value on
       * this component, it must be set with
@@ -1655,7 +1655,7 @@ index 1181d62f13ad53a47bf3280f00f7ed45c826908f..93cce20187ae7142977233f5520e672c
       * to apply the changes.
       *
       * @return component
-@@ -808,7 +803,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -811,7 +806,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      JukeboxPlayableComponent getJukeboxPlayable();
  
      /**
@@ -1664,7 +1664,7 @@ index 1181d62f13ad53a47bf3280f00f7ed45c826908f..93cce20187ae7142977233f5520e672c
       *
       * @param jukeboxPlayable new component
       */
-@@ -835,7 +830,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -838,7 +833,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Return an immutable copy of all {@link Attribute}s and their
       * {@link AttributeModifier}s for a given {@link EquipmentSlot}.<br>

--- a/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
@@ -1748,10 +1748,10 @@ index 597a18a767b68b47e81454b7d44613c7178c1366..bc3440eb72127824b3961fbdae583bb6
      public ItemStack getInput() {
          return this.ingredient.getItemStack();
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 66315ae78d6143ac6bde2b3a2b40b617dc4b1aab..b770541429649cefed3f7f907cc1d9653e395937 100644
+index 93cce20187ae7142977233f5520e672cb554e369..e05b63c1394c5e0a34b469a8ae589480b741d548 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -152,6 +152,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -184,6 +184,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Checks for existence of a localized name.
       *
@@ -1759,7 +1759,7 @@ index 66315ae78d6143ac6bde2b3a2b40b617dc4b1aab..b770541429649cefed3f7f907cc1d965
       * @return true if this has a localized name
       * @deprecated meta no longer exists
       */
-@@ -164,6 +165,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -196,6 +197,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * Plugins should check that hasLocalizedName() returns <code>true</code>
       * before calling this method.
       *
@@ -1767,7 +1767,7 @@ index 66315ae78d6143ac6bde2b3a2b40b617dc4b1aab..b770541429649cefed3f7f907cc1d965
       * @return the localized name that is set
       * @deprecated meta no longer exists
       */
-@@ -174,6 +176,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -206,6 +208,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Sets the localized name.
       *
@@ -1775,7 +1775,7 @@ index 66315ae78d6143ac6bde2b3a2b40b617dc4b1aab..b770541429649cefed3f7f907cc1d965
       * @param name the name to set
       * @deprecated meta no longer exists
       */
-@@ -767,7 +770,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -799,7 +802,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       *
       * @return component
       */

--- a/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0166-Fix-Spigot-annotation-mistakes.patch
@@ -1748,10 +1748,10 @@ index 597a18a767b68b47e81454b7d44613c7178c1366..bc3440eb72127824b3961fbdae583bb6
      public ItemStack getInput() {
          return this.ingredient.getItemStack();
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 93cce20187ae7142977233f5520e672cb554e369..e05b63c1394c5e0a34b469a8ae589480b741d548 100644
+index c083ac4344dd1b2b56cbe103ce80daac945defd5..4012a1b4e9acdfafb38c78a54c4b422ffa07cf04 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -184,6 +184,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -187,6 +187,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Checks for existence of a localized name.
       *
@@ -1759,7 +1759,7 @@ index 93cce20187ae7142977233f5520e672cb554e369..e05b63c1394c5e0a34b469a8ae589480
       * @return true if this has a localized name
       * @deprecated meta no longer exists
       */
-@@ -196,6 +197,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -199,6 +200,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * Plugins should check that hasLocalizedName() returns <code>true</code>
       * before calling this method.
       *
@@ -1767,7 +1767,7 @@ index 93cce20187ae7142977233f5520e672cb554e369..e05b63c1394c5e0a34b469a8ae589480
       * @return the localized name that is set
       * @deprecated meta no longer exists
       */
-@@ -206,6 +208,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -209,6 +211,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Sets the localized name.
       *
@@ -1775,7 +1775,7 @@ index 93cce20187ae7142977233f5520e672cb554e369..e05b63c1394c5e0a34b469a8ae589480
       * @param name the name to set
       * @deprecated meta no longer exists
       */
-@@ -799,7 +802,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -802,7 +805,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       *
       * @return component
       */

--- a/patches/api/0193-Support-components-in-ItemMeta.patch
+++ b/patches/api/0193-Support-components-in-ItemMeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index e05b63c1394c5e0a34b469a8ae589480b741d548..261978893988ed5fba1889ba8ce5ae84897a0653 100644
+index 4012a1b4e9acdfafb38c78a54c4b422ffa07cf04..cca91212e702a73e9fc37ec46d575967fedf68c9 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 @@ -5,6 +5,7 @@ import java.util.Collection;
@@ -16,7 +16,7 @@ index e05b63c1394c5e0a34b469a8ae589480b741d548..261978893988ed5fba1889ba8ce5ae84
  import org.bukkit.NamespacedKey;
  import org.bukkit.Tag;
  import org.bukkit.attribute.Attribute;
-@@ -108,6 +109,20 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -111,6 +112,20 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @NotNull
      String getDisplayName();
  
@@ -37,7 +37,7 @@ index e05b63c1394c5e0a34b469a8ae589480b741d548..261978893988ed5fba1889ba8ce5ae84
      /**
       * Sets the display name.
       *
-@@ -117,6 +132,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -120,6 +135,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Deprecated // Paper
      void setDisplayName(@Nullable String name);
  
@@ -54,7 +54,7 @@ index e05b63c1394c5e0a34b469a8ae589480b741d548..261978893988ed5fba1889ba8ce5ae84
      /**
       * Checks for existence of an item name.
       * <br>
-@@ -253,6 +278,19 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -256,6 +281,19 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Nullable
      List<String> getLore();
  
@@ -74,7 +74,7 @@ index e05b63c1394c5e0a34b469a8ae589480b741d548..261978893988ed5fba1889ba8ce5ae84
      /**
       * Sets the lore for this item.
       * Removes lore when given null.
-@@ -263,6 +301,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -266,6 +304,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Deprecated // Paper
      void setLore(@Nullable List<String> lore);
  

--- a/patches/api/0193-Support-components-in-ItemMeta.patch
+++ b/patches/api/0193-Support-components-in-ItemMeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index eb14949da2b96aee75e3bba63af8176c5550a380..0151a0523069b00a1cf682ad6b54142aaffcfaa6 100644
+index e05b63c1394c5e0a34b469a8ae589480b741d548..261978893988ed5fba1889ba8ce5ae84897a0653 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 @@ -5,6 +5,7 @@ import java.util.Collection;
@@ -16,7 +16,7 @@ index eb14949da2b96aee75e3bba63af8176c5550a380..0151a0523069b00a1cf682ad6b54142a
  import org.bukkit.NamespacedKey;
  import org.bukkit.Tag;
  import org.bukkit.attribute.Attribute;
-@@ -76,6 +77,20 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -108,6 +109,20 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @NotNull
      String getDisplayName();
  
@@ -37,7 +37,7 @@ index eb14949da2b96aee75e3bba63af8176c5550a380..0151a0523069b00a1cf682ad6b54142a
      /**
       * Sets the display name.
       *
-@@ -85,6 +100,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -117,6 +132,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Deprecated // Paper
      void setDisplayName(@Nullable String name);
  
@@ -54,7 +54,7 @@ index eb14949da2b96aee75e3bba63af8176c5550a380..0151a0523069b00a1cf682ad6b54142a
      /**
       * Checks for existence of an item name.
       * <br>
-@@ -221,6 +246,19 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -253,6 +278,19 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Nullable
      List<String> getLore();
  
@@ -74,7 +74,7 @@ index eb14949da2b96aee75e3bba63af8176c5550a380..0151a0523069b00a1cf682ad6b54142a
      /**
       * Sets the lore for this item.
       * Removes lore when given null.
-@@ -231,6 +269,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -263,6 +301,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Deprecated // Paper
      void setLore(@Nullable List<String> lore);
  

--- a/patches/api/0468-General-ItemMeta-fixes.patch
+++ b/patches/api/0468-General-ItemMeta-fixes.patch
@@ -112,10 +112,10 @@ index ff6818b6d9e0207eafdd749928f33aeac3f27191..992f39da07bafe9769effaa7dc6adc01
       * Checks to see if this item has a maximum amount of damage.
       *
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index e95eac71ab43cadccf99ff594cc77a6d364c46bd..f32102441df03645c1b8c80fdfc944018e5544ca 100644
+index 261978893988ed5fba1889ba8ce5ae84897a0653..16a0c8215c9cd0940fb3fbb2617569279d371a13 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -351,7 +351,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -383,7 +383,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Sets the enchantable. Higher values allow higher enchantments.
       *
@@ -124,7 +124,7 @@ index e95eac71ab43cadccf99ff594cc77a6d364c46bd..f32102441df03645c1b8c80fdfc94401
       */
      void setEnchantable(@Nullable Integer enchantable);
  
-@@ -895,8 +895,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -927,8 +927,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
  
      /**
       * Set all {@link Attribute}s and their {@link AttributeModifier}s.

--- a/patches/api/0468-General-ItemMeta-fixes.patch
+++ b/patches/api/0468-General-ItemMeta-fixes.patch
@@ -112,10 +112,10 @@ index ff6818b6d9e0207eafdd749928f33aeac3f27191..992f39da07bafe9769effaa7dc6adc01
       * Checks to see if this item has a maximum amount of damage.
       *
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 261978893988ed5fba1889ba8ce5ae84897a0653..16a0c8215c9cd0940fb3fbb2617569279d371a13 100644
+index cca91212e702a73e9fc37ec46d575967fedf68c9..2035d54de7e446930f8fdd2a572240e70a21c656 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -383,7 +383,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -386,7 +386,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Sets the enchantable. Higher values allow higher enchantments.
       *
@@ -124,7 +124,7 @@ index 261978893988ed5fba1889ba8ce5ae84897a0653..16a0c8215c9cd0940fb3fbb261756927
       */
      void setEnchantable(@Nullable Integer enchantable);
  
-@@ -927,8 +927,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -930,8 +930,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
  
      /**
       * Set all {@link Attribute}s and their {@link AttributeModifier}s.

--- a/patches/api/0478-Add-an-API-for-CanPlaceOn-and-CanDestroy-NBT-values.patch
+++ b/patches/api/0478-Add-an-API-for-CanPlaceOn-and-CanDestroy-NBT-values.patch
@@ -228,10 +228,10 @@ index 6d266c111bfa2bd51338e03ed740f6ac81ed07c7..d71531c384c57ea44d1e1fbe394214c1
          return key;
      }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 16a0c8215c9cd0940fb3fbb2617569279d371a13..115c1d9fd1961499065a7fcd9aadc69095ec6778 100644
+index 2035d54de7e446930f8fdd2a572240e70a21c656..e8c0b8848abce2c9e8b2be880de3897292f0b23e 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -1060,4 +1060,98 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -1063,4 +1063,98 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @SuppressWarnings("javadoc")
      @NotNull
      ItemMeta clone();

--- a/patches/api/0478-Add-an-API-for-CanPlaceOn-and-CanDestroy-NBT-values.patch
+++ b/patches/api/0478-Add-an-API-for-CanPlaceOn-and-CanDestroy-NBT-values.patch
@@ -228,10 +228,10 @@ index 6d266c111bfa2bd51338e03ed740f6ac81ed07c7..d71531c384c57ea44d1e1fbe394214c1
          return key;
      }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index f32102441df03645c1b8c80fdfc944018e5544ca..403c4e7138bcee1321b16fb3aa4cffb2178d4757 100644
+index 16a0c8215c9cd0940fb3fbb2617569279d371a13..115c1d9fd1961499065a7fcd9aadc69095ec6778 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -1028,4 +1028,98 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -1060,4 +1060,98 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @SuppressWarnings("javadoc")
      @NotNull
      ItemMeta clone();

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -5228,7 +5228,7 @@ index c71a4971f127fdfc753306019313ce1a31201120..fd3b12477c30d1eabdbe57ea77902793
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 92dcf22ee3b9cceb742b77c4cc58645eb25d9e67..aa14b5c363824761e81a9a29ae88820841df0166 100644
+index 92dcf22ee3b9cceb742b77c4cc58645eb25d9e67..f97a8aa44ac556cff9925eeffbb8ea3035df64f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -1103,6 +1103,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -5237,19 +5237,28 @@ index 92dcf22ee3b9cceb742b77c4cc58645eb25d9e67..aa14b5c363824761e81a9a29ae888208
  
 +    // Paper start
 +    @Override
-+    public net.kyori.adventure.text.Component displayName() {
++    public net.kyori.adventure.text.Component customName() {
 +        return displayName == null ? null : io.papermc.paper.adventure.PaperAdventure.asAdventure(displayName);
 +    }
 +
 +    @Override
-+    public void displayName(final net.kyori.adventure.text.Component displayName) {
-+        this.displayName = displayName == null ? null : io.papermc.paper.adventure.PaperAdventure.asVanilla(displayName);
++    public void customName(final net.kyori.adventure.text.Component customName) {
++        this.displayName = customName == null ? null : io.papermc.paper.adventure.PaperAdventure.asVanilla(customName);
 +    }
 +    // Paper end
 +
      @Override
      public String getDisplayName() {
          return CraftChatMessage.fromComponent(this.displayName);
+@@ -1114,7 +1126,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+     }
+ 
+     @Override
+-    public boolean hasDisplayName() {
++    public boolean hasCustomName() {
+         return this.displayName != null;
+     }
+ 
 @@ -1133,6 +1145,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.itemName != null;
      }
@@ -5288,6 +5297,78 @@ index 92dcf22ee3b9cceb742b77c4cc58645eb25d9e67..aa14b5c363824761e81a9a29ae888208
      @Override
      public boolean hasRepairCost() {
          return this.repairCost > 0;
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
+index 533c600d632eb733c121f5d8189142726b091713..96ad0f53d39338f310f994e3352c8d2168fc39e8 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
+@@ -109,7 +109,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+ 
+         String name = SerializableMeta.getString(map, CraftMetaPotion.CUSTOM_NAME.BUKKIT, true);
+         if (name != null) {
+-            this.setCustomName(name);
++            this.setCustomPotionName(name);
+         }
+ 
+         Iterable<?> rawEffectList = SerializableMeta.getObject(Iterable.class, map, CraftMetaPotion.POTION_EFFECTS.BUKKIT, true);
+@@ -151,7 +151,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+     }
+ 
+     boolean isPotionEmpty() {
+-        return (this.type == null) && !(this.hasCustomEffects() || this.hasColor() || this.hasCustomName());
++        return (this.type == null) && !(this.hasCustomEffects() || this.hasColor() || this.hasCustomPotionName());
+     }
+ 
+     @Override
+@@ -306,17 +306,17 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+     }
+ 
+     @Override
+-    public boolean hasCustomName() {
++    public boolean hasCustomPotionName() {
+         return this.customName != null;
+     }
+ 
+     @Override
+-    public String getCustomName() {
++    public String getCustomPotionName() {
+         return this.customName;
+     }
+ 
+     @Override
+-    public void setCustomName(String customName) {
++    public void setCustomPotionName(String customName) {
+         this.customName = customName;
+     }
+ 
+@@ -330,7 +330,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+         if (this.hasColor()) {
+             hash = 73 * hash + this.color.hashCode();
+         }
+-        if (this.hasCustomName()) {
++        if (this.hasCustomPotionName()) {
+             hash = 73 * hash + this.customName.hashCode();
+         }
+         if (this.hasCustomEffects()) {
+@@ -350,7 +350,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+             return Objects.equals(this.type, that.type)
+                     && (this.hasCustomEffects() ? that.hasCustomEffects() && this.customEffects.equals(that.customEffects) : !that.hasCustomEffects())
+                     && (this.hasColor() ? that.hasColor() && this.color.equals(that.color) : !that.hasColor())
+-                    && (this.hasCustomName() ? that.hasCustomName() && this.customName.equals(that.customName) : !that.hasCustomName());
++                    && (this.hasCustomPotionName() ? that.hasCustomPotionName() && this.customName.equals(that.customName) : !that.hasCustomPotionName());
+         }
+         return true;
+     }
+@@ -371,8 +371,8 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+             builder.put(CraftMetaPotion.POTION_COLOR.BUKKIT, this.getColor());
+         }
+ 
+-        if (this.hasCustomName()) {
+-            builder.put(CraftMetaPotion.CUSTOM_NAME.BUKKIT, this.getCustomName());
++        if (this.hasCustomPotionName()) {
++            builder.put(CraftMetaPotion.CUSTOM_NAME.BUKKIT, this.getCustomPotionName());
+         }
+ 
+         if (this.hasCustomEffects()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/trim/CraftTrimMaterial.java b/src/main/java/org/bukkit/craftbukkit/inventory/trim/CraftTrimMaterial.java
 index 38fb47bbfcec739be795b46cfb7c2c41a8379fea..caf7e4312e95e90dd0822355c8832006e69a2700 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/trim/CraftTrimMaterial.java

--- a/patches/server/0026-Support-components-in-ItemMeta.patch
+++ b/patches/server/0026-Support-components-in-ItemMeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index aa14b5c363824761e81a9a29ae88820841df0166..784db8fa1b9ef99755440c6446248b802445da67 100644
+index f97a8aa44ac556cff9925eeffbb8ea3035df64f4..ee4d133ab3c3944c7f8c56be13f676b23554b292 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -1120,11 +1120,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -30,7 +30,7 @@ index aa14b5c363824761e81a9a29ae88820841df0166..784db8fa1b9ef99755440c6446248b80
 +    }
 +    // Paper end
      @Override
-     public boolean hasDisplayName() {
+     public boolean hasCustomName() {
          return this.displayName != null;
 @@ -1298,6 +1310,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.lore == null ? null : new ArrayList<String>(Lists.transform(this.lore, CraftChatMessage::fromComponent));

--- a/patches/server/0947-General-ItemMeta-fixes.patch
+++ b/patches/server/0947-General-ItemMeta-fixes.patch
@@ -1049,7 +1049,7 @@ index 566d893a413fd04b99e83dc2da8fe958a48492a8..a944803771d514572f94b4e98a6d4435
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 2c0a61fd4fbfb07ed3d5d27509b3bc8b51cb0a76..ecc68d2f80808c5f96f2de396e4057b481ab662f 100644
+index 22f2376365329e3323a3bc817665570fc1e662b7..fae35e0de7cca6d84647be256518c4d716814b8c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -201,9 +201,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -1605,7 +1605,7 @@ index b118d8ecb505d187c02bb158f14df333f487a87f..fa1d1a7f37aadf2750f03a0e215fb25f
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
-index 6f0eebcaffa20337cf5a7f8485f891c690d948ae..49690dab508b07f9f56b2fb21eeb5f20172b5bd3 100644
+index fd7b7f53c5504549426f7514ab4385e66f15d8e8..f9cf20c1aa99ffddca7c97ae30fbc1fd421ff9f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
 @@ -38,7 +38,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
@@ -1653,7 +1653,7 @@ index 6f0eebcaffa20337cf5a7f8485f891c690d948ae..49690dab508b07f9f56b2fb21eeb5f20
 @@ -317,6 +317,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
  
      @Override
-     public void setCustomName(String customName) {
+     public void setCustomPotionName(String customName) {
 +        Preconditions.checkArgument(customName == null || customName.length() <= 32767, "Custom name is longer than 32767 characters");
          this.customName = customName;
      }


### PR DESCRIPTION
This also needs to rename some PotionMeta methods to not conflict (which we really should do now-ish rather than later, since we can't ignore the customName name forever), but it still needs plugin rewriting. so this might benefit from waiting for 1.21.4