### PR TITLE
Extend HumanEntity#dropItem API

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -703,48 +703,54 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * This will force the entity to drop the item they are holding with
      * an option to drop the entire {@link ItemStack} or just 1 of the items.
      *
+     * @deprecated You should instead use {@link #dropItem(EquipmentSlot, int)} with a {@link EquipmentSlot#HAND} parameter.
      * @param dropAll True to drop entire stack, false to drop 1 of the stack
      * @return True if item was dropped successfully
      */
+    @Deprecated
     public boolean dropItem(boolean dropAll);
-
-    /**
-     * Makes the entity drop an item from their inventory based on the specified ItemStack.
-     * <br>
-     * This method calls {@link HumanEntity#dropItem(int slot, boolean throwRandomly)}
-     * with the first {@link ItemStack} occurrence in the inventory
-     *
-     * @param itemStack     The ItemStack to drop
-     * @param throwRandomly Whether the item should disperse randomly.
-     *                      This means that instead of the item being dropped where the player is currently looking,
-     *                      it instead throws it in any direction, similar to how items drop after a player's death.
-     * @return The dropped item, or null if the action was unsuccessful
-     */
-    public @Nullable Item dropItem(final @NotNull ItemStack itemStack, final boolean throwRandomly);
 
     /**
      * Makes the entity drop an item from their inventory based on the slot.
      *
-     * @param slot          The slot to drop
-     * @param throwRandomly Whether the item should disperse randomly.
-     *                      This means that instead of the item being dropped where the player is currently looking,
-     *                      it instead throws it in any direction, similar to how items drop after a player's death.
+     * @param slot   The slot to drop
+     * @param amount The number of items to drop from this slot. Values below 1 don't drop an Item
      * @return The dropped item entity, or null if the action was unsuccessful
      * @throws IndexOutOfBoundsException If the slot is negative or bigger than the player's inventory
      */
-    public @Nullable Item dropItem(final int slot, final boolean throwRandomly);
+    public @Nullable Item dropItem(int slot, int amount);
 
     /**
      * Makes the player drop an item from their inventory based on the equipment slot.
      *
-     * @param slot          The equipment slot to drop
-     * @param throwRandomly Whether the item should disperse randomly.
-     *                      This means that instead of the item being dropped where the player is currently looking,
-     *                      it instead throws it in any direction, similar to how items drop after a player's death.
+     * @param slot   The equipment slot to drop
+     * @param amount The amount of items to drop from this equipment slot. Values below 1 don't drop an Item
      * @return The dropped item entity, or null if the action was unsuccessful
      */
-    public @Nullable Item dropItem(final @NotNull EquipmentSlot slot, final boolean throwRandomly);
+    public @Nullable Item dropItem(@NotNull EquipmentSlot slot, int amount);
 
+    /**
+     * Makes the entity drop an item from their inventory based on the slot.
+     * Instead of the item being dropped where the player is currently looking, this method makes it drop in
+     * a random direction, similar to how items are dropped after a player's death.
+     *
+     * @param slot   The slot to drop
+     * @param amount The number of items to drop from this slot. Values below 1 don't drop an Item
+     * @return The dropped item entity, or null if the action was unsuccessful
+     * @throws IndexOutOfBoundsException If the slot is negative or bigger than the player's inventory
+     */
+    public @Nullable Item dropItemRandomly(int slot, int amount);
+
+    /**
+     * Makes the player drop an item from their inventory based on the equipment slot.
+     * Instead of the item being dropped where the player is currently looking, this method makes it drop in
+     * a random direction, similar to how items are dropped after a player's death.
+     *
+     * @param slot   The equipment slot to drop
+     * @param amount The amount of items to drop from this equipment slot. Values below 1 don't drop an Item
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
+    public @Nullable Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount);
 
     /**
      * Gets the players current exhaustion level.

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -2,10 +2,12 @@ package org.bukkit.entity;
 
 import java.util.Collection;
 import java.util.Set;
+import java.util.UUID;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.InventoryView;
@@ -706,7 +708,6 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      */
     public boolean dropItem(boolean dropAll);
 
-    // Paper start - Extend HumanEntity#dropItem API
     /**
      * Makes the entity drop the first declared {@link ItemStack} occurrence in the inventory
      *
@@ -720,17 +721,17 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
     /**
      * Makes the entity drop an item from their inventory based on the specified ItemStack.
      * <br>
-     * This method calls {@link HumanEntity#dropItem(int slot, java.util.UUID thrower, boolean throwRandomly)}
+     * This method calls {@link HumanEntity#dropItem(int slot, UUID thrower, boolean throwRandomly)}
      * with the first {@link ItemStack} occurrence in the inventory
      *
      * @param itemStack     The ItemStack to drop
-     * @param thrower       The {@link java.util.UUID} to set the resulting {@link Item}'s thrower to
+     * @param thrower       The {@link UUID} to set the resulting {@link Item}'s thrower to
      * @param throwRandomly Whether the item should disperse randomly.
      *                      This means that instead of the item being dropped where the player is currently looking,
      *                      it instead throws it in any direction, similar to how items drop after a player's death.
      * @return The dropped item, or null if the action was unsuccessful
      */
-    public @Nullable Item dropItem(final @NotNull ItemStack itemStack, final @Nullable java.util.UUID thrower, final boolean throwRandomly);
+    public @Nullable Item dropItem(final @NotNull ItemStack itemStack, final @Nullable UUID thrower, final boolean throwRandomly);
 
     /**
      * Makes the entity drop an item from their inventory based on the slot.
@@ -747,22 +748,22 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * Makes the entity drop an item from their inventory based on the slot.
      *
      * @param slot          The slot to drop
-     * @param thrower       The {@link java.util.UUID} to set the resulting {@link Item}'s thrower to
+     * @param thrower       The {@link UUID} to set the resulting {@link Item}'s thrower to
      * @param throwRandomly Whether the item should disperse randomly.
      *                      This means that instead of the item being dropped where the player is currently looking,
      *                      it instead throws it in any direction, similar to how items drop after a player's death.
      * @return The dropped item entity, or null if the action was unsuccessful
      * @throws IndexOutOfBoundsException If the slot is negative or bigger than the player's inventory
      */
-    public @Nullable Item dropItem(final int slot, final @Nullable java.util.UUID thrower, final boolean throwRandomly);
+    public @Nullable Item dropItem(final int slot, final @Nullable UUID thrower, final boolean throwRandomly);
 
     /**
-     * Makes the entity drop an item from their inventory based on the {@link org.bukkit.inventory.EquipmentSlot}
+     * Makes the entity drop an item from their inventory based on the {@link EquipmentSlot}
      *
      * @param slot The equipment slot to drop
      * @return The dropped item entity, or null if the action was unsuccessful
      */
-    public default @Nullable Item dropItem(final @NotNull org.bukkit.inventory.EquipmentSlot slot) {
+    public default @Nullable Item dropItem(final @NotNull EquipmentSlot slot) {
         return this.dropItem(slot, null, false);
     }
 
@@ -770,14 +771,14 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * Makes the player drop an item from their inventory based on the equipment slot.
      *
      * @param slot          The equipment slot to drop
-     * @param thrower       The {@link java.util.UUID} to set the resulting {@link Item}'s thrower to
+     * @param thrower       The {@link UUID} to set the resulting {@link Item}'s thrower to
      * @param throwRandomly Whether the item should disperse randomly.
      *                      This means that instead of the item being dropped where the player is currently looking,
      *                      it instead throws it in any direction, similar to how items drop after a player's death.
      * @return The dropped item entity, or null if the action was unsuccessful
      */
-    public @Nullable Item dropItem(final @NotNull org.bukkit.inventory.EquipmentSlot slot, final @Nullable java.util.UUID thrower, final boolean throwRandomly);
-    // Paper end
+    public @Nullable Item dropItem(final @NotNull EquipmentSlot slot, final @Nullable UUID thrower, final boolean throwRandomly);
+
 
     /**
      * Gets the players current exhaustion level.

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -708,27 +708,14 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
 
     // Paper start - Extend HumanEntity#dropItem API
     /**
-     * Makes the entity drop an item from their inventory.
-     * <br>
-     * This method calls {@link HumanEntity#dropItem(int slot)}
-     * with the first {@link ItemStack} occurrence in the inventory
+     * Makes the entity drop the first declared {@link ItemStack} occurrence in the inventory
      *
      * @param itemStack The ItemStack to drop
      * @return The dropped item, or null if the action was unsuccessful
      */
-    public @Nullable Item dropItem(final @NotNull ItemStack itemStack);
-
-    /**
-     * Makes the entity drop an item from their inventory.
-     * <br>
-     * This method calls {@link HumanEntity#dropItem(int slot, java.util.UUID thrower)}
-     * with the first {@link ItemStack} occurrence in the inventory
-     *
-     * @param itemStack The ItemStack to drop from their inventory
-     * @param thrower   The {@link java.util.UUID} to set the resulting {@link Item}'s thrower to
-     * @return The dropped item, or null if the action was unsuccessful
-     */
-    public @Nullable Item dropItem(final @NotNull ItemStack itemStack, final @Nullable java.util.UUID thrower);
+    public default @Nullable Item dropItem(final @NotNull ItemStack itemStack) {
+        return this.dropItem(itemStack, null, false);
+    }
 
     /**
      * Makes the entity drop an item from their inventory based on the specified ItemStack.
@@ -752,17 +739,9 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @return The dropped item, or null if the action was unsuccessful
      * @throws IndexOutOfBoundsException If the slot is negative or bigger than the player's inventory
      */
-    public @Nullable Item dropItem(final int slot);
-
-    /**
-     * Makes the entity drop an item from their inventory based on the slot.
-     *
-     * @param slot    The slot to drop
-     * @param thrower The {@link java.util.UUID} to set the resulting {@link Item}'s thrower to
-     * @return The dropped item, or null if the action was unsuccessful
-     * @throws IndexOutOfBoundsException If the slot is negative or bigger than the player's inventory
-     */
-    public @Nullable Item dropItem(final int slot, final @Nullable java.util.UUID thrower);
+    public default @Nullable Item dropItem(final int slot) {
+        return this.dropItem(slot, null, false);
+    }
 
     /**
      * Makes the entity drop an item from their inventory based on the slot.
@@ -783,16 +762,9 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @param slot The equipment slot to drop
      * @return The dropped item entity, or null if the action was unsuccessful
      */
-    public @Nullable Item dropItem(final @NotNull org.bukkit.inventory.EquipmentSlot slot);
-
-    /**
-     * Makes the entity drop an item from their inventory based on the {@link org.bukkit.inventory.EquipmentSlot}
-     *
-     * @param slot    The equipment slot to drop
-     * @param thrower The {@link java.util.UUID} to set the resulting {@link Item}'s thrower to
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    public @Nullable Item dropItem(final @NotNull org.bukkit.inventory.EquipmentSlot slot, final @Nullable java.util.UUID thrower);
+    public default @Nullable Item dropItem(final @NotNull org.bukkit.inventory.EquipmentSlot slot) {
+        return this.dropItem(slot, null, false);
+    }
 
     /**
      * Makes the player drop an item from their inventory based on the equipment slot.

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -737,7 +737,7 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @param slot   The slot to drop
      * @param amount The number of items to drop from this slot. Values below 1 don't drop an Item
      * @return The dropped item entity, or null if the action was unsuccessful
-     * @throws IndexOutOfBoundsException If the slot is negative or bigger than the player's inventory
+     * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
      */
     public @Nullable Item dropItemRandomly(int slot, int amount);
 

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -3,6 +3,7 @@ package org.bukkit.entity;
 import java.util.Collection;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -703,9 +704,9 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * This will force the entity to drop the item they are holding with
      * an option to drop the entire {@link ItemStack} or just 1 of the items.
      *
-     * @deprecated You should instead use {@link #dropItem(EquipmentSlot, int)} with a {@link EquipmentSlot#HAND} parameter.
      * @param dropAll True to drop entire stack, false to drop 1 of the stack
      * @return True if item was dropped successfully
+     * @deprecated You should instead use {@link #dropItem(EquipmentSlot, int)} or {@link #dropItemAll(EquipmentSlot)} with a {@link EquipmentSlot#HAND} parameter.
      */
     @Deprecated(since = "1.21.4")
     public boolean dropItem(boolean dropAll);
@@ -718,7 +719,11 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @return The dropped item entity, or null if the action was unsuccessful
      * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
      */
-    public @Nullable Item dropItem(int slot, int amount);
+    public @Nullable Item dropItem(int slot, int amount, @Nullable Consumer<Item> entityOperation);
+
+    public default @Nullable Item dropItem(int slot, int amount) {
+        return this.dropItem(slot, amount, null);
+    }
 
     /**
      * Makes the player drop an item from their inventory based on the equipment slot.
@@ -727,7 +732,11 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @param amount The amount of items to drop from this equipment slot. Values below 1 don't drop an Item
      * @return The dropped item entity, or null if the action was unsuccessful
      */
-    public @Nullable Item dropItem(@NotNull EquipmentSlot slot, int amount);
+    public @Nullable Item dropItem(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation);
+
+    public default @Nullable Item dropItem(@NotNull EquipmentSlot slot, int amount) {
+        return this.dropItem(slot, amount, null);
+    }
 
     /**
      * Makes the entity drop an item from their inventory based on the slot.
@@ -739,7 +748,11 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @return The dropped item entity, or null if the action was unsuccessful
      * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
      */
-    public @Nullable Item dropItemRandomly(int slot, int amount);
+    public @Nullable Item dropItemRandomly(int slot, int amount, @Nullable Consumer<Item> entityOperation);
+
+    public default @Nullable Item dropItemRandomly(int slot, int amount) {
+        return this.dropItemRandomly(slot, amount, null);
+    }
 
     /**
      * Makes the player drop an item from their inventory based on the equipment slot.
@@ -750,7 +763,58 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @param amount The amount of items to drop from this equipment slot. Values below 1 don't drop an Item
      * @return The dropped item entity, or null if the action was unsuccessful
      */
-    public @Nullable Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount);
+    public @Nullable Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation);
+
+    public default @Nullable Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount) {
+        return this.dropItemRandomly(slot, amount, null);
+    }
+
+
+    public default @Nullable Item dropItemAll(int slot, @Nullable Consumer<Item> entityOperation) {
+        return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
+    }
+
+    public default @Nullable Item dropItemAll(int slot) {
+        return this.dropItemAll(slot, null);
+    }
+
+    public default @Nullable Item dropItemAll(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
+        return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
+    }
+
+    public default @Nullable Item dropItemAll(@NotNull EquipmentSlot slot) {
+        return this.dropItemAll(slot, null);
+    }
+
+
+    public default @Nullable Item dropItemAllRandomly(int slot, @Nullable Consumer<Item> entityOperation) {
+        return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
+    }
+
+    public default @Nullable Item dropItemAllRandomly(int slot) {
+        return this.dropItemAllRandomly(slot, null);
+    }
+
+    public default @Nullable Item dropItemAllRandomly(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
+        return this.dropItemRandomly(slot, Integer.MAX_VALUE, entityOperation);
+    }
+
+    public default @Nullable Item dropItemAllRandomly(@NotNull EquipmentSlot slot) {
+        return this.dropItemAllRandomly(slot, null);
+    }
+
+
+    public @Nullable Item dropAnyItem(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
+
+    public default @Nullable Item dropAnyItem(@Nullable ItemStack itemStack) {
+        return this.dropAnyItem(itemStack, null);
+    }
+
+    public @Nullable Item dropAnyItemRandomly(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
+
+    public default @Nullable Item dropAnyItemRandomly(@Nullable ItemStack itemStack) {
+        return this.dropAnyItemRandomly(itemStack, null);
+    }
 
     /**
      * Gets the players current exhaustion level.

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -2,7 +2,6 @@ package org.bukkit.entity;
 
 import java.util.Collection;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Consumer;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -706,7 +705,7 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      *
      * @param dropAll True to drop entire stack, false to drop 1 of the stack
      * @return True if item was dropped successfully
-     * @deprecated You should instead use {@link #dropItem(EquipmentSlot, int)} or {@link #dropItemAll(EquipmentSlot)} with a {@link EquipmentSlot#HAND} parameter.
+     * @deprecated You should instead use {@link #dropItem(EquipmentSlot, int)} or {@link #dropItems(EquipmentSlot)} with a {@link EquipmentSlot#HAND} parameter.
      */
     @Deprecated(since = "1.21.4")
     public boolean dropItem(boolean dropAll);
@@ -779,44 +778,44 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
 
 
     @Nullable
-    public default Item dropItemAll(int slot, @Nullable Consumer<Item> entityOperation) {
+    public default Item dropItems(int slot, @Nullable Consumer<Item> entityOperation) {
         return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
     }
 
     @Nullable
-    public default Item dropItemAll(int slot) {
-        return this.dropItemAll(slot, null);
+    public default Item dropItems(int slot) {
+        return this.dropItems(slot, null);
     }
 
     @Nullable
-    public default Item dropItemAll(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
+    public default Item dropItems(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
         return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
     }
 
     @Nullable
-    public default Item dropItemAll(@NotNull EquipmentSlot slot) {
-        return this.dropItemAll(slot, null);
+    public default Item dropItems(@NotNull EquipmentSlot slot) {
+        return this.dropItems(slot, null);
     }
 
 
     @Nullable
-    public default Item dropItemAllRandomly(int slot, @Nullable Consumer<Item> entityOperation) {
+    public default Item dropItemsRandomly(int slot, @Nullable Consumer<Item> entityOperation) {
         return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
     }
 
     @Nullable
-    public default Item dropItemAllRandomly(int slot) {
-        return this.dropItemAllRandomly(slot, null);
+    public default Item dropItemsRandomly(int slot) {
+        return this.dropItemsRandomly(slot, null);
     }
 
     @Nullable
-    public default Item dropItemAllRandomly(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
+    public default Item dropItemsRandomly(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
         return this.dropItemRandomly(slot, Integer.MAX_VALUE, entityOperation);
     }
 
     @Nullable
-    public default Item dropItemAllRandomly(@NotNull EquipmentSlot slot) {
-        return this.dropItemAllRandomly(slot, null);
+    public default Item dropItemsRandomly(@NotNull EquipmentSlot slot) {
+        return this.dropItemsRandomly(slot, null);
     }
 
 

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -711,16 +711,25 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
     public boolean dropItem(boolean dropAll);
 
     /**
-     * Makes the entity drop an item from their inventory based on the slot.
+     * Makes the player drop an item from their inventory based on the inventory slot.
      *
-     * @param slot   The slot to drop
-     * @param amount The number of items to drop from this slot. Values below 1 don't drop an Item
+     * @param slot            The slot to drop
+     * @param amount          The number of items to drop from this slot. Values below one always return null
+     * @param entityOperation The function to be run before adding the entity into the world
      * @return The dropped item entity, or null if the action was unsuccessful
      * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
      */
     @Nullable
     public Item dropItem(int slot, int amount, @Nullable Consumer<Item> entityOperation);
 
+    /**
+     * Makes the player drop an item from their inventory based on the inventory slot.
+     *
+     * @param slot   The slot to drop
+     * @param amount The number of items to drop from this slot. Values below one always return null
+     * @return The dropped item entity, or null if the action was unsuccessful
+     * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
+     */
     @Nullable
     public default Item dropItem(int slot, int amount) {
         return this.dropItem(slot, amount, null);
@@ -729,31 +738,50 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
     /**
      * Makes the player drop an item from their inventory based on the equipment slot.
      *
-     * @param slot   The equipment slot to drop
-     * @param amount The amount of items to drop from this equipment slot. Values below 1 don't drop an Item
+     * @param slot            The equipment slot to drop
+     * @param amount          The amount of items to drop from this equipment slot. Values below one always return null
+     * @param entityOperation The function to be run before adding the entity into the world
      * @return The dropped item entity, or null if the action was unsuccessful
      */
     @Nullable
     public Item dropItem(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation);
 
+    /**
+     * Makes the player drop an item from their inventory based on the equipment slot.
+     *
+     * @param slot   The equipment slot to drop
+     * @param amount The amount of items to drop from this equipment slot. Values below one always return null
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public default Item dropItem(@NotNull EquipmentSlot slot, int amount) {
         return this.dropItem(slot, amount, null);
     }
 
     /**
-     * Makes the entity drop an item from their inventory based on the slot.
-     * Instead of the item being dropped where the player is currently looking, this method makes it drop in
+     * Makes the entity drop an item from their inventory based on the inventory slot.
+     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
      * a random direction, similar to how items are dropped after a player's death.
      *
-     * @param slot   The slot to drop
-     * @param amount The number of items to drop from this slot. Values below 1 don't drop an Item
+     * @param slot            The slot to drop
+     * @param amount          The number of items to drop from this slot. Values below one always return null
+     * @param entityOperation The function to be run before adding the entity into the world
      * @return The dropped item entity, or null if the action was unsuccessful
      * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
      */
     @Nullable
     public Item dropItemRandomly(int slot, int amount, @Nullable Consumer<Item> entityOperation);
 
+    /**
+     * Makes the player drop an item from their inventory based on the inventory slot.
+     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
+     * a random direction, similar to how items are dropped after a player's death.
+     *
+     * @param slot   The slot to drop
+     * @param amount The number of items to drop from this slot. Values below one always return null
+     * @return The dropped item entity, or null if the action was unsuccessful
+     * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
+     */
     @Nullable
     public default Item dropItemRandomly(int slot, int amount) {
         return this.dropItemRandomly(slot, amount, null);
@@ -761,75 +789,188 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
 
     /**
      * Makes the player drop an item from their inventory based on the equipment slot.
-     * Instead of the item being dropped where the player is currently looking, this method makes it drop in
+     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
      * a random direction, similar to how items are dropped after a player's death.
      *
-     * @param slot   The equipment slot to drop
-     * @param amount The amount of items to drop from this equipment slot. Values below 1 don't drop an Item
+     * @param slot            The equipment slot to drop
+     * @param amount          The amount of items to drop from this equipment slot. Values below one always return null
+     * @param entityOperation The function to be run before adding the entity into the world
      * @return The dropped item entity, or null if the action was unsuccessful
      */
     @Nullable
     public Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation);
 
+    /**
+     * Makes the player drop an item from their inventory based on the equipment slot.
+     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
+     * a random direction, similar to how items are dropped after a player's death.
+     *
+     * @param slot   The equipment slot to drop
+     * @param amount The amount of items to drop from this equipment slot. Values below one always return null
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public default Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount) {
         return this.dropItemRandomly(slot, amount, null);
     }
 
-
+    /**
+     * Makes the player drop all items from their inventory based on the slot.
+     *
+     * @param slot            The equipment slot to drop
+     * @param entityOperation The function to be run before adding the entity into the world
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public default Item dropItems(int slot, @Nullable Consumer<Item> entityOperation) {
         return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
     }
 
+    /**
+     * Makes the player drop all items from their inventory based on the inventory slot.
+     *
+     * @param slot The equipment slot to drop
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public default Item dropItems(int slot) {
         return this.dropItems(slot, null);
     }
 
+    /**
+     * Makes the player drop all items from their inventory based on the equipment slot.
+     *
+     * @param slot            The equipment slot to drop
+     * @param entityOperation The function to be run before adding the entity into the world
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public default Item dropItems(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
         return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
     }
 
+    /**
+     * Makes the player drop all items from their inventory based on the equipment slot.
+     *
+     * @param slot The equipment slot to drop
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public default Item dropItems(@NotNull EquipmentSlot slot) {
         return this.dropItems(slot, null);
     }
 
-
+    /**
+     * Makes the player drop all items from their inventory based on the inventory slot.
+     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
+     * a random direction, similar to how items are dropped after a player's death.
+     *
+     * @param slot            The equipment slot to drop
+     * @param entityOperation The function to be run before adding the entity into the world
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public default Item dropItemsRandomly(int slot, @Nullable Consumer<Item> entityOperation) {
         return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
     }
 
+    /**
+     * Makes the player drop all items from their inventory based on the inventory slot.
+     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
+     * a random direction, similar to how items are dropped after a player's death.
+     *
+     * @param slot The slot to drop
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public default Item dropItemsRandomly(int slot) {
         return this.dropItemsRandomly(slot, null);
     }
 
+    /**
+     * Makes the player drop all items from their inventory based on the equipment slot.
+     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
+     * a random direction, similar to how items are dropped after a player's death.
+     *
+     * @param slot            The equipment slot to drop
+     * @param entityOperation The function to be run before adding the entity into the world
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public default Item dropItemsRandomly(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
         return this.dropItemRandomly(slot, Integer.MAX_VALUE, entityOperation);
     }
 
+    /**
+     * Makes the player drop all items from their inventory based on the equipment slot.
+     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
+     * a random direction, similar to how items are dropped after a player's death.
+     *
+     * @param slot The equipment slot to drop
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public default Item dropItemsRandomly(@NotNull EquipmentSlot slot) {
         return this.dropItemsRandomly(slot, null);
     }
 
-
+    /**
+     * Makes the player drop any arbitrary {@link ItemStack}, independently of whether the player actually
+     * has that item in their inventory.
+     * This method modifies neither the item nor the player's inventory.
+     * Item removal has to be handled by the method caller.
+     *
+     * @param itemStack       The item to drop
+     * @param entityOperation The function to be run before adding the entity into the world
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public Item dropItem(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
 
+    /**
+     * Makes the player drop any arbitrary {@link ItemStack}, independently of whether the player actually
+     * has that item in their inventory.
+     * This method modifies neither the item nor the player's inventory.
+     * Item removal has to be handled by the method caller.
+     *
+     * @param itemStack       The item to drop
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public default Item dropItem(@Nullable ItemStack itemStack) {
         return this.dropItem(itemStack, null);
     }
 
+    /**
+     * Makes the player drop any arbitrary {@link ItemStack}, independently of whether the player actually
+     * has that item in their inventory.
+     * This method modifies neither the item nor the player's inventory.
+     * Item removal has to be handled by the method caller.
+     * <p>
+     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
+     * a random direction, similar to how items are dropped after a player's death.
+     * </p>
+     *
+     * @param itemStack       The item to drop
+     * @param entityOperation The function to be run before adding the entity into the world
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public Item dropItemRandomly(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
 
+    /**
+     * Makes the player drop any arbitrary {@link ItemStack}, independently of whether the player actually
+     * has that item in their inventory.
+     * This method modifies neither the item nor the player's inventory.
+     * Item removal has to be handled by the method caller.
+     * <p>
+     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
+     * a random direction, similar to how items are dropped after a player's death.
+     * </p>
+     *
+     * @param itemStack       The item to drop
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
     @Nullable
     public default Item dropItemRandomly(@Nullable ItemStack itemStack) {
         return this.dropItemRandomly(itemStack, null);

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -706,6 +706,107 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      */
     public boolean dropItem(boolean dropAll);
 
+    // Paper start - Extend HumanEntity#dropItem API
+    /**
+     * Makes the entity drop an item from their inventory.
+     * <br>
+     * This method calls {@link HumanEntity#dropItem(int slot)}
+     * with the first {@link ItemStack} occurrence in the inventory
+     *
+     * @param itemStack The ItemStack to drop
+     * @return The dropped item, or null if the action was unsuccessful
+     */
+    public @Nullable Item dropItem(final @NotNull ItemStack itemStack);
+
+    /**
+     * Makes the entity drop an item from their inventory.
+     * <br>
+     * This method calls {@link HumanEntity#dropItem(int slot, java.util.UUID thrower)}
+     * with the first {@link ItemStack} occurrence in the inventory
+     *
+     * @param itemStack The ItemStack to drop from their inventory
+     * @param thrower   The {@link java.util.UUID} to set the resulting {@link Item}'s thrower to
+     * @return The dropped item, or null if the action was unsuccessful
+     */
+    public @Nullable Item dropItem(final @NotNull ItemStack itemStack, final @Nullable java.util.UUID thrower);
+
+    /**
+     * Makes the entity drop an item from their inventory based on the specified ItemStack.
+     * <br>
+     * This method calls {@link HumanEntity#dropItem(int slot, java.util.UUID thrower, boolean throwRandomly)}
+     * with the first {@link ItemStack} occurrence in the inventory
+     *
+     * @param itemStack     The ItemStack to drop
+     * @param thrower       The {@link java.util.UUID} to set the resulting {@link Item}'s thrower to
+     * @param throwRandomly Whether the item should disperse randomly.
+     *                      This means that instead of the item being dropped where the player is currently looking,
+     *                      it instead throws it in any direction, similar to how items drop after a player's death.
+     * @return The dropped item, or null if the action was unsuccessful
+     */
+    public @Nullable Item dropItem(final @NotNull ItemStack itemStack, final @Nullable java.util.UUID thrower, final boolean throwRandomly);
+
+    /**
+     * Makes the entity drop an item from their inventory based on the slot.
+     *
+     * @param slot The slot to drop
+     * @return The dropped item, or null if the action was unsuccessful
+     * @throws IndexOutOfBoundsException If the slot is negative or bigger than the player's inventory
+     */
+    public @Nullable Item dropItem(final int slot);
+
+    /**
+     * Makes the entity drop an item from their inventory based on the slot.
+     *
+     * @param slot    The slot to drop
+     * @param thrower The {@link java.util.UUID} to set the resulting {@link Item}'s thrower to
+     * @return The dropped item, or null if the action was unsuccessful
+     * @throws IndexOutOfBoundsException If the slot is negative or bigger than the player's inventory
+     */
+    public @Nullable Item dropItem(final int slot, final @Nullable java.util.UUID thrower);
+
+    /**
+     * Makes the entity drop an item from their inventory based on the slot.
+     *
+     * @param slot          The slot to drop
+     * @param thrower       The {@link java.util.UUID} to set the resulting {@link Item}'s thrower to
+     * @param throwRandomly Whether the item should disperse randomly.
+     *                      This means that instead of the item being dropped where the player is currently looking,
+     *                      it instead throws it in any direction, similar to how items drop after a player's death.
+     * @return The dropped item entity, or null if the action was unsuccessful
+     * @throws IndexOutOfBoundsException If the slot is negative or bigger than the player's inventory
+     */
+    public @Nullable Item dropItem(final int slot, final @Nullable java.util.UUID thrower, final boolean throwRandomly);
+
+    /**
+     * Makes the entity drop an item from their inventory based on the {@link org.bukkit.inventory.EquipmentSlot}
+     *
+     * @param slot The equipment slot to drop
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
+    public @Nullable Item dropItem(final @NotNull org.bukkit.inventory.EquipmentSlot slot);
+
+    /**
+     * Makes the entity drop an item from their inventory based on the {@link org.bukkit.inventory.EquipmentSlot}
+     *
+     * @param slot    The equipment slot to drop
+     * @param thrower The {@link java.util.UUID} to set the resulting {@link Item}'s thrower to
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
+    public @Nullable Item dropItem(final @NotNull org.bukkit.inventory.EquipmentSlot slot, final @Nullable java.util.UUID thrower);
+
+    /**
+     * Makes the player drop an item from their inventory based on the equipment slot.
+     *
+     * @param slot          The equipment slot to drop
+     * @param thrower       The {@link java.util.UUID} to set the resulting {@link Item}'s thrower to
+     * @param throwRandomly Whether the item should disperse randomly.
+     *                      This means that instead of the item being dropped where the player is currently looking,
+     *                      it instead throws it in any direction, similar to how items drop after a player's death.
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
+    public @Nullable Item dropItem(final @NotNull org.bukkit.inventory.EquipmentSlot slot, final @Nullable java.util.UUID thrower, final boolean throwRandomly);
+    // Paper end
+
     /**
      * Gets the players current exhaustion level.
      * <p>

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -719,7 +719,7 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      */
     @Nullable
     default Item dropItem(final int slot) {
-        return this.dropItem(slot, Integer.MAX_VALUE, false, null);
+        return this.dropItem(slot, Integer.MAX_VALUE);
     }
 
     /**
@@ -757,7 +757,7 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      */
     @Nullable
     default Item dropItem(final @NotNull EquipmentSlot slot) {
-        return this.dropItem(slot, Integer.MAX_VALUE, false, null);
+        return this.dropItem(slot, Integer.MAX_VALUE);
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -705,7 +705,7 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      *
      * @param dropAll True to drop entire stack, false to drop 1 of the stack
      * @return True if item was dropped successfully
-     * @deprecated You should instead use {@link #dropItem(EquipmentSlot, int)} or {@link #dropItems(EquipmentSlot)} with a {@link EquipmentSlot#HAND} parameter.
+     * @deprecated You should instead use {@link #dropItem(EquipmentSlot, int)} or {@link #dropItem(EquipmentSlot)} with a {@link EquipmentSlot#HAND} parameter.
      */
     @Deprecated(since = "1.21.4")
     public boolean dropItem(boolean dropAll);
@@ -715,12 +715,14 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      *
      * @param slot            The slot to drop
      * @param amount          The number of items to drop from this slot. Values below one always return null
+     * @param throwRandomly   Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
+     *                        a random direction, similar to how items are dropped after a player's death.
      * @param entityOperation The function to be run before adding the entity into the world
      * @return The dropped item entity, or null if the action was unsuccessful
      * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
      */
     @Nullable
-    public Item dropItem(int slot, int amount, @Nullable Consumer<Item> entityOperation);
+    public Item dropItem(int slot, int amount, boolean throwRandomly, @Nullable Consumer<Item> entityOperation);
 
     /**
      * Makes the player drop an item from their inventory based on the inventory slot.
@@ -732,7 +734,31 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      */
     @Nullable
     public default Item dropItem(int slot, int amount) {
-        return this.dropItem(slot, amount, null);
+        return this.dropItem(slot, amount, false, null);
+    }
+
+    /**
+     * Makes the player drop all items from their inventory based on the inventory slot.
+     *
+     * @param slot The equipment slot to drop
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
+    @Nullable
+    public default Item dropItem(int slot) {
+        return this.dropItem(slot, Integer.MAX_VALUE, false, null);
+    }
+
+    /**
+     * Makes the player drop an item from their inventory based on the inventory slot.
+     *
+     * @param slot            The inventory slot to drop
+     * @param throwRandomly   Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
+     *                        a random direction, similar to how items are dropped after a player's death.
+     * @param entityOperation The function to be run before adding the entity into the world
+     * @return The dropped item entity, or null if the action was unsuccessful
+     */
+    public default Item dropItem(int slot, boolean throwRandomly, @Nullable Consumer<Item> entityOperation) {
+        return this.dropItem(slot, Integer.MAX_VALUE, throwRandomly, entityOperation);
     }
 
     /**
@@ -740,11 +766,13 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      *
      * @param slot            The equipment slot to drop
      * @param amount          The amount of items to drop from this equipment slot. Values below one always return null
+     * @param throwRandomly   Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
+     *                        a random direction, similar to how items are dropped after a player's death.
      * @param entityOperation The function to be run before adding the entity into the world
      * @return The dropped item entity, or null if the action was unsuccessful
      */
     @Nullable
-    public Item dropItem(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation);
+    public Item dropItem(@NotNull EquipmentSlot slot, int amount, boolean throwRandomly, @Nullable Consumer<Item> entityOperation);
 
     /**
      * Makes the player drop an item from their inventory based on the equipment slot.
@@ -755,163 +783,31 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      */
     @Nullable
     public default Item dropItem(@NotNull EquipmentSlot slot, int amount) {
-        return this.dropItem(slot, amount, null);
+        return this.dropItem(slot, amount, false, null);
     }
 
     /**
-     * Makes the entity drop an item from their inventory based on the inventory slot.
-     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     * a random direction, similar to how items are dropped after a player's death.
+     * Makes the player drop all items from their inventory based on the equipment slot.
      *
-     * @param slot            The slot to drop
-     * @param amount          The number of items to drop from this slot. Values below one always return null
-     * @param entityOperation The function to be run before adding the entity into the world
+     * @param slot The equipment slot to drop
      * @return The dropped item entity, or null if the action was unsuccessful
-     * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
      */
     @Nullable
-    public Item dropItemRandomly(int slot, int amount, @Nullable Consumer<Item> entityOperation);
+    public default Item dropItem(@NotNull EquipmentSlot slot) {
+        return this.dropItem(slot, Integer.MAX_VALUE, false, null);
+    }
 
     /**
      * Makes the player drop an item from their inventory based on the inventory slot.
-     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     * a random direction, similar to how items are dropped after a player's death.
-     *
-     * @param slot   The slot to drop
-     * @param amount The number of items to drop from this slot. Values below one always return null
-     * @return The dropped item entity, or null if the action was unsuccessful
-     * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
-     */
-    @Nullable
-    public default Item dropItemRandomly(int slot, int amount) {
-        return this.dropItemRandomly(slot, amount, null);
-    }
-
-    /**
-     * Makes the player drop an item from their inventory based on the equipment slot.
-     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     * a random direction, similar to how items are dropped after a player's death.
      *
      * @param slot            The equipment slot to drop
-     * @param amount          The amount of items to drop from this equipment slot. Values below one always return null
+     * @param throwRandomly   Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
+     *                        a random direction, similar to how items are dropped after a player's death.
      * @param entityOperation The function to be run before adding the entity into the world
      * @return The dropped item entity, or null if the action was unsuccessful
      */
-    @Nullable
-    public Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation);
-
-    /**
-     * Makes the player drop an item from their inventory based on the equipment slot.
-     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     * a random direction, similar to how items are dropped after a player's death.
-     *
-     * @param slot   The equipment slot to drop
-     * @param amount The amount of items to drop from this equipment slot. Values below one always return null
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    @Nullable
-    public default Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount) {
-        return this.dropItemRandomly(slot, amount, null);
-    }
-
-    /**
-     * Makes the player drop all items from their inventory based on the slot.
-     *
-     * @param slot            The equipment slot to drop
-     * @param entityOperation The function to be run before adding the entity into the world
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    @Nullable
-    public default Item dropItems(int slot, @Nullable Consumer<Item> entityOperation) {
-        return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
-    }
-
-    /**
-     * Makes the player drop all items from their inventory based on the inventory slot.
-     *
-     * @param slot The equipment slot to drop
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    @Nullable
-    public default Item dropItems(int slot) {
-        return this.dropItems(slot, null);
-    }
-
-    /**
-     * Makes the player drop all items from their inventory based on the equipment slot.
-     *
-     * @param slot            The equipment slot to drop
-     * @param entityOperation The function to be run before adding the entity into the world
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    @Nullable
-    public default Item dropItems(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
-        return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
-    }
-
-    /**
-     * Makes the player drop all items from their inventory based on the equipment slot.
-     *
-     * @param slot The equipment slot to drop
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    @Nullable
-    public default Item dropItems(@NotNull EquipmentSlot slot) {
-        return this.dropItems(slot, null);
-    }
-
-    /**
-     * Makes the player drop all items from their inventory based on the inventory slot.
-     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     * a random direction, similar to how items are dropped after a player's death.
-     *
-     * @param slot            The equipment slot to drop
-     * @param entityOperation The function to be run before adding the entity into the world
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    @Nullable
-    public default Item dropItemsRandomly(int slot, @Nullable Consumer<Item> entityOperation) {
-        return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
-    }
-
-    /**
-     * Makes the player drop all items from their inventory based on the inventory slot.
-     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     * a random direction, similar to how items are dropped after a player's death.
-     *
-     * @param slot The slot to drop
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    @Nullable
-    public default Item dropItemsRandomly(int slot) {
-        return this.dropItemsRandomly(slot, null);
-    }
-
-    /**
-     * Makes the player drop all items from their inventory based on the equipment slot.
-     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     * a random direction, similar to how items are dropped after a player's death.
-     *
-     * @param slot            The equipment slot to drop
-     * @param entityOperation The function to be run before adding the entity into the world
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    @Nullable
-    public default Item dropItemsRandomly(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
-        return this.dropItemRandomly(slot, Integer.MAX_VALUE, entityOperation);
-    }
-
-    /**
-     * Makes the player drop all items from their inventory based on the equipment slot.
-     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     * a random direction, similar to how items are dropped after a player's death.
-     *
-     * @param slot The equipment slot to drop
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    @Nullable
-    public default Item dropItemsRandomly(@NotNull EquipmentSlot slot) {
-        return this.dropItemsRandomly(slot, null);
+    public default Item dropItem(@NotNull EquipmentSlot slot, boolean throwRandomly, @Nullable Consumer<Item> entityOperation) {
+        return this.dropItem(slot, Integer.MAX_VALUE, throwRandomly, entityOperation);
     }
 
     /**
@@ -925,7 +821,7 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @return The dropped item entity, or null if the action was unsuccessful
      */
     @Nullable
-    public Item dropItem(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
+    public Item dropItem(@Nullable ItemStack itemStack, boolean throwRandomly, @Nullable Consumer<Item> entityOperation);
 
     /**
      * Makes the player drop any arbitrary {@link ItemStack}, independently of whether the player actually
@@ -933,47 +829,12 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * This method modifies neither the item nor the player's inventory.
      * Item removal has to be handled by the method caller.
      *
-     * @param itemStack       The item to drop
+     * @param itemStack The item to drop
      * @return The dropped item entity, or null if the action was unsuccessful
      */
     @Nullable
     public default Item dropItem(@Nullable ItemStack itemStack) {
-        return this.dropItem(itemStack, null);
-    }
-
-    /**
-     * Makes the player drop any arbitrary {@link ItemStack}, independently of whether the player actually
-     * has that item in their inventory.
-     * This method modifies neither the item nor the player's inventory.
-     * Item removal has to be handled by the method caller.
-     * <p>
-     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     * a random direction, similar to how items are dropped after a player's death.
-     * </p>
-     *
-     * @param itemStack       The item to drop
-     * @param entityOperation The function to be run before adding the entity into the world
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    @Nullable
-    public Item dropItemRandomly(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
-
-    /**
-     * Makes the player drop any arbitrary {@link ItemStack}, independently of whether the player actually
-     * has that item in their inventory.
-     * This method modifies neither the item nor the player's inventory.
-     * Item removal has to be handled by the method caller.
-     * <p>
-     * Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     * a random direction, similar to how items are dropped after a player's death.
-     * </p>
-     *
-     * @param itemStack       The item to drop
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    @Nullable
-    public default Item dropItemRandomly(@Nullable ItemStack itemStack) {
-        return this.dropItemRandomly(itemStack, null);
+        return this.dropItem(itemStack, false, null);
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -707,7 +707,7 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @param dropAll True to drop entire stack, false to drop 1 of the stack
      * @return True if item was dropped successfully
      */
-    @Deprecated
+    @Deprecated(since = "1.21.4")
     public boolean dropItem(boolean dropAll);
 
     /**

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -719,9 +719,11 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @return The dropped item entity, or null if the action was unsuccessful
      * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
      */
-    public @Nullable Item dropItem(int slot, int amount, @Nullable Consumer<Item> entityOperation);
+    @Nullable
+    public Item dropItem(int slot, int amount, @Nullable Consumer<Item> entityOperation);
 
-    public default @Nullable Item dropItem(int slot, int amount) {
+    @Nullable
+    public default Item dropItem(int slot, int amount) {
         return this.dropItem(slot, amount, null);
     }
 
@@ -732,9 +734,11 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @param amount The amount of items to drop from this equipment slot. Values below 1 don't drop an Item
      * @return The dropped item entity, or null if the action was unsuccessful
      */
-    public @Nullable Item dropItem(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation);
+    @Nullable
+    public Item dropItem(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation);
 
-    public default @Nullable Item dropItem(@NotNull EquipmentSlot slot, int amount) {
+    @Nullable
+    public default Item dropItem(@NotNull EquipmentSlot slot, int amount) {
         return this.dropItem(slot, amount, null);
     }
 
@@ -748,9 +752,11 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @return The dropped item entity, or null if the action was unsuccessful
      * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
      */
-    public @Nullable Item dropItemRandomly(int slot, int amount, @Nullable Consumer<Item> entityOperation);
+    @Nullable
+    public Item dropItemRandomly(int slot, int amount, @Nullable Consumer<Item> entityOperation);
 
-    public default @Nullable Item dropItemRandomly(int slot, int amount) {
+    @Nullable
+    public default Item dropItemRandomly(int slot, int amount) {
         return this.dropItemRandomly(slot, amount, null);
     }
 
@@ -763,56 +769,70 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @param amount The amount of items to drop from this equipment slot. Values below 1 don't drop an Item
      * @return The dropped item entity, or null if the action was unsuccessful
      */
-    public @Nullable Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation);
+    @Nullable
+    public Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation);
 
-    public default @Nullable Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount) {
+    @Nullable
+    public default Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount) {
         return this.dropItemRandomly(slot, amount, null);
     }
 
 
-    public default @Nullable Item dropItemAll(int slot, @Nullable Consumer<Item> entityOperation) {
+    @Nullable
+    public default Item dropItemAll(int slot, @Nullable Consumer<Item> entityOperation) {
         return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
     }
 
-    public default @Nullable Item dropItemAll(int slot) {
+    @Nullable
+    public default Item dropItemAll(int slot) {
         return this.dropItemAll(slot, null);
     }
 
-    public default @Nullable Item dropItemAll(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
+    @Nullable
+    public default Item dropItemAll(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
         return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
     }
 
-    public default @Nullable Item dropItemAll(@NotNull EquipmentSlot slot) {
+    @Nullable
+    public default Item dropItemAll(@NotNull EquipmentSlot slot) {
         return this.dropItemAll(slot, null);
     }
 
 
-    public default @Nullable Item dropItemAllRandomly(int slot, @Nullable Consumer<Item> entityOperation) {
+    @Nullable
+    public default Item dropItemAllRandomly(int slot, @Nullable Consumer<Item> entityOperation) {
         return this.dropItem(slot, Integer.MAX_VALUE, entityOperation);
     }
 
-    public default @Nullable Item dropItemAllRandomly(int slot) {
+    @Nullable
+    public default Item dropItemAllRandomly(int slot) {
         return this.dropItemAllRandomly(slot, null);
     }
 
-    public default @Nullable Item dropItemAllRandomly(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
+    @Nullable
+    public default Item dropItemAllRandomly(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation) {
         return this.dropItemRandomly(slot, Integer.MAX_VALUE, entityOperation);
     }
 
-    public default @Nullable Item dropItemAllRandomly(@NotNull EquipmentSlot slot) {
+    @Nullable
+    public default Item dropItemAllRandomly(@NotNull EquipmentSlot slot) {
         return this.dropItemAllRandomly(slot, null);
     }
 
 
-    public @Nullable Item dropAnyItem(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
+    @Nullable
+    public Item dropAnyItem(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
 
-    public default @Nullable Item dropAnyItem(@Nullable ItemStack itemStack) {
+    @Nullable
+    public default Item dropAnyItem(@Nullable ItemStack itemStack) {
         return this.dropAnyItem(itemStack, null);
     }
 
-    public @Nullable Item dropAnyItemRandomly(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
+    @Nullable
+    public Item dropAnyItemRandomly(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
 
-    public default @Nullable Item dropAnyItemRandomly(@Nullable ItemStack itemStack) {
+    @Nullable
+    public default Item dropAnyItemRandomly(@Nullable ItemStack itemStack) {
         return this.dropAnyItemRandomly(itemStack, null);
     }
 

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -16,6 +16,7 @@ import org.bukkit.inventory.MainHand;
 import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.FireworkMeta;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -705,137 +706,115 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      *
      * @param dropAll True to drop entire stack, false to drop 1 of the stack
      * @return True if item was dropped successfully
-     * @deprecated You should instead use {@link #dropItem(EquipmentSlot, int)} or {@link #dropItem(EquipmentSlot)} with a {@link EquipmentSlot#HAND} parameter.
+     * @apiNote You should instead use {@link #dropItem(EquipmentSlot, int)} or {@link #dropItem(EquipmentSlot)} with a {@link EquipmentSlot#HAND} parameter.
      */
-    @Deprecated(since = "1.21.4")
-    public boolean dropItem(boolean dropAll);
-
-    /**
-     * Makes the player drop an item from their inventory based on the inventory slot.
-     *
-     * @param slot            The slot to drop
-     * @param amount          The number of items to drop from this slot. Values below one always return null
-     * @param throwRandomly   Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     *                        a random direction, similar to how items are dropped after a player's death.
-     * @param entityOperation The function to be run before adding the entity into the world
-     * @return The dropped item entity, or null if the action was unsuccessful
-     * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
-     */
-    @Nullable
-    public Item dropItem(int slot, int amount, boolean throwRandomly, @Nullable Consumer<Item> entityOperation);
-
-    /**
-     * Makes the player drop an item from their inventory based on the inventory slot.
-     *
-     * @param slot   The slot to drop
-     * @param amount The number of items to drop from this slot. Values below one always return null
-     * @return The dropped item entity, or null if the action was unsuccessful
-     * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
-     */
-    @Nullable
-    public default Item dropItem(int slot, int amount) {
-        return this.dropItem(slot, amount, false, null);
-    }
+    @ApiStatus.Obsolete(since = "1.21.4")
+    boolean dropItem(boolean dropAll);
 
     /**
      * Makes the player drop all items from their inventory based on the inventory slot.
      *
-     * @param slot The equipment slot to drop
-     * @return The dropped item entity, or null if the action was unsuccessful
+     * @param slot the equipment slot to drop
+     * @return the dropped item entity, or null if the action was unsuccessful
      */
     @Nullable
-    public default Item dropItem(int slot) {
+    default Item dropItem(final int slot) {
         return this.dropItem(slot, Integer.MAX_VALUE, false, null);
     }
 
     /**
      * Makes the player drop an item from their inventory based on the inventory slot.
      *
-     * @param slot            The inventory slot to drop
-     * @param throwRandomly   Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     *                        a random direction, similar to how items are dropped after a player's death.
-     * @param entityOperation The function to be run before adding the entity into the world
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    public default Item dropItem(int slot, boolean throwRandomly, @Nullable Consumer<Item> entityOperation) {
-        return this.dropItem(slot, Integer.MAX_VALUE, throwRandomly, entityOperation);
-    }
-
-    /**
-     * Makes the player drop an item from their inventory based on the equipment slot.
-     *
-     * @param slot            The equipment slot to drop
-     * @param amount          The amount of items to drop from this equipment slot. Values below one always return null
-     * @param throwRandomly   Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     *                        a random direction, similar to how items are dropped after a player's death.
-     * @param entityOperation The function to be run before adding the entity into the world
-     * @return The dropped item entity, or null if the action was unsuccessful
+     * @param slot   the slot to drop
+     * @param amount the number of items to drop from this slot. Values below one always return null
+     * @return the dropped item entity, or null if the action was unsuccessful
+     * @throws IllegalArgumentException if the slot is negative or bigger than the player's inventory
      */
     @Nullable
-    public Item dropItem(@NotNull EquipmentSlot slot, int amount, boolean throwRandomly, @Nullable Consumer<Item> entityOperation);
-
-    /**
-     * Makes the player drop an item from their inventory based on the equipment slot.
-     *
-     * @param slot   The equipment slot to drop
-     * @param amount The amount of items to drop from this equipment slot. Values below one always return null
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    @Nullable
-    public default Item dropItem(@NotNull EquipmentSlot slot, int amount) {
+    default Item dropItem(final int slot, final int amount) {
         return this.dropItem(slot, amount, false, null);
     }
 
     /**
-     * Makes the player drop all items from their inventory based on the equipment slot.
+     * Makes the player drop an item from their inventory based on the inventory slot.
      *
-     * @param slot The equipment slot to drop
-     * @return The dropped item entity, or null if the action was unsuccessful
+     * @param slot            the slot to drop
+     * @param amount          the number of items to drop from this slot. Values below one always return null
+     * @param throwRandomly   controls the randomness of the dropped items velocity, where {@code true} mimics dropped
+     *                        items during a player's death, while {@code false} acts like a normal item drop.
+     * @param entityOperation the function to be run before adding the entity into the world
+     * @return the dropped item entity, or null if the action was unsuccessful
+     * @throws IllegalArgumentException if the slot is negative or bigger than the player's inventory
      */
     @Nullable
-    public default Item dropItem(@NotNull EquipmentSlot slot) {
+    Item dropItem(int slot, int amount, boolean throwRandomly, @Nullable Consumer<Item> entityOperation);
+
+    /**
+     * Makes the player drop all items from their inventory based on the equipment slot.
+     *
+     * @param slot the equipment slot to drop
+     * @return the dropped item entity, or null if the action was unsuccessful
+     */
+    @Nullable
+    default Item dropItem(final @NotNull EquipmentSlot slot) {
         return this.dropItem(slot, Integer.MAX_VALUE, false, null);
     }
 
     /**
-     * Makes the player drop an item from their inventory based on the inventory slot.
+     * Makes the player drop an item from their inventory based on the equipment slot.
      *
-     * @param slot            The equipment slot to drop
-     * @param throwRandomly   Instead of the item entity being dropped where the player is currently looking, this method makes it drop in
-     *                        a random direction, similar to how items are dropped after a player's death.
-     * @param entityOperation The function to be run before adding the entity into the world
-     * @return The dropped item entity, or null if the action was unsuccessful
+     * @param slot   the equipment slot to drop
+     * @param amount the amount of items to drop from this equipment slot. Values below one always return null
+     * @return the dropped item entity, or null if the action was unsuccessful
      */
-    public default Item dropItem(@NotNull EquipmentSlot slot, boolean throwRandomly, @Nullable Consumer<Item> entityOperation) {
-        return this.dropItem(slot, Integer.MAX_VALUE, throwRandomly, entityOperation);
+    @Nullable
+    default Item dropItem(final @NotNull EquipmentSlot slot, final int amount) {
+        return this.dropItem(slot, amount, false, null);
     }
 
     /**
-     * Makes the player drop any arbitrary {@link ItemStack}, independently of whether the player actually
-     * has that item in their inventory.
-     * This method modifies neither the item nor the player's inventory.
-     * Item removal has to be handled by the method caller.
+     * Makes the player drop an item from their inventory based on the equipment slot.
      *
-     * @param itemStack       The item to drop
-     * @param entityOperation The function to be run before adding the entity into the world
-     * @return The dropped item entity, or null if the action was unsuccessful
+     * @param slot            the equipment slot to drop
+     * @param amount          The amount of items to drop from this equipment slot. Values below one always return null
+     * @param throwRandomly   controls the randomness of the dropped items velocity, where {@code true} mimics dropped
+     *                        items during a player's death, while {@code false} acts like a normal item drop.
+     * @param entityOperation the function to be run before adding the entity into the world
+     * @return the dropped item entity, or null if the action was unsuccessful
      */
     @Nullable
-    public Item dropItem(@Nullable ItemStack itemStack, boolean throwRandomly, @Nullable Consumer<Item> entityOperation);
+    Item dropItem(@NotNull EquipmentSlot slot, int amount, boolean throwRandomly, @Nullable Consumer<Item> entityOperation);
 
     /**
      * Makes the player drop any arbitrary {@link ItemStack}, independently of whether the player actually
      * has that item in their inventory.
+     * <p>
      * This method modifies neither the item nor the player's inventory.
      * Item removal has to be handled by the method caller.
      *
-     * @param itemStack The item to drop
-     * @return The dropped item entity, or null if the action was unsuccessful
+     * @param itemStack the itemstack to drop
+     * @return the dropped item entity, or null if the action was unsuccessful
      */
     @Nullable
-    public default Item dropItem(@Nullable ItemStack itemStack) {
+    default Item dropItem(final @NotNull ItemStack itemStack) {
         return this.dropItem(itemStack, false, null);
     }
+
+    /**
+     * Makes the player drop any arbitrary {@link ItemStack}, independently of whether the player actually
+     * has that item in their inventory.
+     * <p>
+     * This method modifies neither the item nor the player's inventory.
+     * Item removal has to be handled by the method caller.
+     *
+     * @param itemStack       the itemstack to drop
+     * @param throwRandomly   controls the randomness of the dropped items velocity, where {@code true} mimics dropped
+     *                        items during a player's death, while {@code false} acts like a normal item drop.
+     * @param entityOperation the function to be run before adding the entity into the world
+     * @return the dropped item entity, or null if the action was unsuccessful
+     */
+    @Nullable
+    Item dropItem(final @NotNull ItemStack itemStack, boolean throwRandomly, @Nullable Consumer<Item> entityOperation);
 
     /**
      * Gets the players current exhaustion level.

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -709,75 +709,41 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
     public boolean dropItem(boolean dropAll);
 
     /**
-     * Makes the entity drop the first declared {@link ItemStack} occurrence in the inventory
-     *
-     * @param itemStack The ItemStack to drop
-     * @return The dropped item, or null if the action was unsuccessful
-     */
-    public default @Nullable Item dropItem(final @NotNull ItemStack itemStack) {
-        return this.dropItem(itemStack, null, false);
-    }
-
-    /**
      * Makes the entity drop an item from their inventory based on the specified ItemStack.
      * <br>
-     * This method calls {@link HumanEntity#dropItem(int slot, UUID thrower, boolean throwRandomly)}
+     * This method calls {@link HumanEntity#dropItem(int slot, boolean throwRandomly)}
      * with the first {@link ItemStack} occurrence in the inventory
      *
      * @param itemStack     The ItemStack to drop
-     * @param thrower       The {@link UUID} to set the resulting {@link Item}'s thrower to
      * @param throwRandomly Whether the item should disperse randomly.
      *                      This means that instead of the item being dropped where the player is currently looking,
      *                      it instead throws it in any direction, similar to how items drop after a player's death.
      * @return The dropped item, or null if the action was unsuccessful
      */
-    public @Nullable Item dropItem(final @NotNull ItemStack itemStack, final @Nullable UUID thrower, final boolean throwRandomly);
-
-    /**
-     * Makes the entity drop an item from their inventory based on the slot.
-     *
-     * @param slot The slot to drop
-     * @return The dropped item, or null if the action was unsuccessful
-     * @throws IndexOutOfBoundsException If the slot is negative or bigger than the player's inventory
-     */
-    public default @Nullable Item dropItem(final int slot) {
-        return this.dropItem(slot, null, false);
-    }
+    public @Nullable Item dropItem(final @NotNull ItemStack itemStack, final boolean throwRandomly);
 
     /**
      * Makes the entity drop an item from their inventory based on the slot.
      *
      * @param slot          The slot to drop
-     * @param thrower       The {@link UUID} to set the resulting {@link Item}'s thrower to
      * @param throwRandomly Whether the item should disperse randomly.
      *                      This means that instead of the item being dropped where the player is currently looking,
      *                      it instead throws it in any direction, similar to how items drop after a player's death.
      * @return The dropped item entity, or null if the action was unsuccessful
      * @throws IndexOutOfBoundsException If the slot is negative or bigger than the player's inventory
      */
-    public @Nullable Item dropItem(final int slot, final @Nullable UUID thrower, final boolean throwRandomly);
-
-    /**
-     * Makes the entity drop an item from their inventory based on the {@link EquipmentSlot}
-     *
-     * @param slot The equipment slot to drop
-     * @return The dropped item entity, or null if the action was unsuccessful
-     */
-    public default @Nullable Item dropItem(final @NotNull EquipmentSlot slot) {
-        return this.dropItem(slot, null, false);
-    }
+    public @Nullable Item dropItem(final int slot, final boolean throwRandomly);
 
     /**
      * Makes the player drop an item from their inventory based on the equipment slot.
      *
      * @param slot          The equipment slot to drop
-     * @param thrower       The {@link UUID} to set the resulting {@link Item}'s thrower to
      * @param throwRandomly Whether the item should disperse randomly.
      *                      This means that instead of the item being dropped where the player is currently looking,
      *                      it instead throws it in any direction, similar to how items drop after a player's death.
      * @return The dropped item entity, or null if the action was unsuccessful
      */
-    public @Nullable Item dropItem(final @NotNull EquipmentSlot slot, final @Nullable UUID thrower, final boolean throwRandomly);
+    public @Nullable Item dropItem(final @NotNull EquipmentSlot slot, final boolean throwRandomly);
 
 
     /**

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -716,7 +716,7 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * @param slot   The slot to drop
      * @param amount The number of items to drop from this slot. Values below 1 don't drop an Item
      * @return The dropped item entity, or null if the action was unsuccessful
-     * @throws IndexOutOfBoundsException If the slot is negative or bigger than the player's inventory
+     * @throws IllegalArgumentException If the slot is negative or bigger than the player's inventory
      */
     public @Nullable Item dropItem(int slot, int amount);
 

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -820,19 +820,19 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
 
 
     @Nullable
-    public Item dropAnyItem(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
+    public Item dropItem(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
 
     @Nullable
-    public default Item dropAnyItem(@Nullable ItemStack itemStack) {
-        return this.dropAnyItem(itemStack, null);
+    public default Item dropItem(@Nullable ItemStack itemStack) {
+        return this.dropItem(itemStack, null);
     }
 
     @Nullable
-    public Item dropAnyItemRandomly(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
+    public Item dropItemRandomly(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation);
 
     @Nullable
-    public default Item dropAnyItemRandomly(@Nullable ItemStack itemStack) {
-        return this.dropAnyItemRandomly(itemStack, null);
+    public default Item dropItemRandomly(@Nullable ItemStack itemStack) {
+        return this.dropItemRandomly(itemStack, null);
     }
 
     /**

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -1342,24 +1342,18 @@
      }
  
      public SectionPos getLastSectionPos() {
-@@ -1930,21 +_,66 @@
+@@ -1930,21 +_,55 @@
      }
  
      @Override
 -    public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean traceItem) {
-+    public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean traceItem, boolean callEvent) { // CraftBukkit - SPIGOT-2942: Add boolean to call event
-+        // Paper start - Extend HumanEntity#dropItem API
-+        return this.drop(droppedItem, dropAround, traceItem, callEvent, null);
-+    }
-+
-+    @Override
-+    public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean traceItem, boolean callEvent, @Nullable java.util.function.Consumer<org.bukkit.entity.Item> entityOperation) {
-+        // Paper end - Extend HumanEntity#dropItem API
++    public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean traceItem, boolean callEvent, @Nullable java.util.function.Consumer<org.bukkit.entity.Item> entityOperation) { // Paper start - Extend HumanEntity#dropItem API
          ItemEntity itemEntity = this.createItemStackToDrop(droppedItem, dropAround, traceItem);
          if (itemEntity == null) {
              return null;
          } else {
 +            // CraftBukkit start - fire PlayerDropItemEvent
++            if (entityOperation != null) entityOperation.accept((org.bukkit.entity.Item) itemEntity.getBukkitEntity());
 +            if (callEvent) {
 +                org.bukkit.entity.Player player = this.getBukkitEntity();
 +                org.bukkit.entity.Item drop = (org.bukkit.entity.Item) itemEntity.getBukkitEntity();
@@ -1383,11 +1377,6 @@
 +                    return null;
 +                }
 +            }
-+            // Paper start - Extend HumanEntity#dropItem API
-+            if (entityOperation != null) {
-+                entityOperation.accept((org.bukkit.entity.Item) itemEntity.getBukkitEntity());
-+            }
-+            // Paper end - Extend HumanEntity#dropItem API
 +            // CraftBukkit end
              this.level().addFreshEntity(itemEntity);
              ItemStack item = itemEntity.getItem();

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -1342,12 +1342,19 @@
      }
  
      public SectionPos getLastSectionPos() {
-@@ -1930,21 +_,54 @@
+@@ -1930,21 +_,66 @@
      }
  
      @Override
 -    public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean traceItem) {
 +    public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean traceItem, boolean callEvent) { // CraftBukkit - SPIGOT-2942: Add boolean to call event
++        // Paper start - Extend HumanEntity#dropItem API
++        return this.drop(droppedItem, dropAround, traceItem, callEvent, null);
++    }
++
++    @Override
++    public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean traceItem, boolean callEvent, @Nullable java.util.function.Consumer<org.bukkit.entity.Item> entityOperation) {
++        // Paper end - Extend HumanEntity#dropItem API
          ItemEntity itemEntity = this.createItemStackToDrop(droppedItem, dropAround, traceItem);
          if (itemEntity == null) {
              return null;
@@ -1376,6 +1383,11 @@
 +                    return null;
 +                }
 +            }
++            // Paper start - Extend HumanEntity#dropItem API
++            if (entityOperation != null) {
++                entityOperation.accept((org.bukkit.entity.Item) itemEntity.getBukkitEntity());
++            }
++            // Paper end - Extend HumanEntity#dropItem API
 +            // CraftBukkit end
              this.level().addFreshEntity(itemEntity);
              ItemStack item = itemEntity.getItem();

--- a/paper-server/patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -112,24 +112,17 @@
              this.removeEntitiesOnShoulder();
          }
      }
-@@ -717,6 +_,20 @@
+@@ -717,6 +_,13 @@
  
      @Nullable
      public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean includeThrowerName) {
 +        // CraftBukkit start - SPIGOT-2942: Add boolean to call event
-+        return this.drop(droppedItem, dropAround, includeThrowerName, true);
-+    }
-+
-+    @Nullable
-+    public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean includeThrowerName, boolean callEvent) {
-+        // CraftBukkit end
-+        // Paper start - Extend HumanEntity#dropItem API
-+        return this.drop(droppedItem, dropAround, includeThrowerName, callEvent, null);
++        return this.drop(droppedItem, dropAround, includeThrowerName, true, null);
 +    }
 +
 +    @Nullable
 +    public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean includeThrowerName, boolean callEvent, @Nullable java.util.function.Consumer<org.bukkit.entity.Item> entityOperation) {
-+        // Paper end - Extend HumanEntity#dropItem API
++        // CraftBukkit end
          if (!droppedItem.isEmpty() && this.level().isClientSide) {
              this.swing(InteractionHand.MAIN_HAND);
          }

--- a/paper-server/patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -112,12 +112,17 @@
              this.removeEntitiesOnShoulder();
          }
      }
-@@ -717,6 +_,13 @@
+@@ -717,6 +_,18 @@
  
      @Nullable
      public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean includeThrowerName) {
 +        // CraftBukkit start - SPIGOT-2942: Add boolean to call event
 +        return this.drop(droppedItem, dropAround, includeThrowerName, true, null);
++    }
++
++    @Nullable
++    public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean includeThrowerName, boolean callEvent) {
++        return this.drop(droppedItem, dropAround, includeThrowerName, callEvent, null);
 +    }
 +
 +    @Nullable

--- a/paper-server/patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -112,7 +112,7 @@
              this.removeEntitiesOnShoulder();
          }
      }
-@@ -717,6 +_,13 @@
+@@ -717,6 +_,20 @@
  
      @Nullable
      public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean includeThrowerName) {
@@ -123,6 +123,13 @@
 +    @Nullable
 +    public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean includeThrowerName, boolean callEvent) {
 +        // CraftBukkit end
++        // Paper start - Extend HumanEntity#dropItem API
++        return this.drop(droppedItem, dropAround, includeThrowerName, callEvent, null);
++    }
++
++    @Nullable
++    public ItemEntity drop(ItemStack droppedItem, boolean dropAround, boolean includeThrowerName, boolean callEvent, @Nullable java.util.function.Consumer<org.bukkit.entity.Item> entityOperation) {
++        // Paper end - Extend HumanEntity#dropItem API
          if (!droppedItem.isEmpty() && this.level().isClientSide) {
              this.swing(InteractionHand.MAIN_HAND);
          }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -803,7 +803,6 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         // Paper end - Fix HumanEntity#drop not updating the client inv
     }
 
-    // Paper start - Extend HumanEntity#dropItem API
     @Override
     public @Nullable org.bukkit.entity.Item dropItem(final @NotNull ItemStack itemStack, final @Nullable java.util.UUID thrower, final boolean throwRandomly) {
         final int slot = this.inventory.first(itemStack);
@@ -817,7 +816,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     @Override
     public @Nullable org.bukkit.entity.Item dropItem(final int slot, final @Nullable java.util.UUID thrower, final boolean throwRandomly) {
         // Make sure the slot is in bounds
-        if (slot < 0 || this.inventory.getSize() <= slot) {
+        if (slot < 0 || slot >= this.inventory.getSize()) {
             throw new IndexOutOfBoundsException("Slot " + slot + " out of range for inventory of size " + this.inventory.getSize());
         }
 
@@ -838,7 +837,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     }
 
     private org.bukkit.entity.Item dropItemRaw(final ItemStack is, final @Nullable java.util.UUID thrower, final boolean throwRandomly) {
-        if (is == null || is.getType() == Material.AIR) {
+        if (is == null || is.isEmpty()) {
             return null;
         }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -807,49 +807,48 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     }
 
     @Override
-    public @Nullable Item dropItem(final @NotNull ItemStack itemStack, final @Nullable UUID thrower, final boolean throwRandomly) {
+    public @Nullable Item dropItem(final @NotNull ItemStack itemStack, final boolean throwRandomly) {
         final int slot = this.inventory.first(itemStack);
         if (slot == -1) {
             return null;
         }
 
-        return this.dropItem(slot, thrower, throwRandomly);
+        return this.dropItem(slot, throwRandomly);
     }
 
     @Override
-    public @Nullable Item dropItem(final int slot, final @Nullable UUID thrower, final boolean throwRandomly) {
+    public @Nullable Item dropItem(final int slot, final boolean throwRandomly) {
         // Make sure the slot is in bounds
         if (slot < 0 || slot >= this.inventory.getSize()) {
             throw new IndexOutOfBoundsException("Slot " + slot + " out of range for inventory of size " + this.inventory.getSize());
         }
 
         final ItemStack stack = this.inventory.getItem(slot);
-        final Item itemEntity = dropItemRaw(stack, thrower, throwRandomly);
+        final Item itemEntity = dropItemRaw(stack, throwRandomly);
 
         this.inventory.setItem(slot, null);
         return itemEntity;
     }
 
     @Override
-    public @Nullable Item dropItem(final @NotNull EquipmentSlot slot, final @Nullable UUID thrower, final boolean throwRandomly) {
+    public @Nullable Item dropItem(final @NotNull EquipmentSlot slot, final boolean throwRandomly) {
         final ItemStack stack = this.inventory.getItem(slot);
-        final Item itemEntity = dropItemRaw(stack, thrower, throwRandomly);
+        final Item itemEntity = dropItemRaw(stack, throwRandomly);
 
         this.inventory.setItem(slot, null);
         return itemEntity;
     }
 
-    private Item dropItemRaw(final ItemStack itemStack, final @Nullable UUID thrower, final boolean throwRandomly) {
+    private Item dropItemRaw(final ItemStack itemStack, final boolean throwRandomly) {
         if (itemStack == null || itemStack.isEmpty()) {
             return null;
         }
 
-        final ItemEntity droppedEntity = this.getHandle().drop(CraftItemStack.asNMSCopy(itemStack), throwRandomly);
+        final ItemEntity droppedEntity = this.getHandle().drop(CraftItemStack.asNMSCopy(itemStack), throwRandomly, true);
         if (droppedEntity == null) {
             return null;
         }
 
-        droppedEntity.thrower = thrower;
         return (Item) droppedEntity.getBukkitEntity();
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -807,7 +807,8 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     }
 
     @Override
-    public @Nullable Item dropItem(final int slot, final int amount, final @Nullable Consumer<Item> entityOperation) {
+    @Nullable
+    public Item dropItem(final int slot, final int amount, final @Nullable Consumer<Item> entityOperation) {
         if (slot < 0 || slot >= this.inventory.getSize()) {
             throw new IllegalArgumentException("Slot " + slot + " is not a valid inventory slot.");
         }
@@ -816,12 +817,14 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     }
 
     @Override
-    public @Nullable Item dropItem(final @NotNull EquipmentSlot slot, final int amount, final @Nullable Consumer<Item> entityOperation) {
+    @Nullable
+    public Item dropItem(final @NotNull EquipmentSlot slot, final int amount, final @Nullable Consumer<Item> entityOperation) {
         return dropItemRaw(this.inventory.getItem(slot), amount, false, entityOperation);
     }
 
     @Override
-    public @Nullable Item dropItemRandomly(final int slot, final int amount, final @Nullable Consumer<Item> entityOperation) {
+    @Nullable
+    public Item dropItemRandomly(final int slot, final int amount, final @Nullable Consumer<Item> entityOperation) {
         if (slot < 0 || slot >= this.inventory.getSize()) {
             throw new IllegalArgumentException("Slot " + slot + " is not a valid inventory slot.");
         }
@@ -830,21 +833,25 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     }
 
     @Override
-    public @Nullable Item dropItemRandomly(final @NotNull EquipmentSlot slot, final int amount, final @Nullable Consumer<Item> entityOperation) {
+    @Nullable
+    public Item dropItemRandomly(final @NotNull EquipmentSlot slot, final int amount, final @Nullable Consumer<Item> entityOperation) {
         return dropItemRaw(this.inventory.getItem(slot), amount, true, entityOperation);
     }
 
     @Override
-    public @Nullable Item dropAnyItem(final @Nullable ItemStack itemStack, final @Nullable Consumer<Item> entityOperation) {
+    @Nullable
+    public Item dropAnyItem(final @Nullable ItemStack itemStack, final @Nullable Consumer<Item> entityOperation) {
         return dropAnyItemRaw(itemStack, false, entityOperation);
     }
 
     @Override
-    public @Nullable Item dropAnyItemRandomly(final @Nullable ItemStack itemStack, final @Nullable Consumer<Item> entityOperation) {
+    @Nullable
+    public Item dropAnyItemRandomly(final @Nullable ItemStack itemStack, final @Nullable Consumer<Item> entityOperation) {
         return dropAnyItemRaw(itemStack, true, entityOperation);
     }
 
-    private @Nullable Item dropItemRaw(
+    @Nullable
+    private Item dropItemRaw(
         final ItemStack originalItemStack, final int amount, final boolean throwRandomly,
         final @Nullable Consumer<Item> entityOperation
     ) {
@@ -855,9 +862,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         final net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.unwrap(originalItemStack);
         final net.minecraft.world.item.ItemStack dropContent = nmsItemStack.split(amount);
 
-        // final ItemEntity droppedEntity = this.getHandle().drop(dropContent, throwRandomly, true, true, entityOperation);
-        // TODO: Replace this once NMS changes are in
-        final ItemEntity droppedEntity = this.getHandle().drop(dropContent, throwRandomly, true, true);
+        final ItemEntity droppedEntity = this.getHandle().drop(dropContent, throwRandomly, true, true, entityOperation);
         if (droppedEntity == null) {
             return null;
         }
@@ -865,7 +870,8 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         return (Item) droppedEntity.getBukkitEntity();
     }
 
-    private @Nullable Item dropAnyItemRaw(
+    @Nullable
+    private Item dropAnyItemRaw(
         final ItemStack itemStack, final boolean throwRandomly,
         final @Nullable Consumer<Item> entityOperation
     ) {
@@ -875,9 +881,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
 
         final net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
 
-        // final ItemEntity droppedEntity = this.getHandle().drop(dropContent, throwRandomly, true, true, entityOperation);
-        // TODO: Replace this once NMS changes are in
-        final ItemEntity droppedEntity = this.getHandle().drop(nmsItemStack, throwRandomly, true, true);
+        final ItemEntity droppedEntity = this.getHandle().drop(nmsItemStack, throwRandomly, true, true, entityOperation);
         if (droppedEntity == null) {
             return null;
         }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -839,7 +839,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         }
 
         final net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.unwrap(originalItemStack);
-        final net.minecraft.world.item.ItemStack dropContent = nmsItemStack.split(Math.min(originalItemStack.getAmount(), amount));
+        final net.minecraft.world.item.ItemStack dropContent = nmsItemStack.split(originalItemStack.getAmount());
 
         final ItemEntity droppedEntity = this.getHandle().drop(dropContent, throwRandomly, true);
         if (droppedEntity == null) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -808,53 +808,28 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
 
     @Override
     @Nullable
-    public Item dropItem(final int slot, final int amount, final @Nullable Consumer<Item> entityOperation) {
+    public Item dropItem(final int slot, final int amount, final boolean throwRandomly, final @Nullable Consumer<Item> entityOperation) {
         if (slot < 0 || slot >= this.inventory.getSize()) {
             throw new IllegalArgumentException("Slot " + slot + " is not a valid inventory slot.");
         }
 
-        return dropItemRaw(this.inventory.getItem(slot), amount, false, entityOperation);
+        return dropItemRaw(this.inventory.getItem(slot), amount, throwRandomly, entityOperation);
     }
 
     @Override
     @Nullable
-    public Item dropItem(final @NotNull EquipmentSlot slot, final int amount, final @Nullable Consumer<Item> entityOperation) {
-        return dropItemRaw(this.inventory.getItem(slot), amount, false, entityOperation);
+    public Item dropItem(final @NotNull EquipmentSlot slot, final int amount, final boolean throwRandomly, final @Nullable Consumer<Item> entityOperation) {
+        return dropItemRaw(this.inventory.getItem(slot), amount, throwRandomly, entityOperation);
     }
 
     @Override
     @Nullable
-    public Item dropItemRandomly(final int slot, final int amount, final @Nullable Consumer<Item> entityOperation) {
-        if (slot < 0 || slot >= this.inventory.getSize()) {
-            throw new IllegalArgumentException("Slot " + slot + " is not a valid inventory slot.");
-        }
-
-        return dropItemRaw(this.inventory.getItem(slot), amount, true, entityOperation);
-    }
-
-    @Override
-    @Nullable
-    public Item dropItemRandomly(final @NotNull EquipmentSlot slot, final int amount, final @Nullable Consumer<Item> entityOperation) {
-        return dropItemRaw(this.inventory.getItem(slot), amount, true, entityOperation);
-    }
-
-    @Override
-    @Nullable
-    public Item dropItem(final @Nullable ItemStack itemStack, final @Nullable Consumer<Item> entityOperation) {
-        return dropAnyItemRaw(itemStack, false, entityOperation);
-    }
-
-    @Override
-    @Nullable
-    public Item dropItemRandomly(final @Nullable ItemStack itemStack, final @Nullable Consumer<Item> entityOperation) {
-        return dropAnyItemRaw(itemStack, true, entityOperation);
+    public Item dropItem(final @Nullable ItemStack itemStack, final boolean throwRandomly, final @Nullable Consumer<Item> entityOperation) {
+        return dropAnyItemRaw(itemStack, throwRandomly, entityOperation);
     }
 
     @Nullable
-    private Item dropItemRaw(
-        final ItemStack originalItemStack, final int amount, final boolean throwRandomly,
-        final @Nullable Consumer<Item> entityOperation
-    ) {
+    private Item dropItemRaw(final ItemStack originalItemStack, final int amount, final boolean throwRandomly, final @Nullable Consumer<Item> entityOperation) {
         if (originalItemStack == null || originalItemStack.isEmpty() || amount <= 0) {
             return null;
         }
@@ -871,10 +846,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     }
 
     @Nullable
-    private Item dropAnyItemRaw(
-        final ItemStack itemStack, final boolean throwRandomly,
-        final @Nullable Consumer<Item> entityOperation
-    ) {
+    private Item dropAnyItemRaw(final ItemStack itemStack, final boolean throwRandomly, final @Nullable Consumer<Item> entityOperation) {
         if (itemStack == null || itemStack.isEmpty()) {
             return null;
         }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -808,9 +807,8 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
 
     @Override
     public @Nullable Item dropItem(final int slot, final int amount) {
-        // Make sure the slot is in bounds
         if (slot < 0 || slot >= this.inventory.getSize()) {
-            throw new IndexOutOfBoundsException("Slot " + slot + " out of range for inventory of size " + this.inventory.getSize());
+            throw new IllegalArgumentException("Slot " + slot + " is not a valid inventory slot.");
         }
 
         return dropItemRaw(this.inventory.getItem(slot), amount, false);
@@ -823,9 +821,8 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
 
     @Override
     public @Nullable Item dropItemRandomly(final int slot, final int amount) {
-        // Make sure the slot is in bounds
         if (slot < 0 || slot >= this.inventory.getSize()) {
-            throw new IndexOutOfBoundsException("Slot " + slot + " out of range for inventory of size " + this.inventory.getSize());
+            throw new IllegalArgumentException("Slot " + slot + " is not a valid inventory slot.");
         }
 
         return dropItemRaw(this.inventory.getItem(slot), amount, true);
@@ -841,17 +838,15 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
             return null;
         }
 
-        final ItemStack clonedItemStack = originalItemStack.clone();
-        final int droppedAmount = Math.min(clonedItemStack.getAmount(), amount);
-        clonedItemStack.setAmount(droppedAmount);
+        final net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.unwrap(originalItemStack);
+        final net.minecraft.world.item.ItemStack dropContent = nmsItemStack.split(Math.min(originalItemStack.getAmount(), amount));
 
-        final ItemEntity droppedEntity = this.getHandle().drop(CraftItemStack.asNMSCopy(clonedItemStack), throwRandomly, true);
+        final ItemEntity droppedEntity = this.getHandle().drop(dropContent, throwRandomly, true);
         if (droppedEntity == null) {
             return null;
         }
 
-        originalItemStack.setAmount(originalItemStack.getAmount() - droppedAmount);
-        return new CraftItem(this.server, droppedEntity);
+        return (Item) droppedEntity.getBukkitEntity();
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -48,7 +48,6 @@ import org.bukkit.craftbukkit.inventory.CraftInventoryView;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.inventory.CraftMerchantCustom;
 import org.bukkit.craftbukkit.inventory.CraftRecipe;
-import org.bukkit.craftbukkit.util.CraftChatMessage;
 import org.bukkit.craftbukkit.util.CraftLocation;
 import org.bukkit.entity.Firework;
 import org.bukkit.entity.HumanEntity;
@@ -66,8 +65,8 @@ import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.plugin.Plugin;
-import org.jetbrains.annotations.NotNull;  // Paper - Extend HumanEntity#dropItem API
-import org.jetbrains.annotations.Nullable; // Paper - Extend HumanEntity#dropItem API
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     private CraftInventoryPlayer inventory;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -19,6 +20,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntitySpawnReason;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.HumanoidArm;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.FireworkRocketEntity;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -51,9 +53,11 @@ import org.bukkit.craftbukkit.inventory.CraftRecipe;
 import org.bukkit.craftbukkit.util.CraftLocation;
 import org.bukkit.entity.Firework;
 import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Villager;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
@@ -803,7 +807,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     }
 
     @Override
-    public @Nullable org.bukkit.entity.Item dropItem(final @NotNull ItemStack itemStack, final @Nullable java.util.UUID thrower, final boolean throwRandomly) {
+    public @Nullable Item dropItem(final @NotNull ItemStack itemStack, final @Nullable UUID thrower, final boolean throwRandomly) {
         final int slot = this.inventory.first(itemStack);
         if (slot == -1) {
             return null;
@@ -813,42 +817,41 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     }
 
     @Override
-    public @Nullable org.bukkit.entity.Item dropItem(final int slot, final @Nullable java.util.UUID thrower, final boolean throwRandomly) {
+    public @Nullable Item dropItem(final int slot, final @Nullable UUID thrower, final boolean throwRandomly) {
         // Make sure the slot is in bounds
         if (slot < 0 || slot >= this.inventory.getSize()) {
             throw new IndexOutOfBoundsException("Slot " + slot + " out of range for inventory of size " + this.inventory.getSize());
         }
 
         final ItemStack stack = this.inventory.getItem(slot);
-        final org.bukkit.entity.Item itemEntity = dropItemRaw(stack, thrower, throwRandomly);
+        final Item itemEntity = dropItemRaw(stack, thrower, throwRandomly);
 
         this.inventory.setItem(slot, null);
         return itemEntity;
     }
 
     @Override
-    public @Nullable org.bukkit.entity.Item dropItem(final @NotNull org.bukkit.inventory.EquipmentSlot slot, final @Nullable java.util.UUID thrower, final boolean throwRandomly) {
+    public @Nullable Item dropItem(final @NotNull EquipmentSlot slot, final @Nullable UUID thrower, final boolean throwRandomly) {
         final ItemStack stack = this.inventory.getItem(slot);
-        final org.bukkit.entity.Item itemEntity = dropItemRaw(stack, thrower, throwRandomly);
+        final Item itemEntity = dropItemRaw(stack, thrower, throwRandomly);
 
         this.inventory.setItem(slot, null);
         return itemEntity;
     }
 
-    private org.bukkit.entity.Item dropItemRaw(final ItemStack is, final @Nullable java.util.UUID thrower, final boolean throwRandomly) {
+    private Item dropItemRaw(final ItemStack is, final @Nullable UUID thrower, final boolean throwRandomly) {
         if (is == null || is.isEmpty()) {
             return null;
         }
 
-        final net.minecraft.world.entity.item.ItemEntity droppedEntity = this.getHandle().drop(CraftItemStack.asNMSCopy(is), throwRandomly);
+        final ItemEntity droppedEntity = this.getHandle().drop(CraftItemStack.asNMSCopy(is), throwRandomly);
         if (droppedEntity == null) {
             return null;
         }
 
         droppedEntity.thrower = thrower;
-        return (org.bukkit.entity.Item) droppedEntity.getBukkitEntity();
+        return (Item) droppedEntity.getBukkitEntity();
     }
-    // Paper end
 
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -840,13 +840,13 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
 
     @Override
     @Nullable
-    public Item dropAnyItem(final @Nullable ItemStack itemStack, final @Nullable Consumer<Item> entityOperation) {
+    public Item dropItem(final @Nullable ItemStack itemStack, final @Nullable Consumer<Item> entityOperation) {
         return dropAnyItemRaw(itemStack, false, entityOperation);
     }
 
     @Override
     @Nullable
-    public Item dropAnyItemRandomly(final @Nullable ItemStack itemStack, final @Nullable Consumer<Item> entityOperation) {
+    public Item dropItemRandomly(final @Nullable ItemStack itemStack, final @Nullable Consumer<Item> entityOperation) {
         return dropAnyItemRaw(itemStack, true, entityOperation);
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -839,7 +839,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         }
 
         final net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.unwrap(originalItemStack);
-        final net.minecraft.world.item.ItemStack dropContent = nmsItemStack.split(originalItemStack.getAmount());
+        final net.minecraft.world.item.ItemStack dropContent = nmsItemStack.split(amount);
 
         final ItemEntity droppedEntity = this.getHandle().drop(dropContent, throwRandomly, true);
         if (droppedEntity == null) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -805,16 +805,6 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
 
     // Paper start - Extend HumanEntity#dropItem API
     @Override
-    public @Nullable org.bukkit.entity.Item dropItem(final @NotNull ItemStack itemStack) {
-        return this.dropItem(itemStack, null, false);
-    }
-
-    @Override
-    public @Nullable org.bukkit.entity.Item dropItem(final @NotNull ItemStack itemStack, final @Nullable java.util.UUID thrower) {
-        return this.dropItem(itemStack, thrower, false);
-    }
-
-    @Override
     public @Nullable org.bukkit.entity.Item dropItem(final @NotNull ItemStack itemStack, final @Nullable java.util.UUID thrower, final boolean throwRandomly) {
         final int slot = this.inventory.first(itemStack);
         if (slot == -1) {
@@ -822,16 +812,6 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         }
 
         return this.dropItem(slot, thrower, throwRandomly);
-    }
-
-    @Override
-    public @Nullable org.bukkit.entity.Item dropItem(final int slot) {
-        return this.dropItem(slot, null, false);
-    }
-
-    @Override
-    public @Nullable org.bukkit.entity.Item dropItem(final int slot, final @Nullable java.util.UUID thrower) {
-        return this.dropItem(slot, thrower, false);
     }
 
     @Override
@@ -846,16 +826,6 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
 
         this.inventory.setItem(slot, null);
         return itemEntity;
-    }
-
-    @Override
-    public @Nullable org.bukkit.entity.Item dropItem(final @NotNull org.bukkit.inventory.EquipmentSlot slot) {
-        return dropItem(slot, null, false);
-    }
-
-    @Override
-    public @Nullable org.bukkit.entity.Item dropItem(final @NotNull org.bukkit.inventory.EquipmentSlot slot, final @Nullable java.util.UUID thrower) {
-        return dropItem(slot, thrower, false);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -839,12 +839,12 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         return itemEntity;
     }
 
-    private Item dropItemRaw(final ItemStack is, final @Nullable UUID thrower, final boolean throwRandomly) {
-        if (is == null || is.isEmpty()) {
+    private Item dropItemRaw(final ItemStack itemStack, final @Nullable UUID thrower, final boolean throwRandomly) {
+        if (itemStack == null || itemStack.isEmpty()) {
             return null;
         }
 
-        final ItemEntity droppedEntity = this.getHandle().drop(CraftItemStack.asNMSCopy(is), throwRandomly);
+        final ItemEntity droppedEntity = this.getHandle().drop(CraftItemStack.asNMSCopy(itemStack), throwRandomly);
         if (droppedEntity == null) {
             return null;
         }


### PR DESCRIPTION
Closes #11656
Post-softspoon version of https://github.com/PaperMC/Paper/pull/11689

# Motive
Developers currently have to either use NMS or copy-paste the already existing NMS implementation. This PR aims to fix that by exposing ways to call that NMS implementation more easily by extending onto the (Human)Player#dropItem method to provide more extensive ways of making the player drop items from their inventory.

## What does it add?
The following method have been added:
* `Item dropItem(int slot, int amount, @Nullable Consumer<Item> entityOperation)`
* `Item dropItem(int slot, int amount)`
* `Item dropItem(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation)`
* `Item dropItem(@NotNull EquipmentSlot slot, int amount)`
* `Item dropItemRandomly(int slot, int amount, @Nullable Consumer<Item> entityOperation)`
* `Item dropItemRandomly(int slot, int amount)`
* `Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation)`
* `Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount)`
* `Item dropItems(int slot, @Nullable Consumer<Item> entityOperation)`
* `Item dropItems(int slot)`
* `Item dropItems(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation)`
* `Item dropItems(@NotNull EquipmentSlot slot)`
* `Item dropItemsRandomly(int slot, @Nullable Consumer<Item> entityOperation)`
* `Item dropItemsRandomly(int slot)`
* `Item dropItemsRandomly(@NotNull EquipmentSlot slot, @Nullable Consumer<Item> entityOperation)`
* `Item dropItemsRandomly(@NotNull EquipmentSlot slot)`
* `Item dropItem(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation)`
* `Item dropItem(@Nullable ItemStack itemStack)`
* `Item dropItemRandomly(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation)`
* `Item dropItemRandomly(@Nullable ItemStack itemStack)`

This may look like a lot at first glance (and it kind of is), but in reality, most of these are just default methods on the `HumanEntity` interface. The only, actually implemented methods are:
* `Item dropItem(int slot, int amount, @Nullable Consumer<Item> entityOperation)`
* `Item dropItem(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation)`
* `Item dropItemRandomly(int slot, int amount, @Nullable Consumer<Item> entityOperation)`
* `Item dropItemRandomly(@NotNull EquipmentSlot slot, int amount, @Nullable Consumer<Item> entityOperation)`
* `Item dropItem(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation)`
* `Item dropItemRandomly(@Nullable ItemStack itemStack, @Nullable Consumer<Item> entityOperation)`

And even among these neither have more than 5 lines in their implementation in `CraftHumanEntity`.

All logic goes through the added methods `private CraftHumanEntity#dropItemRaw(...)` and `private CraftHumandEntity#dropAnyItemRaw(...)`, where the logic is fairly simple due to the pre-implemented NMS method `Player.dropItem(...)`.


Furthermore, `booleam dropItem(boolean)` has been deprecated in favor of `Item dropItems(EquipmentSlot.HAND)` or `Item dropItem(EquipmentSlot.HAND, 1)`.

## Implementation details
Internally, the implementation calls `net.minecraft.world.entity.player.Player#dropItem(...)`, making it a fairly maintainable API.

I have added an additional overload to the the `Player#dropItem(...)` method, which takes in a nullable `Consumer<org.bukkit.entity.Item>` to allow for entity operations before the Entity has been added to the world.

## JavaDocs status
JavaDocs have been added.

# Usage example
```java
// Simple command to test some of the added API
this.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event -> {
    event.registrar().register(Commands.literal("drop")
        .then(Commands.literal("one")
            .executes(ctx -> {
                ((Player) ctx.getSource().getExecutor()).dropItemRandomly(EquipmentSlot.HAND, 1);
                return 1;
            }))

        .then(Commands.literal("all")
            .executes(ctx -> {
                ((Player) ctx.getSource().getExecutor()).dropItems(EquipmentSlot.HAND);
                return 1;
            }))

        .then(Commands.literal("any")
            .then(Commands.argument("item", ArgumentTypes.itemStack())
                .executes(ctx -> {
                    ((Player) ctx.getSource().getExecutor()).dropItem(ctx.getArgument("item", ItemStack.class), item -> {
                        item.setGlowing(true);
                    });
                    return 1;
                })))

        .build());
});
```