### PR TITLE
Call EntityChangeBlockEvent with correct block when waxing

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/item/HoneycombItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/HoneycombItem.java.patch
@@ -5,7 +5,7 @@
              Player player = context.getPlayer();
              ItemStack itemInHand = context.getItemInHand();
 +            // Paper start - EntityChangeBlockEvent
-+            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, clickedPos, blockState)) {
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, clickedPos, blockState1)) {
 +                if (!player.isCreative()) {
 +                    player.containerMenu.sendAllDataToRemote();
 +                }


### PR DESCRIPTION
At some point along the hardfork process, this patch got messed up and started passing both the "from" and "to" blocks to be the same when using a honeycomb to wax a copper block.

This patch restores previous behaviour.