### PR TITLE
Separate tick count to ensure vanilla parity

### DIFF
--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -366,7 +366,7 @@ index d95413af04121fe91ca0f3b0c70025b9808acef9..ad665c7535c615d2b03a3e7864be435f
  import org.slf4j.Logger;
  
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index c383aa70e4a3c2bd48fe55eeb65744782ecf4079..a61ceff02688f3494d3a510f7c1a83ab9586e24d 100644
+index 8204528c26456929fdec0d8ba7a5a52128409097..01bc2d1639be9f04afc63e5841c5c99730ea37d8 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -551,6 +551,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -378,7 +378,7 @@ index c383aa70e4a3c2bd48fe55eeb65744782ecf4079..a61ceff02688f3494d3a510f7c1a83ab
                  .forEach(
                      entity -> {
 @@ -980,12 +981,15 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
-         entity.totalTickCount++; // Paper
+         entity.totalEntityAge++; // Paper - age-like counter for all entities
          profilerFiller.push(() -> BuiltInRegistries.ENTITY_TYPE.getKey(entity.getType()).toString());
          profilerFiller.incrementCounter("tickNonPassenger");
 +        final boolean isActive = io.papermc.paper.entity.activation.ActivationRange.checkIfActive(entity); // Paper - EAR 2
@@ -476,12 +476,12 @@ index 24735284fda151414d99faad401d25ba60995f9a..23b342cc31c7e72ade0e1ccad86a9ccf
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 8f73c917a5d287ecf20b6cb47f97ecf92ad41a05..75a4066818deab6e939ff4d9b20e9a89d873b9cf 100644
+index 62598fa46b19d9c28ded959efe2c5e607336ea50..3cb21c66104a63d014720880553aaf5d28b9681a 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -381,6 +381,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
-     public boolean fixedPose = false; // Paper - Expand Pose API
+@@ -380,6 +380,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      private final int despawnTime; // Paper - entity despawn time limit
+     public int totalEntityAge; // Paper - age-like counter for all entities
      public final io.papermc.paper.entity.activation.ActivationType activationType = io.papermc.paper.entity.activation.ActivationType.activationTypeFor(this); // Paper - EAR 2/tracking ranges
 +    // Paper start - EAR 2
 +    public final boolean defaultActivationState;
@@ -495,7 +495,7 @@ index 8f73c917a5d287ecf20b6cb47f97ecf92ad41a05..75a4066818deab6e939ff4d9b20e9a89
  
      public void setOrigin(@javax.annotation.Nonnull org.bukkit.Location location) {
          this.origin = location.toVector();
-@@ -414,6 +423,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -413,6 +422,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.position = Vec3.ZERO;
          this.blockPosition = BlockPos.ZERO;
          this.chunkPosition = ChunkPos.ZERO;
@@ -509,7 +509,7 @@ index 8f73c917a5d287ecf20b6cb47f97ecf92ad41a05..75a4066818deab6e939ff4d9b20e9a89
          SynchedEntityData.Builder builder = new SynchedEntityData.Builder(this);
          builder.define(DATA_SHARED_FLAGS_ID, (byte)0);
          builder.define(DATA_AIR_SUPPLY_ID, this.getMaxAirSupply());
-@@ -978,6 +994,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -977,6 +993,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          } else {
              this.wasOnFire = this.isOnFire();
              if (type == MoverType.PISTON) {
@@ -518,7 +518,7 @@ index 8f73c917a5d287ecf20b6cb47f97ecf92ad41a05..75a4066818deab6e939ff4d9b20e9a89
                  movement = this.limitPistonMovement(movement);
                  if (movement.equals(Vec3.ZERO)) {
                      return;
-@@ -991,6 +1009,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -990,6 +1008,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  this.stuckSpeedMultiplier = Vec3.ZERO;
                  this.setDeltaMovement(Vec3.ZERO);
              }

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -476,10 +476,10 @@ index 24735284fda151414d99faad401d25ba60995f9a..23b342cc31c7e72ade0e1ccad86a9ccf
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 62598fa46b19d9c28ded959efe2c5e607336ea50..3cb21c66104a63d014720880553aaf5d28b9681a 100644
+index b15420ffa1432d49aec8e91e917598bde4e94337..054ece1d539d69a4b7eec57e681179343c7e75c3 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -380,6 +380,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -381,6 +381,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      private final int despawnTime; // Paper - entity despawn time limit
      public int totalEntityAge; // Paper - age-like counter for all entities
      public final io.papermc.paper.entity.activation.ActivationType activationType = io.papermc.paper.entity.activation.ActivationType.activationTypeFor(this); // Paper - EAR 2/tracking ranges
@@ -495,7 +495,7 @@ index 62598fa46b19d9c28ded959efe2c5e607336ea50..3cb21c66104a63d014720880553aaf5d
  
      public void setOrigin(@javax.annotation.Nonnull org.bukkit.Location location) {
          this.origin = location.toVector();
-@@ -413,6 +422,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -414,6 +423,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.position = Vec3.ZERO;
          this.blockPosition = BlockPos.ZERO;
          this.chunkPosition = ChunkPos.ZERO;
@@ -509,7 +509,7 @@ index 62598fa46b19d9c28ded959efe2c5e607336ea50..3cb21c66104a63d014720880553aaf5d
          SynchedEntityData.Builder builder = new SynchedEntityData.Builder(this);
          builder.define(DATA_SHARED_FLAGS_ID, (byte)0);
          builder.define(DATA_AIR_SUPPLY_ID, this.getMaxAirSupply());
-@@ -977,6 +993,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -978,6 +994,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          } else {
              this.wasOnFire = this.isOnFire();
              if (type == MoverType.PISTON) {
@@ -518,7 +518,7 @@ index 62598fa46b19d9c28ded959efe2c5e607336ea50..3cb21c66104a63d014720880553aaf5d
                  movement = this.limitPistonMovement(movement);
                  if (movement.equals(Vec3.ZERO)) {
                      return;
-@@ -990,6 +1008,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -991,6 +1009,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  this.stuckSpeedMultiplier = Vec3.ZERO;
                  this.setDeltaMovement(Vec3.ZERO);
              }
@@ -845,7 +845,7 @@ index 32f184288f6065259c921293922c1b0163df4dc4..0f346faa82b988e86834c38837f6f11b
      public final org.spigotmc.SpigotWorldConfig spigotConfig; // Spigot
      // Paper start - add paper world config
 diff --git a/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java b/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
-index 754cfdcd5a28287aa3545aaffdce1e391cbefc1e..1e6e940fca9d96ef410c7bf05524bd9b24db4a79 100644
+index ce880bd45fbda4829d17de8507034b3a39c68cbb..ee2f8e8deb35059824b5730a1442f383dc79f01c 100644
 --- a/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 +++ b/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 @@ -149,6 +149,10 @@ public class PistonMovingBlockEntity extends BlockEntity {

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -366,7 +366,7 @@ index d95413af04121fe91ca0f3b0c70025b9808acef9..ad665c7535c615d2b03a3e7864be435f
  import org.slf4j.Logger;
  
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 79d23c3403efc6dbef2381a3fa5946023f862452..3b19229427d83290bba1431bee5357e2ced34f94 100644
+index c383aa70e4a3c2bd48fe55eeb65744782ecf4079..a61ceff02688f3494d3a510f7c1a83ab9586e24d 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -551,6 +551,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -377,8 +377,8 @@ index 79d23c3403efc6dbef2381a3fa5946023f862452..3b19229427d83290bba1431bee5357e2
              this.entityTickList
                  .forEach(
                      entity -> {
-@@ -979,12 +980,15 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
-         entity.tickCount++;
+@@ -980,12 +981,15 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+         entity.totalTickCount++; // Paper
          profilerFiller.push(() -> BuiltInRegistries.ENTITY_TYPE.getKey(entity.getType()).toString());
          profilerFiller.incrementCounter("tickNonPassenger");
 +        final boolean isActive = io.papermc.paper.entity.activation.ActivationRange.checkIfActive(entity); // Paper - EAR 2
@@ -394,7 +394,7 @@ index 79d23c3403efc6dbef2381a3fa5946023f862452..3b19229427d83290bba1431bee5357e2
          }
          // Paper start - log detailed entity tick information
          } finally {
-@@ -995,7 +999,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -996,7 +1000,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          // Paper end - log detailed entity tick information
      }
  
@@ -403,7 +403,7 @@ index 79d23c3403efc6dbef2381a3fa5946023f862452..3b19229427d83290bba1431bee5357e2
          if (passengerEntity.isRemoved() || passengerEntity.getVehicle() != ridingEntity) {
              passengerEntity.stopRiding();
          } else if (passengerEntity instanceof Player || this.entityTickList.contains(passengerEntity)) {
-@@ -1004,12 +1008,21 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1006,12 +1010,21 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
              ProfilerFiller profilerFiller = Profiler.get();
              profilerFiller.push(() -> BuiltInRegistries.ENTITY_TYPE.getKey(passengerEntity.getType()).toString());
              profilerFiller.incrementCounter("tickPassenger");
@@ -476,10 +476,10 @@ index 24735284fda151414d99faad401d25ba60995f9a..23b342cc31c7e72ade0e1ccad86a9ccf
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index bf5f2b753e3cbe3dfa8ad86df06718fbc1fbcbc4..988e5740b86c7768fee7391dc7e2900305a51be9 100644
+index 8f73c917a5d287ecf20b6cb47f97ecf92ad41a05..75a4066818deab6e939ff4d9b20e9a89d873b9cf 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -380,6 +380,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -381,6 +381,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public boolean fixedPose = false; // Paper - Expand Pose API
      private final int despawnTime; // Paper - entity despawn time limit
      public final io.papermc.paper.entity.activation.ActivationType activationType = io.papermc.paper.entity.activation.ActivationType.activationTypeFor(this); // Paper - EAR 2/tracking ranges
@@ -495,7 +495,7 @@ index bf5f2b753e3cbe3dfa8ad86df06718fbc1fbcbc4..988e5740b86c7768fee7391dc7e29003
  
      public void setOrigin(@javax.annotation.Nonnull org.bukkit.Location location) {
          this.origin = location.toVector();
-@@ -413,6 +422,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -414,6 +423,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.position = Vec3.ZERO;
          this.blockPosition = BlockPos.ZERO;
          this.chunkPosition = ChunkPos.ZERO;
@@ -509,7 +509,7 @@ index bf5f2b753e3cbe3dfa8ad86df06718fbc1fbcbc4..988e5740b86c7768fee7391dc7e29003
          SynchedEntityData.Builder builder = new SynchedEntityData.Builder(this);
          builder.define(DATA_SHARED_FLAGS_ID, (byte)0);
          builder.define(DATA_AIR_SUPPLY_ID, this.getMaxAirSupply());
-@@ -977,6 +993,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -978,6 +994,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          } else {
              this.wasOnFire = this.isOnFire();
              if (type == MoverType.PISTON) {
@@ -518,7 +518,7 @@ index bf5f2b753e3cbe3dfa8ad86df06718fbc1fbcbc4..988e5740b86c7768fee7391dc7e29003
                  movement = this.limitPistonMovement(movement);
                  if (movement.equals(Vec3.ZERO)) {
                      return;
-@@ -990,6 +1008,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -991,6 +1009,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  this.stuckSpeedMultiplier = Vec3.ZERO;
                  this.setDeltaMovement(Vec3.ZERO);
              }

--- a/paper-server/patches/features/0006-Optimize-Collision-to-not-load-chunks.patch
+++ b/paper-server/patches/features/0006-Optimize-Collision-to-not-load-chunks.patch
@@ -14,10 +14,10 @@ movement will load only the chunk the player enters anyways and avoids loading
 massive amounts of surrounding chunks due to large AABB lookups.
 
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 334859c5ff7023c730513301cc11c9837b2c7823..45f69a914d5a0565196c4105d61541047301470f 100644
+index 3cb21c66104a63d014720880553aaf5d28b9681a..8d8e6deca91fb622edf2d297928e06bea68e4c8a 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -218,6 +218,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -217,6 +217,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      // Paper end - Share random for entities to make them more random
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason; // Paper - Entity#getEntitySpawnReason
  

--- a/paper-server/patches/features/0006-Optimize-Collision-to-not-load-chunks.patch
+++ b/paper-server/patches/features/0006-Optimize-Collision-to-not-load-chunks.patch
@@ -14,10 +14,10 @@ movement will load only the chunk the player enters anyways and avoids loading
 massive amounts of surrounding chunks due to large AABB lookups.
 
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 3cb21c66104a63d014720880553aaf5d28b9681a..8d8e6deca91fb622edf2d297928e06bea68e4c8a 100644
+index 054ece1d539d69a4b7eec57e681179343c7e75c3..6f35067c64f378e955261e763f2bda9a0a6d0153 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -217,6 +217,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -218,6 +218,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      // Paper end - Share random for entities to make them more random
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason; // Paper - Entity#getEntitySpawnReason
  

--- a/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
@@ -26735,7 +26735,7 @@ index da793ad12565c36fffb26eb771ff68c76632caf7..db06f966077928419bfe469260f04d7d
          if (!passengers.equals(this.lastPassengers)) {
              this.broadcastAndSend(new ClientboundSetPassengersPacket(this.entity)); // CraftBukkit
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 0df366186c66323eafaf4626c4ed3b88a64b2808..80684b68a75986f08871bf435720b80a6bcd62c0 100644
+index 4a521a37e5fa0250d2cb7b4bc061d309c977e034..fc4a1efaa1f0005237340a236a231d8d3fec8d84 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -170,7 +170,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
@@ -28375,7 +28375,7 @@ diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity
 index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d05190eb6 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -135,7 +135,7 @@ import net.minecraft.world.scores.ScoreHolder;
+@@ -134,7 +134,7 @@ import net.minecraft.world.scores.ScoreHolder;
  import net.minecraft.world.scores.Team;
  import org.slf4j.Logger;
  
@@ -28384,7 +28384,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
  
      // CraftBukkit start
      private static final int CURRENT_LEVEL = 2;
-@@ -146,7 +146,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -145,7 +145,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      // Paper start - Share random for entities to make them more random
      public static RandomSource SHARED_RANDOM = new RandomRandomSource();
@@ -28403,7 +28403,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
          private boolean locked = false;
  
          @Override
-@@ -159,61 +169,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -158,61 +168,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              }
          }
  
@@ -28466,7 +28466,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
      }
      // Paper end - Share random for entities to make them more random
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason; // Paper - Entity#getEntitySpawnReason
-@@ -416,6 +372,156 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -415,6 +371,156 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return this.dimensions.makeBoundingBox(x, y, z);
      }
      // Paper end
@@ -28623,7 +28623,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
  
      public Entity(EntityType<?> entityType, Level level) {
          this.type = entityType;
-@@ -1324,35 +1430,77 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1323,35 +1429,77 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return distance;
      }
  
@@ -28725,7 +28725,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
      }
  
      private static float[] collectCandidateStepUpHeights(AABB box, List<VoxelShape> colliders, float deltaY, float maxUpStep) {
-@@ -2659,23 +2807,110 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2658,23 +2806,110 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean isInWall() {
@@ -28849,7 +28849,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
      }
  
      public InteractionResult interact(Player player, InteractionHand hand) {
-@@ -4099,15 +4334,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4098,15 +4333,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public Iterable<Entity> getIndirectPassengers() {
@@ -28875,7 +28875,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
      }
  
      public int countPlayerPassengers() {
-@@ -4245,77 +4482,136 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4244,77 +4481,136 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return Mth.lerp(partialTick, this.yRotO, this.yRot);
      }
  
@@ -29066,7 +29066,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
  
      public boolean touchingUnloadedChunk() {
          AABB aabb = this.getBoundingBox().inflate(1.0);
-@@ -4468,6 +4764,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4467,6 +4763,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.setPosRaw(x, y, z, false);
      }
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
@@ -29082,7 +29082,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4598,6 +4903,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4597,6 +4902,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
      public final void setRemoved(Entity.RemovalReason removalReason, org.bukkit.event.entity.EntityRemoveEvent.Cause cause) {
@@ -29095,7 +29095,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
          org.bukkit.craftbukkit.event.CraftEventFactory.callEntityRemoveEvent(this, cause);
          // CraftBukkit end
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
-@@ -4609,7 +4920,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4608,7 +4919,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              this.stopRiding();
          }
  
@@ -29104,7 +29104,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
          this.levelCallback.onRemove(removalReason);
          this.onRemoval(removalReason);
          // Paper start - Folia schedulers
-@@ -4643,7 +4954,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4642,7 +4953,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public boolean shouldBeSaved() {
          return (this.removalReason == null || this.removalReason.shouldSave())
              && !this.isPassenger()

--- a/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
@@ -26735,7 +26735,7 @@ index da793ad12565c36fffb26eb771ff68c76632caf7..db06f966077928419bfe469260f04d7d
          if (!passengers.equals(this.lastPassengers)) {
              this.broadcastAndSend(new ClientboundSetPassengersPacket(this.entity)); // CraftBukkit
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index b851520559b83c800eb240cebced0c40f1b8a66c..a293d1481b5f4a1d18addc3e518486c639223f09 100644
+index 0df366186c66323eafaf4626c4ed3b88a64b2808..80684b68a75986f08871bf435720b80a6bcd62c0 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -170,7 +170,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
@@ -27305,7 +27305,7 @@ index b851520559b83c800eb240cebced0c40f1b8a66c..a293d1481b5f4a1d18addc3e518486c6
      }
  
      // Paper start - log detailed entity tick information
-@@ -1033,6 +1316,11 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1035,6 +1318,11 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      }
  
      public void save(@Nullable ProgressListener progress, boolean flush, boolean skipSave) {
@@ -27317,7 +27317,7 @@ index b851520559b83c800eb240cebced0c40f1b8a66c..a293d1481b5f4a1d18addc3e518486c6
          ServerChunkCache chunkSource = this.getChunkSource();
          if (!skipSave) {
              org.bukkit.Bukkit.getPluginManager().callEvent(new org.bukkit.event.world.WorldSaveEvent(this.getWorld())); // CraftBukkit
-@@ -1045,13 +1333,18 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1047,13 +1335,18 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
                  progress.progressStage(Component.translatable("menu.savingChunks"));
              }
  
@@ -27341,7 +27341,7 @@ index b851520559b83c800eb240cebced0c40f1b8a66c..a293d1481b5f4a1d18addc3e518486c6
  
          // CraftBukkit start - moved from MinecraftServer.saveChunks
          ServerLevel worldserver1 = this;
-@@ -1182,7 +1475,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1184,7 +1477,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
              this.removePlayerImmediately((ServerPlayer)entity, Entity.RemovalReason.DISCARDED);
          }
  
@@ -27350,7 +27350,7 @@ index b851520559b83c800eb240cebced0c40f1b8a66c..a293d1481b5f4a1d18addc3e518486c6
      }
  
      // CraftBukkit start
-@@ -1213,7 +1506,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1215,7 +1508,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
              }
              // CraftBukkit end
  
@@ -27359,7 +27359,7 @@ index b851520559b83c800eb240cebced0c40f1b8a66c..a293d1481b5f4a1d18addc3e518486c6
          }
      }
  
-@@ -1224,7 +1517,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1226,7 +1519,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
  
      public boolean tryAddFreshEntityWithPassengers(Entity entity, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason) {
          // CraftBukkit end
@@ -27368,7 +27368,7 @@ index b851520559b83c800eb240cebced0c40f1b8a66c..a293d1481b5f4a1d18addc3e518486c6
              return false;
          } else {
              this.addFreshEntityWithPassengers(entity, reason); // CraftBukkit
-@@ -1959,7 +2252,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1961,7 +2254,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
                  }
              }
  
@@ -27377,7 +27377,7 @@ index b851520559b83c800eb240cebced0c40f1b8a66c..a293d1481b5f4a1d18addc3e518486c6
              bufferedWriter.write(String.format(Locale.ROOT, "block_entity_tickers: %d\n", this.blockEntityTickers.size()));
              bufferedWriter.write(String.format(Locale.ROOT, "block_ticks: %d\n", this.getBlockTicks().count()));
              bufferedWriter.write(String.format(Locale.ROOT, "fluid_ticks: %d\n", this.getFluidTicks().count()));
-@@ -1977,13 +2270,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1979,13 +2272,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          Path path1 = path.resolve("chunks.csv");
  
          try (Writer bufferedWriter2 = Files.newBufferedWriter(path1)) {
@@ -27393,7 +27393,7 @@ index b851520559b83c800eb240cebced0c40f1b8a66c..a293d1481b5f4a1d18addc3e518486c6
          }
  
          Path path3 = path.resolve("entities.csv");
-@@ -2092,8 +2385,8 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2094,8 +2387,8 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
              Locale.ROOT,
              "players: %s, entities: %s [%s], block_entities: %d [%s], block_ticks: %d, fluid_ticks: %d, chunk_source: %s",
              this.players.size(),
@@ -27404,7 +27404,7 @@ index b851520559b83c800eb240cebced0c40f1b8a66c..a293d1481b5f4a1d18addc3e518486c6
              this.blockEntityTickers.size(),
              getTypeCount(this.blockEntityTickers, TickingBlockEntity::getType),
              this.getBlockTicks().count(),
-@@ -2125,15 +2418,25 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2127,15 +2420,25 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      @Override
      public LevelEntityGetter<Entity> getEntities() {
          org.spigotmc.AsyncCatcher.catchOp("Chunk getEntities call"); // Spigot
@@ -27433,7 +27433,7 @@ index b851520559b83c800eb240cebced0c40f1b8a66c..a293d1481b5f4a1d18addc3e518486c6
      }
  
      public void startTickingChunk(LevelChunk chunk) {
-@@ -2151,32 +2454,45 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2153,32 +2456,45 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      @Override
      public void close() throws IOException {
          super.close();
@@ -27486,7 +27486,7 @@ index b851520559b83c800eb240cebced0c40f1b8a66c..a293d1481b5f4a1d18addc3e518486c6
      }
  
      @Override
-@@ -2230,7 +2546,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2232,7 +2548,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      @Override
      public CrashReportCategory fillReportDetails(CrashReport report) {
          CrashReportCategory crashReportCategory = super.fillReportDetails(report);
@@ -28466,7 +28466,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
      }
      // Paper end - Share random for entities to make them more random
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason; // Paper - Entity#getEntitySpawnReason
-@@ -415,6 +371,156 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -416,6 +372,156 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return this.dimensions.makeBoundingBox(x, y, z);
      }
      // Paper end
@@ -28623,7 +28623,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
  
      public Entity(EntityType<?> entityType, Level level) {
          this.type = entityType;
-@@ -1323,35 +1429,77 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1324,35 +1430,77 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return distance;
      }
  
@@ -28725,7 +28725,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
      }
  
      private static float[] collectCandidateStepUpHeights(AABB box, List<VoxelShape> colliders, float deltaY, float maxUpStep) {
-@@ -2658,23 +2806,110 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2659,23 +2807,110 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean isInWall() {
@@ -28849,7 +28849,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
      }
  
      public InteractionResult interact(Player player, InteractionHand hand) {
-@@ -4098,15 +4333,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4099,15 +4334,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public Iterable<Entity> getIndirectPassengers() {
@@ -28875,7 +28875,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
      }
  
      public int countPlayerPassengers() {
-@@ -4244,77 +4481,136 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4245,77 +4482,136 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return Mth.lerp(partialTick, this.yRotO, this.yRot);
      }
  
@@ -29066,7 +29066,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
  
      public boolean touchingUnloadedChunk() {
          AABB aabb = this.getBoundingBox().inflate(1.0);
-@@ -4467,6 +4763,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4468,6 +4764,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.setPosRaw(x, y, z, false);
      }
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
@@ -29082,7 +29082,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4597,6 +4902,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4598,6 +4903,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
      public final void setRemoved(Entity.RemovalReason removalReason, org.bukkit.event.entity.EntityRemoveEvent.Cause cause) {
@@ -29095,7 +29095,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
          org.bukkit.craftbukkit.event.CraftEventFactory.callEntityRemoveEvent(this, cause);
          // CraftBukkit end
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
-@@ -4608,7 +4919,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4609,7 +4920,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              this.stopRiding();
          }
  
@@ -29104,7 +29104,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
          this.levelCallback.onRemove(removalReason);
          this.onRemoval(removalReason);
          // Paper start - Folia schedulers
-@@ -4642,7 +4953,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4643,7 +4954,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public boolean shouldBeSaved() {
          return (this.removalReason == null || this.removalReason.shouldSave())
              && !this.isPassenger()

--- a/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
@@ -28375,7 +28375,7 @@ diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity
 index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d05190eb6 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -134,7 +134,7 @@ import net.minecraft.world.scores.ScoreHolder;
+@@ -135,7 +135,7 @@ import net.minecraft.world.scores.ScoreHolder;
  import net.minecraft.world.scores.Team;
  import org.slf4j.Logger;
  
@@ -28384,7 +28384,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
  
      // CraftBukkit start
      private static final int CURRENT_LEVEL = 2;
-@@ -145,7 +145,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -146,7 +146,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      // Paper start - Share random for entities to make them more random
      public static RandomSource SHARED_RANDOM = new RandomRandomSource();
@@ -28403,7 +28403,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
          private boolean locked = false;
  
          @Override
-@@ -158,61 +168,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -159,61 +169,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              }
          }
  
@@ -28466,7 +28466,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
      }
      // Paper end - Share random for entities to make them more random
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason; // Paper - Entity#getEntitySpawnReason
-@@ -415,6 +371,156 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -416,6 +372,156 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return this.dimensions.makeBoundingBox(x, y, z);
      }
      // Paper end
@@ -28623,7 +28623,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
  
      public Entity(EntityType<?> entityType, Level level) {
          this.type = entityType;
-@@ -1323,35 +1429,77 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1324,35 +1430,77 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return distance;
      }
  
@@ -28725,7 +28725,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
      }
  
      private static float[] collectCandidateStepUpHeights(AABB box, List<VoxelShape> colliders, float deltaY, float maxUpStep) {
-@@ -2658,23 +2806,110 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2659,23 +2807,110 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean isInWall() {
@@ -28849,7 +28849,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
      }
  
      public InteractionResult interact(Player player, InteractionHand hand) {
-@@ -4098,15 +4333,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4099,15 +4334,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public Iterable<Entity> getIndirectPassengers() {
@@ -28875,7 +28875,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
      }
  
      public int countPlayerPassengers() {
-@@ -4244,77 +4481,136 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4245,77 +4482,136 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return Mth.lerp(partialTick, this.yRotO, this.yRot);
      }
  
@@ -29066,7 +29066,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
  
      public boolean touchingUnloadedChunk() {
          AABB aabb = this.getBoundingBox().inflate(1.0);
-@@ -4467,6 +4763,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4468,6 +4764,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.setPosRaw(x, y, z, false);
      }
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
@@ -29082,7 +29082,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4597,6 +4902,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4598,6 +4903,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
      public final void setRemoved(Entity.RemovalReason removalReason, org.bukkit.event.entity.EntityRemoveEvent.Cause cause) {
@@ -29095,7 +29095,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
          org.bukkit.craftbukkit.event.CraftEventFactory.callEntityRemoveEvent(this, cause);
          // CraftBukkit end
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
-@@ -4608,7 +4919,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4609,7 +4920,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              this.stopRiding();
          }
  
@@ -29104,7 +29104,7 @@ index 19e4576b4b3be92961e993a8b14c8368789c692e..216482b4bb705520411bdeaa58f6044d
          this.levelCallback.onRemove(removalReason);
          this.onRemoval(removalReason);
          // Paper start - Folia schedulers
-@@ -4642,7 +4953,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4643,7 +4954,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public boolean shouldBeSaved() {
          return (this.removalReason == null || this.removalReason.shouldSave())
              && !this.isPassenger()

--- a/paper-server/patches/features/0019-Add-Alternate-Current-redstone-implementation.patch
+++ b/paper-server/patches/features/0019-Add-Alternate-Current-redstone-implementation.patch
@@ -2337,7 +2337,7 @@ index a293d1481b5f4a1d18addc3e518486c639223f09..5bf38ab129451e867b638cfbd2d7be59
  
      public LevelChunk getChunkIfLoaded(int x, int z) {
          return this.chunkSource.getChunkAtIfLoadedImmediately(x, z); // Paper - Use getChunkIfLoadedImmediately
-@@ -2555,6 +2556,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2557,6 +2558,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          return this.chunkSource.getGenerator().getSeaLevel();
      }
  

--- a/paper-server/patches/features/0024-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0024-Incremental-chunk-and-player-saving.patch
@@ -50,10 +50,10 @@ index 409c1134327bfcc338c3ac5e658a83cc396645d1..cc2d442682496197d29ace79b22e6cf6
          ProfilerFiller profilerFiller = Profiler.get();
          this.runAllTasks(); // Paper - move runAllTasks() into full server tick (previously for timings)
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 46dfaed12c998c219a20c711a06531aed2c68012..ebeeb63c3dca505a3ce8b88feaa5d2ca20ec24a2 100644
+index 42995dac38248032b6abecc27124adfe12ec4cab..28a67294c3e678e01d5dfd68b950234213d8e55c 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1316,6 +1316,28 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1318,6 +1318,28 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          return !this.server.isUnderSpawnProtection(this, pos, player) && this.getWorldBorder().isWithinBounds(pos);
      }
  
@@ -83,7 +83,7 @@ index 46dfaed12c998c219a20c711a06531aed2c68012..ebeeb63c3dca505a3ce8b88feaa5d2ca
          // Paper start - add close param
          this.save(progress, flush, skipSave, false);
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 422db52e8a0a08350542670bfc9ba94ad9481d0c..1fe212e8584c177b49e83f29b1a869b534914348 100644
+index f44600604a7bf68c990cd74a1ac2d7900ff6e88e..69b8074e18775c846d5991f40bc2e0a5186500ac 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -180,6 +180,7 @@ import org.slf4j.Logger;
@@ -95,7 +95,7 @@ index 422db52e8a0a08350542670bfc9ba94ad9481d0c..1fe212e8584c177b49e83f29b1a869b5
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      private static final int FLY_STAT_RECORDING_SPEED = 25;
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 5e94dd9e26aa4fd6545dbaae2ae0cb51cb6f13e0..03feaf0adb8ee87e33744a4615dc2507a02f92d7 100644
+index 7d1d4abfb04829d8c4722e326c6c6b8fb2ab91f4..5a4960fdbd97d830ac79845697eea9372c48a13b 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -482,6 +482,7 @@ public abstract class PlayerList {

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -487,7 +487,7 @@
          entity.setOldPosAndRot();
          ProfilerFiller profilerFiller = Profiler.get();
          entity.tickCount++;
-+        entity.totalTickCount++; // Paper
++        entity.totalEntityAge++; // Paper - age-like counter for all entities
          profilerFiller.push(() -> BuiltInRegistries.ENTITY_TYPE.getKey(entity.getType()).toString());
          profilerFiller.incrementCounter("tickNonPassenger");
          entity.tick();
@@ -511,7 +511,7 @@
          } else if (passengerEntity instanceof Player || this.entityTickList.contains(passengerEntity)) {
              passengerEntity.setOldPosAndRot();
              passengerEntity.tickCount++;
-+            passengerEntity.totalTickCount++; // Paper
++            passengerEntity.totalEntityAge++; // Paper - age-like counter for all entities
              ProfilerFiller profilerFiller = Profiler.get();
              profilerFiller.push(() -> BuiltInRegistries.ENTITY_TYPE.getKey(passengerEntity.getType()).toString());
              profilerFiller.incrementCounter("tickPassenger");

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -460,7 +460,7 @@
      }
  
      public void resetEmptyTime() {
-@@ -746,18 +_,45 @@
+@@ -746,18 +_,46 @@
          }
      }
  
@@ -487,6 +487,7 @@
          entity.setOldPosAndRot();
          ProfilerFiller profilerFiller = Profiler.get();
          entity.tickCount++;
++        entity.totalTickCount++; // Paper
          profilerFiller.push(() -> BuiltInRegistries.ENTITY_TYPE.getKey(entity.getType()).toString());
          profilerFiller.incrementCounter("tickNonPassenger");
          entity.tick();
@@ -506,7 +507,12 @@
      }
  
      private void tickPassenger(Entity ridingEntity, Entity passengerEntity) {
-@@ -770,6 +_,7 @@
+@@ -766,10 +_,12 @@
+         } else if (passengerEntity instanceof Player || this.entityTickList.contains(passengerEntity)) {
+             passengerEntity.setOldPosAndRot();
+             passengerEntity.tickCount++;
++            passengerEntity.totalTickCount++; // Paper
+             ProfilerFiller profilerFiller = Profiler.get();
              profilerFiller.push(() -> BuiltInRegistries.ENTITY_TYPE.getKey(passengerEntity.getType()).toString());
              profilerFiller.incrementCounter("tickPassenger");
              passengerEntity.rideTick();

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -109,15 +109,17 @@
      private static final Logger LOGGER = LogUtils.getLogger();
      public static final String ID_TAG = "id";
      public static final String PASSENGERS_TAG = "Passengers";
-@@ -196,7 +_,7 @@
+@@ -196,8 +_,9 @@
      public double zOld;
      public boolean noPhysics;
      private boolean wasOnFire;
 -    public final RandomSource random = RandomSource.create();
 +    public final RandomSource random = SHARED_RANDOM; // Paper - Share random for entities to make them more random
      public int tickCount;
++    public int totalTickCount; // Paper
      private int remainingFireTicks = -this.getFireImmuneTicks();
      public boolean wasTouchingWater;
+     protected Object2DoubleMap<TagKey<Fluid>> fluidHeight = new Object2DoubleArrayMap<>(2);
 @@ -233,7 +_,7 @@
      protected UUID uuid = Mth.createInsecureUUID(this.random);
      protected String stringUUID = this.uuid.toString();
@@ -798,7 +800,7 @@
 +            if (this.maxAirTicks != this.getDefaultMaxAirSupply()) {
 +                compound.putInt("Bukkit.MaxAirSupply", this.getMaxAirSupply());
 +            }
-+            compound.putInt("Spigot.ticksLived", this.tickCount);
++            compound.putInt("Spigot.ticksLived", this.totalTickCount); // Paper
 +            // CraftBukkit end
              Component customName = this.getCustomName();
              if (customName != null) {
@@ -860,7 +862,7 @@
 +            // CraftBukkit start
 +            // Spigot start
 +            if (this instanceof net.minecraft.world.entity.LivingEntity) {
-+                this.tickCount = compound.getInt("Spigot.ticksLived");
++                this.totalTickCount = compound.getInt("Spigot.ticksLived"); // Paper
 +            }
 +            // Spigot end
 +            this.persist = !compound.contains("Bukkit.persist") || compound.getBoolean("Bukkit.persist");

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -3,7 +_,6 @@
- import com.google.common.collect.ImmutableList;
- import com.google.common.collect.Iterables;
- import com.google.common.collect.Lists;
--import com.google.common.collect.Sets;
- import com.google.common.collect.ImmutableList.Builder;
- import com.mojang.logging.LogUtils;
- import it.unimi.dsi.fastutil.floats.FloatArraySet;
 @@ -136,6 +_,108 @@
  import org.slf4j.Logger;
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
+@@ -3,7 +_,6 @@
+ import com.google.common.collect.ImmutableList;
+ import com.google.common.collect.Iterables;
+ import com.google.common.collect.Lists;
+-import com.google.common.collect.Sets;
+ import com.google.common.collect.ImmutableList.Builder;
+ import com.mojang.logging.LogUtils;
+ import it.unimi.dsi.fastutil.floats.FloatArraySet;
 @@ -136,6 +_,108 @@
  import org.slf4j.Logger;
  
@@ -109,17 +117,15 @@
      private static final Logger LOGGER = LogUtils.getLogger();
      public static final String ID_TAG = "id";
      public static final String PASSENGERS_TAG = "Passengers";
-@@ -196,8 +_,9 @@
+@@ -196,7 +_,7 @@
      public double zOld;
      public boolean noPhysics;
      private boolean wasOnFire;
 -    public final RandomSource random = RandomSource.create();
 +    public final RandomSource random = SHARED_RANDOM; // Paper - Share random for entities to make them more random
      public int tickCount;
-+    public int totalTickCount; // Paper
      private int remainingFireTicks = -this.getFireImmuneTicks();
      public boolean wasTouchingWater;
-     protected Object2DoubleMap<TagKey<Fluid>> fluidHeight = new Object2DoubleArrayMap<>(2);
 @@ -233,7 +_,7 @@
      protected UUID uuid = Mth.createInsecureUUID(this.random);
      protected String stringUUID = this.uuid.toString();
@@ -129,7 +135,7 @@
      private final double[] pistonDeltas = new double[]{0.0, 0.0, 0.0};
      private long pistonDeltasGameTime;
      private EntityDimensions dimensions;
-@@ -250,6 +_,59 @@
+@@ -250,6 +_,60 @@
      private final List<Entity.Movement> movementThisTick = new ArrayList<>();
      private final Set<BlockState> blocksInside = new ReferenceArraySet<>();
      private final LongSet visitedBlocks = new LongOpenHashSet();
@@ -160,6 +166,7 @@
 +    public boolean freezeLocked = false; // Paper - Freeze Tick Lock API
 +    public boolean fixedPose = false; // Paper - Expand Pose API
 +    private final int despawnTime; // Paper - entity despawn time limit
++    public int totalEntityAge; // Paper - age-like counter for all entities
 +    public final io.papermc.paper.entity.activation.ActivationType activationType = io.papermc.paper.entity.activation.ActivationType.activationTypeFor(this); // Paper - EAR 2/tracking ranges
 +
 +    public void setOrigin(@javax.annotation.Nonnull org.bukkit.Location location) {
@@ -800,7 +807,7 @@
 +            if (this.maxAirTicks != this.getDefaultMaxAirSupply()) {
 +                compound.putInt("Bukkit.MaxAirSupply", this.getMaxAirSupply());
 +            }
-+            compound.putInt("Spigot.ticksLived", this.totalTickCount); // Paper
++            compound.putInt("Spigot.ticksLived", this.totalEntityAge); // Paper
 +            // CraftBukkit end
              Component customName = this.getCustomName();
              if (customName != null) {
@@ -862,7 +869,7 @@
 +            // CraftBukkit start
 +            // Spigot start
 +            if (this instanceof net.minecraft.world.entity.LivingEntity) {
-+                this.totalTickCount = compound.getInt("Spigot.ticksLived"); // Paper
++                this.totalEntityAge = compound.getInt("Spigot.ticksLived"); // Paper
 +            }
 +            // Spigot end
 +            this.persist = !compound.contains("Bukkit.persist") || compound.getBoolean("Bukkit.persist");

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -370,7 +370,7 @@
  
      public void tick() {
 +        // Paper start - entity despawn time limit
-+        if (this.despawnTime >= 0 && this.tickCount >= this.despawnTime) {
++        if (this.despawnTime >= 0 && this.totalEntityAge >= this.despawnTime) {
 +            this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN);
 +            return;
 +        }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -519,13 +519,14 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
 
     @Override
     public int getTicksLived() {
-        return this.getHandle().tickCount;
+        return this.getHandle().totalTickCount; // Paper
     }
 
     @Override
     public void setTicksLived(int value) {
         Preconditions.checkArgument(value > 0, "Age value (%s) must be greater than 0", value);
         this.getHandle().tickCount = value;
+        this.getHandle().totalTickCount = value; // Paper
     }
 
     public Entity getHandle() {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -519,14 +519,14 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
 
     @Override
     public int getTicksLived() {
-        return this.getHandle().totalTickCount; // Paper
+        return this.getHandle().totalEntityAge;
     }
 
     @Override
     public void setTicksLived(int value) {
         Preconditions.checkArgument(value > 0, "Age value (%s) must be greater than 0", value);
         this.getHandle().tickCount = value;
-        this.getHandle().totalTickCount = value; // Paper
+        this.getHandle().totalEntityAge = value;
     }
 
     public Entity getHandle() {


### PR DESCRIPTION
Closes #12075.

This pull request introduces another entity tick counter `totalTickCount` for api usage, reset vanilla `tickCount` instead of restoring value from Spigot's `Spigot.ticksLived` tag to keep vanilla parity.

## Analysis

Spigot's restore tickCount behavior([See original patch](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/spigot/browse/CraftBukkit-Patches/0027-Save-ticks-lived-to-nbttag.patch)) causes potential issues with Wither's ai, see code below, and lead to wither loses its target when entities are reloaded:
![image](https://github.com/user-attachments/assets/7c6f9b6c-4b26-42d9-b9df-c6568c73309d)

## Api Changes

Now `Entity#getTicksLived` gets value from totalTickCount to avoid api behavior breakage, `Entity#setTicksLived` sets both `tickCount` and `totalTickCount`.

Currently the totalTickCount is only used for apis, if the breakage is fine, the extra counter can be removed.