### PR TITLE
fix PlayerChangedMainHandEvent javadoc

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerChangedMainHandEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerChangedMainHandEvent.java
@@ -12,22 +12,31 @@ public class PlayerChangedMainHandEvent extends PlayerEvent {
 
     private static final HandlerList handlers = new HandlerList();
     //
-    private final MainHand mainHand;
+    private final MainHand newMainHand;
 
-    public PlayerChangedMainHandEvent(@NotNull Player who, @NotNull MainHand mainHand) {
+    public PlayerChangedMainHandEvent(@NotNull Player who, @NotNull MainHand newMainHand) {
         super(who);
-        this.mainHand = mainHand;
+        this.newMainHand = newMainHand;
     }
 
     /**
-     * Gets the new main hand of the player. The old hand is still momentarily
-     * available via {@link Player#getMainHand()}.
+     * Gets the old main hand of the player.
+     *
+     * @return the old {@link MainHand} of the player
+     */
+    @NotNull
+    public MainHand getMainHand() {
+        return newMainHand == MainHand.LEFT ? MainHand.RIGHT : MainHand.LEFT;
+    }
+
+    /**
+     * Gets the new main hand of the player.
      *
      * @return the new {@link MainHand} of the player
      */
     @NotNull
-    public MainHand getMainHand() {
-        return mainHand;
+    public MainHand getNewMainHand() {
+        return newMainHand;
     }
 
     @NotNull

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerChangedMainHandEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerChangedMainHandEvent.java
@@ -1,13 +1,17 @@
 package org.bukkit.event.player;
 
+import com.destroystokyo.paper.event.player.PlayerClientOptionsChangeEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.MainHand;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player changes their main hand in the client settings.
+ * @apiNote Obsolete and replaced by {@link PlayerClientOptionsChangeEvent}.
  */
+@ApiStatus.Obsolete
 public class PlayerChangedMainHandEvent extends PlayerEvent {
 
     private static final HandlerList handlers = new HandlerList();
@@ -20,11 +24,16 @@ public class PlayerChangedMainHandEvent extends PlayerEvent {
     }
 
     /**
-     * Gets the old main hand of the player.
+     * Gets the new main hand of the player. The old hand is still momentarily
+     * available via {@link Player#getMainHand()}.
      *
-     * @return the old {@link MainHand} of the player
+     * @return the new {@link MainHand} of the player
+     * @deprecated has never been functional since its implementation and simply returns the old main hand.
+     * The method is left in this broken state to not break compatibility with plugins that relied on this fact.
+     * Use {@link #getNewMainHand()} instead or migrate to {@link PlayerClientOptionsChangeEvent#getMainHand()}.
      */
     @NotNull
+    @Deprecated(since = "1.21.4", forRemoval = true)
     public MainHand getMainHand() {
         return newMainHand == MainHand.LEFT ? MainHand.RIGHT : MainHand.LEFT;
     }

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -1213,7 +1213,7 @@
 +        if (this.getMainArm() != clientInformation.mainHand()) {
 +            org.bukkit.event.player.PlayerChangedMainHandEvent event = new org.bukkit.event.player.PlayerChangedMainHandEvent(
 +                this.getBukkitEntity(),
-+                this.getMainArm() == HumanoidArm.LEFT ? org.bukkit.inventory.MainHand.LEFT : org.bukkit.inventory.MainHand.RIGHT
++                clientInformation.mainHand() == HumanoidArm.LEFT ? org.bukkit.inventory.MainHand.LEFT : org.bukkit.inventory.MainHand.RIGHT
 +            );
 +            this.server.server.getPluginManager().callEvent(event);
 +        }


### PR DESCRIPTION
This event seems to have been behaving differently than described since it was first introduced.
https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/106ced01e0bd24a20633d4f3aa99c2452736be74#nms-patches%2FEntityPlayer.patch?t=508

TestPlugin
```java
@EventHandler
void event(final PlayerChangedMainHandEvent event) {
    final Player player = event.getPlayer();
    player.sendRawMessage("Current: " + player.getMainHand());
    player.sendRawMessage("New Hand: " + event.getMainHand());
}
```
![image](https://github.com/user-attachments/assets/2586b97f-3cb3-4f66-9978-28a6711ea86b)
`PlayerChangedMainHandEvent#getMainHand()` is returning an old mainhand.