### PR TITLE
Enhance javadoc for World#setAutoSave method

### DIFF
--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2778,13 +2778,11 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
 
     /**
      * Sets whether or not the world will automatically save
-     * <p>
-     * <b>Note:</b>
-     * This does not disable saving entirely, the world will still be saved on shutdown.<br>
-     * The intended use of this method is to disable the periodical autosave by the game.
      *
      * @param value true if the world should automatically save, otherwise
      *     false
+     * @apiNote This does not disable saving entirely, the world will still be saved on shutdown.<br>
+     * The intended use of this method is to disable the periodical autosave by the game.
      */
     public void setAutoSave(boolean value);
 

--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2777,7 +2777,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
     public boolean isAutoSave();
 
     /**
-     * Sets whether or not the world will automatically save<br><br>
+     * Sets whether or not the world will automatically save
+     * <p>
      * <b>Note:</b>
      * This does not disable saving entirely, the world will still be saved on shutdown.<br>
      * The intended use of this method is to disable the periodical autosave by the game.

--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2777,7 +2777,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
     public boolean isAutoSave();
 
     /**
-     * Sets whether or not the world will automatically save
+     * Sets whether or not the world will automatically save<br><br>
+     * <b>Note:</b>
+     * This does not disable saving entirely, the world will still be saved on shutdown.<br>
+     * The intended use of this method is to disable the periodical autosave by the game.
      *
      * @param value true if the world should automatically save, otherwise
      *     false


### PR DESCRIPTION
The autosave option has been causing confusion for quite some time now
This change clarifies that disabling auto-save does not stop all saving operations.
This addition explicitly mentions that the world will still save on shutdown and explains the intended purpose of the method.