### PR TITLE
fix annotation test for null marked inner classes

### DIFF
--- a/paper-api/src/test/java/org/bukkit/AnnotationTest.java
+++ b/paper-api/src/test/java/org/bukkit/AnnotationTest.java
@@ -205,14 +205,16 @@ public class AnnotationTest {
 
     // Paper start - skip class if it's @NullMarked
     private static boolean isClassNullMarked(@NotNull ClassNode clazz, @NotNull Map<String, ClassNode> allClasses) {
+        if (isClassNullMarked0(clazz)) {
+            return true;
+        }
         if (clazz.nestHostClass != null) {
             final ClassNode nestHostNode = allClasses.get(clazz.nestHostClass);
             if (nestHostNode != null) {
-                return isClassNullMarked0(nestHostNode);
+                return isClassNullMarked(nestHostNode, allClasses);
             }
         }
-
-        return isClassNullMarked0(clazz);
+        return false;
     }
 
     private static boolean isClassNullMarked0(@NotNull ClassNode clazz) {


### PR DESCRIPTION
Currently NullMarked inner classes are not detected right by the annotation test. Only when the outer class is annotated the test suceeds.  Something like the following fails.

```java
package com.destroystokyo.paper;

import org.jspecify.annotations.NullMarked;

public interface SkinParts {

    boolean hasCapeEnabled();

    boolean hasJacketEnabled();

    boolean hasLeftSleeveEnabled();

    boolean hasRightSleeveEnabled();

    boolean hasLeftPantsEnabled();

    boolean hasRightPantsEnabled();

    boolean hasHatsEnabled();

    int getRaw();

    @NullMarked
    interface Builder {
        Builder withCape(boolean cape);
        Builder withJacket(boolean jacket);
        Builder withLeftSleeve(boolean leftSleeve);
        Builder withRightSleeve(boolean rightSleeve);
        Builder withLeftPants(boolean leftPants);
        Builder withRightPants(boolean rightPants);
        Builder withHat(boolean hat);
        SkinParts build();
    }
}
```