### PR TITLE
Fix PotionMeta methods redirect

### DIFF
--- a/paper-api/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
@@ -153,9 +153,7 @@ public interface PotionMeta extends ItemMeta {
      * @return true if this has a custom potion name
      */
     @Deprecated(forRemoval = true, since = "1.21.4")
-    default boolean hasCustomName() {
-        return this.hasCustomPotionName();
-    }
+    boolean hasCustomName();
 
     /**
      * Gets the potion name translation suffix that is set.
@@ -168,9 +166,7 @@ public interface PotionMeta extends ItemMeta {
      */
     @Deprecated(forRemoval = true, since = "1.21.4")
     @Nullable
-    default String getCustomName() {
-        return this.getCustomPotionName();
-    }
+    String getCustomName();
 
     /**
      * Sets the potion name translation suffix.
@@ -179,9 +175,7 @@ public interface PotionMeta extends ItemMeta {
      * @param name the name to set
      */
     @Deprecated(forRemoval = true, since = "1.21.4")
-    default void setCustomName(@Nullable String name) {
-        this.setCustomPotionName(name);
-    }
+    void setCustomName(@Nullable String name);
 
     /**
      * Checks for existence of a custom potion name translation suffix.

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
@@ -310,6 +310,23 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
         return this.customName != null;
     }
 
+    // Paper start - Deprecated PotionMeta methods redirect
+    @Override
+    public boolean hasCustomName() {
+        return this.hasCustomPotionName();
+    }
+
+    @Override
+    public String getCustomName() {
+        return this.getCustomPotionName();
+    }
+
+    @Override
+    public void setCustomName(String name) {
+        this.setCustomPotionName(name);
+    }
+    // Paper end - Deprecated PotionMeta methods redirect
+
     @Override
     public String getCustomPotionName() {
         return this.customName;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
@@ -310,7 +310,6 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
         return this.customName != null;
     }
 
-    // Paper start - Deprecated PotionMeta methods redirect
     @Override
     public boolean hasCustomName() {
         return this.hasCustomPotionName();
@@ -325,7 +324,6 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
     public void setCustomName(String name) {
         this.setCustomPotionName(name);
     }
-    // Paper end - Deprecated PotionMeta methods redirect
 
     @Override
     public String getCustomPotionName() {


### PR DESCRIPTION
This pull request fixes #11732.

### Api changes

Move deprecate methods redirect to CraftMetaPotion, make sure they have same behavior as Spigot. Java prior to call method implementation in classes first instead of default methods in interfaces