### PR TITLE
Add FishHookStateChangeEvent to detect fishing hook state transitions.

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/entity/FishHookStateChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/FishHookStateChangeEvent.java
@@ -1,20 +1,25 @@
 package io.papermc.paper.event.entity;
 
 import org.bukkit.entity.FishHook;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.EntityEvent;
+import org.bukkit.event.player.PlayerFishEvent;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 /**
  * Called just before a {@link FishHook}'s {@link FishHook.HookState} is changed.
+ *
+ * <p>If you want to monitor a player's fishing state transitions, you can listen to them using {@link PlayerFishEvent}.</p>
  */
 @NullMarked
-public final class FishHookStateChangeEvent extends EntityEvent {
+public final class FishHookStateChangeEvent extends EntityEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final FishHook.HookState newHookState;
+    private boolean cancelled;
 
     @ApiStatus.Internal
     public FishHookStateChangeEvent(final FishHook entity, final FishHook.HookState newHookState) {
@@ -25,7 +30,8 @@ public final class FishHookStateChangeEvent extends EntityEvent {
     /**
      * Get the <strong>new</strong> hook state of the {@link FishHook}.
      *
-     * <p>Refer to {@link FishHook#getState()} to get the current hook state.</p>
+     * <p>This is what the {@link FishHook}'s new hook state will be after this event if it isn't cancelled.<br>
+     * Refer to {@link FishHook#getState()} to get the current hook state.</p>
      *
      * @return the <strong>new</strong> hook state
      */
@@ -45,5 +51,24 @@ public final class FishHookStateChangeEvent extends EntityEvent {
 
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
+    }
+
+    /**
+     * Set whether to cancel the {@link FishHook}'s {@link FishHook.HookState} change.
+     *
+     * <p>Note: Even if you cancel this event, if the conditions for the state change are met in the next tick,
+     * the event will be called again.<br>
+     * In other words, this event may be triggered repeatedly every tick, so use it with caution.</p>
+     *
+     * @param cancel {@code true} if you wish to cancel the state change
+     */
+    @Override
+    public void setCancelled(final boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/FishHookStateChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/FishHookStateChangeEvent.java
@@ -1,7 +1,6 @@
 package io.papermc.paper.event.entity;
 
 import org.bukkit.entity.FishHook;
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.EntityEvent;
 import org.bukkit.event.player.PlayerFishEvent;
@@ -14,12 +13,11 @@ import org.jspecify.annotations.NullMarked;
  * <p>If you want to monitor a player's fishing state transitions, you can listen to them using {@link PlayerFishEvent}.</p>
  */
 @NullMarked
-public final class FishHookStateChangeEvent extends EntityEvent implements Cancellable {
+public final class FishHookStateChangeEvent extends EntityEvent {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final FishHook.HookState newHookState;
-    private boolean cancelled;
 
     @ApiStatus.Internal
     public FishHookStateChangeEvent(final FishHook entity, final FishHook.HookState newHookState) {
@@ -30,8 +28,7 @@ public final class FishHookStateChangeEvent extends EntityEvent implements Cance
     /**
      * Get the <strong>new</strong> hook state of the {@link FishHook}.
      *
-     * <p>This is what the {@link FishHook}'s new hook state will be after this event if it isn't cancelled.<br>
-     * Refer to {@link FishHook#getState()} to get the current hook state.</p>
+     * <p>Refer to {@link FishHook#getState()} to get the current hook state.</p>
      *
      * @return the <strong>new</strong> hook state
      */
@@ -51,24 +48,5 @@ public final class FishHookStateChangeEvent extends EntityEvent implements Cance
 
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
-    }
-
-    /**
-     * Set whether to cancel the {@link FishHook}'s {@link FishHook.HookState} change.
-     *
-     * <p>Note: Even if you cancel this event, if the conditions for the state change are met in the next tick,
-     * the event will be called again.<br>
-     * In other words, this event may be triggered repeatedly every tick, so use it with caution.</p>
-     *
-     * @param cancel {@code true} if you wish to cancel the state change
-     */
-    @Override
-    public void setCancelled(final boolean cancel) {
-        this.cancelled = cancel;
-    }
-
-    @Override
-    public boolean isCancelled() {
-        return this.cancelled;
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/FishHookStateChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/FishHookStateChangeEvent.java
@@ -1,0 +1,49 @@
+package io.papermc.paper.event.entity;
+
+import org.bukkit.entity.FishHook;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Called just before a {@link FishHook}'s {@link FishHook.HookState} is changed.
+ */
+@NullMarked
+public final class FishHookStateChangeEvent extends EntityEvent {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final FishHook.HookState newHookState;
+
+    @ApiStatus.Internal
+    public FishHookStateChangeEvent(final FishHook entity, final FishHook.HookState newHookState) {
+        super(entity);
+        this.newHookState = newHookState;
+    }
+
+    /**
+     * Get the <strong>new</strong> hook state of the {@link FishHook}.
+     *
+     * <p>Refer to {@link FishHook#getState()} to get the current hook state.</p>
+     *
+     * @return the <strong>new</strong> hook state
+     */
+    public FishHook.HookState getNewHookState() {
+        return this.newHookState;
+    }
+
+    @Override
+    public FishHook getEntity() {
+        return (FishHook) super.getEntity();
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/FishHookStateChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/FishHookStateChangeEvent.java
@@ -10,7 +10,7 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Called just before a {@link FishHook}'s {@link FishHook.HookState} is changed.
  *
- * <p>If you want to monitor a player's fishing state transitions, you can listen to them using {@link PlayerFishEvent}.</p>
+ * <p>If you want to monitor a player's fishing state transition, you can use {@link PlayerFishEvent}.</p>
  */
 @NullMarked
 public final class FishHookStateChangeEvent extends EntityEvent {

--- a/paper-api/src/main/java/org/bukkit/entity/FishHook.java
+++ b/paper-api/src/main/java/org/bukkit/entity/FishHook.java
@@ -1,6 +1,10 @@
 package org.bukkit.entity;
 
+<<<<<<< HEAD
 import org.bukkit.inventory.EquipmentSlot;
+=======
+import io.papermc.paper.event.entity.FishHookStateChangeEvent;
+>>>>>>> 7d6207536d (Implement Cancellable in FishHookStateChangeEvent.)
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -306,6 +310,7 @@ public interface FishHook extends Projectile {
 
     /**
      * Represents a state in which a fishing hook may be.
+     * State transitions can be listened for in {@link FishHookStateChangeEvent}
      */
     public enum HookState {
 

--- a/paper-api/src/main/java/org/bukkit/entity/FishHook.java
+++ b/paper-api/src/main/java/org/bukkit/entity/FishHook.java
@@ -1,10 +1,7 @@
 package org.bukkit.entity;
 
-<<<<<<< HEAD
 import org.bukkit.inventory.EquipmentSlot;
-=======
 import io.papermc.paper.event.entity.FishHookStateChangeEvent;
->>>>>>> 7d6207536d (Implement Cancellable in FishHookStateChangeEvent.)
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -310,7 +307,7 @@ public interface FishHook extends Projectile {
 
     /**
      * Represents a state in which a fishing hook may be.
-     * State transitions can be listened for in {@link FishHookStateChangeEvent}
+     * State transitions can be listened for using {@link FishHookStateChangeEvent}
      */
     public enum HookState {
 

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Thrown when a player is fishing
  *
- * <p>If you want to monitor a fishhook state transitions, you can listen to them using {@link FishHookStateChangeEvent}.</p>
+ * <p>If you want to monitor a fishhooks state transition, you can use {@link FishHookStateChangeEvent}.</p>
  */
 public class PlayerFishEvent extends PlayerEvent implements Cancellable {
 

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.player;
 
+import io.papermc.paper.event.entity.FishHookStateChangeEvent;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.FishHook;
 import org.bukkit.entity.Player;
@@ -12,6 +13,8 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Thrown when a player is fishing
+ *
+ * <p>If you want to monitor a fishhook state transitions, you can listen to them using {@link FishHookStateChangeEvent}.</p>
  */
 public class PlayerFishEvent extends PlayerEvent implements Cancellable {
 

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
@@ -42,48 +42,34 @@
                      return;
                  }
              } else {
-@@ -169,15 +_,23 @@
+@@ -169,15 +_,19 @@
              boolean flag = f > 0.0F;
              if (this.currentState == FishingHook.FishHookState.FLYING) {
                  if (this.hookedIn != null) {
--                    this.setDeltaMovement(Vec3.ZERO);
--                    this.currentState = FishingHook.FishHookState.HOOKED_IN_ENTITY;
--                    return;
-+                    // Paper start - Add FishHookStateChangeEvent. #HOOKED_ENTITY
-+                    if (new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.HOOKED_ENTITY).callEvent()) {
-+                        this.setDeltaMovement(Vec3.ZERO); // before this.setDeltaMovement(Vec3.ZERO);
-+                        this.currentState = FishingHook.FishHookState.HOOKED_IN_ENTITY;
-+                        return;
-+                    }
-+                    // Paper end - Add FishHookStateChangeEvent. #HOOKED_ENTITY
++                    if (new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.HOOKED_ENTITY).callEvent()) {// Paper start - Add FishHookStateChangeEvent. #HOOKED_ENTITY
+                     this.setDeltaMovement(Vec3.ZERO);
+                     this.currentState = FishingHook.FishHookState.HOOKED_IN_ENTITY;
+                     return;
++                    }// Paper end - Add FishHookStateChangeEvent. #HOOKED_ENTITY
                  }
  
                  if (flag) {
--                    this.setDeltaMovement(this.getDeltaMovement().multiply(0.3, 0.2, 0.3));
--                    this.currentState = FishingHook.FishHookState.BOBBING;
--                    return;
-+                    // Paper start - Add FishHookStateChangeEvent. #BOBBING
-+                    if (new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.BOBBING).callEvent()) {
-+                        this.setDeltaMovement(this.getDeltaMovement().multiply(0.3, 0.2, 0.3));
-+                        this.currentState = FishingHook.FishHookState.BOBBING;
-+                        return;
-+                    }
-+                    // Paper end - Add FishHookStateChangeEvent. #BOBBING
++                    if (new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.BOBBING).callEvent()) {// Paper start - Add FishHookStateChangeEvent. #BOBBING
+                     this.setDeltaMovement(this.getDeltaMovement().multiply(0.3, 0.2, 0.3));
+                     this.currentState = FishingHook.FishHookState.BOBBING;
+                     return;
++                    }// Paper end - Add FishHookStateChangeEvent. #BOBBING
                  }
  
                  this.checkCollision();
-@@ -187,8 +_,12 @@
+@@ -187,8 +_,10 @@
                          if (!this.hookedIn.isRemoved() && this.hookedIn.level().dimension() == this.level().dimension()) {
                              this.setPos(this.hookedIn.getX(), this.hookedIn.getY(0.8), this.hookedIn.getZ());
                          } else {
--                            this.setHookedEntity(null);
--                            this.currentState = FishingHook.FishHookState.FLYING;
-+                            // Paper start - Add FishHookStateChangeEvent. #UNHOOKED
-+                            if (new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.UNHOOKED).callEvent()) {
-+                                this.setHookedEntity(null);
-+                                this.currentState = FishingHook.FishHookState.FLYING;
-+                            }
-+                            // Paper end - Add FishHookStateChangeEvent. #UNHOOKED
++                            if (new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.UNHOOKED).callEvent()) {// Paper start - Add FishHookStateChangeEvent. #UNHOOKED
+                             this.setHookedEntity(null);
+                             this.currentState = FishingHook.FishHookState.FLYING;
++                            }// Paper end - Add FishHookStateChangeEvent. #UNHOOKED
                          }
                      }
 @@ -247,14 +_,14 @@

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
@@ -42,34 +42,27 @@
                      return;
                  }
              } else {
-@@ -169,15 +_,19 @@
-             boolean flag = f > 0.0F;
+@@ -170,12 +_,14 @@
              if (this.currentState == FishingHook.FishHookState.FLYING) {
                  if (this.hookedIn != null) {
-+                    if (new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.HOOKED_ENTITY).callEvent()) {// Paper start - Add FishHookStateChangeEvent. #HOOKED_ENTITY
                      this.setDeltaMovement(Vec3.ZERO);
++                    new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.HOOKED_ENTITY).callEvent(); // Paper - Add FishHookStateChangeEvent. #HOOKED_ENTITY
                      this.currentState = FishingHook.FishHookState.HOOKED_IN_ENTITY;
                      return;
-+                    }// Paper end - Add FishHookStateChangeEvent. #HOOKED_ENTITY
                  }
  
                  if (flag) {
-+                    if (new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.BOBBING).callEvent()) {// Paper start - Add FishHookStateChangeEvent. #BOBBING
                      this.setDeltaMovement(this.getDeltaMovement().multiply(0.3, 0.2, 0.3));
++                    new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.BOBBING).callEvent(); // Paper - Add FishHookStateChangeEvent. #BOBBING
                      this.currentState = FishingHook.FishHookState.BOBBING;
                      return;
-+                    }// Paper end - Add FishHookStateChangeEvent. #BOBBING
                  }
- 
-                 this.checkCollision();
-@@ -187,8 +_,10 @@
-                         if (!this.hookedIn.isRemoved() && this.hookedIn.level().dimension() == this.level().dimension()) {
+@@ -188,6 +_,7 @@
                              this.setPos(this.hookedIn.getX(), this.hookedIn.getY(0.8), this.hookedIn.getZ());
                          } else {
-+                            if (new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.UNHOOKED).callEvent()) {// Paper start - Add FishHookStateChangeEvent. #UNHOOKED
                              this.setHookedEntity(null);
++                            new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.UNHOOKED).callEvent(); // Paper - Add FishHookStateChangeEvent. #UNHOOKED
                              this.currentState = FishingHook.FishHookState.FLYING;
-+                            }// Paper end - Add FishHookStateChangeEvent. #UNHOOKED
                          }
                      }
 @@ -247,14 +_,14 @@

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
@@ -42,7 +42,7 @@
                      return;
                  }
              } else {
-@@ -170,12 +_,14 @@
+@@ -166,12 +_,14 @@
              if (this.currentState == FishingHook.FishHookState.FLYING) {
                  if (this.hookedIn != null) {
                      this.setDeltaMovement(Vec3.ZERO);
@@ -57,7 +57,7 @@
                      this.currentState = FishingHook.FishHookState.BOBBING;
                      return;
                  }
-@@ -188,6 +_,7 @@
+@@ -184,6 +_,7 @@
                              this.setPos(this.hookedIn.getX(), this.hookedIn.getY(0.8), this.hookedIn.getZ());
                          } else {
                              this.setHookedEntity(null);

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
@@ -42,6 +42,29 @@
                      return;
                  }
              } else {
+@@ -170,12 +_,14 @@
+             if (this.currentState == FishingHook.FishHookState.FLYING) {
+                 if (this.hookedIn != null) {
+                     this.setDeltaMovement(Vec3.ZERO);
++                    new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.HOOKED_ENTITY).callEvent(); // Paper - Add FishHookStateChangeEvent
+                     this.currentState = FishingHook.FishHookState.HOOKED_IN_ENTITY;
+                     return;
+                 }
+ 
+                 if (flag) {
+                     this.setDeltaMovement(this.getDeltaMovement().multiply(0.3, 0.2, 0.3));
++                    new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.BOBBING).callEvent(); // Paper - Add FishHookStateChangeEvent
+                     this.currentState = FishingHook.FishHookState.BOBBING;
+                     return;
+                 }
+@@ -188,6 +_,7 @@
+                             this.setPos(this.hookedIn.getX(), this.hookedIn.getY(0.8), this.hookedIn.getZ());
+                         } else {
+                             this.setHookedEntity(null);
++                            new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.UNHOOKED).callEvent(); // Paper - Add FishHookStateChangeEvent
+                             this.currentState = FishingHook.FishHookState.FLYING;
+                         }
+                     }
 @@ -247,14 +_,14 @@
          if (!player.isRemoved() && player.isAlive() && (isFishingRod || isFishingRod1) && !(this.distanceToSqr(player) > 1024.0)) {
              return false;

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
@@ -42,27 +42,48 @@
                      return;
                  }
              } else {
-@@ -170,12 +_,14 @@
+@@ -169,15 +_,23 @@
+             boolean flag = f > 0.0F;
              if (this.currentState == FishingHook.FishHookState.FLYING) {
                  if (this.hookedIn != null) {
-                     this.setDeltaMovement(Vec3.ZERO);
-+                    new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.HOOKED_ENTITY).callEvent(); // Paper - Add FishHookStateChangeEvent
-                     this.currentState = FishingHook.FishHookState.HOOKED_IN_ENTITY;
-                     return;
+-                    this.setDeltaMovement(Vec3.ZERO);
+-                    this.currentState = FishingHook.FishHookState.HOOKED_IN_ENTITY;
+-                    return;
++                    // Paper start - Add FishHookStateChangeEvent. #HOOKED_ENTITY
++                    if (new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.HOOKED_ENTITY).callEvent()) {
++                        this.setDeltaMovement(Vec3.ZERO); // before this.setDeltaMovement(Vec3.ZERO);
++                        this.currentState = FishingHook.FishHookState.HOOKED_IN_ENTITY;
++                        return;
++                    }
++                    // Paper end - Add FishHookStateChangeEvent. #HOOKED_ENTITY
                  }
  
                  if (flag) {
-                     this.setDeltaMovement(this.getDeltaMovement().multiply(0.3, 0.2, 0.3));
-+                    new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.BOBBING).callEvent(); // Paper - Add FishHookStateChangeEvent
-                     this.currentState = FishingHook.FishHookState.BOBBING;
-                     return;
+-                    this.setDeltaMovement(this.getDeltaMovement().multiply(0.3, 0.2, 0.3));
+-                    this.currentState = FishingHook.FishHookState.BOBBING;
+-                    return;
++                    // Paper start - Add FishHookStateChangeEvent. #BOBBING
++                    if (new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.BOBBING).callEvent()) {
++                        this.setDeltaMovement(this.getDeltaMovement().multiply(0.3, 0.2, 0.3));
++                        this.currentState = FishingHook.FishHookState.BOBBING;
++                        return;
++                    }
++                    // Paper end - Add FishHookStateChangeEvent. #BOBBING
                  }
