### PR TITLE
Fix potion effect type removal

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -388,7 +388,6 @@
  
      @Nullable
      public MobEffectInstance removeEffectNoUpdate(Holder<MobEffect> effect) {
--        return this.activeEffects.remove(effect);
 +        // CraftBukkit start
 +        return this.removeEffectNoUpdate(effect, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.UNKNOWN);
 +    }
@@ -410,7 +409,7 @@
 +            return null;
 +        }
 +
-+        return this.activeEffects.remove(effectInstance);
+         return this.activeEffects.remove(effect);
      }
  
      public boolean removeEffect(Holder<MobEffect> effect) {


### PR DESCRIPTION
An incorrectly updated hunk attempted to remove the MobEffectInstance
from the active effect map instead of the Holder<MobEffect> as the
parameter name was changed from holder to effect during hardfork.

Resolves: #11777
