### PR TITLE
Feat: Add 'with' methods to CommandSourceStack

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/command/brigadier/CommandSourceStack.java
+++ b/paper-api/src/main/java/io/papermc/paper/command/brigadier/CommandSourceStack.java
@@ -1,5 +1,7 @@
 package io.papermc.paper.command.brigadier;
 
+import com.mojang.brigadier.RedirectModifier;
+import com.mojang.brigadier.tree.CommandNode;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
@@ -48,8 +50,24 @@ public interface CommandSourceStack {
      * @return entity that executes this command
      */
     @Nullable Entity getExecutor();
-    
+
+    /**
+     * Creates a new CommandSourceStack object with a different location for redirecting commands to other nodes.
+     *
+     * @param location The location to create a new CommandSourceStack object with
+     * @return The newly created CommandSourceStack
+     * @see #getLocation()
+     * @see com.mojang.brigadier.builder.ArgumentBuilder#fork(CommandNode, RedirectModifier)
+     */
     CommandSourceStack withLocation(Location location);
-    
+
+    /**
+     * Creates a new CommandSourceStack object with a different executor for redirecting commands to other nodes.
+     *
+     * @param executor The executing entity to create a new CommandSourceStack object with
+     * @return The newly created CommandSourceStack
+     * @see #getExecutor()
+     * @see com.mojang.brigadier.builder.ArgumentBuilder#fork(CommandNode, RedirectModifier)
+     */
     CommandSourceStack withExecutor(Entity executor);
 }

--- a/paper-api/src/main/java/io/papermc/paper/command/brigadier/CommandSourceStack.java
+++ b/paper-api/src/main/java/io/papermc/paper/command/brigadier/CommandSourceStack.java
@@ -4,7 +4,6 @@ import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.ApiStatus;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -50,7 +49,7 @@ public interface CommandSourceStack {
      */
     @Nullable Entity getExecutor();
     
-    CommandSourceStack withLocation(@NonNull Location location);
+    CommandSourceStack withLocation(Location location);
     
-    CommandSourceStack withExecutor(@Nullable Entity executor);
+    CommandSourceStack withExecutor(Entity executor);
 }

--- a/paper-api/src/main/java/io/papermc/paper/command/brigadier/CommandSourceStack.java
+++ b/paper-api/src/main/java/io/papermc/paper/command/brigadier/CommandSourceStack.java
@@ -4,6 +4,7 @@ import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -48,4 +49,8 @@ public interface CommandSourceStack {
      * @return entity that executes this command
      */
     @Nullable Entity getExecutor();
+    
+    CommandSourceStack withLocation(@NonNull Location location);
+    
+    CommandSourceStack withExecutor(@Nullable Entity executor);
 }

--- a/paper-server/patches/features/0009-Fix-entity-type-tags-suggestions-in-selectors.patch
+++ b/paper-server/patches/features/0009-Fix-entity-type-tags-suggestions-in-selectors.patch
@@ -10,10 +10,10 @@ when if this was fixed on the client, that wouldn't be needed.
 Mojira Issue: https://bugs.mojang.com/browse/MC-235045
 
 diff --git a/net/minecraft/commands/CommandSourceStack.java b/net/minecraft/commands/CommandSourceStack.java
-index 2c6469fd0715217b784680064083b386d723e559..e17ddd3351faa623084ddab9878d78f9108a3d82 100644
+index cf923441da598637be74a5ffa4b4f948e01ff532..cbf32be9235921ebcaca88225120c2ca70a72771 100644
 --- a/net/minecraft/commands/CommandSourceStack.java
 +++ b/net/minecraft/commands/CommandSourceStack.java
-@@ -671,4 +671,20 @@ public class CommandSourceStack implements ExecutionCommandSource<CommandSourceS
+@@ -676,4 +676,20 @@ public class CommandSourceStack implements ExecutionCommandSource<CommandSourceS
          return this.source.getBukkitSender(this);
      }
      // CraftBukkit end

