### PR TITLE
Fix first execution of async delayed/repeating tasks being sync

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/threadedregions/scheduler/FoliaAsyncScheduler.java
+++ b/paper-server/src/main/java/io/papermc/paper/threadedregions/scheduler/FoliaAsyncScheduler.java
@@ -181,7 +181,7 @@ public final class FoliaAsyncScheduler implements AsyncScheduler {
 
         private void setDelay(final ScheduledFuture<?> delay) {
             this.delay = delay;
-            this.state = STATE_SCHEDULED_EXECUTOR;
+            this.state = delay == null ? STATE_SCHEDULED_EXECUTOR : STATE_ON_TIMER;
         }
 
         @Override


### PR DESCRIPTION
Closes #12038

This PR makes it so that setDelay changes the task's state in the same way as the constructor does, so that the state can properly become STATE_ON_TIMER