### PR TITLE
Fix composter block setting bukkit owner twice

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/ComposterBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/ComposterBlock.java.patch
@@ -106,7 +106,7 @@
          }
  
          @Override
-@@ -381,9 +_,11 @@
+@@ -381,6 +_,7 @@
  
          public InputContainer(BlockState state, LevelAccessor level, BlockPos pos) {
              super(1);
@@ -114,10 +114,6 @@
              this.state = state;
              this.level = level;
              this.pos = pos;
-+            this.bukkitOwner = new org.bukkit.craftbukkit.inventory.CraftBlockInventoryHolder(level, pos, this); // CraftBukkit
-         }
- 
-         @Override
 @@ -412,6 +_,11 @@
              if (!item.isEmpty()) {
                  this.changed = true;
@@ -130,6 +126,14 @@
                  this.level.levelEvent(1500, this.pos, blockState != this.state ? 1 : 0);
                  this.removeItemNoUpdate(0);
              }
+@@ -426,6 +_,7 @@
+ 
+         public OutputContainer(BlockState state, LevelAccessor level, BlockPos pos, ItemStack stack) {
+             super(stack);
++            this.bukkitOwner = new org.bukkit.craftbukkit.inventory.CraftBlockInventoryHolder(level, pos, this); // Paper
+             this.state = state;
+             this.level = level;
+             this.pos = pos;
 @@ -453,8 +_,15 @@
  
          @Override


### PR DESCRIPTION
The line setting the bukkit owner seems to somehow have been duplicated.