### PR TITLE
Fix terminal color on Windows

### DIFF
--- a/patches/server/0011-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0011-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -266,7 +266,7 @@ index 8323f135d6bf2e1f12525e05094ffa3f2420e7e1..a143ea1e58464a3122fbd8ccafe417bd
      }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index daf20aa9a83a2583c0c61a4123cc2e528d19801d..afb67956031f4bcccee12f0ece4bb8a7e6f02cfc 100644
+index 2e6259e1d07892cb4fbcc81de069b75144d6f533..8e369a3e5c8e89891787a97ec9c29b2b64018dc1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -161,7 +161,7 @@ import com.mojang.serialization.Dynamic;
@@ -429,7 +429,7 @@ index c3774d9a253d4fda80f63d4040722ab5c1c94be4..41aa22f431c989d60dde5c85ca2821d5
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 41ceea1093edbf777f9ebe252114be7f75438420..b6e449c2f29b0a201e5e7495de81d21a19f67a25 100644
+index 41ceea1093edbf777f9ebe252114be7f75438420..28837044fb3668a39b944d9b8a4e544c92c16a91 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -13,7 +13,6 @@ import java.util.logging.Logger;
@@ -468,12 +468,13 @@ index 41ceea1093edbf777f9ebe252114be7f75438420..b6e449c2f29b0a201e5e7495de81d21a
                  }
  
                  if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
-@@ -231,6 +241,8 @@ public class Main {
+@@ -231,6 +241,9 @@ public class Main {
                      }
                  }
  
 +                System.setProperty("library.jansi.version", "Paper"); // Paper - set meaningless jansi version to prevent git builds from crashing on Windows
 +                System.setProperty("jdk.console", "java.base"); // Paper - revert default console provider back to java.base so we can have our own jline
++                if (org.jline.utils.OSUtils.IS_WINDOWS) System.setProperty("net.kyori.ansi.colorLevel", "truecolor"); // Paper - fix terminal color on Windows by assuming the Windows always supports true color
                  System.out.println("Loading libraries, please wait...");
                  net.minecraft.server.Main.main(options);
              } catch (Throwable t) {

--- a/patches/server/0033-Expose-server-build-information.patch
+++ b/patches/server/0033-Expose-server-build-information.patch
@@ -11,7 +11,7 @@ Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 Co-authored-by: masmc05 <masmc05@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 7aee6d9849f0a9c64db0368d2faa03c0633a72a4..40afa9e2cfb4518e9050ccac739aec3215f95d56 100644
+index 8d05216e246bfaec5945cdd55d08b6a388a769e8..cb100e337521fd278893ec775606f128717105f7 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -1,4 +1,5 @@
@@ -533,7 +533,7 @@ index 0000000000000000000000000000000000000000..790bad0494454ca12ee152e3de6da3da
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 709c6361aa5eb78071ce9d0f2a65ce8a56af1443..b86d8a3756cb8c1adb1aceda57f60b0ccdb3f659 100644
+index 047cbaf7699b38764fb104d272328fbfa2714cd2..e763b89dac66c36f43afaf45f5226f34bd119ceb 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -45,7 +45,6 @@ import java.util.Set;
@@ -659,7 +659,7 @@ index 16d2b3e59b8a6ef65b411afb9d94c61e6d797e36..e4335bfc98272c5499651977625e1f0c
      public List<CraftPlayer> getOnlinePlayers() {
          return this.playerView;
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 99bc6e3d472edc0a0182e7b53286cb6a0170ae80..44b6fd8a64e7d7756eb62cd3816b1c4dcc5c5927 100644
+index 85a67859c9e4f296f67f71c053127fa334c3eade..ee039b22c97ad7c591f6b2c6c397a141cc4d606e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -15,6 +15,7 @@ import joptsimple.OptionSet;
@@ -679,10 +679,10 @@ index 99bc6e3d472edc0a0182e7b53286cb6a0170ae80..44b6fd8a64e7d7756eb62cd3816b1c4d
                          System.err.println("*** Server will start in 20 seconds ***");
                          Thread.sleep(TimeUnit.SECONDS.toMillis(20));
                      }
-@@ -249,8 +250,9 @@ public class Main {
- 
+@@ -250,8 +251,9 @@ public class Main {
                  System.setProperty("library.jansi.version", "Paper"); // Paper - set meaningless jansi version to prevent git builds from crashing on Windows
                  System.setProperty("jdk.console", "java.base"); // Paper - revert default console provider back to java.base so we can have our own jline
+                 if (org.jline.utils.OSUtils.IS_WINDOWS) System.setProperty("net.kyori.ansi.colorLevel", "truecolor"); // Paper - fix terminal color on Windows by assuming the Windows always supports true color
 -                System.out.println("Loading libraries, please wait...");
 -                net.minecraft.server.Main.main(options);
 +                //System.out.println("Loading libraries, please wait...");


### PR DESCRIPTION
Fix terminal color on Windows to close #11637.

There is no `%TERM%` or `%COLORTERM%` environment variables set by default on Windows system, also, the `%WT_SESSION%` variable won't always exist in terminal for some reason on Windows 10+, so the `ColorLevel#compute` in ansi will return no color for most of circumstances on Windows. But we can assume that terminals on Windows are always support the color and just set the `-Dnet.kyori.ansi.colorLevel=truecolor` flag.

Tested on Windows Server 2012 R2 / Windows Server 2019 / Windows 10 / Windows 11, and all work fine, the color come back.