### PR TITLE
Fix PlayerTradeEvent/PlayerPurchase visual issue when being cancelled

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/inventory/MerchantResultSlot.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/MerchantResultSlot.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/inventory/MerchantResultSlot.java
 +++ b/net/minecraft/world/inventory/MerchantResultSlot.java
-@@ -47,13 +_,32 @@
+@@ -47,13 +_,34 @@
  
      @Override
      public void onTake(Player player, ItemStack stack) {
@@ -19,6 +19,8 @@
 +                if (!event.callEvent()) {
 +                    stack.setCount(0);
 +                    event.getPlayer().updateInventory();
++                    int level = merchant instanceof net.minecraft.world.entity.npc.Villager villager ? villager.getVillagerData().getLevel() : 1;
++                    serverPlayer.sendMerchantOffers(player.containerMenu.containerId, merchant.getOffers(), level, merchant.getVillagerXp(), merchant.showProgressBar(), merchant.canRestock());
 +                    return;
 +                }
 +                activeOffer = org.bukkit.craftbukkit.inventory.CraftMerchantRecipe.fromBukkit(event.getTrade()).toMinecraft();


### PR DESCRIPTION
This pull request fixes #11693.

Reopen #11730.

### Changes made

Fixes client-side visual issues when cancelling PlayerTradeEvent/PlayerPurchaseEvent by resending merchant offer packets.
The value `1` here is for WanderingTrader and CustomMerchantMenu.

### To reproduce
Make a plugin that cancels PlayerTradeEvent like this code snippet:
```java
@EventHandler
 public void onPlayerTrade(PlayerTradeEvent event) {
      event.setCancelled(true);
      event.setRewardExp(false);
      event.setIncreaseTradeUses(false);
 }
```