### PR TITLE
Fix `disable-tripwire-updates` option not cancelling tripwire hook updates

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/TripWireHookBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TripWireHookBlock.java.patch
@@ -1,6 +1,11 @@
 --- a/net/minecraft/world/level/block/TripWireHookBlock.java
 +++ b/net/minecraft/world/level/block/TripWireHookBlock.java
-@@ -127,10 +_,10 @@
+@@ -123,14 +_,15 @@
+     public static void calculateState(
+         Level level, BlockPos pos, BlockState hookState, boolean attaching, boolean shouldNotifyNeighbours, int searchRange, @Nullable BlockState state
+     ) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent tripwire from updating
+         Optional<Direction> optionalValue = hookState.getOptionalValue(FACING);
          if (optionalValue.isPresent()) {
              Direction direction = optionalValue.get();
              boolean flag = hookState.getOptionalValue(ATTACHED).orElse(false);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/TripWireHookBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TripWireHookBlock.java.patch
@@ -1,11 +1,6 @@
 --- a/net/minecraft/world/level/block/TripWireHookBlock.java
 +++ b/net/minecraft/world/level/block/TripWireHookBlock.java
-@@ -123,14 +_,15 @@
-     public static void calculateState(
-         Level level, BlockPos pos, BlockState hookState, boolean attaching, boolean shouldNotifyNeighbours, int searchRange, @Nullable BlockState state
-     ) {
-+        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent tripwire from updating
-         Optional<Direction> optionalValue = hookState.getOptionalValue(FACING);
+@@ -127,10 +_,10 @@
          if (optionalValue.isPresent()) {
              Direction direction = optionalValue.get();
              boolean flag = hookState.getOptionalValue(ATTACHED).orElse(false);
@@ -68,3 +63,11 @@
  
              if (flag != flag2) {
                  for (int i2 = 1; i2 < i; i2++) {
+@@ -188,6 +_,7 @@
+                     BlockState blockState2 = blockStates[i2];
+                     if (blockState2 != null) {
+                         BlockState blockState3 = level.getBlockState(blockPos1);
++                        if (blockState3.is(Blocks.TRIPWIRE) && io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent tripwire from updating
+                         if (blockState3.is(Blocks.TRIPWIRE) || blockState3.is(Blocks.TRIPWIRE_HOOK)) {
+                             level.setBlock(blockPos1, blockState2.trySetValue(ATTACHED, Boolean.valueOf(flag2)), 3);
+                         }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/TripWireHookBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TripWireHookBlock.java.patch
@@ -63,11 +63,12 @@
  
              if (flag != flag2) {
                  for (int i2 = 1; i2 < i; i2++) {
-@@ -188,6 +_,7 @@
-                     BlockState blockState2 = blockStates[i2];
+@@ -189,7 +_,7 @@
                      if (blockState2 != null) {
                          BlockState blockState3 = level.getBlockState(blockPos1);
-+                        if (blockState3.is(Blocks.TRIPWIRE) && io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent tripwire from updating
                          if (blockState3.is(Blocks.TRIPWIRE) || blockState3.is(Blocks.TRIPWIRE_HOOK)) {
-                             level.setBlock(blockPos1, blockState2.trySetValue(ATTACHED, Boolean.valueOf(flag2)), 3);
+-                            level.setBlock(blockPos1, blockState2.trySetValue(ATTACHED, Boolean.valueOf(flag2)), 3);
++                            if (!blockState3.is(Blocks.TRIPWIRE) || !io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) level.setBlock(blockPos1, blockState2.trySetValue(ATTACHED, Boolean.valueOf(flag2)), 3); // Paper - prevent tripwire from updating
                          }
+                     }
+                 }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/TripWireHookBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TripWireHookBlock.java.patch
@@ -68,7 +68,7 @@
                          BlockState blockState3 = level.getBlockState(blockPos1);
                          if (blockState3.is(Blocks.TRIPWIRE) || blockState3.is(Blocks.TRIPWIRE_HOOK)) {
 -                            level.setBlock(blockPos1, blockState2.trySetValue(ATTACHED, Boolean.valueOf(flag2)), 3);
-+                            if (!blockState3.is(Blocks.TRIPWIRE) || !io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) level.setBlock(blockPos1, blockState2.trySetValue(ATTACHED, Boolean.valueOf(flag2)), 3); // Paper - prevent tripwire from updating
++                            if (!io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates || !blockState3.is(Blocks.TRIPWIRE)) level.setBlock(blockPos1, blockState2.trySetValue(ATTACHED, Boolean.valueOf(flag2)), 3); // Paper - prevent tripwire from updating
                          }
                      }
                  }


### PR DESCRIPTION
Fixes #12127 

Currently the `disable-tripwire-updates` has a bug, it does NOT cancel updates from tripwire hook blocks, which change the attached state property of the tripwire.

This PR fixes this by blocking the `calculateState` method inside `TripWireHookBlock` from running.

This is justified as the methods only functionality is:
- Checking nearby blocks to find a correct tripwire line
- Setting `attached` appropriately
- Also managing redstone signals and firing events related to them (which already never happens when `disable-tripwire-updates` is on as the tripwires never get `powered`)

TLDR it only does block updates and nothing else, half of which are already not being ran with `disable-tripwire-updates`, hence I think the best solution is to just cancel the entire method.