### PR TITLE
[ci skip] update jb annotations to 26.0.1

### DIFF
--- a/paper-api-generator/build.gradle.kts
+++ b/paper-api-generator/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("com.squareup:javapoet:1.13.0")
     implementation(project(":paper-api"))
     implementation("io.github.classgraph:classgraph:4.8.47")
-    implementation("org.jetbrains:annotations:24.1.0")
+    implementation("org.jetbrains:annotations:26.0.1")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/paper-api/build.gradle.kts
+++ b/paper-api/build.gradle.kts
@@ -9,7 +9,7 @@ java {
     withJavadocJar()
 }
 
-val annotationsVersion = "24.1.0"
+val annotationsVersion = "26.0.1"
 val bungeeCordChatVersion = "1.20-R0.2"
 val adventureVersion = "4.18.0"
 val slf4jVersion = "2.0.9"


### PR DESCRIPTION
Removes experimental from `@Contract(mutates=)` which we use a bunch