### PR TITLE
Support lowercase in Material.getMaterial()

### DIFF
--- a/patches/api/0502-Support-lowercase-in-Material.getMaterial.patch
+++ b/patches/api/0502-Support-lowercase-in-Material.getMaterial.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dertfin3051 <dertfin@gmail.com>
+Date: Fri, 13 Dec 2024 21:45:49 +0300
+Subject: [PATCH] Support lowercase in Material.getMaterial()
+
+
+diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
+index e89edabd36a6755912694d8a8700da4ebe5c5829..ea89d6e59666fb5aacabaef7c113558f045212bc 100644
+--- a/src/main/java/org/bukkit/Material.java
++++ b/src/main/java/org/bukkit/Material.java
+@@ -5074,14 +5074,14 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+     public static Material getMaterial(@NotNull String name, boolean legacyName) {
+         if (legacyName) {
+             if (!name.startsWith(LEGACY_PREFIX)) {
+-                name = LEGACY_PREFIX + name;
++                name = LEGACY_PREFIX + name.toUpperCase();
+             }
+ 
+             Material match = BY_NAME.get(name);
+             return Bukkit.getUnsafe().fromLegacy(match);
+         }
+ 
+-        return BY_NAME.get(name);
++        return BY_NAME.get(name.toUpperCase());
+     }
+ 
+     /**


### PR DESCRIPTION
It's very inconvenient that `Material.getMaterial()` requires capital letters. This can be confusing for newbies. 

This change will allow you to pass the name of Material as arguments in any case