### PR TITLE
Expose all possible block data states

### DIFF
--- a/paper-api/src/main/java/org/bukkit/block/BlockType.java
+++ b/paper-api/src/main/java/org/bukkit/block/BlockType.java
@@ -121,6 +121,7 @@ import org.bukkit.inventory.ItemType;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * While this API is in a public interface, it is not intended for use by
@@ -176,9 +177,8 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
          *
          * @return new block data collection
          */
-        @NotNull
         @Override
-        Collection<B> createBlockDataStates();
+        @Unmodifiable @NotNull Collection<B> createBlockDataStates();
 
         /**
          * Creates a new {@link BlockData} instance for this block type, with all
@@ -3497,8 +3497,7 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
      *
      * @return new block data collection
      */
-    @NotNull
-    Collection<? extends BlockData> createBlockDataStates();
+    @Unmodifiable @NotNull Collection<? extends BlockData> createBlockDataStates();
 
     /**
      * Creates a new {@link BlockData} instance for this block type, with all

--- a/paper-api/src/main/java/org/bukkit/block/BlockType.java
+++ b/paper-api/src/main/java/org/bukkit/block/BlockType.java
@@ -1,5 +1,6 @@
 package org.bukkit.block;
 
+import java.util.Set;
 import java.util.function.Consumer;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
@@ -168,6 +169,16 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
         @NotNull
         @Override
         B createBlockData();
+
+        /**
+         * Creates a set of {@link BlockData} instances for this block type, with all
+         * possible combinations of properties values.
+         *
+         * @return new block data set
+         */
+        @NotNull
+        @Override
+        Set<B> createBlockDataStates();
 
         /**
          * Creates a new {@link BlockData} instance for this block type, with all
@@ -3479,6 +3490,15 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
      */
     @NotNull
     BlockData createBlockData();
+
+    /**
+     * Creates a set of {@link BlockData} instances for this block type, with all
+     * possible combinations of properties values.
+     *
+     * @return new block data set
+     */
+    @NotNull
+    Set<? extends BlockData> createBlockDataStates();
 
     /**
      * Creates a new {@link BlockData} instance for this block type, with all

--- a/paper-api/src/main/java/org/bukkit/block/BlockType.java
+++ b/paper-api/src/main/java/org/bukkit/block/BlockType.java
@@ -171,10 +171,10 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
         B createBlockData();
 
         /**
-         * Creates a set of {@link BlockData} instances for this block type, with all
+         * Creates a collection of {@link BlockData} instances for this block type, with all
          * possible combinations of properties values.
          *
-         * @return new block data set
+         * @return new block data collection
          */
         @NotNull
         @Override
@@ -3492,10 +3492,10 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
     BlockData createBlockData();
 
     /**
-     * Creates a set of {@link BlockData} instances for this block type, with all
+     * Creates a collection of {@link BlockData} instances for this block type, with all
      * possible combinations of properties values.
      *
-     * @return new block data set
+     * @return new block data collection
      */
     @NotNull
     Collection<? extends BlockData> createBlockDataStates();

--- a/paper-api/src/main/java/org/bukkit/block/BlockType.java
+++ b/paper-api/src/main/java/org/bukkit/block/BlockType.java
@@ -1,6 +1,6 @@
 package org.bukkit.block;
 
-import java.util.Set;
+import java.util.Collection;
 import java.util.function.Consumer;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
@@ -178,7 +178,7 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
          */
         @NotNull
         @Override
-        Set<B> createBlockDataStates();
+        Collection<B> createBlockDataStates();
 
         /**
          * Creates a new {@link BlockData} instance for this block type, with all
@@ -3498,7 +3498,7 @@ public interface BlockType extends Keyed, Translatable, net.kyori.adventure.tran
      * @return new block data set
      */
     @NotNull
-    Set<? extends BlockData> createBlockDataStates();
+    Collection<? extends BlockData> createBlockDataStates();
 
     /**
      * Creates a new {@link BlockData} instance for this block type, with all

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
@@ -3,9 +3,9 @@ package org.bukkit.craftbukkit.block;
 import com.google.common.base.Preconditions;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Set;
+import java.util.Collection;
 import java.util.function.Consumer;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.InteractionHand;
@@ -150,13 +150,13 @@ public class CraftBlockType<B extends BlockData> implements BlockType.Typed<B>, 
     }
 
     @Override
-    public @NotNull Set<B> createBlockDataStates() {
+    public @NotNull Collection<B> createBlockDataStates() {
         return this.block.getStateDefinition()
             .getPossibleStates()
             .stream()
             .map(BlockState::createCraftBlockData)
             .map(this.blockDataClass::cast)
-            .collect(ImmutableSet.toImmutableSet());
+            .collect(ImmutableList.toImmutableList());
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
@@ -5,7 +5,6 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
@@ -151,12 +151,12 @@ public class CraftBlockType<B extends BlockData> implements BlockType.Typed<B>, 
 
     @Override
     public @NotNull Collection<B> createBlockDataStates() {
-        return this.block.getStateDefinition()
-            .getPossibleStates()
-            .stream()
-            .map(BlockState::createCraftBlockData)
-            .map(this.blockDataClass::cast)
-            .collect(ImmutableList.toImmutableList());
+        final ImmutableList<BlockState> possibleStates = this.block.getStateDefinition().getPossibleStates();
+        final ImmutableList.Builder<B> builder = ImmutableList.builderWithExpectedSize(possibleStates.size());
+        for (final BlockState possibleState : possibleStates) {
+            builder.add(this.blockDataClass.cast(possibleState.createCraftBlockData()));
+        }
+        return builder.build();
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
@@ -3,7 +3,10 @@ package org.bukkit.craftbukkit.block;
 import com.google.common.base.Preconditions;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import com.google.common.collect.ImmutableSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.InteractionHand;
@@ -145,6 +148,16 @@ public class CraftBlockType<B extends BlockData> implements BlockType.Typed<B>, 
     @Override
     public B createBlockData() {
         return this.createBlockData((String) null);
+    }
+
+    @Override
+    public @NotNull Set<B> createBlockDataStates() {
+        return this.block.getStateDefinition()
+            .getPossibleStates()
+            .stream()
+            .map(BlockState::createCraftBlockData)
+            .map(this.blockDataClass::cast)
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     @Override


### PR DESCRIPTION
Adds a possibility to get a set of all possible combinations of block proprieties in a block data.