### PR TITLE
Always pass event block to damage source

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/damagesource/DamageSource.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/damagesource/DamageSource.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/damagesource/DamageSource.java
 +++ b/net/minecraft/world/damagesource/DamageSource.java
-@@ -20,6 +_,92 @@
+@@ -20,6 +_,97 @@
      private final Entity directEntity;
      @Nullable
      private final Vec3 damageSourcePosition;
@@ -60,11 +60,16 @@
 +        return this.fromBlockSnapshot;
 +    }
 +
-+    public DamageSource causingBlockSnapshot(final @Nullable org.bukkit.block.BlockState blockState) {
++    public DamageSource causingBlockSnapshot(
++        final net.minecraft.world.level.LevelAccessor level,
++        final net.minecraft.core.BlockPos pos,
++        final @Nullable org.bukkit.block.BlockState blockState
++    ) {
 +        if (this.eventBlockDamager != null) {
 +            throw new IllegalStateException("Cannot set a block snapshot when an event block damager is already set (report a bug to Paper)");
 +        }
 +        final DamageSource damageSource = this.copy();
++        damageSource.eventBlockDamager = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
 +        damageSource.fromBlockSnapshot = blockState;
 +        return damageSource;
 +    }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/BedBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/BedBlock.java.patch
@@ -59,7 +59,7 @@
 +        }
 +
 +        Vec3 center = pos.getCenter();
-+        level.explode(null, level.damageSources().badRespawnPointExplosion(center).causingBlockSnapshot(blockState), null, center, 5.0F, true, Level.ExplosionInteraction.BLOCK); // CraftBukkit - add state
++        level.explode(null, level.damageSources().badRespawnPointExplosion(center).causingBlockSnapshot(level, pos, blockState), null, center, 5.0F, true, Level.ExplosionInteraction.BLOCK); // CraftBukkit - add state
 +        return InteractionResult.SUCCESS_SERVER;
 +     }
 +    // CraftBukkit end

--- a/paper-server/patches/sources/net/minecraft/world/level/block/RespawnAnchorBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/RespawnAnchorBlock.java.patch
@@ -31,7 +31,7 @@
          Vec3 center = pos2.getCenter();
          level.explode(
 -            null, level.damageSources().badRespawnPointExplosion(center), explosionDamageCalculator, center, 5.0F, true, Level.ExplosionInteraction.BLOCK
-+            null, level.damageSources().badRespawnPointExplosion(center).causingBlockSnapshot(blockState), explosionDamageCalculator, center, 5.0F, true, Level.ExplosionInteraction.BLOCK // CraftBukkit - add state
++            null, level.damageSources().badRespawnPointExplosion(center).causingBlockSnapshot(level, pos2, blockState), explosionDamageCalculator, center, 5.0F, true, Level.ExplosionInteraction.BLOCK // CraftBukkit - add state
          );
      }
  


### PR DESCRIPTION
Always passes the respective block to a damage source when passing a
block state. While we could technically use the damageSourcePosition
here by, we'd have to translate it back to a block position by
subtracting .5 from all its components.
Such behaviour however relies on the caller logic's mutation of the
damageSourcePosition and will break once this position is not the centre
of the block.

Passing in the block at the specific callsite is a lot more future
proof.

Resolves: #12157
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-12158.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/2625842562.zip)