### PR TITLE
Port basic lookAt methods from Player to Entity

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -150,6 +150,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      * @return <code>true</code> if the teleport was successful
      */
     boolean teleport(@NotNull Location location, @NotNull TeleportCause cause, @NotNull io.papermc.paper.entity.TeleportFlag @NotNull... teleportFlags);
+
+    /**
+     * Causes the entity to look towards the given position.
+     *
+     * @param x x coordinate
+     * @param y y coordinate
+     * @param z z coordinate
+     * @param entityAnchor What part of the entity should face the given position
+     */
+    void lookAt(double x, double y, double z, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
+
+    /**
+     * Causes the entity to look towards the given position.
+     *
+     * @param position Position to look at in the player's current world
+     * @param entityAnchor What part of the entity should face the given position
+     */
+    default void lookAt(@NotNull io.papermc.paper.math.Position position, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor) {
+        this.lookAt(position.x(), position.y(), position.z(), entityAnchor);
+    }
     // Paper end - Teleport API
 
     /**

--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -3,6 +3,7 @@ package org.bukkit.entity;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import io.papermc.paper.entity.LookAnchor;
 import org.bukkit.Chunk; // Paper
 import org.bukkit.EntityEffect;
 import org.bukkit.Location;
@@ -159,7 +160,7 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      * @param z z coordinate
      * @param entityAnchor What part of the entity should face the given position
      */
-    void lookAt(double x, double y, double z, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
+    void lookAt(double x, double y, double z, @NotNull LookAnchor entityAnchor);
 
     /**
      * Causes the entity to look towards the given position.
@@ -167,7 +168,7 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      * @param position Position to look at in the player's current world
      * @param entityAnchor What part of the entity should face the given position
      */
-    default void lookAt(@NotNull io.papermc.paper.math.Position position, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor) {
+    default void lookAt(@NotNull io.papermc.paper.math.Position position, @NotNull LookAnchor entityAnchor) {
         this.lookAt(position.x(), position.y(), position.z(), entityAnchor);
     }
     // Paper end - Teleport API

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import io.papermc.paper.entity.LookAnchor;
 import org.bukkit.BanEntry;
 import org.bukkit.DyeColor;
 import org.bukkit.Effect;
@@ -3737,7 +3738,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      * @param playerAnchor What part of the player should face the entity
      * @param entityAnchor What part of the entity the player should face
      */
-    void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
+    void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull LookAnchor playerAnchor, @NotNull LookAnchor entityAnchor);
     // Paper end - Teleport API
 
     // Paper start

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -1309,8 +1309,8 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      * they have seen it before because this method was called.
      * Note this method does not make the player invulnerable, which is normally expected when viewing credits.
      *
-     * @see #hasSeenWinScreen() 
-     * @see #setHasSeenWinScreen(boolean) 
+     * @see #hasSeenWinScreen()
+     * @see #setHasSeenWinScreen(boolean)
      * @see <a href="https://minecraft.wiki/wiki/End_Poem#Technical_details">https://minecraft.wiki/wiki/End_Poem#Technical_details</a>
      */
     public void showWinScreen();
@@ -3392,7 +3392,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      * @param simulationDistance the player's new simulation distance
      */
     public void setSimulationDistance(int simulationDistance);
-    
+
     /**
      * Gets the no-ticking view distance for this player.
      * <p>
@@ -3729,26 +3729,6 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      * @param pitch the pitch
      */
     void setRotation(float yaw, float pitch);
-
-    /**
-     * Causes the player to look towards the given position.
-     *
-     * @param x x coordinate
-     * @param y y coordinate
-     * @param z z coordinate
-     * @param playerAnchor What part of the player should face the given position
-     */
-    void lookAt(double x, double y, double z, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor);
-
-    /**
-     * Causes the player to look towards the given position.
-     *
-     * @param position Position to look at in the player's current world
-     * @param playerAnchor What part of the player should face the given position
-     */
-    default void lookAt(@NotNull io.papermc.paper.math.Position position, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor) {
-        this.lookAt(position.x(), position.y(), position.z(), playerAnchor);
-    }
 
     /**
      * Causes the player to look towards the given entity.

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import io.papermc.paper.entity.LookAnchor;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
@@ -300,21 +301,21 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     }
 
     @Override
-    public void lookAt(double x, double y, double z, io.papermc.paper.entity.LookAnchor entityAnchor) {
+    public void lookAt(double x, double y, double z, LookAnchor entityAnchor) {
         this.getHandle().lookAt(toNmsAnchor(entityAnchor), new net.minecraft.world.phys.Vec3(x, y, z));
     }
 
-    public static net.minecraft.commands.arguments.EntityAnchorArgument.Anchor toNmsAnchor(io.papermc.paper.entity.LookAnchor nmsAnchor) {
+    public static net.minecraft.commands.arguments.EntityAnchorArgument.Anchor toNmsAnchor(LookAnchor nmsAnchor) {
         return switch (nmsAnchor) {
             case EYES -> net.minecraft.commands.arguments.EntityAnchorArgument.Anchor.EYES;
             case FEET -> net.minecraft.commands.arguments.EntityAnchorArgument.Anchor.FEET;
         };
     }
 
-    public static io.papermc.paper.entity.LookAnchor toApiAnchor(net.minecraft.commands.arguments.EntityAnchorArgument.Anchor playerAnchor) {
+    public static LookAnchor toApiAnchor(net.minecraft.commands.arguments.EntityAnchorArgument.Anchor playerAnchor) {
         return switch (playerAnchor) {
-            case EYES -> io.papermc.paper.entity.LookAnchor.EYES;
-            case FEET -> io.papermc.paper.entity.LookAnchor.FEET;
+            case EYES -> LookAnchor.EYES;
+            case FEET -> LookAnchor.FEET;
         };
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -300,6 +300,25 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     }
 
     @Override
+    public void lookAt(double x, double y, double z, io.papermc.paper.entity.LookAnchor entityAnchor) {
+        this.getHandle().lookAt(toNmsAnchor(entityAnchor), new net.minecraft.world.phys.Vec3(x, y, z));
+    }
+
+    public static net.minecraft.commands.arguments.EntityAnchorArgument.Anchor toNmsAnchor(io.papermc.paper.entity.LookAnchor nmsAnchor) {
+        return switch (nmsAnchor) {
+            case EYES -> net.minecraft.commands.arguments.EntityAnchorArgument.Anchor.EYES;
+            case FEET -> net.minecraft.commands.arguments.EntityAnchorArgument.Anchor.FEET;
+        };
+    }
+
+    public static io.papermc.paper.entity.LookAnchor toApiAnchor(net.minecraft.commands.arguments.EntityAnchorArgument.Anchor playerAnchor) {
+        return switch (playerAnchor) {
+            case EYES -> io.papermc.paper.entity.LookAnchor.EYES;
+            case FEET -> io.papermc.paper.entity.LookAnchor.FEET;
+        };
+    }
+
+    @Override
     public List<org.bukkit.entity.Entity> getNearbyEntities(double x, double y, double z) {
         Preconditions.checkState(!this.entity.generation, "Cannot get nearby entities during world generation");
         org.spigotmc.AsyncCatcher.catchOp("getNearbyEntities"); // Spigot

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -7,6 +7,7 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.datafixers.util.Pair;
 import io.netty.buffer.Unpooled;
 import io.papermc.paper.FeatureHooks;
+import io.papermc.paper.entity.LookAnchor;
 import it.unimi.dsi.fastutil.shorts.ShortArraySet;
 import it.unimi.dsi.fastutil.shorts.ShortSet;
 import java.io.ByteArrayOutputStream;
@@ -1377,7 +1378,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     }
 
     @Override
-    public void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor) {
+    public void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull LookAnchor playerAnchor, @NotNull LookAnchor entityAnchor) {
         this.getHandle().lookAt(toNmsAnchor(playerAnchor), ((CraftEntity) entity).getHandle(), toNmsAnchor(entityAnchor));
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1381,25 +1381,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
         this.getHandle().lookAt(toNmsAnchor(playerAnchor), ((CraftEntity) entity).getHandle(), toNmsAnchor(entityAnchor));
     }
 
-    @Override
-    public void lookAt(double x, double y, double z, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor) {
-        this.getHandle().lookAt(toNmsAnchor(playerAnchor), new net.minecraft.world.phys.Vec3(x, y, z));
-    }
-
-    public static net.minecraft.commands.arguments.EntityAnchorArgument.Anchor toNmsAnchor(io.papermc.paper.entity.LookAnchor nmsAnchor) {
-        return switch (nmsAnchor) {
-            case EYES -> net.minecraft.commands.arguments.EntityAnchorArgument.Anchor.EYES;
-            case FEET -> net.minecraft.commands.arguments.EntityAnchorArgument.Anchor.FEET;
-        };
-    }
-
-    public static io.papermc.paper.entity.LookAnchor toApiAnchor(net.minecraft.commands.arguments.EntityAnchorArgument.Anchor playerAnchor) {
-        return switch (playerAnchor) {
-            case EYES -> io.papermc.paper.entity.LookAnchor.EYES;
-            case FEET -> io.papermc.paper.entity.LookAnchor.FEET;
-        };
-    }
-
     public static net.minecraft.world.entity.Relative deltaRelativeToNMS(io.papermc.paper.entity.TeleportFlag.Relative apiFlag) {
         return switch (apiFlag) {
             case VELOCITY_X -> net.minecraft.world.entity.Relative.DELTA_X;


### PR DESCRIPTION
Exists methods for lookAt available in the entity NMS class like mention #11754 this PR just move that methods from player to entity.

Close #11754 