### PR TITLE
Fix parse of sound event in MusicInstrument

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftMusicInstrument.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftMusicInstrument.java
@@ -1,24 +1,24 @@
 package org.bukkit.craftbukkit;
 
 import com.google.common.base.Preconditions;
+import io.papermc.paper.registry.RegistryAccess;
+import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.util.Holderable;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.item.Instrument;
 import org.bukkit.MusicInstrument;
 import org.bukkit.NamespacedKey;
-import org.bukkit.Registry;
-import org.bukkit.craftbukkit.util.Handleable;
 import org.jetbrains.annotations.NotNull;
 
 public class CraftMusicInstrument extends MusicInstrument implements io.papermc.paper.util.Holderable<Instrument> {
 
     public static MusicInstrument minecraftToBukkit(Instrument minecraft) {
-        return CraftRegistry.minecraftToBukkit(minecraft, Registries.INSTRUMENT, Registry.INSTRUMENT);
+        return CraftRegistry.minecraftToBukkit(minecraft, Registries.INSTRUMENT, RegistryAccess.registryAccess().getRegistry(RegistryKey.INSTRUMENT));
     }
 
     public static MusicInstrument minecraftHolderToBukkit(Holder<Instrument> minecraft) {
-        return CraftRegistry.minecraftHolderToBukkit(minecraft, Registry.INSTRUMENT); // Paper - switch to Holder
+        return CraftRegistry.minecraftHolderToBukkit(minecraft, RegistryAccess.registryAccess().getRegistry(RegistryKey.INSTRUMENT));
     }
 
     public static Instrument bukkitToMinecraft(MusicInstrument bukkit) {
@@ -26,22 +26,46 @@ public class CraftMusicInstrument extends MusicInstrument implements io.papermc.
     }
 
     public static Holder<Instrument> bukkitToMinecraftHolder(MusicInstrument bukkit) {
-        return CraftRegistry.bukkitToMinecraftHolder(bukkit, Registries.INSTRUMENT); // Paper - switch to Holder
+        return CraftRegistry.bukkitToMinecraftHolder(bukkit, Registries.INSTRUMENT);
     }
 
-    public static Object bukkitToString(MusicInstrument bukkit) { // Paper - switch to Holder
+    public static Object bukkitToString(MusicInstrument bukkit) {
         Preconditions.checkArgument(bukkit != null);
 
-        return ((CraftMusicInstrument) bukkit).toBukkitSerializationObject(Instrument.CODEC); // Paper - switch to Holder
+        return ((CraftMusicInstrument) bukkit).toBukkitSerializationObject(Instrument.CODEC);
     }
 
-    public static MusicInstrument stringToBukkit(Object string) { // Paper - switch to Holder
+    public static MusicInstrument stringToBukkit(Object string) {
         Preconditions.checkArgument(string != null);
 
-        return io.papermc.paper.util.Holderable.fromBukkitSerializationObject(string, Instrument.CODEC, Registry.INSTRUMENT); // Paper - switch to Holder
+        return io.papermc.paper.util.Holderable.fromBukkitSerializationObject(string, Instrument.CODEC, RegistryAccess.registryAccess().getRegistry(RegistryKey.INSTRUMENT));
     }
 
-    // Paper start - switch to Holder
+    private final Holder<Instrument> holder;
+
+    public CraftMusicInstrument(Holder<Instrument> holder) {
+        this.holder = holder;
+    }
+
+    @Override
+    public Holder<Instrument> getHolder() {
+        return this.holder;
+        }
+
+    @NotNull
+    @Override
+    public NamespacedKey getKey() {
+        return Holderable.super.getKey();
+    }
+
+    @Override
+    public @NotNull String translationKey() {
+        if (!(this.getHandle().description().getContents() instanceof final net.minecraft.network.chat.contents.TranslatableContents translatableContents)) {
+            throw new UnsupportedOperationException("Description isn't translatable!"); // Paper
+        }
+        return translatableContents.getKey();
+    }
+
     @Override
     public boolean equals(final Object o) {
         return this.implEquals(o);
@@ -56,33 +80,4 @@ public class CraftMusicInstrument extends MusicInstrument implements io.papermc.
     public String toString() {
         return this.implToString();
     }
-
-    private final Holder<Instrument> holder;
-    public CraftMusicInstrument(Holder<Instrument> holder) {
-        this.holder = holder;
-        // Paper end - switch to Holder
-    }
-
-    @Override
-    public Holder<Instrument> getHolder() { // Paper - switch to Holder
-        return this.holder; // Paper - switch to Holder
-    }
-
-    @NotNull
-    @Override
-    public NamespacedKey getKey() {
-        return Holderable.super.getKey();
-    }
-
-    // Paper start - add translationKey methods
-    @Override
-    public @NotNull String translationKey() {
-        if (!(this.getHandle().description().getContents() instanceof final net.minecraft.network.chat.contents.TranslatableContents translatableContents)) {
-            throw new UnsupportedOperationException("Description isn't translatable!"); // Paper
-        }
-        return translatableContents.getKey();
-    }
-    // Paper end - add translationKey methods
-
-    // Paper - switch to Holder
 }


### PR DESCRIPTION
This PR is refer a issue mentioned in Discord where a item with a sound event in the instrument component throw a convert issue when call getItemMeta.
in a few tests i come to the CraftMusicInstrument and notice the use of a deprecate registry thing i change this and works but not really sure if this is the correct fix.. mostly the issue is ItemMeta and the expected things...