### PR TITLE
feat: add new message for velocity in online mode

### DIFF
--- a/paper-server/patches/features/0017-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0017-Moonrise-optimisation-patches.patch
@@ -23552,7 +23552,7 @@ index 2b46ca9a2a046063cad422bec00d76107537b091..9aa664537cc37e44db46d5a2a64ae311
                  thread1 -> {
                      DedicatedServer dedicatedServer1 = new DedicatedServer(
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index b92a3da5c325e69f5601416d4205fb33429742b3..d967d605c2e4227ae980c30f1c8b86edbc680d6d 100644
+index 244e2eae7e52c3f92d085a7cb7f961df1a38168f..acc669108e5efa0c742820676be5d4bba9b27027 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -173,7 +173,7 @@ import net.minecraft.world.phys.Vec2;
@@ -23751,10 +23751,10 @@ index b92a3da5c325e69f5601416d4205fb33429742b3..d967d605c2e4227ae980c30f1c8b86ed
      // CraftBukkit start
      public boolean isDebugging() {
 diff --git a/net/minecraft/server/dedicated/DedicatedServer.java b/net/minecraft/server/dedicated/DedicatedServer.java
-index f8c81d795b19e73d56d6e0196c75e441ab4c2bef..97a294d2f5c1ddf0af7ffec3e1425eb329c5751b 100644
+index 20360d5ab30356b5fea95be035f4c8dbd4f31283..778ecb1a17c8753056082bbcbe0ee454584cb500 100644
 --- a/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -433,7 +433,33 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -437,7 +437,33 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
          return level.dimension() != Level.NETHER || this.getProperties().allowNether;
      }
  
@@ -27496,7 +27496,7 @@ index 192977dd661ee795ada13db895db770293e9b402..95a4e37a3c93f9b3c56c7a7376ed521c
      }
  
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 097ec55166b9e9269142be58992c29687122fe28..aeabb79512aabd7a9e8af1be72e1745f0e7eefe4 100644
+index 472693a7d10dc67b116db02e3e4472adbc5a4d62..422db52e8a0a08350542670bfc9ba94ad9481d0c 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -178,7 +178,7 @@ import net.minecraft.world.scores.Team;

--- a/paper-server/patches/sources/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -187,7 +187,7 @@
          InetAddress inetAddress = null;
          if (!this.getLocalIp().isEmpty()) {
              inetAddress = InetAddress.getByName(this.getLocalIp());
-@@ -147,36 +_,62 @@
+@@ -147,36 +_,66 @@
          if (this.getPort() < 0) {
              this.setPort(properties.serverPort);
          }
@@ -209,6 +209,7 @@
              return false;
          }
  
+-        if (!this.usesAuthentication()) {
 +        // CraftBukkit start
 +        // this.setPlayerList(new DedicatedPlayerList(this, this.registries(), this.playerDataStorage)); // Spigot - moved up
 +        this.server.loadPlugins();
@@ -220,7 +221,7 @@
 +        String proxyFlavor = (io.papermc.paper.configuration.GlobalConfiguration.get().proxies.velocity.enabled) ? "Velocity" : "BungeeCord";
 +        String proxyLink = (io.papermc.paper.configuration.GlobalConfiguration.get().proxies.velocity.enabled) ? "https://docs.papermc.io/velocity/security" : "http://www.spigotmc.org/wiki/firewall-guide/";
 +        // Paper end - Add Velocity IP Forwarding Support
-         if (!this.usesAuthentication()) {
++        if (!this.usesAuthentication() && !io.papermc.paper.configuration.GlobalConfiguration.get().proxies.velocity.onlineMode) {
              LOGGER.warn("**** SERVER IS RUNNING IN OFFLINE/INSECURE MODE!");
              LOGGER.warn("The server will make no attempt to authenticate usernames. Beware.");
 -            LOGGER.warn(
@@ -237,6 +238,10 @@
 +            }
 +            // Spigot end
              LOGGER.warn("To change this, set \"online-mode\" to \"true\" in the server.properties file.");
++        } else if (!this.usesAuthentication() && (usingProxy && io.papermc.paper.configuration.GlobalConfiguration.get().proxies.velocity.onlineMode)) {
++            LOGGER.info("**** SERVER IS RUNNING IN OFFLINE/INSECURE MODE!");
++            LOGGER.info("However, you're currently using Velocity in online mode, which means that your Velocity proxy is authenticating usernames.");
++            LOGGER.info("This server will make no attempt to authenticate usernames. Beware.");
          }
  
 +        // CraftBukkit start


### PR DESCRIPTION
Back in https://github.com/PaperMC/Paper/pull/8812 I added support for detecting if the end user is using Velocity over Bungeecord for the offline mode warning.

This expands upon that and will swap up the message whenever they're using Velocity in online mode. It's still enough of a message to let people know but without being a complete nag. 

It'll also make it, so people are less confused when they see the message in server logs in the paper-help channel. 

Definitely open to different wording on the message. I'm not really good at Englishing properly some days. 