### PR TITLE
Fix ipv6 loopback addresses being able to get connection throttled

### DIFF
--- a/paper-server/patches/features/0016-Fix-entity-tracker-desync-when-new-players-are-added.patch
+++ b/paper-server/patches/features/0016-Fix-entity-tracker-desync-when-new-players-are-added.patch
@@ -60,7 +60,7 @@ index 1463c31ba980ab0eb2174e3e891d1423a505e9dc..886340232b58afd59caa6df29e211589
                  } else if (this.seenBy.remove(player.connection)) {
                      this.serverEntity.removePairing(player);
 diff --git a/net/minecraft/server/level/ServerEntity.java b/net/minecraft/server/level/ServerEntity.java
-index 0005a1784ccaa00e5d6d67e7be98445150487982..257ecbcf7d463eefb951867a5426eaf24e356305 100644
+index a1ae77b70f69852d9e4332bf1cb3409c33b21de0..b118e91f1e0b5a8b8c0b2a4a32faabc5a34a5954 100644
 --- a/net/minecraft/server/level/ServerEntity.java
 +++ b/net/minecraft/server/level/ServerEntity.java
 @@ -103,6 +103,13 @@ public class ServerEntity {
@@ -77,7 +77,7 @@ index 0005a1784ccaa00e5d6d67e7be98445150487982..257ecbcf7d463eefb951867a5426eaf2
      public void sendChanges() {
          // Paper start - optimise collisions
          if (((ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity)this.entity).moonrise$isHardColliding()) {
-@@ -136,7 +143,7 @@ public class ServerEntity {
+@@ -141,7 +148,7 @@ public class ServerEntity {
              this.sendDirtyEntityData();
          }
  
@@ -86,7 +86,7 @@ index 0005a1784ccaa00e5d6d67e7be98445150487982..257ecbcf7d463eefb951867a5426eaf2
              byte b = Mth.packDegrees(this.entity.getYRot());
              byte b1 = Mth.packDegrees(this.entity.getXRot());
              boolean flag = Math.abs(b - this.lastSentYRot) >= 1 || Math.abs(b1 - this.lastSentXRot) >= 1;
-@@ -171,7 +178,7 @@ public class ServerEntity {
+@@ -176,7 +183,7 @@ public class ServerEntity {
                  long l1 = this.positionCodec.encodeY(vec3);
                  long l2 = this.positionCodec.encodeZ(vec3);
                  boolean flag5 = l < -32768L || l > 32767L || l1 < -32768L || l1 > 32767L || l2 < -32768L || l2 > 32767L;
@@ -95,7 +95,7 @@ index 0005a1784ccaa00e5d6d67e7be98445150487982..257ecbcf7d463eefb951867a5426eaf2
                      this.wasOnGround = this.entity.onGround();
                      this.teleportDelay = 0;
                      packet = ClientboundEntityPositionSyncPacket.of(this.entity);
-@@ -236,6 +243,7 @@ public class ServerEntity {
+@@ -241,6 +248,7 @@ public class ServerEntity {
              }
  
              this.entity.hasImpulse = false;

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java.patch
@@ -9,10 +9,10 @@
 +    static final java.util.regex.Pattern HOST_PATTERN = java.util.regex.Pattern.compile("[0-9a-f\\.:]{0,45}");
 +    static final java.util.regex.Pattern PROP_PATTERN = java.util.regex.Pattern.compile("\\w{0,16}");
 +    // Spigot end
-+    // CraftBukkit start - add fields
-+    private static final java.util.HashMap<java.net.InetAddress, Long> throttleTracker = new java.util.HashMap<>();
++    // Paper start - Connection throttle
++    private static final java.util.Map<java.net.InetAddress, Long> throttleTracker = new java.util.HashMap<>();
 +    private static int throttleCounter = 0;
-+    // CraftBukkit end
++    // Paper end - Connection throttle
 +    private static final boolean BYPASS_HOSTCHECK = Boolean.getBoolean("Paper.bypassHostCheck"); // Paper
      private final MinecraftServer server;
      private final Connection connection;
@@ -29,7 +29,7 @@
          switch (packet.intention()) {
              case LOGIN:
                  this.beginLogin(packet, false);
-@@ -50,22 +_,117 @@
+@@ -50,22 +_,118 @@
              default:
                  throw new UnsupportedOperationException("Invalid intention " + packet.intention());
          }
@@ -42,17 +42,18 @@
  
      private void beginLogin(ClientIntentionPacket packet, boolean transferred) {
          this.connection.setupOutboundProtocol(LoginProtocols.CLIENTBOUND);
-+        // CraftBukkit start - Connection throttle
++        // Paper start - Connection throttle
 +        try {
-+            if (!(this.connection.channel.localAddress() instanceof io.netty.channel.unix.DomainSocketAddress)) { // Paper - Unix domain socket support; the connection throttle is useless when you have a Unix domain socket
++            final long connectionThrottle = this.server.server.getConnectionThrottle();
++            final boolean isUnixDomainSocket = this.connection.channel.localAddress() instanceof io.netty.channel.unix.DomainSocketAddress; // Paper - Unix domain socket support; the connection throttle is useless when you have a Unix domain socket
++            if (connectionThrottle > 0 && !isUnixDomainSocket && this.connection.getRemoteAddress() instanceof java.net.InetSocketAddress socketAddress && !socketAddress.isUnresolved() && !socketAddress.getAddress().isLoopbackAddress()) {
 +                long currentTime = System.currentTimeMillis();
-+                long connectionThrottle = this.server.server.getConnectionThrottle();
-+                java.net.InetAddress address = ((java.net.InetSocketAddress) this.connection.getRemoteAddress()).getAddress();
++                java.net.InetAddress address = socketAddress.getAddress();
 +
 +                synchronized (ServerHandshakePacketListenerImpl.throttleTracker) {
-+                    if (ServerHandshakePacketListenerImpl.throttleTracker.containsKey(address) && !"127.0.0.1".equals(address.getHostAddress()) && currentTime - ServerHandshakePacketListenerImpl.throttleTracker.get(address) < connectionThrottle) {
++                    if (ServerHandshakePacketListenerImpl.throttleTracker.containsKey(address) && currentTime - ServerHandshakePacketListenerImpl.throttleTracker.get(address) < connectionThrottle) {
 +                        ServerHandshakePacketListenerImpl.throttleTracker.put(address, currentTime);
-+                        Component chatmessage = io.papermc.paper.adventure.PaperAdventure.asVanilla(io.papermc.paper.configuration.GlobalConfiguration.get().messages.kick.connectionThrottle); // Paper - Configurable connection throttle kick message
++                        Component chatmessage = io.papermc.paper.adventure.PaperAdventure.asVanilla(io.papermc.paper.configuration.GlobalConfiguration.get().messages.kick.connectionThrottle);
 +                        this.connection.send(new ClientboundLoginDisconnectPacket(chatmessage));
 +                        this.connection.disconnect(chatmessage);
 +                        return;
@@ -67,11 +68,11 @@
 +                        ServerHandshakePacketListenerImpl.throttleTracker.values().removeIf(time -> time > connectionThrottle);
 +                    }
 +                }
-+            } // Paper - Unix domain socket support
++            }
 +        } catch (Throwable t) {
 +            org.apache.logging.log4j.LogManager.getLogger().debug("Failed to check connection throttle", t);
 +        }
-+        // CraftBukkit end
++        // Paper end - Connection throttle
          if (packet.protocolVersion() != SharedConstants.getCurrentVersion().getProtocolVersion()) {
 -            Component component;
 -            if (packet.protocolVersion() < 754) {


### PR DESCRIPTION
Cleans up the connection throttle code and replaces a hardcoded check excluding the ipv4 loopback address 