### PR TITLE
Prevent duplicate raider in RaidSpawnWaveEvent list

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
@@ -126,7 +126,7 @@
                          this.joinRaid(i, raider1, pos, false);
                          raider1.moveTo(pos, 0.0F, 0.0F);
                          raider1.startRiding(raider);
-+                        raiders.add(raider); // CraftBukkit
++                        raiders.add(raider1); // CraftBukkit
                      }
                  }
              }

--- a/paper-server/patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/raid/Raid.java.patch
@@ -99,42 +99,20 @@
                      this.stop();
                      return;
                  }
-@@ -491,6 +_,10 @@
+@@ -486,7 +_,7 @@
+ 
+     private void spawnGroup(BlockPos pos) {
+         boolean flag = false;
+-        int i = this.groupsSpawned + 1;
++        int i = this.groupsSpawned + 1; final int wave = i; // Paper - OBFHELPER
+         this.totalHealth = 0.0F;
          DifficultyInstance currentDifficultyAt = this.level.getCurrentDifficultyAt(pos);
          boolean shouldSpawnBonusGroup = this.shouldSpawnBonusGroup();
- 
-+        // CraftBukkit start
-+        Raider leader = null;
-+        List<Raider> raiders = new java.util.ArrayList<>();
-+        // CraftBukkit end
-         for (Raid.RaiderType raiderType : Raid.RaiderType.VALUES) {
-             int i1 = this.getDefaultNumSpawns(raiderType, i, shouldSpawnBonusGroup)
-                 + this.getPotentialBonusSpawns(raiderType, this.random, i, currentDifficultyAt, shouldSpawnBonusGroup);
-@@ -506,9 +_,11 @@
-                     raider.setPatrolLeader(true);
-                     this.setLeader(i, raider);
-                     flag = true;
-+                    leader = raider; // CraftBukkit
-                 }
- 
-                 this.joinRaid(i, raider, pos, false);
-+                raiders.add(raider); // CraftBukkit
-                 if (raiderType.entityType == EntityType.RAVAGER) {
-                     Raider raider1 = null;
-                     if (i == this.getNumGroups(Difficulty.NORMAL)) {
-@@ -526,6 +_,7 @@
-                         this.joinRaid(i, raider1, pos, false);
-                         raider1.moveTo(pos, 0.0F, 0.0F);
-                         raider1.startRiding(raider);
-+                        raiders.add(raider1); // CraftBukkit
-                     }
-                 }
-             }
 @@ -535,6 +_,7 @@
          this.groupsSpawned++;
          this.updateBossbar();
          this.setDirty();
-+        org.bukkit.craftbukkit.event.CraftEventFactory.callRaidSpawnWaveEvent(this, leader, raiders); // CraftBukkit
++        org.bukkit.craftbukkit.event.CraftEventFactory.callRaidSpawnWaveEvent(this, java.util.Objects.requireNonNull(this.getLeader(wave)), this.groupRaiderMap.get(wave)); // CraftBukkit
      }
  
      public void joinRaid(int wave, Raider raider, @Nullable BlockPos pos, boolean isRecruited) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -87,7 +88,6 @@ import org.bukkit.craftbukkit.damage.CraftDamageSource;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
-import org.bukkit.craftbukkit.entity.CraftRaider;
 import org.bukkit.craftbukkit.entity.CraftSpellcaster;
 import org.bukkit.craftbukkit.inventory.CraftInventoryCrafting;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
@@ -2015,7 +2015,7 @@ public class CraftEventFactory {
         Bukkit.getPluginManager().callEvent(event);
     }
 
-    public static void callRaidSpawnWaveEvent(Raid raid, net.minecraft.world.entity.raid.Raider leader, List<net.minecraft.world.entity.raid.Raider> raiders) {
+    public static void callRaidSpawnWaveEvent(Raid raid, net.minecraft.world.entity.raid.Raider leader, Set<net.minecraft.world.entity.raid.Raider> raiders) {
         Raider bukkitLeader = (Raider) leader.getBukkitEntity();
         List<Raider> bukkitRaiders = new ArrayList<>(raiders.size());
         for (net.minecraft.world.entity.raid.Raider raider : raiders) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -2016,13 +2016,13 @@ public class CraftEventFactory {
     }
 
     public static void callRaidSpawnWaveEvent(Raid raid, net.minecraft.world.entity.raid.Raider leader, List<net.minecraft.world.entity.raid.Raider> raiders) {
-        Raider craftLeader = (CraftRaider) leader.getBukkitEntity();
-        List<Raider> craftRaiders = new ArrayList<>();
-        for (net.minecraft.world.entity.raid.Raider entityRaider : raiders) {
-            craftRaiders.add((Raider) entityRaider.getBukkitEntity());
+        Raider bukkitLeader = (Raider) leader.getBukkitEntity();
+        List<Raider> bukkitRaiders = new ArrayList<>(raiders.size());
+        for (net.minecraft.world.entity.raid.Raider raider : raiders) {
+            bukkitRaiders.add((Raider) raider.getBukkitEntity());
         }
-        RaidSpawnWaveEvent event = new RaidSpawnWaveEvent(new CraftRaid(raid), raid.getLevel().getWorld(), craftLeader, craftRaiders);
-        Bukkit.getPluginManager().callEvent(event);
+        RaidSpawnWaveEvent event = new RaidSpawnWaveEvent(new CraftRaid(raid), raid.getLevel().getWorld(), bukkitLeader, bukkitRaiders);
+        event.callEvent();
     }
 
     public static LootGenerateEvent callLootGenerateEvent(Container inventory, LootTable lootTable, LootContext lootInfo, List<ItemStack> loot, boolean plugin) {


### PR DESCRIPTION
When a raider ride a ravager during a raid. The exposed raider list in the event will contains the vehicle twice instead of the rider.