### PR TITLE
Hide unnecessary decorated pot data

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/DecoratedPotBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/DecoratedPotBlockEntity.java.patch
@@ -49,3 +49,28 @@
      public static final String TAG_SHERDS = "sherds";
      public static final String TAG_ITEM = "item";
      public static final int EVENT_POT_WOBBLES = 1;
+@@ -41,8 +_,8 @@
+     protected void saveAdditional(CompoundTag tag, HolderLookup.Provider registries) {
+         super.saveAdditional(tag, registries);
+         this.decorations.save(tag);
+-        if (!this.trySaveLootTable(tag) && !this.item.isEmpty()) {
+-            tag.put("item", this.item.save(registries));
++        if (!this.trySaveLootTable(tag) && !this.item.isEmpty()) { // Paper - diff on change - hide unnecessary update data
++            tag.put("item", this.item.save(registries)); // Paper - diff on change - hide unnecessary update data
+         }
+     }
+ 
+@@ -66,7 +_,12 @@
+ 
+     @Override
+     public CompoundTag getUpdateTag(HolderLookup.Provider registries) {
+-        return this.saveCustomOnly(registries);
++        // Paper start - hide unnecessary update data
++        // Like chests, decorated pots should not allow clients to inspect their contents without breaking them.
++        final CompoundTag compoundTag = new CompoundTag();
++        this.decorations.save(compoundTag);
++        return compoundTag;
++        // Paper end - hide unnecessary update data
+     }
+ 
+     public Direction getDirection() {


### PR DESCRIPTION
Prevent decorated pots from sending their contents to clients as
contents are not needed for rendering.
