### PR TITLE
Fix unstable Suggestion comparison

### DIFF
--- a/paper-server/patches/sources/com/mojang/brigadier/suggestion/IntegerSuggestion.java.patch
+++ b/paper-server/patches/sources/com/mojang/brigadier/suggestion/IntegerSuggestion.java.patch
@@ -1,0 +1,19 @@
+--- a/com/mojang/brigadier/suggestion/IntegerSuggestion.java
++++ b/com/mojang/brigadier/suggestion/IntegerSuggestion.java
+@@ -53,7 +_,7 @@
+ 
+     @Override
+     public int compareTo(final Suggestion o) {
+-        if (o instanceof IntegerSuggestion) {
++        if (false && o instanceof IntegerSuggestion) { // Paper - fix unstable Suggestion comparison
+             return Integer.compare(value, ((IntegerSuggestion) o).value);
+         }
+         return super.compareTo(o);
+@@ -61,6 +_,6 @@
+ 
+     @Override
+     public int compareToIgnoreCase(final Suggestion b) {
+-        return compareTo(b);
++        return super.compareToIgnoreCase(b); // Paper - fix unstable Suggestion comparison
+     }
+ }

--- a/paper-server/patches/sources/com/mojang/brigadier/suggestion/Suggestion.java.patch
+++ b/paper-server/patches/sources/com/mojang/brigadier/suggestion/Suggestion.java.patch
@@ -1,0 +1,32 @@
+--- a/com/mojang/brigadier/suggestion/Suggestion.java
++++ b/com/mojang/brigadier/suggestion/Suggestion.java
+@@ -76,13 +_,27 @@
+             '}';
+     }
+ 
++    // Paper start - fix unstable Suggestion comparison
++    private static int compare0(final Suggestion lhs, final Suggestion rhs, final java.util.Comparator<String> textComparator) {
++        if (lhs instanceof final IntegerSuggestion lis && rhs instanceof final IntegerSuggestion ris) {
++            return Integer.compare(lis.getValue(), ris.getValue());
++        } else if (lhs instanceof IntegerSuggestion) {
++            return -1;
++        } else if (rhs instanceof IntegerSuggestion) {
++            return 1;
++        } else {
++            return textComparator.compare(lhs.text, rhs.text);
++        }
++    }
++    // Paper end - fix unstable Suggestion comparison
++
+     @Override
+     public int compareTo(final Suggestion o) {
+-        return text.compareTo(o.text);
++        return compare0(this, o, java.util.Comparator.naturalOrder()); // Paper - fix unstable Suggestion comparison
+     }
+ 
+     public int compareToIgnoreCase(final Suggestion b) {
+-        return text.compareToIgnoreCase(b.text);
++        return compare0(this, b, String.CASE_INSENSITIVE_ORDER); // Paper - fix unstable Suggestion comparison
+     }
+ 
+     public Suggestion expand(final String command, final StringRange range) {


### PR DESCRIPTION
Brigadier's `Suggestion#compareTo(IgnoreCase)` fails to consider that the other suggestion can be an `IntegerSuggestion`, as well as `IntegerSuggestion#compareToIgnoreCase` simply delegates to `#compareTo`.

This patch adds a stable comparator that considers all IntegerSuggestions to be less than text Suggestions, then within each group, int or text (case-insensitive if applicable) comparison is performed.

Fixes #11852