### PR TITLE
[ci skip] Fix spelling of ignition's word into javadoc (#11862)

### DIFF
--- a/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
+++ b/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
@@ -88,10 +88,14 @@ public interface Attribute extends OldEnum<Attribute>, Keyed, Translatable, net.
      * Strength with which an Entity will jump.
      */
     Attribute JUMP_STRENGTH = getAttribute("jump_strength");
+
+    // Paper start - Fix spelling of ignition's word
     /**
-     * How long an entity remains burning after ingition.
+     * How long an entity remains burning after ignition.
      */
     Attribute BURNING_TIME = getAttribute("burning_time");
+    // Paper end - Fix spelling of ignition's word
+
     /**
      * Resistance to knockback from explosions.
      */

--- a/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
+++ b/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
@@ -88,12 +88,10 @@ public interface Attribute extends OldEnum<Attribute>, Keyed, Translatable, net.
      * Strength with which an Entity will jump.
      */
     Attribute JUMP_STRENGTH = getAttribute("jump_strength");
-
     /**
      * How long an entity remains burning after ignition.
      */
     Attribute BURNING_TIME = getAttribute("burning_time");
-
     /**
      * Resistance to knockback from explosions.
      */

--- a/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
+++ b/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
@@ -89,12 +89,10 @@ public interface Attribute extends OldEnum<Attribute>, Keyed, Translatable, net.
      */
     Attribute JUMP_STRENGTH = getAttribute("jump_strength");
 
-    // Paper start - Fix spelling of ignition's word
     /**
-     * How long an entity remains burning after ignition. 
+     * How long an entity remains burning after ignition.
      */
     Attribute BURNING_TIME = getAttribute("burning_time");
-    // Paper end - Fix spelling of ignition's word
 
     /**
      * Resistance to knockback from explosions.

--- a/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
+++ b/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
@@ -91,7 +91,7 @@ public interface Attribute extends OldEnum<Attribute>, Keyed, Translatable, net.
 
     // Paper start - Fix spelling of ignition's word
     /**
-     * How long an entity remains burning after ignition.
+     * How long an entity remains burning after ignition. 
      */
     Attribute BURNING_TIME = getAttribute("burning_time");
     // Paper end - Fix spelling of ignition's word


### PR DESCRIPTION
Just a small fix into javadoc of Attribute's class for spelling the ignition's word caused by Spigot.