### PR TITLE
Add TrialSpawner methods for end of cooldown and next mob spawn time

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -624,8 +624,10 @@ public net.minecraft.world.level.block.entity.TheEndGatewayBlockEntity exitPorta
 public net.minecraft.world.level.block.entity.TrialSpawnerBlockEntity trialSpawner
 public net.minecraft.world.level.block.entity.trialspawner.TrialSpawner isOminous
 public net.minecraft.world.level.block.entity.trialspawner.TrialSpawner stateAccessor
+public net.minecraft.world.level.block.entity.trialspawner.TrialSpawnerData cooldownEndsAt
 public net.minecraft.world.level.block.entity.trialspawner.TrialSpawnerData currentMobs
 public net.minecraft.world.level.block.entity.trialspawner.TrialSpawnerData detectedPlayers
+public net.minecraft.world.level.block.entity.trialspawner.TrialSpawnerData nextMobSpawnsAt
 public net.minecraft.world.level.block.entity.trialspawner.TrialSpawnerData nextSpawnData
 public net.minecraft.world.level.block.state.BlockBehaviour getMenuProvider(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/MenuProvider;
 public net.minecraft.world.level.block.state.BlockBehaviour hasCollision

--- a/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
+++ b/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
@@ -4,13 +4,40 @@ import java.util.Collection;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.spawner.TrialSpawnerConfiguration;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a captured state of a trial spawner.
  */
 public interface TrialSpawner extends TileState {
+
+    /**
+     * Gets the Gametime in ticks when the cooldown ends. 0 if not currently in cooldown.
+     *
+     * @return the Gametime in ticks
+     */
+    public long getCooldownEndsAt();
+
+    /**
+     * Sets the Gametime in ticks when the cooldown ends.
+     *
+     * @param ticks the GameTime in ticks for the new cooldown
+     */
+    public void setCooldownEndsAt(long ticks);
+
+    /**
+     * Gets the Gametime in ticks when the next spawn attempt happens. 0 if not currently active.
+     *
+     * @return the Gametime in ticks
+     */
+    public long getNextMobSpawnsAt();
+
+    /**
+     * Sets the Gametime in ticks when the next spawn attempt happens.
+     *
+     * @param ticks the Gametime in ticks for the next mob spawn
+     */
+    public void setNextMobSpawnsAt(long ticks);
 
     /**
      * Gets the length in ticks the spawner will stay in cooldown for.

--- a/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
+++ b/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
@@ -132,7 +132,7 @@ public interface TrialSpawner extends TileState {
      * @return a collection of entities this spawner is tracking or an empty
      *         collection if there aren't any
      */
-     Collection<Entity> getTrackedEntities();
+    Collection<Entity> getTrackedEntities();
 
     /**
      * Checks if this spawner is currently tracking the provided entity.

--- a/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
+++ b/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
@@ -16,14 +16,14 @@ public interface TrialSpawner extends TileState {
      *
      * @return the Gametime in ticks
      */
-    public long getCooldownEndsAt();
+    public long getCooldownEnd();
 
     /**
      * Sets the Gametime in ticks when the cooldown ends.
      *
      * @param ticks the GameTime in ticks for the new cooldown
      */
-    public void setCooldownEndsAt(long ticks);
+    public void setCooldownEnd(long ticks);
 
     /**
      * Gets the Gametime in ticks when the next spawn attempt happens. 0 if not currently active.

--- a/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
+++ b/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
@@ -12,30 +12,32 @@ import org.jetbrains.annotations.NotNull;
 public interface TrialSpawner extends TileState {
 
     /**
-     * Gets the Gametime in ticks when the cooldown ends. 0 if not currently in cooldown.
+     * Gets the game time in ticks when the cooldown ends. 0 if not currently in cooldown.
      *
-     * @return the Gametime in ticks
+     * @return the game time in ticks
+     * @see org.bukkit.World#getGameTime()
      */
     long getCooldownEnd();
 
     /**
-     * Sets the Gametime in ticks when the cooldown ends.
+     * Sets the game time in ticks when the cooldown ends.
      *
-     * @param ticks the GameTime in ticks for the new cooldown
+     * @param ticks the game time in ticks for the new cooldown
      */
     void setCooldownEnd(long ticks);
 
     /**
-     * Gets the Gametime in ticks when the next spawn attempt happens. 0 if not currently active.
+     * Gets the game time in ticks when the next spawn attempt happens. 0 if not currently active.
      *
-     * @return the Gametime in ticks
+     * @return the game time in ticks
+     * @see org.bukkit.World#getGameTime()
      */
     long getNextSpawnAttempt();
 
     /**
-     * Sets the Gametime in ticks when the next spawn attempt happens.
+     * Sets the game time in ticks when the next spawn attempt happens.
      *
-     * @param ticks the Gametime in ticks for the next mob spawn
+     * @param ticks the game time in ticks for the next mob spawn
      */
     void setNextSpawnAttempt(long ticks);
 

--- a/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
+++ b/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
@@ -30,14 +30,14 @@ public interface TrialSpawner extends TileState {
      *
      * @return the Gametime in ticks
      */
-    public long getNextMobSpawnsAt();
+    public long getNextSpawnAttempt();
 
     /**
      * Sets the Gametime in ticks when the next spawn attempt happens.
      *
      * @param ticks the Gametime in ticks for the next mob spawn
      */
-    public void setNextMobSpawnsAt(long ticks);
+    public void setNextSpawnAttempt(long ticks);
 
     /**
      * Gets the length in ticks the spawner will stay in cooldown for.

--- a/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
+++ b/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
@@ -16,42 +16,42 @@ public interface TrialSpawner extends TileState {
      *
      * @return the Gametime in ticks
      */
-    public long getCooldownEnd();
+    long getCooldownEnd();
 
     /**
      * Sets the Gametime in ticks when the cooldown ends.
      *
      * @param ticks the GameTime in ticks for the new cooldown
      */
-    public void setCooldownEnd(long ticks);
+    void setCooldownEnd(long ticks);
 
     /**
      * Gets the Gametime in ticks when the next spawn attempt happens. 0 if not currently active.
      *
      * @return the Gametime in ticks
      */
-    public long getNextSpawnAttempt();
+    long getNextSpawnAttempt();
 
     /**
      * Sets the Gametime in ticks when the next spawn attempt happens.
      *
      * @param ticks the Gametime in ticks for the next mob spawn
      */
-    public void setNextSpawnAttempt(long ticks);
+    void setNextSpawnAttempt(long ticks);
 
     /**
      * Gets the length in ticks the spawner will stay in cooldown for.
      *
      * @return the number of ticks
      */
-    public int getCooldownLength();
+    int getCooldownLength();
 
     /**
      * Sets the length in ticks the spawner will stay in cooldown for.
      *
      * @param ticks the number of ticks
      */
-    public void setCooldownLength(int ticks);
+    void setCooldownLength(int ticks);
 
     /**
      * Get the maximum distance(squared) a player can be in order for this
@@ -65,7 +65,7 @@ public interface TrialSpawner extends TileState {
      * @return the maximum distance(squared) a player can be in order for this
      * spawner to be active.
      */
-    public int getRequiredPlayerRange();
+    int getRequiredPlayerRange();
 
     /**
      * Set the maximum distance (squared) a player can be in order for this
@@ -77,7 +77,7 @@ public interface TrialSpawner extends TileState {
      * @param requiredPlayerRange the maximum distance (squared) a player can be
      * in order for this spawner to be active.
      */
-    public void setRequiredPlayerRange(int requiredPlayerRange);
+    void setRequiredPlayerRange(int requiredPlayerRange);
 
     /**
      * Gets the players this spawner is currently tracking.
@@ -89,8 +89,7 @@ public interface TrialSpawner extends TileState {
      * @return a collection of players this spawner is tracking or an empty
      *         collection if there aren't any
      */
-    @NotNull
-    public Collection<Player> getTrackedPlayers();
+    @NotNull Collection<Player> getTrackedPlayers();
 
     /**
      * Checks if this spawner is currently tracking the provided player.
@@ -98,7 +97,7 @@ public interface TrialSpawner extends TileState {
      * @param player the player
      * @return true if this spawner is tracking the provided player
      */
-    public boolean isTrackingPlayer(@NotNull Player player);
+    boolean isTrackingPlayer(@NotNull Player player);
 
     /**
      * Force this spawner to start tracking the provided player.
@@ -108,7 +107,7 @@ public interface TrialSpawner extends TileState {
      *
      * @param player the player
      */
-    public void startTrackingPlayer(@NotNull Player player);
+    void startTrackingPlayer(@NotNull Player player);
 
     /**
      * Force this spawner to stop tracking the provided player.
@@ -118,7 +117,7 @@ public interface TrialSpawner extends TileState {
      *
      * @param player the player
      */
-    public void stopTrackingPlayer(@NotNull Player player);
+    void stopTrackingPlayer(@NotNull Player player);
 
     /**
      * Gets a list of entities this spawner is currently tracking.
@@ -130,8 +129,7 @@ public interface TrialSpawner extends TileState {
      * @return a collection of entities this spawner is tracking or an empty
      *         collection if there aren't any
      */
-    @NotNull
-    public Collection<Entity> getTrackedEntities();
+    @NotNull Collection<Entity> getTrackedEntities();
 
     /**
      * Checks if this spawner is currently tracking the provided entity.
@@ -139,7 +137,7 @@ public interface TrialSpawner extends TileState {
      * @param entity the entity
      * @return true if this spawner is tracking the provided entity
      */
-    public boolean isTrackingEntity(@NotNull Entity entity);
+    boolean isTrackingEntity(@NotNull Entity entity);
 
     /**
      * Force this spawner to start tracking the provided entity.
@@ -149,7 +147,7 @@ public interface TrialSpawner extends TileState {
      *
      * @param entity the entity
      */
-    public void startTrackingEntity(@NotNull Entity entity);
+    void startTrackingEntity(@NotNull Entity entity);
 
     /**
      * Force this spawner to stop tracking the provided entity.
@@ -159,7 +157,7 @@ public interface TrialSpawner extends TileState {
      *
      * @param entity the entity
      */
-    public void stopTrackingEntity(@NotNull Entity entity);
+    void stopTrackingEntity(@NotNull Entity entity);
 
     /**
      * Checks if this spawner is using the ominous
@@ -167,7 +165,7 @@ public interface TrialSpawner extends TileState {
      *
      * @return true is using the ominous configuration
      */
-    public boolean isOminous();
+    boolean isOminous();
 
     /**
      * Changes this spawner between the normal and ominous
@@ -176,7 +174,7 @@ public interface TrialSpawner extends TileState {
      * @param ominous true to use the ominous TrialSpawnerConfiguration, false to
      *                use the normal one.
      */
-    public void setOminous(boolean ominous);
+    void setOminous(boolean ominous);
 
     /**
      * Gets the {@link TrialSpawnerConfiguration} used when {@link #isOminous()} is
@@ -184,8 +182,7 @@ public interface TrialSpawner extends TileState {
      *
      * @return the TrialSpawnerConfiguration
      */
-    @NotNull
-    public TrialSpawnerConfiguration getNormalConfiguration();
+    @NotNull TrialSpawnerConfiguration getNormalConfiguration();
 
     /**
      * Gets the {@link TrialSpawnerConfiguration} used when {@link #isOminous()} is
@@ -193,6 +190,5 @@ public interface TrialSpawner extends TileState {
      *
      * @return the TrialSpawnerConfiguration
      */
-    @NotNull
-    public TrialSpawnerConfiguration getOminousConfiguration();
+    @NotNull TrialSpawnerConfiguration getOminousConfiguration();
 }

--- a/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
+++ b/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
@@ -4,11 +4,12 @@ import java.util.Collection;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.spawner.TrialSpawnerConfiguration;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Represents a captured state of a trial spawner.
  */
+@NullMarked
 public interface TrialSpawner extends TileState {
 
     /**
@@ -91,7 +92,7 @@ public interface TrialSpawner extends TileState {
      * @return a collection of players this spawner is tracking or an empty
      *         collection if there aren't any
      */
-    @NotNull Collection<Player> getTrackedPlayers();
+    Collection<Player> getTrackedPlayers();
 
     /**
      * Checks if this spawner is currently tracking the provided player.
@@ -99,7 +100,7 @@ public interface TrialSpawner extends TileState {
      * @param player the player
      * @return true if this spawner is tracking the provided player
      */
-    boolean isTrackingPlayer(@NotNull Player player);
+    boolean isTrackingPlayer(final Player player);
 
     /**
      * Force this spawner to start tracking the provided player.
@@ -109,7 +110,7 @@ public interface TrialSpawner extends TileState {
      *
      * @param player the player
      */
-    void startTrackingPlayer(@NotNull Player player);
+    void startTrackingPlayer(final Player player);
 
     /**
      * Force this spawner to stop tracking the provided player.
@@ -119,7 +120,7 @@ public interface TrialSpawner extends TileState {
      *
      * @param player the player
      */
-    void stopTrackingPlayer(@NotNull Player player);
+    void stopTrackingPlayer(final Player player);
 
     /**
      * Gets a list of entities this spawner is currently tracking.
@@ -131,7 +132,7 @@ public interface TrialSpawner extends TileState {
      * @return a collection of entities this spawner is tracking or an empty
      *         collection if there aren't any
      */
-    @NotNull Collection<Entity> getTrackedEntities();
+     Collection<Entity> getTrackedEntities();
 
     /**
      * Checks if this spawner is currently tracking the provided entity.
@@ -139,7 +140,7 @@ public interface TrialSpawner extends TileState {
      * @param entity the entity
      * @return true if this spawner is tracking the provided entity
      */
-    boolean isTrackingEntity(@NotNull Entity entity);
+    boolean isTrackingEntity(final Entity entity);
 
     /**
      * Force this spawner to start tracking the provided entity.
@@ -149,7 +150,7 @@ public interface TrialSpawner extends TileState {
      *
      * @param entity the entity
      */
-    void startTrackingEntity(@NotNull Entity entity);
+    void startTrackingEntity(final Entity entity);
 
     /**
      * Force this spawner to stop tracking the provided entity.
@@ -159,7 +160,7 @@ public interface TrialSpawner extends TileState {
      *
      * @param entity the entity
      */
-    void stopTrackingEntity(@NotNull Entity entity);
+    void stopTrackingEntity(final Entity entity);
 
     /**
      * Checks if this spawner is using the ominous
@@ -184,7 +185,7 @@ public interface TrialSpawner extends TileState {
      *
      * @return the TrialSpawnerConfiguration
      */
-    @NotNull TrialSpawnerConfiguration getNormalConfiguration();
+    TrialSpawnerConfiguration getNormalConfiguration();
 
     /**
      * Gets the {@link TrialSpawnerConfiguration} used when {@link #isOminous()} is
@@ -192,5 +193,5 @@ public interface TrialSpawner extends TileState {
      *
      * @return the TrialSpawnerConfiguration
      */
-    @NotNull TrialSpawnerConfiguration getOminousConfiguration();
+    TrialSpawnerConfiguration getOminousConfiguration();
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrialSpawner.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrialSpawner.java
@@ -44,12 +44,12 @@ public class CraftTrialSpawner extends CraftBlockEntityState<TrialSpawnerBlockEn
     }
 
     @Override
-    public long getNextMobSpawnsAt() {
+    public long getNextSpawnAttempt() {
         return this.getSnapshot().trialSpawner.getData().nextMobSpawnsAt;
     }
 
     @Override
-    public void setNextMobSpawnsAt(long ticks) {
+    public void setNextSpawnAttempt(long ticks) {
         this.getSnapshot().trialSpawner.getData().nextMobSpawnsAt = ticks;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrialSpawner.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrialSpawner.java
@@ -34,12 +34,12 @@ public class CraftTrialSpawner extends CraftBlockEntityState<TrialSpawnerBlockEn
     }
 
     @Override
-    public long getCooldownEndsAt() {
+    public long getCooldownEnd() {
         return this.getSnapshot().trialSpawner.getData().cooldownEndsAt;
     }
 
     @Override
-    public void setCooldownEndsAt(long ticks) {
+    public void setCooldownEnd(long ticks) {
         this.getSnapshot().trialSpawner.getData().cooldownEndsAt = ticks;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrialSpawner.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrialSpawner.java
@@ -34,6 +34,26 @@ public class CraftTrialSpawner extends CraftBlockEntityState<TrialSpawnerBlockEn
     }
 
     @Override
+    public long getCooldownEndsAt() {
+        return this.getSnapshot().trialSpawner.getData().cooldownEndsAt;
+    }
+
+    @Override
+    public void setCooldownEndsAt(long ticks) {
+        this.getSnapshot().trialSpawner.getData().cooldownEndsAt = ticks;
+    }
+
+    @Override
+    public long getNextMobSpawnsAt() {
+        return this.getSnapshot().trialSpawner.getData().nextMobSpawnsAt;
+    }
+
+    @Override
+    public void setNextMobSpawnsAt(long ticks) {
+        this.getSnapshot().trialSpawner.getData().nextMobSpawnsAt = ticks;
+    }
+
+    @Override
     public int getCooldownLength() {
         return this.getSnapshot().trialSpawner.getTargetCooldownLength();
     }

--- a/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
+++ b/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
@@ -1,43 +1,14 @@
 package io.papermc.testplugin;
 
-import org.bukkit.Material;
-import org.bukkit.block.data.BlockData;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.defaults.BukkitCommand;
-import org.bukkit.entity.Armadillo;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.jetbrains.annotations.NotNull;
-import java.util.List;
 
 public final class TestPlugin extends JavaPlugin implements Listener {
-
-    BlockData testBlockData;
 
     @Override
     public void onEnable() {
         this.getServer().getPluginManager().registerEvents(this, this);
 
         // io.papermc.testplugin.brigtests.Registration.registerViaOnEnable(this);
-        testBlockData = Material.PISTON.createBlockData();
-
-        this.getServer().getCommandMap().register("fallback", new BukkitCommand("test", "cool test command", "<>", List.of()) {
-            @Override
-            public boolean execute(@NotNull CommandSender sender, @NotNull String commandLabel, @NotNull String[] args) {
-                sender.sendMessage("hi");
-                sender.sendMessage(testBlockData.toString());
-                return true;
-            }
-        });
-        this.getServer().getCommandMap().register("fallback", new BukkitCommand("test2", "cool test command", "<>", List.of()) {
-            @Override
-            public boolean execute(@NotNull CommandSender sender, @NotNull String commandLabel, @NotNull String[] args) {
-                sender.sendMessage("hi");
-                sender.sendMessage(Material.PISTON.createBlockData().toString());
-                return true;
-            }
-        });
     }
-
-
 }


### PR DESCRIPTION
This resolve #12023 by adding two new methods related to the when the cooldown ends in gametime and when the next mob spawn in gametime.

ref: https://minecraft.wiki/w/Trial_Spawner