### PR TITLE
Hide soul speed particles for vanished players

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -870,11 +870,11 @@
          double zOffset,
          double speed
      ) {
-+    // CraftBukkit start - visibility api support
++    // Paper start - visibility api support
 +        return this.sendParticlesSource(null, type, overrideLimiter, alwaysShow, posX, posY, posZ, particleCount, xOffset, yOffset, zOffset, speed);
 +    }
 +    public <T extends ParticleOptions> int sendParticlesSource(
-+        @javax.annotation.Nullable ServerPlayer sender,
++        @javax.annotation.Nullable Entity sender,
 +        T type,
 +        boolean overrideLimiter,
 +        boolean alwaysShow,
@@ -891,7 +891,7 @@
 +    }
 +    public <T extends ParticleOptions> int sendParticlesSource(
 +        List<ServerPlayer> receivers,
-+        @javax.annotation.Nullable ServerPlayer sender,
++        @javax.annotation.Nullable Entity sender,
 +        T type,
 +        boolean overrideLimiter,
 +        boolean alwaysShow,
@@ -904,7 +904,7 @@
 +        double zOffset,
 +        double speed
 +    ) {
-+    // CraftBukkit end - visibility api support
++    // Paper end - visibility api support
          ClientboundLevelParticlesPacket clientboundLevelParticlesPacket = new ClientboundLevelParticlesPacket(
              type, overrideLimiter, alwaysShow, posX, posY, posZ, (float)xOffset, (float)yOffset, (float)zOffset, (float)speed, particleCount
          );

--- a/paper-server/patches/sources/net/minecraft/world/item/enchantment/effects/SpawnParticlesEffect.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/enchantment/effects/SpawnParticlesEffect.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/world/item/enchantment/effects/SpawnParticlesEffect.java
++++ b/net/minecraft/world/item/enchantment/effects/SpawnParticlesEffect.java
+@@ -58,8 +58,13 @@ public record SpawnParticlesEffect(
+         Vec3 knownMovement = entity.getKnownMovement();
+         float bbWidth = entity.getBbWidth();
+         float bbHeight = entity.getBbHeight();
+-        level.sendParticles(
++        // Paper start - Hide soul speed particles for vanished players
++        level.sendParticlesSource(
++            entity instanceof net.minecraft.server.level.ServerPlayer player ? player : null,
+             this.particle,
++            false,
++            false,
++        // Paper end - Hide soul speed particles for vanished players
+             this.horizontalPosition.getCoordinate(origin.x(), origin.x(), bbWidth, random),
+             this.verticalPosition.getCoordinate(origin.y(), origin.y() + bbHeight / 2.0F, bbHeight, random),
+             this.horizontalPosition.getCoordinate(origin.z(), origin.z(), bbWidth, random),

--- a/paper-server/patches/sources/net/minecraft/world/item/enchantment/effects/SpawnParticlesEffect.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/enchantment/effects/SpawnParticlesEffect.java.patch
@@ -1,13 +1,13 @@
 --- a/net/minecraft/world/item/enchantment/effects/SpawnParticlesEffect.java
 +++ b/net/minecraft/world/item/enchantment/effects/SpawnParticlesEffect.java
-@@ -58,8 +58,13 @@ public record SpawnParticlesEffect(
+@@ -58,8 +_,13 @@
          Vec3 knownMovement = entity.getKnownMovement();
          float bbWidth = entity.getBbWidth();
          float bbHeight = entity.getBbHeight();
 -        level.sendParticles(
 +        // Paper start - Hide soul speed particles for vanished players
 +        level.sendParticlesSource(
-+            entity instanceof net.minecraft.server.level.ServerPlayer player ? player : null,
++            entity,
              this.particle,
 +            false,
 +            false,


### PR DESCRIPTION
Replaces the call to `sendParticles()` with `sendParticlesSource()` in `SpawnParticlesEffect` in order to attribute the effect to the player