### PR TITLE
Fix DiscoveredDatapack#getSource

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/datapack/PaperDiscoveredDatapack.java
+++ b/paper-server/src/main/java/io/papermc/paper/datapack/PaperDiscoveredDatapack.java
@@ -64,6 +64,6 @@ public class PaperDiscoveredDatapack implements DiscoveredDatapack {
 
     @Override
     public DatapackSource getSource() {
-        return PACK_SOURCES.computeIfAbsent(this.pack.location().source(), source -> new DatapackSourceImpl(source.toString()));
+        return PACK_SOURCES.get(this.pack.location().source());
     }
 }

--- a/paper-server/src/main/resources/data/minecraft/datapacks/paper/pack.mcmeta
+++ b/paper-server/src/main/resources/data/minecraft/datapacks/paper/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
         "description": "Built-in Paper Datapack",
-        "pack_format": 41
+        "pack_format": 61
     }
 }


### PR DESCRIPTION
PACK_SOURCES is an immutable map and will throw UOE when used.
Also bump the datapack version of the built-in datapack so the api doesn't say paper is outdated.