### PR TITLE
BlockProperty API

### DIFF
--- a/.checkstyle/checkstyle_base.xml
+++ b/.checkstyle/checkstyle_base.xml
@@ -55,7 +55,9 @@
         <module name="AvoidNoArgumentSuperConstructorCall"/>
         <module name="ConstructorsDeclarationGrouping"/>
         <module name="CovariantEquals"/>
-        <module name="DeclarationOrder"/>
+        <module name="DeclarationOrder">
+            <property name="ignoreConstructors" value="true"/>
+        </module>
         <module name="DefaultComesLast"/>
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
@@ -120,7 +122,9 @@
         </module>
         <module name="JavadocMissingLeadingAsterisk"/>
         <module name="JavadocMissingWhitespaceAfterAsterisk"/>
-        <module name="JavadocStyle"/> <!--checks all, but doesn't require. If we have a doc, it should be valid-->
+        <module name="JavadocStyle"> <!--checks all, but doesn't require. If we have a doc, it should be valid-->
+            <property name="endOfSentenceFormat" value="([.?!:][ \t\n\r\f&lt;])|([.?!:]$)"/><!--default but allow ':' to end a "sentence", violation message is still unclear tho-->
+        </module>
         <module name="JavadocTagContinuationIndentation"/>
         <module name="JavadocType"/> <!--checks all, but doesn't require. If we have a doc, it should be valid-->
         <module name="NonEmptyAtclauseDescription"/>

--- a/.checkstyle/xpath-suppressions.xml
+++ b/.checkstyle/xpath-suppressions.xml
@@ -6,8 +6,9 @@
     <suppress-xpath checks=".*" query="//*[MODIFIERS/ANNOTATION[(@text = 'Deprecated' or *[@text = 'Deprecated'] and ANNOTATION_MEMBER_VALUE_PAIR/IDENT[@text='forRemoval'])]]/descendant-or-self::node()"/>
     <!--special case to ignore extra checks outside the root CLASS_DEF if the root CLASS_DEF is marked as deprecated for removal-->
     <suppress-xpath checks=".*" query="/COMPILATION_UNIT[CLASS_DEF/MODIFIERS/ANNOTATION[IDENT[@text = 'Deprecated'] and ANNOTATION_MEMBER_VALUE_PAIR/IDENT[@text='forRemoval']]]/descendant-or-self::node()"/>
-    <!--ignores MissingJavadoc for ApiStatus.Internal children-->
-    <suppress-xpath checks="MissingJavadoc(Method|Type)" query="//*[MODIFIERS/ANNOTATION/DOT[@text = 'Internal' or *[@text = 'Internal']]]/descendant-or-self::node()"/>
+    <!--ignores javadoc checks for ApiStatus.Internal children-->
+    <!--TODO: still report some failure on better stats PR-->
+    <suppress-xpath checks="MissingJavadoc(Method|Type)|JavadocMethod" query="//*[MODIFIERS/ANNOTATION/DOT[@text = 'Internal' or *[@text = 'Internal']]]/descendant-or-self::node()"/>
 
     <!--skip for private classes-->
     <suppress-xpath checks="FinalClass" query="//CLASS_DEF[MODIFIERS/LITERAL_PRIVATE]"/>

--- a/paper-api/.checkstyle/checkstyle.xml
+++ b/paper-api/.checkstyle/checkstyle.xml
@@ -9,7 +9,14 @@
         <!--[A-Z].* check is for java annotations inside code blocks inside Javadocs-->
         <property name="arguments" value="(${custom_javadoc_tags}|[A-Z].*)"/>
     </module>
+    <module name="SuppressWarningsFilter" />
     <module name="TreeWalker">
+        <module name="SuppressWarningsHolder" />
+        <!--Skip generate content by typewriter-->
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="Start generate - [\w\|]+"/>
+            <property name="onCommentFormat" value="End generate - [\w\|]+"/>
+        </module>
         <module name="JavadocVariable">
             <!--requires on public fields-->
             <property name="accessModifiers" value="public"/>
@@ -20,7 +27,7 @@
         </module>
         <module name="MissingJavadocPackage"/>
         <module name="MissingJavadocType">
-            <property name="skipAnnotations" value="Generated, ApiStatus.Internal" />
+            <property name="skipAnnotations" value="Generated, ApiStatus.Internal"/>
         </module>
     </module>
 </module>

--- a/paper-api/src/main/java/io/papermc/paper/InternalAPIBridge.java
+++ b/paper-api/src/main/java/io/papermc/paper/InternalAPIBridge.java
@@ -1,6 +1,7 @@
 package io.papermc.paper;
 
 import com.destroystokyo.paper.SkinParts;
+import io.papermc.paper.block.property.EnumBlockProperty;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.datacomponent.item.ResolvableProfile;
 import io.papermc.paper.entity.poi.PoiType;
@@ -113,4 +114,14 @@ public interface InternalAPIBridge {
     <MODERN, LEGACY> GameRule<LEGACY> legacyGameRuleBridge(GameRule<MODERN> rule, Function<LEGACY, MODERN> fromLegacyToModern, Function<MODERN, LEGACY> toLegacyFromModern, Class<LEGACY> legacyClass);
 
     Set<Pose> validMannequinPoses();
+
+    /**
+     * Gets the string representation for this bukkit enum.
+     *
+     * @param enumProperty the enum data property
+     * @param bukkitEnum the enum to get the string representation of
+     * @param <B> the bukkit enum type
+     * @return the string representation of the supplied enum
+     */
+    <B extends Enum<B>> String getPropertyEnumName(EnumBlockProperty<B> enumProperty, B bukkitEnum);
 }

--- a/paper-api/src/main/java/io/papermc/paper/InternalAPIBridge.java
+++ b/paper-api/src/main/java/io/papermc/paper/InternalAPIBridge.java
@@ -2,6 +2,7 @@ package io.papermc.paper;
 
 import com.destroystokyo.paper.SkinParts;
 import com.destroystokyo.paper.util.VersionFetcher;
+import io.papermc.paper.block.property.EnumBlockProperty;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.datacomponent.item.ResolvableProfile;
 import io.papermc.paper.entity.poi.PoiType;
@@ -121,4 +122,6 @@ public interface InternalAPIBridge {
     Component resolveWithContext(Component component, @Nullable CommandSender context, @Nullable Entity scoreboardSubject, boolean bypassPermissions) throws IOException;
 
     ComponentFlattener componentFlattener();
+
+    <B extends Enum<B>> String getPropertyEnumName(EnumBlockProperty<B> enumProperty, B bukkitEnum);
 }

--- a/paper-api/src/main/java/io/papermc/paper/block/fluid/FluidData.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/fluid/FluidData.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.block.fluid;
 
+import io.papermc.paper.block.property.BlockPropertyHolder;
 import org.bukkit.Fluid;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
@@ -11,7 +12,7 @@ import org.jspecify.annotations.NullMarked;
  * This type is not linked to a specific location and hence mostly resembles a {@link org.bukkit.block.data.BlockData}.
  */
 @NullMarked
