### PR TITLE
Fix outdated behaviour in temperature related javadocs

### DIFF
--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2593,9 +2593,6 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * <p>
      * It is safe to run this method when the block does not exist, it will
      * not create the block.
-     * <p>
-     * This method will return the raw temperature without adjusting for block
-     * height effects.
      *
      * @param x X coordinate of the block
      * @param z Z coordinate of the block
@@ -2610,9 +2607,6 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * <p>
      * It is safe to run this method when the block does not exist, it will
      * not create the block.
-     * <p>
-     * This method will return the raw temperature without adjusting for block
-     * height effects.
      *
      * @param x X coordinate of the block
      * @param y Y coordinate of the block

--- a/paper-api/src/main/java/org/bukkit/block/Block.java
+++ b/paper-api/src/main/java/org/bukkit/block/Block.java
@@ -509,9 +509,6 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
 
     /**
      * Gets the temperature of this block.
-     * <p>
-     * If the raw biome temperature without adjusting for height effects is
-     * required then please use {@link World#getTemperature(int, int, int)}.
      *
      * @return Temperature of this block
      */


### PR DESCRIPTION
In 1.15 spigot changed the behavior of all temperature methods to always return height adjusted temperature, this pr fixes those javadocs (a full solution would come with https://github.com/PaperMC/Paper/pull/11952 giving the possibility to properly chose between the 2)