### PR TITLE
Do not queue player info packets

### DIFF
--- a/paper-server/patches/features/0001-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
+++ b/paper-server/patches/features/0001-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
@@ -28,7 +28,7 @@ and then catch exceptions and close if they fire.
 Part of this commit was authored by: Spottedleaf, sandtechnology
 
 diff --git a/net/minecraft/network/Connection.java b/net/minecraft/network/Connection.java
-index 42f44c7cb0bd55ddfacd18acb0e596e7a953870e..ad8f8428b75e37097487cdfbd0db2421ee4cbe37 100644
+index 42f44c7cb0bd55ddfacd18acb0e596e7a953870e..161ee86d67b9a23368a18481fde9768c022d913d 100644
 --- a/net/minecraft/network/Connection.java
 +++ b/net/minecraft/network/Connection.java
 @@ -85,7 +85,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -232,7 +232,7 @@ index 42f44c7cb0bd55ddfacd18acb0e596e7a953870e..ad8f8428b75e37097487cdfbd0db2421
                  // Paper start - Add PlayerConnectionCloseEvent
                  if (packetListener instanceof net.minecraft.server.network.ServerCommonPacketListenerImpl commonPacketListener) {
                      /* Player was logged in, either game listener or configuration listener */
-@@ -797,4 +888,93 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -797,4 +888,96 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      public void setBandwidthLogger(LocalSampleLogger bandwithLogger) {
          this.bandwidthDebugMonitor = new BandwidthDebugMonitor(bandwithLogger);
      }
@@ -280,6 +280,7 @@ index 42f44c7cb0bd55ddfacd18acb0e596e7a953870e..ad8f8428b75e37097487cdfbd0db2421
 +                packet instanceof net.minecraft.network.protocol.common.ClientboundKeepAlivePacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundPlayerChatPacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundSystemChatPacket ||
++                packet instanceof net.minecraft.network.protocol.game.ClientboundDisguisedChatPacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundCommandSuggestionsPacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundSetTitleTextPacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundSetSubtitleTextPacket ||
@@ -290,6 +291,8 @@ index 42f44c7cb0bd55ddfacd18acb0e596e7a953870e..ad8f8428b75e37097487cdfbd0db2421
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundSoundEntityPacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundStopSoundPacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket ||
++                packet instanceof net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket ||
++                packet instanceof net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundBossEventPacket;
 +        }
 +    }


### PR DESCRIPTION
Player info packets carry chat state to other clients since the
introduction of chat signatures. Queuing these packets while force
pushing chat packets allows for potentially inverted packet order, which
may cause chain corruption on clients.
