### PR TITLE
Add missing nullability annotation to sendEquipmentChange method

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -1061,7 +1061,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      * @param items the slots to change, where the values are the items to which
      * the slot should be changed. null values will set the slot to air, empty map is not allowed
      */
-    public void sendEquipmentChange(LivingEntity entity, Map<EquipmentSlot, ItemStack> items);
+    public void sendEquipmentChange(LivingEntity entity, Map<EquipmentSlot, @Nullable ItemStack> items);
 
     // Paper start
     /**


### PR DESCRIPTION

Marked ItemStack parameter as `@Nullable` to explicitly indicate it can be null. This improves clarity, avoids nullability problems, and aligns with the method's documented behavior for handling null values.