### PR TITLE
Correctly die when cancelling EntityResurrectEvent

### DIFF
--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -533,10 +533,10 @@ index e7889c9c7b155db46730f5e168bb7fd3d1732a8c..334859c5ff7023c730513301cc11c983
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index a71a153a91de5a564b946091d8d3ccbb330e4b89..195e1151f7b2a32d6c4eb67edd1952e38f58b266 100644
+index ff513e8c87bf42be756e46f4dbfec8dda2b8cb60..239c443ddc9bacc08a39a8ef2ab17016a2480549 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3094,6 +3094,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3096,6 +3096,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return false;
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -654,7 +654,7 @@
      }
  
      private boolean checkTotemDeathProtection(DamageSource damageSource) {
-@@ -1274,18 +_,37 @@
+@@ -1274,18 +_,39 @@
              ItemStack itemStack = null;
              DeathProtection deathProtection = null;
  
@@ -673,12 +673,14 @@
 +                }
 +            }
 +
-+            org.bukkit.inventory.EquipmentSlot handSlot = (hand != null) ? org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(hand) : null;
-+            EntityResurrectEvent event = new EntityResurrectEvent((org.bukkit.entity.LivingEntity) this.getBukkitEntity(), handSlot);
++            final org.bukkit.inventory.EquipmentSlot handSlot = (hand != null) ? org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(hand) : null;
++            final EntityResurrectEvent event = new EntityResurrectEvent((org.bukkit.entity.LivingEntity) this.getBukkitEntity(), handSlot);
 +            event.setCancelled(itemStack == null);
 +            this.level().getCraftServer().getPluginManager().callEvent(event);
-+
-+            if (!event.isCancelled()) {
++            if (event.isCancelled()) {
++                // Set death protection to null as the event was cancelled. Prevent any attempt at ressurection.
++                deathProtection = null;
++            } else {
 +                if (!itemInHand.isEmpty() && itemStack != null) { // Paper - only reduce item if actual totem was found
                      itemInHand.shrink(1);
 -                    break;
@@ -694,8 +696,8 @@
 +                    deathProtection = DeathProtection.TOTEM_OF_UNDYING;
 +                }
 +                // Paper end - fix NPE when pre-cancelled EntityResurrectEvent is uncancelled
-+                if (itemStack != null && this instanceof ServerPlayer serverPlayer) {
-+                    // CraftBukkit end
++                if (itemStack != null && this instanceof final ServerPlayer serverPlayer) {
++            // CraftBukkit end
                      serverPlayer.awardStat(Stats.ITEM_USED.get(itemStack.getItem()));
                      CriteriaTriggers.USED_TOTEM.trigger(serverPlayer, itemStack);
                      this.gameEvent(GameEvent.ITEM_INTERACT_FINISH);


### PR DESCRIPTION
The existing logic in LivingEntity#checkTotemDeathProtection completes
by checking whether the death protection component is null or not.
In cases where the event was cancelled, the component needs to be nulled
out to prevent the method from returning true, causing the player to
properly die.

Resolves: #11780
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-11785.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/2356375725.zip)