### PR TITLE
[ci skip] Fix spelling of ignition's word into javadoc (#11862)

### DIFF
--- a/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
+++ b/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
@@ -88,10 +88,14 @@ public interface Attribute extends OldEnum<Attribute>, Keyed, Translatable, net.
      * Strength with which an Entity will jump.
      */
     Attribute JUMP_STRENGTH = getAttribute("jump_strength");
+
+    // Paper start - Fix spelling of ignition's word
     /**
-     * How long an entity remains burning after ingition.
+     * How long an entity remains burning after ignition.
      */
     Attribute BURNING_TIME = getAttribute("burning_time");
+    // Paper end - Fix spelling of ignition's word
+
     /**
      * Resistance to knockback from explosions.
      */


### PR DESCRIPTION
This pull request fix just a word into javadoc of Attribute class which is caused by Spigot.