### PR TITLE
Entity#teleport changes to use vanilla logic

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -182,6 +182,7 @@ public net.minecraft.world.entity.Display$TextDisplay setFlags(B)V
 public net.minecraft.world.entity.Display$TextDisplay setText(Lnet/minecraft/network/chat/Component;)V
 public net.minecraft.world.entity.Display$TextDisplay setTextOpacity(B)V
 public net.minecraft.world.entity.Entity FLAG_INVISIBLE
+public net.minecraft.world.entity.Entity calculatePassengerTransition(Lnet/minecraft/world/level/portal/TeleportTransition;Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/level/portal/TeleportTransition;
 public net.minecraft.world.entity.Entity getEncodeId()Ljava/lang/String;
 public net.minecraft.world.entity.Entity getFireImmuneTicks()I
 public net.minecraft.world.entity.Entity getSharedFlag(I)Z

--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -154,6 +154,17 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
     boolean teleport(@NotNull Location location, @NotNull TeleportCause cause, @NotNull io.papermc.paper.entity.TeleportFlag @NotNull... teleportFlags);
 
     /**
+     * Teleports this entity to the given location.
+     *
+     * @param location New location to teleport this entity to
+     * @param cause The cause of this teleportation
+     * @param teleportFlags Flags to be used in this teleportation
+     * @return <code>true</code> if the teleport was successful
+     */
+    boolean teleportVanilla(@NotNull Location location, @NotNull TeleportCause cause, @NotNull io.papermc.paper.entity.TeleportFlag @NotNull... teleportFlags);
+
+
+    /**
      * Causes the entity to look towards the given position.
      *
      * @param x x coordinate

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -668,12 +668,24 @@
                  this.isChangingDimension = true;
                  LevelData levelData = level.getLevelData();
                  this.connection.send(new ClientboundRespawnPacket(this.createCommonSpawnInfo(level), (byte)3));
-@@ -1050,16 +_,30 @@
+@@ -1050,16 +_,42 @@
                  playerList.sendPlayerPermissionLevel(this);
                  serverLevel.removePlayerImmediately(this, Entity.RemovalReason.CHANGED_DIMENSION);
                  this.unsetRemoved();
 +                */
 +                // CraftBukkit end
++                // Paper start - Teleport with passengers
++                List<Entity> passengers = this.getPassengers();
++                List<Entity> newPassengers = new java.util.ArrayList<>(passengers.size());
++                this.ejectPassengers();
++
++                for (Entity passenger : passengers) {
++                    Entity newPassenger = passenger.teleport(this.calculatePassengerTransition(teleportTransition, passenger));
++                    if (newPassenger != null) {
++                        newPassengers.add(newPassenger);
++                    }
++                }
++                // Paper end - Teleport with passengers
                  ProfilerFiller profilerFiller = Profiler.get();
                  profilerFiller.push("moving");
 -                if (resourceKey == Level.OVERWORLD && level.dimension() == Level.NETHER) {
@@ -701,12 +713,16 @@
                  this.connection.resetPosition();
                  level.addDuringTeleport(this);
                  profilerFiller.pop();
-@@ -1073,10 +_,40 @@
+@@ -1073,10 +_,44 @@
                  this.lastSentExp = -1;
                  this.lastSentHealth = -1.0F;
                  this.lastSentFood = -1;
 +
-+
++                // Paper start - Teleport with passengers
++                for (Entity passenger : newPassengers) {
++                    passenger.startRiding(this, true);
++                }
++                // Paper end - Teleport with passengers
 +                // CraftBukkit start
 +                org.bukkit.event.player.PlayerChangedWorldEvent changeEvent = new org.bukkit.event.player.PlayerChangedWorldEvent(this.getBukkitEntity(), serverLevel.getWorld());
 +                this.level().getCraftServer().getPluginManager().callEvent(changeEvent);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -263,8 +263,8 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
             level,
             CraftLocation.toVec3D(location),
             this.getHandle().getDeltaMovement(),
-            location.getPitch(),
             location.getYaw(),
+            location.getPitch(),
             relatives,
             TeleportTransition.DO_NOTHING,
             cause);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -11,6 +11,7 @@ import io.papermc.paper.FeatureHooks;
 import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.entity.PaperPlayerGiveResult;
 import io.papermc.paper.entity.PlayerGiveResult;
+import io.papermc.paper.entity.TeleportFlag;
 import it.unimi.dsi.fastutil.shorts.ShortArraySet;
 import it.unimi.dsi.fastutil.shorts.ShortSet;
 import java.io.ByteArrayOutputStream;
@@ -1406,6 +1407,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
             case ROTATE_DELTA -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_ROTATION;
             default -> null;
         };
+    }
+
+    @Override
+    public boolean teleportVanilla(Location location, PlayerTeleportEvent.TeleportCause cause, TeleportFlag... flags) {
+        Preconditions.checkArgument(location != null, "location cannot be null");
+        if (this.isSleeping()) {
+            this.wakeup(false);
+        }
+        return super.teleportVanilla(location, cause, flags);
     }
 
     @Override


### PR DESCRIPTION
This PR aims to create a new method for teleporting using vanilla logic.
Minecraft handles a lot of the teleport logic that Bukkit/CB has used over the years.
A lot of the CraftBukkit teleport code is so old, and limits what users can do with teleporting.
This chance allows the user to rely on Minecraft to handle the teleport logic rather than CraftBukkit limitations.

# A Few Notes:
- I chose the method name `teleportVanilla` as a temporary placeholder. Would definitely like a better name. Maybe `teleportWithPassengers`?
- I haven't added all the possible methods yet for Bukkit Entity, I wanted to get feedback first before writing all those out
- I slightly changed ServerPlayer teleport logic to handle the player's passengers (Minecraft by default doesn't allow players having passengers, this is seen when attempting to use the `/ride` command... the API however let's us do this, so I wanted to make sure that worked.).

I have done a fair bit of testing, including:
- Player with a stack of passengers (I had 5 chickens above me)
- Player riding another mob (a sheep)
- Player riding a stack of mobs (5 chickens again)
- Player riding a player (and attempting to teleport both players)
All of this has worked as expected, all teleports were successful.

# Final Note:
As discussed in a previous PR of mine fixing the retain passengers flag... a lot of this NMS stuff often goes over my head.
I've spent a decent amount of time digging around to make sure I was fully understanding the logic, and making sure not to break anything, but as always, Im open to feedback.