### PR TITLE
Add FishHook#(get/set)BobbingFluids API

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/FishHook.java
+++ b/paper-api/src/main/java/org/bukkit/entity/FishHook.java
@@ -1,5 +1,11 @@
 package org.bukkit.entity;
 
+import io.papermc.paper.registry.keys.FluidKeys;
+import io.papermc.paper.registry.keys.tags.FluidTagKeys;
+import io.papermc.paper.registry.tag.TagKey;
+import org.bukkit.Fluid;
+import org.bukkit.event.player.PlayerFishEvent;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -367,5 +373,25 @@ public interface FishHook extends Projectile {
      * enchantment.
      */
     void resetFishingState();
+
+    /**
+     * Gets the bobbing fluid tag key that this fish hook can bob in.
+     *
+     * <p>The default is {@link FluidTagKeys#WATER}, meaning the hook will bob in water.</p>
+     * @return the fluid tag key that this fish hook can bob in
+     */
+    @ApiStatus.Experimental
+    @NotNull
+    TagKey<Fluid> getBobbingFluids();
+
+    /**
+     * Sets the bobbing fluid tag key that this fish hook can bob in.
+     *
+     * <p>The hook will be able to bob in the specified fluid. Notably, setting this to a tag key that
+     * includes {@link FluidKeys#LAVA} or {@link FluidKeys#FLOWING_LAVA} allows fish to bite even in lava.
+     * This also means that {@link PlayerFishEvent} will be triggered accordingly based on the state.</p>
+     */
+    @ApiStatus.Experimental
+    void setBobbingFluids(@NotNull TagKey<Fluid> fluids);
     // Paper end
 }

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/projectile/FishingHook.java
 +++ b/net/minecraft/world/entity/projectile/FishingHook.java
-@@ -66,10 +_,26 @@
+@@ -66,10 +_,28 @@
      private final int luck;
      private final int lureSpeed;
  
@@ -15,6 +15,8 @@
 +    public boolean rainInfluenced = true;
 +    public boolean skyInfluenced = true;
 +    // CraftBukkit end
