### PR TITLE
Fix vanilla parity on enchantable items with no targets

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/inventory/EnchantmentMenu.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/EnchantmentMenu.java.patch
@@ -125,7 +125,7 @@
 +                        org.bukkit.craftbukkit.inventory.CraftItemStack craftItemStack = org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack);
 +                        Holder<Enchantment> holder = registry.byId(this.enchantClue[id]);
 +                        if (holder == null) return;
-+                        org.bukkit.enchantments.Enchantment hintedEnchantment = org.bukkit.craftbukkit.enchantments.CraftEnchantment.minecraftHolderToBukkit(registry.byId(this.enchantClue[id]));
++                        org.bukkit.enchantments.Enchantment hintedEnchantment = org.bukkit.craftbukkit.enchantments.CraftEnchantment.minecraftHolderToBukkit(holder);
 +                        int hintedEnchantmentLevel = this.levelClue[id];
 +                        org.bukkit.event.enchantment.EnchantItemEvent event = new org.bukkit.event.enchantment.EnchantItemEvent((org.bukkit.entity.Player) player.getBukkitEntity(), this.getBukkitView(), this.access.getLocation().getBlock(), craftItemStack, this.costs[id], enchants, hintedEnchantment, hintedEnchantmentLevel, id);
 +                        level.getCraftServer().getPluginManager().callEvent(event);

--- a/paper-server/patches/sources/net/minecraft/world/inventory/EnchantmentMenu.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/EnchantmentMenu.java.patch
@@ -64,7 +64,7 @@
                  this.access.execute((level, blockPos) -> {
                      IdMap<Holder<Enchantment>> holderIdMap = level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT).asHolderIdMap();
                      int i1 = 0;
-@@ -119,6 +_,42 @@
+@@ -119,6 +_,41 @@
                          }
                      }
  
@@ -97,7 +97,6 @@
 +                                .bukkitToMinecraftHolder(offer.getEnchantment()));
 +                            this.levelClue[j] = offer.getEnchantmentLevel();
 +                        } else {
-+                            this.costs[j] = 0;
 +                            this.enchantClue[j] = -1;
 +                            this.levelClue[j] = -1;
 +                        }
@@ -107,7 +106,7 @@
                      this.broadcastChanges();
                  });
              } else {
-@@ -145,19 +_,51 @@
+@@ -145,19 +_,53 @@
                  return false;
              } else {
                  this.access.execute((level, blockPos) -> {
@@ -124,6 +123,8 @@
 +                            enchants.put(org.bukkit.craftbukkit.enchantments.CraftEnchantment.minecraftHolderToBukkit(instance.enchantment), instance.level);
 +                        }
 +                        org.bukkit.craftbukkit.inventory.CraftItemStack craftItemStack = org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack);
++                        Holder<Enchantment> holder = registry.byId(this.enchantClue[id]);
++                        if (holder == null) return;
 +                        org.bukkit.enchantments.Enchantment hintedEnchantment = org.bukkit.craftbukkit.enchantments.CraftEnchantment.minecraftHolderToBukkit(registry.byId(this.enchantClue[id]));
 +                        int hintedEnchantmentLevel = this.levelClue[id];
 +                        org.bukkit.event.enchantment.EnchantItemEvent event = new org.bukkit.event.enchantment.EnchantItemEvent((org.bukkit.entity.Player) player.getBukkitEntity(), this.getBukkitView(), this.access.getLocation().getBlock(), craftItemStack, this.costs[id], enchants, hintedEnchantment, hintedEnchantmentLevel, id);

--- a/paper-server/patches/sources/net/minecraft/world/inventory/EnchantmentMenu.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/EnchantmentMenu.java.patch
@@ -64,7 +64,7 @@
                  this.access.execute((level, blockPos) -> {
                      IdMap<Holder<Enchantment>> holderIdMap = level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT).asHolderIdMap();
                      int i1 = 0;
-@@ -119,6 +_,41 @@
+@@ -119,6 +_,42 @@
                          }
                      }
  
@@ -97,6 +97,7 @@
 +                                .bukkitToMinecraftHolder(offer.getEnchantment()));
 +                            this.levelClue[j] = offer.getEnchantmentLevel();
 +                        } else {
++                            if (enchantClue[j] != -1) this.costs[j] = 0;
 +                            this.enchantClue[j] = -1;
 +                            this.levelClue[j] = -1;
 +                        }


### PR DESCRIPTION
This pull request fixes #11821

Previously after the enchantment event took place bukkit would clear out all empty enchantments and send a completely empty offer list to the client. Minecraft handles this differently by default by still sending a cost to the client so the slots illuminate as seen in the attached issue.

This pull request attempts to address this issue by not setting back enchantment offer cost to 0 after PrepareItemEnchantEvent. This keeps the original price that was generated through the loop earlier within the slotsChanged method.

As far as drawbacks go for this fix after looking into this it would largely be thinking about how things are handled event side, because something would need to be done. If a developer wants to null out a spot how do we address this while maintaining vanilla behavior when an item may have no offers available? Or should vanilla behavior be kept to start with?

For reference when blanking out all 3 offers an enchanment table now looks like this, client side the hover shows no enchantment names, however displays all levels.
```kotlin
    @EventHandler
    fun onEnchant(event: PrepareItemEnchantEvent) {
        for (index in event.offers.indices) {
            event.offers[index] = null
        }
    }
```
![image](https://github.com/user-attachments/assets/08cd499e-685b-4a97-a0cf-2c15fa743182)

within default vanilla behavior as far as I'm aware there is no scenario where three enchantments aren't sent.