-public interface FluidData extends Cloneable {
+public interface FluidData extends Cloneable, BlockPropertyHolder {
 
     /**
      * Gets the fluid type of this fluid data.

--- a/paper-api/src/main/java/io/papermc/paper/block/property/AsIntegerProperty.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/AsIntegerProperty.java
@@ -1,0 +1,34 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
+import java.util.function.IntFunction;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+sealed interface AsIntegerProperty<T extends Comparable<T>> extends BlockProperty<T> permits NoteBlockProperty, RotationBlockProperty {
+
+    static <T extends Comparable<T>> BiMap<Integer, T> createCache(final int max, final IntFunction<? extends T> function) {
+        final ImmutableBiMap.Builder<Integer, T> builder = ImmutableBiMap.builder();
+        for (int i = 0; i <= max; i++) {
+            builder.put(i, function.apply(i));
+        }
+        return builder.buildOrThrow();
+    }
+
+    BiMap<Integer, T> cache();
+
+    default int toIntValue(final T value) {
+        if (!this.cache().inverse().containsKey(value)) {
+            throw ExceptionCreator.INSTANCE.create(value, ExceptionCreator.Type.VALUE, this);
+        }
+        return this.cache().inverse().get(value);
+    }
+
+    default T fromIntValue(final int value) {
+        if (!this.cache().containsKey(value)) {
+            throw ExceptionCreator.INSTANCE.create(value, ExceptionCreator.Type.VALUE, this);
+        }
+        return this.cache().get(value);
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/AsIntegerProperty.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/AsIntegerProperty.java
@@ -1,0 +1,32 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
+import java.util.function.IntFunction;
+
+sealed interface AsIntegerProperty<T extends Comparable<T>> extends BlockProperty<T> permits NoteBlockProperty, RotationBlockProperty {
+
+    static <T extends Comparable<T>> BiMap<Integer, T> createCache(final int max, final IntFunction<? extends T> mapper) {
+        final ImmutableBiMap.Builder<Integer, T> builder = ImmutableBiMap.builder();
+        for (int i = 0; i <= max; i++) {
+            builder.put(i, mapper.apply(i));
+        }
+        return builder.buildOrThrow();
+    }
+
+    BiMap<Integer, T> cache();
+
+    default int toIntValue(final T value) {
+        if (!this.cache().inverse().containsKey(value)) {
+            throw ExceptionCreator.NOT_VALID.create(value, ExceptionCreator.Type.VALUE, this);
+        }
+        return this.cache().inverse().get(value);
+    }
+
+    default T fromIntValue(final int value) {
+        if (!this.cache().containsKey(value)) {
+            throw ExceptionCreator.NOT_VALID.create(value, ExceptionCreator.Type.VALUE, this);
+        }
+        return this.cache().get(value);
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/BlockProperties.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/BlockProperties.java
@@ -1,0 +1,203 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.bukkit.Axis;
+import org.bukkit.Instrument;
+import org.bukkit.Note;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.Orientation;
+import org.bukkit.block.data.Bisected;
+import org.bukkit.block.data.FaceAttachable;
+import org.bukkit.block.data.Rail;
+import org.bukkit.block.data.SideChaining;
+import org.bukkit.block.data.type.Bamboo;
+import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.Bell;
+import org.bukkit.block.data.type.BigDripleaf;
+import org.bukkit.block.data.type.Chest;
+import org.bukkit.block.data.type.Comparator;
+import org.bukkit.block.data.type.CopperGolemStatue;
+import org.bukkit.block.data.type.CreakingHeart;
+import org.bukkit.block.data.type.Door;
+import org.bukkit.block.data.type.PointedDripstone;
+import org.bukkit.block.data.type.RedstoneWire;
+import org.bukkit.block.data.type.SculkSensor;
+import org.bukkit.block.data.type.Slab;
+import org.bukkit.block.data.type.Stairs;
+import org.bukkit.block.data.type.StructureBlock;
+import org.bukkit.block.data.type.TechnicalPiston;
+import org.bukkit.block.data.type.TestBlock;
+import org.bukkit.block.data.type.TrialSpawner;
+import org.bukkit.block.data.type.Vault;
+import org.bukkit.block.data.type.Wall;
+
+/**
+ * All block properties applicable to {@link BlockPropertyHolder}s.
+ */
+public final class BlockProperties {
+
+    static final Multimap<String, BlockProperty<?>> PROPERTIES = HashMultimap.create();
+
+    // Start generate - BlockProperties
+    public static final BooleanBlockProperty ATTACHED = bool("attached");
+    public static final BooleanBlockProperty BERRIES = bool("berries");
+    public static final BooleanBlockProperty BLOOM = bool("bloom");
+    public static final BooleanBlockProperty BOTTOM = bool("bottom");
+    public static final BooleanBlockProperty CAN_SUMMON = bool("can_summon");
+    public static final BooleanBlockProperty CONDITIONAL = bool("conditional");
+    public static final BooleanBlockProperty CRACKED = bool("cracked");
+    public static final BooleanBlockProperty CRAFTING = bool("crafting");
+    public static final BooleanBlockProperty DISARMED = bool("disarmed");
+    public static final BooleanBlockProperty DOWN = bool("down");
+    public static final BooleanBlockProperty DRAG = bool("drag");
+    public static final BooleanBlockProperty EAST = bool("east");
+    public static final BooleanBlockProperty ENABLED = bool("enabled");
+    public static final BooleanBlockProperty EXTENDED = bool("extended");
+    public static final BooleanBlockProperty EYE = bool("eye");
+    public static final BooleanBlockProperty FALLING = bool("falling");
+    public static final BooleanBlockProperty HANGING = bool("hanging");
+    public static final BooleanBlockProperty HAS_BOOK = bool("has_book");
+    public static final BooleanBlockProperty HAS_BOTTLE_0 = bool("has_bottle_0");
+    public static final BooleanBlockProperty HAS_BOTTLE_1 = bool("has_bottle_1");
+    public static final BooleanBlockProperty HAS_BOTTLE_2 = bool("has_bottle_2");
+    public static final BooleanBlockProperty HAS_RECORD = bool("has_record");
+    public static final BooleanBlockProperty INVERTED = bool("inverted");
+    public static final BooleanBlockProperty IN_WALL = bool("in_wall");
+    public static final BooleanBlockProperty LIT = bool("lit");
+    public static final BooleanBlockProperty LOCKED = bool("locked");
+    public static final BooleanBlockProperty MAP = bool("map");
+    public static final BooleanBlockProperty NATURAL = bool("natural");
+    public static final BooleanBlockProperty NORTH = bool("north");
+    public static final BooleanBlockProperty OCCUPIED = bool("occupied");
+    public static final BooleanBlockProperty OMINOUS = bool("ominous");
+    public static final BooleanBlockProperty OPEN = bool("open");
+    public static final BooleanBlockProperty PERSISTENT = bool("persistent");
+    public static final BooleanBlockProperty POWERED = bool("powered");
+    public static final BooleanBlockProperty SHORT = bool("short");
+    public static final BooleanBlockProperty SHRIEKING = bool("shrieking");
+    public static final BooleanBlockProperty SIGNAL_FIRE = bool("signal_fire");
+    public static final BooleanBlockProperty SLOT_0_OCCUPIED = bool("slot_0_occupied");
+    public static final BooleanBlockProperty SLOT_1_OCCUPIED = bool("slot_1_occupied");
+    public static final BooleanBlockProperty SLOT_2_OCCUPIED = bool("slot_2_occupied");
+    public static final BooleanBlockProperty SLOT_3_OCCUPIED = bool("slot_3_occupied");
+    public static final BooleanBlockProperty SLOT_4_OCCUPIED = bool("slot_4_occupied");
+    public static final BooleanBlockProperty SLOT_5_OCCUPIED = bool("slot_5_occupied");
+    public static final BooleanBlockProperty SNOWY = bool("snowy");
+    public static final BooleanBlockProperty SOUTH = bool("south");
+    public static final BooleanBlockProperty TIP = bool("tip");
+    public static final BooleanBlockProperty TRIGGERED = bool("triggered");
+    public static final BooleanBlockProperty UNSTABLE = bool("unstable");
+    public static final BooleanBlockProperty UP = bool("up");
+    public static final BooleanBlockProperty WATERLOGGED = bool("waterlogged");
+    public static final BooleanBlockProperty WEST = bool("west");
+    public static final EnumBlockProperty<FaceAttachable.AttachedFace> ATTACH_FACE = enumeration("face", FaceAttachable.AttachedFace.class);
+    public static final EnumBlockProperty<Axis> AXIS = enumeration("axis", Axis.class);
+    public static final EnumBlockProperty<Bamboo.Leaves> BAMBOO_LEAVES = enumeration("leaves", Bamboo.Leaves.class);
+    public static final EnumBlockProperty<Bed.Part> BED_PART = enumeration("part", Bed.Part.class);
+    public static final EnumBlockProperty<Bell.Attachment> BELL_ATTACHMENT = enumeration("attachment", Bell.Attachment.class);
+    public static final EnumBlockProperty<Chest.Type> CHEST_TYPE = enumeration("type", Chest.Type.class);
+    public static final EnumBlockProperty<CopperGolemStatue.Pose> COPPER_GOLEM_POSE = enumeration("copper_golem_pose", CopperGolemStatue.Pose.class);
+    public static final EnumBlockProperty<CreakingHeart.State> CREAKING_HEART_STATE = enumeration("creaking_heart_state", CreakingHeart.State.class);
+    public static final EnumBlockProperty<Door.Hinge> DOOR_HINGE = enumeration("hinge", Door.Hinge.class);
+    public static final EnumBlockProperty<Bisected.Half> DOUBLE_BLOCK_HALF = enumeration("half", Bisected.Half.class);
+    public static final EnumBlockProperty<PointedDripstone.Thickness> DRIPSTONE_THICKNESS = enumeration("thickness", PointedDripstone.Thickness.class);
+    public static final EnumBlockProperty<RedstoneWire.Connection> EAST_REDSTONE = enumeration("east", RedstoneWire.Connection.class);
+    public static final EnumBlockProperty<Wall.Height> EAST_WALL = enumeration("east", Wall.Height.class);
+    public static final EnumBlockProperty<BlockFace> FACING = enumeration("facing", BlockFace.class, BlockFace::isCartesian);
+    public static final EnumBlockProperty<BlockFace> FACING_HOPPER = enumeration("facing", BlockFace.class, ((Predicate<BlockFace>) BlockFace::isCartesian).and(face -> face != BlockFace.UP));
+    public static final EnumBlockProperty<Bisected.Half> HALF = enumeration("half", Bisected.Half.class);
+    public static final EnumBlockProperty<Axis> HORIZONTAL_AXIS = enumeration("axis", Axis.class, Axis::isHorizontal);
+    public static final EnumBlockProperty<BlockFace> HORIZONTAL_FACING = enumeration("facing", BlockFace.class, BlockFace::isCardinal);
+    public static final EnumBlockProperty<Comparator.Mode> MODE_COMPARATOR = enumeration("mode", Comparator.Mode.class);
+    public static final EnumBlockProperty<RedstoneWire.Connection> NORTH_REDSTONE = enumeration("north", RedstoneWire.Connection.class);
+    public static final EnumBlockProperty<Wall.Height> NORTH_WALL = enumeration("north", Wall.Height.class);
+    public static final EnumBlockProperty<Instrument> NOTEBLOCK_INSTRUMENT = enumeration("instrument", Instrument.class);
+    public static final EnumBlockProperty<Orientation> ORIENTATION = enumeration("orientation", Orientation.class);
+    public static final EnumBlockProperty<TechnicalPiston.Type> PISTON_TYPE = enumeration("type", TechnicalPiston.Type.class);
+    public static final EnumBlockProperty<Rail.Shape> RAIL_SHAPE = enumeration("shape", Rail.Shape.class);
+    public static final EnumBlockProperty<Rail.Shape> RAIL_SHAPE_STRAIGHT = enumeration("shape", Rail.Shape.class, Rail.Shape::isStraight);
+    public static final EnumBlockProperty<SculkSensor.Phase> SCULK_SENSOR_PHASE = enumeration("sculk_sensor_phase", SculkSensor.Phase.class);
+    public static final EnumBlockProperty<SideChaining.ChainPart> SIDE_CHAIN_PART = enumeration("side_chain", SideChaining.ChainPart.class);
+    public static final EnumBlockProperty<Slab.Type> SLAB_TYPE = enumeration("type", Slab.Type.class);
+    public static final EnumBlockProperty<RedstoneWire.Connection> SOUTH_REDSTONE = enumeration("south", RedstoneWire.Connection.class);
+    public static final EnumBlockProperty<Wall.Height> SOUTH_WALL = enumeration("south", Wall.Height.class);
+    public static final EnumBlockProperty<Stairs.Shape> STAIRS_SHAPE = enumeration("shape", Stairs.Shape.class);
+    public static final EnumBlockProperty<StructureBlock.Mode> STRUCTUREBLOCK_MODE = enumeration("mode", StructureBlock.Mode.class);
+    public static final EnumBlockProperty<TestBlock.Mode> TEST_BLOCK_MODE = enumeration("mode", TestBlock.Mode.class);
+    public static final EnumBlockProperty<BigDripleaf.Tilt> TILT = enumeration("tilt", BigDripleaf.Tilt.class);
+    public static final EnumBlockProperty<TrialSpawner.State> TRIAL_SPAWNER_STATE = enumeration("trial_spawner_state", TrialSpawner.State.class);
+    public static final EnumBlockProperty<Vault.State> VAULT_STATE = enumeration("vault_state", Vault.State.class);
+    public static final EnumBlockProperty<BlockFace> VERTICAL_DIRECTION = enumeration("vertical_direction", BlockFace.class, face -> face.getModY() != 0);
+    public static final EnumBlockProperty<RedstoneWire.Connection> WEST_REDSTONE = enumeration("west", RedstoneWire.Connection.class);
+    public static final EnumBlockProperty<Wall.Height> WEST_WALL = enumeration("west", Wall.Height.class);
+    public static final IntegerBlockProperty AGE_1 = integer("age", 0, 1);
+    public static final IntegerBlockProperty AGE_15 = integer("age", 0, 15);
+    public static final IntegerBlockProperty AGE_2 = integer("age", 0, 2);
+    public static final IntegerBlockProperty AGE_25 = integer("age", 0, 25);
+    public static final IntegerBlockProperty AGE_3 = integer("age", 0, 3);
+    public static final IntegerBlockProperty AGE_4 = integer("age", 0, 4);
+    public static final IntegerBlockProperty AGE_5 = integer("age", 0, 5);
+    public static final IntegerBlockProperty AGE_7 = integer("age", 0, 7);
+    public static final IntegerBlockProperty BITES = integer("bites", 0, 6);
+    public static final IntegerBlockProperty CANDLES = integer("candles", 1, 4);
+    public static final IntegerBlockProperty DELAY = integer("delay", 1, 4);
+    public static final IntegerBlockProperty DISTANCE = integer("distance", 1, 7);
+    public static final IntegerBlockProperty DRIED_GHAST_HYDRATION_LEVELS = integer("hydration", 0, 3);
+    public static final IntegerBlockProperty DUSTED = integer("dusted", 0, 3);
+    public static final IntegerBlockProperty EGGS = integer("eggs", 1, 4);
+    public static final IntegerBlockProperty FLOWER_AMOUNT = integer("flower_amount", 1, 4);
+    public static final IntegerBlockProperty HATCH = integer("hatch", 0, 2);
+    public static final IntegerBlockProperty LAYERS = integer("layers", 1, 8);
+    public static final IntegerBlockProperty LEVEL = integer("level", 0, 15);
+    public static final IntegerBlockProperty LEVEL_CAULDRON = integer("level", 1, 3);
+    public static final IntegerBlockProperty LEVEL_COMPOSTER = integer("level", 0, 8);
+    public static final IntegerBlockProperty LEVEL_FLOWING = integer("level", 1, 8);
+    public static final IntegerBlockProperty LEVEL_HONEY = integer("honey_level", 0, 5);
+    public static final IntegerBlockProperty MOISTURE = integer("moisture", 0, 7);
+    public static final BlockProperty<Note> NOTE = register(new NoteBlockProperty("note"));
+    public static final IntegerBlockProperty PICKLES = integer("pickles", 1, 4);
+    public static final IntegerBlockProperty POWER = integer("power", 0, 15);
+    public static final IntegerBlockProperty RESPAWN_ANCHOR_CHARGES = integer("charges", 0, 4);
+    public static final EnumBlockProperty<BlockFace> ROTATION_16 = register(new RotationBlockProperty("rotation"));
+    public static final IntegerBlockProperty SEGMENT_AMOUNT = integer("segment_amount", 1, 4);
+    public static final IntegerBlockProperty STABILITY_DISTANCE = integer("distance", 0, 7);
+    public static final IntegerBlockProperty STAGE = integer("stage", 0, 1);
+    // End generate - BlockProperties
+
+    private BlockProperties() {
+    }
+
+    //<editor-fold defaultstate="collapsed" desc="static factory methods">
+    private static IntegerBlockProperty integer(final String name, final int min, final int max) {
+        return register(new IntegerBlockPropertyImpl(name, min, max));
+    }
+
+    private static BooleanBlockProperty bool(final String name) {
+        return register(new BooleanBlockPropertyImpl(name));
+    }
+
+    private static <E extends Enum<E>> EnumBlockProperty<E> enumeration(final String name, final Class<E> enumClass) {
+        return enumeration(name, enumClass, enumClass.getEnumConstants());
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    @SafeVarargs
+    private static <E extends Enum<E>> EnumBlockProperty<E> enumeration(final String name, final Class<E> enumClass, final E... values) {
+        return register(new EnumBlockPropertyImpl<>(name, enumClass, Set.of(values)));
+    }
+
+    private static <E extends Enum<E>> EnumBlockProperty<E> enumeration(final String name, final Class<E> enumClass, final Predicate<E> test) {
+        return register(new EnumBlockPropertyImpl<>(name, enumClass, Arrays.stream(enumClass.getEnumConstants()).filter(test).collect(Collectors.toSet())));
+    }
+
+    private static <V extends Comparable<V>, P extends BlockProperty<V>> P register(final P property) {
+        PROPERTIES.put(property.name(), property);
+        return property;
+    }
+    //</editor-fold>
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/BlockProperties.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/BlockProperties.java
@@ -1,0 +1,205 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.bukkit.Axis;
+import org.bukkit.Instrument;
+import org.bukkit.Note;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.Orientation;
+import org.bukkit.block.data.Bisected;
+import org.bukkit.block.data.FaceAttachable;
+import org.bukkit.block.data.Rail;
+import org.bukkit.block.data.SideChaining;
+import org.bukkit.block.data.type.Bamboo;
+import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.Bell;
+import org.bukkit.block.data.type.BigDripleaf;
+import org.bukkit.block.data.type.Chest;
+import org.bukkit.block.data.type.Comparator;
+import org.bukkit.block.data.type.CopperGolemStatue;
+import org.bukkit.block.data.type.CreakingHeart;
+import org.bukkit.block.data.type.Door;
+import org.bukkit.block.data.type.PotentSulfur;
+import org.bukkit.block.data.type.RedstoneWire;
+import org.bukkit.block.data.type.SculkSensor;
+import org.bukkit.block.data.type.Slab;
+import org.bukkit.block.data.type.Speleothem;
+import org.bukkit.block.data.type.Stairs;
+import org.bukkit.block.data.type.StructureBlock;
+import org.bukkit.block.data.type.TechnicalPiston;
+import org.bukkit.block.data.type.TestBlock;
+import org.bukkit.block.data.type.TrialSpawner;
+import org.bukkit.block.data.type.Vault;
+import org.bukkit.block.data.type.Wall;
+
+/**
+ * All block properties applicable to {@link BlockPropertyHolder}s.
+ */
+public final class BlockProperties {
+
+    static final Multimap<String, BlockProperty<?>> PROPERTIES = HashMultimap.create();
+
+    // Start generate - BlockProperties
+    public static final BooleanBlockProperty ATTACHED = bool("attached");
+    public static final BooleanBlockProperty BERRIES = bool("berries");
+    public static final BooleanBlockProperty BLOOM = bool("bloom");
+    public static final BooleanBlockProperty BOTTOM = bool("bottom");
+    public static final BooleanBlockProperty CAN_SUMMON = bool("can_summon");
+    public static final BooleanBlockProperty CONDITIONAL = bool("conditional");
+    public static final BooleanBlockProperty CRACKED = bool("cracked");
+    public static final BooleanBlockProperty CRAFTING = bool("crafting");
+    public static final BooleanBlockProperty DISARMED = bool("disarmed");
+    public static final BooleanBlockProperty DOWN = bool("down");
+    public static final BooleanBlockProperty DRAG = bool("drag");
+    public static final BooleanBlockProperty EAST = bool("east");
+    public static final BooleanBlockProperty ENABLED = bool("enabled");
+    public static final BooleanBlockProperty EXTENDED = bool("extended");
+    public static final BooleanBlockProperty EYE = bool("eye");
+    public static final BooleanBlockProperty FALLING = bool("falling");
+    public static final BooleanBlockProperty HANGING = bool("hanging");
+    public static final BooleanBlockProperty HAS_BOOK = bool("has_book");
+    public static final BooleanBlockProperty HAS_BOTTLE_0 = bool("has_bottle_0");
+    public static final BooleanBlockProperty HAS_BOTTLE_1 = bool("has_bottle_1");
+    public static final BooleanBlockProperty HAS_BOTTLE_2 = bool("has_bottle_2");
+    public static final BooleanBlockProperty HAS_RECORD = bool("has_record");
+    public static final BooleanBlockProperty INVERTED = bool("inverted");
+    public static final BooleanBlockProperty IN_WALL = bool("in_wall");
+    public static final BooleanBlockProperty LIT = bool("lit");
+    public static final BooleanBlockProperty LOCKED = bool("locked");
+    public static final BooleanBlockProperty MAP = bool("map");
+    public static final BooleanBlockProperty NATURAL = bool("natural");
+    public static final BooleanBlockProperty NORTH = bool("north");
+    public static final BooleanBlockProperty OCCUPIED = bool("occupied");
+    public static final BooleanBlockProperty OMINOUS = bool("ominous");
+    public static final BooleanBlockProperty OPEN = bool("open");
+    public static final BooleanBlockProperty PERSISTENT = bool("persistent");
+    public static final BooleanBlockProperty POWERED = bool("powered");
+    public static final BooleanBlockProperty SHORT = bool("short");
+    public static final BooleanBlockProperty SHRIEKING = bool("shrieking");
+    public static final BooleanBlockProperty SIGNAL_FIRE = bool("signal_fire");
+    public static final BooleanBlockProperty SLOT_0_OCCUPIED = bool("slot_0_occupied");
+    public static final BooleanBlockProperty SLOT_1_OCCUPIED = bool("slot_1_occupied");
+    public static final BooleanBlockProperty SLOT_2_OCCUPIED = bool("slot_2_occupied");
+    public static final BooleanBlockProperty SLOT_3_OCCUPIED = bool("slot_3_occupied");
+    public static final BooleanBlockProperty SLOT_4_OCCUPIED = bool("slot_4_occupied");
+    public static final BooleanBlockProperty SLOT_5_OCCUPIED = bool("slot_5_occupied");
+    public static final BooleanBlockProperty SNOWY = bool("snowy");
+    public static final BooleanBlockProperty SOUTH = bool("south");
+    public static final BooleanBlockProperty TIP = bool("tip");
+    public static final BooleanBlockProperty TRIGGERED = bool("triggered");
+    public static final BooleanBlockProperty UNSTABLE = bool("unstable");
+    public static final BooleanBlockProperty UP = bool("up");
+    public static final BooleanBlockProperty WATERLOGGED = bool("waterlogged");
+    public static final BooleanBlockProperty WEST = bool("west");
+    public static final EnumBlockProperty<FaceAttachable.AttachedFace> ATTACH_FACE = enumeration("face", FaceAttachable.AttachedFace.class);
+    public static final EnumBlockProperty<Axis> AXIS = enumeration("axis", Axis.class);
+    public static final EnumBlockProperty<Bamboo.Leaves> BAMBOO_LEAVES = enumeration("leaves", Bamboo.Leaves.class);
+    public static final EnumBlockProperty<Bed.Part> BED_PART = enumeration("part", Bed.Part.class);
+    public static final EnumBlockProperty<Bell.Attachment> BELL_ATTACHMENT = enumeration("attachment", Bell.Attachment.class);
+    public static final EnumBlockProperty<Chest.Type> CHEST_TYPE = enumeration("type", Chest.Type.class);
+    public static final EnumBlockProperty<CopperGolemStatue.Pose> COPPER_GOLEM_POSE = enumeration("copper_golem_pose", CopperGolemStatue.Pose.class);
+    public static final EnumBlockProperty<CreakingHeart.State> CREAKING_HEART_STATE = enumeration("creaking_heart_state", CreakingHeart.State.class);
+    public static final EnumBlockProperty<Door.Hinge> DOOR_HINGE = enumeration("hinge", Door.Hinge.class);
+    public static final EnumBlockProperty<Bisected.Half> DOUBLE_BLOCK_HALF = enumeration("half", Bisected.Half.class);
+    public static final EnumBlockProperty<RedstoneWire.Connection> EAST_REDSTONE = enumeration("east", RedstoneWire.Connection.class);
+    public static final EnumBlockProperty<Wall.Height> EAST_WALL = enumeration("east", Wall.Height.class);
+    public static final EnumBlockProperty<BlockFace> FACING = enumeration("facing", BlockFace.class, BlockFace::isCartesian);
+    public static final EnumBlockProperty<BlockFace> FACING_HOPPER = enumeration("facing", BlockFace.class, ((Predicate<BlockFace>) BlockFace::isCartesian).and(face -> face != BlockFace.UP));
+    public static final EnumBlockProperty<Bisected.Half> HALF = enumeration("half", Bisected.Half.class);
+    public static final EnumBlockProperty<Axis> HORIZONTAL_AXIS = enumeration("axis", Axis.class, Axis::isHorizontal);
+    public static final EnumBlockProperty<BlockFace> HORIZONTAL_FACING = enumeration("facing", BlockFace.class, BlockFace::isCardinal);
+    public static final EnumBlockProperty<Comparator.Mode> MODE_COMPARATOR = enumeration("mode", Comparator.Mode.class);
+    public static final EnumBlockProperty<RedstoneWire.Connection> NORTH_REDSTONE = enumeration("north", RedstoneWire.Connection.class);
+    public static final EnumBlockProperty<Wall.Height> NORTH_WALL = enumeration("north", Wall.Height.class);
+    public static final EnumBlockProperty<Instrument> NOTEBLOCK_INSTRUMENT = enumeration("instrument", Instrument.class);
+    public static final EnumBlockProperty<Orientation> ORIENTATION = enumeration("orientation", Orientation.class);
+    public static final EnumBlockProperty<TechnicalPiston.Type> PISTON_TYPE = enumeration("type", TechnicalPiston.Type.class);
+    public static final EnumBlockProperty<PotentSulfur.State> POTENT_SULFUR_STATE = enumeration("potent_sulfur_state", PotentSulfur.State.class);
+    public static final EnumBlockProperty<Rail.Shape> RAIL_SHAPE = enumeration("shape", Rail.Shape.class);
+    public static final EnumBlockProperty<Rail.Shape> RAIL_SHAPE_STRAIGHT = enumeration("shape", Rail.Shape.class, Rail.Shape::isStraight);
+    public static final EnumBlockProperty<SculkSensor.Phase> SCULK_SENSOR_PHASE = enumeration("sculk_sensor_phase", SculkSensor.Phase.class);
+    public static final EnumBlockProperty<SideChaining.ChainPart> SIDE_CHAIN_PART = enumeration("side_chain", SideChaining.ChainPart.class);
+    public static final EnumBlockProperty<Slab.Type> SLAB_TYPE = enumeration("type", Slab.Type.class);
+    public static final EnumBlockProperty<RedstoneWire.Connection> SOUTH_REDSTONE = enumeration("south", RedstoneWire.Connection.class);
+    public static final EnumBlockProperty<Wall.Height> SOUTH_WALL = enumeration("south", Wall.Height.class);
+    public static final EnumBlockProperty<Speleothem.Thickness> SPELEOTHEM_THICKNESS = enumeration("thickness", Speleothem.Thickness.class);
+    public static final EnumBlockProperty<Stairs.Shape> STAIRS_SHAPE = enumeration("shape", Stairs.Shape.class);
+    public static final EnumBlockProperty<StructureBlock.Mode> STRUCTUREBLOCK_MODE = enumeration("mode", StructureBlock.Mode.class);
+    public static final EnumBlockProperty<TestBlock.Mode> TEST_BLOCK_MODE = enumeration("mode", TestBlock.Mode.class);
+    public static final EnumBlockProperty<BigDripleaf.Tilt> TILT = enumeration("tilt", BigDripleaf.Tilt.class);
+    public static final EnumBlockProperty<TrialSpawner.State> TRIAL_SPAWNER_STATE = enumeration("trial_spawner_state", TrialSpawner.State.class);
+    public static final EnumBlockProperty<Vault.State> VAULT_STATE = enumeration("vault_state", Vault.State.class);
+    public static final EnumBlockProperty<BlockFace> VERTICAL_DIRECTION = enumeration("vertical_direction", BlockFace.class, face -> face.getModY() != 0);
+    public static final EnumBlockProperty<RedstoneWire.Connection> WEST_REDSTONE = enumeration("west", RedstoneWire.Connection.class);
+    public static final EnumBlockProperty<Wall.Height> WEST_WALL = enumeration("west", Wall.Height.class);
+    public static final IntegerBlockProperty AGE_1 = integer("age", 0, 1);
+    public static final IntegerBlockProperty AGE_15 = integer("age", 0, 15);
+    public static final IntegerBlockProperty AGE_2 = integer("age", 0, 2);
+    public static final IntegerBlockProperty AGE_25 = integer("age", 0, 25);
+    public static final IntegerBlockProperty AGE_3 = integer("age", 0, 3);
+    public static final IntegerBlockProperty AGE_4 = integer("age", 0, 4);
+    public static final IntegerBlockProperty AGE_5 = integer("age", 0, 5);
+    public static final IntegerBlockProperty AGE_7 = integer("age", 0, 7);
+    public static final IntegerBlockProperty BITES = integer("bites", 0, 6);
+    public static final IntegerBlockProperty CANDLES = integer("candles", 1, 4);
+    public static final IntegerBlockProperty DELAY = integer("delay", 1, 4);
+    public static final IntegerBlockProperty DISTANCE = integer("distance", 1, 7);
+    public static final IntegerBlockProperty DRIED_GHAST_HYDRATION_LEVELS = integer("hydration", 0, 3);
+    public static final IntegerBlockProperty DUSTED = integer("dusted", 0, 3);
+    public static final IntegerBlockProperty EGGS = integer("eggs", 1, 4);
+    public static final IntegerBlockProperty FLOWER_AMOUNT = integer("flower_amount", 1, 4);
+    public static final IntegerBlockProperty HATCH = integer("hatch", 0, 2);
+    public static final IntegerBlockProperty LAYERS = integer("layers", 1, 8);
+    public static final IntegerBlockProperty LEVEL = integer("level", 0, 15);
+    public static final IntegerBlockProperty LEVEL_CAULDRON = integer("level", 1, 3);
+    public static final IntegerBlockProperty LEVEL_COMPOSTER = integer("level", 0, 8);
+    public static final IntegerBlockProperty LEVEL_FLOWING = integer("level", 1, 8);
+    public static final IntegerBlockProperty LEVEL_HONEY = integer("honey_level", 0, 5);
+    public static final IntegerBlockProperty MOISTURE = integer("moisture", 0, 7);
+    public static final BlockProperty<Note> NOTE = register(new NoteBlockProperty("note"));
+    public static final IntegerBlockProperty PICKLES = integer("pickles", 1, 4);
+    public static final IntegerBlockProperty POWER = integer("power", 0, 15);
+    public static final IntegerBlockProperty RESPAWN_ANCHOR_CHARGES = integer("charges", 0, 4);
+    public static final EnumBlockProperty<BlockFace> ROTATION_16 = register(new RotationBlockProperty("rotation"));
+    public static final IntegerBlockProperty SEGMENT_AMOUNT = integer("segment_amount", 1, 4);
+    public static final IntegerBlockProperty STABILITY_DISTANCE = integer("distance", 0, 7);
+    public static final IntegerBlockProperty STAGE = integer("stage", 0, 1);
+    // End generate - BlockProperties
+
+    private BlockProperties() {
+    }
+
+    //<editor-fold defaultstate="collapsed" desc="static factory methods">
+    private static IntegerBlockProperty integer(final String name, final int min, final int max) {
+        return register(new IntegerBlockPropertyImpl(name, min, max));
+    }
+
+    private static BooleanBlockProperty bool(final String name) {
+        return register(new BooleanBlockPropertyImpl(name));
+    }
+
+    private static <E extends Enum<E>> EnumBlockProperty<E> enumeration(final String name, final Class<E> enumClass) {
+        return enumeration(name, enumClass, enumClass.getEnumConstants());
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    @SafeVarargs
+    private static <E extends Enum<E>> EnumBlockProperty<E> enumeration(final String name, final Class<E> enumClass, final E... values) {
+        return register(new EnumBlockPropertyImpl<>(name, enumClass, Set.of(values)));
+    }
+
+    private static <E extends Enum<E>> EnumBlockProperty<E> enumeration(final String name, final Class<E> enumClass, final Predicate<E> test) {
+        return register(new EnumBlockPropertyImpl<>(name, enumClass, Arrays.stream(enumClass.getEnumConstants()).filter(test).collect(Collectors.toSet())));
+    }
+
+    private static <V extends Comparable<V>, P extends BlockProperty<V>> P register(final P property) {
+        PROPERTIES.put(property.name(), property);
+        return property;
+    }
+    //</editor-fold>
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/BlockProperty.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/BlockProperty.java
@@ -1,0 +1,123 @@
+package io.papermc.paper.block.property;
+
+import java.util.Optional;
+import java.util.Set;
+import org.jetbrains.annotations.Unmodifiable;
+
+/**
+ * A property that applies to a {@link BlockPropertyHolder} such
+ * as {@link org.bukkit.block.data.BlockData} or {@link io.papermc.paper.block.fluid.FluidData}.
+ *
+ * @param <T> the value type
+ * @see BlockProperties
+ */
+public sealed interface BlockProperty<T extends Comparable<T>> permits AsIntegerProperty, BooleanBlockProperty, EnumBlockProperty, IntegerBlockProperty {
+
+    /**
+     * Gets the name of this property.
+     *
+     * @return the name
+     */
+    String name();
+
+    /**
+     * Gets the value type of this property.
+     *
+     * @return the value type
+     */
+    Class<T> type();
+
+    /**
+     * Gets the string name for a value of this property.
+     *
+     * @param value the value to get the string name of
+     * @return the string name of the value
+     * @throws IllegalArgumentException if the value is not valid for
+     * @see #value(String)
+     */
+    String name(T value);
+
+    /**
+     * Checks if the name is a valid name
+     * for a value of this property.
+     *
+     * @param name the name to check
+     * @return true if valid
+     * @see #value(String)
+     */
+    boolean isValidName(String name);
+
+    /**
+     * Gets the value of this property from the string name.
+     * Throws an exception if no value is found with that name.
+     *
+     * @param name the name of the value
+     * @return the property with the specified name
+     * @see #isValidName(String)
+     */
+    T value(String name);
+
+    /**
+     * Checks if the value is valid for this property.
+     *
+     * @param value the value to check
+     * @return true if valid
+     */
+    boolean isValidValue(T value);
+
+    /**
+     * Gets an immutable collection of possible values for this property.
+     *
+     * @return an immutable collection of values
+     */
+    @Unmodifiable Set<T> values();
+
+    /**
+     * Checks if a {@link BlockPropertyHolder} has this property.
+     *
+     * @param holder the holder of a set of properties (like {@link org.bukkit.block.data.BlockData})
+     * @return true if this property is present
+     * @see BlockPropertyHolder#hasProperty(BlockProperty)
+     */
+    default boolean hasValueOn(final BlockPropertyHolder holder) {
+        return holder.hasProperty(this);
+    }
+
+    /**
+     * Gets the value from a {@link BlockPropertyHolder} for this property.
+     *
+     * @param holder the holder of a set of properties (like {@link org.bukkit.block.data.BlockData})
+     * @return the non-null value
+     * @throws IllegalArgumentException if this property is not present
+     * @see #hasValueOn(BlockPropertyHolder)
+     * @see BlockPropertyHolder#getValue(BlockProperty)
+     */
+    default T getValue(final BlockPropertyHolder holder) {
+        return holder.getValue(this);
+    }
+
+    /**
+     * Gets the optional of the value for this property.
+     *
+     * @param holder the holder of a set of properties (like {@link org.bukkit.block.data.BlockData})
+     * @return the optional of the value, will be empty if the property is not present
+     * @see #getValue(BlockPropertyHolder)
+     * @see BlockPropertyHolder#getOptionalValue(BlockProperty)
+     */
+    default Optional<T> getOptionalValue(final BlockPropertyHolder holder) {
+        return holder.getOptionalValue(this);
+    }
+
+    /**
+     * Sets the value on a {@link BlockPropertyHolder} for this property.
+     *
+     * @param holder the mutable holder of a set of properties (like {@link org.bukkit.block.data.BlockData})
+     * @param value  the value for this property
+     * @throws IllegalArgumentException if this property is not present
+     * @see #hasValueOn(BlockPropertyHolder)
+     * @see BlockPropertyHolder#hasProperty(BlockProperty)
+     */
+    default void setValue(final BlockPropertyHolder.Mutable holder, final T value) {
+        holder.setValue(this, value);
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/BlockProperty.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/BlockProperty.java
@@ -1,0 +1,122 @@
+package io.papermc.paper.block.property;
+
+import java.util.Optional;
+import java.util.Set;
+import org.jetbrains.annotations.Unmodifiable;
+
+/**
+ * A property that applies to a {@link BlockPropertyHolder} such
+ * as {@link org.bukkit.block.data.BlockData} or {@link io.papermc.paper.block.fluid.FluidData}.
+ *
+ * @param <T> the value type
+ * @see BlockProperties
+ */
+public sealed interface BlockProperty<T extends Comparable<T>> permits AsIntegerProperty, BooleanBlockProperty, EnumBlockProperty, IntegerBlockProperty {
+
+    /**
+     * Gets the name of this property.
+     *
+     * @return the name
+     */
+    String name();
+
+    /**
+     * Gets the value's type of this property.
+     *
+     * @return the value type
+     */
+    Class<T> type();
+
+    /**
+     * Gets the name for a value of this property.
+     *
+     * @param value the value to get the name of
+     * @return the name of the value
+     * @throws IllegalArgumentException if the value is invalid
+     * @see #value(String)
+     */
+    String name(T value);
+
+    /**
+     * Checks if the name is valid for a value of this property.
+     *
+     * @param name the name to check
+     * @return {@code true} if valid
+     * @see #value(String)
+     */
+    boolean isValidName(String name);
+
+    /**
+     * Gets the value of this property from the name.
+     *
+     * @param name the name of the value
+     * @return the property with the specified name
+     * @throws IllegalArgumentException if no value is found with that name
+     * @see #isValidName(String)
+     */
+    T value(String name);
+
+    /**
+     * Checks if the value is valid for this property.
+     *
+     * @param value the value to check
+     * @return {@code true} if valid
+     */
+    boolean isValidValue(T value);
+
+    /**
+     * Gets an immutable collection of possible values for this property.
+     *
+     * @return an immutable collection of values
+     */
+    @Unmodifiable Set<T> values();
+
+    /**
+     * Checks if a {@link BlockPropertyHolder} has this property.
+     *
+     * @param holder the holder of a set of properties (like {@link org.bukkit.block.data.BlockData})
+     * @return {@code true} if this property is present
+     * @see BlockPropertyHolder#hasProperty(BlockProperty)
+     */
+    default boolean hasValueOn(final BlockPropertyHolder holder) {
+        return holder.hasProperty(this);
+    }
+
+    /**
+     * Gets the value from a {@link BlockPropertyHolder} for this property.
+     *
+     * @param holder the holder of a set of properties (like {@link org.bukkit.block.data.BlockData})
+     * @return the non-{@code null} value
+     * @throws IllegalArgumentException if this property is not present
+     * @see #hasValueOn(BlockPropertyHolder)
+     * @see BlockPropertyHolder#getValue(BlockProperty)
+     */
+    default T getValue(final BlockPropertyHolder holder) {
+        return holder.getValue(this);
+    }
+
+    /**
+     * Gets the value optionally for this property.
+     *
+     * @param holder the holder of a set of properties (like {@link org.bukkit.block.data.BlockData})
+     * @return the value if the property is present
+     * @see #getValue(BlockPropertyHolder)
+     * @see BlockPropertyHolder#getOptionalValue(BlockProperty)
+     */
+    default Optional<T> getOptionalValue(final BlockPropertyHolder holder) {
+        return holder.getOptionalValue(this);
+    }
+
+    /**
+     * Sets the value on a {@link BlockPropertyHolder} for this property.
+     *
+     * @param holder the mutable holder of a set of properties (like {@link org.bukkit.block.data.BlockData})
+     * @param value  the value for this property
+     * @throws IllegalArgumentException if this property is not present
+     * @see #hasValueOn(BlockPropertyHolder)
+     * @see BlockPropertyHolder#hasProperty(BlockProperty)
+     */
+    default void setValue(final BlockPropertyHolder.Mutable holder, final T value) {
+        holder.setValue(this, value);
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/BlockPropertyHolder.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/BlockPropertyHolder.java
@@ -1,0 +1,83 @@
+package io.papermc.paper.block.property;
+
+import java.util.Collection;
+import java.util.Optional;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents an object that holds {@link BlockProperty BlockProperties}.
+ *
+ * @see BlockProperties
+ */
+public interface BlockPropertyHolder {
+
+    /**
+     * Gets the property with this name on the holder (if it exists)
+     *
+     * @param propertyName name of the property
+     * @param <T>          property type;
+     * @return the property, if one is found with that name
+     */
+    <T extends Comparable<T>> @Nullable BlockProperty<T> getProperty(String propertyName);
+
+    /**
+     * Checks if this has the property.
+     *
+     * @param property the property to check for
+     * @param <T>      property type
+     * @return true if property is present
+     * @see BlockProperty#hasValueOn(BlockPropertyHolder)
+     */
+    <T extends Comparable<T>> boolean hasProperty(BlockProperty<T> property);
+
+    /**
+     * Gets the value for the specified property
+     *
+     * @param property the property
+     * @param <T>      property type
+     * @return the non-null value
+     * @throws IllegalArgumentException if the property is not present
+     * @see #hasProperty(BlockProperty)
+     * @see BlockProperty#getValue(BlockPropertyHolder)
+     */
+    <T extends Comparable<T>> T getValue(BlockProperty<T> property);
+
+    /**
+     * Gets the optional of the value for the specified property.
+     *
+     * @param property the property
+     * @param <T>      property type
+     * @return the optional of the value, will be empty if the property is not present
+     * @see #getValue(BlockProperty)
+     * @see BlockProperty#getOptionalValue(BlockPropertyHolder)
+     */
+    <T extends Comparable<T>> Optional<T> getOptionalValue(BlockProperty<T> property);
+
+    /**
+     * Get all properties present on this.
+     *
+     * @return an unmodifiable collection of properties
+     */
+    @Unmodifiable Collection<BlockProperty<?>> getProperties();
+
+    /**
+     * Represents an object that holds {@link BlockProperty}s that can be changed.
+     *
+     * @see BlockProperties
+     */
+    interface Mutable extends BlockPropertyHolder {
+
+        /**
+         * Sets the value of the specified property.
+         *
+         * @param property the property
+         * @param value    the value for the property
+         * @param <T>      property type
+         * @throws IllegalArgumentException if the property is not present or if the value is invalid
+         * @see #hasProperty(BlockProperty)
+         * @see BlockProperty#setValue(Mutable, Comparable)
+         */
+        <T extends Comparable<T>> void setValue(BlockProperty<T> property, T value);
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/BlockPropertyHolder.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/BlockPropertyHolder.java
@@ -1,0 +1,83 @@
+package io.papermc.paper.block.property;
+
+import java.util.Collection;
+import java.util.Optional;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents an object that holds {@linkplain BlockProperty block properties}.
+ *
+ * @see BlockProperties
+ */
+public interface BlockPropertyHolder {
+
+    /**
+     * Gets the property with this name on the holder (if present).
+     *
+     * @param propertyName name of the property
+     * @param <T>          property type
+     * @return the property, if one is found with that name
+     */
+    <T extends Comparable<T>> @Nullable BlockProperty<T> getProperty(String propertyName);
+
+    /**
+     * Checks if this holder has the given property.
+     *
+     * @param property the property to check for
+     * @param <T>      property type
+     * @return {@code true} if property is present
+     * @see BlockProperty#hasValueOn(BlockPropertyHolder)
+     */
+    <T extends Comparable<T>> boolean hasProperty(BlockProperty<T> property);
+
+    /**
+     * Gets the value for the given property.
+     *
+     * @param property the property
+     * @param <T>      property type
+     * @return the non-{@code null} value
+     * @throws IllegalArgumentException if the property is not present
+     * @see #hasProperty(BlockProperty)
+     * @see BlockProperty#getValue(BlockPropertyHolder)
+     */
+    <T extends Comparable<T>> T getValue(BlockProperty<T> property);
+
+    /**
+     * Gets the value optionally for the given property.
+     *
+     * @param property the property
+     * @param <T>      property type
+     * @return the value if the property is present
+     * @see #getValue(BlockProperty)
+     * @see BlockProperty#getOptionalValue(BlockPropertyHolder)
+     */
+    <T extends Comparable<T>> Optional<T> getOptionalValue(BlockProperty<T> property);
+
+    /**
+     * Get all properties present on this holder.
+     *
+     * @return an unmodifiable collection of properties
+     */
+    @Unmodifiable Collection<BlockProperty<?>> getProperties();
+
+    /**
+     * Represents an object that holds {@linkplain BlockProperty block properties} that can be changed.
+     *
+     * @see BlockProperties
+     */
+    interface Mutable extends BlockPropertyHolder {
+
+        /**
+         * Sets the value of the given property.
+         *
+         * @param property the property
+         * @param value    the value for the property
+         * @param <T>      property type
+         * @throws IllegalArgumentException if the property is not present or if the value is invalid
+         * @see #hasProperty(BlockProperty)
+         * @see BlockProperty#setValue(Mutable, Comparable)
+         */
+        <T extends Comparable<T>> void setValue(BlockProperty<T> property, T value);
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/BooleanBlockProperty.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/BooleanBlockProperty.java
@@ -1,0 +1,9 @@
+package io.papermc.paper.block.property;
+
+/**
+ * A block data property for a {@code boolean} value.
+ *
+ * @see BlockProperties
+ */
+public sealed interface BooleanBlockProperty extends BlockProperty<Boolean> permits BooleanBlockPropertyImpl {
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/BooleanBlockPropertyImpl.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/BooleanBlockPropertyImpl.java
@@ -1,0 +1,45 @@
+package io.papermc.paper.block.property;
+
+import it.unimi.dsi.fastutil.booleans.BooleanSet;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Unmodifiable;
+
+@ApiStatus.Internal
+record BooleanBlockPropertyImpl(String name) implements BooleanBlockProperty {
+
+    private static final BooleanSet VALUES = BooleanSet.of(true, false);
+
+    @Override
+    public Class<Boolean> type() {
+        return Boolean.class;
+    }
+
+    @Override
+    public String name(final Boolean value) {
+        return value.toString();
+    }
+
+    @Override
+    public boolean isValidName(final String name) {
+        return "true".equals(name) || "false".equals(name);
+    }
+
+    @Override
+    public Boolean value(final String name) {
+        return switch (name) {
+            case "true" -> true;
+            case "false" -> false;
+            default -> throw ExceptionCreator.INSTANCE.create(name, ExceptionCreator.Type.NAME, this);
+        };
+    }
+
+    @Override
+    public boolean isValidValue(final Boolean value) {
+        return true;
+    }
+
+    @Override
+    public @Unmodifiable BooleanSet values() {
+        return VALUES;
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/BooleanBlockPropertyImpl.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/BooleanBlockPropertyImpl.java
@@ -1,0 +1,43 @@
+package io.papermc.paper.block.property;
+
+import it.unimi.dsi.fastutil.booleans.BooleanSet;
+import org.jetbrains.annotations.Unmodifiable;
+
+record BooleanBlockPropertyImpl(String name) implements BooleanBlockProperty {
+
+    private static final BooleanSet VALUES = BooleanSet.of(true, false);
+
+    @Override
+    public Class<Boolean> type() {
+        return Boolean.class;
+    }
+
+    @Override
+    public String name(final Boolean value) {
+        return value.toString();
+    }
+
+    @Override
+    public boolean isValidName(final String name) {
+        return "true".equals(name) || "false".equals(name);
+    }
+
+    @Override
+    public Boolean value(final String name) {
+        return switch (name) {
+            case "true" -> true;
+            case "false" -> false;
+            default -> throw ExceptionCreator.NOT_VALID.create(name, ExceptionCreator.Type.NAME, this);
+        };
+    }
+
+    @Override
+    public boolean isValidValue(final Boolean value) {
+        return true;
+    }
+
+    @Override
+    public @Unmodifiable BooleanSet values() {
+        return VALUES;
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/EnumBlockProperty.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/EnumBlockProperty.java
@@ -1,0 +1,9 @@
+package io.papermc.paper.block.property;
+
+/**
+ * A block data property for an {@code enum} value.
+ *
+ * @see BlockProperties
+ */
+public sealed interface EnumBlockProperty<E extends Enum<E>> extends BlockProperty<E> permits EnumBlockPropertyImpl {
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/EnumBlockProperty.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/EnumBlockProperty.java
@@ -1,0 +1,10 @@
+package io.papermc.paper.block.property;
+
+/**
+ * A block data property for an {@code enum} value.
+ *
+ * @param <E> the enum type
+ * @see BlockProperties
+ */
+public sealed interface EnumBlockProperty<E extends Enum<E>> extends BlockProperty<E> permits EnumBlockPropertyImpl {
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/EnumBlockPropertyImpl.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/EnumBlockPropertyImpl.java
@@ -1,0 +1,79 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Sets;
+import io.papermc.paper.InternalAPIBridge;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import net.kyori.adventure.util.Index;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Unmodifiable;
+
+@ApiStatus.Internal
+sealed class EnumBlockPropertyImpl<E extends Enum<E>> implements EnumBlockProperty<E> permits RotationBlockProperty {
+
+    private final String name;
+    private final Class<E> type;
+    private final Set<E> values;
+    private final Supplier<Index<String, E>> byNameIndex;
+
+    EnumBlockPropertyImpl(final String name, final Class<E> type, final Collection<E> values) {
+        this.name = name;
+        this.type = type;
+        this.values = Sets.immutableEnumSet(values);
+        this.byNameIndex = Suppliers.memoize(this::createByNameIndex);
+    }
+
+    @Override
+    public String name() {
+        return this.name;
+    }
+
+    @Override
+    public Class<E> type() {
+        return this.type;
+    }
+
+    private Index<String, E> byNameIndex() {
+        return this.byNameIndex.get();
+    }
+
+    private Index<String, E> createByNameIndex() {
+        return Index.create(e -> InternalAPIBridge.get().getPropertyEnumName(this, e), List.copyOf(this.values));
+    }
+
+    @Override
+    public String name(final E value) {
+        final String valueName = this.byNameIndex().key(value);
+        if (valueName == null) {
+            throw ExceptionCreator.INSTANCE.create(value, ExceptionCreator.Type.VALUE, this);
+        }
+        return valueName;
+    }
+
+    @Override
+    public boolean isValidName(final String name) {
+        return this.byNameIndex().value(name) != null;
+    }
+
+    @Override
+    public E value(final String name) {
+        final E value = this.byNameIndex().value(name);
+        if (value == null) {
+            throw ExceptionCreator.INSTANCE.create(name, ExceptionCreator.Type.NAME, this);
+        }
+        return value;
+    }
+
+    @Override
+    public boolean isValidValue(final E enumValue) {
+        return this.values.contains(enumValue);
+    }
+
+    @Override
+    public @Unmodifiable Set<E> values() {
+        return this.values;
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/EnumBlockPropertyImpl.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/EnumBlockPropertyImpl.java
@@ -1,0 +1,77 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Sets;
+import io.papermc.paper.InternalAPIBridge;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import net.kyori.adventure.util.Index;
+import org.jetbrains.annotations.Unmodifiable;
+
+sealed class EnumBlockPropertyImpl<E extends Enum<E>> implements EnumBlockProperty<E> permits RotationBlockProperty {
+
+    private final String name;
+    private final Class<E> type;
+    private final Set<E> values;
+    private final Supplier<Index<String, E>> byNameIndex;
+
+    EnumBlockPropertyImpl(final String name, final Class<E> type, final Collection<E> values) {
+        this.name = name;
+        this.type = type;
+        this.values = Sets.immutableEnumSet(values);
+        this.byNameIndex = Suppliers.memoize(this::createByNameIndex);
+    }
+
+    @Override
+    public String name() {
+        return this.name;
+    }
+
+    @Override
+    public Class<E> type() {
+        return this.type;
+    }
+
+    private Index<String, E> byNameIndex() {
+        return this.byNameIndex.get();
+    }
+
+    private Index<String, E> createByNameIndex() {
+        return Index.create(e -> InternalAPIBridge.get().getPropertyEnumName(this, e), List.copyOf(this.values));
+    }
+
+    @Override
+    public String name(final E value) {
+        final String valueName = this.byNameIndex().key(value);
+        if (valueName == null) {
+            throw ExceptionCreator.NOT_VALID.create(value, ExceptionCreator.Type.VALUE, this);
+        }
+        return valueName;
+    }
+
+    @Override
+    public boolean isValidName(final String name) {
+        return this.byNameIndex().value(name) != null;
+    }
+
+    @Override
+    public E value(final String name) {
+        final E value = this.byNameIndex().value(name);
+        if (value == null) {
+            throw ExceptionCreator.NOT_VALID.create(name, ExceptionCreator.Type.NAME, this);
+        }
+        return value;
+    }
+
+    @Override
+    public boolean isValidValue(final E value) {
+        return this.values.contains(value);
+    }
+
+    @Override
+    public @Unmodifiable Set<E> values() {
+        return this.values;
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/ExceptionCreator.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/ExceptionCreator.java
@@ -1,0 +1,18 @@
+package io.papermc.paper.block.property;
+
+import java.util.Locale;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+@FunctionalInterface
+interface ExceptionCreator {
+
+    ExceptionCreator INSTANCE = (value, type, property) -> new IllegalArgumentException(String.format("%s (%s) is not a valid %s for %s", value, value.getClass().getSimpleName(), type.name().toLowerCase(Locale.ENGLISH), property));
+
+    IllegalArgumentException create(Object value, Type type, BlockProperty<?> property);
+
+    enum Type {
+        NAME,
+        VALUE,
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/ExceptionCreator.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/ExceptionCreator.java
@@ -3,6 +3,7 @@ package io.papermc.paper.block.property;
 import java.util.Locale;
 
 @FunctionalInterface
+@SuppressWarnings("checkstyle:JavadocVariable") // todo see https://github.com/checkstyle/checkstyle/issues/17117
 interface ExceptionCreator {
 
     ExceptionCreator NOT_VALID = (value, type, property) -> new IllegalArgumentException(String.format("%s (%s) is not a valid %s for %s", value, value.getClass().getSimpleName(), type.name().toLowerCase(Locale.ENGLISH), property));

--- a/paper-api/src/main/java/io/papermc/paper/block/property/ExceptionCreator.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/ExceptionCreator.java
@@ -1,0 +1,16 @@
+package io.papermc.paper.block.property;
+
+import java.util.Locale;
+
+@FunctionalInterface
+interface ExceptionCreator {
+
+    ExceptionCreator NOT_VALID = (value, type, property) -> new IllegalArgumentException(String.format("%s (%s) is not a valid %s for %s", value, value.getClass().getSimpleName(), type.name().toLowerCase(Locale.ENGLISH), property));
+
+    IllegalArgumentException create(Object value, Type type, BlockProperty<?> property);
+
+    enum Type {
+        NAME,
+        VALUE,
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/IntegerBlockProperty.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/IntegerBlockProperty.java
@@ -1,0 +1,23 @@
+package io.papermc.paper.block.property;
+
+/**
+ * A block data property for an {@code int} value.
+ *
+ * @see BlockProperties
+ */
+public sealed interface IntegerBlockProperty extends BlockProperty<Integer> permits IntegerBlockPropertyImpl {
+
+    /**
+     * Gets the min value for this property.
+     *
+     * @return the min value
+     */
+    int min();
+
+    /**
+     * Gets the max value for this property.
+     *
+     * @return the max value
+     */
+    int max();
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/IntegerBlockPropertyImpl.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/IntegerBlockPropertyImpl.java
@@ -1,0 +1,88 @@
+package io.papermc.paper.block.property;
+
+import it.unimi.dsi.fastutil.ints.IntLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+record IntegerBlockPropertyImpl(String name, IntSet values, int min, int max) implements IntegerBlockProperty {
+
+    IntegerBlockPropertyImpl(final String name, final int min, final int max) {
+        this(name, createValues(min, max), min, max);
+    }
+
+    static IntSet createValues(final int min, final int max) {
+        if (min < 0 || max <= min) {
+            throw new IllegalArgumentException("Invalid range. Min: " + min + ", Max: " + max);
+        }
+        final IntSet set = new IntLinkedOpenHashSet();
+        for (int i = min; i <= max; i++) {
+            set.add(i);
+        }
+        return IntSets.unmodifiable(set); // use unmodifiable to preserve order (but in reality its immutable)
+    }
+
+    @Override
+    public Class<Integer> type() {
+        return Integer.class;
+    }
+
+    /**
+     * Gets the min value for this property.
+     *
+     * @return the min value
+     */
+    @Override
+    public int min() {
+        return this.min;
+    }
+
+    /**
+     * Gets the max value for this property.
+     *
+     * @return the max value
+     */
+    @Override
+    public int max() {
+        return this.max;
+    }
+
+    @Override
+    public String name(final Integer value) {
+        if (value > this.max || value < this.min) {
+            throw ExceptionCreator.INSTANCE.create(value, ExceptionCreator.Type.VALUE, this);
+        }
+        return value.toString();
+    }
+
+    @Override
+    public boolean isValidName(final String name) {
+        try {
+            final int value = Integer.parseInt(name);
+            if (this.values.contains(value)) {
+                return true;
+            }
+        } catch (final NumberFormatException _) {
+        }
+        return false;
+    }
+
+    @Override
+    public Integer value(final String name) {
+        try {
+            final int value = Integer.parseInt(name);
+            if (this.values.contains(value)) {
+                return value;
+            }
+            throw ExceptionCreator.INSTANCE.create(name, ExceptionCreator.Type.NAME, this);
+        } catch (final NumberFormatException exception) {
+            throw ExceptionCreator.INSTANCE.create(name, ExceptionCreator.Type.NAME, this);
+        }
+    }
+
+    @Override
+    public boolean isValidValue(final Integer num) {
+        return num >= this.min && num <= this.max;
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/IntegerBlockPropertyImpl.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/IntegerBlockPropertyImpl.java
@@ -1,0 +1,83 @@
+package io.papermc.paper.block.property;
+
+import it.unimi.dsi.fastutil.ints.IntLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+
+record IntegerBlockPropertyImpl(String name, IntSet values, int min, int max) implements IntegerBlockProperty {
+
+    IntegerBlockPropertyImpl(final String name, final int min, final int max) {
+        this(name, createValues(min, max), min, max);
+    }
+
+    static IntSet createValues(final int min, final int max) {
+        if (min < 0 || max <= min) {
+            throw new IllegalArgumentException("Invalid range. Min: " + min + ", Max: " + max);
+        }
+        final IntSet set = new IntLinkedOpenHashSet();
+        for (int i = min; i <= max; i++) {
+            set.add(i);
+        }
+        return IntSets.unmodifiable(set); // use unmodifiable to preserve order (but in reality its immutable)
+    }
+
+    @Override
+    public Class<Integer> type() {
+        return Integer.class;
+    }
+
+    /**
+     * Gets the min value for this property.
+     *
+     * @return the min value
+     */
+    @Override
+    public int min() {
+        return this.min;
+    }
+
+    /**
+     * Gets the max value for this property.
+     *
+     * @return the max value
+     */
+    @Override
+    public int max() {
+        return this.max;
+    }
+
+    @Override
+    public String name(final Integer value) {
+        if (!this.isValidValue(value)) {
+            throw ExceptionCreator.NOT_VALID.create(value, ExceptionCreator.Type.VALUE, this);
+        }
+        return value.toString();
+    }
+
+    @Override
+    public boolean isValidName(final String name) {
+        try {
+            this.value(name);
+        } catch (IllegalArgumentException _) {
+        }
+        return false;
+    }
+
+    @Override
+    public Integer value(final String name) {
+        try {
+            final int value = Integer.parseInt(name);
+            if (this.isValidValue(value)) {
+                return value;
+            }
+            throw ExceptionCreator.NOT_VALID.create(name, ExceptionCreator.Type.NAME, this);
+        } catch (NumberFormatException _) {
+            throw ExceptionCreator.NOT_VALID.create(name, ExceptionCreator.Type.NAME, this);
+        }
+    }
+
+    @Override
+    public boolean isValidValue(final Integer value) {
+        return value >= this.min && value <= this.max;
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/NoteBlockProperty.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/NoteBlockProperty.java
@@ -1,0 +1,61 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.collect.BiMap;
+import java.util.Collections;
+import java.util.Set;
+import org.bukkit.Note;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Unmodifiable;
+
+@ApiStatus.Internal
+record NoteBlockProperty(String name, BiMap<Integer, Note> cache) implements AsIntegerProperty<Note> {
+    
+    NoteBlockProperty(final String name) {
+        this(name, AsIntegerProperty.createCache(24, Note::new));
+    }
+
+    @Override
+    public Class<Note> type() {
+        return Note.class;
+    }
+
+    @Override
+    public String name(final Note value) {
+        return String.valueOf(value.getId());
+    }
+
+    @Override
+    public boolean isValidName(final String name) {
+        try {
+            final Integer value = Integer.valueOf(name);
+            if (this.cache.containsKey(value)) {
+                return true;
+            }
+        } catch (final NumberFormatException _) {
+        }
+        return false;
+    }
+
+    @Override
+    public Note value(final String name) {
+        try {
+            final Integer value = Integer.valueOf(name);
+            if (this.cache.containsKey(value)) {
+                return this.cache.get(value);
+            }
+            throw ExceptionCreator.INSTANCE.create(name, ExceptionCreator.Type.NAME, this);
+        } catch (final NumberFormatException exception) {
+            throw ExceptionCreator.INSTANCE.create(name, ExceptionCreator.Type.NAME, this);
+        }
+    }
+
+    @Override
+    public boolean isValidValue(final Note note) {
+        return this.cache.inverse().containsKey(note);
+    }
+
+    @Override
+    public @Unmodifiable Set<Note> values() {
+        return Collections.unmodifiableSet(this.cache.values());
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/NoteBlockProperty.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/NoteBlockProperty.java
@@ -1,0 +1,59 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.collect.BiMap;
+import java.util.Collections;
+import java.util.Set;
+import org.bukkit.Note;
+import org.jetbrains.annotations.Unmodifiable;
+
+record NoteBlockProperty(String name, BiMap<Integer, Note> cache) implements AsIntegerProperty<Note> {
+
+    NoteBlockProperty(final String name) {
+        this(name, AsIntegerProperty.createCache(24, Note::new));
+    }
+
+    @Override
+    public Class<Note> type() {
+        return Note.class;
+    }
+
+    @Override
+    public String name(final Note value) {
+        return String.valueOf(value.getId());
+    }
+
+    @Override
+    public boolean isValidName(final String name) {
+        try {
+            final Integer value = Integer.parseInt(name);
+            if (this.cache.containsKey(value)) {
+                return true;
+            }
+        } catch (NumberFormatException _) {
+        }
+        return false;
+    }
+
+    @Override
+    public Note value(final String name) {
+        try {
+            final Integer value = Integer.parseInt(name);
+            if (this.cache.containsKey(value)) {
+                return this.cache.get(value);
+            }
+            throw ExceptionCreator.NOT_VALID.create(name, ExceptionCreator.Type.NAME, this);
+        } catch (NumberFormatException _) {
+            throw ExceptionCreator.NOT_VALID.create(name, ExceptionCreator.Type.NAME, this);
+        }
+    }
+
+    @Override
+    public boolean isValidValue(final Note note) {
+        return this.cache.inverse().containsKey(note);
+    }
+
+    @Override
+    public @Unmodifiable Set<Note> values() {
+        return Collections.unmodifiableSet(this.cache.values());
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/RotationBlockProperty.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/RotationBlockProperty.java
@@ -1,0 +1,64 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.Sets;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.bukkit.block.BlockFace;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Special exception for the {@link BlockProperties#ROTATION_16} property because
+ * in the API it's represented as an enum, but stored as an integer.
+ */
+@ApiStatus.Internal
+final class RotationBlockProperty extends EnumBlockPropertyImpl<BlockFace> implements AsIntegerProperty<BlockFace> {
+
+    private static final Set<BlockFace> VALUES;
+
+    static {
+        final Set<BlockFace> values = new LinkedHashSet<>();
+        for (final BlockFace face : BlockFace.values()) {
+            if (face.getModY() == 0 && (face.getModZ() != 0 || face.getModX() != 0)) {
+                values.add(face);
+            }
+        }
+        Preconditions.checkArgument(values.size() == 16, "Expected 16 enum values");
+        VALUES = Sets.immutableEnumSet(values);
+    }
+
+    private final BiMap<Integer, BlockFace> cache;
+
+    RotationBlockProperty(final String name) {
+        super(name, BlockFace.class, VALUES);
+        this.cache = AsIntegerProperty.createCache(0xF, RotationBlockProperty::intToEnum);
+    }
+
+    @Override
+    public BiMap<Integer, BlockFace> cache() {
+        return this.cache;
+    }
+
+    private static BlockFace intToEnum(final int value) {
+        return switch (value) {
+            case 0x0 -> BlockFace.SOUTH;
+            case 0x1 -> BlockFace.SOUTH_SOUTH_WEST;
+            case 0x2 -> BlockFace.SOUTH_WEST;
+            case 0x3 -> BlockFace.WEST_SOUTH_WEST;
+            case 0x4 -> BlockFace.WEST;
+            case 0x5 -> BlockFace.WEST_NORTH_WEST;
+            case 0x6 -> BlockFace.NORTH_WEST;
+            case 0x7 -> BlockFace.NORTH_NORTH_WEST;
+            case 0x8 -> BlockFace.NORTH;
+            case 0x9 -> BlockFace.NORTH_NORTH_EAST;
+            case 0xA -> BlockFace.NORTH_EAST;
+            case 0xB -> BlockFace.EAST_NORTH_EAST;
+            case 0xC -> BlockFace.EAST;
+            case 0xD -> BlockFace.EAST_SOUTH_EAST;
+            case 0xE -> BlockFace.SOUTH_EAST;
+            case 0xF -> BlockFace.SOUTH_SOUTH_EAST;
+            default -> throw new IllegalArgumentException("Illegal value " + value);
+        };
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/RotationBlockProperty.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/RotationBlockProperty.java
@@ -1,0 +1,62 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.Sets;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.bukkit.block.BlockFace;
+
+/**
+ * Special exception for the {@link BlockProperties#ROTATION_16} property because
+ * in the API it's represented as an enum, but stored as an integer.
+ */
+final class RotationBlockProperty extends EnumBlockPropertyImpl<BlockFace> implements AsIntegerProperty<BlockFace> {
+
+    private static final Set<BlockFace> VALUES;
+
+    static {
+        final Set<BlockFace> values = new LinkedHashSet<>();
+        for (final BlockFace face : BlockFace.values()) {
+            if (face.getModY() == 0 && face != BlockFace.SELF) {
+                values.add(face);
+            }
+        }
+        Preconditions.checkArgument(values.size() == 16, "Expected 16 enum values");
+        VALUES = Sets.immutableEnumSet(values);
+    }
+
+    private final BiMap<Integer, BlockFace> cache;
+
+    RotationBlockProperty(final String name) {
+        super(name, BlockFace.class, VALUES);
+        this.cache = AsIntegerProperty.createCache(0xF, RotationBlockProperty::intToEnum);
+    }
+
+    @Override
+    public BiMap<Integer, BlockFace> cache() {
+        return this.cache;
+    }
+
+    private static BlockFace intToEnum(final int value) {
+        return switch (value) {
+            case 0x0 -> BlockFace.SOUTH;
+            case 0x1 -> BlockFace.SOUTH_SOUTH_WEST;
+            case 0x2 -> BlockFace.SOUTH_WEST;
+            case 0x3 -> BlockFace.WEST_SOUTH_WEST;
+            case 0x4 -> BlockFace.WEST;
+            case 0x5 -> BlockFace.WEST_NORTH_WEST;
+            case 0x6 -> BlockFace.NORTH_WEST;
+            case 0x7 -> BlockFace.NORTH_NORTH_WEST;
+            case 0x8 -> BlockFace.NORTH;
+            case 0x9 -> BlockFace.NORTH_NORTH_EAST;
+            case 0xA -> BlockFace.NORTH_EAST;
+            case 0xB -> BlockFace.EAST_NORTH_EAST;
+            case 0xC -> BlockFace.EAST;
+            case 0xD -> BlockFace.EAST_SOUTH_EAST;
+            case 0xE -> BlockFace.SOUTH_EAST;
+            case 0xF -> BlockFace.SOUTH_SOUTH_EAST;
+            default -> throw new IllegalArgumentException("Illegal value " + value);
+        };
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/property/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/property/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Package for block properties.
+ */
+@NullMarked
+package io.papermc.paper.block.property;
+
+import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BlockItemDataProperties.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BlockItemDataProperties.java
@@ -1,5 +1,7 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.block.property.BlockProperty;
+import io.papermc.paper.block.property.BlockPropertyHolder;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.bukkit.block.BlockType;
 import org.bukkit.block.data.BlockData;
@@ -46,6 +48,34 @@ public interface BlockItemDataProperties {
     @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<BlockItemDataProperties> {
-        // building this requires BlockProperty API, so an empty builder for now (essentially read-only)
+
+        /**
+         * Sets all the properties from the given {@link BlockPropertyHolder}.
+         *
+         * @param properties the properties to set
+         * @return the builder for chaining
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        default Builder setFrom(final BlockPropertyHolder properties) {
+            properties.getProperties().forEach(property -> {
+                this.setFromHelper(properties, property);
+            });
+            return this;
+        }
+
+        private <T extends Comparable<T>> void setFromHelper(final BlockPropertyHolder propertyHolder, final BlockProperty<T> property) {
+            this.set(property, propertyHolder.getValue(property));
+        }
+
+        /**
+         * Sets a property to the given value.
+         *
+         * @param property the property to set
+         * @param value the value to set
+         * @param <T> the property type
+         * @return the builder for chaining
+         */
+        @Contract(value = "_, _ -> this", mutates = "this")
+        <T extends Comparable<T>> Builder set(BlockProperty<T> property, T value);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BlockItemDataProperties.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BlockItemDataProperties.java
@@ -1,5 +1,7 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.block.property.BlockProperty;
+import io.papermc.paper.block.property.BlockPropertyHolder;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.bukkit.block.BlockType;
 import org.bukkit.block.data.BlockData;
@@ -44,6 +46,34 @@ public interface BlockItemDataProperties {
      */
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<BlockItemDataProperties> {
-        // building this requires BlockProperty API, so an empty builder for now (essentially read-only)
+
+        /**
+         * Sets all the properties from the given {@link BlockPropertyHolder}.
+         *
+         * @param properties the properties to set
+         * @return the builder for chaining
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        default Builder setFrom(final BlockPropertyHolder properties) {
+            properties.getProperties().forEach(property -> {
+                this.setFromHelper(properties, property);
+            });
+            return this;
+        }
+
+        private <T extends Comparable<T>> void setFromHelper(final BlockPropertyHolder propertyHolder, final BlockProperty<T> property) {
+            this.set(property, propertyHolder.getValue(property));
+        }
+
+        /**
+         * Sets a property to the given value.
+         *
+         * @param property the property to set
+         * @param value the value to set
+         * @param <T> the property type
+         * @return the builder for chaining
+         */
+        @Contract(value = "_, _ -> this", mutates = "this")
+        <T extends Comparable<T>> Builder set(BlockProperty<T> property, T value);
     }
 }

--- a/paper-api/src/main/java/org/bukkit/Axis.java
+++ b/paper-api/src/main/java/org/bukkit/Axis.java
@@ -18,4 +18,8 @@ public enum Axis {
      * The z axis.
      */
     Z;
+
+    public boolean isHorizontal() {
+        return this == X || this == Z;
+    }
 }

--- a/paper-api/src/main/java/org/bukkit/Note.java
+++ b/paper-api/src/main/java/org/bukkit/Note.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * A note class to store a specific note.
  */
-public class Note {
+public class Note implements Comparable<Note> {
 
     /**
      * An enum holding tones.
@@ -293,6 +293,12 @@ public class Note {
             return false;
         return true;
     }
+
+    @Override
+    public int compareTo(final @NotNull Note other) {
+        return Byte.compare(this.note, other.note);
+    }
+
 
     @Override
     public String toString() {

--- a/paper-api/src/main/java/org/bukkit/block/BlockFace.java
+++ b/paper-api/src/main/java/org/bukkit/block/BlockFace.java
@@ -104,6 +104,13 @@ public enum BlockFace {
         }
     }
 
+    public boolean isCardinal() {
+        return switch (this) {
+            case NORTH, SOUTH, EAST, WEST -> true;
+            default -> false;
+        };
+    }
+
     @NotNull
     public BlockFace getOppositeFace() {
         switch (this) {

--- a/paper-api/src/main/java/org/bukkit/block/data/BlockData.java
+++ b/paper-api/src/main/java/org/bukkit/block/data/BlockData.java
@@ -1,5 +1,6 @@
 package org.bukkit.block.data;
 
+import io.papermc.paper.block.property.BlockPropertyHolder;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -17,7 +18,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public interface BlockData extends Cloneable {
+public interface BlockData extends Cloneable, BlockPropertyHolder.Mutable {
 
     /**
      * Get the Material represented by this block data.

--- a/paper-api/src/main/java/org/bukkit/block/data/Rail.java
+++ b/paper-api/src/main/java/org/bukkit/block/data/Rail.java
@@ -83,5 +83,9 @@ public interface Rail extends Waterlogged {
          * block.
          */
         NORTH_EAST;
+
+        public boolean isStraight() {
+            return this != SOUTH_EAST && this != SOUTH_WEST && this != NORTH_WEST && this != NORTH_EAST;
+        }
     }
 }

--- a/paper-checkstyle/.checkstyle/checkstyle.xml
+++ b/paper-checkstyle/.checkstyle/checkstyle.xml
@@ -2,6 +2,18 @@
     "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
     "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
+    <!--TODO: remove once base config is uncommented-->
+    <module name="TreeWalker">
+        <module name="FinalLocalVariable">
+            <property name="validateEnhancedForLoopVariable" value="true"/>
+            <property name="validateUnnamedVariables" value="true"/>
+            <property name="tokens" value="PARAMETER_DEF,VARIABLE_DEF"/>
+        </module>
+        <!-- Overlaps with the configured FinalLocalVariable, but is stricter  -->
+        <module name="FinalParameters">
+            <property name="tokens" value="METHOD_DEF,CTOR_DEF,LITERAL_CATCH,FOR_EACH_CLAUSE,PATTERN_VARIABLE_DEF"/>
+        </module>
+    </module>
     <module name="SuppressionSingleFilter">
         <property name="checks" value=".*"/>
         <property name="files" value="src[\\/]testData[\\/]java[^\\/]*[\\/].*"/>

--- a/paper-checkstyle/src/main/java/io/papermc/checkstyle/checks/JavadocAlignParameterDescriptionCheck.java
+++ b/paper-checkstyle/src/main/java/io/papermc/checkstyle/checks/JavadocAlignParameterDescriptionCheck.java
@@ -6,7 +6,10 @@ import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import io.papermc.checkstyle.Util;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.function.IntPredicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -40,7 +43,9 @@ public final class JavadocAlignParameterDescriptionCheck extends AbstractJavadoc
                 continue;
             }
             // iterate over all text nodes (multiline)
-            for (final DetailNode textNode : JavadocUtil.getAllNodesOfType(paramDescription, JavadocCommentsTokenTypes.TEXT)) {
+            for (final DetailNode textNode : getFirstNodeOfTypePerLine(
+                paramDescription, type -> type == JavadocCommentsTokenTypes.TEXT || type == JavadocCommentsTokenTypes.JAVADOC_INLINE_TAG
+            )) {
                 final Matcher matcher = SPACE_PREFIX.matcher(textNode.getText());
                 int paramDescColNum = textNode.getColumnNumber();
                 if (matcher.find()) {
@@ -65,5 +70,19 @@ public final class JavadocAlignParameterDescriptionCheck extends AbstractJavadoc
                 );
             }
         }
+    }
+
+    // taken from getAllNodesOfType
+    private static List<DetailNode> getFirstNodeOfTypePerLine(final DetailNode detailNode, final IntPredicate types) {
+        final List<DetailNode> nodes = new ArrayList<>();
+        final Set<Integer> seen = new HashSet<>();
+        DetailNode node = detailNode.getFirstChild();
+        while (node != null) {
+            if (types.test(node.getType()) && seen.add(node.getLineNumber())) {
+                nodes.add(node);
+            }
+            node = node.getNextSibling();
+        }
+        return nodes;
     }
 }

--- a/paper-checkstyle/src/main/java/io/papermc/checkstyle/checks/UnnecessaryFullyQualifiedImportCheck.java
+++ b/paper-checkstyle/src/main/java/io/papermc/checkstyle/checks/UnnecessaryFullyQualifiedImportCheck.java
@@ -8,7 +8,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Requires that the codebase be set up to follow standard naming conventions.
+ * Requires that the codebase be set up to follow standard naming conventions:
  * <ul>
  *     <li>packages are always all lowercase</li>
  *     <li>class names start with a capital letter</li>

--- a/paper-generator/src/main/java/io/papermc/generator/Rewriters.java
+++ b/paper-generator/src/main/java/io/papermc/generator/Rewriters.java
@@ -11,6 +11,7 @@ import io.papermc.generator.rewriter.types.registry.PaperFeatureFlagMapping;
 import io.papermc.generator.rewriter.types.registry.RegistryFieldRewriter;
 import io.papermc.generator.rewriter.types.registry.RegistryTagRewriter;
 import io.papermc.generator.rewriter.types.registry.TagRewriter;
+import io.papermc.generator.rewriter.types.simple.BlockPropertiesRewriter;
 import io.papermc.generator.rewriter.types.simple.BlockTypeRewriter;
 import io.papermc.generator.rewriter.types.simple.CraftBlockDataMapping;
 import io.papermc.generator.rewriter.types.simple.CraftBlockEntityStateMapping;
@@ -19,10 +20,12 @@ import io.papermc.generator.rewriter.types.simple.EntityTypeRewriter;
 import io.papermc.generator.rewriter.types.simple.MapPaletteRewriter;
 import io.papermc.generator.rewriter.types.simple.MaterialRewriter;
 import io.papermc.generator.rewriter.types.simple.MemoryKeyRewriter;
+import io.papermc.generator.rewriter.types.simple.PaperBlockPropertiesRewriter;
 import io.papermc.generator.rewriter.types.simple.StatisticRewriter;
 import io.papermc.generator.rewriter.types.simple.trial.VillagerProfessionRewriter;
 import io.papermc.generator.types.goal.MobGoalNames;
 import io.papermc.generator.utils.Formatting;
+import io.papermc.paper.block.property.BlockProperties;
 import io.papermc.paper.datacomponent.item.SwingAnimation;
 import io.papermc.paper.datacomponent.item.consumable.ItemUseAnimation;
 import io.papermc.paper.dialog.Dialog;
@@ -233,6 +236,7 @@ public final class Rewriters {
             .register("ZombieNautilusVariant", ZombieNautilus.Variant.class, new RegistryFieldRewriter<>(Registries.ZOMBIE_NAUTILUS_VARIANT, "getVariant"))
             .register("Dialog", Dialog.class, new RegistryFieldRewriter<>(Registries.DIALOG, "getDialog"))
             .register("PoiTypes", PoiTypes.class, new RegistryFieldRewriter<>(Registries.POINT_OF_INTEREST_TYPE, "get"))
+            .register("BlockProperties", BlockProperties.class, new BlockPropertiesRewriter())
             .register("MemoryKey", MemoryKey.class, new MemoryKeyRewriter())
             // .register("ItemType", org.bukkit.inventory.ItemType.class, new io.papermc.generator.rewriter.types.simple.ItemTypeRewriter()) - disable for now, lynx want the generic type
             .register("BlockType", BlockType.class, new BlockTypeRewriter())
@@ -255,6 +259,7 @@ public final class Rewriters {
                 holder("CraftPotionUtil#extendable", new CraftPotionUtilRewriter("long"))
             ))
             .register("PaperFeatureFlagProviderImpl#FLAGS", Types.PAPER_FEATURE_FLAG_PROVIDER_IMPL, new PaperFeatureFlagMapping())
+            .register("PaperBlockProperties", Types.PAPER_BLOCK_PROPERTIES, new PaperBlockPropertiesRewriter())
             .register("MobGoalHelper#BUKKIT_BRIDGE", Types.MOB_GOAL_HELPER, new SearchReplaceRewriter() {
                 @Override
                 protected void insert(SearchMetadata metadata, StringBuilder builder) {

--- a/paper-generator/src/main/java/io/papermc/generator/Rewriters.java
+++ b/paper-generator/src/main/java/io/papermc/generator/Rewriters.java
@@ -11,6 +11,7 @@ import io.papermc.generator.rewriter.types.registry.PaperFeatureFlagMapping;
 import io.papermc.generator.rewriter.types.registry.RegistryFieldRewriter;
 import io.papermc.generator.rewriter.types.registry.RegistryTagRewriter;
 import io.papermc.generator.rewriter.types.registry.TagRewriter;
+import io.papermc.generator.rewriter.types.simple.BlockPropertiesRewriter;
 import io.papermc.generator.rewriter.types.simple.BlockTypeRewriter;
 import io.papermc.generator.rewriter.types.simple.CraftBlockDataMapping;
 import io.papermc.generator.rewriter.types.simple.CraftBlockEntityStateMapping;
@@ -19,10 +20,12 @@ import io.papermc.generator.rewriter.types.simple.EntityTypeRewriter;
 import io.papermc.generator.rewriter.types.simple.MapPaletteRewriter;
 import io.papermc.generator.rewriter.types.simple.MaterialRewriter;
 import io.papermc.generator.rewriter.types.simple.MemoryKeyRewriter;
+import io.papermc.generator.rewriter.types.simple.PaperBlockPropertiesRewriter;
 import io.papermc.generator.rewriter.types.simple.StatisticRewriter;
 import io.papermc.generator.rewriter.types.simple.trial.VillagerProfessionRewriter;
 import io.papermc.generator.types.goal.MobGoalNames;
 import io.papermc.generator.utils.Formatting;
+import io.papermc.paper.block.property.BlockProperties;
 import io.papermc.paper.datacomponent.item.SwingAnimation;
 import io.papermc.paper.datacomponent.item.consumable.ItemUseAnimation;
 import io.papermc.paper.dialog.Dialog;
@@ -242,6 +245,7 @@ public final class Rewriters {
             .register("SulfurCubeArchetype", SulfurCube.Archetype.class, new RegistryFieldRewriter<>(Registries.SULFUR_CUBE_ARCHETYPE, "getArchetype"))
             .register("Dialog", Dialog.class, new RegistryFieldRewriter<>(Registries.DIALOG, "getDialog"))
             .register("PoiTypes", PoiTypes.class, new RegistryFieldRewriter<>(Registries.POINT_OF_INTEREST_TYPE, "get"))
+            .register("BlockProperties", BlockProperties.class, new BlockPropertiesRewriter())
             .register("MemoryKey", MemoryKey.class, new MemoryKeyRewriter())
             // .register("ItemType", org.bukkit.inventory.ItemType.class, new io.papermc.generator.rewriter.types.simple.ItemTypeRewriter()) // - disable for now, lynx want the generic type
             .register("BlockType", BlockType.class, new BlockTypeRewriter())
@@ -264,6 +268,7 @@ public final class Rewriters {
                 holder("CraftPotionUtil#extendable", new CraftPotionUtilRewriter("long"))
             ))
             .register("PaperFeatureFlagProviderImpl#FLAGS", Types.PAPER_FEATURE_FLAG_PROVIDER_IMPL, new PaperFeatureFlagMapping())
+            .register("PaperBlockProperties", Types.PAPER_BLOCK_PROPERTIES, new PaperBlockPropertiesRewriter())
             .register("MobGoalHelper#BUKKIT_BRIDGE", Types.MOB_GOAL_HELPER, new SearchReplaceRewriter() {
                 @Override
                 protected void insert(SearchMetadata metadata, StringBuilder builder) {

--- a/paper-generator/src/main/java/io/papermc/generator/rewriter/types/Types.java
+++ b/paper-generator/src/main/java/io/papermc/generator/rewriter/types/Types.java
@@ -26,5 +26,11 @@ public final class Types {
 
     public static final ClassNamed PAPER_SIMPLE_REGISTRY = ClassNamed.of("io.papermc.paper.registry", "PaperSimpleRegistry");
 
+    public static final ClassNamed PAPER_BLOCK_PROPERTIES = ClassNamed.of("io.papermc.paper.block.property", "PaperBlockProperties");
+
+    public static final ClassNamed ROTATION_BLOCK_PROPERTY = ClassNamed.of("io.papermc.paper.block.property", "RotationBlockProperty");
+
+    public static final ClassNamed NOTE_BLOCK_PROPERTY = ClassNamed.of("io.papermc.paper.block.property", "NoteBlockProperty");
+
     public static final ClassNamed MOB_GOAL_HELPER = ClassNamed.of("com.destroystokyo.paper.entity.ai", "MobGoalHelper");
 }

--- a/paper-generator/src/main/java/io/papermc/generator/rewriter/types/simple/BlockPropertiesRewriter.java
+++ b/paper-generator/src/main/java/io/papermc/generator/rewriter/types/simple/BlockPropertiesRewriter.java
@@ -1,0 +1,146 @@
+package io.papermc.generator.rewriter.types.simple;
+
+import io.papermc.generator.rewriter.types.Types;
+import io.papermc.generator.utils.BlockStateMapping;
+import io.papermc.paper.block.property.BlockProperty;
+import io.papermc.paper.block.property.BooleanBlockProperty;
+import io.papermc.paper.block.property.EnumBlockProperty;
+import io.papermc.paper.block.property.IntegerBlockProperty;
+import io.papermc.typewriter.ClassNamed;
+import io.papermc.typewriter.replace.SearchMetadata;
+import io.papermc.typewriter.replace.SearchReplaceRewriter;
+import io.papermc.typewriter.util.ClassHelper;
+import java.lang.reflect.Field;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.world.level.block.state.properties.Property;
+import org.bukkit.Axis;
+import org.bukkit.Note;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Rail;
+import org.jspecify.annotations.Nullable;
+
+import static io.papermc.generator.utils.Formatting.quoted;
+import static javax.lang.model.element.Modifier.FINAL;
+import static javax.lang.model.element.Modifier.PUBLIC;
+import static javax.lang.model.element.Modifier.STATIC;
+
+public class BlockPropertiesRewriter extends SearchReplaceRewriter {
+
+    private record BlockPropertyData(Class<? extends BlockProperty> propertyClass, String accessorName) {
+    }
+
+    private static final Map<Class<? extends Property>, BlockPropertyData> DATA = Map.of(
+        BooleanProperty.class, new BlockPropertyData(BooleanBlockProperty.class, "bool"),
+        IntegerProperty.class, new BlockPropertyData(IntegerBlockProperty.class, "integer"),
+        EnumProperty.class, new BlockPropertyData(EnumBlockProperty.class, "enumeration")
+    );
+
+    // propertyClass is Internal and not exposed to this module
+    private record PropertyType(Class<? extends BlockProperty> typeClass, ClassNamed propertyClass, @Nullable Class<?> valueClass) {
+    }
+
+    private static final Map<Property<?>, PropertyType> MODIFIED_TYPES = Map.of(
+        BlockStateProperties.NOTE, new PropertyType(BlockProperty.class, Types.NOTE_BLOCK_PROPERTY, Note.class),
+        BlockStateProperties.ROTATION_16, new PropertyType(EnumBlockProperty.class, Types.ROTATION_BLOCK_PROPERTY, BlockFace.class)
+    );
+
+    private interface CodeContext {
+        void write(StringBuilder builder, Function<Class<?>, String> imported);
+    }
+
+    private static final Map<Property<?>, CodeContext> PREDICATES = Map.of(
+        BlockStateProperties.FACING, (builder, imported) -> {
+            builder.append("%s::isCartesian".formatted(imported.apply(BlockFace.class)));
+        },
+        BlockStateProperties.HORIZONTAL_FACING, (builder, imported) -> {
+            builder.append("%s::isCardinal".formatted(imported.apply(BlockFace.class)));
+        },
+        BlockStateProperties.FACING_HOPPER, (builder, imported) -> {
+            builder.append("((%1$s<%2$s>) %2$s::isCartesian).and(face -> face != %2$s.UP)".formatted(
+                Predicate.class.getSimpleName(),
+                imported.apply(BlockFace.class)
+            ));
+        },
+        BlockStateProperties.VERTICAL_DIRECTION, (builder, _) -> {
+            builder.append("%1$s -> %1$s.getModY() != 0".formatted("face"));
+        },
+        BlockStateProperties.HORIZONTAL_AXIS, (builder, imported) -> {
+            builder.append("%s::isHorizontal".formatted(
+                imported.apply(Axis.class)
+            ));
+        },
+        BlockStateProperties.RAIL_SHAPE_STRAIGHT, (builder, imported) -> {
+            builder.append("%s::isStraight".formatted(
+                imported.apply(Rail.Shape.class)
+            ));
+        }
+    );
+
+    private static final Comparator<? super Map.Entry<Property<?>, Field>> FIELD_ORDER =
+        Comparator.<Map.Entry<Property<?>, Field>, String>comparing(entry -> entry.getKey().getClass().getSimpleName())
+        .thenComparing(entry -> entry.getValue().getName());
+
+    @Override
+    protected void insert(SearchMetadata metadata, StringBuilder builder) {
+        for (Map.Entry<Property<?>, Field> entry : BlockStateMapping.FALLBACK_GENERIC_FIELDS.entrySet().stream().sorted(FIELD_ORDER).toList()) {
+            Property<?> property = entry.getKey();
+            builder.append(metadata.indent());
+            builder.append("%s %s %s ".formatted(PUBLIC, STATIC, FINAL));
+            BlockPropertyData data = DATA.get(property.getClass());
+
+            if (MODIFIED_TYPES.containsKey(property)) {
+                PropertyType type = MODIFIED_TYPES.get(property);
+                builder.append("%s<%s> %s = register(new %s(%s));".formatted(
+                    type.typeClass().getSimpleName(),
+                    this.importCollector.getShortName(type.valueClass()),
+                    entry.getValue().getName(),
+                    type.propertyClass().simpleName(),
+                    quoted(entry.getKey().getName())
+                ));
+            } else {
+                builder.append(data.propertyClass().getSimpleName());
+                Class<?> enumType = null;
+                if (property.getClass().equals(EnumProperty.class)) {
+                    builder.append('<');
+                    enumType = BlockStateMapping.ENUM_BRIDGE.get(property.getValueClass());
+                    if (enumType == null) {
+                        throw new IllegalStateException("Unknown enum type for " + property);
+                    }
+                    builder.append(this.importCollector.getShortName(enumType));
+                    builder.append('>');
+                }
+
+                builder.append(' ');
+                builder.append(entry.getValue().getName());
+                builder.append(" = ");
+                builder.append(data.accessorName());
+                builder.append('(');
+                builder.append(quoted(entry.getKey().getName()));
+                if (property instanceof IntegerProperty intProperty) {
+                    builder.append(", ");
+                    List<Integer> values = intProperty.getPossibleValues();
+                    builder.append("%d, %d".formatted(values.getFirst(), values.getLast()));
+                } else if (enumType != null) {
+                    builder.append(", ");
+                    builder.append("%s.class".formatted(ClassHelper.retrieveFullNestedName(enumType))); // already imported
+                    CodeContext predicate = PREDICATES.get(property);
+                    if (predicate != null) {
+                        builder.append(", ");
+                        predicate.write(builder, name -> this.importCollector.getShortName(name));
+                    }
+                }
+                builder.append(");");
+            }
+
+            builder.append('\n');
+        }
+    }
+}

--- a/paper-generator/src/main/java/io/papermc/generator/rewriter/types/simple/PaperBlockPropertiesRewriter.java
+++ b/paper-generator/src/main/java/io/papermc/generator/rewriter/types/simple/PaperBlockPropertiesRewriter.java
@@ -1,0 +1,39 @@
+package io.papermc.generator.rewriter.types.simple;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import io.papermc.generator.utils.BlockStateMapping;
+import io.papermc.generator.utils.Formatting;
+import io.papermc.paper.block.property.BlockProperties;
+import io.papermc.typewriter.replace.SearchMetadata;
+import io.papermc.typewriter.replace.SearchReplaceRewriter;
+import java.lang.reflect.Field;
+import java.util.Map;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.Property;
+
+public class PaperBlockPropertiesRewriter extends SearchReplaceRewriter {
+
+    @Override
+    protected void insert(SearchMetadata metadata, StringBuilder builder) {
+        Multimap<String, Property<?>> nameToProperties = BlockStateMapping.FALLBACK_GENERIC_FIELDS.entrySet().stream().collect(
+            Multimaps.toMultimap(entry -> entry.getKey().getName(), Map.Entry::getKey,
+                HashMultimap::create)
+        );
+
+        for (Map.Entry<Property<?>, Field> entry : BlockStateMapping.FALLBACK_GENERIC_FIELDS.entrySet()
+            .stream().sorted(Formatting.alphabeticKeyOrder(entry -> entry.getValue().getName())).toList()) {
+            if (nameToProperties.get(entry.getKey().getName()).size() <= 1) {
+                continue;
+            }
+
+            builder.append(metadata.indent()).append("register(%1$s.%3$s, %2$s.%3$s);".formatted(
+                this.importCollector.getShortName(BlockStateProperties.class),
+                BlockProperties.class.getSimpleName(),
+                entry.getValue().getName()
+            ));
+            builder.append('\n');
+        }
+    }
+}

--- a/paper-generator/src/main/java/io/papermc/generator/types/craftblockdata/CraftBlockDataGenerator.java
+++ b/paper-generator/src/main/java/io/papermc/generator/types/craftblockdata/CraftBlockDataGenerator.java
@@ -32,10 +32,8 @@ import net.minecraft.world.level.block.ChiseledBookShelfBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.Property;
-import org.bukkit.Axis;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.block.data.Rail;
 import org.jspecify.annotations.NullMarked;
 
 import static io.papermc.generator.utils.NamingManager.keywordGet;
@@ -74,7 +72,7 @@ public class CraftBlockDataGenerator<T extends BlockData> extends OverriddenClas
             method.addStatement("$T.checkArgument($N.isCartesian(), $S)", Preconditions.class, param, "Invalid face, only cartesian face are allowed for this property!");
         },
         BlockStateProperties.HORIZONTAL_FACING, (param, method) -> {
-            method.addStatement("$1T.checkArgument($2N.isCartesian() && $2N.getModY() == 0, $3S)", Preconditions.class, param, "Invalid face, only cartesian horizontal face are allowed for this property!");
+            method.addStatement("$T.checkArgument($N.isCardinal(), $S)", Preconditions.class, param, "Invalid face, only cardinal face are allowed for this property!");
         },
         BlockStateProperties.FACING_HOPPER, (param, method) -> {
             method.addStatement("$1T.checkArgument($2N.isCartesian() && $2N != $3T.UP, $4S)", Preconditions.class, param, BlockFace.class, "Invalid face, only cartesian face (excluding UP) are allowed for this property!");
@@ -86,10 +84,10 @@ public class CraftBlockDataGenerator<T extends BlockData> extends OverriddenClas
             method.addStatement("$1T.checkArgument($2N != $3T.SELF && $2N.getModY() == 0, $4S)", Preconditions.class, param, BlockFace.class, "Invalid face, only horizontal face are allowed for this property!");
         },
         BlockStateProperties.HORIZONTAL_AXIS, (param, method) -> {
-            method.addStatement("$1T.checkArgument($2N == $3T.X || $2N == $3T.Z, $4S)", Preconditions.class, param, Axis.class, "Invalid axis, only horizontal axis are allowed for this property!");
+            method.addStatement("$T.checkArgument($N.isHorizontal(), $S)", Preconditions.class, param, "Invalid axis, only horizontal axis are allowed for this property!");
         },
         BlockStateProperties.RAIL_SHAPE_STRAIGHT, (param, method) -> {
-            method.addStatement("$1T.checkArgument($2N != $3T.NORTH_EAST && $2N != $3T.NORTH_WEST && $2N != $3T.SOUTH_EAST && $2N != $3T.SOUTH_WEST, $4S)", Preconditions.class, param, Rail.Shape.class, "Invalid rail shape, only straight rail are allowed for this property!");
+            method.addStatement("$T.checkArgument($N.isStraight(), $S)", Preconditions.class, param, "Invalid rail shape, only straight rail shape are allowed for this property!");
         }
     );
 

--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -28453,7 +28453,7 @@ index c974b6cafb1f6aa2a57cfdc8a39c887f02f42b1d..ec40f02032f965f548b0c0a29aa9d9bb
          // Paper start - PlayerChunkLoadEvent
          if (io.papermc.paper.event.packet.PlayerChunkLoadEvent.getHandlerList().getRegisteredListeners().length > 0) {
 diff --git a/net/minecraft/server/network/config/PrepareSpawnTask.java b/net/minecraft/server/network/config/PrepareSpawnTask.java
-index 83af9ee3ba150da85b9b694cd76a5fabb5b2d8ef..1fb40837bd02672850ec9adc2797190df22b33fc 100644
+index b5d993095aa77bb132c513f73dbf6d2afb2e3943..8b318dd8aa918284c5fa89e990b13bec425102cb 100644
 --- a/net/minecraft/server/network/config/PrepareSpawnTask.java
 +++ b/net/minecraft/server/network/config/PrepareSpawnTask.java
 @@ -171,7 +171,7 @@ public class PrepareSpawnTask implements ConfigurationTask {
@@ -32317,7 +32317,7 @@ index f837d8029127e74f7181aa183e341a47ee8125a9..b0f90ce47b60cc775cece33ec7d2d301
  
      @Override
 diff --git a/net/minecraft/world/level/block/state/properties/Property.java b/net/minecraft/world/level/block/state/properties/Property.java
-index 8970be0f45631e0710ccfbf45a25caf7717d0988..22d309410f5752a5f6b356e4f5cbda86444423f6 100644
+index 6c046b1219dc29a1b6f887edcc15a6810bf5a9cd..e0f038cc6b712875687c5a78254eec67df42e76b 100644
 --- a/net/minecraft/world/level/block/state/properties/Property.java
 +++ b/net/minecraft/world/level/block/state/properties/Property.java
 @@ -10,7 +10,7 @@ import java.util.stream.Stream;
@@ -32326,10 +32326,10 @@ index 8970be0f45631e0710ccfbf45a25caf7717d0988..22d309410f5752a5f6b356e4f5cbda86
  
 -public abstract class Property<T extends Comparable<T>> {
 +public abstract class Property<T extends Comparable<T>> implements ca.spottedleaf.moonrise.patches.blockstate_propertyaccess.PropertyAccess<T> { // Paper - optimise blockstate property access
+     public static final com.google.common.collect.Multimap<String, Property<?>> PROPERTY_MULTIMAP = com.google.common.collect.Multimaps.newSetMultimap(new java.util.HashMap<>(), com.google.common.collect.Sets::newIdentityHashSet); // Paper - property API
      private final Class<T> clazz;
      private final String name;
-     private @Nullable Integer hashCode;
-@@ -23,9 +23,38 @@ public abstract class Property<T extends Comparable<T>> {
+@@ -24,9 +24,38 @@ public abstract class Property<T extends Comparable<T>> {
          );
      private final Codec<Property.Value<T>> valueCodec = this.codec.xmap(this::value, Property.Value::value);
  
@@ -32365,9 +32365,9 @@ index 8970be0f45631e0710ccfbf45a25caf7717d0988..22d309410f5752a5f6b356e4f5cbda86
          this.clazz = clazz;
          this.name = name;
 +        this.id = ID_GENERATOR.getAndIncrement(); // Paper - optimise blockstate property access
+         PROPERTY_MULTIMAP.put(this.name, this); // Paper - property API
      }
  
-     public Property.Value<T> value(final T value) {
 diff --git a/net/minecraft/world/level/chunk/ChunkAccess.java b/net/minecraft/world/level/chunk/ChunkAccess.java
 index 28a0f11af688c8bca4b1132b4de2977ee32e19db..c974b1c276d29610cb59566afaad19f5bcf0c602 100644
 --- a/net/minecraft/world/level/chunk/ChunkAccess.java

--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -32720,10 +32720,10 @@ index b95665559d646ab8de313a19dadc197a1e8be02c..b82b935272efbc7a7518e148f665f4f2
  
 -public abstract class Property<T extends Comparable<T>> {
 +public abstract class Property<T extends Comparable<T>> implements ca.spottedleaf.moonrise.patches.blockstate_propertyaccess.PropertyAccess<T> { // Paper - optimise blockstate property access
+     public static final com.google.common.collect.Multimap<String, Property<?>> PROPERTY_MULTIMAP = com.google.common.collect.Multimaps.newSetMultimap(new java.util.HashMap<>(), com.google.common.collect.Sets::newIdentityHashSet); // Paper - property API
      private final Class<T> clazz;
      private final String name;
-     private @Nullable Integer hashCode;
-@@ -23,9 +23,38 @@ public abstract class Property<T extends Comparable<T>> {
+@@ -24,9 +24,38 @@ public abstract class Property<T extends Comparable<T>> {
          );
      private final Codec<Property.Value<T>> valueCodec = this.codec.xmap(this::value, Property.Value::value);
  
@@ -32759,9 +32759,9 @@ index b95665559d646ab8de313a19dadc197a1e8be02c..b82b935272efbc7a7518e148f665f4f2
          this.clazz = clazz;
          this.name = name;
 +        this.id = ID_GENERATOR.getAndIncrement(); // Paper - optimise blockstate property access
+         PROPERTY_MULTIMAP.put(this.name, this); // Paper - property API
      }
  
-     public Property.Value<T> value(final T value) {
 diff --git a/net/minecraft/world/level/chunk/ChunkAccess.java b/net/minecraft/world/level/chunk/ChunkAccess.java
 index de6c4c7518a48c237df4b7a1ca6ef5e6e0aa99e3..8b51041370c5184d5a1926ea3262f9111703a6d3 100644
 --- a/net/minecraft/world/level/chunk/ChunkAccess.java

--- a/paper-server/patches/sources/net/minecraft/world/level/block/state/properties/Property.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/state/properties/Property.java.patch
@@ -1,5 +1,21 @@
 --- a/net/minecraft/world/level/block/state/properties/Property.java
 +++ b/net/minecraft/world/level/block/state/properties/Property.java
+@@ -11,6 +_,7 @@
+ import org.jspecify.annotations.Nullable;
+ 
+ public abstract class Property<T extends Comparable<T>> {
++    public static final com.google.common.collect.Multimap<String, Property<?>> PROPERTY_MULTIMAP = com.google.common.collect.Multimaps.newSetMultimap(new java.util.HashMap<>(), com.google.common.collect.Sets::newIdentityHashSet); // Paper - property API
+     private final Class<T> clazz;
+     private final String name;
+     private @Nullable Integer hashCode;
+@@ -26,6 +_,7 @@
+     protected Property(final String name, final Class<T> clazz) {
+         this.clazz = clazz;
+         this.name = name;
++        PROPERTY_MULTIMAP.put(this.name, this); // Paper - property API
+     }
+ 
+     public Property.Value<T> value(final T value) {
 @@ -71,7 +_,7 @@
  
      @Override

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftAnvil.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftAnvil.java
@@ -29,7 +29,7 @@ public class CraftAnvil extends CraftBlockData implements Directional {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftAttachedStem.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftAttachedStem.java
@@ -29,7 +29,7 @@ public class CraftAttachedStem extends CraftBlockData implements Directional {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBaseCoralWallFan.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBaseCoralWallFan.java
@@ -32,7 +32,7 @@ public class CraftBaseCoralWallFan extends CraftBlockData implements CoralWallFa
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBed.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBed.java
@@ -35,7 +35,7 @@ public class CraftBed extends CraftBlockData implements Bed {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBeehive.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBeehive.java
@@ -32,7 +32,7 @@ public class CraftBeehive extends CraftBlockData implements Beehive {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBell.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBell.java
@@ -46,7 +46,7 @@ public class CraftBell extends CraftBlockData implements Bell {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBigDripleaf.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBigDripleaf.java
@@ -35,7 +35,7 @@ public class CraftBigDripleaf extends CraftBlockData implements BigDripleaf {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBigDripleafStem.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBigDripleafStem.java
@@ -33,7 +33,7 @@ public class CraftBigDripleafStem extends CraftBlockData implements Dripleaf {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBlastFurnace.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftBlastFurnace.java
@@ -32,7 +32,7 @@ public class CraftBlastFurnace extends CraftBlockData implements Furnace {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftButton.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftButton.java
@@ -47,7 +47,7 @@ public class CraftButton extends CraftBlockData implements Switch {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCalibratedSculkSensor.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCalibratedSculkSensor.java
@@ -38,7 +38,7 @@ public class CraftCalibratedSculkSensor extends CraftBlockData implements Calibr
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCampfire.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCampfire.java
@@ -36,7 +36,7 @@ public class CraftCampfire extends CraftBlockData implements Campfire {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCarvedPumpkin.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCarvedPumpkin.java
@@ -29,7 +29,7 @@ public class CraftCarvedPumpkin extends CraftBlockData implements Directional {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftChest.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftChest.java
@@ -35,7 +35,7 @@ public class CraftChest extends CraftBlockData implements Chest {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftChiseledBookShelf.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftChiseledBookShelf.java
@@ -34,7 +34,7 @@ public class CraftChiseledBookShelf extends CraftBlockData implements ChiseledBo
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCocoa.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCocoa.java
@@ -47,7 +47,7 @@ public class CraftCocoa extends CraftBlockData implements Cocoa {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftComparator.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftComparator.java
@@ -35,7 +35,7 @@ public class CraftComparator extends CraftBlockData implements Comparator {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCopperChest.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCopperChest.java
@@ -35,7 +35,7 @@ public class CraftCopperChest extends CraftBlockData implements Chest {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCopperGolemStatue.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCopperGolemStatue.java
@@ -45,7 +45,7 @@ public class CraftCopperGolemStatue extends CraftBlockData implements CopperGole
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCoralWallFan.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftCoralWallFan.java
@@ -32,7 +32,7 @@ public class CraftCoralWallFan extends CraftBlockData implements CoralWallFan {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftDecoratedPot.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftDecoratedPot.java
@@ -44,7 +44,7 @@ public class CraftDecoratedPot extends CraftBlockData implements DecoratedPot {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(HORIZONTAL_FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftDetectorRail.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftDetectorRail.java
@@ -43,7 +43,7 @@ public class CraftDetectorRail extends CraftBlockData implements RedstoneRail {
     @Override
     public void setShape(final org.bukkit.block.data.Rail.Shape shape) {
         Preconditions.checkArgument(shape != null, "shape cannot be null!");
-        Preconditions.checkArgument(shape != org.bukkit.block.data.Rail.Shape.NORTH_EAST && shape != org.bukkit.block.data.Rail.Shape.NORTH_WEST && shape != org.bukkit.block.data.Rail.Shape.SOUTH_EAST && shape != org.bukkit.block.data.Rail.Shape.SOUTH_WEST, "Invalid rail shape, only straight rail are allowed for this property!");
+        Preconditions.checkArgument(shape.isStraight(), "Invalid rail shape, only straight rail shape are allowed for this property!");
         this.set(SHAPE, shape);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftDoor.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftDoor.java
@@ -40,7 +40,7 @@ public class CraftDoor extends CraftBlockData implements Door {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftDriedGhast.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftDriedGhast.java
@@ -35,7 +35,7 @@ public class CraftDriedGhast extends CraftBlockData implements DriedGhast {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftEndPortalFrame.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftEndPortalFrame.java
@@ -42,7 +42,7 @@ public class CraftEndPortalFrame extends CraftBlockData implements EndPortalFram
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftEnderChest.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftEnderChest.java
@@ -32,7 +32,7 @@ public class CraftEnderChest extends CraftBlockData implements EnderChest {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftFenceGate.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftFenceGate.java
@@ -36,7 +36,7 @@ public class CraftFenceGate extends CraftBlockData implements Gate {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftFlowerBed.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftFlowerBed.java
@@ -32,7 +32,7 @@ public class CraftFlowerBed extends CraftBlockData implements FlowerBed {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftFurnace.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftFurnace.java
@@ -32,7 +32,7 @@ public class CraftFurnace extends CraftBlockData implements Furnace {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftGlazedTerracotta.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftGlazedTerracotta.java
@@ -29,7 +29,7 @@ public class CraftGlazedTerracotta extends CraftBlockData implements Directional
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftGrindstone.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftGrindstone.java
@@ -44,7 +44,7 @@ public class CraftGrindstone extends CraftBlockData implements Grindstone {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftLadder.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftLadder.java
@@ -32,7 +32,7 @@ public class CraftLadder extends CraftBlockData implements Ladder {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftLeafLitter.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftLeafLitter.java
@@ -32,7 +32,7 @@ public class CraftLeafLitter extends CraftBlockData implements LeafLitter {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftLectern.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftLectern.java
@@ -34,7 +34,7 @@ public class CraftLectern extends CraftBlockData implements Lectern {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftLever.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftLever.java
@@ -47,7 +47,7 @@ public class CraftLever extends CraftBlockData implements Switch {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftLoom.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftLoom.java
@@ -29,7 +29,7 @@ public class CraftLoom extends CraftBlockData implements Directional {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftNetherPortal.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftNetherPortal.java
@@ -29,7 +29,7 @@ public class CraftNetherPortal extends CraftBlockData implements Orientable {
     @Override
     public void setAxis(final Axis axis) {
         Preconditions.checkArgument(axis != null, "axis cannot be null!");
-        Preconditions.checkArgument(axis == Axis.X || axis == Axis.Z, "Invalid axis, only horizontal axis are allowed for this property!");
+        Preconditions.checkArgument(axis.isHorizontal(), "Invalid axis, only horizontal axis are allowed for this property!");
         this.set(AXIS, axis);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftPiglinWallSkull.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftPiglinWallSkull.java
@@ -32,7 +32,7 @@ public class CraftPiglinWallSkull extends CraftBlockData implements WallSkull {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftPlayerWallHead.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftPlayerWallHead.java
@@ -32,7 +32,7 @@ public class CraftPlayerWallHead extends CraftBlockData implements WallSkull {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftPoweredRail.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftPoweredRail.java
@@ -43,7 +43,7 @@ public class CraftPoweredRail extends CraftBlockData implements RedstoneRail {
     @Override
     public void setShape(final org.bukkit.block.data.Rail.Shape shape) {
         Preconditions.checkArgument(shape != null, "shape cannot be null!");
-        Preconditions.checkArgument(shape != org.bukkit.block.data.Rail.Shape.NORTH_EAST && shape != org.bukkit.block.data.Rail.Shape.NORTH_WEST && shape != org.bukkit.block.data.Rail.Shape.SOUTH_EAST && shape != org.bukkit.block.data.Rail.Shape.SOUTH_WEST, "Invalid rail shape, only straight rail are allowed for this property!");
+        Preconditions.checkArgument(shape.isStraight(), "Invalid rail shape, only straight rail shape are allowed for this property!");
         this.set(SHAPE, shape);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftRedstoneWallTorch.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftRedstoneWallTorch.java
@@ -32,7 +32,7 @@ public class CraftRedstoneWallTorch extends CraftBlockData implements RedstoneWa
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftRepeater.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftRepeater.java
@@ -57,7 +57,7 @@ public class CraftRepeater extends CraftBlockData implements Repeater {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftShelf.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftShelf.java
@@ -37,7 +37,7 @@ public class CraftShelf extends CraftBlockData implements Shelf {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftSmallDripleaf.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftSmallDripleaf.java
@@ -36,7 +36,7 @@ public class CraftSmallDripleaf extends CraftBlockData implements SmallDripleaf 
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftSmoker.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftSmoker.java
@@ -32,7 +32,7 @@ public class CraftSmoker extends CraftBlockData implements Furnace {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftStair.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftStair.java
@@ -37,7 +37,7 @@ public class CraftStair extends CraftBlockData implements Stairs {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftStonecutter.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftStonecutter.java
@@ -29,7 +29,7 @@ public class CraftStonecutter extends CraftBlockData implements Directional {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftTrapDoor.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftTrapDoor.java
@@ -38,7 +38,7 @@ public class CraftTrapDoor extends CraftBlockData implements TrapDoor {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftTrappedChest.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftTrappedChest.java
@@ -35,7 +35,7 @@ public class CraftTrappedChest extends CraftBlockData implements Chest {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftTripWireHook.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftTripWireHook.java
@@ -44,7 +44,7 @@ public class CraftTripWireHook extends CraftBlockData implements TripwireHook {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftVault.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftVault.java
@@ -36,7 +36,7 @@ public class CraftVault extends CraftBlockData implements Vault {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWallBanner.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWallBanner.java
@@ -29,7 +29,7 @@ public class CraftWallBanner extends CraftBlockData implements Directional {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWallHangingSign.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWallHangingSign.java
@@ -32,7 +32,7 @@ public class CraftWallHangingSign extends CraftBlockData implements WallHangingS
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWallSign.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWallSign.java
@@ -32,7 +32,7 @@ public class CraftWallSign extends CraftBlockData implements WallSign {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWallSkull.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWallSkull.java
@@ -32,7 +32,7 @@ public class CraftWallSkull extends CraftBlockData implements WallSkull {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWallTorch.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWallTorch.java
@@ -29,7 +29,7 @@ public class CraftWallTorch extends CraftBlockData implements Directional {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWeatheringCopperChest.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWeatheringCopperChest.java
@@ -35,7 +35,7 @@ public class CraftWeatheringCopperChest extends CraftBlockData implements Chest 
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWeatheringCopperDoor.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWeatheringCopperDoor.java
@@ -40,7 +40,7 @@ public class CraftWeatheringCopperDoor extends CraftBlockData implements Door {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWeatheringCopperGolemStatue.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWeatheringCopperGolemStatue.java
@@ -45,7 +45,7 @@ public class CraftWeatheringCopperGolemStatue extends CraftBlockData implements 
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWeatheringCopperStair.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWeatheringCopperStair.java
@@ -37,7 +37,7 @@ public class CraftWeatheringCopperStair extends CraftBlockData implements Stairs
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWeatheringCopperTrapDoor.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWeatheringCopperTrapDoor.java
@@ -38,7 +38,7 @@ public class CraftWeatheringCopperTrapDoor extends CraftBlockData implements Tra
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWitherWallSkull.java
+++ b/paper-server/src/generated/java/org/bukkit/craftbukkit/block/impl/CraftWitherWallSkull.java
@@ -32,7 +32,7 @@ public class CraftWitherWallSkull extends CraftBlockData implements WallSkull {
     @Override
     public void setFacing(final BlockFace blockFace) {
         Preconditions.checkArgument(blockFace != null, "blockFace cannot be null!");
-        Preconditions.checkArgument(blockFace.isCartesian() && blockFace.getModY() == 0, "Invalid face, only cartesian horizontal face are allowed for this property!");
+        Preconditions.checkArgument(blockFace.isCardinal(), "Invalid face, only cardinal face are allowed for this property!");
         this.set(FACING, blockFace);
     }
 

--- a/paper-server/src/main/java/io/papermc/paper/PaperServerInternalAPIBridge.java
+++ b/paper-server/src/main/java/io/papermc/paper/PaperServerInternalAPIBridge.java
@@ -3,13 +3,18 @@ package io.papermc.paper;
 import com.destroystokyo.paper.PaperSkinParts;
 import com.destroystokyo.paper.SkinParts;
 import io.papermc.paper.adventure.PaperAdventure;
+import io.papermc.paper.block.property.EnumBlockProperty;
+import io.papermc.paper.block.property.PaperBlockProperties;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.datacomponent.item.PaperResolvableProfile;
 import io.papermc.paper.datacomponent.item.ResolvableProfile;
+import io.papermc.paper.entity.poi.PaperPoiType;
+import io.papermc.paper.entity.poi.PoiType;
 import io.papermc.paper.world.damagesource.CombatEntry;
 import io.papermc.paper.world.damagesource.FallLocationType;
 import io.papermc.paper.world.damagesource.PaperCombatEntryWrapper;
 import io.papermc.paper.world.damagesource.PaperCombatTrackerWrapper;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -17,14 +22,15 @@ import net.kyori.adventure.text.Component;
 import net.minecraft.Optionull;
 import net.minecraft.commands.Commands;
 import net.minecraft.world.damagesource.FallLocation;
+import net.minecraft.world.entity.ai.village.poi.PoiManager;
 import net.minecraft.world.entity.decoration.Mannequin;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.level.block.state.properties.Property;
 import org.bukkit.GameRule;
 import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.CraftGameRule;
 import org.bukkit.craftbukkit.block.CraftBiome;
-import io.papermc.paper.entity.poi.PaperPoiType;
-import io.papermc.paper.entity.poi.PoiType;
-import net.minecraft.world.entity.ai.village.poi.PoiManager;
+import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.damage.CraftDamageEffect;
 import org.bukkit.craftbukkit.damage.CraftDamageSource;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
@@ -42,7 +48,7 @@ public class PaperServerInternalAPIBridge implements InternalAPIBridge {
 
     @Override
     public DamageEffect getDamageEffect(final String key) {
-        return CraftDamageEffect.getById(key);
+        return Objects.requireNonNull(CraftDamageEffect.getById(key), "Unknown damage effect key: " + key);
     }
 
     @Override
@@ -131,5 +137,14 @@ public class PaperServerInternalAPIBridge implements InternalAPIBridge {
     @Override
     public Set<Pose> validMannequinPoses() {
         return CraftMannequin.VALID_POSES;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <A extends Enum<A>> String getPropertyEnumName(final EnumBlockProperty<A> property, final A bukkitEnum) {
+        final Property<?> propertyd = PaperBlockProperties.convertTointernalProperty(property);
+        if (!(PaperBlockProperties.convertTointernalProperty(property) instanceof final EnumProperty enumProperty)) {
+            throw new IllegalArgumentException("Could not convert " + property + " to an nms EnumProperty");
+        }
+        return enumProperty.getName(CraftBlockData.toVanilla(bukkitEnum, enumProperty.getValueClass()));
     }
 }

--- a/paper-server/src/main/java/io/papermc/paper/PaperServerInternalAPIBridge.java
+++ b/paper-server/src/main/java/io/papermc/paper/PaperServerInternalAPIBridge.java
@@ -8,6 +8,8 @@ import com.google.common.base.Preconditions;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import io.papermc.paper.adventure.PaperAdventure;
 import io.papermc.paper.attribute.UnmodifiableAttributeMap;
+import io.papermc.paper.block.property.EnumBlockProperty;
+import io.papermc.paper.block.property.PaperBlockProperties;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.datacomponent.item.PaperResolvableProfile;
 import io.papermc.paper.datacomponent.item.ResolvableProfile;
@@ -39,6 +41,7 @@ import net.minecraft.world.damagesource.FallLocation;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.minecraft.world.entity.ai.village.poi.PoiManager;
 import net.minecraft.world.entity.decoration.Mannequin;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
 import org.bukkit.GameRule;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Statistic;
@@ -48,6 +51,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.craftbukkit.CraftGameRule;
 import org.bukkit.craftbukkit.CraftStatistic;
 import org.bukkit.craftbukkit.block.CraftBiome;
+import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.command.VanillaCommandWrapper;
 import org.bukkit.craftbukkit.damage.CraftDamageEffect;
 import org.bukkit.craftbukkit.damage.CraftDamageSource;
@@ -256,5 +260,14 @@ public class PaperServerInternalAPIBridge implements InternalAPIBridge {
     @Override
     public ComponentFlattener componentFlattener() {
         return PaperAdventure.FLATTENER;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public <A extends Enum<A>> String getPropertyEnumName(final EnumBlockProperty<A> property, final A bukkitEnum) {
+        if (!(PaperBlockProperties.convertTointernalProperty(property) instanceof final EnumProperty enumProperty)) {
+            throw new IllegalArgumentException("Could not convert " + property + " to an nms EnumProperty");
+        }
+        return enumProperty.getName(CraftBlockData.toVanilla(bukkitEnum, enumProperty.getValueClass()));
     }
 }

--- a/paper-server/src/main/java/io/papermc/paper/block/fluid/PaperFluidData.java
+++ b/paper-server/src/main/java/io/papermc/paper/block/fluid/PaperFluidData.java
@@ -3,17 +3,22 @@ package io.papermc.paper.block.fluid;
 import com.google.common.base.Preconditions;
 import io.papermc.paper.block.fluid.type.PaperFallingFluidData;
 import io.papermc.paper.block.fluid.type.PaperFlowingFluidData;
+import io.papermc.paper.block.property.PaperBlockPropertyHolder;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraft.world.level.material.FluidState;
 import org.bukkit.Fluid;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.CraftFluid;
 import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.util.CraftLocation;
 import org.bukkit.craftbukkit.util.CraftVector;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
-public class PaperFluidData implements FluidData {
+public class PaperFluidData implements FluidData, PaperBlockPropertyHolder<net.minecraft.world.level.material.Fluid, FluidState> {
 
     private final FluidState state;
 
@@ -21,8 +26,14 @@ public class PaperFluidData implements FluidData {
         this.state = state;
     }
 
+    @Override
     public FluidState getState() {
         return this.state;
+    }
+
+    @Override
+    public StateDefinition<net.minecraft.world.level.material.Fluid, FluidState> getStateDefinition() {
+        return this.state.getType().getStateDefinition();
     }
 
     @Override
@@ -77,6 +88,16 @@ public class PaperFluidData implements FluidData {
     @Override
     public String toString() {
         return "PaperFluidData{" + this.state + "}";
+    }
+
+    @Override
+    public <T extends Comparable<T>> T get(final Property<T> property) {
+        return this.state.getValue(property);
+    }
+
+    @Override
+    public <A extends Enum<A>> A get(final EnumProperty<?> property, final Class<A> bukkitClass) {
+        return CraftBlockData.fromVanilla(this.state.getValue(property), bukkitClass);
     }
 
     public static PaperFluidData createData(final FluidState state) {

--- a/paper-server/src/main/java/io/papermc/paper/block/property/PaperBlockProperties.java
+++ b/paper-server/src/main/java/io/papermc/paper/block/property/PaperBlockProperties.java
@@ -1,0 +1,85 @@
+package io.papermc.paper.block.property;
+
+import java.util.Collection;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.Property;
+import org.bukkit.craftbukkit.block.data.CraftBlockData;
+
+public final class PaperBlockProperties {
+
+    public static void setup() {
+        //<editor-fold desc="Paper API Properties Registration" defaultstate="collapsed">
+        // Start generate - PaperBlockProperties
+        register(BlockStateProperties.AGE_1, BlockProperties.AGE_1);
+        register(BlockStateProperties.AGE_2, BlockProperties.AGE_2);
+        register(BlockStateProperties.AGE_3, BlockProperties.AGE_3);
+        register(BlockStateProperties.AGE_4, BlockProperties.AGE_4);
+        register(BlockStateProperties.AGE_5, BlockProperties.AGE_5);
+        register(BlockStateProperties.AGE_7, BlockProperties.AGE_7);
+        register(BlockStateProperties.AGE_15, BlockProperties.AGE_15);
+        register(BlockStateProperties.AGE_25, BlockProperties.AGE_25);
+        register(BlockStateProperties.AXIS, BlockProperties.AXIS);
+        register(BlockStateProperties.CHEST_TYPE, BlockProperties.CHEST_TYPE);
+        register(BlockStateProperties.DISTANCE, BlockProperties.DISTANCE);
+        register(BlockStateProperties.DOUBLE_BLOCK_HALF, BlockProperties.DOUBLE_BLOCK_HALF);
+        register(BlockStateProperties.EAST, BlockProperties.EAST);
+        register(BlockStateProperties.EAST_REDSTONE, BlockProperties.EAST_REDSTONE);
+        register(BlockStateProperties.EAST_WALL, BlockProperties.EAST_WALL);
+        register(BlockStateProperties.FACING, BlockProperties.FACING);
+        register(BlockStateProperties.FACING_HOPPER, BlockProperties.FACING_HOPPER);
+        register(BlockStateProperties.HALF, BlockProperties.HALF);
+        register(BlockStateProperties.HORIZONTAL_AXIS, BlockProperties.HORIZONTAL_AXIS);
+        register(BlockStateProperties.HORIZONTAL_FACING, BlockProperties.HORIZONTAL_FACING);
+        register(BlockStateProperties.LEVEL, BlockProperties.LEVEL);
+        register(BlockStateProperties.LEVEL_CAULDRON, BlockProperties.LEVEL_CAULDRON);
+        register(BlockStateProperties.LEVEL_COMPOSTER, BlockProperties.LEVEL_COMPOSTER);
+        register(BlockStateProperties.LEVEL_FLOWING, BlockProperties.LEVEL_FLOWING);
+        register(BlockStateProperties.MODE_COMPARATOR, BlockProperties.MODE_COMPARATOR);
+        register(BlockStateProperties.NORTH, BlockProperties.NORTH);
+        register(BlockStateProperties.NORTH_REDSTONE, BlockProperties.NORTH_REDSTONE);
+        register(BlockStateProperties.NORTH_WALL, BlockProperties.NORTH_WALL);
+        register(BlockStateProperties.PISTON_TYPE, BlockProperties.PISTON_TYPE);
+        register(BlockStateProperties.RAIL_SHAPE, BlockProperties.RAIL_SHAPE);
+        register(BlockStateProperties.RAIL_SHAPE_STRAIGHT, BlockProperties.RAIL_SHAPE_STRAIGHT);
+        register(BlockStateProperties.SLAB_TYPE, BlockProperties.SLAB_TYPE);
+        register(BlockStateProperties.SOUTH, BlockProperties.SOUTH);
+        register(BlockStateProperties.SOUTH_REDSTONE, BlockProperties.SOUTH_REDSTONE);
+        register(BlockStateProperties.SOUTH_WALL, BlockProperties.SOUTH_WALL);
+        register(BlockStateProperties.STABILITY_DISTANCE, BlockProperties.STABILITY_DISTANCE);
+        register(BlockStateProperties.STAIRS_SHAPE, BlockProperties.STAIRS_SHAPE);
+        register(BlockStateProperties.STRUCTUREBLOCK_MODE, BlockProperties.STRUCTUREBLOCK_MODE);
+        register(BlockStateProperties.TEST_BLOCK_MODE, BlockProperties.TEST_BLOCK_MODE);
+        register(BlockStateProperties.WEST, BlockProperties.WEST);
+        register(BlockStateProperties.WEST_REDSTONE, BlockProperties.WEST_REDSTONE);
+        register(BlockStateProperties.WEST_WALL, BlockProperties.WEST_WALL);
+        // End generate - PaperBlockProperties
+        //</editor-fold>
+    }
+
+    private static void register(final Property<?> property, final BlockProperty<?> paperProperty) {
+        CraftBlockData.DATA_PROPERTY_CACHE_MAP.put(property, paperProperty);
+    }
+
+
+    public static BlockProperty<?> convertToPaperProperty(final Property<?> property) {
+        return CraftBlockData.DATA_PROPERTY_CACHE_MAP.computeIfAbsent(property, p -> {
+            final Collection<BlockProperty<?>> properties = BlockProperties.PROPERTIES.get(p.getName());
+            if (properties.size() == 1) {
+                return properties.iterator().next();
+            } else {
+                throw new IllegalArgumentException(property + " should already be present in DATA_PROPERTY_CACHE_MAP");
+            }
+        });
+    }
+
+    public static Property<?> convertTointernalProperty(final BlockProperty<?> paperProperty) {
+        return CraftBlockData.DATA_PROPERTY_CACHE_MAP.inverse().computeIfAbsent(paperProperty, p -> {
+            final Collection<Property<?>> properties = Property.PROPERTY_MULTIMAP.get(p.name());
+            if (properties.size() == 1) {
+                return properties.iterator().next();
+            } else {
+                throw new IllegalArgumentException(paperProperty + " should already be present in DATA_PROPERTY_CACHE_MAP");
+            }
+        });
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/block/property/PaperBlockProperties.java
+++ b/paper-server/src/main/java/io/papermc/paper/block/property/PaperBlockProperties.java
@@ -1,0 +1,88 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import java.util.Collection;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.Property;
+
+public final class PaperBlockProperties {
+
+    private static final BiMap<Property<?>, BlockProperty<?>> DATA_PROPERTY_CACHE_MAP = HashBiMap.create();
+
+    public static void setup() {
+        //<editor-fold desc="Block properties initialized cache for conflicting property names" defaultstate="collapsed">
+        // Start generate - PaperBlockProperties
+        register(BlockStateProperties.AGE_1, BlockProperties.AGE_1);
+        register(BlockStateProperties.AGE_2, BlockProperties.AGE_2);
+        register(BlockStateProperties.AGE_3, BlockProperties.AGE_3);
+        register(BlockStateProperties.AGE_4, BlockProperties.AGE_4);
+        register(BlockStateProperties.AGE_5, BlockProperties.AGE_5);
+        register(BlockStateProperties.AGE_7, BlockProperties.AGE_7);
+        register(BlockStateProperties.AGE_15, BlockProperties.AGE_15);
+        register(BlockStateProperties.AGE_25, BlockProperties.AGE_25);
+        register(BlockStateProperties.AXIS, BlockProperties.AXIS);
+        register(BlockStateProperties.CHEST_TYPE, BlockProperties.CHEST_TYPE);
+        register(BlockStateProperties.DISTANCE, BlockProperties.DISTANCE);
+        register(BlockStateProperties.DOUBLE_BLOCK_HALF, BlockProperties.DOUBLE_BLOCK_HALF);
+        register(BlockStateProperties.EAST, BlockProperties.EAST);
+        register(BlockStateProperties.EAST_REDSTONE, BlockProperties.EAST_REDSTONE);
+        register(BlockStateProperties.EAST_WALL, BlockProperties.EAST_WALL);
+        register(BlockStateProperties.FACING, BlockProperties.FACING);
+        register(BlockStateProperties.FACING_HOPPER, BlockProperties.FACING_HOPPER);
+        register(BlockStateProperties.HALF, BlockProperties.HALF);
+        register(BlockStateProperties.HORIZONTAL_AXIS, BlockProperties.HORIZONTAL_AXIS);
+        register(BlockStateProperties.HORIZONTAL_FACING, BlockProperties.HORIZONTAL_FACING);
+        register(BlockStateProperties.LEVEL, BlockProperties.LEVEL);
+        register(BlockStateProperties.LEVEL_CAULDRON, BlockProperties.LEVEL_CAULDRON);
+        register(BlockStateProperties.LEVEL_COMPOSTER, BlockProperties.LEVEL_COMPOSTER);
+        register(BlockStateProperties.LEVEL_FLOWING, BlockProperties.LEVEL_FLOWING);
+        register(BlockStateProperties.MODE_COMPARATOR, BlockProperties.MODE_COMPARATOR);
+        register(BlockStateProperties.NORTH, BlockProperties.NORTH);
+        register(BlockStateProperties.NORTH_REDSTONE, BlockProperties.NORTH_REDSTONE);
+        register(BlockStateProperties.NORTH_WALL, BlockProperties.NORTH_WALL);
+        register(BlockStateProperties.PISTON_TYPE, BlockProperties.PISTON_TYPE);
+        register(BlockStateProperties.RAIL_SHAPE, BlockProperties.RAIL_SHAPE);
+        register(BlockStateProperties.RAIL_SHAPE_STRAIGHT, BlockProperties.RAIL_SHAPE_STRAIGHT);
+        register(BlockStateProperties.SLAB_TYPE, BlockProperties.SLAB_TYPE);
+        register(BlockStateProperties.SOUTH, BlockProperties.SOUTH);
+        register(BlockStateProperties.SOUTH_REDSTONE, BlockProperties.SOUTH_REDSTONE);
+        register(BlockStateProperties.SOUTH_WALL, BlockProperties.SOUTH_WALL);
+        register(BlockStateProperties.STABILITY_DISTANCE, BlockProperties.STABILITY_DISTANCE);
+        register(BlockStateProperties.STAIRS_SHAPE, BlockProperties.STAIRS_SHAPE);
+        register(BlockStateProperties.STRUCTUREBLOCK_MODE, BlockProperties.STRUCTUREBLOCK_MODE);
+        register(BlockStateProperties.TEST_BLOCK_MODE, BlockProperties.TEST_BLOCK_MODE);
+        register(BlockStateProperties.WEST, BlockProperties.WEST);
+        register(BlockStateProperties.WEST_REDSTONE, BlockProperties.WEST_REDSTONE);
+        register(BlockStateProperties.WEST_WALL, BlockProperties.WEST_WALL);
+        // End generate - PaperBlockProperties
+        //</editor-fold>
+    }
+
+    private static void register(final Property<?> property, final BlockProperty<?> paperProperty) {
+        DATA_PROPERTY_CACHE_MAP.put(property, paperProperty);
+    }
+
+
+    public static BlockProperty<?> convertToPaperProperty(final Property<?> property) {
+        return DATA_PROPERTY_CACHE_MAP.computeIfAbsent(property, p -> {
+            final Collection<BlockProperty<?>> properties = BlockProperties.PROPERTIES.get(p.getName());
+            if (properties.size() == 1) {
+                return properties.iterator().next();
+            } else {
+                throw new IllegalArgumentException(property + " should already be present in DATA_PROPERTY_CACHE_MAP");
+            }
+        });
+    }
+
+    public static Property<?> convertTointernalProperty(final BlockProperty<?> paperProperty) {
+        return DATA_PROPERTY_CACHE_MAP.inverse().computeIfAbsent(paperProperty, p -> {
+            final Collection<Property<?>> properties = Property.PROPERTY_MULTIMAP.get(p.name());
+            if (properties.size() == 1) {
+                return properties.iterator().next();
+            } else {
+                throw new IllegalArgumentException(paperProperty + " should already be present in DATA_PROPERTY_CACHE_MAP");
+            }
+        });
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/block/property/PaperBlockPropertyHolder.java
+++ b/paper-server/src/main/java/io/papermc/paper/block/property/PaperBlockPropertyHolder.java
@@ -1,0 +1,109 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Collections2;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import net.minecraft.util.StringRepresentable;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.StateHolder;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.world.level.block.state.properties.Property;
+import org.jspecify.annotations.Nullable;
+
+public interface PaperBlockPropertyHolder<O, S extends StateHolder<O, S>> extends BlockPropertyHolder {
+
+    StateHolder<O, S> getState();
+
+    StateDefinition<O, S> getStateDefinition();
+
+    <T extends Comparable<T>> T get(Property<T> property);
+
+    <A extends Enum<A>> A get(EnumProperty<?> property, Class<A> bukkitClass);
+
+    @SuppressWarnings("unchecked")
+    @Override
+    default <T extends Comparable<T>> @Nullable BlockProperty<T> getProperty(final String propertyName) {
+        final Property<?> property = this.getStateDefinition().getProperty(propertyName);
+        if (property != null) {
+            return (BlockProperty<T>) PaperBlockProperties.convertToPaperProperty(property);
+        }
+        return null;
+    }
+
+    @Override
+    default <T extends Comparable<T>> boolean hasProperty(final BlockProperty<T> property) {
+        return this.getState().hasProperty(PaperBlockProperties.convertTointernalProperty(property));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    default <T extends Comparable<T>> T getValue(final BlockProperty<T> property) {
+        final Property<?> internalProperty = PaperBlockProperties.convertTointernalProperty(property);
+        Preconditions.checkArgument(this.getState().hasProperty(internalProperty), property.name() + " is not present on " + this);
+        switch (internalProperty) {
+            case final IntegerProperty intProperty -> {
+                final T value;
+                if (property instanceof final AsIntegerProperty<T> intRepresented) {
+                    value = intRepresented.fromIntValue(this.get(intProperty));
+                } else {
+                    value = this.get((Property<T>) intProperty);
+                }
+                return value;
+            }
+            case final BooleanProperty _ -> {
+                return this.get((Property<T>) internalProperty);
+            }
+            case final EnumProperty<?> enumProperty when property instanceof final EnumBlockProperty<?> enumDataProperty -> {
+                return (T) this.get(enumProperty, enumDataProperty.type());
+            }
+            default -> throw new IllegalArgumentException("Did not recognize " + property + " and " + internalProperty);
+        }
+    }
+
+    @Override
+    default <T extends Comparable<T>> Optional<T> getOptionalValue(final BlockProperty<T> property) {
+        if (!this.hasProperty(property)) {
+            return Optional.empty();
+        } else {
+            return Optional.of(this.getValue(property));
+        }
+    }
+
+    @Override
+    default Collection<BlockProperty<?>> getProperties() {
+        return Collections.unmodifiableCollection(Collections2.transform(this.getState().getProperties(), PaperBlockProperties::convertToPaperProperty));
+    }
+
+    interface PaperMutable<O, S extends StateHolder<O, S>> extends PaperBlockPropertyHolder<O, S>, BlockPropertyHolder.Mutable {
+
+        <T extends Comparable<T>, V extends T> void set(Property<T> property, V value);
+
+        <M extends Enum<M> & StringRepresentable> void set(EnumProperty<M> property, Enum<?> bukkit);
+
+        @Override
+        default <T extends Comparable<T>> void setValue(final BlockProperty<T> property, final T value) {
+            Preconditions.checkNotNull(value, "Cannot set a data property to null");
+            final Property<?> internalProperty = PaperBlockProperties.convertTointernalProperty(property);
+            Preconditions.checkArgument(this.getState().hasProperty(internalProperty), property.name() + " is not present on " + this);
+            switch (internalProperty) {
+                case final IntegerProperty intProperty -> {
+                    final int intValue;
+                    if (property instanceof final AsIntegerProperty<T> intRepresented) {
+                        intValue = intRepresented.toIntValue(value);
+                    } else {
+                        intValue = (Integer) value;
+                    }
+                    this.set(intProperty, intValue);
+                }
+                case final BooleanProperty booleanProperty -> this.set(booleanProperty, (Boolean) value);
+                case final EnumProperty<?> enumProperty when value instanceof final Enum<?> enumValue -> this.set(enumProperty, enumValue);
+                default ->
+                    throw new IllegalArgumentException("Did not recognize " + property + " with value " + value + " (" + value.getClass().getSimpleName() + ") for " + internalProperty);
+            }
+        }
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/block/property/PaperBlockPropertyHolder.java
+++ b/paper-server/src/main/java/io/papermc/paper/block/property/PaperBlockPropertyHolder.java
@@ -1,0 +1,109 @@
+package io.papermc.paper.block.property;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Collections2;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import net.minecraft.util.StringRepresentable;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.StateHolder;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.world.level.block.state.properties.Property;
+import org.jspecify.annotations.Nullable;
+
+public interface PaperBlockPropertyHolder<O, S extends StateHolder<O, S>> extends BlockPropertyHolder {
+
+    StateHolder<O, S> getState();
+
+    StateDefinition<O, S> getStateDefinition();
+
+    <T extends Comparable<T>> T get(Property<T> property);
+
+    <A extends Enum<A>> A get(EnumProperty<?> property, Class<A> bukkitClass);
+
+    @SuppressWarnings("unchecked")
+    @Override
+    default <T extends Comparable<T>> @Nullable BlockProperty<T> getProperty(final String name) {
+        final Property<?> property = this.getStateDefinition().getProperty(name);
+        if (property != null) {
+            return (BlockProperty<T>) PaperBlockProperties.convertToPaperProperty(property);
+        }
+        return null;
+    }
+
+    @Override
+    default <T extends Comparable<T>> boolean hasProperty(final BlockProperty<T> property) {
+        return this.getState().hasProperty(PaperBlockProperties.convertTointernalProperty(property));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    default <T extends Comparable<T>> T getValue(final BlockProperty<T> property) {
+        final Property<?> internalProperty = PaperBlockProperties.convertTointernalProperty(property);
+        Preconditions.checkArgument(this.getState().hasProperty(internalProperty), property.name() + " is not present on " + this);
+        switch (internalProperty) {
+            case final IntegerProperty intProperty -> {
+                final T value;
+                if (property instanceof final AsIntegerProperty<T> intRepresented) {
+                    value = intRepresented.fromIntValue(this.get(intProperty));
+                } else {
+                    value = this.get((Property<T>) intProperty);
+                }
+                return value;
+            }
+            case final BooleanProperty _ -> {
+                return this.get((Property<T>) internalProperty);
+            }
+            case final EnumProperty<?> enumProperty when property instanceof final EnumBlockProperty<?> enumDataProperty -> {
+                return (T) this.get(enumProperty, enumDataProperty.type());
+            }
+            default -> throw new IllegalArgumentException("Did not recognize " + property + " and " + internalProperty);
+        }
+    }
+
+    @Override
+    default <T extends Comparable<T>> Optional<T> getOptionalValue(final BlockProperty<T> property) {
+        if (!this.hasProperty(property)) {
+            return Optional.empty();
+        } else {
+            return Optional.of(this.getValue(property));
+        }
+    }
+
+    @Override
+    default Collection<BlockProperty<?>> getProperties() {
+        return Collections.unmodifiableCollection(Collections2.transform(this.getState().getProperties(), PaperBlockProperties::convertToPaperProperty));
+    }
+
+    interface PaperMutable<O, S extends StateHolder<O, S>> extends PaperBlockPropertyHolder<O, S>, BlockPropertyHolder.Mutable {
+
+        <T extends Comparable<T>, V extends T> void set(Property<T> property, V value);
+
+        <M extends Enum<M> & StringRepresentable> void set(EnumProperty<M> property, Enum<?> bukkit);
+
+        @Override
+        default <T extends Comparable<T>> void setValue(final BlockProperty<T> property, final T value) {
+            Preconditions.checkArgument(value != null, "Cannot set a data property to null");
+            final Property<?> internalProperty = PaperBlockProperties.convertTointernalProperty(property);
+            Preconditions.checkArgument(this.getState().hasProperty(internalProperty), property.name() + " is not present on " + this);
+            switch (internalProperty) {
+                case final IntegerProperty intProperty -> {
+                    final int intValue;
+                    if (property instanceof final AsIntegerProperty<T> intRepresented) {
+                        intValue = intRepresented.toIntValue(value);
+                    } else {
+                        intValue = (Integer) value;
+                    }
+                    this.set(intProperty, intValue);
+                }
+                case final BooleanProperty booleanProperty -> this.set(booleanProperty, (Boolean) value);
+                case final EnumProperty<?> enumProperty when value instanceof final Enum<?> enumValue -> this.set(enumProperty, enumValue);
+                default ->
+                    throw new IllegalArgumentException("Did not recognize " + property + " with value " + value + " (" + value.getClass().getSimpleName() + ") for " + internalProperty);
+            }
+        }
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/block/property/package-info.java
+++ b/paper-server/src/main/java/io/papermc/paper/block/property/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.papermc.paper.block.property;
+
+import org.jspecify.annotations.NullMarked;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBlockItemDataProperties.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBlockItemDataProperties.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.block.property.BlockProperty;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import java.util.Map;
 import net.minecraft.world.item.component.BlockItemStateProperties;
@@ -37,7 +38,11 @@ public record PaperBlockItemDataProperties(
 
         private final Map<String, String> properties = new Object2ObjectOpenHashMap<>();
 
-        // TODO when BlockProperty API is merged
+        @Override
+        public <T extends Comparable<T>> Builder set(final BlockProperty<T> property, final T value) {
+            this.properties.put(property.name(), property.name(value));
+            return this;
+        }
 
         @Override
         public BlockItemDataProperties build() {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
@@ -2,9 +2,14 @@ package org.bukkit.craftbukkit.block.data;
 
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableSet;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import io.papermc.paper.block.property.BlockProperty;
+import io.papermc.paper.block.property.PaperBlockProperties;
+import io.papermc.paper.block.property.PaperBlockPropertyHolder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +33,7 @@ import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.StateHolder;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.block.state.properties.Property;
@@ -56,12 +62,14 @@ import org.bukkit.craftbukkit.util.CraftLocation;
 import org.bukkit.craftbukkit.util.CraftVoxelShape;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-public class CraftBlockData implements BlockData {
+@NullMarked
+public class CraftBlockData implements BlockData, PaperBlockPropertyHolder.PaperMutable<Block, BlockState> {
 
     private BlockState state;
-    private List<Property.Value<?>> parsedStates;
+    private @Nullable List<Property.Value<?>> parsedStates;
 
     protected CraftBlockData(BlockState state) {
         this.state = state;
@@ -72,8 +80,14 @@ public class CraftBlockData implements BlockData {
         return this.state.getBukkitMaterial();
     }
 
+    @Override
     public BlockState getState() {
         return this.state;
+    }
+
+    @Override
+    public StateDefinition<Block, BlockState> getStateDefinition() {
+        return this.getState().getBlock().getStateDefinition();
     }
 
     @Override
@@ -101,7 +115,7 @@ public class CraftBlockData implements BlockData {
     }
 
     @Override
-    public boolean matches(BlockData data) {
+    public boolean matches(@Nullable BlockData data) {
         if (!(data instanceof final CraftBlockData craft)) {
             return false;
         }
@@ -148,7 +162,8 @@ public class CraftBlockData implements BlockData {
         return internalClass.cast(rawValue);
     }
 
-    protected <A extends Enum<A>> A get(EnumProperty<?> property, Class<A> bukkitClass) {
+    @Override
+    public <A extends Enum<A>> A get(EnumProperty<?> property, Class<A> bukkitClass) {
         return fromVanilla(this.state.getValue(property), bukkitClass);
     }
 
@@ -163,17 +178,20 @@ public class CraftBlockData implements BlockData {
         return result.build();
     }
 
-    protected <A extends Enum<A>, M extends Enum<M> & StringRepresentable> void set(EnumProperty<M> property, A bukkit) {
+    @Override
+    public <M extends Enum<M> & StringRepresentable> void set(EnumProperty<M> property, Enum<?> bukkit) {
         this.parsedStates = null;
         this.state = this.state.setValue(property, toVanilla(bukkit, property.getValueClass()));
     }
 
     // Straight integer or boolean getter
-    protected <T extends Comparable<T>> T get(Property<T> property) {
+    @Override
+    public <T extends Comparable<T>> T get(Property<T> property) {
         return this.state.getValue(property);
     }
 
     // Straight integer or boolean setter
+    @Override
     public <T extends Comparable<T>, V extends T> void set(Property<T> property, V value) {
         this.parsedStates = null;
         this.state = this.state.setValue(property, value);
@@ -242,6 +260,7 @@ public class CraftBlockData implements BlockData {
     };
 
     private static final Map<Class<? extends Block>, Function<BlockState, CraftBlockData>> INSTANCE_CREATOR = new HashMap<>();
+    public static final BiMap<Property<?>, BlockProperty<?>> DATA_PROPERTY_CACHE_MAP = HashBiMap.create();
 
     static {
         //<editor-fold desc="CraftBlockData Registration" defaultstate="collapsed">
@@ -436,6 +455,7 @@ public class CraftBlockData implements BlockData {
         register(net.minecraft.world.level.block.piston.PistonHeadBlock.class, org.bukkit.craftbukkit.block.impl.CraftPistonHead::new);
         // End generate - CraftBlockData#INSTANCE_CREATOR
         //</editor-fold>
+        PaperBlockProperties.setup();
     }
 
     private static void register(Class<? extends Block> blockClass, Function<BlockState, CraftBlockData> newInstance) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
@@ -5,6 +5,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import io.papermc.paper.block.property.PaperBlockProperties;
+import io.papermc.paper.block.property.PaperBlockPropertyHolder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +30,7 @@ import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.StateHolder;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.block.state.properties.Property;
@@ -56,12 +59,14 @@ import org.bukkit.craftbukkit.util.CraftLocation;
 import org.bukkit.craftbukkit.util.CraftVoxelShape;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-public class CraftBlockData implements BlockData {
+@NullMarked
+public class CraftBlockData implements BlockData, PaperBlockPropertyHolder.PaperMutable<Block, BlockState> {
 
     private BlockState state;
-    private List<Property.Value<?>> parsedStates;
+    private @Nullable List<Property.Value<?>> parsedStates;
 
     protected CraftBlockData(BlockState state) {
         this.state = state;
@@ -72,8 +77,14 @@ public class CraftBlockData implements BlockData {
         return this.state.getBukkitMaterial();
     }
 
+    @Override
     public BlockState getState() {
         return this.state;
+    }
+
+    @Override
+    public StateDefinition<Block, BlockState> getStateDefinition() {
+        return this.state.getBlock().getStateDefinition();
     }
 
     @Override
@@ -101,7 +112,7 @@ public class CraftBlockData implements BlockData {
     }
 
     @Override
-    public boolean matches(BlockData data) {
+    public boolean matches(@Nullable BlockData data) {
         if (!(data instanceof final CraftBlockData craft)) {
             return false;
         }
@@ -148,7 +159,8 @@ public class CraftBlockData implements BlockData {
         return internalClass.cast(rawValue);
     }
 
-    protected <A extends Enum<A>> A get(EnumProperty<?> property, Class<A> bukkitClass) {
+    @Override
+    public <A extends Enum<A>> A get(EnumProperty<?> property, Class<A> bukkitClass) {
         return fromVanilla(this.state.getValue(property), bukkitClass);
     }
 
@@ -163,17 +175,20 @@ public class CraftBlockData implements BlockData {
         return result.build();
     }
 
-    protected <A extends Enum<A>, M extends Enum<M> & StringRepresentable> void set(EnumProperty<M> property, A bukkit) {
+    @Override
+    public <M extends Enum<M> & StringRepresentable> void set(EnumProperty<M> property, Enum<?> bukkit) {
         this.parsedStates = null;
         this.state = this.state.setValue(property, toVanilla(bukkit, property.getValueClass()));
     }
 
     // Straight integer or boolean getter
-    protected <T extends Comparable<T>> T get(Property<T> property) {
+    @Override
+    public <T extends Comparable<T>> T get(Property<T> property) {
         return this.state.getValue(property);
     }
 
     // Straight integer or boolean setter
+    @Override
     public <T extends Comparable<T>, V extends T> void set(Property<T> property, V value) {
         this.parsedStates = null;
         this.state = this.state.setValue(property, value);
@@ -438,6 +453,7 @@ public class CraftBlockData implements BlockData {
         register(net.minecraft.world.level.block.piston.PistonHeadBlock.class, org.bukkit.craftbukkit.block.impl.CraftPistonHead::new);
         // End generate - CraftBlockData#INSTANCE_CREATOR
         //</editor-fold>
+        PaperBlockProperties.setup();
     }
 
     private static void register(Class<? extends Block> blockClass, Function<BlockState, CraftBlockData> newInstance) {


### PR DESCRIPTION
Replaces https://github.com/PaperMC/Paper/pull/7223

----

My take on how to add a "get block data properties individually" on top of bukkit's existing method-based system.

### Structure
3 types of data properties: `Boolean`, `Integer`, and `Enum`. This pr creates a base `BlockProperty` class with 3 (+ special cases) implementations of it for each type.

#### Special Cases
So far, I've noticed 2 API types that are used to wrap integers, so this also adds handling for those, not exposing them as integers.
* `rotation` as BlockFace
* `note` as Note

The `BlockPropertyHolder` interface contains all the methods to interact with a set of properties. I left it as a standalone interface in case other uses in the future popup where a separate impl might be warranted. I added a `Mutable` subinterface to that to separate out the "set" methods, some implementations of it might not want to support mutating properties (such as future FluidState API https://github.com/PaperMC/Paper/pull/8609).