### PR TITLE
Cache Bukkit Command when wrapping CommandNodes

### DIFF
--- a/paper-server/patches/sources/com/mojang/brigadier/tree/CommandNode.java.patch
+++ b/paper-server/patches/sources/com/mojang/brigadier/tree/CommandNode.java.patch
@@ -13,7 +13,7 @@
 +    public CommandNode<net.minecraft.commands.CommandSourceStack> clientNode; // Paper - Brigadier API
 +    public CommandNode<io.papermc.paper.command.brigadier.CommandSourceStack> unwrappedCached = null; // Paper - Brigadier Command API
 +    public CommandNode<io.papermc.paper.command.brigadier.CommandSourceStack> wrappedCached = null; // Paper - Brigadier Command API
-+    public org.bukkit.command.Command wrappedBukkitCommandCached = null; // Paper - Brigadier Command API
++    public org.bukkit.command.Command cachedWrappedBukkitCommand = null; // Paper - Brigadier Command API
 +    // CraftBukkit start
 +    public void removeCommand(String name) {
 +        this.children.remove(name);

--- a/paper-server/patches/sources/com/mojang/brigadier/tree/CommandNode.java.patch
+++ b/paper-server/patches/sources/com/mojang/brigadier/tree/CommandNode.java.patch
@@ -1,6 +1,6 @@
 --- a/com/mojang/brigadier/tree/CommandNode.java
 +++ b/com/mojang/brigadier/tree/CommandNode.java
-@@ -27,11 +_,21 @@
+@@ -27,11 +_,22 @@
      private final Map<String, CommandNode<S>> children = new LinkedHashMap<>();
      private final Map<String, LiteralCommandNode<S>> literals = new LinkedHashMap<>();
      private final Map<String, ArgumentCommandNode<S, ?>> arguments = new LinkedHashMap<>();
@@ -13,6 +13,7 @@
 +    public CommandNode<net.minecraft.commands.CommandSourceStack> clientNode; // Paper - Brigadier API
 +    public CommandNode<io.papermc.paper.command.brigadier.CommandSourceStack> unwrappedCached = null; // Paper - Brigadier Command API
 +    public CommandNode<io.papermc.paper.command.brigadier.CommandSourceStack> wrappedCached = null; // Paper - Brigadier Command API
++    public org.bukkit.command.Command wrappedBukkitCommandCached = null; // Paper - Brigadier Command API
 +    // CraftBukkit start
 +    public void removeCommand(String name) {
 +        this.children.remove(name);

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitBrigForwardingMap.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitBrigForwardingMap.java
@@ -83,12 +83,12 @@ public class BukkitBrigForwardingMap extends HashMap<String, Command> {
             return null;
         }
 
-        if (node.wrappedBukkitCommandCached != null) {
-            return node.wrappedBukkitCommandCached;
+        if (node.cachedWrappedBukkitCommand != null) {
+            return node.cachedWrappedBukkitCommand;
         }
 
         Command bukkitCommand = PaperBrigadier.wrapNode(node);
-        node.wrappedBukkitCommandCached = bukkitCommand;
+        node.cachedWrappedBukkitCommand = bukkitCommand;
         return bukkitCommand;
     }
 

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitBrigForwardingMap.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitBrigForwardingMap.java
@@ -83,11 +83,13 @@ public class BukkitBrigForwardingMap extends HashMap<String, Command> {
             return null;
         }
 
-        if (node instanceof BukkitCommandNode bukkitCommandNode) {
-            return bukkitCommandNode.getBukkitCommand();
+        if (node.wrappedBukkitCommandCached != null) {
+            return node.wrappedBukkitCommandCached;
         }
 
-        return PaperBrigadier.wrapNode(node);
+        Command bukkitCommand = PaperBrigadier.wrapNode(node);
+        node.wrappedBukkitCommandCached = bukkitCommand;
+        return bukkitCommand;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
@@ -43,6 +43,7 @@ public class BukkitCommandNode extends LiteralCommandNode<CommandSourceStack> {
             null, null, false
         );
         this.command = command;
+        this.wrappedBukkitCommandCached = command;
     }
 
     public static BukkitCommandNode of(String name, Command command) {

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitCommandNode.java
@@ -43,7 +43,7 @@ public class BukkitCommandNode extends LiteralCommandNode<CommandSourceStack> {
             null, null, false
         );
         this.command = command;
-        this.wrappedBukkitCommandCached = command;
+        this.cachedWrappedBukkitCommand = command;
     }
 
     public static BukkitCommandNode of(String name, Command command) {


### PR DESCRIPTION
Reopens #11385.

Resolves #11378 by "restoring" the Spigot behavior where VanillaCommandNodes are only created once. Before this commit, `BukkitBrigForwardingMap` would create a new `VanillaCommandWrapper` each time a `CommandNode` was requested via the Bukkit `CommandMap`. This meant that calls to `Command#setPermission` would not persist between retrievals from the map.

This allows command frameworks that insert `CommandNode`s directly into the Brigadier dispatcher to change the permission String of the `VanillaCommandNode`s created for their commands, rather than it always being the default `"minecraft.commands.<name>"`.

As discussed on the original PR, it's probably a good idea to eventually migrate the behavior of `Bukkit#dispatchCommand` to use Brigadier directly rather than working via the Bukkit `CommandMap`, which causes issues like this. Now that the hardfork is real, Paper may eventually fully remove `CommandMap` in favor of direct Brigadier API, which would make fixing `CommandMap` behavior like this PR does irrelevant. However, I feel like while Paper is still using the `CommandMap` fixes like this are still valuable.

If we'd rather fix #11378 by changing the implementation of `Bukkit#dispatchCommand` to use Brigadier directly, feel free to close this PR. Although, while not a requirement of the Map interface, it is also neat when `map.get(a) == map.get(a)` for all `a`, which isn't necessarily true for the `BukkitBrigForwardingMap`  before this PR.