### PR TITLE
Add EntityHarvestBlockEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityHarvestBlockEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityHarvestBlockEvent.java
@@ -1,9 +1,10 @@
-package org.bukkit.event.entity;
+package io.papermc.paper.event.entity;
 
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import java.util.List;
@@ -22,7 +23,7 @@ import java.util.List;
  */
 public class EntityHarvestBlockEvent extends EntityEvent implements Cancellable {
 
-    private static final HandlerList handlers = new HandlerList();
+    private static final HandlerList HANDLER_LIST = new HandlerList();
     private boolean cancel = false;
     private final Block harvestedBlock;
     private final List<ItemStack> itemsHarvested;
@@ -66,11 +67,11 @@ public class EntityHarvestBlockEvent extends EntityEvent implements Cancellable 
     @NotNull
     @Override
     public HandlerList getHandlers() {
-        return handlers;
+        return HANDLER_LIST;
     }
 
     @NotNull
     public static HandlerList getHandlerList() {
-        return handlers;
+        return HANDLER_LIST;
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityHarvestBlockEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityHarvestBlockEvent.java
@@ -51,6 +51,9 @@ public class EntityHarvestBlockEvent extends EntityEvent implements Cancellable 
      * Gets a list of items that are being harvested from this block.
      *
      * @return A mutable list of items that are being harvested from this block
+     * @apiNote {@link org.bukkit.entity.Fox} has a behavior where, if it does not have an item
+     * in {@link org.bukkit.inventory.EquipmentSlot#HAND}, it will take one unit from the first
+     * item in its inventory stack and use it in the hand slot.
      */
     public List<ItemStack> getItemsHarvested() {
         return itemsHarvested;

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityHarvestBlockEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityHarvestBlockEvent.java
@@ -6,7 +6,8 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.EntityEvent;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 import java.util.List;
 
 /**
@@ -21,14 +22,17 @@ import java.util.List;
  * for {@link org.bukkit.event.block.BlockBreakEvent} and
  * {@link org.bukkit.event.block.BlockDropItemEvent}.
  */
+@NullMarked
 public class EntityHarvestBlockEvent extends EntityEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
+
     private boolean cancel = false;
     private final Block harvestedBlock;
     private final List<ItemStack> itemsHarvested;
 
-    public EntityHarvestBlockEvent(@NotNull Entity entity, @NotNull Block harvestedBlock, @NotNull List<ItemStack> itemsHarvested) {
+    @ApiStatus.Internal
+    public EntityHarvestBlockEvent(final Entity entity, final Block harvestedBlock, final List<ItemStack> itemsHarvested) {
         super(entity);
         this.harvestedBlock = harvestedBlock;
         this.itemsHarvested = itemsHarvested;
@@ -39,7 +43,6 @@ public class EntityHarvestBlockEvent extends EntityEvent implements Cancellable 
      *
      * @return The block that is being harvested
      */
-    @NotNull
     public Block getHarvestedBlock() {
         return harvestedBlock;
     }
@@ -49,7 +52,6 @@ public class EntityHarvestBlockEvent extends EntityEvent implements Cancellable 
      *
      * @return A list of items that are being harvested from this block
      */
-    @NotNull
     public List<ItemStack> getItemsHarvested() {
         return itemsHarvested;
     }
@@ -64,13 +66,11 @@ public class EntityHarvestBlockEvent extends EntityEvent implements Cancellable 
         this.cancel = cancel;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
 
-    @NotNull
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityHarvestBlockEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityHarvestBlockEvent.java
@@ -50,7 +50,7 @@ public class EntityHarvestBlockEvent extends EntityEvent implements Cancellable 
     /**
      * Gets a list of items that are being harvested from this block.
      *
-     * @return A list of items that are being harvested from this block
+     * @return A mutable list of items that are being harvested from this block
      */
     public List<ItemStack> getItemsHarvested() {
         return itemsHarvested;

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityHarvestBlockEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityHarvestBlockEvent.java
@@ -51,9 +51,9 @@ public class EntityHarvestBlockEvent extends EntityEvent implements Cancellable 
      * Gets a list of items that are being harvested from this block.
      *
      * @return A mutable list of items that are being harvested from this block
-     * @apiNote {@link org.bukkit.entity.Fox} has a behavior where, if it does not have an item
-     * in {@link org.bukkit.inventory.EquipmentSlot#HAND}, it will take one unit from the first
-     * item in its inventory stack and use it in the hand slot.
+     * @apiNote {@link org.bukkit.entity.Fox} has a behavior where, if it does not have
+     * an item in its mouth ({@link org.bukkit.inventory.EquipmentSlot#HAND}), it will
+     * take one unit from the first ItemStack in this harvest and put it there.
      */
     public List<ItemStack> getItemsHarvested() {
         return itemsHarvested;

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityHarvestBlockEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityHarvestBlockEvent.java
@@ -8,6 +8,7 @@ import org.bukkit.event.entity.EntityEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -29,7 +30,7 @@ public class EntityHarvestBlockEvent extends EntityEvent implements Cancellable 
 
     private boolean cancel = false;
     private final Block harvestedBlock;
-    private final List<ItemStack> itemsHarvested;
+    private List<ItemStack> itemsHarvested;
 
     @ApiStatus.Internal
     public EntityHarvestBlockEvent(final Entity entity, final Block harvestedBlock, final List<ItemStack> itemsHarvested) {
@@ -44,24 +45,34 @@ public class EntityHarvestBlockEvent extends EntityEvent implements Cancellable 
      * @return The block that is being harvested
      */
     public Block getHarvestedBlock() {
-        return harvestedBlock;
+        return this.harvestedBlock;
     }
 
     /**
-     * Gets a list of items that are being harvested from this block.
+     * Gets an immutable list of items that are being harvested from this block.
      *
-     * @return A mutable list of items that are being harvested from this block
+     * @return An immutable list of items that are being harvested from this block
      * @apiNote {@link org.bukkit.entity.Fox} has a behavior where, if it does not have
      * an item in its mouth ({@link org.bukkit.inventory.EquipmentSlot#HAND}), it will
      * take one unit from the first ItemStack in this harvest and put it there.
+     * @apiNote This list contains copy of the items; you need to set the items to the list to change them.
      */
     public List<ItemStack> getItemsHarvested() {
-        return itemsHarvested;
+        return Collections.unmodifiableList(this.itemsHarvested);
+    }
+
+    /**
+     * Sets the items that are being harvested from this block.
+     *
+     * @param itemsHarvested A list of items that are being harvested from this block
+     */
+    public void setItemsHarvested(List<ItemStack> itemsHarvested) {
+        this.itemsHarvested = itemsHarvested;
     }
 
     @Override
     public boolean isCancelled() {
-        return cancel;
+        return this.cancel;
     }
 
     @Override

--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityHarvestBlockEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityHarvestBlockEvent.java
@@ -1,0 +1,76 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import java.util.List;
+
+/**
+ * This event is called whenever an entity harvests a block.
+ * <br>
+ * For the player case please use {@link org.bukkit.event.player.PlayerHarvestBlockEvent}
+ * <br>
+ * A 'harvest' is when a block drops an item (usually some sort of crop) and
+ * changes state, but is not broken in order to drop the item.
+ * <br>
+ * This event is not called for when a block is broken, to handle that, listen
+ * for {@link org.bukkit.event.block.BlockBreakEvent} and
+ * {@link org.bukkit.event.block.BlockDropItemEvent}.
+ */
+public class EntityHarvestBlockEvent extends EntityEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
+    private final Block harvestedBlock;
+    private final List<ItemStack> itemsHarvested;
+
+    public EntityHarvestBlockEvent(@NotNull Entity entity, @NotNull Block harvestedBlock, @NotNull List<ItemStack> itemsHarvested) {
+        super(entity);
+        this.harvestedBlock = harvestedBlock;
+        this.itemsHarvested = itemsHarvested;
+    }
+
+    /**
+     * Gets the block that is being harvested.
+     *
+     * @return The block that is being harvested
+     */
+    @NotNull
+    public Block getHarvestedBlock() {
+        return harvestedBlock;
+    }
+
+    /**
+     * Gets a list of items that are being harvested from this block.
+     *
+     * @return A list of items that are being harvested from this block
+     */
+    @NotNull
+    public List<ItemStack> getItemsHarvested() {
+        return itemsHarvested;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerHarvestBlockEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerHarvestBlockEvent.java
@@ -70,7 +70,7 @@ public class PlayerHarvestBlockEvent extends PlayerEvent implements Cancellable 
     /**
      * Gets a list of items that are being harvested from this block.
      *
-     * @return A list of items that are being harvested from this block
+     * @return A mutable list of items that are being harvested from this block
      */
     @NotNull
     public List<ItemStack> getItemsHarvested() {

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerHarvestBlockEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerHarvestBlockEvent.java
@@ -5,6 +5,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityHarvestBlockEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
@@ -12,6 +13,8 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * This event is called whenever a player harvests a block.
+ * <br>
+ * For the entity case please use {@link org.bukkit.event.entity.EntityHarvestBlockEvent}
  * <br>
  * A 'harvest' is when a block drops an item (usually some sort of crop) and
  * changes state, but is not broken in order to drop the item.

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerHarvestBlockEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerHarvestBlockEvent.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * This event is called whenever a player harvests a block.
  * <br>
- * For the entity case please use {@link org.bukkit.event.entity.EntityHarvestBlockEvent}
+ * For cases involving entities, please use {@link EntityHarvestBlockEvent}.
  * <br>
  * A 'harvest' is when a block drops an item (usually some sort of crop) and
  * changes state, but is not broken in order to drop the item.

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerHarvestBlockEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerHarvestBlockEvent.java
@@ -5,7 +5,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
-import org.bukkit.event.entity.EntityHarvestBlockEvent;
+import io.papermc.paper.event.entity.EntityHarvestBlockEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/Fox.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/Fox.java.patch
@@ -146,11 +146,39 @@
                          );
                  }
              }
-@@ -955,6 +_,7 @@
+@@ -955,15 +_,32 @@
          private void pickSweetBerries(BlockState state) {
              int ageValue = state.getValue(SweetBerryBushBlock.AGE);
              state.setValue(SweetBerryBushBlock.AGE, 1);
 +            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(Fox.this, this.blockPos, state.setValue(SweetBerryBushBlock.AGE, 1))) return; // CraftBukkit - call EntityChangeBlockEvent
              int i = 1 + Fox.this.level().random.nextInt(2) + (ageValue == 3 ? 1 : 0);
              ItemStack itemBySlot = Fox.this.getItemBySlot(EquipmentSlot.MAINHAND);
++            // Paper start - call HarvestBlockEvent for the item dropped
++            ItemStack itemHarvest = new ItemStack(Items.SWEET_BERRIES, i);
++            io.papermc.paper.event.entity.EntityHarvestBlockEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityHarvestBlockEvent(Fox.this.level(), this.blockPos, Fox.this, java.util.Collections.singletonList(itemHarvest));
++            java.util.ArrayList<org.bukkit.inventory.ItemStack> itemsHarvested = new java.util.ArrayList<>(event.getItemsHarvested());
++            if (event.isCancelled()) {
++                return;
++            }
              if (itemBySlot.isEmpty()) {
+-                Fox.this.setItemSlot(EquipmentSlot.MAINHAND, new ItemStack(Items.SWEET_BERRIES));
++                if (!itemsHarvested.isEmpty()) {
++                    org.bukkit.inventory.ItemStack firstItemForSlot = itemsHarvested.getFirst().clone();
++                    if (firstItemForSlot.getAmount() == 1) {
++                        itemsHarvested.removeFirst();
++                    } else {
++                        itemsHarvested.set(0, firstItemForSlot.subtract());
++                    }
++                    Fox.this.setItemSlot(EquipmentSlot.MAINHAND, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(firstItemForSlot.asOne()));
++                }
++                // Paper end
+                 i--;
+             }
+ 
+-            if (i > 0) {
+-                Block.popResource(Fox.this.level(), this.blockPos, new ItemStack(Items.SWEET_BERRIES, i));
++            for (org.bukkit.inventory.ItemStack itemStack : itemsHarvested) { // Paper - handle harvest items
++                Block.popResource(Fox.this.level(), this.blockPos, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(itemStack)); // Paper
+             }
+ 
+             Fox.this.playSound(SoundEvents.SWEET_BERRY_BUSH_PICK_BERRIES, 1.0F, 1.0F);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/CaveVines.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/CaveVines.java.patch
@@ -13,14 +13,14 @@
                  Block.dropFromBlockInteractLootTable(
                      serverLevel,
                      BuiltInLootTables.HARVEST_CAVE_VINE,
-@@ -30,8 +_,25 @@
+@@ -30,8 +_,29 @@
                      level.getBlockEntity(pos),
                      null,
                      entity,
 -                    (serverLevel1, itemStack) -> Block.popResource(serverLevel1, pos, itemStack)
 +                    (serverLevel1, itemStack) -> drops.add(itemStack) // Paper - call player harvest block event - store drops from loottable
                  );
-+                // Paper start - call player harvest block event
++                // Paper start - call harvest block event
 +                if (entity instanceof net.minecraft.world.entity.player.Player player) {
 +                    org.bukkit.event.player.PlayerHarvestBlockEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerHarvestBlockEvent(
 +                        level, pos, player, net.minecraft.world.InteractionHand.MAIN_HAND, drops
@@ -32,11 +32,15 @@
 +                        Block.popResource(level, pos, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(itemStack));
 +                    }
 +                } else {
-+                    for (net.minecraft.world.item.ItemStack itemStack : drops) {
-+                        Block.popResource(level, pos, itemStack);
++                    io.papermc.paper.event.entity.EntityHarvestBlockEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityHarvestBlockEvent(level, pos, entity, drops);
++                    if (event.isCancelled()) {
++                        return InteractionResult.SUCCESS; // We need to return a success either way, because making it PASS or FAIL will result in a bug where cancelling while harvesting w/ block in hand places block
++                    }
++                    for (org.bukkit.inventory.ItemStack itemStack : event.getItemsHarvested()) {
++                        Block.popResource(level, pos, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(itemStack));
 +                    }
 +                }
-+                // Paper end - call player harvest block event
++                // Paper end - call harvest block event
                  float f = Mth.randomBetween(serverLevel.random, 0.8F, 1.2F);
                  serverLevel.playSound(null, pos, SoundEvents.CAVE_VINES_PICK_BERRIES, SoundSource.BLOCKS, 1.0F, f);
                  BlockState blockState = state.setValue(BERRIES, false);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/ComposterBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/ComposterBlock.java.patch
@@ -33,7 +33,7 @@
              stack.shrink(1);
              return blockState;
          } else {
-@@ -286,6 +_,14 @@
+@@ -286,11 +_,40 @@
      }
  
      public static BlockState extractProduce(Entity entity, BlockState state, Level level, BlockPos pos) {
@@ -48,6 +48,34 @@
          if (!level.isClientSide()) {
              Vec3 vec3 = Vec3.atLowerCornerWithOffset(pos, 0.5, 1.01, 0.5).offsetRandom(level.random, 0.7F);
              ItemEntity itemEntity = new ItemEntity(level, vec3.x(), vec3.y(), vec3.z(), new ItemStack(Items.BONE_MEAL));
+-            itemEntity.setDefaultPickUpDelay();
+-            level.addFreshEntity(itemEntity);
++            // Paper start - call HarvestBlockEvent for the item dropped
++            // itemEntity.setDefaultPickUpDelay(); // used later
++            // level.addFreshEntity(itemEntity); // used later
++            java.util.List<org.bukkit.inventory.ItemStack> itemsHarvested;
++            if (entity instanceof Player player) {
++                org.bukkit.event.player.PlayerHarvestBlockEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerHarvestBlockEvent(level, pos, player, InteractionHand.MAIN_HAND, java.util.Collections.singletonList(itemEntity.getItem()));
++                itemsHarvested = event.getItemsHarvested();
++                if (event.isCancelled()) {
++                    return state;
++                }
++                } else {
++                    io.papermc.paper.event.entity.EntityHarvestBlockEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityHarvestBlockEvent(level, pos, entity, java.util.Collections.singletonList(itemEntity.getItem()));
++                    itemsHarvested = event.getItemsHarvested();
++                    if (event.isCancelled()) {
++                        return state;
++                    }
++            }
++            for (org.bukkit.inventory.ItemStack itemStack : itemsHarvested) {
++                ItemEntity harvestItemEntity = new ItemEntity(level, vec3.x(), vec3.y(), vec3.z(), org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(itemStack));
++                harvestItemEntity.setDefaultPickUpDelay();
++                level.addFreshEntity(harvestItemEntity);
++            }
++            // Paper end
+         }
+ 
+         BlockState blockState = empty(entity, state, level, pos);
 @@ -305,14 +_,39 @@
          return blockState;
      }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -10,6 +10,7 @@ import io.papermc.paper.adventure.PaperAdventure;
 import io.papermc.paper.connection.HorriblePlayerLoginEventHack;
 import io.papermc.paper.connection.PlayerConnection;
 import io.papermc.paper.event.connection.PlayerConnectionValidateLoginEvent;
+import io.papermc.paper.event.entity.EntityHarvestBlockEvent;
 import io.papermc.paper.event.entity.ItemTransportingEntityValidateTargetEvent;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -319,10 +320,21 @@ public class CraftEventFactory {
         return entityEnterLoveModeEvent;
     }
 
+    /**
+     * Entity Harvest Block Event
+     */
+    public static EntityHarvestBlockEvent callEntityHarvestBlockEvent(Level world, BlockPos blockposition, net.minecraft.world.entity.Entity who, List<ItemStack> itemsToHarvest) {
+        List<org.bukkit.inventory.ItemStack> bukkitItemsToHarvest = itemsToHarvest.stream().map(CraftItemStack::asBukkitCopy).collect(Collectors.toList());
+        org.bukkit.entity.Entity entity = who.getBukkitEntity();
+        EntityHarvestBlockEvent entityHarvestBlockEvent = new EntityHarvestBlockEvent(entity, CraftBlock.at(world, blockposition), bukkitItemsToHarvest);
+        entityHarvestBlockEvent.callEvent();
+        return entityHarvestBlockEvent;
+    }
+
     public static PlayerHarvestBlockEvent callPlayerHarvestBlockEvent(Level world, BlockPos pos, net.minecraft.world.entity.player.Player player, InteractionHand hand, List<ItemStack> itemsToHarvest) {
-        List<org.bukkit.inventory.ItemStack> bukkitItemsToHarvest = new ArrayList<>(itemsToHarvest.stream().map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()));
+        List<org.bukkit.inventory.ItemStack> bukkitItemsToHarvest = itemsToHarvest.stream().map(CraftItemStack::asBukkitCopy).collect(Collectors.toList());
         PlayerHarvestBlockEvent playerHarvestBlockEvent = new PlayerHarvestBlockEvent((Player) player.getBukkitEntity(), CraftBlock.at(world, pos), CraftEquipmentSlot.getHand(hand), bukkitItemsToHarvest);
-        Bukkit.getPluginManager().callEvent(playerHarvestBlockEvent);
+        playerHarvestBlockEvent.callEvent();
         return playerHarvestBlockEvent;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -324,7 +324,7 @@ public class CraftEventFactory {
      * Entity Harvest Block Event
      */
     public static EntityHarvestBlockEvent callEntityHarvestBlockEvent(Level world, BlockPos blockposition, net.minecraft.world.entity.Entity who, List<ItemStack> itemsToHarvest) {
-        List<org.bukkit.inventory.ItemStack> bukkitItemsToHarvest = itemsToHarvest.stream().map(CraftItemStack::asBukkitCopy).collect(Collectors.toList());
+        List<org.bukkit.inventory.ItemStack> bukkitItemsToHarvest = itemsToHarvest.stream().map(CraftItemStack::asBukkitCopy).map(org.bukkit.inventory.ItemStack::clone).collect(Collectors.toList());
         org.bukkit.entity.Entity entity = who.getBukkitEntity();
         EntityHarvestBlockEvent entityHarvestBlockEvent = new EntityHarvestBlockEvent(entity, CraftBlock.at(world, blockposition), bukkitItemsToHarvest);
         entityHarvestBlockEvent.callEvent();


### PR DESCRIPTION
This starts in [discord](https://canary.discord.com/channels/289587909051416579/555462289851940864/1327837651876970569) where the Composter when drop a bone meal not has any event... the first thing was use the Drop or Dispenser event but that not handle correctly in this behaviour... then Machine Maker suggest a new event.

Then this PR add a new event for the case when a Entity harvest a block currently for Vines and Composter. this new event cannot be a base of the player side by the original design... then add in the docs the mention for this cases...