### PR TITLE
Fix typo in no-permission message text

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -88,7 +88,7 @@ public class GlobalConfiguration extends ConfigurationPart {
             public Component flyingVehicle = Component.translatable("multiplayer.disconnect.flying");
         }
 
-        public Component noPermission = Component.text("I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error.", NamedTextColor.RED);
+        public Component noPermission = Component.text("I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is an error.", NamedTextColor.RED);
         public boolean useDisplayNameInQuitMessage = false;
     }
 


### PR DESCRIPTION
Just a simple fix for a little typo