### PR TITLE
Extend BukkitScheduler with new/simplified methods

### DIFF
--- a/paper-api/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
+++ b/paper-api/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
@@ -1,5 +1,8 @@
 package org.bukkit.scheduler;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -20,6 +23,21 @@ public interface BukkitScheduler {
      * @return Task id number (-1 if scheduling failed)
      */
     public int scheduleSyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay);
+
+    /**
+     * Schedules a once off task to occur after a delay.
+     * <p>
+     * Note that the smallest unit for {@link org.bukkit.scheduler.BukkitScheduler} is still 1 tick (50ms).
+     * Values smaller than 50ms will be rounded down.
+     * <p>
+     * This task will be executed by the main server thread.
+     *
+     * @param plugin Plugin that owns the task
+     * @param task Task to be executed
+     * @param delay Delay in {@link java.time.Duration} before executing task
+     * @return Task id number (-1 if scheduling failed)
+     */
+    public int scheduleSyncDelayedTask(@NotNull Plugin plugin, @NotNull Runnable task, @NotNull Duration delay);
 
     /**
      * @param plugin Plugin that owns the task
@@ -63,6 +81,22 @@ public interface BukkitScheduler {
      * @return Task id number (-1 if scheduling failed)
      */
     public int scheduleSyncRepeatingTask(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period);
+
+    /**
+     * Schedules a repeating task.
+     * <p>
+     * Note that the smallest unit for {@link org.bukkit.scheduler.BukkitScheduler} is still 1 tick (50ms).
+     * Values smaller than 50ms will be rounded down.
+     * <p>
+     * This task will be executed by the main server thread.
+     *
+     * @param plugin Plugin that owns the task
+     * @param task Task to be executed
+     * @param delay Delay in {@link java.time.Duration} before executing first repeat
+     * @param period Period in {@link java.time.Duration} of the task execution
+     * @return Task id number (-1 if scheduling failed)
+     */
+    public int scheduleSyncRepeatingTask(@NotNull Plugin plugin, @NotNull Runnable task, @NotNull Duration delay, @NotNull Duration period);
 
     /**
      * @param plugin Plugin that owns the task
@@ -295,6 +329,9 @@ public interface BukkitScheduler {
     @NotNull
     public BukkitTask runTaskLater(@NotNull Plugin plugin, @NotNull Runnable task, long delay) throws IllegalArgumentException;
 
+    @NotNull
+    public BukkitTask runTaskLater(@NotNull Plugin plugin, @NotNull Runnable task, @NotNull Duration delay) throws IllegalArgumentException;
+
     /**
      * Returns a task that will run after the specified number of server
      * ticks.
@@ -306,6 +343,22 @@ public interface BukkitScheduler {
      * @throws IllegalArgumentException if task is null
      */
     public void runTaskLater(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay) throws IllegalArgumentException;
+
+    /**
+     * Returns a task that will run after the specified duration.
+     * <p>
+     * The time given in {@link java.time.Duration} is converted to number of ticks.
+     * Note that the smallest unit for {@link org.bukkit.scheduler.BukkitScheduler} is still 1 tick (50ms).
+     * Values smaller than 50ms will be rounded down.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param task the task to be run
+     * @param delay duration to wait before running the task
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if task is null
+     * @throws IllegalArgumentException if delay is null
+     */
+    public void runTaskLater(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, @NotNull Duration delay) throws IllegalArgumentException;
 
     /**
      * @param plugin the reference to the plugin scheduling task
@@ -341,6 +394,27 @@ public interface BukkitScheduler {
      * <b>Asynchronous tasks should never access any API in Bukkit.</b> <b>Great care
      * should be taken to assure the thread-safety of asynchronous tasks.</b>
      * <p>
+     * Returns a task that will run asynchronously after the specified duration.
+     * <p>
+     * The time given in {@link java.time.Duration} is converted to number of ticks.
+     * Note that the smallest unit for {@link org.bukkit.scheduler.BukkitScheduler} is still 1 tick (50ms).
+     * Values smaller than 50ms will be rounded down.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param task the task to be run
+     * @param delay the duration to wait before running the task
+     * @return a BukkitTask that contains the id number
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if task is null
+     * @throws IllegalArgumentException if delay is null
+     */
+    @NotNull
+    public BukkitTask runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, @NotNull Duration delay) throws IllegalArgumentException;
+
+    /**
+     * <b>Asynchronous tasks should never access any API in Bukkit.</b> <b>Great care
+     * should be taken to assure the thread-safety of asynchronous tasks.</b>
+     * <p>
      * Returns a task that will run asynchronously after the specified number
      * of server ticks.
      *
@@ -351,6 +425,25 @@ public interface BukkitScheduler {
      * @throws IllegalArgumentException if task is null
      */
     public void runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay) throws IllegalArgumentException;
