### PR TITLE
Fix Water Animal spawn height option for Squids and Dolphins

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/AgeableWaterCreature.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/AgeableWaterCreature.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/entity/animal/AgeableWaterCreature.java
++++ b/net/minecraft/world/entity/animal/AgeableWaterCreature.java
+@@ -68,6 +_,10 @@
+     ) {
+         int seaLevel = level.getSeaLevel();
+         int i = seaLevel - 13;
++        // Paper start - Make water animal spawn height configurable
++        seaLevel = level.getMinecraftWorld().paperConfig().entities.spawning.wateranimalSpawnHeight.maximum.or(seaLevel);
++        i = level.getMinecraftWorld().paperConfig().entities.spawning.wateranimalSpawnHeight.minimum.or(i);
++        // Paper end - Make water animal spawn height configurable
+         return pos.getY() >= i
+             && pos.getY() <= seaLevel
+             && level.getFluidState(pos.below()).is(FluidTags.WATER)


### PR DESCRIPTION
In 1.21.2 when squids and dolphins got baby variants they were moved from WaterAnimal to AgeableWaterCreature, but the Paper water animal spawn configuration code wasn't updated there.

We found this out when squids didn't spawn in our custom map with a custom sea level, even though it was configured.