### PR TITLE
Readd dropped hunk for ender dragon fight data

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -204,15 +204,17 @@
              chunkGenerator,
              this.chunkSource.randomState(),
              this,
-@@ -281,7 +_,7 @@
+@@ -281,8 +_,8 @@
              fixerUpper
          );
          this.structureManager = new StructureManager(this, server.getWorldData().worldGenOptions(), this.structureCheck);
 -        if (this.dimension() == Level.END && this.dimensionTypeRegistration().is(BuiltinDimensionTypes.END)) {
+-            this.dragonFight = new EndDragonFight(this, seed, server.getWorldData().endDragonFightData());
 +        if (this.dimension() == Level.END && this.dimensionTypeRegistration().is(BuiltinDimensionTypes.END) || env == org.bukkit.World.Environment.THE_END) { // CraftBukkit - Allow to create EnderDragonBattle in default and custom END
-             this.dragonFight = new EndDragonFight(this, seed, server.getWorldData().endDragonFightData());
++            this.dragonFight = new EndDragonFight(this, this.serverLevelData.worldGenOptions().seed(), this.serverLevelData.endDragonFightData()); // CraftBukkit
          } else {
              this.dragonFight = null;
+         }
 @@ -292,7 +_,15 @@
          this.randomSequences = Objects.requireNonNullElseGet(
              randomSequences, () -> this.getDataStorage().computeIfAbsent(RandomSequences.factory(seed), "random_sequences")


### PR DESCRIPTION
Dragon fight data should be read from the now split world instead of the
main world level.dat.
Partial hunk was dropped during hardfork.
