### PR TITLE
[ci skip] Add @throws to BlockData#createBlockState JavaDoc

### DIFF
--- a/paper-api/src/main/java/org/bukkit/block/data/BlockData.java
+++ b/paper-api/src/main/java/org/bukkit/block/data/BlockData.java
@@ -275,6 +275,7 @@ public interface BlockData extends Cloneable {
      * bound to a location.
      *
      * @return a new {@link BlockState}
+     * @throws IllegalStateException if the block is required to be placed to get a BlockState
      */
     @NotNull
     @ApiStatus.Experimental


### PR DESCRIPTION
Properly indicate in the JavaDoc that the method can throw an IllegalStateException if a block requires to be placed to get a BlockState for it (Currently only occurs for MOVING_PISTON).

Addresses #11887 