### PR TITLE
Fix wrong piston world border check

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
@@ -66,7 +66,7 @@
  
      public static boolean isPushable(BlockState state, Level level, BlockPos pos, Direction movementDirection, boolean allowDestroy, Direction pistonFacing) {
 -        if (pos.getY() < level.getMinY() || pos.getY() > level.getMaxY() || !level.getWorldBorder().isWithinBounds(pos)) {
-+        if (pos.getY() < level.getMinY() || pos.getY() > level.getMaxY() || !level.getWorldBorder().isWithinBounds(pos.relative(movementDirection))) { // Paper - Fix MC-82010
++        if (pos.getY() < level.getMinY() || pos.getY() > level.getMaxY() || !level.getWorldBorder().isWithinBounds(pos) || !level.getWorldBorder().isWithinBounds(pos.relative(movementDirection))) { // Paper - Fix piston world border check
              return false;
          } else if (state.isAir()) {
              return true;

--- a/paper-server/patches/sources/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
@@ -61,6 +61,15 @@
              }
  
              level.playSound(null, pos, SoundEvents.PISTON_CONTRACT, SoundSource.BLOCKS, 0.5F, level.random.nextFloat() * 0.15F + 0.6F);
+@@ -249,7 +_,7 @@
+     }
+ 
+     public static boolean isPushable(BlockState state, Level level, BlockPos pos, Direction movementDirection, boolean allowDestroy, Direction pistonFacing) {
+-        if (pos.getY() < level.getMinY() || pos.getY() > level.getMaxY() || !level.getWorldBorder().isWithinBounds(pos)) {
++        if (pos.getY() < level.getMinY() || pos.getY() > level.getMaxY() || !level.getWorldBorder().isWithinBounds(pos.relative(movementDirection))) { // Paper - Fix MC-82010
+             return false;
+         } else if (state.isAir()) {
+             return true;
 @@ -305,12 +_,54 @@
              BlockState[] blockStates = new BlockState[toPush.size() + toDestroy.size()];
              Direction direction = extending ? facing : facing.getOpposite();


### PR DESCRIPTION
Closes #11983.

This pull request fixes vanilla wrong piston world border check([MC-82010](https://bugs.mojang.com/browse/MC-82010), thanks to FX-PR0CESS)


Before(Paper 1.21.4 build 121):

![before](https://github.com/user-attachments/assets/95a5a76d-b07e-4589-bcb6-4cb0b688b5cc)

After:

![after](https://github.com/user-attachments/assets/8021906b-6d1e-46d1-90cb-9d38036669b0)

