### PR TITLE
Remove itemstack mutation on player drop method

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -27025,7 +27025,7 @@ index f25d50bcccf9b35ae70f8162c6b2b67fffcd319a..5494b92ab1c3c202a640e483e8a4bcb6
      }
  
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index b09e6a9fa5fbe9a0d3df615d02109992612b4416..8688d1eb7427b8d07757af84d615781867a34288 100644
+index 09470e7c4238a66be16b3cf8cf93444700cc2508..55d27aa4cff91ea61ff2ab9256acd2cd8694304a 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -201,7 +201,7 @@ import net.minecraft.world.scores.criteria.ObjectiveCriteria;
@@ -28123,7 +28123,7 @@ index 8cc5c0716392ba06501542ff5cbe71ee43979e5d..09fd99c9cbd23b5f3c899bfb00c9b896
 +    // Paper end - block counting
  }
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 7cc307666b7b4e4597673852ba456034fcef7590..69020a6e12254b935ccc0a06a73357c64b7e9d1c 100644
+index f88ac0961d2474ed0d3c18ff77e789c0ad1c3b50..c272211766d931a5ee3524567781dd41e9dbca20 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -152,7 +152,7 @@ import org.jetbrains.annotations.Contract;
@@ -28476,7 +28476,7 @@ index 7cc307666b7b4e4597673852ba456034fcef7590..69020a6e12254b935ccc0a06a73357c6
      }
  
      private static float[] collectCandidateStepUpHeights(AABB box, List<VoxelShape> colliders, float deltaY, float maxUpStep) {
-@@ -2708,21 +2856,110 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -2707,21 +2855,110 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
      }
  
      public boolean isInWall() {
@@ -28598,7 +28598,7 @@ index 7cc307666b7b4e4597673852ba456034fcef7590..69020a6e12254b935ccc0a06a73357c6
      }
  
      public InteractionResult interact(Player player, InteractionHand hand) {
-@@ -4313,15 +4550,17 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -4312,15 +4549,17 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
      }
  
      public Iterable<Entity> getIndirectPassengers() {
@@ -28624,7 +28624,7 @@ index 7cc307666b7b4e4597673852ba456034fcef7590..69020a6e12254b935ccc0a06a73357c6
      }
  
      public int countPlayerPassengers() {
-@@ -4470,77 +4709,126 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -4469,77 +4708,126 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
          return Mth.lerp(partialTick, this.yRotO, this.yRot);
      }
  
