### PR TITLE
Don't run player loot table for spectators

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -470,7 +470,7 @@
 +                }
 +            }
 +        }
-+        if (this.shouldDropLoot(this.level())) { // Paper - fix player loottables running when mob loot gamerule is false
++        if (!this.isSpectator() && this.shouldDropLoot(this.level())) { // Paper - fix player loottables running when mob loot gamerule is false
 +            // SPIGOT-5071: manually add player loot tables (SPIGOT-5195 - ignores keepInventory rule)
 +            this.dropFromLootTable(this.level(), damageSource, this.lastHurtByPlayerMemoryTime > 0);
 +            // Paper - Restore vanilla drops behaviour; custom death loot is a noop on server player, remove.


### PR DESCRIPTION
I think there's also an issue with spectators and xp dropping, but I can't test that out right now. Until I check that, this can be a draft.

Fixes https://github.com/PaperMC/Paper/issues/11463

----

Replaces https://github.com/PaperMC/Paper/pull/11464