### PR TITLE
Fix TargetHitEvent#getSignalStrength() post-hard-fork

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/TargetBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TargetBlock.java.patch
@@ -20,12 +20,12 @@
 +        if (projectile instanceof Projectile) {
 +            final org.bukkit.craftbukkit.block.CraftBlock craftBlock = org.bukkit.craftbukkit.block.CraftBlock.at(level, hit.getBlockPos());
 +            final org.bukkit.block.BlockFace blockFace = org.bukkit.craftbukkit.block.CraftBlock.notchToBlockFace(hit.getDirection());
-+            final io.papermc.paper.event.block.TargetHitEvent targetHitEvent = new io.papermc.paper.event.block.TargetHitEvent((org.bukkit.entity.Projectile) projectile.getBukkitEntity(), craftBlock, blockFace, i);
++            final io.papermc.paper.event.block.TargetHitEvent targetHitEvent = new io.papermc.paper.event.block.TargetHitEvent((org.bukkit.entity.Projectile) projectile.getBukkitEntity(), craftBlock, blockFace, redstoneStrength);
 +            if (targetHitEvent.callEvent()) {
-+                i = targetHitEvent.getSignalStrength();
++                redstoneStrength = targetHitEvent.getSignalStrength();
 +                shouldAward = true;
 +            } else {
-+                return i;
++                return redstoneStrength;
 +            }
 +        }
 +        // Paper end - Add TargetHitEvent

--- a/paper-server/patches/sources/net/minecraft/world/level/block/TargetBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TargetBlock.java.patch
@@ -35,7 +35,7 @@
 +
 +        // Paper start - Award Hit Criteria after Block Update
 +        if (shouldAward) {
-+            awardTargetHitCriteria((Projectile) projectile, hit, i);
++            awardTargetHitCriteria((Projectile) projectile, hit, redstoneStrength);
 +        }
 +        // Paper end - Award Hit Criteria after Block Update
  


### PR DESCRIPTION
Reported in discord `TargetHitEvent#getSignalStrength()` return just 20 or 8 based in the projectile this behaviour is a side-effect caused by hard-fork where pre-hard-fork the value used is called "i" (ref: https://github.com/PaperMC/Paper/blob/master/patches/server/0441-Add-TargetHitEvent.patch and broken in https://github.com/PaperMC/Paper/commit/e9680a5afedcf05341b332870e0c542a17d78efa#diff-3a492050417244fc5b90189b40134f0124f010ffb92b94158329562b71014f59R16) but now is called `redstoneStrength` and `i` is just used for another thing.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-11897.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/2385196968.zip)