### PR TITLE
[ci skip] Add missing Nullable annotations for NMS DamageSource

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/damagesource/DamageSource.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/damagesource/DamageSource.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/damagesource/DamageSource.java
 +++ b/net/minecraft/world/damagesource/DamageSource.java
-@@ -20,6 +_,105 @@
+@@ -20,6 +_,107 @@
      private final Entity directEntity;
      @Nullable
      private final Vec3 damageSourcePosition;
@@ -58,18 +58,19 @@
 +        return damageSource;
 +    }
 +
++    @Nullable
 +    public org.bukkit.block.Block getDirectBlock() {
 +        return this.directBlock;
 +    }
 +
-+    public DamageSource directBlock(net.minecraft.world.level.Level world, net.minecraft.core.BlockPos blockPosition) {
++    public DamageSource directBlock(@Nullable net.minecraft.world.level.Level world, @Nullable net.minecraft.core.BlockPos blockPosition) {
 +        if (blockPosition == null || world == null) {
 +            return this;
 +        }
 +        return this.directBlock(org.bukkit.craftbukkit.block.CraftBlock.at(world, blockPosition));
 +    }
 +
-+    public DamageSource directBlock(org.bukkit.block.Block block) {
++    public DamageSource directBlock(@Nullable org.bukkit.block.Block block) {
 +        if (block == null) {
 +            return this;
 +        }
@@ -79,11 +80,12 @@
 +        return damageSource;
 +    }
 +
++    @Nullable
 +    public org.bukkit.block.BlockState getDirectBlockState() {
 +        return this.directBlockState;
 +    }
 +
-+    public DamageSource directBlockState(org.bukkit.block.BlockState blockState) {
++    public DamageSource directBlockState(@Nullable org.bukkit.block.BlockState blockState) {
 +        if (blockState == null) {
 +            return this;
 +        }


### PR DESCRIPTION
When make https://github.com/PaperMC/Paper/pull/11840 i notice a few missing annotation in DamageSource where custom fields has the Nullable annotation but the get methods added or a few parameter not.. this PR just add things missing things for make more clear in IDE the nullable thing...