### PR TITLE
Fix vanilla map decorations sending when not dirty

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java.patch
@@ -193,7 +193,7 @@
  
              Collection<MapDecoration> collection;
 -            if (this.dirtyDecorations && this.tick++ % 5 == 0) {
-+            if ((true || this.dirtyDecorations) && this.tick++ % 5 == 0) { // CraftBukkit - custom maps don't update this yet // TODO fix this
++            if ((!vanillaMaps || this.dirtyDecorations) && this.tick++ % 5 == 0) { // Paper - bypass dirtyDecorations for custom maps
                  this.dirtyDecorations = false;
 -                collection = MapItemSavedData.this.decorations.values();
 +                // CraftBukkit start


### PR DESCRIPTION
Closes #11677

As a fix for custom maps not being able to affect the dirtyDecorations field here, CB seems to have simply ignored this field entirely for all maps.

This fix restores vanilla behavior while still allowing custom maps to be updated, reducing the amount of map data packets that get sent for vanilla maps.