### PR TITLE
Fix removing the "LootTable" nbt tag from Block entities

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/RandomizableContainer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/RandomizableContainer.java.patch
@@ -9,7 +9,7 @@
          this.setLootTable(lootTable);
          this.setLootTableSeed(seed);
      }
-@@ -50,14 +_,15 @@
+@@ -50,15 +_,17 @@
  
      default boolean tryLoadLootTable(CompoundTag tag) {
          if (tag.contains("LootTable", 8)) {
@@ -25,8 +25,10 @@
 -            return true;
 +            return this.lootableData() == null; // Paper - only track the loot table if there is chance for replenish
          } else {
++            setLootTable(null); // Paper - Fix removing loottable from nbt not updating block entity, MC-279196
              return false;
          }
+     }
 @@ -69,26 +_,42 @@
              return false;
          } else {


### PR DESCRIPTION
Also fixes Lootable blocks not respecting Lootable.setLootTable(null)
Note: when testing, the #setLootTable() call needs to be followed by #update(), as with other block entities

This bug affects vanilla, and was reported as [MC-279196](https://bugs.mojang.com/browse/MC-279196)