+
+    /**
+     * <b>Asynchronous tasks should never access any API in Bukkit.</b> <b>Great care
+     * should be taken to assure the thread-safety of asynchronous tasks.</b>
+     * <p>
+     * Returns a task that will run asynchronously after the specified duration.
+     * <p>
+     * The time given in {@link java.time.Duration} is converted to number of ticks.
+     * Note that the smallest unit for {@link org.bukkit.scheduler.BukkitScheduler} is still 1 tick (50ms).
+     * Values smaller than 50ms will be rounded down.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param task the task to be run
+     * @param delay the duration to wait before running the task
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if task is null
+     * @throws IllegalArgumentException if delay is null
+     */
+    public void runTaskLaterAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, @NotNull Duration delay) throws IllegalArgumentException;
 
     /**
      * @param plugin the reference to the plugin scheduling task
@@ -381,6 +474,27 @@ public interface BukkitScheduler {
     public BukkitTask runTaskTimer(@NotNull Plugin plugin, @NotNull Runnable task, long delay, long period) throws IllegalArgumentException;
 
     /**
+     * Returns a task that will repeatedly run until cancelled,
+     * starting after the specified duration.
+     * <p>
+     * The time given in {@link java.time.Duration} is converted to number of ticks.
+     * Note that the smallest unit for {@link org.bukkit.scheduler.BukkitScheduler} is still 1 tick (50ms).
+     * Values smaller than 50ms will be rounded down.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param task the task to be run
+     * @param delay the duration to wait before running the task
+     * @param period the duration to wait between runs
+     * @return a BukkitTask that contains the id number
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if task is null
+     * @throws IllegalArgumentException if delay is null
+     * @throws IllegalArgumentException if period is null
+     */
+    @NotNull
+    public BukkitTask runTaskTimer(@NotNull Plugin plugin, @NotNull Runnable task, @NotNull Duration delay, @NotNull Duration period) throws IllegalArgumentException;
+
+    /**
      * Returns a task that will repeatedly run until cancelled, starting after
      * the specified number of server ticks.
      *
@@ -392,6 +506,25 @@ public interface BukkitScheduler {
      * @throws IllegalArgumentException if task is null
      */
     public void runTaskTimer(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay, long period) throws IllegalArgumentException;
+
+    /**
+     * Returns a task that will repeatedly run until cancelled,
+     * starting after the specified duration.
+     * <p>
+     * The time given in {@link java.time.Duration} is converted to number of ticks.
+     * Note that the smallest unit for {@link org.bukkit.scheduler.BukkitScheduler} is still 1 tick (50ms).
+     * Values smaller than 50ms will be rounded down.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param task the task to be run
+     * @param delay the duration to wait before running the task
+     * @param period the duration to wait between runs
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if task is null
+     * @throws IllegalArgumentException if delay is null
+     * @throws IllegalArgumentException if period is null
+     */
+    public void runTaskTimer(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, @NotNull Duration delay, @NotNull Duration period) throws IllegalArgumentException;
 
     /**
      * @param plugin the reference to the plugin scheduling task
@@ -431,6 +564,31 @@ public interface BukkitScheduler {
      * should be taken to assure the thread-safety of asynchronous tasks.</b>
      * <p>
      * Returns a task that will repeatedly run asynchronously until cancelled,
+     * starting after the specified duration.
+     * <p>
+     * The time given in {@link java.time.Duration} is converted to number of ticks.
+     * Note that the smallest unit for {@link org.bukkit.scheduler.BukkitScheduler} is still 1 tick (50ms).
+     * Values smaller than 50ms will be rounded down.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param task the task to be run
+     * @param delay the duration to wait before running the task for the
+     *     first time
+     * @param period the duration to wait between runs
+     * @return a BukkitTask that contains the id number
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if task is null
+     * @throws IllegalArgumentException if delay is null
+     * @throws IllegalArgumentException if period is null
+     */
+    @NotNull
+    public BukkitTask runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Runnable task, @NotNull Duration delay, @NotNull Duration period) throws IllegalArgumentException;
+
+    /**
+     * <b>Asynchronous tasks should never access any API in Bukkit.</b> <b>Great care
+     * should be taken to assure the thread-safety of asynchronous tasks.</b>
+     * <p>
+     * Returns a task that will repeatedly run asynchronously until cancelled,
      * starting after the specified number of server ticks.
      *
      * @param plugin the reference to the plugin scheduling task
@@ -442,6 +600,29 @@ public interface BukkitScheduler {
      * @throws IllegalArgumentException if task is null
      */
     public void runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, long delay, long period) throws IllegalArgumentException;
