### PR TITLE
Biome - Fix snow accumulating in custom biomes without precipitation

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/biome/Biome.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/biome/Biome.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/biome/Biome.java
++++ b/net/minecraft/world/level/biome/Biome.java
+@@ -138,7 +_,7 @@
+     }
+ 
+     public boolean shouldFreeze(LevelReader level, BlockPos water, boolean mustBeAtEdge) {
+-        if (this.warmEnoughToRain(water, level.getSeaLevel())) {
++        if (this.getPrecipitationAt(water, level.getSeaLevel()) != Precipitation.SNOW) { // Paper - Fixes MC-248212
+             return false;
+         } else {
+             if (level.isInsideBuildHeight(water.getY()) && level.getBrightness(LightLayer.BLOCK, water) < 10) {

--- a/paper-server/patches/sources/net/minecraft/world/level/biome/Biome.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/biome/Biome.java.patch
@@ -1,11 +1,11 @@
 --- a/net/minecraft/world/level/biome/Biome.java
 +++ b/net/minecraft/world/level/biome/Biome.java
-@@ -138,7 +_,7 @@
+@@ -176,7 +_,7 @@
      }
  
-     public boolean shouldFreeze(LevelReader level, BlockPos water, boolean mustBeAtEdge) {
--        if (this.warmEnoughToRain(water, level.getSeaLevel())) {
-+        if (this.getPrecipitationAt(water, level.getSeaLevel()) != Precipitation.SNOW) { // Paper - Fixes MC-248212
+     public boolean shouldSnow(LevelReader level, BlockPos pos) {
+-        if (this.warmEnoughToRain(pos, level.getSeaLevel())) {
++        if (this.getPrecipitationAt(pos, level.getSeaLevel()) != Precipitation.SNOW) { // Paper - Fixes MC-248212
              return false;
          } else {
-             if (level.isInsideBuildHeight(water.getY()) && level.getBrightness(LightLayer.BLOCK, water) < 10) {
+             if (level.isInsideBuildHeight(pos.getY()) && level.getBrightness(LightLayer.BLOCK, pos) < 10) {


### PR DESCRIPTION
This PR aims to fix a bug in Minecraft in which a custom biome which is cold enough but does NOT have precipitation will accumulate snow on the ground during rain.
The biome will not visually snow, but the snow will still form on the ground.
This has been reported on MoJira [**MC-248212**](https://bugs.mojang.com/browse/MC-248212) and is marked as a bug.