### PR TITLE
Fix PlayerTrade/PurchaseEvent visual issue when being cancelled

### DIFF
--- a/patches/server/0909-Add-PlayerTradeEvent-and-PlayerPurchaseEvent.patch
+++ b/patches/server/0909-Add-PlayerTradeEvent-and-PlayerPurchaseEvent.patch
@@ -4,6 +4,7 @@ Date: Thu, 2 Jul 2020 16:12:10 -0700
 Subject: [PATCH] Add PlayerTradeEvent and PlayerPurchaseEvent
 
 Co-authored-by: Alexander <protonull@protonmail.com>
+Co-authored-by: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/npc/AbstractVillager.java b/src/main/java/net/minecraft/world/entity/npc/AbstractVillager.java
 index 5ea56c6048a356d84472ef0e744af41fe063ccc7..3c037cabd8331eb96a6523b37abab4e73ab79a02 100644
@@ -157,10 +158,10 @@ index 5c1f2496f3d4123f6e69239820dd759db0af420e..54c43acb3c401a9b616f4d1b871d7c4d
  
          return itemstack;
 diff --git a/src/main/java/net/minecraft/world/inventory/MerchantResultSlot.java b/src/main/java/net/minecraft/world/inventory/MerchantResultSlot.java
-index 26227033613a641a9d5a6f29356b19e54753b3f1..c2376538215604210d08acd33e8e5fdc8a35c7d3 100644
+index 26227033613a641a9d5a6f29356b19e54753b3f1..02397eca1494370ee36dd30226f8806e3f70d51e 100644
 --- a/src/main/java/net/minecraft/world/inventory/MerchantResultSlot.java
 +++ b/src/main/java/net/minecraft/world/inventory/MerchantResultSlot.java
-@@ -47,13 +47,32 @@ public class MerchantResultSlot extends Slot {
+@@ -47,13 +47,34 @@ public class MerchantResultSlot extends Slot {
  
      @Override
      public void onTake(Player player, ItemStack stack) {
@@ -179,6 +180,8 @@ index 26227033613a641a9d5a6f29356b19e54753b3f1..c2376538215604210d08acd33e8e5fdc
 +                if (!event.callEvent()) {
 +                    stack.setCount(0);
 +                    event.getPlayer().updateInventory();
++                    int level = merchant instanceof net.minecraft.world.entity.npc.Villager villager ? villager.getVillagerData().getLevel() : 1;
++                    serverPlayer.sendMerchantOffers(player.containerMenu.containerId, merchant.getOffers(), level, merchant.getVillagerXp(), merchant.showProgressBar(), merchant.canRestock());
 +                    return;
 +                }
 +                merchantOffer = org.bukkit.craftbukkit.inventory.CraftMerchantRecipe.fromBukkit(event.getTrade()).toMinecraft();


### PR DESCRIPTION
This pull request fixes #11693.

### Changes made

Fixes client-side visual issues when cancelling PlayerTradeEvent/PlayerPurchaseEvent by resending merchant offer packets.

### To reproduce
Make a plugin that cancels PlayerTradeEvent like this code snippet:
```java
@EventHandler
 public void onPlayerTrade(PlayerTradeEvent event) {
      event.setCancelled(true);
      event.setRewardExp(false);
      event.setIncreaseTradeUses(false);
 }
```