### PR TITLE
[ci skip] fix incomplete example in javadocs for PreFlattenTagRegistrar

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/tag/PreFlattenTagRegistrar.java
+++ b/paper-api/src/main/java/io/papermc/paper/tag/PreFlattenTagRegistrar.java
@@ -22,7 +22,7 @@ import org.jspecify.annotations.NullMarked;
  * <pre>{@code
  * class YourBootstrapClass implements PluginBootstrap {
  *
- *     public static final TagKey<ItemType> AXE_PICKAXE = TagKey.create(RegistryKey.ITEM, Key.key("test", "axe_pickaxe"));
+ *     public static final TagKey<ItemType> AXE_PICKAXE = TagKey.create(RegistryKey.ITEM, Key.key("papermc:axe_pickaxe"));
  *
  *     @Override
  *     public void bootstrap(BootstrapContext context) {

--- a/paper-api/src/main/java/io/papermc/paper/tag/PreFlattenTagRegistrar.java
+++ b/paper-api/src/main/java/io/papermc/paper/tag/PreFlattenTagRegistrar.java
@@ -22,6 +22,8 @@ import org.jspecify.annotations.NullMarked;
  * <pre>{@code
  * class YourBootstrapClass implements PluginBootstrap {
  *
+ *     public static final TagKey<ItemType> AXE_PICKAXE = TagKey.create(RegistryKey.ITEM, Key.key("test", "axe_pickaxe"));
+ *
  *     @Override
  *     public void bootstrap(BootstrapContext context) {
  *         LifecycleEventManager<BootstrapContext> manager = context.getLifecycleManager();


### PR DESCRIPTION
This resolve #12100 adding the missing declaration used in the example..