### PR TITLE
Add additional ray trace API

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/raytracing/BlockCollisionMode.java
+++ b/paper-api/src/main/java/io/papermc/paper/raytracing/BlockCollisionMode.java
@@ -1,0 +1,20 @@
+package io.papermc.paper.raytracing;
+
+/**
+ * Determines the collision behavior when blocks get hit during ray tracing.
+ */
+public enum BlockCollisionMode {
+
+    /**
+     * Use the collision shape.
+     */
+    COLLIDER,
+    /**
+     * Use the outline shape.
+     */
+    OUTLINE,
+    /**
+     * Use the visual shape.
+     */
+    VISUAL
+}

--- a/paper-api/src/main/java/io/papermc/paper/raytracing/PositionedRayTraceConfigurationBuilder.java
+++ b/paper-api/src/main/java/io/papermc/paper/raytracing/PositionedRayTraceConfigurationBuilder.java
@@ -46,9 +46,6 @@ public interface PositionedRayTraceConfigurationBuilder {
 
     /**
      * Sets the FluidCollisionMode when looking for block collisions.
-     * <p>
-     * If collisions with passable blocks are ignored, fluid collisions are
-     * ignored as well regardless of the fluid collision mode.
      *
      * @param fluidCollisionMode the new FluidCollisionMode
      * @return a reference to this object
@@ -57,15 +54,17 @@ public interface PositionedRayTraceConfigurationBuilder {
     PositionedRayTraceConfigurationBuilder fluidCollisionMode(FluidCollisionMode fluidCollisionMode);
 
     /**
+     * Sets the BlockCollisionMode when looking for block collisions.
+     *
+     * @param blockCollisionMode the new BlockCollisionMode
+     * @return a reference to this object
+     */
+    @Contract(value = "_ -> this", mutates = "this")
+    PositionedRayTraceConfigurationBuilder blockCollisionMode(BlockCollisionMode blockCollisionMode);
+
+    /**
      * Sets whether the raytrace should ignore passable blocks when looking for
      * block collisions.
-     * <p>
-     * If collisions with passable blocks are ignored, fluid collisions are
-     * ignored as well regardless of the fluid collision mode.
-     * <p>
-     * Portal blocks are only considered passable if the ray starts within them.
-     * Apart from that collisions with portal blocks will be considered even if
-     * collisions with passable blocks are otherwise ignored.
      *
      * @param ignorePassableBlocks if the raytrace should ignore passable blocks
      * @return a reference to this object

--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -1901,13 +1901,6 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * Performs a ray trace that checks for block collisions using the blocks'
      * precise collision shapes.
      * <p>
-     * If collisions with passable blocks are ignored, fluid collisions are
-     * ignored as well regardless of the fluid collision mode.
-     * <p>
-     * Portal blocks are only considered passable if the ray starts within
-     * them. Apart from that collisions with portal blocks will be considered
-     * even if collisions with passable blocks are otherwise ignored.
-     * <p>
      * This may cause loading of chunks! Some implementations may impose
      * artificial restrictions on the maximum distance.
      *
@@ -1924,17 +1917,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
         return this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, null);
     }
 
-    // Paper start
     /**
      * Performs a ray trace that checks for block collisions using the blocks'
      * precise collision shapes.
-     * <p>
-     * If collisions with passable blocks are ignored, fluid collisions are
-     * ignored as well regardless of the fluid collision mode.
-     * <p>
-     * Portal blocks are only considered passable if the ray starts within
-     * them. Apart from that collisions with portal blocks will be considered
-     * even if collisions with passable blocks are otherwise ignored.
      * <p>
      * This may cause loading of chunks! Some implementations may impose
      * artificial restrictions on the maximum distance.
@@ -1950,7 +1935,6 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * @return the ray trace hit result, or <code>null</code> if there is no hit
      */
     @Nullable RayTraceResult rayTraceBlocks(io.papermc.paper.math.@NotNull Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, @Nullable Predicate<? super Block> canCollide);
-    // Paper end
 
     /**
      * Performs a ray trace that checks for both block and entity collisions.
@@ -1958,13 +1942,6 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * Block collisions use the blocks' precise collision shapes. The
      * <code>raySize</code> parameter is only taken into account for entity
      * collision checks.
-     * <p>
-     * If collisions with passable blocks are ignored, fluid collisions are
-     * ignored as well regardless of the fluid collision mode.
-     * <p>
-     * Portal blocks are only considered passable if the ray starts within them.
-     * Apart from that collisions with portal blocks will be considered even if
-     * collisions with passable blocks are otherwise ignored.
      * <p>
      * This may cause loading of chunks! Some implementations may impose
      * artificial restrictions on the maximum distance.
@@ -1987,20 +1964,12 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
         return this.rayTrace(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, raySize, filter, null);
     }
 
-    // Paper start
     /**
      * Performs a ray trace that checks for both block and entity collisions.
      * <p>
      * Block collisions use the blocks' precise collision shapes. The
      * <code>raySize</code> parameter is only taken into account for entity
      * collision checks.
-     * <p>
-     * If collisions with passable blocks are ignored, fluid collisions are
-     * ignored as well regardless of the fluid collision mode.
-     * <p>
-     * Portal blocks are only considered passable if the ray starts within them.
-     * Apart from that collisions with portal blocks will be considered even if
-     * collisions with passable blocks are otherwise ignored.
      * <p>
      * This may cause loading of chunks! Some implementations may impose
      * artificial restrictions on the maximum distance.
@@ -2021,7 +1990,6 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      *     entity, or <code>null</code> if there is no hit
      */
     @Nullable RayTraceResult rayTrace(io.papermc.paper.math.@NotNull Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, @Nullable Predicate<? super Entity> filter, @Nullable Predicate<? super Block> canCollide);
-    // Paper end
 
     /**
      * Performs a ray trace that checks for collisions with the specified

--- a/paper-server/src/main/java/io/papermc/paper/raytracing/PositionedRayTraceConfigurationBuilderImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/raytracing/PositionedRayTraceConfigurationBuilderImpl.java
@@ -19,7 +19,7 @@ public class PositionedRayTraceConfigurationBuilderImpl implements PositionedRay
     public @Nullable Vector direction;
     public OptionalDouble maxDistance = OptionalDouble.empty();
     public FluidCollisionMode fluidCollisionMode = FluidCollisionMode.NEVER;
-    public boolean ignorePassableBlocks;
+    public BlockCollisionMode blockCollisionMode = BlockCollisionMode.OUTLINE;
     public double raySize = 0.0D;
     public @Nullable Predicate<? super Entity> entityFilter;
     public @Nullable Predicate<? super Block> blockFilter;
@@ -54,8 +54,15 @@ public class PositionedRayTraceConfigurationBuilderImpl implements PositionedRay
     }
 
     @Override
+    public PositionedRayTraceConfigurationBuilder blockCollisionMode(final BlockCollisionMode blockCollisionMode) {
+        Preconditions.checkArgument(blockCollisionMode != null, "blockCollisionMode must not be null");
+        this.blockCollisionMode = blockCollisionMode;
+        return this;
+    }
+
+    @Override
     public PositionedRayTraceConfigurationBuilder ignorePassableBlocks(final boolean ignorePassableBlocks) {
-        this.ignorePassableBlocks = ignorePassableBlocks;
+        this.blockCollisionMode = ignorePassableBlocks ? BlockCollisionMode.COLLIDER : BlockCollisionMode.OUTLINE;
         return this;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -7,6 +7,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Lists;
 import com.mojang.datafixers.util.Pair;
 import io.papermc.paper.FeatureHooks;
+import io.papermc.paper.raytracing.BlockCollisionMode;
 import io.papermc.paper.raytracing.PositionedRayTraceConfigurationBuilder;
 import io.papermc.paper.raytracing.PositionedRayTraceConfigurationBuilderImpl;
 import io.papermc.paper.raytracing.RayTraceTarget;
@@ -1035,6 +1036,10 @@ public class CraftWorld extends CraftRegionAccessor implements World {
 
     @Override
     public RayTraceResult rayTraceBlocks(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, Predicate<? super Block> canCollide) {
+        return this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks ? BlockCollisionMode.COLLIDER : BlockCollisionMode.OUTLINE, canCollide);
+    }
+
+    public RayTraceResult rayTraceBlocks(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, BlockCollisionMode blockCollisionMode, Predicate<? super Block> canCollide) {
         Preconditions.checkArgument(start != null, "Location start cannot be null");
         Preconditions.checkArgument(!(start instanceof Location location) || this.equals(location.getWorld()), "Location start cannot be in a different world");
         Preconditions.checkArgument(start.isFinite(), "Location start is not finite");
@@ -1044,6 +1049,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
 
         Preconditions.checkArgument(direction.lengthSquared() > 0, "Direction's magnitude (%s) need to be greater than 0", direction.lengthSquared());
         Preconditions.checkArgument(fluidCollisionMode != null, "FluidCollisionMode cannot be null");
+        Preconditions.checkArgument(blockCollisionMode != null, "BlockCollisionMode cannot be null");
 
         if (maxDistance < 0.0D) {
             return null;
@@ -1052,14 +1058,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
         Vector dir = direction.clone().normalize().multiply(maxDistance);
         Vec3 startPos = io.papermc.paper.util.MCUtil.toVec3(start); // Paper - Add predicate for blocks when raytracing
         Vec3 endPos = startPos.add(dir.getX(), dir.getY(), dir.getZ());
-        HitResult hitResult = this.getHandle().clip(new ClipContext(startPos, endPos, ignorePassableBlocks ? ClipContext.Block.COLLIDER : ClipContext.Block.OUTLINE, CraftFluidCollisionMode.toFluid(fluidCollisionMode), CollisionContext.empty()), canCollide); // Paper - Add predicate for blocks when raytracing
+        HitResult hitResult = this.getHandle().clip(new ClipContext(startPos, endPos, ClipContext.Block.values()[blockCollisionMode.ordinal()], CraftFluidCollisionMode.toFluid(fluidCollisionMode), CollisionContext.empty()), canCollide);
 
         return CraftRayTraceResult.convertFromInternal(this.getHandle(), hitResult);
     }
 
     @Override
     public RayTraceResult rayTrace(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<? super Entity> filter, Predicate<? super Block> canCollide) {
-        RayTraceResult blockHit = this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, canCollide);
+        return this.rayTrace(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks ? BlockCollisionMode.COLLIDER : BlockCollisionMode.OUTLINE, raySize, filter, null);
+    }
+
+    public RayTraceResult rayTrace(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, BlockCollisionMode blockCollisionMode, double raySize, Predicate<? super Entity> filter, Predicate<? super Block> canCollide) {
+        RayTraceResult blockHit = this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, blockCollisionMode, canCollide);
         Vector startVec = null;
         double blockHitDistance = maxDistance;
 
@@ -1100,11 +1110,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
         final double maxDistance = builder.maxDistance.getAsDouble();
         if (builder.targets.contains(RayTraceTarget.ENTITY)) {
             if (builder.targets.contains(RayTraceTarget.BLOCK)) {
-                return this.rayTrace(builder.start, builder.direction, maxDistance, builder.fluidCollisionMode, builder.ignorePassableBlocks, builder.raySize, builder.entityFilter, builder.blockFilter);
+                return this.rayTrace(builder.start, builder.direction, maxDistance, builder.fluidCollisionMode, builder.blockCollisionMode, builder.raySize, builder.entityFilter, builder.blockFilter);
             }
             return this.rayTraceEntities(builder.start, builder.direction, maxDistance, builder.raySize, builder.entityFilter);
         }
-        return this.rayTraceBlocks(builder.start, builder.direction, maxDistance, builder.fluidCollisionMode, builder.ignorePassableBlocks, builder.blockFilter);
+        return this.rayTraceBlocks(builder.start, builder.direction, maxDistance, builder.fluidCollisionMode, builder.blockCollisionMode, builder.blockFilter);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1065,7 +1065,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
 
     @Override
     public RayTraceResult rayTrace(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<? super Entity> filter, Predicate<? super Block> canCollide) {
-        return this.rayTrace(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks ? BlockCollisionMode.COLLIDER : BlockCollisionMode.OUTLINE, raySize, filter, null);
+        return this.rayTrace(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks ? BlockCollisionMode.COLLIDER : BlockCollisionMode.OUTLINE, raySize, filter, canCollide);
     }
 
     public RayTraceResult rayTrace(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, BlockCollisionMode blockCollisionMode, double raySize, Predicate<? super Entity> filter, Predicate<? super Block> canCollide) {


### PR DESCRIPTION
Supersedes #11166.

- Adds overloads to `World#rayTrace` and `World#rayTraceBlocks`, as well as the method `PositionedRayTraceConfigurationBuilder#blockCollisionMode`, that take a `BlockCollisionMode` instead of the boolean `ignorePassableBlocks` to determine block collisions.
- ~~Add `FluidCollisionMode.WATER`.~~
- Remove outdated javadocs on `World#rayTrace`, `World#rayTraceBlocks`, `PositionedRayTraceConfigurationBuilder#fluidCollisionMode`, and `PositionedRayTraceConfigurationBuilder#ignorePassableBlocks` that mention caveats with portal blocks and fluids that no longer exist. Portal blocks are always considered 'passable', and the value of `ignorePassableBlocks` has no effect on fluid collisions.