--- a/paper-server/patches/features/0009-Fix-entity-type-tags-suggestions-in-selectors.patch
+++ b/paper-server/patches/features/0009-Fix-entity-type-tags-suggestions-in-selectors.patch
@@ -10,10 +10,10 @@ when if this was fixed on the client, that wouldn't be needed.
 Mojira Issue: https://bugs.mojang.com/browse/MC-235045
 
 diff --git a/net/minecraft/commands/CommandSourceStack.java b/net/minecraft/commands/CommandSourceStack.java
-index 704a63890a06d793f8ac3452838917e7c7335232..75262c8c9eaecb4a88a94f4076d67119c67a97da 100644
+index 2c6469fd0715217b784680064083b386d723e559..e17ddd3351faa623084ddab9878d78f9108a3d82 100644
 --- a/net/minecraft/commands/CommandSourceStack.java
 +++ b/net/minecraft/commands/CommandSourceStack.java
-@@ -652,4 +652,20 @@ public class CommandSourceStack implements ExecutionCommandSource<CommandSourceS
+@@ -671,4 +671,20 @@ public class CommandSourceStack implements ExecutionCommandSource<CommandSourceS
          return this.source.getBukkitSender(this);
      }
      // CraftBukkit end

--- a/paper-server/patches/sources/net/minecraft/commands/CommandSourceStack.java.patch
+++ b/paper-server/patches/sources/net/minecraft/commands/CommandSourceStack.java.patch
@@ -18,6 +18,32 @@
  
      public CommandSourceStack(
          CommandSource source,
+@@ -187,6 +_,25 @@
+                 this.chatMessageChainer
+             );
+     }
++    
++    // Paper start - Expose 'with' functions from the CommandSourceStack
++    @Override
++    public CommandSourceStack withLocation(org.bukkit.Location location) {
++        return this.getLocation().equals(location)
++            ? this
++            : new CommandSourceStack(
++            this.source,
++            new Vec3(location.x(), location.y(), location.z()),
++            new Vec2(location.getYaw(), location.getPitch()),
++            ((org.bukkit.craftbukkit.CraftWorld) location.getWorld()).getHandle(),
++            this.permissionLevel,
++            this.textName,
++            this.displayName,
++            this.server,
++            this.entity
++        );        
++    }
++    // Paper end - Expose 'with' functions from the CommandSourceStack
+ 
+     public CommandSourceStack withRotation(Vec2 rotation) {
+         return this.rotation.equals(rotation)
 @@ -391,9 +_,44 @@
  
      @Override

--- a/paper-server/patches/sources/net/minecraft/commands/CommandSourceStack.java.patch
+++ b/paper-server/patches/sources/net/minecraft/commands/CommandSourceStack.java.patch
@@ -31,14 +31,14 @@
 +            : new CommandSourceStack(
 +            this.source,
 +            new Vec3(location.x(), location.y(), location.z()),
-+            new Vec2(location.getYaw(), location.getPitch()),
++            new Vec2(location.getPitch(), location.getYaw()),
 +            ((org.bukkit.craftbukkit.CraftWorld) location.getWorld()).getHandle(),
 +            this.permissionLevel,
 +            this.textName,
 +            this.displayName,
 +            this.server,
 +            this.entity
-+        );        
++        );
 +    }
 +    // Paper end - Expose 'with' functions from the CommandSourceStack
  

--- a/paper-server/patches/sources/net/minecraft/commands/CommandSourceStack.java.patch
+++ b/paper-server/patches/sources/net/minecraft/commands/CommandSourceStack.java.patch
@@ -18,7 +18,7 @@
  
      public CommandSourceStack(
          CommandSource source,
-@@ -187,6 +_,25 @@
+@@ -187,6 +_,30 @@
                  this.chatMessageChainer
              );
      }
@@ -37,7 +37,12 @@
 +            this.textName,
 +            this.displayName,
 +            this.server,
-+            this.entity
++            this.entity,
++            this.silent,
++            this.resultCallback,
++            this.anchor,
++            this.signingContext,
++            this.chatMessageChainer
 +        );
 +    }
 +    // Paper end - Expose 'with' functions from the CommandSourceStack

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommandSourceStack.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommandSourceStack.java
@@ -6,9 +6,11 @@ import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
+import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
 
 public interface PaperCommandSourceStack extends CommandSourceStack, BukkitBrigadierCommandSource {
 
@@ -38,6 +40,12 @@ public interface PaperCommandSourceStack extends CommandSourceStack, BukkitBriga
         }
 
         return nmsEntity.getBukkitEntity();
