### PR TITLE
Add EntityAttemptSmashAttackEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityAttemptSmashAttackEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityAttemptSmashAttackEvent.java
@@ -1,7 +1,6 @@
 package io.papermc.paper.event.entity;
 
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.EntityEvent;
 import org.bukkit.inventory.ItemStack;
@@ -9,71 +8,88 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Called when an entity tries to perform a smash attack
- * <p>
- * Note: This event is marked as cancelled if the player can't normally perform the smash attack
+ * Called when an entity attempts to perform a smash attack.
  */
 @NullMarked
-public class EntityAttemptSmashAttackEvent extends EntityEvent implements Cancellable {
+public class EntityAttemptSmashAttackEvent extends EntityEvent {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final LivingEntity target;
     private final ItemStack weapon;
-    private final boolean canSmashAttack;
-
-    private boolean cancelled;
+    private final boolean originalResult;
+    private Result result = Result.DEFAULT;
 
     @ApiStatus.Internal
-    public EntityAttemptSmashAttackEvent(LivingEntity attacker, LivingEntity target, ItemStack weapon, boolean canSmashAttack) {
+    public EntityAttemptSmashAttackEvent(
+        final LivingEntity attacker,
+        final LivingEntity target,
+        final ItemStack weapon,
+        final boolean originalResult
+    ) {
         super(attacker);
         this.target = target;
         this.weapon = weapon;
-        this.canSmashAttack = canSmashAttack;
+        this.originalResult = originalResult;
     }
 
     /**
-     * @return The entity being attacked with a smash attack
+     * Yields the target of the attempted smash attack.
+     *
+     * @return the target entity
      */
     public LivingEntity getTarget() {
         return target;
     }
 
     /**
-     * @return The weapon being used to perform a smash attack
+     * Yields a copy of the itemstack used in the smash attack attempt.
+     *
+     * @return the itemstack
      */
     public ItemStack getWeapon() {
         return weapon.clone();
     }
 
     /**
-     * @return If the entity can perform a smash attack before any modifications have been made by this event
+     * Yields the original result the server computed.
+     *
+     * @return {@code true} if this attempt would have been successful by vanilla's logic, {@code false} otherwise.
      */
-    public boolean canSmashAttack() {
-        return canSmashAttack;
+    public boolean getOriginalResult() {
+        return originalResult;
     }
 
     /**
-     * Gets the cancellation state of this event.
-     * <p>
-     * This is equivalent to whether the player can perform the smash attack
-     * @see #setCancelled(boolean)
-     * @return boolean cancellation state
+     * Yields the effective result of this event.
+     * The result may take one of three values:
+     *
+     * <ul>
+     *     <li>{@link Result#ALLOW}: The attempt will succeed.</li>
+     *     <li>{@link Result#DENY}: The attempt will fail.</li>
+     *     <li>{@link Result#DEFAULT}: The attempt will succeed if {@link #getOriginalResult()} is {@code true} and fail otherwise.</li>
+     * </ul>
+     *
+     * @return the result.
      */
-    @Override
-    public boolean isCancelled() {
-        return cancelled;
+    public Result getResult() {
+        return this.result;
     }
 
     /**
-     * Sets the cancellation state of this event. A canceled event will not be
-     * executed in the server, but will still pass to other plugins.
-     * @see #isCancelled()
-     * @param cancel true if you wish to cancel this event
+     * Configures a new result for this event.
+     * The passes result may take one of three values:
+     *
+     * <ul>
+     *     <li>{@link Result#ALLOW}: The attempt will succeed.</li>
+     *     <li>{@link Result#DENY}: The attempt will fail.</li>
+     *     <li>{@link Result#DEFAULT}: The attempt will succeed if {@link #getOriginalResult()} is {@code true} and fail otherwise.</li>
+     * </ul>
+     *
+     * @param result the new result of the event.
      */
-    @Override
-    public void setCancelled(boolean cancel) {
-        this.cancelled = cancel;
+    public void setResult(final Result result) {
+        this.result = result;
     }
 
     @Override

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityAttemptSmashAttackEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityAttemptSmashAttackEvent.java
@@ -10,6 +10,8 @@ import org.jspecify.annotations.NullMarked;
 
 /**
  * Called when an entity tries to perform a smash attack
+ * <p>
+ * Note: This event is marked as cancelled if the player can't normally perform the smash attack
  */
 @NullMarked
 public class EntityAttemptSmashAttackEvent extends EntityEvent implements Cancellable {
@@ -18,15 +20,17 @@ public class EntityAttemptSmashAttackEvent extends EntityEvent implements Cancel
 
     private final LivingEntity target;
     private final ItemStack weapon;
+    private final boolean canSmashAttack;
 
-    private Result result;
+    private boolean cancelled;
 
     @ApiStatus.Internal
-    public EntityAttemptSmashAttackEvent(LivingEntity attacker, LivingEntity target, ItemStack weapon) {
+    public EntityAttemptSmashAttackEvent(LivingEntity attacker, LivingEntity target, ItemStack weapon, boolean canSmashAttack) {
         super(attacker);
         this.target = target;
         this.weapon = weapon;
-        this.result = Result.DEFAULT;
+        this.canSmashAttack = canSmashAttack;
+        this.cancelled = !canSmashAttack;
     }
 
     /**
@@ -44,47 +48,33 @@ public class EntityAttemptSmashAttackEvent extends EntityEvent implements Cancel
     }
 
     /**
-     * Gets the result of this event.
-     *
-     * @return the result
-     * @see #setResult(Result)
+     * @return If the entity can perform a smash attack before any modifications have been made by this event
      */
-    public Result getResult() {
-        return result;
-    }
-
-    /**
-     * Sets the result of this event. {@link Result#DEFAULT} is the default
-     * allowing the vanilla logic to check if the entity can perform a smash attack. Set to {@link Result#ALLOW}
-     * or {@link Result#DENY} to override that behavior.
-     * @param result the result of this event
-     */
-    public void setResult(Result result) {
-        this.result = result;
+    public boolean canSmashAttack() {
+        return canSmashAttack;
     }
 
     /**
      * Gets the cancellation state of this event.
-     * @see #setResult(Result)
+     * <p>
+     * This is equivalent to whether the player can perform the smash attack
      * @see #setCancelled(boolean)
      * @return boolean cancellation state
      */
     @Override
     public boolean isCancelled() {
-        return getResult() == Result.DENY;
+        return cancelled;
     }
 
     /**
      * Sets the cancellation state of this event. A canceled event will not be
      * executed in the server, but will still pass to other plugins.
-     * <p>
-     * Canceling this event will prevent the smash attack.
-     *
+     * @see #isCancelled()
      * @param cancel true if you wish to cancel this event
      */
     @Override
     public void setCancelled(boolean cancel) {
-        setResult(cancel ? Result.DENY : Result.ALLOW);
+        this.cancelled = cancel;
     }
 
     @Override

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityAttemptSmashAttackEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityAttemptSmashAttackEvent.java
@@ -30,7 +30,6 @@ public class EntityAttemptSmashAttackEvent extends EntityEvent implements Cancel
         this.target = target;
         this.weapon = weapon;
         this.canSmashAttack = canSmashAttack;
-        this.cancelled = !canSmashAttack;
     }
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityAttemptSmashAttackEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityAttemptSmashAttackEvent.java
@@ -12,7 +12,7 @@ import org.jspecify.annotations.NullMarked;
  * Called when an entity tries to perform a smash attack
  */
 @NullMarked
-public class EntitySmashAttackEvent extends EntityEvent implements Cancellable {
+public class EntityAttemptSmashAttackEvent extends EntityEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
@@ -22,7 +22,7 @@ public class EntitySmashAttackEvent extends EntityEvent implements Cancellable {
     private Result result;
 
     @ApiStatus.Internal
-    public EntitySmashAttackEvent(LivingEntity attacker, LivingEntity target, ItemStack weapon) {
+    public EntityAttemptSmashAttackEvent(LivingEntity attacker, LivingEntity target, ItemStack weapon) {
         super(attacker);
         this.target = target;
         this.weapon = weapon;

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntitySmashAttackEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntitySmashAttackEvent.java
@@ -1,0 +1,98 @@
+package io.papermc.paper.event.entity;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Called when an entity tries to perform a smash attack
+ */
+@NullMarked
+public class EntitySmashAttackEvent extends EntityEvent implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final LivingEntity target;
+    private final ItemStack weapon;
+
+    private Result result;
+
+    @ApiStatus.Internal
+    public EntitySmashAttackEvent(LivingEntity attacker, LivingEntity target, ItemStack weapon) {
+        super(attacker);
+        this.target = target;
+        this.weapon = weapon;
+        this.result = Result.DEFAULT;
+    }
+
+    /**
+     * @return The entity being attacked with a smash attack
+     */
+    public LivingEntity getTarget() {
+        return target;
+    }
+
+    /**
+     * @return The weapon being used to perform a smash attack
+     */
+    public ItemStack getWeapon() {
+        return weapon.clone();
+    }
+
+    /**
+     * Gets the result of this event.
+     *
+     * @return the result
+     * @see #setResult(Result)
+     */
+    public Result getResult() {
+        return result;
+    }
+
+    /**
+     * Sets the result of this event. {@link Result#DEFAULT} is the default
+     * allowing the vanilla logic to check if the entity can perform a smash attack. Set to {@link Result#ALLOW}
+     * or {@link Result#DENY} to override that behavior.
+     * @param result the result of this event
+     */
+    public void setResult(Result result) {
+        this.result = result;
+    }
+
+    /**
+     * Gets the cancellation state of this event.
+     * @see #setResult(Result)
+     * @see #setCancelled(boolean)
+     * @return boolean cancellation state
+     */
+    @Override
+    public boolean isCancelled() {
+        return getResult() == Result.DENY;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A canceled event will not be
+     * executed in the server, but will still pass to other plugins.
+     * <p>
+     * Canceling this event will prevent the smash attack.
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    @Override
+    public void setCancelled(boolean cancel) {
+        setResult(cancel ? Result.DENY : Result.ALLOW);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/paper-server/patches/sources/net/minecraft/world/item/MaceItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/MaceItem.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/item/MaceItem.java
++++ b/net/minecraft/world/item/MaceItem.java
+@@ -61,7 +_,9 @@
+ 
+     @Override
+     public boolean hurtEnemy(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+-        if (canSmashAttack(attacker)) {
++        io.papermc.paper.event.entity.EntitySmashAttackEvent event = new io.papermc.paper.event.entity.EntitySmashAttackEvent(attacker.getBukkitLivingEntity(), target.getBukkitLivingEntity(), stack.asBukkitCopy());
++        event.callEvent();
++        if ((event.getResult() == org.bukkit.event.Event.Result.DEFAULT && canSmashAttack(attacker)) || event.getResult() == org.bukkit.event.Event.Result.ALLOW) {
+             ServerLevel serverLevel = (ServerLevel)attacker.level();
+             attacker.setDeltaMovement(attacker.getDeltaMovement().with(Direction.Axis.Y, 0.01F));
+             if (attacker instanceof ServerPlayer serverPlayer) {

--- a/paper-server/patches/sources/net/minecraft/world/item/MaceItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/MaceItem.java.patch
@@ -5,7 +5,7 @@
      @Override
      public boolean hurtEnemy(ItemStack stack, LivingEntity target, LivingEntity attacker) {
 -        if (canSmashAttack(attacker)) {
-+        io.papermc.paper.event.entity.EntitySmashAttackEvent event = new io.papermc.paper.event.entity.EntitySmashAttackEvent(attacker.getBukkitLivingEntity(), target.getBukkitLivingEntity(), stack.asBukkitCopy());
++        io.papermc.paper.event.entity.EntityAttemptSmashAttackEvent event = new io.papermc.paper.event.entity.EntityAttemptSmashAttackEvent(attacker.getBukkitLivingEntity(), target.getBukkitLivingEntity(), stack.asBukkitCopy());
 +        event.callEvent();
 +        if ((event.getResult() == org.bukkit.event.Event.Result.DEFAULT && canSmashAttack(attacker)) || event.getResult() == org.bukkit.event.Event.Result.ALLOW) {
              ServerLevel serverLevel = (ServerLevel)attacker.level();

--- a/paper-server/patches/sources/net/minecraft/world/item/MaceItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/MaceItem.java.patch
@@ -5,9 +5,9 @@
      @Override
      public boolean hurtEnemy(ItemStack stack, LivingEntity target, LivingEntity attacker) {
 -        if (canSmashAttack(attacker)) {
-+        io.papermc.paper.event.entity.EntityAttemptSmashAttackEvent event = new io.papermc.paper.event.entity.EntityAttemptSmashAttackEvent(attacker.getBukkitLivingEntity(), target.getBukkitLivingEntity(), stack.asBukkitCopy());
++        io.papermc.paper.event.entity.EntityAttemptSmashAttackEvent event = new io.papermc.paper.event.entity.EntityAttemptSmashAttackEvent(attacker.getBukkitLivingEntity(), target.getBukkitLivingEntity(), stack.asBukkitCopy(), canSmashAttack(attacker));
 +        event.callEvent();
-+        if ((event.getResult() == org.bukkit.event.Event.Result.DEFAULT && canSmashAttack(attacker)) || event.getResult() == org.bukkit.event.Event.Result.ALLOW) {
++        if (!event.isCancelled()) {
              ServerLevel serverLevel = (ServerLevel)attacker.level();
              attacker.setDeltaMovement(attacker.getDeltaMovement().with(Direction.Axis.Y, 0.01F));
              if (attacker instanceof ServerPlayer serverPlayer) {

--- a/paper-server/patches/sources/net/minecraft/world/item/MaceItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/MaceItem.java.patch
@@ -1,15 +1,17 @@
 --- a/net/minecraft/world/item/MaceItem.java
 +++ b/net/minecraft/world/item/MaceItem.java
-@@ -61,7 +_,11 @@
+@@ -61,7 +_,13 @@
  
      @Override
      public boolean hurtEnemy(ItemStack stack, LivingEntity target, LivingEntity attacker) {
 -        if (canSmashAttack(attacker)) {
-+        boolean canSmashAttack = canSmashAttack(attacker);
++        // Paper start - Add EntityAttemptSmashAttackEvent
++        final boolean canSmashAttack = canSmashAttack(attacker);
 +        io.papermc.paper.event.entity.EntityAttemptSmashAttackEvent event = new io.papermc.paper.event.entity.EntityAttemptSmashAttackEvent(attacker.getBukkitLivingEntity(), target.getBukkitLivingEntity(), stack.asBukkitCopy(), canSmashAttack);
-+        event.setCancelled(!canSmashAttack);
 +        event.callEvent();
-+        if (!event.isCancelled()) {
++        final org.bukkit.event.Event.Result result = event.getResult();
++        if (result == org.bukkit.event.Event.Result.ALLOW || (canSmashAttack && result == org.bukkit.event.Event.Result.DEFAULT)) {
++        // Paper end - Add EntityAttemptSmashAttackEvent
              ServerLevel serverLevel = (ServerLevel)attacker.level();
              attacker.setDeltaMovement(attacker.getDeltaMovement().with(Direction.Axis.Y, 0.01F));
              if (attacker instanceof ServerPlayer serverPlayer) {

--- a/paper-server/patches/sources/net/minecraft/world/item/MaceItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/MaceItem.java.patch
@@ -1,11 +1,13 @@
 --- a/net/minecraft/world/item/MaceItem.java
 +++ b/net/minecraft/world/item/MaceItem.java
-@@ -61,7 +_,9 @@
+@@ -61,7 +_,11 @@
  
      @Override
      public boolean hurtEnemy(ItemStack stack, LivingEntity target, LivingEntity attacker) {
 -        if (canSmashAttack(attacker)) {
-+        io.papermc.paper.event.entity.EntityAttemptSmashAttackEvent event = new io.papermc.paper.event.entity.EntityAttemptSmashAttackEvent(attacker.getBukkitLivingEntity(), target.getBukkitLivingEntity(), stack.asBukkitCopy(), canSmashAttack(attacker));
++        boolean canSmashAttack = canSmashAttack(attacker);
++        io.papermc.paper.event.entity.EntityAttemptSmashAttackEvent event = new io.papermc.paper.event.entity.EntityAttemptSmashAttackEvent(attacker.getBukkitLivingEntity(), target.getBukkitLivingEntity(), stack.asBukkitCopy(), canSmashAttack);
++        event.setCancelled(!canSmashAttack);
 +        event.callEvent();
 +        if (!event.isCancelled()) {
              ServerLevel serverLevel = (ServerLevel)attacker.level();


### PR DESCRIPTION
Allows controlling of smash attacks. Makes it possible to bypass vanilla requirements (high enough fall distance and not flying) or set your own.