### PR TITLE
Add Vault block API

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -632,6 +632,7 @@ public net.minecraft.world.level.block.entity.vault.VaultBlockEntity serverData
 public net.minecraft.world.level.block.entity.vault.VaultServerData getRewardedPlayers()Ljava/util/Set;
 public net.minecraft.world.level.block.entity.vault.VaultServerData pauseStateUpdatingUntil(J)V
 public net.minecraft.world.level.block.entity.vault.VaultServerData stateUpdatingResumesAt()J
+public net.minecraft.world.level.block.entity.vault.VaultSharedData getConnectedPlayers()Ljava/util/Set;
 public net.minecraft.world.level.block.state.BlockBehaviour getMenuProvider(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/MenuProvider;
 public net.minecraft.world.level.block.state.BlockBehaviour hasCollision
 public net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase destroySpeed

--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -628,6 +628,10 @@ public net.minecraft.world.level.block.entity.trialspawner.TrialSpawner stateAcc
 public net.minecraft.world.level.block.entity.trialspawner.TrialSpawnerData currentMobs
 public net.minecraft.world.level.block.entity.trialspawner.TrialSpawnerData detectedPlayers
 public net.minecraft.world.level.block.entity.trialspawner.TrialSpawnerData nextSpawnData
+public net.minecraft.world.level.block.entity.vault.VaultBlockEntity serverData
+public net.minecraft.world.level.block.entity.vault.VaultServerData getRewardedPlayers()Ljava/util/Set;
+public net.minecraft.world.level.block.entity.vault.VaultServerData pauseStateUpdatingUntil(J)V
+public net.minecraft.world.level.block.entity.vault.VaultServerData stateUpdatingResumesAt()J
 public net.minecraft.world.level.block.state.BlockBehaviour getMenuProvider(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/MenuProvider;
 public net.minecraft.world.level.block.state.BlockBehaviour hasCollision
 public net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase destroySpeed

--- a/paper-api/src/main/java/org/bukkit/block/Vault.java
+++ b/paper-api/src/main/java/org/bukkit/block/Vault.java
@@ -6,6 +6,7 @@ import org.bukkit.loot.LootTable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import java.util.Collection;
 import java.util.Set;
 import java.util.UUID;
 
@@ -136,4 +137,30 @@ public interface Vault extends TileState {
      * @apiNote Only the most recent 128 player UUIDs will be stored by vault blocks.
      */
     boolean removeRewardedPlayer(UUID playerUUID);
+
+    /**
+     * Gets an unmodifiable collection of "connected players"; players who are inside this vault's activation range and who have not received rewards yet.
+     *
+     * @apiNote Vaults will only periodically scan for nearby players, so this collection may take until the next {@link #getNextStateUpdateTime() update time} to update
+     * upon a player entering its range.
+     *
+     * @return An unmodifiable list of connected player uuids.
+     */
+    @Unmodifiable
+    Collection<UUID> getConnectedPlayers();
+
+    /**
+     * Gets the item currently being displayed inside this vault. Displayed items will automatically cycle between random items from the {@link #getDisplayedLootTable()}
+     * or {@link #getLootTable()} loot tables while this vault is active.
+     *
+     * @return The item currently being displayed inside this vault.
+     */
+    ItemStack getDisplayedItem();
+
+    /**
+     * Sets the item to display inside this vault until the next cycle.
+     *
+     * @param displayedItem The item to display
+     */
+    void setDisplayedItem(ItemStack displayedItem);
 }

--- a/paper-api/src/main/java/org/bukkit/block/Vault.java
+++ b/paper-api/src/main/java/org/bukkit/block/Vault.java
@@ -80,14 +80,14 @@ public interface Vault extends TileState {
      * @return The {@link LootTable} that will be used to display items.
      */
     @Nullable
-    LootTable getDisplayLootTable();
+    LootTable getDisplayedLootTable();
 
     /**
      * Sets the loot table that this vault will display items from.
      *
-     * @param lootTable The new display loot table, or {@code null} to clear this display override.
+     * @param lootTable The new loot table to display, or {@code null} to clear this display override.
      */
-    void setDisplayLootTable(@Nullable LootTable lootTable);
+    void setDisplayedLootTable(@Nullable LootTable lootTable);
 
     /**
      * Gets the next time (in {@link World#getGameTime() game time}) that this vault block will be updated/ticked at.

--- a/paper-api/src/main/java/org/bukkit/block/Vault.java
+++ b/paper-api/src/main/java/org/bukkit/block/Vault.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import java.util.Collection;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -146,15 +147,15 @@ public interface Vault extends TileState {
     boolean hasRewardedPlayer(UUID playerUUID);
 
     /**
-     * Gets an unmodifiable collection of "connected players"; players who are inside this vault's activation range and who have not received rewards yet.
+     * Gets an unmodifiable set of "connected players"; players who are inside this vault's activation range and who have not received rewards yet.
      *
      * @apiNote Vaults will only periodically scan for nearby players, so it may take until the next {@link #getNextStateUpdateTime() update time} for this
      * collection to be updated upon a player entering its range.
      *
-     * @return An unmodifiable collection of connected player uuids.
+     * @return An unmodifiable set of connected player uuids.
      */
     @Unmodifiable
-    Collection<UUID> getConnectedPlayers();
+    Set<UUID> getConnectedPlayers();
 
     /**
      * Returns whether a given player is currently connected to this vault.

--- a/paper-api/src/main/java/org/bukkit/block/Vault.java
+++ b/paper-api/src/main/java/org/bukkit/block/Vault.java
@@ -1,7 +1,139 @@
 package org.bukkit.block;
 
+import org.bukkit.World;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.loot.LootTable;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import java.util.Set;
+import java.util.UUID;
+
 /**
- * Represents a captured state of a trial spawner.
+ * Represents a captured state of a vault.
  */
+@NullMarked
 public interface Vault extends TileState {
+    /**
+     * Gets the range in blocks at which this vault will become active when a player is near.
+     *
+     * @return This vault's activation range.
+     */
+    double getActivationRange();
+
+    /**
+     * Sets the range in blocks at which the vault will become active when a player is near.
+     *
+     * @param activationRange The new activation range.
+     * @throws IllegalArgumentException if the new range is not a number, or if the new range is more than {@link #getDeactivationRange()}.
+     */
+    void setActivationRange(double activationRange);
+
+    /**
+     * Gets the range in blocks at which this vault will become inactive when a player is not near.
+     *
+     * @return This vault's deactivation range.
+     */
+    double getDeactivationRange();
+
+    /**
+     * Sets the range in blocks at which this vault will become inactive when a player is not near.
+     *
+     * @param deactivationRange The new deactivation range
+     * @throws IllegalArgumentException if the new range is not a number, or if the new range is less than {@link #getActivationRange()}.
+     */
+    void setDeactivationRange(double deactivationRange);
+
+    /**
+     * Gets the {@link ItemStack} that players must use to unlock this vault.
+     *
+     * @return The item that players must use to unlock this vault.
+     */
+    ItemStack getKeyItem();
+
+    /**
+     * Sets the {@link ItemStack} that players must use to unlock this vault.
+     *
+     * @param key The key item.
+     */
+    void setKeyItem(ItemStack key);
+
+    /**
+     * Gets the {@link LootTable} that this vault will select rewards from.
+     *
+     * @return The loot table.
+     */
+    LootTable getLootTable();
+
+    /**
+     * Sets the {@link LootTable} that this vault will select rewards from.
+     *
+     * @param lootTable The new loot table.
+     */
+    void setLootTable(LootTable lootTable);
+
+    /**
+     * Gets the loot table that this vault will display items from.
+     * <p>
+     * Falls back to the regular {@link #getLootTable() loot table} if unset.
+     *
+     * @return The {@link LootTable} that will be used to display items.
+     */
+    @Nullable
+    LootTable getDisplayLootTable();
+
+    /**
+     * Sets the loot table that this vault will display items from.
+     *
+     * @param lootTable The new display loot table, or {@code null} to clear this display override.
+     */
+    void setDisplayLootTable(@Nullable LootTable lootTable);
+
+    /**
+     * Gets the next time (in {@link World#getGameTime() game time}) that this vault block will be updated/ticked at.
+     *
+     * @return The next time that this vault block will be updated/ticked at.
+     * @see World#getGameTime()
+     */
+    long getNextStateUpdateTime();
+
+    /**
+     * Sets the next time that this vault block will be updated/ticked at, if this value is less than or equals to the current
+     * {@link World#getGameTime()}, then it will be updated in the first possible tick.
+     *
+     * @param nextStateUpdateTime The next time that this vault block will be updated/ticked at.
+     * @see World#getGameTime()
+     */
+    void setNextStateUpdateTime(long nextStateUpdateTime);
+
+    /**
+     * Gets the players who have used a key on this vault and unlocked it.
+     *
+     * @return An unmodifiable set of player uuids.
+     *
+     * @apiNote Only the most recent 128 player UUIDs will be stored by vault blocks.
+     */
+    @Unmodifiable
+    Set<UUID> getRewardedPlayers();
+
+    /**
+     * Adds a player as rewarded for this vault.
+     *
+     * @param playerUUID The player's uuid.
+     * @return {@code true} if this player was previously not rewarded, and has been added as a result of this operation.
+     *
+     * @apiNote Only the most recent 128 player UUIDs will be stored by vault blocks. Attempting to add more will result in
+     *      the first player UUID being removed.
+     */
+    boolean addRewardedPlayer(UUID playerUUID);
+
+    /**
+     * Removes a player as rewarded for this vault, allowing them to use a {@link #getKeyItem() key item} again to receive rewards.
+     *
+     * @param playerUUID The player's uuid.
+     * @return {@code true} if this player was previously rewarded, and has been removed as a result of this operation.
+     *
+     * @apiNote Only the most recent 128 player UUIDs will be stored by vault blocks.
+     */
+    boolean removeRewardedPlayer(UUID playerUUID);
 }

--- a/paper-api/src/main/java/org/bukkit/block/Vault.java
+++ b/paper-api/src/main/java/org/bukkit/block/Vault.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import java.util.Collection;
-import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -110,12 +109,12 @@ public interface Vault extends TileState {
     /**
      * Gets the players who have used a key on this vault and unlocked it.
      *
-     * @return An unmodifiable set of player uuids.
+     * @return An unmodifiable collection of player uuids.
      *
      * @apiNote Only the most recent 128 player UUIDs will be stored by vault blocks.
      */
     @Unmodifiable
-    Set<UUID> getRewardedPlayers();
+    Collection<UUID> getRewardedPlayers();
 
     /**
      * Adds a player as rewarded for this vault.
@@ -139,15 +138,33 @@ public interface Vault extends TileState {
     boolean removeRewardedPlayer(UUID playerUUID);
 
     /**
-     * Gets an unmodifiable set of "connected players"; players who are inside this vault's activation range and who have not received rewards yet.
+     * Returns whether a given player has already been rewarded by this vault.
+     *
+     * @param playerUUID The player's uuid.
+     * @return Whether this player was previously rewarded by this vault.
+     */
+    boolean hasRewardedPlayer(UUID playerUUID);
+
+    /**
+     * Gets an unmodifiable collection of "connected players"; players who are inside this vault's activation range and who have not received rewards yet.
      *
      * @apiNote Vaults will only periodically scan for nearby players, so it may take until the next {@link #getNextStateUpdateTime() update time} for this
-     * set to be updated upon a player entering its range.
+     * collection to be updated upon a player entering its range.
      *
-     * @return An unmodifiable set of connected player uuids.
+     * @return An unmodifiable collection of connected player uuids.
      */
     @Unmodifiable
-    Set<UUID> getConnectedPlayers();
+    Collection<UUID> getConnectedPlayers();
+
+    /**
+     * Returns whether a given player is currently connected to this vault.
+     *
+     * @param playerUUID the player's uuid
+     * @return {@code true} if this player is currently connected to this vault.
+     *
+     * @see #getConnectedPlayers()
+     */
+    boolean hasConnectedPlayer(UUID playerUUID);
 
     /**
      * Gets the item currently being displayed inside this vault. Displayed items will automatically cycle between random items from the {@link #getDisplayedLootTable()}

--- a/paper-api/src/main/java/org/bukkit/block/Vault.java
+++ b/paper-api/src/main/java/org/bukkit/block/Vault.java
@@ -139,10 +139,10 @@ public interface Vault extends TileState {
     boolean removeRewardedPlayer(UUID playerUUID);
 
     /**
-     * Gets an unmodifiable collection of "connected players"; players who are inside this vault's activation range and who have not received rewards yet.
+     * Gets an unmodifiable set of "connected players"; players who are inside this vault's activation range and who have not received rewards yet.
      *
-     * @apiNote Vaults will only periodically scan for nearby players, so this collection may take until the next {@link #getNextStateUpdateTime() update time} to update
-     * upon a player entering its range.
+     * @apiNote  Vaults will only periodically scan for nearby players, so it may take until the next {@link #getNextStateUpdateTime() update time} for this
+     * set to be updated upon a player entering its range.
      *
      * @return An unmodifiable set of connected player uuids.
      */

--- a/paper-api/src/main/java/org/bukkit/block/Vault.java
+++ b/paper-api/src/main/java/org/bukkit/block/Vault.java
@@ -141,7 +141,7 @@ public interface Vault extends TileState {
     /**
      * Gets an unmodifiable set of "connected players"; players who are inside this vault's activation range and who have not received rewards yet.
      *
-     * @apiNote  Vaults will only periodically scan for nearby players, so it may take until the next {@link #getNextStateUpdateTime() update time} for this
+     * @apiNote Vaults will only periodically scan for nearby players, so it may take until the next {@link #getNextStateUpdateTime() update time} for this
      * set to be updated upon a player entering its range.
      *
      * @return An unmodifiable set of connected player uuids.

--- a/paper-api/src/main/java/org/bukkit/block/Vault.java
+++ b/paper-api/src/main/java/org/bukkit/block/Vault.java
@@ -144,10 +144,10 @@ public interface Vault extends TileState {
      * @apiNote Vaults will only periodically scan for nearby players, so this collection may take until the next {@link #getNextStateUpdateTime() update time} to update
      * upon a player entering its range.
      *
-     * @return An unmodifiable list of connected player uuids.
+     * @return An unmodifiable set of connected player uuids.
      */
     @Unmodifiable
-    Collection<UUID> getConnectedPlayers();
+    Set<UUID> getConnectedPlayers();
 
     /**
      * Gets the item currently being displayed inside this vault. Displayed items will automatically cycle between random items from the {@link #getDisplayedLootTable()}

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/vault/VaultServerData.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/vault/VaultServerData.java.patch
@@ -1,0 +1,36 @@
+--- a/net/minecraft/world/level/block/entity/vault/VaultServerData.java
++++ b/net/minecraft/world/level/block/entity/vault/VaultServerData.java
+@@ -64,9 +_,22 @@
+         return this.rewardedPlayers.contains(player.getUUID());
+     }
+ 
++    // Paper start - Vault API
++    public boolean removeFromRewardedPlayers(UUID uuid) {
++        final boolean result = this.rewardedPlayers.remove(uuid);
++        if (result)
++            this.markChanged();
++
++        return result;
++    }
++
+     @VisibleForTesting
+-    public void addToRewardedPlayers(Player player) {
+-        this.rewardedPlayers.add(player.getUUID());
++    public boolean addToRewardedPlayers(Player player) {
++        return addToRewardedPlayers(player.getUUID());
++    }
++
++    public boolean addToRewardedPlayers(UUID uuid) {
++        final boolean result = this.rewardedPlayers.add(uuid);
+         if (this.rewardedPlayers.size() > 128) {
+             Iterator<UUID> iterator = this.rewardedPlayers.iterator();
+             if (iterator.hasNext()) {
+@@ -76,6 +_,8 @@
+         }
+ 
+         this.markChanged();
++        return result;
++        // Paper end - Vault API
+     }
+ 
+     public long stateUpdatingResumesAt() {

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/vault/VaultServerData.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/vault/VaultServerData.java.patch
@@ -1,23 +1,12 @@
 --- a/net/minecraft/world/level/block/entity/vault/VaultServerData.java
 +++ b/net/minecraft/world/level/block/entity/vault/VaultServerData.java
-@@ -64,9 +_,22 @@
-         return this.rewardedPlayers.contains(player.getUUID());
-     }
+@@ -66,7 +_,12 @@
  
-+    // Paper start - Vault API
-+    public boolean removeFromRewardedPlayers(UUID uuid) {
-+        final boolean result = this.rewardedPlayers.remove(uuid);
-+        if (result)
-+            this.markChanged();
-+
-+        return result;
-+    }
-+
      @VisibleForTesting
--    public void addToRewardedPlayers(Player player) {
+     public void addToRewardedPlayers(Player player) {
 -        this.rewardedPlayers.add(player.getUUID());
-+    public boolean addToRewardedPlayers(Player player) {
-+        return addToRewardedPlayers(player.getUUID());
++    // Paper start - Vault API
++        addToRewardedPlayers(player.getUUID());
 +    }
 +
 +    public boolean addToRewardedPlayers(UUID uuid) {
@@ -25,12 +14,22 @@
          if (this.rewardedPlayers.size() > 128) {
              Iterator<UUID> iterator = this.rewardedPlayers.iterator();
              if (iterator.hasNext()) {
-@@ -76,6 +_,8 @@
+@@ -76,7 +_,17 @@
          }
  
          this.markChanged();
+-    }
 +        return result;
-+        // Paper end - Vault API
-     }
++    }
++
++    public boolean removeFromRewardedPlayers(UUID uuid) {
++        final boolean result = this.rewardedPlayers.remove(uuid);
++        if (result)
++            this.markChanged();
++
++        return result;
++    }
++    // Paper end - Vault API
  
      public long stateUpdatingResumesAt() {
+         return this.stateUpdatingResumesAt;

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/vault/VaultServerData.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/vault/VaultServerData.java.patch
@@ -8,28 +8,33 @@
 +    // Paper start - Vault API
 +        addToRewardedPlayers(player.getUUID());
 +    }
-+
-+    public boolean addToRewardedPlayers(UUID uuid) {
-+        final boolean result = this.rewardedPlayers.add(uuid);
++    public boolean addToRewardedPlayers(final java.util.UUID player) {
++        final boolean removed = this.rewardedPlayers.add(player);
++    // Paper end - Vault API
          if (this.rewardedPlayers.size() > 128) {
              Iterator<UUID> iterator = this.rewardedPlayers.iterator();
              if (iterator.hasNext()) {
-@@ -76,7 +_,17 @@
+@@ -76,6 +_,7 @@
          }
  
          this.markChanged();
--    }
-+        return result;
-+    }
-+
-+    public boolean removeFromRewardedPlayers(UUID uuid) {
-+        final boolean result = this.rewardedPlayers.remove(uuid);
-+        if (result)
-+            this.markChanged();
-+
-+        return result;
-+    }
-+    // Paper end - Vault API
++        return removed; // Paper - Vault API
+     }
  
      public long stateUpdatingResumesAt() {
-         return this.stateUpdatingResumesAt;
+@@ -131,4 +_,15 @@
+     public float ejectionProgress() {
+         return this.totalEjectionsNeeded == 1 ? 1.0F : 1.0F - Mth.inverseLerp((float)this.getItemsToEject().size(), 1.0F, (float)this.totalEjectionsNeeded);
+     }
++
++    // Paper start - Vault API
++    public boolean removeFromRewardedPlayers(final UUID uuid) {
++        if (this.rewardedPlayers.remove(uuid)) {
++            this.markChanged();
++            return true;
++        }
++
++        return false;
++    }
++    // Paper end - Vault API
+ }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
@@ -1,17 +1,32 @@
 package org.bukkit.craftbukkit.block;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.block.entity.vault.VaultBlockEntity;
+import net.minecraft.world.level.block.entity.vault.VaultConfig;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Vault;
+import org.bukkit.craftbukkit.CraftLootTable;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.loot.LootTable;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
+@NullMarked
 public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implements Vault {
 
     public CraftVault(World world, VaultBlockEntity tileEntity) {
         super(world, tileEntity);
     }
 
-    protected CraftVault(CraftVault state, Location location) {
+    protected CraftVault(CraftVault state, @Nullable Location location) {
         super(state, location);
     }
 
@@ -23,5 +38,97 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
     @Override
     public CraftVault copy(Location location) {
         return new CraftVault(this, location);
+    }
+
+    @Override
+    public double getActivationRange() {
+        return this.getSnapshot().getConfig().activationRange();
+    }
+
+    @Override
+    public void setActivationRange(final double activationRange) {
+        Preconditions.checkArgument(Double.isFinite(activationRange), "deactivation range must be a number");
+        Preconditions.checkArgument(activationRange <= getDeactivationRange(), "New activation range (%f) must be less or equal to deactivation range (%f)".formatted(activationRange, getDeactivationRange()));
+
+        final VaultConfig config = this.getSnapshot().getConfig();
+        this.getSnapshot().setConfig(new VaultConfig(config.lootTable(), activationRange, config.deactivationRange(), config.keyItem(), config.overrideLootTableToDisplay()));
+    }
+
+    @Override
+    public double getDeactivationRange() {
+        return this.getSnapshot().getConfig().deactivationRange();
+    }
+
+    @Override
+    public void setDeactivationRange(final double deactivationRange) {
+        Preconditions.checkArgument(Double.isFinite(deactivationRange), "deactivation range must be a number");
+        Preconditions.checkArgument(deactivationRange >= getActivationRange(), "New deactivation range (%f) must be more or equal to activation range (%f)".formatted(deactivationRange, getActivationRange()));
+
+        final VaultConfig config = this.getSnapshot().getConfig();
+        this.getSnapshot().setConfig(new VaultConfig(config.lootTable(), config.activationRange(), deactivationRange, config.keyItem(), config.overrideLootTableToDisplay()));
+    }
+
+    @Override
+    public ItemStack getKeyItem() {
+        return this.getSnapshot().getConfig().keyItem().asBukkitCopy();
+    }
+
+    @Override
+    public void setKeyItem(final ItemStack key) {
+        Preconditions.checkNotNull(key, "key must not be null");
+
+        final VaultConfig config = this.getSnapshot().getConfig();
+        this.getSnapshot().setConfig(new VaultConfig(config.lootTable(), config.activationRange(), config.deactivationRange(), CraftItemStack.asNMSCopy(key), config.overrideLootTableToDisplay()));
+    }
+
+    @Override
+    public LootTable getLootTable() {
+        return CraftLootTable.minecraftToBukkit(this.getSnapshot().getConfig().lootTable());
+    }
+
+    @Override
+    public void setLootTable(final LootTable lootTable) {
+        final ResourceKey<net.minecraft.world.level.storage.loot.LootTable> lootTableKey = CraftLootTable.bukkitToMinecraft(lootTable);
+        Preconditions.checkNotNull(lootTableKey, "lootTable must not be null");
+
+        final VaultConfig config = this.getSnapshot().getConfig();
+        this.getSnapshot().setConfig(new VaultConfig(lootTableKey, config.activationRange(), config.deactivationRange(), config.keyItem(), config.overrideLootTableToDisplay()));
+    }
+
+    @Override
+    public @Nullable LootTable getDisplayLootTable() {
+        return this.getSnapshot().getConfig().overrideLootTableToDisplay().map(CraftLootTable::minecraftToBukkit).orElse(null);
+    }
+
+    @Override
+    public void setDisplayLootTable(final @Nullable LootTable lootTable) {
+        final VaultConfig config = this.getSnapshot().getConfig();
+
+        this.getSnapshot().setConfig(new VaultConfig(config.lootTable(), config.activationRange(), config.deactivationRange(), config.keyItem(), Optional.ofNullable(CraftLootTable.bukkitToMinecraft(lootTable))));
+    }
+
+    @Override
+    public long getNextStateUpdateTime() {
+        return this.getSnapshot().serverData.stateUpdatingResumesAt();
+    }
+
+    @Override
+    public void setNextStateUpdateTime(final long nextStateUpdateTime) {
+        this.getSnapshot().serverData.pauseStateUpdatingUntil(nextStateUpdateTime);
+    }
+
+    @Override
+    public @Unmodifiable Set<UUID> getRewardedPlayers() {
+        return ImmutableSet.copyOf(this.getSnapshot().serverData.getRewardedPlayers());
+    }
+
+    @Override
+    public boolean addRewardedPlayer(final UUID playerUUID) {
+        return this.getSnapshot().serverData.addToRewardedPlayers(playerUUID);
+    }
+
+    @Override
+    public boolean removeRewardedPlayer(final UUID playerUUID) {
+        return this.getSnapshot().serverData.removeFromRewardedPlayers(playerUUID);
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
@@ -15,6 +15,7 @@ import org.bukkit.loot.LootTable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -118,7 +119,7 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
     }
 
     @Override
-    public @Unmodifiable Set<UUID> getRewardedPlayers() {
+    public @Unmodifiable Collection<UUID> getRewardedPlayers() {
         return ImmutableSet.copyOf(this.getSnapshot().serverData.getRewardedPlayers());
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
@@ -89,7 +89,7 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
     @Override
     public void setLootTable(final LootTable lootTable) {
         final ResourceKey<net.minecraft.world.level.storage.loot.LootTable> lootTableKey = CraftLootTable.bukkitToMinecraft(lootTable);
-        Preconditions.checkNotNull(lootTableKey, "lootTable must not be null");
+        Preconditions.checkArgument(lootTableKey != null, "lootTable must not be null");
 
         final VaultConfig config = this.getSnapshot().getConfig();
         this.getSnapshot().setConfig(new VaultConfig(lootTableKey, config.activationRange(), config.deactivationRange(), config.keyItem(), config.overrideLootTableToDisplay()));

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
@@ -96,12 +96,12 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
     }
 
     @Override
-    public @Nullable LootTable getDisplayLootTable() {
+    public @Nullable LootTable getDisplayedLootTable() {
         return this.getSnapshot().getConfig().overrideLootTableToDisplay().map(CraftLootTable::minecraftToBukkit).orElse(null);
     }
 
     @Override
-    public void setDisplayLootTable(final @Nullable LootTable lootTable) {
+    public void setDisplayedLootTable(final @Nullable LootTable lootTable) {
         final VaultConfig config = this.getSnapshot().getConfig();
 
         this.getSnapshot().setConfig(new VaultConfig(config.lootTable(), config.activationRange(), config.deactivationRange(), config.keyItem(), Optional.ofNullable(CraftLootTable.bukkitToMinecraft(lootTable))));

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
@@ -47,7 +47,7 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
 
     @Override
     public void setActivationRange(final double activationRange) {
-        Preconditions.checkArgument(Double.isFinite(activationRange), "deactivation range must not be NaN or infinite");
+        Preconditions.checkArgument(Double.isFinite(activationRange), "ctivation range must not be NaN or infinite");
         Preconditions.checkArgument(activationRange <= this.getDeactivationRange(), "New activation range (%s) must be less or equal to deactivation range (%s)", activationRange, this.getDeactivationRange());
 
         final VaultConfig config = this.getSnapshot().getConfig();

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
@@ -15,7 +15,6 @@ import org.bukkit.loot.LootTable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -136,7 +135,7 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
     }
 
     @Override
-    public @Unmodifiable Collection<UUID> getConnectedPlayers() {
+    public @Unmodifiable Set<UUID> getConnectedPlayers() {
         return ImmutableSet.copyOf(this.getSnapshot().getSharedData().getConnectedPlayers());
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
@@ -47,7 +47,7 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
 
     @Override
     public void setActivationRange(final double activationRange) {
-        Preconditions.checkArgument(Double.isFinite(activationRange), "deactivation range must be a number");
+        Preconditions.checkArgument(Double.isFinite(activationRange), "deactivation range must not be NaN or infinite");
         Preconditions.checkArgument(activationRange <= getDeactivationRange(), "New activation range (%f) must be less or equal to deactivation range (%f)".formatted(activationRange, getDeactivationRange()));
 
         final VaultConfig config = this.getSnapshot().getConfig();
@@ -61,7 +61,7 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
 
     @Override
     public void setDeactivationRange(final double deactivationRange) {
-        Preconditions.checkArgument(Double.isFinite(deactivationRange), "deactivation range must be a number");
+        Preconditions.checkArgument(Double.isFinite(deactivationRange), "deactivation range must not be NaN or infinite");
         Preconditions.checkArgument(deactivationRange >= getActivationRange(), "New deactivation range (%f) must be more or equal to activation range (%f)".formatted(deactivationRange, getActivationRange()));
 
         final VaultConfig config = this.getSnapshot().getConfig();
@@ -75,7 +75,7 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
 
     @Override
     public void setKeyItem(final ItemStack key) {
-        Preconditions.checkNotNull(key, "key must not be null");
+        Preconditions.checkArgument(key != null, "key must not be null");
 
         final VaultConfig config = this.getSnapshot().getConfig();
         this.getSnapshot().setConfig(new VaultConfig(config.lootTable(), config.activationRange(), config.deactivationRange(), CraftItemStack.asNMSCopy(key), config.overrideLootTableToDisplay()));
@@ -124,11 +124,13 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
 
     @Override
     public boolean addRewardedPlayer(final UUID playerUUID) {
+        Preconditions.checkArgument(playerUUID != null, "playerUUID must not be null");
         return this.getSnapshot().serverData.addToRewardedPlayers(playerUUID);
     }
 
     @Override
     public boolean removeRewardedPlayer(final UUID playerUUID) {
+        Preconditions.checkArgument(playerUUID != null, "playerUUID must not be null");
         return this.getSnapshot().serverData.removeFromRewardedPlayers(playerUUID);
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
@@ -48,7 +48,7 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
     @Override
     public void setActivationRange(final double activationRange) {
         Preconditions.checkArgument(Double.isFinite(activationRange), "deactivation range must not be NaN or infinite");
-        Preconditions.checkArgument(activationRange <= getDeactivationRange(), "New activation range (%f) must be less or equal to deactivation range (%f)".formatted(activationRange, getDeactivationRange()));
+        Preconditions.checkArgument(activationRange <= this.getDeactivationRange(), "New activation range (%s) must be less or equal to deactivation range (%s)", activationRange, this.getDeactivationRange());
 
         final VaultConfig config = this.getSnapshot().getConfig();
         this.getSnapshot().setConfig(new VaultConfig(config.lootTable(), activationRange, config.deactivationRange(), config.keyItem(), config.overrideLootTableToDisplay()));
@@ -62,7 +62,7 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
     @Override
     public void setDeactivationRange(final double deactivationRange) {
         Preconditions.checkArgument(Double.isFinite(deactivationRange), "deactivation range must not be NaN or infinite");
-        Preconditions.checkArgument(deactivationRange >= getActivationRange(), "New deactivation range (%f) must be more or equal to activation range (%f)".formatted(deactivationRange, getActivationRange()));
+        Preconditions.checkArgument(deactivationRange >= this.getActivationRange(), "New deactivation range (%s) must be more or equal to activation range (%s)", deactivationRange, this.getActivationRange());
 
         final VaultConfig config = this.getSnapshot().getConfig();
         this.getSnapshot().setConfig(new VaultConfig(config.lootTable(), config.activationRange(), deactivationRange, config.keyItem(), config.overrideLootTableToDisplay()));

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
@@ -135,8 +135,18 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
     }
 
     @Override
+    public boolean hasRewardedPlayer(final UUID playerUUID) {
+        return this.getSnapshot().serverData.getRewardedPlayers().contains(playerUUID);
+    }
+
+    @Override
     public @Unmodifiable Set<UUID> getConnectedPlayers() {
         return ImmutableSet.copyOf(this.getSnapshot().getSharedData().getConnectedPlayers());
+    }
+
+    @Override
+    public boolean hasConnectedPlayer(final UUID playerUUID) {
+        return this.getSnapshot().getSharedData().getConnectedPlayers().contains(playerUUID);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
@@ -15,6 +15,7 @@ import org.bukkit.loot.LootTable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -132,5 +133,21 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
     public boolean removeRewardedPlayer(final UUID playerUUID) {
         Preconditions.checkArgument(playerUUID != null, "playerUUID must not be null");
         return this.getSnapshot().serverData.removeFromRewardedPlayers(playerUUID);
+    }
+
+    @Override
+    public @Unmodifiable Collection<UUID> getConnectedPlayers() {
+        return ImmutableSet.copyOf(this.getSnapshot().getSharedData().getConnectedPlayers());
+    }
+
+    @Override
+    public ItemStack getDisplayedItem() {
+        return CraftItemStack.asBukkitCopy(this.getSnapshot().getSharedData().getDisplayItem());
+    }
+
+    @Override
+    public void setDisplayedItem(final ItemStack displayedItem) {
+        Preconditions.checkArgument(displayedItem != null, "displayedItem must not be null");
+        this.getSnapshot().getSharedData().setDisplayItem(CraftItemStack.asNMSCopy(displayedItem));
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftVault.java
@@ -47,7 +47,7 @@ public class CraftVault extends CraftBlockEntityState<VaultBlockEntity> implemen
 
     @Override
     public void setActivationRange(final double activationRange) {
-        Preconditions.checkArgument(Double.isFinite(activationRange), "ctivation range must not be NaN or infinite");
+        Preconditions.checkArgument(Double.isFinite(activationRange), "activation range must not be NaN or infinite");
         Preconditions.checkArgument(activationRange <= this.getDeactivationRange(), "New activation range (%s) must be less or equal to deactivation range (%s)", activationRange, this.getDeactivationRange());
 
         final VaultConfig config = this.getSnapshot().getConfig();


### PR DESCRIPTION
Supersedes #11159

Adds new API for vault blocks

Changes made compared to the previous PR:
- Added some javadocs.
- Removed itemsToEject methods, these items are only populated when a player is opening a vault, but these can already be changed with the block dispense loot event, and also can't think of any use case for changing items in the middle of ejecting.
- Removed rewarded players methods with player instances.
- Added API for state update time.
- Made the VaultBlockEntity#serverData field public to be able to directly update the server data, without having to access the actual tile entity.