### PR TITLE
Fix 0 parameter in Player#applyMending

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1896,7 +1896,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                 handle.serverLevel(), itemstack, amount
             );
             int i = Math.min(possibleDurabilityFromXp, itemstack.getDamageValue());
-            final int consumedExperience = possibleDurabilityFromXp > 0 ? i * amount / possibleDurabilityFromXp : possibleDurabilityFromXp; // Paper - taken from ExperienceOrb#repairPlayerItems + prevent division by 0
+            final int consumedExperience = i > 0 ? i * amount / possibleDurabilityFromXp : possibleDurabilityFromXp; // Paper - taken from ExperienceOrb#repairPlayerItems + prevent division by 0
             org.bukkit.event.player.PlayerItemMendEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerItemMendEvent(handle, orb, itemstack, stackEntry.get().inSlot(), i, consumedExperience);
             i = event.getRepairAmount();
             orb.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1896,7 +1896,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                 handle.serverLevel(), itemstack, amount
             );
             int i = Math.min(possibleDurabilityFromXp, itemstack.getDamageValue());
-            final int consumedExperience = i * amount / possibleDurabilityFromXp; // Paper - taken from ExperienceOrb#repairPlayerItems
+            final int consumedExperience = possibleDurabilityFromXp > 0 ? i * amount / possibleDurabilityFromXp : possibleDurabilityFromXp; // Paper - taken from ExperienceOrb#repairPlayerItems + prevent division by 0
             org.bukkit.event.player.PlayerItemMendEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerItemMendEvent(handle, orb, itemstack, stackEntry.get().inSlot(), i, consumedExperience);
             i = event.getRepairAmount();
             orb.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN);


### PR DESCRIPTION
Prevent division by zero in Player#applyMending by simply using zero
instead if the divider itself is zero.
This matches vanilla behaviour in the sense that
ExperienceOrb#repairPlayerItems, which this logic is lifted from, does
pass zero to the enchantment helper and runs its first iteration on
repairing. Vanilla is not affected as the computation failing with zero
is used to compute the leftover exp value, which is not needed if zero
itself is passed in.
As the paper impl however exposes said value to the initial event, our
code needs to account for the zero division.

Resolves: #11800
