### PR TITLE
Add a way to check if pathfinder allows the mob to fly

### DIFF
--- a/paper-api/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
@@ -181,6 +181,13 @@ public interface Pathfinder {
     void setCanFloat(boolean canFloat);
 
     /**
+     * Checks if this pathfinder allows the mob to fly
+     *
+     * @return if this pathfinder allows the mob to fly
+     */
+    boolean canFly();
+
+    /**
      * Represents the result of a pathfinding calculation
      */
     interface PathResult {

--- a/paper-server/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java
+++ b/paper-server/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java
@@ -1,5 +1,6 @@
 package com.destroystokyo.paper.entity;
 
+import net.minecraft.world.entity.ai.navigation.FlyingPathNavigation;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
@@ -97,6 +98,11 @@ public class PaperPathfinder implements com.destroystokyo.paper.entity.Pathfinde
     @Override
     public void setCanFloat(boolean canFloat) {
         entity.getNavigation().pathFinder.nodeEvaluator.setCanFloat(canFloat);
+    }
+
+    @Override
+    public boolean canFly() {
+        return entity.getNavigation() instanceof FlyingPathNavigation;
     }
 
     public class PaperPathResult implements com.destroystokyo.paper.entity.PaperPathfinder.PathResult {


### PR DESCRIPTION
There's no universal way to check if mob can fly and the only shared logic between flying mobs in NMS is `FlyingPathNavigation`.
Not sure about the method name, but should be ok