### PR TITLE
Increase outdated build delay to two weeks

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/Main.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/Main.java
@@ -263,11 +263,11 @@ public class Main {
                     Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
 
                     Calendar deadline = Calendar.getInstance();
-                    deadline.add(Calendar.DAY_OF_YEAR, -2);
+                    deadline.add(Calendar.DAY_OF_YEAR, -14);
                     if (buildDate.before(deadline.getTime())) {
                         // Paper start - This is some stupid bullshit
                         System.err.println("*** Warning, you've not updated in a while! ***");
-                        System.err.println("*** Please download a new build as per instructions from https://papermc.io/downloads/paper ***"); // Paper
+                        System.err.println("*** Please download a new build from https://papermc.io/downloads/paper ***"); // Paper
                         //System.err.println("*** Server will start in 20 seconds ***");
                         //Thread.sleep(TimeUnit.SECONDS.toMillis(20));
                         // Paper end


### PR DESCRIPTION
Our old upstream loved to always randomly shift this value to arbitrary amounts of days, but since going stable this hasn't been touched yet. Two weeks seems like a good middle ground to keep it at (though I wonder if this message is even still needed).

The "as per instructions" part also seems like a holdout from spigot, since our downloads page has no instructions.