### PR TITLE
Fix Inventory#addItem javadoc mismatch with behaviour

### DIFF
--- a/paper-api/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/Inventory.java
@@ -85,11 +85,12 @@ public interface Inventory extends Iterable<ItemStack> {
      * index of the varargs parameter. If all items are stored, it will return
      * an empty HashMap.
      * <p>
-     * The maximum size of the stack added to this inventory will be the minimum
+     * Items resulted from this method will not exceed the minimum
      * of {@link ItemStack#getMaxStackSize()} and {@link #getMaxStackSize()}.
      * <p>
-     * First, this method will try to fill the partial stacks in the inventory.
-     * Then, it will try to fill empty slots.
+     * First, this method will try to fill all the partial stacks in the inventory.
+     * Then it will try to fill empty slots, over-stacked items being able to
+     * fill several empty slots. The rest are placed in the returned map.
      * <p>
      * It is known that in some implementations this method will also set
      * the inputted argument amount to the number of that item not placed in

--- a/paper-api/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/Inventory.java
@@ -85,12 +85,11 @@ public interface Inventory extends Iterable<ItemStack> {
      * index of the varargs parameter. If all items are stored, it will return
      * an empty HashMap.
      * <p>
-     * If you pass in ItemStacks which exceed the maximum stack size for the
-     * Material, first they will be added to partial stacks where
-     * Material.getMaxStackSize() is not exceeded, up to
-     * Material.getMaxStackSize(). When there are no partial stacks left
-     * stacks will be split on Inventory.getMaxStackSize() allowing you to
-     * exceed the maximum stack size for that material.
+     * The maximum size of the stack added to this inventory will be the minimum
+     * of {@link ItemStack#getMaxStackSize()} and {@link #getMaxStackSize()}.
+     * <p>
+     * First, this method will try to fill the partial stacks in the inventory.
+     * Then, it will try to fill empty slots.
      * <p>
      * It is known that in some implementations this method will also set
      * the inputted argument amount to the number of that item not placed in


### PR DESCRIPTION
Spigot recently changed the behavior of Inventory#addItem by not allowing making overstacked items in inventory with it, but didn't update the javadocs, making it inconsistent with the implementation