### PR TITLE
Add ServerChangeMaxPlayerSlotsEvent

### DIFF
--- a/patches/api/0502-Add-ServerChangeMaxPlayerSlotsEvent.patch
+++ b/patches/api/0502-Add-ServerChangeMaxPlayerSlotsEvent.patch
@@ -1,0 +1,93 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ammo <ammo@slne.dev>
+Date: Thu, 5 Dec 2024 19:46:42 +0100
+Subject: [PATCH] Add ServerChangeMaxPlayerSlotsEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/server/ServerChangeMaxPlayerSlotsEvent.java b/src/main/java/io/papermc/paper/event/server/ServerChangeMaxPlayerSlotsEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..081842250078e9037016afcf0c4faab9db9ada54
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/server/ServerChangeMaxPlayerSlotsEvent.java
+@@ -0,0 +1,81 @@
++package io.papermc.paper.event.server;
++
++import com.google.common.base.Preconditions;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.server.ServerEvent;
++import org.jetbrains.annotations.Range;
++import org.jspecify.annotations.NullMarked;
++
++/**
++ * Called when the max player slots of the server are changed.
++ */
++@NullMarked
++public class ServerChangeMaxPlayerSlotsEvent extends ServerEvent implements Cancellable {
++
++    public static final HandlerList HANDLER_LIST = new HandlerList();
++    private boolean cancelled = false;
++
++    private final int oldMaxPlayers;
++    private int newMaxPlayers;
++
++    /**
++     * Create a new ServerChangeMaxPlayerSlotsEvent.
++     *
++     * @param oldMaxPlayers the old max player slots
++     * @param newMaxPlayers the new max player slots
++     */
++    public ServerChangeMaxPlayerSlotsEvent(int oldMaxPlayers, int newMaxPlayers) {
++        this.oldMaxPlayers = oldMaxPlayers;
++        this.newMaxPlayers = newMaxPlayers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    /**
++     * Get the old max player slots.
++     *
++     * @return the old max player slots
++     */
++    public int getOldMaxPlayers() {
++        return oldMaxPlayers;
++    }
++
++    /**
++     * Get the new max player slots.
++     *
++     * @return the new max player slots
++     */
++    public int getNewMaxPlayers() {
++        return newMaxPlayers;
++    }
++
++    /**
++     * Set the new max player slots.
++     *
++     * @param newMaxPlayers the new max player slots
++     * @throws IllegalArgumentException if newMaxPlayers is less than 0
++     */
++    public void setNewMaxPlayers(@Range(from = 0, to = Integer.MAX_VALUE) int newMaxPlayers) {
++        Preconditions.checkArgument(newMaxPlayers >= 0, "newMaxPlayers must be >= 0");
++
++        this.newMaxPlayers = newMaxPlayers;
++    }
++
++    @Override
++    public void setCancelled(boolean cancelled) {
++        this.cancelled = cancelled;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++}

--- a/patches/server/1073-Add-ServerChangeMaxPlayerSlotsEvent.patch
+++ b/patches/server/1073-Add-ServerChangeMaxPlayerSlotsEvent.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ammo <ammo@slne.dev>
+Date: Thu, 5 Dec 2024 19:46:42 +0100
+Subject: [PATCH] Add ServerChangeMaxPlayerSlotsEvent
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 97b5d6ba2b19a7c730730c74175a29157aed1840..48807d397cd1efd4bebf2a6a4f8a2a9e63215dce 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -773,7 +773,13 @@ public final class CraftServer implements Server {
+     public void setMaxPlayers(int maxPlayers) {
+         Preconditions.checkArgument(maxPlayers >= 0, "maxPlayers must be >= 0");
+ 
+-        this.playerList.maxPlayers = maxPlayers;
++        // Paper start - Add ServerChangeMaxPlayerSlotsEvent
++        io.papermc.paper.event.server.ServerChangeMaxPlayerSlotsEvent event = new io.papermc.paper.event.server.ServerChangeMaxPlayerSlotsEvent(this.getMaxPlayers(), maxPlayers);
++        if(event.callEvent()) {
++            this.playerList.maxPlayers = event.getNewMaxPlayers();
++        }
++        // this.playerList.maxPlayers = maxPlayers;
++        // Paper end
+     }
+ 
+     // NOTE: These are dependent on the corresponding call in MinecraftServer


### PR DESCRIPTION
This pull request introduces a new event to handle changes in the maximum number of player slots on the server. The changes include the addition of a new event class and its integration into the server code.

### Event Addition:

* [`patches/api/0502-Add-ServerChangeMaxPlayerSlotsEvent.patch`](diffhunk://#diff-b73ef3a414bef72d2cc05c05d8f005f103b7c4aa770fb672a141127b6136f9ceR1-R93): Added a new event class `ServerChangeMaxPlayerSlotsEvent` to handle changes in the maximum number of player slots. This class includes methods to get and set the old and new maximum player slots, as well as to handle event cancellation.

### Server Integration:

* [`patches/server/1073-Add-ServerChangeMaxPlayerSlotsEvent.patch`](diffhunk://#diff-1a861686eefd12089c93250b2626ea6714848b2de830ec9a2896d22a478ef4caR1-R25): Integrated the `ServerChangeMaxPlayerSlotsEvent` into the `CraftServer` class. The event is called when the maximum number of player slots is set, allowing for the new maximum to be adjusted or the event to be cancelled.