-@@ -188,6 +_,7 @@
+ 
+                 this.checkCollision();
+@@ -187,8 +_,12 @@
+                         if (!this.hookedIn.isRemoved() && this.hookedIn.level().dimension() == this.level().dimension()) {
                              this.setPos(this.hookedIn.getX(), this.hookedIn.getY(0.8), this.hookedIn.getZ());
                          } else {
-                             this.setHookedEntity(null);
-+                            new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.UNHOOKED).callEvent(); // Paper - Add FishHookStateChangeEvent
-                             this.currentState = FishingHook.FishHookState.FLYING;
+-                            this.setHookedEntity(null);
+-                            this.currentState = FishingHook.FishHookState.FLYING;
++                            // Paper start - Add FishHookStateChangeEvent. #UNHOOKED
++                            if (new io.papermc.paper.event.entity.FishHookStateChangeEvent((org.bukkit.entity.FishHook) getBukkitEntity(), org.bukkit.entity.FishHook.HookState.UNHOOKED).callEvent()) {
++                                this.setHookedEntity(null);
++                                this.currentState = FishingHook.FishHookState.FLYING;
++                            }
++                            // Paper end - Add FishHookStateChangeEvent. #UNHOOKED
                          }
                      }
 @@ -247,14 +_,14 @@


### PR DESCRIPTION
Currently, `PlayerFishEvent` is not triggered when a `FishHook` changes its state. This means that if you want to track state transitions, you have to monitor them using a scheduler, which is inefficient. To address this, I have implemented `FishHookStateChangeEvent`.  

- This event is useful when you want to send messages, titles, or sounds to players based on fishing hook state transitions.  
- ~~Canceling the transition to `HookState.BOBBING` prevents `Minecraft#FishingHook#catchingFish` from executing.~~
- ~~Be cautious when handling this event, as canceling it will not prevent the state transition from being re-evaluated in the next tick. If the conditions are still met, the event will be instantiated and called repeatedly. (This behavior is documented in the Javadoc.)~~ Reverted due to spamming of events and desync with the client side.

For consistency, this event is mostly copied from `PufferFishStateChangeEvent`. However, I feel that "State Transition" might be a more appropriate term than "State Change."  