### PR TITLE
Check for empty when sending equipment changes

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -1063,7 +1063,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      *
      * @param entity the entity whose equipment to change
      * @param items the slots to change, where the values are the items to which
-     * the slot should be changed. null values will set the slot to air
+     * the slot should be changed. null values will set the slot to air, empty map is not allowed
      */
     public void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull Map<EquipmentSlot, ItemStack> items);
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1161,6 +1161,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     public void sendEquipmentChange(LivingEntity entity, Map<EquipmentSlot, ItemStack> items) {
         Preconditions.checkArgument(entity != null, "Entity cannot be null");
         Preconditions.checkArgument(items != null, "items cannot be null");
+        Preconditions.checkArgument(!items.isEmpty(), "items cannot be empty");
 
         if (this.getHandle().connection == null) {
             return;


### PR DESCRIPTION
Closes #12005.

Add checks for empty in CraftPlayer#sendEquipmentChange, will give a clear error for what's going on instead of directly disconnect the player.
Add notes in `Player#sendEquipmentChange(LivingEntity, Map<EquipmentSlot,ItemStack>)` javadoc.
