### PR TITLE
Fix activation range config and water animal status

### DIFF
--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -15,7 +15,7 @@ Adds villagers as separate config
 
 diff --git a/io/papermc/paper/entity/activation/ActivationRange.java b/io/papermc/paper/entity/activation/ActivationRange.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..bd888ef719b9bfc93bace0b1d0fb771ac659f515
+index 0000000000000000000000000000000000000000..ade6110cc6adb1263c0359ff7e96e96b959e61f3
 --- /dev/null
 +++ b/io/papermc/paper/entity/activation/ActivationRange.java
 @@ -0,0 +1,318 @@
@@ -105,10 +105,10 @@ index 0000000000000000000000000000000000000000..bd888ef719b9bfc93bace0b1d0fb771a
 +     * @return boolean If it should always tick.
 +     */
 +    public static boolean initializeEntityActivationState(final Entity entity, final SpigotWorldConfig config) {
-+        return (entity.activationType == ActivationType.MISC && config.miscActivationRange == 0)
-+            || (entity.activationType == ActivationType.RAIDER && config.raiderActivationRange == 0)
-+            || (entity.activationType == ActivationType.ANIMAL && config.animalActivationRange == 0)
-+            || (entity.activationType == ActivationType.MONSTER && config.monsterActivationRange == 0)
++        return (entity.activationType == ActivationType.MISC && config.miscActivationRange <= 0)
++            || (entity.activationType == ActivationType.RAIDER && config.raiderActivationRange <= 0)
++            || (entity.activationType == ActivationType.ANIMAL && config.animalActivationRange <= 0)
++            || (entity.activationType == ActivationType.MONSTER && config.monsterActivationRange <= 0)
 +            || (entity.activationType == ActivationType.VILLAGER && config.villagerActivationRange <= 0)
 +            || (entity.activationType == ActivationType.WATER && config.waterActivationRange <= 0)
 +            || (entity.activationType == ActivationType.FLYING_MONSTER && config.flyingMonsterActivationRange <= 0)

--- a/paper-server/src/main/java/io/papermc/paper/entity/activation/ActivationType.java
+++ b/paper-server/src/main/java/io/papermc/paper/entity/activation/ActivationType.java
@@ -4,6 +4,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.FlyingMob;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ambient.AmbientCreature;
+import net.minecraft.world.entity.animal.AgeableWaterCreature;
 import net.minecraft.world.entity.animal.WaterAnimal;
 import net.minecraft.world.entity.monster.Enemy;
 import net.minecraft.world.entity.npc.Villager;
@@ -28,7 +29,7 @@ public enum ActivationType {
      * @return activation type
      */
     public static ActivationType activationTypeFor(final Entity entity) {
-        if (entity instanceof WaterAnimal) {
+        if (entity instanceof WaterAnimal || entity instanceof AgeableWaterCreature) {
             return ActivationType.WATER;
         } else if (entity instanceof Villager) {
             return ActivationType.VILLAGER;


### PR DESCRIPTION
This fixes two issues:
- Activation range config not handling negative range properly after the hardfork reported in https://github.com/PaperMC/Folia/issues/325#issuecomment-2619470436 which happens after https://github.com/PaperMC/Paper/pull/11747/commits/47c06357f71ff81759d3748ef0c26a6921e25d63
- Move squid and dolphin back to water type