++
++    public net.minecraft.tags.TagKey<net.minecraft.world.level.material.Fluid> fluidTagKey = FluidTags.WATER; // Paper - Add FishHook#(set/get)bobbingFluids api
 +
      private FishingHook(EntityType<? extends FishingHook> entityType, Level level, int luck, int lureSpeed) {
          super(entityType, level);
@@ -42,6 +44,24 @@
                      return;
                  }
              } else {
+@@ -162,7 +_,7 @@
+             float f = 0.0F;
+             BlockPos blockPos = this.blockPosition();
+             FluidState fluidState = this.level().getFluidState(blockPos);
+-            if (fluidState.is(FluidTags.WATER)) {
++            if (fluidState.is(this.fluidTagKey)) { // Paper - Add FishHook#(set/get)bobbingFluids api
+                 f = fluidState.getHeight(this.level(), blockPos);
+             }
+ 
+@@ -226,7 +_,7 @@
+                 }
+             }
+ 
+-            if (!fluidState.is(FluidTags.WATER)) {
++            if (!fluidState.is(this.fluidTagKey)) { // Paper - Add FishHook#(set/get)bobbingFluids api
+                 this.setDeltaMovement(this.getDeltaMovement().add(0.0, -0.03, 0.0));
+             }
+ 
 @@ -251,14 +_,14 @@
          if (!player.isRemoved() && player.isAlive() && (isFishingRod || isFishingRod1) && !(this.distanceToSqr(player) > 1024.0)) {
              return false;
@@ -84,6 +104,21 @@
              }
          } else if (this.timeUntilHooked > 0) {
              this.timeUntilHooked -= i;
+@@ -314,8 +_,12 @@
+                 double d = this.getX() + sin * this.timeUntilHooked * 0.1F;
+                 double d1 = Mth.floor(this.getY()) + 1.0F;
+                 double d2 = this.getZ() + cos * this.timeUntilHooked * 0.1F;
+-                BlockState blockState = serverLevel.getBlockState(BlockPos.containing(d, d1 - 1.0, d2));
+-                if (blockState.is(Blocks.WATER)) {
++                // Paper start - Modify to generate particles with fluids other than water.
++                // BlockState blockState = serverLevel.getBlockState(BlockPos.containing(d, d1 - 1.0, d2));
++                // if (blockState.is(Blocks.WATER)) {
++                FluidState fluidState = serverLevel.getFluidState(BlockPos.containing(d, d1 - 1.0, d2));
++                if (fluidState.is(this.fluidTagKey)) {
++                // Paper end - Modify to generate particles with fluids other than water.
+                     if (this.random.nextFloat() < 0.15F) {
+                         serverLevel.sendParticles(ParticleTypes.BUBBLE, d, d1 - 0.1F, d2, 1, sin, 0.1, cos, 0.0);
+                     }
 @@ -326,6 +_,13 @@
                      serverLevel.sendParticles(ParticleTypes.FISHING, d, d1, d2, 0, -f2, 0.01, f1, 1.0);
                  }
@@ -98,7 +133,20 @@
                  this.playSound(SoundEvents.FISHING_BOBBER_SPLASH, 0.25F, 1.0F + (this.random.nextFloat() - this.random.nextFloat()) * 0.4F);
                  double d3 = this.getY() + 0.5;
                  serverLevel.sendParticles(
-@@ -377,14 +_,33 @@
+@@ -370,21 +_,44 @@
+                 double d = this.getX() + Mth.sin(sin) * cos * 0.1;
+                 double d1 = Mth.floor(this.getY()) + 1.0F;
+                 double d2 = this.getZ() + Mth.cos(sin) * cos * 0.1;
+-                BlockState blockState = serverLevel.getBlockState(BlockPos.containing(d, d1 - 1.0, d2));
+-                if (blockState.is(Blocks.WATER)) {
++                // Paper start - Modify to generate particles with fluids other than water.
++                // BlockState blockState = serverLevel.getBlockState(BlockPos.containing(d, d1 - 1.0, d2));
++                // if (blockState.is(Blocks.WATER)) {
++                FluidState fluidState = serverLevel.getFluidState(BlockPos.containing(d, d1 - 1.0, d2));
++                if (fluidState.is(this.fluidTagKey)) {
++                // Paper end - Modify to generate particles with fluids other than water.
+                     serverLevel.sendParticles(ParticleTypes.SPLASH, d, d1, d2, 2 + this.random.nextInt(2), 0.1F, 0.0, 0.1F, 0.0);
+                 }
              }
  
              if (this.timeUntilLured <= 0) {
@@ -136,6 +184,15 @@
  
      public boolean calculateOpenWater(BlockPos pos) {
          FishingHook.OpenWaterType openWaterType = FishingHook.OpenWaterType.INVALID;
+@@ -423,7 +_,7 @@
+         BlockState blockState = this.level().getBlockState(pos);
+         if (!blockState.isAir() && !blockState.is(Blocks.LILY_PAD)) {
+             FluidState fluidState = blockState.getFluidState();
+-            return fluidState.is(FluidTags.WATER) && fluidState.isSource() && blockState.getCollisionShape(this.level(), pos).isEmpty()
++            return fluidState.is(this.fluidTagKey) && fluidState.isSource() && blockState.getCollisionShape(this.level(), pos).isEmpty() // Paper - More fishhook api
+                 ? FishingHook.OpenWaterType.INSIDE_WATER
+                 : FishingHook.OpenWaterType.INVALID;
+         } else {
 @@ -443,15 +_,34 @@
      public void readAdditionalSaveData(CompoundTag compound) {
      }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
@@ -1,11 +1,15 @@
 package org.bukkit.craftbukkit.entity;
 
 import com.google.common.base.Preconditions;
+import io.papermc.paper.registry.PaperRegistries;
+import io.papermc.paper.registry.tag.TagKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.projectile.FishingHook;
+import org.bukkit.Fluid;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.FishHook;
+import org.jetbrains.annotations.NotNull;
 
 public class CraftFishHook extends CraftProjectile implements FishHook {
     private double biteChance = -1;
@@ -232,6 +236,16 @@ public class CraftFishHook extends CraftProjectile implements FishHook {
         final FishingHook hook = this.getHandle();
         hook.resetTimeUntilLured();
         hook.timeUntilHooked = 0; // Reset time until hooked, will be repopulated once lured time is ticked down.
+    }
+
+    @Override
+    public @NotNull TagKey<Fluid> getBobbingFluids() {
+        return PaperRegistries.fromNms(this.getHandle().fluidTagKey);
+    }
+
+    @Override
+    public void setBobbingFluids(@NotNull final TagKey<Fluid> fluids) {
+        this.getHandle().fluidTagKey = PaperRegistries.toNms(fluids);
     }
     // Paper end
 }


### PR DESCRIPTION
### Implements #12126

This PR allows modifying the `TagKey` referenced by `FishHook` for bobbing.  
If the associated `TagKey` includes `lava` or `flowing_lava`, fish will now be able to bite in those fluids as well.  

### ⚠ Important Notes  
This works correctly on the **server-side**, but there are some strange **client-side desync issues** to be aware of.  

If the `TagKey` includes `lava` or `flowing_lava` **without** including `water` or `flowing_water`, the client perceives the behavior differently:  
- The fishing hook **does not appear to bob** on lava.  
- The fishing hook **appears to bob** on water, even if it shouldn't.  

To make this issue clearer, I’ve attached a video demonstrating the behavior.

https://github.com/user-attachments/assets/befab695-133e-46a3-862b-5a68bf354217



I'm not very familiar with **packet handling**, so I don’t know of a good solution for this—sorry about that.  

### Other Notes  
I’ve read the **CONTRIBUTING.md**, but since this is my first contribution to Paper and my English isn’t very strong, I might have written something strange. Please check the javadoc carefully! 😆  

Additionally, I used **`PaperRegistries`** for the conversion between NMS and Paper `TagKey`, but I’m not entirely sure if that’s the correct approach.  

Thank you for your time and review! 🙇‍♂️ 