+
+    /**
+     * <b>Asynchronous tasks should never access any API in Bukkit.</b> <b>Great care
+     * should be taken to assure the thread-safety of asynchronous tasks.</b>
+     * <p>
+     * Returns a task that will repeatedly run asynchronously until cancelled,
+     * starting after the specified duration.
+     * <p>
+     * The time given in {@link java.time.Duration} is converted to number of ticks.
+     * Note that the smallest unit for {@link org.bukkit.scheduler.BukkitScheduler} is still 1 tick (50ms).
+     * Values smaller than 50ms will be rounded down.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param task the task to be run
+     * @param delay the duration to wait before running the task for the
+     *     first time
+     * @param period the duration to wait between runs
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if task is null
+     * @throws IllegalArgumentException if delay is null
+     * @throws IllegalArgumentException if period is null
+     */
+    public void runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, @NotNull Duration delay, @NotNull Duration period) throws IllegalArgumentException;
 
     /**
      * @param plugin the reference to the plugin scheduling task
@@ -457,6 +638,120 @@ public interface BukkitScheduler {
     @Deprecated(since = "1.7.10")
     @NotNull
     public BukkitTask runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay, long period) throws IllegalArgumentException;
+
+    /**
+     * Returns a task that will run at a specified date time.
+     * <p>
+     * The LocalDateTime used is the local time, appropriate
+     * time zone adjustments are made automatically.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param runnable the task to be run
+     * @param localDateTime the time to run this task at
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if runnable is null
+     * @throws IllegalArgumentException if localDateTime is nll
+     */
+    @NotNull
+    public BukkitTask runTaskAtTime(@NotNull Plugin plugin, @NotNull Runnable runnable, @NotNull LocalDateTime localDateTime) throws IllegalArgumentException;
+
+    /**
+     * Returns a task that will run at a specified date time.
+     * <p>
+     * The LocalDateTime used is the local time, appropriate
+     * time zone adjustments are made automatically.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param task the task to be run
+     * @param localDateTime the time to run this task at
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if runnable is null
+     * @throws IllegalArgumentException if localDateTime is nll
+     */
+    @NotNull
+    public void runTaskAtTime(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, @NotNull LocalDateTime localDateTime) throws IllegalArgumentException;
+
+    /**
+     * <b>Asynchronous tasks should never access any API in Bukkit.</b> <b>Great care
+     * should be taken to assure the thread-safety of asynchronous tasks.</b>
+     * <p>
+     * Returns a task that will run asynchronously
+     * at a specified date time.
+     * <p>
+     * The LocalDateTime used is the local time, appropriate
+     * time zone adjustments are made automatically.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param runnable the task to be run
+     * @param localDateTime the time to run this task at
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if runnable is null
+     * @throws IllegalArgumentException if localDateTime is nll
+     */
+    @NotNull
+    public BukkitTask runTaskAtTimeAsynchronously(@NotNull Plugin plugin, @NotNull Runnable runnable, @NotNull LocalDateTime localDateTime) throws IllegalArgumentException;
+
+    /**
+     * <b>Asynchronous tasks should never access any API in Bukkit.</b> <b>Great care
+     * should be taken to assure the thread-safety of asynchronous tasks.</b>
+     * <p>
+     * Returns a task that will run asynchronously
+     * at a specified date time.
+     * <p>
+     * The LocalDateTime used is the local time, appropriate
+     * time zone adjustments are made automatically.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param task the task to be run
+     * @param localDateTime the time to run this task at
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if runnable is null
+     * @throws IllegalArgumentException if localDateTime is nll
+     */
+    @NotNull
+    public void runTaskAtTimeAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, @NotNull LocalDateTime localDateTime) throws IllegalArgumentException;
+
+    /**
+     * Returns a task that will run every day at
+     * a specified time (hour, minute and second).
+     * <p>
+     * The LocalTime used is the local time, appropriate
+     * time zone adjustments are made automatically.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param runnable the task to be run
+     * @param localTime the time to run this task at
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if runnable is null
+     * @throws IllegalArgumentException if LocalTime is nll
+     */
+    @NotNull
+    public BukkitTask runRepeatedTaskAtTime(@NotNull Plugin plugin, @NotNull Runnable runnable, @NotNull LocalTime localTime) throws IllegalArgumentException;
+
+    /**
+     * Returns a task that will run every day at
+     * a specified time (hour, minute and second).
+     * <p>
+     * The LocalTime used is the local time, appropriate
+     * time zone adjustments are made automatically.
+     *
+     * @param plugin the reference to the plugin scheduling task
+     * @param task the task to be run
+     * @param localTime the time to run this task at
+     * @throws IllegalArgumentException if plugin is null
+     * @throws IllegalArgumentException if runnable is null
+     * @throws IllegalArgumentException if LocalTime is nll
+     */
+    @NotNull
+    public void runRepeatedTaskAtTime(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, @NotNull LocalTime localTime) throws IllegalArgumentException;
+
+    /*
+    @NotNull
+    public BukkitTask runRepeatedTaskAtTimeAsynchronously(@NotNull Plugin plugin, @NotNull Runnable runnable, @NotNull LocalTime localTime) throws IllegalArgumentException;
+
+    @NotNull
+    public void runRepeatedTaskAtTimeAsynchronously(@NotNull Plugin plugin, @NotNull Consumer<? super BukkitTask> task, @NotNull LocalTime localTime) throws IllegalArgumentException;
+    */
 
     // Paper start - add getMainThreadExecutor
     /**

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftSyncDailyTask.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftSyncDailyTask.java
@@ -1,0 +1,55 @@
+package org.bukkit.craftbukkit.scheduler;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class CraftSyncDailyTask extends CraftTask {
+
+    private final LocalTime scheduleTime;
+    private final ZoneId zoneId;
+    private ZonedDateTime nextRun;
+
+    public CraftSyncDailyTask(Plugin plugin, Object task, int id, LocalTime scheduleTime) {
+        super(plugin, task, id, -1);
+        this.scheduleTime = scheduleTime;
+        this.zoneId = ZoneId.systemDefault();
+        this.nextRun = calculateNextRun(scheduleTime, zoneId);
+    }
+
+    @Override
+    public void run() {
+        try {
+            super.run();
+        } finally {
+            // After running, calculate the next run time
+            ZonedDateTime now = ZonedDateTime.now(zoneId);
+            ZonedDateTime next = calculateNextRun(scheduleTime, zoneId);
+            nextRun = next;
+
+            setNextRun(Bukkit.getCurrentTick() + calculateDelayTicks(now, next));
+        }
+    }
+
+    static ZonedDateTime calculateNextRun(LocalTime scheduleTime, ZoneId zoneId) {
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime next = now.with(scheduleTime);
+
+        // If time already passed today, schedule to tomorrow
+        if (!now.toLocalTime().isBefore(scheduleTime)) {
+            next = next.plusDays(1);
+        }
+
+        // Ensure we're using the correct offset for the target time
+        return next.withZoneSameInstant(zoneId);
+    }
+
+    static long calculateDelayTicks(ZonedDateTime from, ZonedDateTime to) {
+        return Math.max(0, Duration.between(from, to).toMillis() / CraftScheduler.MILLISECONDS_PER_TICK);
+    }
+
+}


### PR DESCRIPTION
For quite some time, I’ve noticed various plugins implementing strange calculations for converting real time into ticks, especially when scheduling tasks at real-world dates and times. These implementations often involve a lot of complexity around time zones.

In this PR, I’ve added several methods aimed at simplifying scheduler usage. I utilized Java’s modern time API, including `Duration`, `LocalDateTime` and `LocalTime`

**Added API:**
- Standard: scheduling of tasks to run after a specific `Duration`
- Standard: scheduling of repeating tasks at a specified `Duration` interval
- New: scheduling single-run (non-repeated) tasks for a specific date and time, using `LocalDateTime`. Time zone handling and potential clock adjustments are managed automatically without user intervention
- New: scheduling of repeated tasks, daily at the same time (hour, minute, second), using `LocalTime`. As with the above, time zone handling does not require user intervention. This required the creation of a new class extending `CraftTask`. In the current version of this PR, I implemented this only for synchronous tasks, as doing it for asynchronous ones would be more complex. I’d like to hear your opinion on this approach first. The existing class has been coded in such a way to share most of the code if the async version was created

This was quite challenging to implement, cause the `CraftScheduler` codebase is very inconsistent. I tried to model my methods on the existing ones in style and structure. I did not touch methods that were annotated as deprecated. I believe the scheduler’s overall design is something that should be addressed, but I refrained from making changes myself as I’m unsure if that’s something the team desires.

I’ve provided proper Javadocs for all the new methods, based on the existing ones and adding some additional notes for users to consider.

I’m not entirely sure how the team prefers these methods to be implemented or which parts of the API should be designed differently. However, I think that these methods will help simplify plugin code and improve its readability. If implemented and documented correctly, these methods shouldn’t cause any issues.

I will be grateful for your feedback and happy to adapt to it