### PR TITLE
Rename getPotentialBedLocation to getPotentialRespawnLocation

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -430,7 +430,9 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      */
     @Nullable
     @Deprecated(since = "1.21.4")
-    public Location getPotentialBedLocation();
+    default Location getPotentialBedLocation() {
+        return this.getPotentialRespawnLocation();
+    }
 
     /**
      * Gets the Location where the player will spawn at, null if they

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -424,9 +424,23 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * is still valid.
      *
      * @return Bed Location if has slept in one, otherwise null.
+     * @see #getPotentialRespawnLocation()
+     * @deprecated Misleading name. This method also returns the location of
+     * respawn anchors.
      */
     @Nullable
+    @Deprecated(since = "1.21.4")
     public Location getPotentialBedLocation();
+
+    /**
+     * Gets the Location where the player will spawn at, null if they
+     * don't have a valid respawn point. This method will not attempt
+     * to validate if the current respawn location is still valid.
+     *
+     * @return respawn location if exists, otherwise null.
+     */
+    @Nullable
+    Location getPotentialRespawnLocation();
     // Paper end
     // Paper start
     /**

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -152,6 +152,10 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     // Paper start - Potential bed api
     @Override
     public Location getPotentialBedLocation() {
+        return this.getPotentialRespawnLocation();
+    }
+    @Override
+    public Location getPotentialRespawnLocation() {
         ServerPlayer handle = (ServerPlayer) getHandle();
         BlockPos bed = handle.getRespawnPosition();
         if (bed == null) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -151,10 +151,6 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
 
     // Paper start - Potential bed api
     @Override
-    public Location getPotentialBedLocation() {
-        return this.getPotentialRespawnLocation();
-    }
-    @Override
     public Location getPotentialRespawnLocation() {
         ServerPlayer handle = (ServerPlayer) getHandle();
         BlockPos bed = handle.getRespawnPosition();


### PR DESCRIPTION
Spigot renamed [getBedSpawnLocation](<https://jd.papermc.io/paper/1.21.4/org/bukkit/entity/Player.html#getBedSpawnLocation()>) to [getRespawnLocation](<https://jd.papermc.io/paper/1.21.4/org/bukkit/entity/Player.html#getRespawnLocation()>) in 1.20.4, this pr makes getPotentialBedLocation match that change, making it also more accessible to find by people who are currently using the new getRespawnLocation name.