### PR TITLE
Add support for lz4 region compression

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/chunk/storage/RegionFileVersion.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/chunk/storage/RegionFileVersion.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/chunk/storage/RegionFileVersion.java
 +++ b/net/minecraft/world/level/chunk/storage/RegionFileVersion.java
-@@ -61,6 +_,15 @@
+@@ -61,6 +_,16 @@
      private final RegionFileVersion.StreamWrapper<InputStream> inputWrapper;
      private final RegionFileVersion.StreamWrapper<OutputStream> outputWrapper;
  
@@ -9,6 +9,7 @@
 +        return switch (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.compressionFormat) {
 +            case GZIP -> VERSION_GZIP;
 +            case ZLIB -> VERSION_DEFLATE;
++            case LZ4 -> VERSION_LZ4;
 +            case NONE -> VERSION_NONE;
 +        };
 +    }

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -186,6 +186,7 @@ public class GlobalConfiguration extends ConfigurationPart {
         public enum CompressionFormat {
             GZIP,
             ZLIB,
+            LZ4,
             NONE
         }
     }


### PR DESCRIPTION
Mojang added this early 2024, however, it wasn't ever added to the actual config option
inside of paper
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-12053.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/2521660704.zip)