### PR TITLE
Fix recipe book items order

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/item/crafting/RecipeMap.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/crafting/RecipeMap.java.patch
@@ -7,7 +7,7 @@
 -        return new RecipeMap(builder.build(), builder1.build());
 -    }
 +        // CraftBukkit start - mutable
-+        return new RecipeMap(com.google.common.collect.LinkedHashMultimap.create(builder.build()), com.google.common.collect.Maps.newHashMap(builder1.build()));
++        return new RecipeMap(com.google.common.collect.LinkedHashMultimap.create(builder.build()), com.google.common.collect.Maps.newLinkedHashMap(builder1.build()));
 +    }
 +
 +    public void addRecipe(RecipeHolder<?> holder) {


### PR DESCRIPTION
This pull request fixes #11764.

### Changes

Replace HashMap in RecipeMap with LinkedHashMap to ensure insert order. Tested and works fine.