### PR TITLE
Fix cancelled HangingPlaceEvent inventory desync

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/item/HangingEntityItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/HangingEntityItem.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/HangingEntityItem.java
 +++ b/net/minecraft/world/item/HangingEntityItem.java
-@@ -66,6 +_,19 @@
+@@ -66,6 +_,20 @@
  
              if (hangingEntity.survives()) {
                  if (!level.isClientSide) {
@@ -14,6 +14,7 @@
 +                    level.getCraftServer().getPluginManager().callEvent(event);
 +
 +                    if (event.isCancelled()) {
++                        if (player != null) player.containerMenu.sendAllDataToRemote(); // Paper - Fix inventory desync
 +                        return InteractionResult.FAIL;
 +                    }
 +                    // CraftBukkit end


### PR DESCRIPTION
Like other events of this nature, the client will still shrink the item by 1 when the event is cancelled and become desynced.