@@ -28809,7 +28809,7 @@ index 7cc307666b7b4e4597673852ba456034fcef7590..69020a6e12254b935ccc0a06a73357c6
  
      public boolean touchingUnloadedChunk() {
          AABB aabb = this.getBoundingBox().inflate(1.0);
-@@ -4700,6 +4988,15 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -4699,6 +4987,15 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
      }
  
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
@@ -28825,7 +28825,7 @@ index 7cc307666b7b4e4597673852ba456034fcef7590..69020a6e12254b935ccc0a06a73357c6
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4849,6 +5146,12 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -4848,6 +5145,12 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
  
      @Override
      public final void setRemoved(Entity.RemovalReason removalReason, org.bukkit.event.entity.EntityRemoveEvent.@Nullable Cause cause) { // CraftBukkit - add Bukkit remove cause
@@ -28838,7 +28838,7 @@ index 7cc307666b7b4e4597673852ba456034fcef7590..69020a6e12254b935ccc0a06a73357c6
          org.bukkit.craftbukkit.event.CraftEventFactory.callEntityRemoveEvent(this, cause); // CraftBukkit
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
          if (this.removalReason == null) {
-@@ -4859,7 +5162,7 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -4858,7 +5161,7 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
              this.stopRiding();
          }
  
@@ -28847,7 +28847,7 @@ index 7cc307666b7b4e4597673852ba456034fcef7590..69020a6e12254b935ccc0a06a73357c6
          this.levelCallback.onRemove(removalReason);
          this.onRemoval(removalReason);
          // Paper start - Folia schedulers
-@@ -4893,7 +5196,7 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -4892,7 +5195,7 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
      public boolean shouldBeSaved() {
          return (this.removalReason == null || this.removalReason.shouldSave())
              && !this.isPassenger()

--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -28123,7 +28123,7 @@ index 8cc5c0716392ba06501542ff5cbe71ee43979e5d..09fd99c9cbd23b5f3c899bfb00c9b896
 +    // Paper end - block counting
  }
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 262ac42b02b2809439aec5b9e8f4bc3fba04e7fe..9cd31bf05ef7e5b14696cb33bbf995a9405481e3 100644
+index 7cc307666b7b4e4597673852ba456034fcef7590..69020a6e12254b935ccc0a06a73357c64b7e9d1c 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -152,7 +152,7 @@ import org.jetbrains.annotations.Contract;
@@ -28476,7 +28476,7 @@ index 262ac42b02b2809439aec5b9e8f4bc3fba04e7fe..9cd31bf05ef7e5b14696cb33bbf995a9
      }
  
      private static float[] collectCandidateStepUpHeights(AABB box, List<VoxelShape> colliders, float deltaY, float maxUpStep) {
-@@ -2709,21 +2857,110 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -2708,21 +2856,110 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
      }
  
      public boolean isInWall() {
@@ -28598,7 +28598,7 @@ index 262ac42b02b2809439aec5b9e8f4bc3fba04e7fe..9cd31bf05ef7e5b14696cb33bbf995a9
      }
  
      public InteractionResult interact(Player player, InteractionHand hand) {
-@@ -4314,15 +4551,17 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -4313,15 +4550,17 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
      }
  
      public Iterable<Entity> getIndirectPassengers() {
@@ -28624,7 +28624,7 @@ index 262ac42b02b2809439aec5b9e8f4bc3fba04e7fe..9cd31bf05ef7e5b14696cb33bbf995a9
      }
  
      public int countPlayerPassengers() {
-@@ -4471,77 +4710,126 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -4470,77 +4709,126 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
          return Mth.lerp(partialTick, this.yRotO, this.yRot);
      }
  
@@ -28809,7 +28809,7 @@ index 262ac42b02b2809439aec5b9e8f4bc3fba04e7fe..9cd31bf05ef7e5b14696cb33bbf995a9
  
      public boolean touchingUnloadedChunk() {
          AABB aabb = this.getBoundingBox().inflate(1.0);
-@@ -4701,6 +4989,15 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -4700,6 +4988,15 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
      }
  
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
@@ -28825,7 +28825,7 @@ index 262ac42b02b2809439aec5b9e8f4bc3fba04e7fe..9cd31bf05ef7e5b14696cb33bbf995a9
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4850,6 +5147,12 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -4849,6 +5146,12 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
  
      @Override
      public final void setRemoved(Entity.RemovalReason removalReason, org.bukkit.event.entity.EntityRemoveEvent.@Nullable Cause cause) { // CraftBukkit - add Bukkit remove cause
@@ -28838,7 +28838,7 @@ index 262ac42b02b2809439aec5b9e8f4bc3fba04e7fe..9cd31bf05ef7e5b14696cb33bbf995a9
          org.bukkit.craftbukkit.event.CraftEventFactory.callEntityRemoveEvent(this, cause); // CraftBukkit
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
          if (this.removalReason == null) {
-@@ -4860,7 +5163,7 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -4859,7 +5162,7 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
              this.stopRiding();
          }
  
@@ -28847,7 +28847,7 @@ index 262ac42b02b2809439aec5b9e8f4bc3fba04e7fe..9cd31bf05ef7e5b14696cb33bbf995a9
          this.levelCallback.onRemove(removalReason);
          this.onRemoval(removalReason);
          // Paper start - Folia schedulers
-@@ -4894,7 +5197,7 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -4893,7 +5196,7 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
      public boolean shouldBeSaved() {
          return (this.removalReason == null || this.removalReason.shouldSave())
              && !this.isPassenger()

--- a/paper-server/patches/features/0024-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0024-Optimise-EntityScheduler-ticking.patch
@@ -67,10 +67,10 @@ index e7df5f105c721f2e1be1a13694275c0f03b7932b..0f56d83701ac770799970fceeb73eab5
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.DIALOG_CLICK_MANAGER.handleQueue(this.tickCount); // Paper
          profilerFiller.push("commandFunctions");
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 521c85df76f86678d19c141c1a424cbe6c2d632e..d6cc75a769e9379eeb77623204d5f07199ff8c8c 100644
+index c830385dd64ee67fd89d912d5d2c8aa2ff35b83b..80526e1e61d38736f4f86fcad282df093121fe49 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -5213,6 +5213,11 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -5212,6 +5212,11 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
          this.getBukkitEntity().taskScheduler.retire();
      }
      // Paper end - Folia schedulers

--- a/paper-server/patches/features/0024-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0024-Optimise-EntityScheduler-ticking.patch
@@ -67,10 +67,10 @@ index e7df5f105c721f2e1be1a13694275c0f03b7932b..0f56d83701ac770799970fceeb73eab5
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.DIALOG_CLICK_MANAGER.handleQueue(this.tickCount); // Paper
          profilerFiller.push("commandFunctions");
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index e491170cd817b5f2a6951456d36b4ca1bf45c15f..81b860d18f54d5007b12a2a723bde931456211c4 100644
+index 521c85df76f86678d19c141c1a424cbe6c2d632e..d6cc75a769e9379eeb77623204d5f07199ff8c8c 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -5214,6 +5214,11 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -5213,6 +5213,11 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
          this.getBukkitEntity().taskScheduler.retire();
      }
      // Paper end - Folia schedulers

