### PR TITLE
Deprecate Server#setSpawnRadius

### DIFF
--- a/paper-api/src/main/java/org/bukkit/Bukkit.java
+++ b/paper-api/src/main/java/org/bukkit/Bukkit.java
@@ -1373,8 +1373,9 @@ public final class Bukkit {
      * Sets the radius, in blocks, around each worlds spawn point to protect.
      *
      * @param value new spawn radius, or 0 if none
-     * @deprecated don't work anymore, set the {@code spawn-protection} in
-     * server.properties or use a plugin
+     * @deprecated has not functioned for a long time as the spawn radius is defined by the server.properties file.
+     * There is no API replacement for this method. It is generally recommended to implement "protection"-like behaviour
+     * via events or third-party plugin APIs.
      */
     @Deprecated(since = "1.21.4", forRemoval = true)
     public static void setSpawnRadius(int value) {

--- a/paper-api/src/main/java/org/bukkit/Bukkit.java
+++ b/paper-api/src/main/java/org/bukkit/Bukkit.java
@@ -1373,7 +1373,10 @@ public final class Bukkit {
      * Sets the radius, in blocks, around each worlds spawn point to protect.
      *
      * @param value new spawn radius, or 0 if none
+     * @deprecated don't work anymore, set the {@code spawn-protection} in
+     * server.properties or use a plugin
      */
+    @Deprecated(since = "1.21.4", forRemoval = true)
     public static void setSpawnRadius(int value) {
         server.setSpawnRadius(value);
     }

--- a/paper-api/src/main/java/org/bukkit/Server.java
+++ b/paper-api/src/main/java/org/bukkit/Server.java
@@ -1219,8 +1219,9 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      * Sets the radius, in blocks, around each worlds spawn point to protect.
      *
      * @param value new spawn radius, or 0 if none
-     * @deprecated don't work anymore, set the {@code spawn-protection} in
-     * server.properties or use a plugin
+     * @deprecated has not functioned for a long time as the spawn radius is defined by the server.properties file.
+     * There is no API replacement for this method. It is generally recommended to implement "protection"-like behaviour
+     * via events or third-party plugin APIs.
      */
     @Deprecated(since = "1.21.4", forRemoval = true)
     public void setSpawnRadius(int value);

--- a/paper-api/src/main/java/org/bukkit/Server.java
+++ b/paper-api/src/main/java/org/bukkit/Server.java
@@ -1219,7 +1219,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      * Sets the radius, in blocks, around each worlds spawn point to protect.
      *
      * @param value new spawn radius, or 0 if none
+     * @deprecated don't work anymore, set the {@code spawn-protection} in
+     * server.properties or use a plugin
      */
+    @Deprecated(since = "1.21.4", forRemoval = true)
     public void setSpawnRadius(int value);
 
     /**

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -1864,22 +1864,12 @@ public final class CraftServer implements Server {
         return result;
     }
 
-    public void removeBukkitSpawnRadius() {
-        this.configuration.set("settings.spawn-radius", null);
-        this.saveConfig();
-    }
-
-    public int getBukkitSpawnRadius() {
-        return this.configuration.getInt("settings.spawn-radius", -1);
-    }
-
-    // Paper start
     @Override
     public net.kyori.adventure.text.Component shutdownMessage() {
         String msg = getShutdownMessage();
         return msg != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(msg) : null;
     }
-    // Paper end
+
     @Override
     @Deprecated // Paper
     public String getShutdownMessage() {


### PR DESCRIPTION
This method doesn't works for a while, previously bukkit had a
migration path that was removed at some point and i don't think it's worth
to restore it.