### PR TITLE
[ci skip] Fix annotation fields used in NMS getBukkitEntity

### DIFF
--- a/paper-server/patches/features/0006-Optimize-Collision-to-not-load-chunks.patch
+++ b/paper-server/patches/features/0006-Optimize-Collision-to-not-load-chunks.patch
@@ -22,7 +22,7 @@ index 334859c5ff7023c730513301cc11c9837b2c7823..45f69a914d5a0565196c4105d6154104
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason; // Paper - Entity#getEntitySpawnReason
  
 +    public boolean collisionLoadChunks = false; // Paper
-     private org.bukkit.craftbukkit.entity.CraftEntity bukkitEntity;
+     private @Nullable org.bukkit.craftbukkit.entity.CraftEntity bukkitEntity;
  
      public org.bukkit.craftbukkit.entity.CraftEntity getBukkitEntity() {
 diff --git a/net/minecraft/world/level/BlockCollisions.java b/net/minecraft/world/level/BlockCollisions.java

--- a/paper-server/patches/sources/net/minecraft/server/bossevents/CustomBossEvent.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/bossevents/CustomBossEvent.java.patch
@@ -5,7 +5,7 @@
      private int value;
      private int max = 100;
 +    // CraftBukkit start
-+    private org.bukkit.boss.KeyedBossBar bossBar;
++    private @javax.annotation.Nullable org.bukkit.boss.KeyedBossBar bossBar;
 +
 +    public org.bukkit.boss.KeyedBossBar getBukkitEntity() {
 +        if (this.bossBar == null) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -86,7 +86,7 @@
 +    // Paper end - Share random for entities to make them more random
 +    public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason; // Paper - Entity#getEntitySpawnReason
 +
-+    private org.bukkit.craftbukkit.entity.CraftEntity bukkitEntity;
++    private @Nullable org.bukkit.craftbukkit.entity.CraftEntity bukkitEntity;
 +
 +    public org.bukkit.craftbukkit.entity.CraftEntity getBukkitEntity() {
 +        if (this.bukkitEntity == null) {
@@ -101,7 +101,7 @@
 +        return this.bukkitEntity;
 +    }
 +    // Paper start
-+    public org.bukkit.craftbukkit.entity.CraftEntity getBukkitEntityRaw() {
++    public @Nullable org.bukkit.craftbukkit.entity.CraftEntity getBukkitEntityRaw() {
 +        return this.bukkitEntity;
 +    }
 +    // Paper end


### PR DESCRIPTION
This PR just add the missing annotation for nullable in bukkitEntity.