### PR TITLE
Fix settings changes not being saved (closes #11878)

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/dedicated/Settings.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/dedicated/Settings.java.patch
@@ -122,7 +122,7 @@
              Properties map = Settings.this.cloneProperties();
              map.put(this.key, this.serializer.apply(newValue));
 -            return Settings.this.reload(registryAccess, map);
-+            return Settings.this.reload(registryAccess, properties, Settings.this.options); // CraftBukkit
++            return Settings.this.reload(registryAccess, map, Settings.this.options); // CraftBukkit
          }
      }
  }


### PR DESCRIPTION
Closes #11878.
I accidentally broke this during the hard fork, since properties is the name of the existing map this compiled fine and slipped by.