### PR TITLE
Improve performance of PoiCompetitorScan by unrolling stream

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java.patch
@@ -14,26 +14,26 @@
 +                                // Paper start - Improve performance of PoiCompetitorScan by unrolling stream
 +                                // The previous logic used Stream#reduce to simulate a form of single-iteration bubble sort
 +                                // in which the "winning" villager would maintain MemoryModuleType.JOB_SITE while all others
-+                                // would loose said memory module type by passing each "current winner" and incoming next
++                                // would lose said memory module type by passing each "current winner" and incoming next
 +                                // villager to #selectWinner.
 +                                poi -> {
 +                                    final List<LivingEntity> livingEntities = instance.get(nearestLivingEntities);
 +
 +                                    Villager winner = villager;
-+                                    for (LivingEntity entity : livingEntities) {
-+                                        if (entity == villager) {
++                                    for (final LivingEntity other : livingEntities) {
++                                        if (other == villager) {
 +                                            continue;
 +                                        }
-+                                        if (!(entity instanceof final net.minecraft.world.entity.npc.Villager other)) {
++                                        if (!(other instanceof final net.minecraft.world.entity.npc.Villager otherVillager)) {
 +                                            continue;
 +                                        }
-+                                        if (!entity.isAlive()) {
++                                        if (!other.isAlive()) {
 +                                            continue;
 +                                        }
-+                                        if (!competesForSameJobsite(globalPos, poi, other)) {
++                                        if (!competesForSameJobsite(globalPos, poi, otherVillager)) {
 +                                            continue;
 +                                        }
-+                                        winner = selectWinner(winner, other);
++                                        winner = selectWinner(winner, otherVillager);
 +                                    }
 +                                }
 +                                // Paper end - Improve performance of PoiCompetitorScan by unrolling stream

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java.patch
@@ -1,0 +1,33 @@
+--- a/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java
++++ b/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java
+@@ -22,13 +_,23 @@
+                         level.getPoiManager()
+                             .getType(globalPos.pos())
+                             .ifPresent(
+-                                poi -> instance.<List<LivingEntity>>get(nearestLivingEntities)
+-                                    .stream()
+-                                    .filter(entity -> entity instanceof Villager && entity != villager)
+-                                    .map(entity -> (Villager)entity)
+-                                    .filter(LivingEntity::isAlive)
+-                                    .filter(v -> competesForSameJobsite(globalPos, poi, v))
+-                                    .reduce(villager, PoiCompetitorScan::selectWinner)
++                                poi -> {
++                                    List<LivingEntity> livingEntities = instance.get(nearestLivingEntities);
++
++                                    Villager winner = villager;
++                                    for (LivingEntity entity : livingEntities) {
++                                        if (!(entity instanceof Villager && entity != villager)) {
++                                            continue;
++                                        }
++                                        if (!entity.isAlive()) {
++                                            continue;
++                                        }
++                                        if (!competesForSameJobsite(globalPos, poi, (Villager) entity)) {
++                                            continue;
++                                        }
++                                        winner = selectWinner(winner, (Villager) entity);
++                                    }
++                                }
+                             );
+                         return true;
+                     }

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java.patch
@@ -1,6 +1,12 @@
 --- a/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java
 +++ b/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java
-@@ -22,13 +_,23 @@
+@@ -17,18 +_,33 @@
+             instance -> instance.group(instance.present(MemoryModuleType.JOB_SITE), instance.present(MemoryModuleType.NEAREST_LIVING_ENTITIES))
+                 .apply(
+                     instance,
+-                    (jobSite, nearestLivingEntities) -> (level, villager, gameTime) -> {
++                    (jobSite, nearestLivingEntities) -> (level, villagerA, gameTime) -> {
+                         GlobalPos globalPos = instance.get(jobSite);
                          level.getPoiManager()
                              .getType(globalPos.pos())
                              .ifPresent(
@@ -12,21 +18,26 @@
 -                                    .filter(v -> competesForSameJobsite(globalPos, poi, v))
 -                                    .reduce(villager, PoiCompetitorScan::selectWinner)
 +                                poi -> {
++                                    // Paper start - Improve performance of PoiCompetitorScan by unrolling stream
 +                                    List<LivingEntity> livingEntities = instance.get(nearestLivingEntities);
 +
-+                                    Villager winner = villager;
++                                    Villager winner = villagerA;
 +                                    for (LivingEntity entity : livingEntities) {
-+                                        if (!(entity instanceof Villager && entity != villager)) {
++                                        if (entity == villagerA) {
++                                            continue;
++                                        }
++                                        if (!(entity instanceof net.minecraft.world.entity.npc.Villager villagerB)) {
 +                                            continue;
 +                                        }
 +                                        if (!entity.isAlive()) {
 +                                            continue;
 +                                        }
-+                                        if (!competesForSameJobsite(globalPos, poi, (Villager) entity)) {
++                                        if (!competesForSameJobsite(globalPos, poi, villagerB)) {
 +                                            continue;
 +                                        }
-+                                        winner = selectWinner(winner, (Villager) entity);
++                                        winner = selectWinner(winner, villagerB);
 +                                    }
++                                    // Paper end - Improve performance of PoiCompetitorScan by unrolling stream
 +                                }
                              );
                          return true;

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java
 +++ b/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java
-@@ -17,18 +_,33 @@
+@@ -17,21 +_,36 @@
              instance -> instance.group(instance.present(MemoryModuleType.JOB_SITE), instance.present(MemoryModuleType.NEAREST_LIVING_ENTITIES))
                  .apply(
                      instance,
 -                    (jobSite, nearestLivingEntities) -> (level, villager, gameTime) -> {
++                    // Paper start - Improve performance of PoiCompetitorScan by unrolling stream
 +                    (jobSite, nearestLivingEntities) -> (level, villagerA, gameTime) -> {
                          GlobalPos globalPos = instance.get(jobSite);
                          level.getPoiManager()
@@ -18,7 +19,6 @@
 -                                    .filter(v -> competesForSameJobsite(globalPos, poi, v))
 -                                    .reduce(villager, PoiCompetitorScan::selectWinner)
 +                                poi -> {
-+                                    // Paper start - Improve performance of PoiCompetitorScan by unrolling stream
 +                                    List<LivingEntity> livingEntities = instance.get(nearestLivingEntities);
 +
 +                                    Villager winner = villagerA;
@@ -37,8 +37,11 @@
 +                                        }
 +                                        winner = selectWinner(winner, villagerB);
 +                                    }
-+                                    // Paper end - Improve performance of PoiCompetitorScan by unrolling stream
 +                                }
                              );
                          return true;
                      }
++                    // Paper end - Improve performance of PoiCompetitorScan by unrolling stream
+                 )
+         );
+     }

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java.patch
@@ -1,13 +1,6 @@
 --- a/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java
 +++ b/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java
-@@ -17,21 +_,36 @@
-             instance -> instance.group(instance.present(MemoryModuleType.JOB_SITE), instance.present(MemoryModuleType.NEAREST_LIVING_ENTITIES))
-                 .apply(
-                     instance,
--                    (jobSite, nearestLivingEntities) -> (level, villager, gameTime) -> {
-+                    // Paper start - Improve performance of PoiCompetitorScan by unrolling stream
-+                    (jobSite, nearestLivingEntities) -> (level, villagerA, gameTime) -> {
-                         GlobalPos globalPos = instance.get(jobSite);
+@@ -22,13 +_,32 @@
                          level.getPoiManager()
                              .getType(globalPos.pos())
                              .ifPresent(
@@ -18,30 +11,32 @@
 -                                    .filter(LivingEntity::isAlive)
 -                                    .filter(v -> competesForSameJobsite(globalPos, poi, v))
 -                                    .reduce(villager, PoiCompetitorScan::selectWinner)
++                                // Paper start - Improve performance of PoiCompetitorScan by unrolling stream
++                                // The previous logic used Stream#reduce to simulate a form of single-iteration bubble sort
++                                // in which the "winning" villager would maintain MemoryModuleType.JOB_SITE while all others
++                                // would loose said memory module type by passing each "current winner" and incoming next
++                                // villager to #selectWinner.
 +                                poi -> {
-+                                    List<LivingEntity> livingEntities = instance.get(nearestLivingEntities);
++                                    final List<LivingEntity> livingEntities = instance.get(nearestLivingEntities);
 +
-+                                    Villager winner = villagerA;
++                                    Villager winner = villager;
 +                                    for (LivingEntity entity : livingEntities) {
-+                                        if (entity == villagerA) {
++                                        if (entity == villager) {
 +                                            continue;
 +                                        }
-+                                        if (!(entity instanceof net.minecraft.world.entity.npc.Villager villagerB)) {
++                                        if (!(entity instanceof final net.minecraft.world.entity.npc.Villager other)) {
 +                                            continue;
 +                                        }
 +                                        if (!entity.isAlive()) {
 +                                            continue;
 +                                        }
-+                                        if (!competesForSameJobsite(globalPos, poi, villagerB)) {
++                                        if (!competesForSameJobsite(globalPos, poi, other)) {
 +                                            continue;
 +                                        }
-+                                        winner = selectWinner(winner, villagerB);
++                                        winner = selectWinner(winner, other);
 +                                    }
 +                                }
++                                // Paper end - Improve performance of PoiCompetitorScan by unrolling stream
                              );
                          return true;
                      }
-+                    // Paper end - Improve performance of PoiCompetitorScan by unrolling stream
-                 )
-         );
-     }


### PR DESCRIPTION
I was debugging villagers and I noticed that the reduce on the stream has massive overhead so I decided to unroll it.
Here are sparks for before and after:
[Before](https://spark.lucko.me/3fTr1E6BK8)
[After](https://spark.lucko.me/rc6SrM21zA)
Those numbers are with 229 active villagers on R7 5700X with 64GB of RAM.
![image](https://github.com/user-attachments/assets/40dfdfe9-73b8-4920-91cd-ade6fd375222)
Here is the test world:
[world.tar.gz](https://github.com/user-attachments/files/18280935/world.tar.gz)