### PR TITLE
Improve performance of PoiCompetitorScan by unrolling stream

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java.patch
@@ -1,0 +1,33 @@
+--- a/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java
++++ b/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java
+@@ -22,13 +_,23 @@
+                         level.getPoiManager()
+                             .getType(globalPos.pos())
+                             .ifPresent(
+-                                poi -> instance.<List<LivingEntity>>get(nearestLivingEntities)
+-                                    .stream()
+-                                    .filter(entity -> entity instanceof Villager && entity != villager)
+-                                    .map(entity -> (Villager)entity)
+-                                    .filter(LivingEntity::isAlive)
+-                                    .filter(v -> competesForSameJobsite(globalPos, poi, v))
+-                                    .reduce(villager, PoiCompetitorScan::selectWinner)
++                                poi -> {
++                                    List<LivingEntity> livingEntities = instance.get(nearestLivingEntities);
++
++                                    Villager winner = villager;
++                                    for (LivingEntity entity : livingEntities) {
++                                        if (!(entity instanceof Villager && entity != villager)) {
++                                            continue;
++                                        }
++                                        if (!entity.isAlive()) {
++                                            continue;
++                                        }
++                                        if (!competesForSameJobsite(globalPos, poi, (Villager) entity)) {
++                                            continue;
++                                        }
++                                        winner = selectWinner(winner, (Villager) entity);
++                                    }
++                                }
+                             );
+                         return true;
+                     }


### PR DESCRIPTION
I was debugging villagers and I noticed that the reduce on the stream has massive overhead so I decided to unroll it.
Here are sparks for before and after:
[Before](https://spark.lucko.me/3fTr1E6BK8)
[After](https://spark.lucko.me/rc6SrM21zA)
Those numbers are with 229 active villagers on R7 5700X with 64GB of RAM.
![image](https://github.com/user-attachments/assets/40dfdfe9-73b8-4920-91cd-ade6fd375222)
Here is the test world:
[world.tar.gz](https://github.com/user-attachments/files/18280935/world.tar.gz)

