### PR TITLE
Fix MapItem incorectly fetching water biomes on treasure maps

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/item/MapItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/MapItem.java.patch
@@ -16,7 +16,7 @@
                  for (int i5 = 0; i5 < 128; i5++) {
                      for (int i6 = 0; i6 < 128; i6++) {
 -                        Holder<Biome> biome = serverLevel.getBiome(mutableBlockPos.set((i3 + i6) * i, 0, (i4 + i5) * i));
-+                        Holder<Biome> biome = serverLevel.getUncachedNoiseBiome((i3 + i6) * i, 0, (i4 + i5) * i); // Paper - Perf: Use seed based lookup for treasure maps
++                        Holder<Biome> biome = serverLevel.getUncachedNoiseBiome(net.minecraft.core.QuartPos.fromBlock((i3 + i6) * i), net.minecraft.core.QuartPos.fromBlock(0), net.minecraft.core.QuartPos.fromBlock((i4 + i5) * i)); // Paper - Perf: Use seed based lookup for treasure maps
                          flags[i5 * 128 + i6] = biome.is(BiomeTags.WATER_ON_MAP_OUTLINES);
                      }
                  }


### PR DESCRIPTION
This fixes a slight deviation from vanilla in that we incorrectly use the x/y/z coordinates rather than passing section coords.
This is because the old method (getBiome) uses block coords, while uncached noise uses the section positions.

This whole "optimization" creates a big enough deviation in that it probably isn't noticeable. So maybe in future, this should be made configurable? 

Note: This is an old issue, not hardfork issue.