--- a/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/server/commands/GiveCommand.java
 +++ b/net/minecraft/server/commands/GiveCommand.java
-@@ -54,6 +_,7 @@
- 
-     private static int giveItem(CommandSourceStack source, ItemInput item, Collection<ServerPlayer> targets, int count) throws CommandSyntaxException {
-         ItemStack itemStack = item.createItemStack(1, false);
-+        final Component displayName = itemStack.getDisplayName(); // Paper - get display name early
-         int maxStackSize = itemStack.getMaxStackSize();
-         int i = maxStackSize * 100;
-         if (count > i) {
 @@ -69,7 +_,7 @@
                      ItemStack itemStack1 = item.createItemStack(min, false);
                      boolean flag = serverPlayer.getInventory().add(itemStack1);
@@ -26,17 +18,3 @@
                          if (itemEntity != null) {
                              itemEntity.setNoPickUpDelay();
                              itemEntity.setTarget(serverPlayer.getUUID());
-@@ -98,11 +_,11 @@
- 
-             if (targets.size() == 1) {
-                 source.sendSuccess(
--                    () -> Component.translatable("commands.give.success.single", count, itemStack.getDisplayName(), targets.iterator().next().getDisplayName()),
-+                    () -> Component.translatable("commands.give.success.single", count, displayName, targets.iterator().next().getDisplayName()), // Paper - use cached display name
-                     true
-                 );
-             } else {
--                source.sendSuccess(() -> Component.translatable("commands.give.success.single", count, itemStack.getDisplayName(), targets.size()), true);
-+                source.sendSuccess(() -> Component.translatable("commands.give.success.single", count, displayName, targets.size()), true); // Paper - use cached display name
-             }
- 
-             return targets.size();

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -943,7 +943,7 @@
      protected abstract void addAdditionalSaveData(ValueOutput output);
  
      public @Nullable ItemEntity spawnAtLocation(ServerLevel level, ItemLike item) {
-@@ -2106,11 +_,60 @@
+@@ -2106,11 +_,59 @@
      }
  
      public @Nullable ItemEntity spawnAtLocation(ServerLevel level, ItemStack stack, Vec3 offset) {
@@ -970,8 +970,6 @@
          if (stack.isEmpty()) {
              return null;
          } else {
--            ItemEntity itemEntity = new ItemEntity(level, this.getX() + offset.x, this.getY() + offset.y, this.getZ() + offset.z, stack);
--            itemEntity.setDefaultPickUpDelay();
 +            // CraftBukkit start - Capture drops for death event
 +            if (this instanceof net.minecraft.world.entity.LivingEntity && !this.forceDrops) {
 +                // Paper start - Restore vanilla drops behavior
@@ -985,8 +983,8 @@
 +                return null;
 +            }
 +            // CraftBukkit end
-+            ItemEntity itemEntity = new ItemEntity(level, this.getX() + offset.x, this.getY() + offset.y, this.getZ() + offset.z, stack.copy()); // Paper - copy so we can destroy original
-+            stack.setCount(0); // Paper - destroy this item - if this ever leaks due to game bugs, ensure it doesn't dupe
+             ItemEntity itemEntity = new ItemEntity(level, this.getX() + offset.x, this.getY() + offset.y, this.getZ() + offset.z, stack);
+-            itemEntity.setDefaultPickUpDelay();
 +
 +            itemEntity.setDefaultPickUpDelay(); // Paper - diff on change (in dropConsumer)
 +            // Paper start - Call EntityDropItemEvent

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -943,7 +943,7 @@
      protected abstract void addAdditionalSaveData(ValueOutput output);
  
      public @Nullable ItemEntity spawnAtLocation(ServerLevel level, ItemLike item) {
-@@ -2106,11 +_,59 @@
+@@ -2106,11 +_,58 @@
      }
  
      public @Nullable ItemEntity spawnAtLocation(ServerLevel level, ItemStack stack, Vec3 offset) {
@@ -985,7 +985,6 @@
 +            // CraftBukkit end
              ItemEntity itemEntity = new ItemEntity(level, this.getX() + offset.x, this.getY() + offset.y, this.getZ() + offset.z, stack);
 -            itemEntity.setDefaultPickUpDelay();
-+
 +            itemEntity.setDefaultPickUpDelay(); // Paper - diff on change (in dropConsumer)
 +            // Paper start - Call EntityDropItemEvent
 +            return this.spawnAtLocation(level, itemEntity);

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -1682,18 +1682,6 @@
      private void updatingUsingItem() {
          if (this.isUsingItem()) {
              if (ItemStack.isSameItem(this.getItemInHand(this.getUsedItemHand()), this.useItem)) {
-@@ -3297,6 +_,11 @@
-             return null;
-         } else {
-             double d = this.getEyeY() - 0.3F;
-+            // Paper start
-+            final ItemStack tmp = stack.copy();
-+            stack.setCount(0);
-+            stack = tmp;
-+            // Paper end
-             ItemEntity itemEntity = new ItemEntity(this.level(), this.getX(), d, this.getZ(), stack);
-             itemEntity.setPickUpDelay(40);
-             if (includeThrower) {
 @@ -3328,7 +_,12 @@
  
      protected void updateUsingItem(ItemStack usingItem) {

--- a/paper-server/patches/sources/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -192,6 +192,19 @@
              ItemStack item = inventory.getItem(button);
              Slot slot = this.slots.get(slotIndex);
              ItemStack carried = slot.getItem();
+@@ -528,7 +_,11 @@
+                     }
+ 
+                     carried = slot2.safeTake(i1, Integer.MAX_VALUE, player);
+-                    player.drop(carried, true);
++                    // CraftBukkit start - SPIGOT-8010: break loop
++                    if (player.drop(carried, true) == null) {
++                        break;
++                    }
++                    // CraftBukkit end - SPIGOT-8010: break loop
+                     player.handleCreativeModeItemDrop(carried);
+                 }
+             }
 @@ -588,8 +_,9 @@
          if (player instanceof ServerPlayer) {
              ItemStack carried = this.getCarried();

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -1001,7 +1001,6 @@ public class CraftEventFactory {
             if (stack == null || stack.getType() == Material.AIR || stack.getAmount() == 0) continue;
 
             drop.runConsumer(s -> world.dropItem(entity.getLocation(), s)); // Paper - Restore vanilla drops behavior
-            if (stack instanceof CraftItemStack) stack.setAmount(0); // Paper - destroy this item - if this ever leaks due to game bugs, ensure it doesn't dupe, but don't nuke bukkit stacks of manually added items
         }
 
         return event;


### PR DESCRIPTION
This appears to cause alot of issues, as the general assumption when calling this method is that the itemstack would not be mutated.

Common issues that this seems to cause is item related actions that later increment a statistic, which is no longer true because the item type changes since its now considered empty.
The dupe that this was meant to resolve was patched.

Fixes #11520 
Fixes #11765
Supercedes https://github.com/PaperMC/Paper/pull/11521