### PR TITLE
Fix inconsistencies between offline/online spawn position getter

### DIFF
--- a/paper-api/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/paper-api/src/main/java/org/bukkit/OfflinePlayer.java
@@ -295,8 +295,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
      * @return respawn location if exists, otherwise {@code null}.
      * @see #getRespawnLocation(boolean) for more fine-grained control over chunk loading and validation behaviour.
      */
-    @Nullable
-    default Location getRespawnLocation() {
+    default @Nullable Location getRespawnLocation() {
         return this.getRespawnLocation(false); // keep old behavior for offline players
     }
 
@@ -309,8 +308,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
      *                                will induce a sync chunk load and must hence be used with caution.
      * @return respawn location if exists, otherwise {@code null}.
      */
-    @Nullable
-    Location getRespawnLocation(boolean loadLocationAndValidate);
+    @Nullable Location getRespawnLocation(boolean loadLocationAndValidate);
 
     /**
      * Increments the given statistic for this player.

--- a/paper-api/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/paper-api/src/main/java/org/bukkit/OfflinePlayer.java
@@ -287,13 +287,28 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
     // Paper end
 
     /**
-     * Gets the Location where the player will spawn at, null if they
+     * Gets the Location where the player will spawn at, {@code null} if they
      * don't have a valid respawn point.
+     * <br>
+     * Unlike online players, the location if found will not be loaded by default.
      *
-     * @return respawn location if exists, otherwise null.
+     * @return respawn location if exists, otherwise {@code null}.
      */
     @Nullable
-    public Location getRespawnLocation();
+    default Location getRespawnLocation() {
+        return this.getRespawnLocation(false); // keep old behavior for offline players
+    }
+
+    /**
+     * Gets the Location where the player will spawn at, {@code null} if they
+     * don't have a valid respawn point.
+     *
+     * @param load load the current location to retrieve the exact position of the spawn block
+     *             and check if this position is still valid or not
+     * @return respawn location if exists, otherwise {@code null}.
+     */
+    @Nullable
+    Location getRespawnLocation(boolean load);
 
     /**
      * Increments the given statistic for this player.

--- a/paper-api/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/paper-api/src/main/java/org/bukkit/OfflinePlayer.java
@@ -293,6 +293,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
      * Unlike online players, the location if found will not be loaded by default.
      *
      * @return respawn location if exists, otherwise {@code null}.
+     * @see #getRespawnLocation(boolean) for more fine-grained control over chunk loading and validation behaviour.
      */
     @Nullable
     default Location getRespawnLocation() {
@@ -303,12 +304,13 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
      * Gets the Location where the player will spawn at, {@code null} if they
      * don't have a valid respawn point.
      *
-     * @param load load the current location to retrieve the exact position of the spawn block
-     *             and check if this position is still valid or not
+     * @param loadLocationAndValidate load the expected respawn location to retrieve the exact position of the spawn
+     *                                block and check if this position is still valid or not. Loading the location
+     *                                will induce a sync chunk load and must hence be used with caution.
      * @return respawn location if exists, otherwise {@code null}.
      */
     @Nullable
-    Location getRespawnLocation(boolean load);
+    Location getRespawnLocation(boolean loadLocationAndValidate);
 
     /**
      * Increments the given statistic for this player.

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -485,8 +485,8 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * to validate if the current respawn location is still valid.
      *
      * @return respawn location if exists, otherwise null.
-     * @deprecated this method doesn't take in account the respawn angle, use
-     * {@link Player#getRespawnLocation(boolean)} with load = false instead
+     * @deprecated this method doesn't take the respawn angle into account, use
+     * {@link Player#getRespawnLocation(boolean)} with loadLocationAndValidate = false instead
      */
     @Deprecated(since = "1.21.5")
     @Nullable Location getPotentialRespawnLocation();

--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -485,9 +485,11 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * to validate if the current respawn location is still valid.
      *
      * @return respawn location if exists, otherwise null.
+     * @deprecated this method doesn't take in account the respawn angle, use
+     * {@link Player#getRespawnLocation(boolean)} with load = false instead
      */
-    @Nullable
-    Location getPotentialRespawnLocation();
+    @Deprecated(since = "1.21.5")
+    @Nullable Location getPotentialRespawnLocation();
 
     /**
      * @return the player's fishing hook if they are fishing

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -545,6 +545,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      */
     public boolean isSleepingIgnored();
 
+    @Nullable
+    @Override
+    default Location getRespawnLocation() {
+        return this.getRespawnLocation(true);
+    }
+
     /**
      * Sets the Location where the player will spawn at their bed.
      *

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -545,9 +545,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      */
     public boolean isSleepingIgnored();
 
-    @Nullable
+    /**
+     * Gets the Location where the player will spawn at, {@code null} if they
+     * don't have a valid respawn point.
+     * <br>
+     * Unlike offline players, the location if found will be loaded to validate by default.
+     *
+     * @return respawn location if exists, otherwise {@code null}.
+     * @see #getRespawnLocation(boolean) for more fine-grained control over chunk loading and validation behaviour.
+     */
     @Override
-    default Location getRespawnLocation() {
+    default @Nullable Location getRespawnLocation() {
         return this.getRespawnLocation(true);
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
@@ -6,7 +6,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import net.minecraft.core.GlobalPos;
@@ -33,8 +32,6 @@ import org.bukkit.configuration.serialization.SerializableAs;
 import org.bukkit.craftbukkit.util.CraftLocation;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
-import org.bukkit.metadata.MetadataValue;
-import org.bukkit.plugin.Plugin;
 
 @SerializableAs("Player")
 public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializable {
@@ -362,7 +359,7 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
     }
 
     @Override
-    public Location getRespawnLocation() {
+    public Location getRespawnLocation(boolean load) {
         CompoundTag data = this.getData();
         if (data == null) return null;
 
@@ -370,7 +367,13 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
         if (respawnConfig != null) {
             final ServerLevel level = this.server.console.getLevel(respawnConfig.dimension());
             if (level != null) {
-                return CraftLocation.toBukkit(respawnConfig.pos(), level.getWorld(), respawnConfig.angle(), 0);
+                if (!load) {
+                    return CraftLocation.toBukkit(respawnConfig.pos(), level.getWorld(), respawnConfig.angle(), 0);
+                }
+
+                return ServerPlayer.findRespawnAndUseSpawnBlock(level, respawnConfig, false)
+                    .map(resolvedPos -> CraftLocation.toBukkit(resolvedPos.position(), level.getWorld(), resolvedPos.yaw(), 0))
+                    .orElse(null);
             }
         }
         return null;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
@@ -359,24 +359,23 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
     }
 
     @Override
-    public Location getRespawnLocation(boolean load) {
-        CompoundTag data = this.getData();
+    public Location getRespawnLocation(final boolean loadLocationAndValidate) {
+        final CompoundTag data = this.getData();
         if (data == null) return null;
 
         final ServerPlayer.RespawnConfig respawnConfig = data.read("respawn", ServerPlayer.RespawnConfig.CODEC).orElse(null);
-        if (respawnConfig != null) {
-            final ServerLevel level = this.server.console.getLevel(respawnConfig.dimension());
-            if (level != null) {
-                if (!load) {
-                    return CraftLocation.toBukkit(respawnConfig.pos(), level.getWorld(), respawnConfig.angle(), 0);
-                }
+        if (respawnConfig == null) return null;
 
-                return ServerPlayer.findRespawnAndUseSpawnBlock(level, respawnConfig, false)
-                    .map(resolvedPos -> CraftLocation.toBukkit(resolvedPos.position(), level.getWorld(), resolvedPos.yaw(), 0))
-                    .orElse(null);
-            }
+        final ServerLevel level = this.server.console.getLevel(respawnConfig.dimension());
+        if (level == null) return null;
+
+        if (!loadLocationAndValidate) {
+            return CraftLocation.toBukkit(respawnConfig.pos(), level.getWorld(), respawnConfig.angle(), 0);
         }
-        return null;
+
+        return ServerPlayer.findRespawnAndUseSpawnBlock(level, respawnConfig, false)
+            .map(resolvedPos -> CraftLocation.toBukkit(resolvedPos.position(), level.getWorld(), resolvedPos.yaw(), 0))
+            .orElse(null);
     }
 
     private ServerStatsCounter getStatisticManager() {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1541,23 +1541,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     }
 
     @Override
-    public Location getRespawnLocation(boolean load) {
+    public Location getRespawnLocation(final boolean loadLocationAndValidate) {
         final ServerPlayer.RespawnConfig respawnConfig = this.getHandle().getRespawnConfig();
         if (respawnConfig == null) return null;
 
-        ServerLevel world = this.getHandle().server.getLevel(respawnConfig.dimension());
-        if (world != null) {
-            if (!load) {
-                return CraftLocation.toBukkit(respawnConfig.pos(), world.getWorld(), respawnConfig.angle(), 0);
-            }
+        final ServerLevel world = this.getHandle().server.getLevel(respawnConfig.dimension());
+        if (world == null) return null;
 
-            Optional<ServerPlayer.RespawnPosAngle> spawnLoc = ServerPlayer.findRespawnAndUseSpawnBlock(world, respawnConfig, false);
-            if (spawnLoc.isPresent()) {
-                ServerPlayer.RespawnPosAngle vec = spawnLoc.get();
-                return CraftLocation.toBukkit(vec.position(), world.getWorld(), vec.yaw(), 0);
-            }
+        if (!loadLocationAndValidate) {
+            return CraftLocation.toBukkit(respawnConfig.pos(), world.getWorld(), respawnConfig.angle(), 0);
         }
-        return null;
+
+        return ServerPlayer.findRespawnAndUseSpawnBlock(world, respawnConfig, false)
+            .map(pos -> CraftLocation.toBukkit(pos.position(), world.getWorld(), pos.yaw(), 0))
+            .orElse(null);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1541,13 +1541,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     }
 
     @Override
-    public Location getRespawnLocation() {
+    public Location getRespawnLocation(boolean load) {
         final ServerPlayer.RespawnConfig respawnConfig = this.getHandle().getRespawnConfig();
         if (respawnConfig == null) return null;
 
         ServerLevel world = this.getHandle().server.getLevel(respawnConfig.dimension());
         if (world != null) {
-            Optional<ServerPlayer.RespawnPosAngle> spawnLoc = ServerPlayer.findRespawnAndUseSpawnBlock(world, respawnConfig, true);
+            if (!load) {
+                return CraftLocation.toBukkit(respawnConfig.pos(), world.getWorld(), respawnConfig.angle(), 0);
+            }
+
+            Optional<ServerPlayer.RespawnPosAngle> spawnLoc = ServerPlayer.findRespawnAndUseSpawnBlock(world, respawnConfig, false);
             if (spawnLoc.isPresent()) {
                 ServerPlayer.RespawnPosAngle vec = spawnLoc.get();
                 return CraftLocation.toBukkit(vec.position(), world.getWorld(), vec.yaw(), 0);


### PR DESCRIPTION
Original: https://github.com/PaperMC/Paper/pull/8243
Also deprecated the old HumanEntity#getPotentialRespawnLocation since it doesn't track the respawn angle.