### PR TITLE
Add Throw EntityChangeBlockEvent for BrushableBlockEntity#brush

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/BrushableBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/BrushableBlockEntity.java.patch
@@ -1,6 +1,70 @@
 --- a/net/minecraft/world/level/block/entity/BrushableBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/BrushableBlockEntity.java
-@@ -139,7 +_,12 @@
+@@ -64,17 +_,34 @@
+             return false;
+         } else {
+             this.coolDownEndsAtTick = startTick + 10L;
++            // Paper start - EntityChangeBlockEvent
++            // The vanilla logic here is *so* backwards, we'd be moving basically *all* following calls down.
++            // Instead, compute vanilla ourselves up here and just replace the below usages with our computed values for a free diff-on-change.
++            final int currentCompletionStage = this.getCompletionState();
++            final boolean enoughBrushesToBreak = ++this.brushCount >= REQUIRED_BRUSHES_TO_BREAK;
++            final int nextCompletionStage = this.getCompletionState();
++            final boolean differentCompletionStages = currentCompletionStage != nextCompletionStage;
++            final BlockState nextBrokenBlockState = this.getBlockState().setValue(BlockStateProperties.DUSTED, nextCompletionStage);
++            if (enoughBrushesToBreak || differentCompletionStages) {
++                if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(
++                    player, this.worldPosition, enoughBrushesToBreak ? computeTurnsTo().defaultBlockState() : nextBrokenBlockState
++                )) {
++                    brushCount--;
++                    return false;
++                }
++            }
++            // Paper end - EntityChangeBlockEvent
+             this.unpackLootTable(level, player, stack);
+-            int completionState = this.getCompletionState();
+-            if (++this.brushCount >= 10) {
++            int completionState = currentCompletionStage; // Paper - EntityChangeBlockEvent - use precomputed - diff on change
++            if (enoughBrushesToBreak) { // Paper - EntityChangeBlockEvent - use precomputed - diff on change
+                 this.brushingCompleted(level, player, stack);
+                 return true;
+             } else {
+                 level.scheduleTick(this.getBlockPos(), this.getBlockState().getBlock(), 2);
+-                int completionState1 = this.getCompletionState();
+-                if (completionState != completionState1) {
++                int completionState1 = nextCompletionStage; // Paper - EntityChangeBlockEvent - use precomputed - diff on change
++                if (differentCompletionStages) { // Paper - EntityChangeBlockEvent - use precomputed - diff on change
+                     BlockState blockState = this.getBlockState();
+-                    BlockState blockState1 = blockState.setValue(BlockStateProperties.DUSTED, Integer.valueOf(completionState1));
++                    BlockState blockState1 = nextBrokenBlockState; // Paper - EntityChangeBlockEvent - use precomputed - diff on change
+                     level.setBlock(this.getBlockPos(), blockState1, 3);
+                 }
+ 
+@@ -115,13 +_,22 @@
+         this.dropContent(level, player, stack);
+         BlockState blockState = this.getBlockState();
+         level.levelEvent(3008, this.getBlockPos(), Block.getId(blockState));
++    // Paper start - EntityChangeEvent - extract result block logic
++        this.brushingCompleteUpdateBlock(this.computeTurnsTo());
++    }
++    private Block computeTurnsTo() {
++    // Paper end - EntityChangeEvent - extract result block logic
+         Block turnsInto;
+         if (this.getBlockState().getBlock() instanceof BrushableBlock brushableBlock) {
+             turnsInto = brushableBlock.getTurnsInto();
+         } else {
+             turnsInto = Blocks.AIR;
+         }
+-
++    // Paper start - EntityChangeEvent - extract result block logic
++        return turnsInto;
++    }
++    public void brushingCompleteUpdateBlock(final Block turnsInto) {
++    // Paper end - EntityChangeEvent - extract result block logic
+         level.setBlock(this.worldPosition, turnsInto.defaultBlockState(), 3);
+     }
+ 
+@@ -138,7 +_,10 @@
              double d5 = blockPos.getZ() + 0.5 * d1 + d2;
              ItemEntity itemEntity = new ItemEntity(level, d3, d4, d5, this.item.split(level.random.nextInt(21) + 10));
              itemEntity.setDeltaMovement(Vec3.ZERO);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/BrushableBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/BrushableBlockEntity.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/entity/BrushableBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/BrushableBlockEntity.java
-@@ -64,17 +_,34 @@
+@@ -65,9 +_,26 @@
              return false;
          } else {
              this.coolDownEndsAtTick = startTick + 10L;
@@ -14,34 +14,32 @@
 +            final BlockState nextBrokenBlockState = this.getBlockState().setValue(BlockStateProperties.DUSTED, nextCompletionStage);
 +            if (enoughBrushesToBreak || differentCompletionStages) {
 +                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(
-+                    player, this.worldPosition, enoughBrushesToBreak ? computeTurnsTo().defaultBlockState() : nextBrokenBlockState
++                    brusher, this.worldPosition, enoughBrushesToBreak ? computeTurnsTo().defaultBlockState() : nextBrokenBlockState
 +                )) {
 +                    brushCount--;
 +                    return false;
 +                }
 +            }
 +            // Paper end - EntityChangeBlockEvent
-             this.unpackLootTable(level, player, stack);
+             this.unpackLootTable(level, brusher, stack);
 -            int completionState = this.getCompletionState();
 -            if (++this.brushCount >= 10) {
 +            int completionState = currentCompletionStage; // Paper - EntityChangeBlockEvent - use precomputed - diff on change
 +            if (enoughBrushesToBreak) { // Paper - EntityChangeBlockEvent - use precomputed - diff on change
-                 this.brushingCompleted(level, player, stack);
+                 this.brushingCompleted(level, brusher, stack);
                  return true;
              } else {
-                 level.scheduleTick(this.getBlockPos(), this.getBlockState().getBlock(), 2);
--                int completionState1 = this.getCompletionState();
--                if (completionState != completionState1) {
-+                int completionState1 = nextCompletionStage; // Paper - EntityChangeBlockEvent - use precomputed - diff on change
-+                if (differentCompletionStages) { // Paper - EntityChangeBlockEvent - use precomputed - diff on change
+@@ -75,7 +_,7 @@
+                 int completionState1 = this.getCompletionState();
+                 if (completionState != completionState1) {
                      BlockState blockState = this.getBlockState();
--                    BlockState blockState1 = blockState.setValue(BlockStateProperties.DUSTED, Integer.valueOf(completionState1));
+-                    BlockState blockState1 = blockState.setValue(BlockStateProperties.DUSTED, completionState1);
 +                    BlockState blockState1 = nextBrokenBlockState; // Paper - EntityChangeBlockEvent - use precomputed - diff on change
                      level.setBlock(this.getBlockPos(), blockState1, 3);
                  }
  
-@@ -115,6 +_,11 @@
-         this.dropContent(level, player, stack);
+@@ -116,6 +_,11 @@
+         this.dropContent(level, brusher, stack);
          BlockState blockState = this.getBlockState();
          level.levelEvent(3008, this.getBlockPos(), Block.getId(blockState));
 +    // Paper start - EntityChangeEvent - extract result block logic
@@ -52,7 +50,7 @@
          Block turnsInto;
          if (this.getBlockState().getBlock() instanceof BrushableBlock brushableBlock) {
              turnsInto = brushableBlock.getTurnsInto();
-@@ -122,6 +_,11 @@
+@@ -123,6 +_,11 @@
              turnsInto = Blocks.AIR;
          }
  
@@ -64,7 +62,7 @@
          level.setBlock(this.worldPosition, turnsInto.defaultBlockState(), 3);
      }
  
-@@ -138,7 +_,10 @@
+@@ -139,7 +_,12 @@
              double d5 = blockPos.getZ() + 0.5 * d1 + d2;
              ItemEntity itemEntity = new ItemEntity(level, d3, d4, d5, this.item.split(level.random.nextInt(21) + 10));
              itemEntity.setDeltaMovement(Vec3.ZERO);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/BrushableBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/BrushableBlockEntity.java.patch
@@ -40,7 +40,7 @@
                      level.setBlock(this.getBlockPos(), blockState1, 3);
                  }
  
-@@ -115,13 +_,22 @@
+@@ -115,6 +_,11 @@
          this.dropContent(level, player, stack);
          BlockState blockState = this.getBlockState();
          level.levelEvent(3008, this.getBlockPos(), Block.getId(blockState));
@@ -52,10 +52,10 @@
          Block turnsInto;
          if (this.getBlockState().getBlock() instanceof BrushableBlock brushableBlock) {
              turnsInto = brushableBlock.getTurnsInto();
-         } else {
+@@ -122,6 +_,11 @@
              turnsInto = Blocks.AIR;
          }
--
+ 
 +    // Paper start - EntityChangeEvent - extract result block logic
 +        return turnsInto;
 +    }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/BrushableBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/BrushableBlockEntity.java.patch
@@ -13,7 +13,7 @@
 +            final boolean differentCompletionStages = currentCompletionStage != nextCompletionStage;
 +            final BlockState nextBrokenBlockState = this.getBlockState().setValue(BlockStateProperties.DUSTED, nextCompletionStage);
 +            if (enoughBrushesToBreak || differentCompletionStages) {
-+                if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(
++                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(
 +                    player, this.worldPosition, enoughBrushesToBreak ? computeTurnsTo().defaultBlockState() : nextBrokenBlockState
 +                )) {
 +                    brushCount--;


### PR DESCRIPTION
This Pull Request adds calls for EntityChangeBlockEvent for BrushableBlockEntities. This allows for the increased tracking described in #12132.

This warrants further testing due to the fact that the point where the loot table is unpacked at *could* cause issues, however, I was unable to notice anything significant during my testing. Input for this aspect is appreciated.