### PR TITLE
Fix client visual desync if cooldown events are cancelled

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/item/ServerItemCooldowns.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/ServerItemCooldowns.java.patch
@@ -38,7 +38,7 @@
 +                duration
 +            );
 +            if (!event.callEvent()) {
-+                this.onCooldownStarted(groupId, this.getCurrentCooldown(groupId));
++                this.player.connection.send(new ClientboundCooldownPacket(groupId, this.getCurrentCooldown(groupId)));
 +                return;
 +            }
 +

--- a/paper-server/patches/sources/net/minecraft/world/item/ServerItemCooldowns.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/ServerItemCooldowns.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/ServerItemCooldowns.java
 +++ b/net/minecraft/world/item/ServerItemCooldowns.java
-@@ -11,6 +_,39 @@
+@@ -11,6 +_,42 @@
          this.player = player;
      }
  
@@ -15,7 +15,9 @@
 +            duration
 +        );
 +        if (event.callEvent()) {
-+            super.addCooldown(cooldownGroup, event.getCooldown(), false);
++            this.addCooldown(cooldownGroup, event.getCooldown(), false);
++        } else {
++            this.onCooldownEnded(cooldownGroup);
 +        }
 +    }
 +
@@ -28,6 +30,7 @@
 +                duration
 +            );
 +            if (!event.callEvent()) {
++                this.onCooldownEnded(groupId);
 +                return;
 +            }
 +

--- a/paper-server/patches/sources/net/minecraft/world/item/ServerItemCooldowns.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/ServerItemCooldowns.java.patch
@@ -10,7 +10,7 @@
 +        if (cooldownInstance == null) {
 +            return 0;
 +        }
-+        return cooldownInstance.endTime() - this.tickCount;
++        return Math.max(0, cooldownInstance.endTime() - this.tickCount);
 +    }
 +
 +    @Override
@@ -25,7 +25,7 @@
 +        if (event.callEvent()) {
 +            this.addCooldown(cooldownGroup, event.getCooldown(), false);
 +        } else {
-+            this.onCooldownStarted(cooldownGroup, this.getCurrentCooldown(cooldownGroup));
++            this.player.connection.send(new ClientboundCooldownPacket(cooldownGroup, this.getCurrentCooldown(cooldownGroup)));
 +        }
 +    }
 +

--- a/paper-server/patches/sources/net/minecraft/world/item/ServerItemCooldowns.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/ServerItemCooldowns.java.patch
@@ -1,10 +1,18 @@
 --- a/net/minecraft/world/item/ServerItemCooldowns.java
 +++ b/net/minecraft/world/item/ServerItemCooldowns.java
-@@ -11,6 +_,42 @@
+@@ -11,6 +_,50 @@
          this.player = player;
      }
  
 +    // Paper start - Add PlayerItemCooldownEvent
++    private int getCurrentCooldown(final ResourceLocation groupId) {
++        final net.minecraft.world.item.ItemCooldowns.CooldownInstance cooldownInstance = this.cooldowns.get(groupId);
++        if (cooldownInstance == null) {
++            return 0;
++        }
++        return cooldownInstance.endTime() - this.tickCount;
++    }
++
 +    @Override
 +    public void addCooldown(ItemStack item, int duration) {
 +        final ResourceLocation cooldownGroup = this.getCooldownGroup(item);
@@ -17,7 +25,7 @@
 +        if (event.callEvent()) {
 +            this.addCooldown(cooldownGroup, event.getCooldown(), false);
 +        } else {
-+            this.onCooldownEnded(cooldownGroup);
++            this.onCooldownStarted(cooldownGroup, this.getCurrentCooldown(cooldownGroup));
 +        }
 +    }
 +
@@ -30,7 +38,7 @@
 +                duration
 +            );
 +            if (!event.callEvent()) {
-+                this.onCooldownEnded(groupId);
++                this.onCooldownStarted(groupId, this.getCurrentCooldown(groupId));
 +                return;
 +            }
 +


### PR DESCRIPTION
This PR aims to fix a visual desync when a cooldown is cancelled, currently if you cancel the event the client still think the cooldown is running show in hotbar the effect for cooldown, them this PR add a call in the server instance of cooldown for call the onCooldownEnded behaviour for notice client about the change (still show the effect but like 1 tick... rather than the supposed time) also this make a minor change for not call super and call the same methods in the server instance where already call the super methods if need.

PD: Not sure if is intended but based in how vanilla works not sure in what cases the PlayerItemGroupCooldownEvent can run, because PlayerItemCooldownEvent is called first and then just tell now call the event again for the group.

**Testing Code**
I found this because i wanna use the cooldown but wanna fire in another moment rather than the use.. then i set the component and cancel the use cooldown for call later when need using the Bukkit method.
```java
public final class TestPlugin extends JavaPlugin implements Listener {

    private NamespacedKey KEY_COOLDOWN;

    @Override
    public void onEnable() {
        this.getServer().getPluginManager().registerEvents(this, this);

        this.getServer().getCommandMap().register("fallback", new BukkitCommand("test", "cool test command", "<>", List.of("test-alias")) {
            @Override
            public boolean execute(@NotNull CommandSender sender, @NotNull String commandLabel, @NotNull String[] args) {
                if (sender instanceof Player player) {
                    ItemStack itemStack = new ItemStack(Material.FISHING_ROD);
                    itemStack.setData(DataComponentTypes.USE_COOLDOWN, UseCooldown.useCooldown(2).cooldownGroup(KEY_COOLDOWN).build());
                    player.getInventory().addItem(itemStack);
                }
                return true;
            }
        });
    }

    @EventHandler
    public void onCooldown(PlayerItemGroupCooldownEvent event){
        final Player player = event.getPlayer();
        if (KEY_COOLDOWN.equals(event.getCooldownGroup())) {
            event.setCancelled(true);
        }
    }
}
```

**Behaviour Pre-PR**
https://github.com/user-attachments/assets/5df5d056-884f-4ceb-89ef-394e9331eb90

**Behaviour Post-PR**
https://github.com/user-attachments/assets/0f05bbaf-ffab-4b97-ae1a-19e1012f4ff2

