### PR TITLE
Fix NullPointerException in PlayerInteractEvent#getClickedPosition

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
@@ -241,6 +241,9 @@ public class PlayerInteractEvent extends PlayerEvent implements Cancellable {
     @Nullable
     @Deprecated // Paper
     public Vector getClickedPosition() {
+        if (this.clickedPosistion == null) {
+            return null;
+        }
         return clickedPosistion.clone();
     }
 


### PR DESCRIPTION
Fixes a NullPointerException in PlayerInteractEvent#getClickedPosition

Re: https://github.com/EngineHub/CraftBook/issues/1340