### PR TITLE
Fix issue in fillUsableCommands where child node requirements were not checked during redirection command flattening

### DIFF
--- a/paper-server/patches/features/0009-Fix-entity-type-tags-suggestions-in-selectors.patch
+++ b/paper-server/patches/features/0009-Fix-entity-type-tags-suggestions-in-selectors.patch
@@ -35,7 +35,7 @@ index cf923441da598637be74a5ffa4b4f948e01ff532..cbf32be9235921ebcaca88225120c2ca
 +    // Paper end - tell clients to ask server for suggestions for EntityArguments
  }
 diff --git a/net/minecraft/commands/Commands.java b/net/minecraft/commands/Commands.java
-index fa8c5ba4e0efd0c36613aaa8eaafba0cb70ceb87..19ccf3abf14c67f72a1ca065e4a304f50e645ef4 100644
+index 9f9b114c9f804676dc3d738bc6aa2d84346a959b..3ed19afd4f59543b8360d97c61cf8071cfdc46f8 100644
 --- a/net/minecraft/commands/Commands.java
 +++ b/net/minecraft/commands/Commands.java
 @@ -509,6 +509,7 @@ public class Commands {
@@ -46,7 +46,7 @@ index fa8c5ba4e0efd0c36613aaa8eaafba0cb70ceb87..19ccf3abf14c67f72a1ca065e4a304f5
          for (CommandNode<CommandSourceStack> commandNode : children) { // Paper - Perf: Async command map building; pass copy of children
              // Paper start - Brigadier API
              if (commandNode.clientNode != null) {
-@@ -572,6 +573,12 @@ public class Commands {
+@@ -574,6 +575,12 @@ public class Commands {
                      RequiredArgumentBuilder<SharedSuggestionProvider, ?> requiredArgumentBuilder = (RequiredArgumentBuilder<SharedSuggestionProvider, ?>)argumentBuilder;
                      if (requiredArgumentBuilder.getSuggestionsProvider() != null) {
                          requiredArgumentBuilder.suggests(SuggestionProviders.safelySwap(requiredArgumentBuilder.getSuggestionsProvider()));

--- a/paper-server/patches/sources/net/minecraft/commands/Commands.java.patch
+++ b/paper-server/patches/sources/net/minecraft/commands/Commands.java.patch
@@ -150,7 +150,7 @@
              }
  
              return null;
-@@ -360,25 +_,130 @@
+@@ -360,25 +_,132 @@
      }
  
      public void sendCommands(ServerPlayer player) {
@@ -264,7 +264,9 @@
 +                    }
 +                    // Diff copied from LiteralCommand#createBuilder
 +                    for (CommandNode<SharedSuggestionProvider> child : redirect.getChildren()) {
-+                        builder.then(child);
++                        if (child.canUse(source)) {
++                            builder.then(child);
++                        }
 +                    }
 +
 +                    argumentBuilder = builder;


### PR DESCRIPTION
I recently found out that admin subcommands are visible to all players.