### PR TITLE
Fix hopper updates source slot twice

### DIFF
--- a/paper-server/patches/features/0029-Optimize-Hoppers.patch
+++ b/paper-server/patches/features/0029-Optimize-Hoppers.patch
@@ -60,7 +60,7 @@ index cc2d442682496197d29ace79b22e6cf6fb7edf5e..ae220a732c78ab076261f20b5a54c71d
              /* Drop global time updates
              if (this.tickCount % 20 == 0) {
 diff --git a/net/minecraft/world/item/ItemStack.java b/net/minecraft/world/item/ItemStack.java
-index 47bf8051da9a04ab333bb2bf6421d6253556b71c..ba31bbdac96e58d299dc260b47aaedf767735a42 100644
+index 0eb9811e573f0c38de3eeb17099872efcbb4c2dd..b511fe8295369ac4014beb351cd2e3f770c10170 100644
 --- a/net/minecraft/world/item/ItemStack.java
 +++ b/net/minecraft/world/item/ItemStack.java
 @@ -808,10 +808,16 @@ public final class ItemStack implements DataComponentHolder {
@@ -103,7 +103,7 @@ index 2ebdf1ad323bb53dfe9eed319e25856b35a1443c..77618757c0e678532dbab814aceed83f
          }
      }
 diff --git a/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index e58a32593e8b42bfc534d13457240860293dd3f4..5cd1326ad5d046c88b2b3449d610a78fa880b4cd 100644
+index e58a32593e8b42bfc534d13457240860293dd3f4..59c067e083bc059060ccd4563f2ba7f521f336f3 100644
 --- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 @@ -139,18 +139,56 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
@@ -618,7 +618,15 @@ index e58a32593e8b42bfc534d13457240860293dd3f4..5cd1326ad5d046c88b2b3449d610a78f
          ItemStack itemStack = item.getItem().copy();
          ItemStack itemStack1 = addItem(null, container, itemStack, null);
          if (itemStack1.isEmpty()) {
-@@ -431,7 +678,9 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -419,6 +666,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+     }
+ 
+     private static ItemStack tryMoveInItem(@Nullable Container source, Container destination, ItemStack stack, int slot, @Nullable Direction direction) {
++        stack = stack.copy(); // Paper - Perf: Optimize Hoppers
+         ItemStack item = destination.getItem(slot);
+         if (canPlaceItemInContainer(destination, stack, slot, direction)) {
+             boolean flag = false;
+@@ -431,7 +679,9 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
                      stack = stack.split(destination.getMaxStackSize());
                  }
                  // Spigot end
@@ -628,7 +636,7 @@ index e58a32593e8b42bfc534d13457240860293dd3f4..5cd1326ad5d046c88b2b3449d610a78f
                  stack = leftover; // Paper - Make hoppers respect inventory max stack size
                  flag = true;
              } else if (canMergeItems(item, stack)) {
-@@ -519,13 +768,19 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -519,13 +769,19 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
  
      @Nullable
      public static Container getContainerAt(Level level, BlockPos pos) {
@@ -650,7 +658,7 @@ index e58a32593e8b42bfc534d13457240860293dd3f4..5cd1326ad5d046c88b2b3449d610a78f
              blockContainer = getEntityContainer(level, x, y, z);
          }
  
-@@ -551,14 +806,14 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -551,14 +807,14 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
  
      @Nullable
      private static Container getEntityContainer(Level level, double x, double y, double z) {


### PR DESCRIPTION
Fix #11740 

The `hopperPush`/`hopperPull` methods introduced by the [Optimize Hoppers](https://github.com/PaperMC/Paper/blob/main/paper-server/patches/features/0029-Optimize-Hoppers.patch) patch already update the source slot correctly after moving items:

- `hopperPush`:
  ![image](https://github.com/user-attachments/assets/def49ca9-03cf-4d37-b0f8-cc93b5a3e7a5)

- `hopperPull`:
  ![image](https://github.com/user-attachments/assets/14b9fad8-79bd-4733-bfc6-4ae035aa49dc)

However, in `HopperBlockEntity#tryMoveInItem`, if the target slot isn't empty (i.e., a merge happens), the source slot is updated once again by shrinking the source `ItemStack`. This causes issues with certain source containers, such as the chiseled bookshelf.

![image](https://github.com/user-attachments/assets/1c4411f3-c46e-4499-bcb2-6a5c140e1f4e)

Since the `ChiseledBookShelfBlockEntity` checks whether the `removeItem` call is meaningful (i.e., ensuring it doesn't attempt to remove an already empty slot), and `tryMoveInItem` is called before `removeItem`, the block state of the current chiseled bookshelf isn't updated properly. As a result, the book still visually remains in the bookshelf:

![image](https://github.com/user-attachments/assets/99b178cc-00e6-48f3-ba37-7888108a2ed4)

The return value of `tryMoveInItem` is essential (it’s used by `hopperPush`/`hopperPull`), so I've added a copy before operating the source `ItemStack` to resolve this issue.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-11945.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/2418542664.zip)