### PR TITLE
Only attempt to resync display entities' position/rotation when it has actually changed to fix teleport interpolation issues

### DIFF
--- a/patches/server/1073-Only-attempt-to-resync-display-entities-position-whe.patch
+++ b/patches/server/1073-Only-attempt-to-resync-display-entities-position-whe.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MrPowerGamerBR <git@mrpowergamerbr.com>
+Date: Sun, 1 Dec 2024 01:23:17 -0300
+Subject: [PATCH] Only attempt to resync display entities' position when it has
+ actually changed to fix teleport interpolation issues
+
+On display entities, any new Pos/Rot packet causes the teleport duration interpolation to reset
+
+While this does not cause issues when you spawn a display entity -> set the interpolation -> teleport after the data has been sent to the client, this DOES cause issues on entities that have lived for >60 ticks, where if you spawn a display with interpolation -> wait ~8 ticks -> teleport it, the end of the teleport will look slow due to the server resyncing the display entity position/rotation
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
+index 90eb4927fa51ce3df86aa7b6c71f49150a03e337..cb8f9a0182000fbf671f9ddccfd6b4999abf184b 100644
+--- a/src/main/java/net/minecraft/server/level/ServerEntity.java
++++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
+@@ -208,6 +208,7 @@ public class ServerEntity {
+ 
+                     if (!this.forceStateResync && !flag5 && this.teleportDelay <= 400 && !this.wasRiding && this.wasOnGround == this.entity.onGround()) { // Paper - fix desync when a player is added to the tracker
+                         if ((!flag2 || !flag) && !(this.entity instanceof AbstractArrow)) {
++                            if (!(this.entity instanceof net.minecraft.world.entity.Display) || (flag || flag1)) { // Paper start - Only attempt to resync display entities' position when it has actually changed to fix teleport interpolation issues
+                             if (flag2) {
+                                 packet1 = new ClientboundMoveEntityPacket.Pos(this.entity.getId(), (short) ((int) i), (short) ((int) j), (short) ((int) k), this.entity.onGround());
+                                 flag3 = true;
+@@ -215,6 +216,7 @@ public class ServerEntity {
+                                 packet1 = new ClientboundMoveEntityPacket.Rot(this.entity.getId(), b0, b1, this.entity.onGround());
+                                 flag4 = true;
+                             }
++                            } // Paper end
+                         } else {
+                             packet1 = new ClientboundMoveEntityPacket.PosRot(this.entity.getId(), (short) ((int) i), (short) ((int) j), (short) ((int) k), b0, b1, this.entity.onGround());
+                             flag3 = true;


### PR DESCRIPTION
On display entities, any new Pos/Rot packet causes the teleport duration interpolation to reset

While this does not cause issues when you spawn a display entity -> set the interpolation -> teleport after the data has been sent to the client, this DOES cause issues on entities that have lived for >60 ticks, where if you spawn a display with interpolation -> wait ~8 ticks -> teleport it, the end of the teleport will look slow due to the server resyncing the display entity position/rotation

HOWEVER I will be honest, I'm not sure what are the side effects of not periodically resyncing entity positions, this could be a Very Bad Idea:tm:

I must say that there is a workaround for this issue... and the workaround is "create a new entity display every 60 ticks". So this PR is mostly to get a "is this ACTUALLY a good idea, or is this ACTUALLY a bug that Paper must fix, or should plugin devs manually workaround this issue?" discussion going. If this is something that plugin devs should manually workaround, I think that it would be a good idea to document that behavior on Paper’s docs on the website ([which has a section dedicated to displays](https://docs.papermc.io/paper/dev/display-entities)) because wow, the only place that somewhat touches on this issue is in the [snapshot 23w31a changelog on Minecraft's website](https://www.minecraft.net/en-us/article/minecraft-snapshot-23w31a) and even then they do not go in depth, because they said that they clamp the `teleport_duration` value to 59 because "this value is clamped to avoid glitches due to periodic position updates"... but that doesn't fix the issue at all?!?!

I thought about an alternative implementation that tracks when was the last teleport + `teleport_duration`, but that would be way more complex than the current implementation, and, due to circumstances, the entity may not be interpolating on the client when the teleport_duration is set, example: if you set the teleport duration and teleport the entity on the same tick, the teleport_duration would be set but the client would not interpolate it, because you need to force a entity refresh to the client to cause it to interpolate on the same tick.

Fixes #11694

This also has the cool side effect that you can actually set teleport duration of display values above >59 ticks and the client interpolates it without any issues. (`(cameraEntity as CraftTextDisplay).handle.entityData.set(net.minecraft.world.entity.Display.DATA_POS_ROT_INTERPOLATION_DURATION_ID, 120)`)