+    }
+
+    @Override
+    @NonNull
+    default CommandSourceStack withExecutor(@Nullable Entity executor) {
+        return executor == null ? this.getHandle().withEntity(null) : this.getHandle().withEntity(((CraftEntity) executor).getHandle());
     }
 
     // OLD METHODS

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommandSourceStack.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommandSourceStack.java
@@ -1,6 +1,7 @@
 package io.papermc.paper.command.brigadier;
 
 import com.destroystokyo.paper.brigadier.BukkitBrigadierCommandSource;
+import com.google.common.base.Preconditions;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
@@ -8,16 +9,15 @@ import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.entity.Entity;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public interface PaperCommandSourceStack extends CommandSourceStack, BukkitBrigadierCommandSource {
 
     net.minecraft.commands.CommandSourceStack getHandle();
 
     @Override
-    default @NotNull Location getLocation() {
+    default @NonNull Location getLocation() {
         Vec2 rot = this.getHandle().getRotation();
         Vec3 pos = this.getHandle().getPosition();
         Level level = this.getHandle().getLevel();
@@ -26,7 +26,7 @@ public interface PaperCommandSourceStack extends CommandSourceStack, BukkitBriga
     }
 
     @Override
-    @NotNull
+    @NonNull
     default CommandSender getSender() {
         return this.getHandle().getBukkitSender();
     }
@@ -43,9 +43,9 @@ public interface PaperCommandSourceStack extends CommandSourceStack, BukkitBriga
     }
 
     @Override
-    @NonNull
-    default CommandSourceStack withExecutor(@Nullable Entity executor) {
-        return executor == null ? this.getHandle().withEntity(null) : this.getHandle().withEntity(((CraftEntity) executor).getHandle());
+    default CommandSourceStack withExecutor(@NonNull Entity executor) {
+        Preconditions.checkNotNull(executor, "Executor cannot be null.");
+        return this.getHandle().withEntity(((CraftEntity) executor).getHandle());
     }
 
     // OLD METHODS


### PR DESCRIPTION
fixes #11866 

The following methods have been added:
- `CommandSourceStack#withExecutor(@Nullable Entity)`
- `CommandSourceStack#withLocation(Location location)`

JavaDocs hasn't been added yet, but that is something I will be doing very soon.

Testing the code can be done via the following:
```java
this.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event -> {
    final LiteralCommandNode<CommandSourceStack> node = Commands.literal("test")
        .then(Commands.literal("run")
            .executes(ctx -> {
                Bukkit.broadcast(MiniMessage.miniMessage().deserialize("<name>: I am at <x> <y> <z>",
                    Placeholder.component("name", ctx.getSource().getExecutor().name()),
                    Placeholder.unparsed("x", String.valueOf(ctx.getSource().getLocation().x())),
                    Placeholder.unparsed("y", String.valueOf(ctx.getSource().getLocation().y())),
                    Placeholder.unparsed("z", String.valueOf(ctx.getSource().getLocation().z()))
                ));

                return 1;
            })).build();

    final LiteralCommandNode<CommandSourceStack> withNode = Commands.literal("testwith")
        .then(Commands.argument("entities", ArgumentTypes.entities())
            .then(Commands.literal("run")
                .fork(node, ctx -> {
                    final EntitySelectorArgumentResolver entities = ctx.getArgument("entities", EntitySelectorArgumentResolver.class);
                    final List<Entity> resolved = entities.resolve(ctx.getSource());

                    return resolved.stream()
                        .map(entity -> ctx.getSource().withExecutor(entity).withLocation(entity.getLocation()))
                        .toList();
                }))).build();

    event.registrar().register(node);
    event.registrar().register(withNode);
});
```

Running `/test run` works as expected, printing out the executing player's location.
Running `/testwith @e[limit=2,type=!player] run run` also works, printing out two entities names and locations.

![testwith-command](https://github.com/user-attachments/assets/a3cb79c8-71da-4b11-8ec8-53bfecfc06cf)