### PR TITLE
For new registry values, allow copying from existing

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/registry/RegistryBuilderFactory.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/RegistryBuilderFactory.java
@@ -1,0 +1,39 @@
+package io.papermc.paper.registry;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A factory to create a {@link RegistryBuilder} for a given {@link TypedKey}. For
+ * each instance of this class, once either {@link #empty()} or {@link #copyOf(TypedKey)}
+ * is called once, any future calls to either method will throw an {@link IllegalStateException}.
+ *
+ * @param <T> The type of the registry
+ * @param <B> The type of the registry builder
+ */
+@NullMarked
+@ApiStatus.Experimental
+@ApiStatus.NonExtendable
+public interface RegistryBuilderFactory<T, B extends RegistryBuilder<T>> {
+
+    /**
+     * Creates a new empty {@link RegistryBuilder}.
+     *
+     * @return A new empty {@link RegistryBuilder}
+     * @throws IllegalStateException if this method or {@link #copyOf(TypedKey)}) has already been called once
+     */
+    @Contract("-> new")
+    B empty();
+
+    /**
+     * Creates a new {@link RegistryBuilder} with the same properties as the given {@link TypedKey}.
+     *
+     * @param key The key to copy properties from
+     * @return A new {@link RegistryBuilder} with the same properties as the given key
+     * @throws IllegalStateException if this method or {@link #empty()} has already been called once
+     * @throws IllegalArgumentException if key doesn't exist
+     */
+    @Contract("_ -> new")
+    B copyOf(TypedKey<T> key);
+}

--- a/paper-api/src/main/java/io/papermc/paper/registry/RegistryBuilderFactory.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/RegistryBuilderFactory.java
@@ -6,7 +6,7 @@ import org.jspecify.annotations.NullMarked;
 
 /**
  * A factory to create a {@link RegistryBuilder} for a given {@link TypedKey}. For
- * each instance of this class, once either {@link #empty()} or {@link #copyOf(TypedKey)}
+ * each instance of this class, once either {@link #empty()} or {@link #copyFrom(TypedKey)}
  * is called once, any future calls to either method will throw an {@link IllegalStateException}.
  *
  * @param <T> The type of the registry
@@ -21,7 +21,7 @@ public interface RegistryBuilderFactory<T, B extends RegistryBuilder<T>> {
      * Creates a new empty {@link RegistryBuilder}.
      *
      * @return A new empty {@link RegistryBuilder}
-     * @throws IllegalStateException if this method or {@link #copyOf(TypedKey)}) has already been called once
+     * @throws IllegalStateException if this method or {@link #copyFrom(TypedKey)}) has already been called once
      */
     @Contract("-> new")
     B empty();
@@ -35,5 +35,5 @@ public interface RegistryBuilderFactory<T, B extends RegistryBuilder<T>> {
      * @throws IllegalArgumentException if key doesn't exist
      */
     @Contract("_ -> new")
-    B copyOf(TypedKey<T> key);
+    B copyFrom(TypedKey<T> key);
 }

--- a/paper-api/src/main/java/io/papermc/paper/registry/RegistryKey.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/RegistryKey.java
@@ -209,6 +209,7 @@ public sealed interface RegistryKey<T> extends Keyed permits RegistryKeyImpl {
      * @param key the key of the typed key.
      * @return the constructed typed key.
      */
+    @ApiStatus.Experimental
     default TypedKey<T> typedKey(final Key key) {
         return TypedKey.create(this, key);
     }
@@ -219,6 +220,7 @@ public sealed interface RegistryKey<T> extends Keyed permits RegistryKeyImpl {
      * @param key the string representation of the key that will be passed to {@link Key#key(String)}.
      * @return the constructed typed key.
      */
+    @ApiStatus.Experimental
     default TypedKey<T> typedKey(final @KeyPattern String key) {
         return TypedKey.create(this, key);
     }

--- a/paper-api/src/main/java/io/papermc/paper/registry/RegistryKey.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/RegistryKey.java
@@ -1,6 +1,8 @@
 package io.papermc.paper.registry;
 
 import io.papermc.paper.datacomponent.DataComponentType;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import net.kyori.adventure.key.Keyed;
 import org.bukkit.Art;
 import org.bukkit.Fluid;
@@ -200,4 +202,24 @@ public sealed interface RegistryKey<T> extends Keyed permits RegistryKeyImpl {
     RegistryKey<Particle> PARTICLE_TYPE = create("particle_type");
     RegistryKey<PotionType> POTION = create("potion");
     RegistryKey<MemoryKey<?>> MEMORY_MODULE_TYPE = create("memory_module_type");
+
+    /**
+     * Constructs a new {@link TypedKey} for this registry given the typed key's key.
+     *
+     * @param key the key of the typed key.
+     * @return the constructed typed key.
+     */
+    default TypedKey<T> typedKey(final Key key) {
+        return TypedKey.create(this, key);
+    }
+
+    /**
+     * Constructs a new {@link TypedKey} for this registry given the typed key's key.
+     *
+     * @param key the string representation of the key that will be passed to {@link Key#key(String)}.
+     * @return the constructed typed key.
+     */
+    default TypedKey<T> typedKey(final @KeyPattern String key) {
+        return TypedKey.create(this, key);
+    }
 }

--- a/paper-api/src/main/java/io/papermc/paper/registry/TypedKey.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/TypedKey.java
@@ -1,6 +1,7 @@
 package io.papermc.paper.registry;
 
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import net.kyori.adventure.key.Keyed;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
@@ -41,5 +42,19 @@ public sealed interface TypedKey<T> extends Key permits TypedKeyImpl {
     @ApiStatus.Experimental
     static <T> TypedKey<T> create(final RegistryKey<T> registryKey, final Key key) {
         return new TypedKeyImpl<>(key, registryKey);
+    }
+
+    /**
+     * Create a typed key from a string and a registry key.
+     *
+     * @param registryKey the registry this key is for
+     * @param key         the string version of a {@link Key} that will be passed to {@link Key#key(String)} for parsing.
+     * @param <T>         value type
+     * @return a new key for the value key and registry key
+     * @see Key#key(String)
+     */
+    @ApiStatus.Experimental
+    static <T> TypedKey<T> create(final RegistryKey<T> registryKey, final @KeyPattern String key) {
+        return create(registryKey, Key.key(key));
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/registry/event/WritableRegistry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/event/WritableRegistry.java
@@ -26,7 +26,7 @@ public interface WritableRegistry<T, B extends RegistryBuilder<T>> {
      * @param value a consumer for the entry's builder
      */
     default void register(final TypedKey<T> key, final Consumer<? super B> value) {
-        this.factoryRegister(key, factory -> value.accept(factory.empty()));
+        this.registerWith(key, factory -> value.accept(factory.empty()));
     }
 
     /**
@@ -38,5 +38,5 @@ public interface WritableRegistry<T, B extends RegistryBuilder<T>> {
      * @param key the entry's key (must be unique from others)
      * @param value a consumer of a builder factory
      */
-    void factoryRegister(TypedKey<T> key, Consumer<RegistryBuilderFactory<T, B>> value);
+    void registerWith(TypedKey<T> key, Consumer<RegistryBuilderFactory<T, B>> value);
 }

--- a/paper-api/src/main/java/io/papermc/paper/registry/event/WritableRegistry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/event/WritableRegistry.java
@@ -25,4 +25,17 @@ public interface WritableRegistry<T, B extends RegistryBuilder<T>> {
      * @param value a consumer for the entry's builder
      */
     void register(TypedKey<T> key, Consumer<? super B> value);
+
+    /**
+     * Register a new value with the specified key. This will
+     * fire a {@link RegistryEntryAddEvent} for the new entry. The
+     * builder in the consumer will be pre-filled with the values
+     * from the copyFrom key.
+     *
+     * @param key the entry's key (must be unique from others)
+     * @param copyFrom the key to copy values from (must already be registered)
+     * @param value a consumer for the entry's builder
+     * @throws IllegalArgumentException if copyFrom doesn't exist
+     */
+    void register(TypedKey<T> key, TypedKey<T> copyFrom, Consumer<? super B> value);
 }

--- a/paper-api/src/main/java/io/papermc/paper/registry/event/WritableRegistry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/event/WritableRegistry.java
@@ -1,6 +1,7 @@
 package io.papermc.paper.registry.event;
 
 import io.papermc.paper.registry.RegistryBuilder;
+import io.papermc.paper.registry.RegistryBuilderFactory;
 import io.papermc.paper.registry.TypedKey;
 import java.util.function.Consumer;
 import org.jetbrains.annotations.ApiStatus;
@@ -24,18 +25,18 @@ public interface WritableRegistry<T, B extends RegistryBuilder<T>> {
      * @param key the entry's key (must be unique from others)
      * @param value a consumer for the entry's builder
      */
-    void register(TypedKey<T> key, Consumer<? super B> value);
+    default void register(final TypedKey<T> key, final Consumer<? super B> value) {
+        this.factoryRegister(key, factory -> value.accept(factory.empty()));
+    }
 
     /**
      * Register a new value with the specified key. This will
      * fire a {@link RegistryEntryAddEvent} for the new entry. The
-     * builder in the consumer will be pre-filled with the values
-     * from the copyFrom key.
+     * {@link RegistryBuilderFactory} lets you pre-fill a builder with
+     * an already-existing entry's properties.
      *
      * @param key the entry's key (must be unique from others)
-     * @param copyFrom the key to copy values from (must already be registered)
-     * @param value a consumer for the entry's builder
-     * @throws IllegalArgumentException if copyFrom doesn't exist
+     * @param value a consumer of a builder factory
      */
-    void register(TypedKey<T> key, TypedKey<T> copyFrom, Consumer<? super B> value);
+    void factoryRegister(TypedKey<T> key, Consumer<RegistryBuilderFactory<T, B>> value);
 }

--- a/paper-server/patches/features/0017-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0017-Moonrise-optimisation-patches.patch
@@ -23508,10 +23508,10 @@ index 3d3eec1db91cb47395f40c4f47aa77164ad42175..216f97207dac88cc1dc3df59c6ee8a62
 +    // Paper end - optimise collisions
  }
 diff --git a/net/minecraft/core/MappedRegistry.java b/net/minecraft/core/MappedRegistry.java
-index 47b1fafd91b39e73c4e9134b0b8048000fba108a..76994c1491221c06cca5405ba239e6ff642b19ed 100644
+index 452c358c2cfa0c39e0b09853cd4a9a12c6ced65d..5f752603aa5611ce9d3dd44cc5b70c27ac46a86e 100644
 --- a/net/minecraft/core/MappedRegistry.java
 +++ b/net/minecraft/core/MappedRegistry.java
-@@ -50,6 +50,19 @@ public class MappedRegistry<T> implements WritableRegistry<T> {
+@@ -51,6 +51,19 @@ public class MappedRegistry<T> implements WritableRegistry<T> {
          return this.getTags();
      }
  
@@ -23531,10 +23531,10 @@ index 47b1fafd91b39e73c4e9134b0b8048000fba108a..76994c1491221c06cca5405ba239e6ff
      public MappedRegistry(ResourceKey<? extends Registry<T>> key, Lifecycle registryLifecycle) {
          this(key, registryLifecycle, false);
      }
-@@ -114,6 +127,7 @@ public class MappedRegistry<T> implements WritableRegistry<T> {
-             this.toId.put(value, size);
+@@ -116,6 +129,7 @@ public class MappedRegistry<T> implements WritableRegistry<T> {
              this.registrationInfos.put(key, registrationInfo);
              this.registryLifecycle = this.registryLifecycle.add(registrationInfo.lifecycle());
+             this.temporaryUnfrozenMap.put(key.location(), value); // Paper - support pre-filling in registry mod API
 +            this.injectFluidRegister(key, value); // Paper - fluid method optimisations
              return reference;
          }

--- a/paper-server/patches/sources/net/minecraft/core/MappedRegistry.java.patch
+++ b/paper-server/patches/sources/net/minecraft/core/MappedRegistry.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/core/MappedRegistry.java
 +++ b/net/minecraft/core/MappedRegistry.java
-@@ -33,11 +_,11 @@
+@@ -33,17 +_,18 @@
  public class MappedRegistry<T> implements WritableRegistry<T> {
      private final ResourceKey<? extends Registry<T>> key;
      private final ObjectList<Holder.Reference<T>> byId = new ObjectArrayList<>(256);
@@ -17,6 +17,29 @@
      private Lifecycle registryLifecycle;
      private final Map<TagKey<T>, HolderSet.Named<T>> frozenTags = new IdentityHashMap<>();
      MappedRegistry.TagSet<T> allTags = MappedRegistry.TagSet.unbound();
+     private boolean frozen;
+     @Nullable
+     private Map<T, Holder.Reference<T>> unregisteredIntrusiveHolders;
++    public final Map<ResourceLocation, T> temporaryUnfrozenMap = new HashMap<>(); // Paper - support pre-filling in registry mod API
+ 
+     @Override
+     public Stream<HolderSet.Named<T>> listTags() {
+@@ -114,6 +_,7 @@
+             this.toId.put(value, size);
+             this.registrationInfos.put(key, registrationInfo);
+             this.registryLifecycle = this.registryLifecycle.add(registrationInfo.lifecycle());
++            this.temporaryUnfrozenMap.put(key.location(), value); // Paper - support pre-filling in registry mod API
+             return reference;
+         }
+     }
+@@ -275,6 +_,7 @@
+             return this;
+         } else {
+             this.frozen = true;
++            this.temporaryUnfrozenMap.clear(); // Paper - support pre-filling in registry mod API
+             this.byValue.forEach((object, reference) -> reference.bindValue((T)object));
+             List<ResourceLocation> list = this.byKey
+                 .entrySet()
 @@ -509,4 +_,13 @@
  
          Stream<HolderSet.Named<T>> getTags();

--- a/paper-server/src/main/java/io/papermc/paper/registry/PaperRegistryBuilderFactory.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/PaperRegistryBuilderFactory.java
@@ -40,7 +40,7 @@ public class PaperRegistryBuilderFactory<M, A extends Keyed, B extends PaperRegi
     }
 
     @Override
-    public B copyOf(final TypedKey<A> key) {
+    public B copyFrom(final TypedKey<A> key) {
         this.validate();
         final M existing = this.existingValueGetter.apply(PaperAdventure.asVanilla(key));
         if (existing == null) {

--- a/paper-server/src/main/java/io/papermc/paper/registry/PaperRegistryBuilderFactory.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/PaperRegistryBuilderFactory.java
@@ -1,0 +1,52 @@
+package io.papermc.paper.registry;
+
+import io.papermc.paper.adventure.PaperAdventure;
+import io.papermc.paper.registry.data.util.Conversions;
+import io.papermc.paper.registry.entry.RegistryEntryMeta;
+import java.util.function.Function;
+import net.minecraft.resources.ResourceLocation;
+import org.bukkit.Keyed;
+import org.jspecify.annotations.Nullable;
+
+public class PaperRegistryBuilderFactory<M, A extends Keyed, B extends PaperRegistryBuilder<M, A>> implements RegistryBuilderFactory<A, B> { // TODO remove Keyed
+
+    private final Conversions conversions;
+    private final RegistryEntryMeta.Buildable<M, A, B> meta;
+    private final Function<? super ResourceLocation, ? extends @Nullable M> existingValueGetter;
+    private @Nullable B builder;
+
+    public PaperRegistryBuilderFactory(final Conversions conversions, final RegistryEntryMeta.Buildable<M, A, B> meta, final Function<? super ResourceLocation, ? extends @Nullable M> existingValueGetter) {
+        this.conversions = conversions;
+        this.meta = meta;
+        this.existingValueGetter = existingValueGetter;
+    }
+
+    private void validate() {
+        if (this.builder != null) {
+            throw new IllegalStateException("Already created a builder");
+        }
+    }
+
+    public B requireBuilder() {
+        if (this.builder == null) {
+            throw new IllegalStateException("Builder not created yet");
+        }
+        return this.builder;
+    }
+
+    @Override
+    public B empty() {
+        this.validate();
+        return this.builder = this.meta.builderFiller().create(this.conversions);
+    }
+
+    @Override
+    public B copyOf(final TypedKey<A> key) {
+        this.validate();
+        final M existing = this.existingValueGetter.apply(PaperAdventure.asVanilla(key));
+        if (existing == null) {
+            throw new IllegalArgumentException("Key " + key + " doesn't exist");
+        }
+        return this.builder = this.meta.builderFiller().fill(this.conversions, existing);
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/registry/PaperRegistryBuilderFactory.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/PaperRegistryBuilderFactory.java
@@ -2,7 +2,6 @@ package io.papermc.paper.registry;
 
 import io.papermc.paper.adventure.PaperAdventure;
 import io.papermc.paper.registry.data.util.Conversions;
-import io.papermc.paper.registry.entry.RegistryEntryMeta;
 import java.util.function.Function;
 import net.minecraft.resources.ResourceLocation;
 import org.bukkit.Keyed;
@@ -11,13 +10,13 @@ import org.jspecify.annotations.Nullable;
 public class PaperRegistryBuilderFactory<M, A extends Keyed, B extends PaperRegistryBuilder<M, A>> implements RegistryBuilderFactory<A, B> { // TODO remove Keyed
 
     private final Conversions conversions;
-    private final RegistryEntryMeta.Buildable<M, A, B> meta;
+    private final PaperRegistryBuilder.Filler<M, A, B> builderFiller;
     private final Function<? super ResourceLocation, ? extends @Nullable M> existingValueGetter;
     private @Nullable B builder;
 
-    public PaperRegistryBuilderFactory(final Conversions conversions, final RegistryEntryMeta.Buildable<M, A, B> meta, final Function<? super ResourceLocation, ? extends @Nullable M> existingValueGetter) {
+    public PaperRegistryBuilderFactory(final Conversions conversions, final PaperRegistryBuilder.Filler<M, A, B> builderFiller, final Function<? super ResourceLocation, ? extends @Nullable M> existingValueGetter) {
         this.conversions = conversions;
-        this.meta = meta;
+        this.builderFiller = builderFiller;
         this.existingValueGetter = existingValueGetter;
     }
 
@@ -37,7 +36,7 @@ public class PaperRegistryBuilderFactory<M, A extends Keyed, B extends PaperRegi
     @Override
     public B empty() {
         this.validate();
-        return this.builder = this.meta.builderFiller().create(this.conversions);
+        return this.builder = this.builderFiller.create(this.conversions);
     }
 
     @Override
@@ -47,6 +46,6 @@ public class PaperRegistryBuilderFactory<M, A extends Keyed, B extends PaperRegi
         if (existing == null) {
             throw new IllegalArgumentException("Key " + key + " doesn't exist");
         }
-        return this.builder = this.meta.builderFiller().fill(this.conversions, existing);
+        return this.builder = this.builderFiller.fill(this.conversions, existing);
     }
 }

--- a/paper-server/src/main/java/io/papermc/paper/registry/WritableCraftRegistry.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/WritableCraftRegistry.java
@@ -56,7 +56,7 @@ public class WritableCraftRegistry<M, T extends Keyed, B extends PaperRegistryBu
         }
 
         @Override
-        public void factoryRegister(final TypedKey<T> key, final Consumer<RegistryBuilderFactory<T, B>> value) {
+        public void registerWith(final TypedKey<T> key, final Consumer<RegistryBuilderFactory<T, B>> value) {
             WritableCraftRegistry.this.register(key, value, this.conversions);
         }
     }

--- a/paper-server/src/main/java/io/papermc/paper/registry/WritableCraftRegistry.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/WritableCraftRegistry.java
@@ -1,8 +1,6 @@
 package io.papermc.paper.registry;
 
-import com.google.common.base.Preconditions;
 import com.mojang.serialization.Lifecycle;
-import io.papermc.paper.adventure.PaperAdventure;
 import io.papermc.paper.registry.data.util.Conversions;
 import io.papermc.paper.registry.entry.RegistryEntryMeta;
 import io.papermc.paper.registry.event.WritableRegistry;
@@ -13,7 +11,6 @@ import net.minecraft.core.RegistrationInfo;
 import net.minecraft.resources.ResourceKey;
 import org.bukkit.Keyed;
 import org.bukkit.craftbukkit.CraftRegistry;
-import org.jspecify.annotations.Nullable;
 
 public class WritableCraftRegistry<M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> extends CraftRegistry<T, M> {
 
@@ -31,23 +28,16 @@ public class WritableCraftRegistry<M, T extends Keyed, B extends PaperRegistryBu
         this.meta = meta;
     }
 
-    public void register(final TypedKey<T> key, final @Nullable TypedKey<T> copyFrom, final Consumer<? super B> value, final Conversions conversions) {
+    public void register(final TypedKey<T> key, final Consumer<RegistryBuilderFactory<T, B>> value, final Conversions conversions) {
         final ResourceKey<M> resourceKey = PaperRegistries.toNms(key);
         this.registry.validateWrite(resourceKey);
-        final B builder;
-        if (copyFrom != null) {
-            final M existing = this.registry.temporaryUnfrozenMap.get(PaperAdventure.asVanilla(copyFrom));
-            Preconditions.checkArgument(existing != null, "Cannot copy from unregistered key: %s", copyFrom);
-            builder = this.meta.builderFiller().fill(conversions, existing);
-        } else {
-            builder = this.meta.builderFiller().create(conversions);
-        }
-        value.accept(builder);
+        final PaperRegistryBuilderFactory<M, T, B> builderFactory = new PaperRegistryBuilderFactory<>(conversions, this.meta, this.registry.temporaryUnfrozenMap::get);
+        value.accept(builderFactory);
         PaperRegistryListenerManager.INSTANCE.registerWithListeners(
             this.registry,
             this.meta,
             resourceKey,
-            builder,
+            builderFactory.requireBuilder(),
             FROM_PLUGIN,
             conversions
         );
@@ -66,13 +56,8 @@ public class WritableCraftRegistry<M, T extends Keyed, B extends PaperRegistryBu
         }
 
         @Override
-        public void register(final TypedKey<T> key, final Consumer<? super B> value) {
-            WritableCraftRegistry.this.register(key, null, value, this.conversions);
-        }
-
-        @Override
-        public void register(final TypedKey<T> key, final TypedKey<T> copyFrom, final Consumer<? super B> value) {
-            WritableCraftRegistry.this.register(key, copyFrom, value, this.conversions);
+        public void factoryRegister(final TypedKey<T> key, final Consumer<RegistryBuilderFactory<T, B>> value) {
+            WritableCraftRegistry.this.register(key, value, this.conversions);
         }
     }
 }

--- a/paper-server/src/main/java/io/papermc/paper/registry/WritableCraftRegistry.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/WritableCraftRegistry.java
@@ -31,7 +31,7 @@ public class WritableCraftRegistry<M, T extends Keyed, B extends PaperRegistryBu
     public void register(final TypedKey<T> key, final Consumer<RegistryBuilderFactory<T, B>> value, final Conversions conversions) {
         final ResourceKey<M> resourceKey = PaperRegistries.toNms(key);
         this.registry.validateWrite(resourceKey);
-        final PaperRegistryBuilderFactory<M, T, B> builderFactory = new PaperRegistryBuilderFactory<>(conversions, this.meta, this.registry.temporaryUnfrozenMap::get);
+        final PaperRegistryBuilderFactory<M, T, B> builderFactory = new PaperRegistryBuilderFactory<>(conversions, this.meta.builderFiller(), this.registry.temporaryUnfrozenMap::get);
         value.accept(builderFactory);
         PaperRegistryListenerManager.INSTANCE.registerWithListeners(
             this.registry,


### PR DESCRIPTION
Replaces https://github.com/PaperMC/Paper/pull/11724

----

This creates a copy of the `power` enchant and just changes some things about it. This is useful because you don't have to redefine everything about the other enchant, and it will stay updated to the other enchant's values.
```java
@Override
public void bootstrap(@NotNull BootstrapContext context) {
    // io.papermc.testplugin.brigtests.Registration.registerViaBootstrap(context);

    final TypedKey<Enchantment> NEW = EnchantmentKeys.create(Key.key("mm:test"));
    context.getLifecycleManager().registerEventHandler(RegistryEvents.ENCHANTMENT.freeze(), event -> {
        event.registry().factoryRegistry(
			NEW,
			builderFactory -> builderFactory
				.copyFrom(EnchantmentKeys.POWER)
				.maxLevel(10);
            	.description(text("MOARR POWER")
        );
    });

    context.getLifecycleManager().registerEventHandler(LifecycleEvents.TAGS.preFlatten(RegistryKey.ENCHANTMENT), event -> {
        final PreFlattenTagRegistrar<Enchantment> registrar = event.registrar();
        registrar.addToTag(EnchantmentTagKeys.IN_ENCHANTING_TABLE, List.of(TagEntry.valueEntry(NEW)));
    });
}
```