### PR TITLE
Copy forward when registering alias (fixes #10827)

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
@@ -132,6 +132,7 @@ public class PaperCommands implements Commands, PaperRegistrar<LifecycleEventOwn
         if (redirectTo.getChildren().isEmpty() || hasFlattenRedirectFlag) {
             redirect = Commands.literal(aliasLiteral)
                 .executes(redirectTo.getCommand())
+                .forward(redirectTo.getRedirect(), redirectTo.getRedirectModifier(), redirectTo.isFork())
                 .requires(redirectTo.getRequirement())
                 .build();
 


### PR DESCRIPTION
When flattening any command or registering an alias to a node with no direct children (such as a redirect), the code now takes into account any potential redirect/fork/forward on the target node. This fixes the issue where, when registering a command that was simply a redirect, only the namespaced literal would work, and not any aliases of the command.

This fixes #10827 and has been reopened post hard-fork from #10952 