### PR TITLE
Fix #11887

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 +++ b/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
+@@ -35,7 +_,7 @@
+     private static final double PUSH_OFFSET = 0.01;
+     public static final double TICK_MOVEMENT = 0.51;
+     private BlockState movedState = Blocks.AIR.defaultBlockState();
+-    private Direction direction;
++    private Direction direction = Direction.DOWN; // Paper - default to first value to avoid NPE
+     private boolean extending;
+     private boolean isSourcePiston;
+     private static final ThreadLocal<Direction> NOCLIP = ThreadLocal.withInitial(() -> null);
 @@ -299,7 +_,7 @@
                  if (level.getBlockState(pos).is(Blocks.MOVING_PISTON)) {
                      BlockState blockState = Block.updateFromNeighbourShapes(blockEntity.movedState, level, pos);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
@@ -50,8 +50,13 @@ public abstract class CraftBlockEntityState<T extends BlockEntity> extends Craft
             if (thr instanceof ThreadDeath) {
                 throw (ThreadDeath)thr;
             }
-            String worldName = world == null ? "null" : world.getName();
-            throw new RuntimeException("Failed to read BlockState at: world: " + worldName + " location: (" + this.getX() + ", " + this.getY() + ", " + this.getZ() + ")", thr);
+            String message;
+            if (world == null) {
+                message = "Failed to read non-placed BlockState";
+            } else {
+                message = "Failed to read BlockState at: world: " + world.getName() + " location: (" + this.getX() + ", " + this.getY() + ", " + this.getZ() + ")";
+            }
+            throw new RuntimeException(message, thr);
         }
         // Paper end - Show blockstate location if we failed to read it
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
@@ -50,7 +50,8 @@ public abstract class CraftBlockEntityState<T extends BlockEntity> extends Craft
             if (thr instanceof ThreadDeath) {
                 throw (ThreadDeath)thr;
             }
-            throw new RuntimeException("Failed to read BlockState at: world: " + this.getWorld().getName() + " location: (" + this.getX() + ", " + this.getY() + ", " + this.getZ() + ")", thr);
+            String worldName = world == null ? "null" : world.getName();
+            throw new RuntimeException("Failed to read BlockState at: world: " + worldName + " location: (" + this.getX() + ", " + this.getY() + ", " + this.getZ() + ")", thr);
         }
         // Paper end - Show blockstate location if we failed to read it
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
@@ -50,13 +50,12 @@ public abstract class CraftBlockEntityState<T extends BlockEntity> extends Craft
             if (thr instanceof ThreadDeath) {
                 throw (ThreadDeath)thr;
             }
-            String message;
-            if (world == null) {
-                message = "Failed to read non-placed BlockState";
-            } else {
-                message = "Failed to read BlockState at: world: " + world.getName() + " location: (" + this.getX() + ", " + this.getY() + ", " + this.getZ() + ")";
-            }
-            throw new RuntimeException(message, thr);
+            throw new RuntimeException(
+                world == null
+                    ? "Failed to read non-placed BlockState"
+                    : "Failed to read BlockState at: world: " + world.getName() + " location: (" + this.getX() + ", " + this.getY() + ", " + this.getZ() + ")",
+                thr
+            );
         }
         // Paper end - Show blockstate location if we failed to read it
     }


### PR DESCRIPTION
Closes #11887
Fixes both the wrapper exception for non-placed tile entities and creation of a craft moving piston