### PR TITLE
Fixes totems negating the incorrect item

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -669,22 +669,25 @@
                  if (deathProtection != null) {
 +                    hand = interactionHand; // CraftBukkit
                      itemStack = itemInHand.copy();
--                    itemInHand.shrink(1);
 +                    // itemInHand.shrink(1); // CraftBukkit
-                     break;
-                 }
-             }
- 
--            if (itemStack != null) {
--                if (this instanceof ServerPlayer serverPlayer) {
++                    break;
++                }
++            }
++
 +            org.bukkit.inventory.EquipmentSlot handSlot = (hand != null) ? org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(hand) : null;
 +            EntityResurrectEvent event = new EntityResurrectEvent((org.bukkit.entity.LivingEntity) this.getBukkitEntity(), handSlot);
 +            event.setCancelled(itemStack == null);
 +            this.level().getCraftServer().getPluginManager().callEvent(event);
 +
 +            if (!event.isCancelled()) {
-+                if (!itemStack.isEmpty() && itemStack != null) { // Paper - only reduce item if actual totem was found
-+                    itemStack.shrink(1);
++                if (!itemInHand.isEmpty() && itemStack != null) { // Paper - only reduce item if actual totem was found
+                     itemInHand.shrink(1);
+-                    break;
+-                }
+-            }
+-
+-            if (itemStack != null) {
+-                if (this instanceof ServerPlayer serverPlayer) {
 +                }
 +                // Paper start - fix NPE when pre-cancelled EntityResurrectEvent is uncancelled
 +                // restore the previous behavior in that case by defaulting to vanillas totem of undying efect


### PR DESCRIPTION
The .patch diff is a bit confusing, but basically:

Before: 
```java
if (!event.isCancelled()) {
                if (!itemStack.isEmpty() && itemStack != null) { // Paper - only reduce item if actual totem was found
                    itemStack.shrink(1);
                }
```

After:
```java
            if (!event.isCancelled()) {
                if (!itemInHand.isEmpty() && itemStack != null) { // Paper - only reduce item if actual totem was found
                    itemInHand.shrink(1);
                }
```
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-11776.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/2354307617.zip)