### PR TITLE
Add skipTripwireHookPlacementValidation

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/TripWireHookBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TripWireHookBlock.java.patch
@@ -53,7 +53,7 @@
 +            if (!cancelledEmitterHook) { // Paper - Call BlockRedstoneEvent
              emitState(level, pos, flag2, flag3, flag, flag1);
              if (!attaching) {
-+                if (level.getBlockState(pos).is(Blocks.TRIPWIRE_HOOK)) // Paper - Validate tripwire hook placement before update
++                if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.skipTripwireHookPlacementValidation || level.getBlockState(pos).is(Blocks.TRIPWIRE_HOOK)) // Paper - Validate tripwire hook placement before update
                  level.setBlock(pos, blockState1.setValue(FACING, direction), 3);
                  if (shouldNotifyNeighbours) {
                      notifyNeighbors(block, level, pos, direction);

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -171,6 +171,8 @@ public class GlobalConfiguration extends ConfigurationPart {
     public class UnsupportedSettings extends ConfigurationPart {
         @Comment("This setting allows for exploits related to end portals, for example sand duping")
         public boolean allowUnsafeEndPortalTeleportation = false;
+        @Comment("This setting controls the ability to enable dupes related to tripwires.")
+        public boolean skipTripwireHookPlacementValidation = false;
         @Comment("This setting controls if players should be able to break bedrock, end portals and other intended to be permanent blocks.")
         public boolean allowPermanentBlockBreakExploits = false;
         @Comment("This setting controls if player should be able to use TNT duplication, but this also allows duplicating carpet, rails and potentially other items")


### PR DESCRIPTION
This allows for the configuration of tripwire hook duping.

Tested with https://www.youtube.com/watch?v=sRYuZn4r9RY

With this option disabled, both tripwires are broken. 
With this option enabled, only one tripwire "breaks", but 2 items are dropped... (so it dupes)

```yaml
unsupported-settings:
  skip-tripwire-hook-placement-validation: true
```

Resolves https://github.com/PaperMC/Paper/issues/12074

https://github.com/PaperMC/docs/pull/541