### PR TITLE
Fix framed maps looping through all players in world

### DIFF
--- a/paper-server/patches/features/0018-Fix-entity-tracker-desync-when-new-players-are-added.patch
+++ b/paper-server/patches/features/0018-Fix-entity-tracker-desync-when-new-players-are-added.patch
@@ -60,7 +60,7 @@ index 3dff97f13586be3b52bbe786852c185f6753a019..ff6503bf8eb88d1264c3d848a89d0255
                  } else if (this.seenBy.remove(player.connection)) {
                      this.serverEntity.removePairing(player);
 diff --git a/net/minecraft/server/level/ServerEntity.java b/net/minecraft/server/level/ServerEntity.java
-index 870b9efd445ddadb3725e88351555ad986ce7c72..a4da36060ca75968f5831adfc3f7117281649b7a 100644
+index db06f966077928419bfe469260f04d7dfda69f28..0fb253aa55a24b56b17f524b3261c5b75c7d7e59 100644
 --- a/net/minecraft/server/level/ServerEntity.java
 +++ b/net/minecraft/server/level/ServerEntity.java
 @@ -90,6 +90,13 @@ public class ServerEntity {
@@ -77,7 +77,7 @@ index 870b9efd445ddadb3725e88351555ad986ce7c72..a4da36060ca75968f5831adfc3f71172
      public void sendChanges() {
          // Paper start - optimise collisions
          if (((ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity)this.entity).moonrise$isHardColliding()) {
-@@ -130,7 +137,7 @@ public class ServerEntity {
+@@ -131,7 +138,7 @@ public class ServerEntity {
              this.sendDirtyEntityData();
          }
  
@@ -86,7 +86,7 @@ index 870b9efd445ddadb3725e88351555ad986ce7c72..a4da36060ca75968f5831adfc3f71172
              byte b = Mth.packDegrees(this.entity.getYRot());
              byte b1 = Mth.packDegrees(this.entity.getXRot());
              boolean flag = Math.abs(b - this.lastSentYRot) >= 1 || Math.abs(b1 - this.lastSentXRot) >= 1;
-@@ -165,7 +172,7 @@ public class ServerEntity {
+@@ -166,7 +173,7 @@ public class ServerEntity {
                  long l1 = this.positionCodec.encodeY(vec3);
                  long l2 = this.positionCodec.encodeZ(vec3);
                  boolean flag5 = l < -32768L || l > 32767L || l1 < -32768L || l1 > 32767L || l2 < -32768L || l2 > 32767L;
@@ -95,7 +95,7 @@ index 870b9efd445ddadb3725e88351555ad986ce7c72..a4da36060ca75968f5831adfc3f71172
                      this.wasOnGround = this.entity.onGround();
                      this.teleportDelay = 0;
                      packet = ClientboundEntityPositionSyncPacket.of(this.entity);
-@@ -230,6 +237,7 @@ public class ServerEntity {
+@@ -231,6 +238,7 @@ public class ServerEntity {
              }
  
              this.entity.hasImpulse = false;

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerEntity.java.patch
@@ -29,7 +29,7 @@
              removedPassengers(passengers, this.lastPassengers)
                  .forEach(
                      removedPassenger -> {
-@@ -102,10 +_,10 @@
+@@ -102,13 +_,14 @@
              this.lastPassengers = passengers;
          }
  
@@ -42,7 +42,12 @@
 +                MapId mapId = itemFrame.cachedMapId; // Paper - Perf: Cache map ids on item frames
                  MapItemSavedData savedData = MapItem.getSavedData(mapId, this.level);
                  if (savedData != null) {
-                     for (ServerPlayer serverPlayer : this.level.players()) {
+-                    for (ServerPlayer serverPlayer : this.level.players()) {
++                    for (final net.minecraft.server.network.ServerPlayerConnection connection : this.trackedPlayers) { // Paper
++                        final ServerPlayer serverPlayer = connection.getPlayer(); // Paper
+                         savedData.tickCarriedBy(serverPlayer, item);
+                         Packet<?> updatePacket = savedData.getUpdatePacket(mapId, serverPlayer);
+                         if (updatePacket != null) {
 @@ -141,7 +_,13 @@
              } else {
                  this.teleportDelay++;


### PR DESCRIPTION
This diff used to be part of CB ([link](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/browse/nms-patches/net/minecraft/server/level/EntityTrackerEntry.patch#54)) but seems to have been dropped, this fixes tickCarriedBy being called & update packets being sent unnecessarily to players who are not in range of the framed map.