### PR TITLE
Fix a rare crash with a concurrent modification of a set

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -2858,7 +2859,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
         if (!this.scaledHealth && !force) {
             return;
         }
-        java.util.Iterator<AttributeInstance> iterator = collection.iterator();
+        Iterator<AttributeInstance> iterator = collection.iterator();
         while (iterator.hasNext()) {
             AttributeInstance genericInstance = iterator.next();
             if (genericInstance.getAttribute() == Attributes.MAX_HEALTH) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -2858,9 +2858,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
         if (!this.scaledHealth && !force) {
             return;
         }
-        for (AttributeInstance genericInstance : collection) {
+        java.util.Iterator<AttributeInstance> iterator = collection.iterator();
+        while (iterator.hasNext()) {
+            AttributeInstance genericInstance = iterator.next();
             if (genericInstance.getAttribute() == Attributes.MAX_HEALTH) {
-                collection.remove(genericInstance);
+                iterator.remove();
                 break;
             }
         }


### PR DESCRIPTION
This PR attempts to fix an issue introduced in CraftBukkit 5 years ago in https://github.com/PaperMC/Paper/commit/fcfcbd39757f71150e2ba3845cbaeb687bc01a48 (how did noone catch this??)

Relevant part of a crash report: https://pastes.dev/cKg6BswffG (1.21.3 server - but it does not matter here)