### PR TITLE
Fix locate command dist overflow/underflow

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/commands/LocateCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/LocateCommand.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/server/commands/LocateCommand.java
++++ b/net/minecraft/server/commands/LocateCommand.java
+@@ -202,6 +_,6 @@
+     private static float dist(int x1, int z1, int x2, int z2) {
+         int i = x2 - x1;
+         int i1 = z2 - z1;
+-        return Mth.sqrt(i * i + i1 * i1);
++        return (float) Math.hypot(i, i1); // Paper - Fix MC-177381
+     }
+ }


### PR DESCRIPTION
This pull request fixes [MC-177381](https://bugs.mojang.com/browse/MC-177381), which causes distance of structure overflow/underflow during calculation.

### Changes

Replace `Mth.sqrt` in LocateCommand with `Math.hypot` to prevent any overflow/underflow.

This can be reproduced in latest Paper build with seed `-1064495411872206035`, use /locate command to search for a stronghold at coordinate -2735 ~ 688484.