### PR TITLE
Normalizes CraftEntity#toString/getHandle

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/entity/LingeringPotionSplashEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/LingeringPotionSplashEvent.java
@@ -18,27 +18,27 @@ public class LingeringPotionSplashEvent extends ProjectileHitEvent implements Ca
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
-    private final AreaEffectCloud entity;
+    private final AreaEffectCloud effectCloud;
     private boolean allowEmptyAreaEffectCreation;
 
     private boolean cancelled;
 
     @ApiStatus.Internal
     @Deprecated(since = "1.20.2", forRemoval = true)
-    public LingeringPotionSplashEvent(@NotNull final ThrownPotion potion, @NotNull final AreaEffectCloud entity) {
-       this(potion, null, null, null, entity);
+    public LingeringPotionSplashEvent(@NotNull final ThrownPotion potion, @NotNull final AreaEffectCloud effectCloud) {
+       this(potion, null, null, null, effectCloud);
     }
 
     @ApiStatus.Internal
-    public LingeringPotionSplashEvent(@NotNull final ThrownPotion potion, @Nullable Entity hitEntity, @Nullable Block hitBlock, @Nullable BlockFace hitFace, @NotNull final AreaEffectCloud entity) {
+    public LingeringPotionSplashEvent(@NotNull final ThrownPotion potion, @Nullable Entity hitEntity, @Nullable Block hitBlock, @Nullable BlockFace hitFace, @NotNull final AreaEffectCloud effectCloud) {
         super(potion, hitEntity, hitBlock, hitFace);
-        this.entity = entity;
+        this.effectCloud = effectCloud;
     }
 
     @NotNull
     @Override
     public ThrownPotion getEntity() {
-        return (ThrownPotion) super.getEntity();
+        return (ThrownPotion) this.entity;
     }
 
     /**
@@ -48,10 +48,9 @@ public class LingeringPotionSplashEvent extends ProjectileHitEvent implements Ca
      */
     @NotNull
     public AreaEffectCloud getAreaEffectCloud() {
-        return entity;
+        return effectCloud;
     }
 
-    // Paper start
     /**
      * Sets if an Empty AreaEffectCloud may be created
      *
@@ -69,7 +68,6 @@ public class LingeringPotionSplashEvent extends ProjectileHitEvent implements Ca
     public boolean allowsEmptyCreation() {
         return allowEmptyAreaEffectCreation;
     }
-    // Paper end
 
     @Override
     public boolean isCancelled() {

--- a/paper-server/src/main/java/io/papermc/paper/entity/PaperSchoolableFish.java
+++ b/paper-server/src/main/java/io/papermc/paper/entity/PaperSchoolableFish.java
@@ -13,7 +13,7 @@ public class PaperSchoolableFish extends CraftFish implements SchoolableFish {
 
     @Override
     public AbstractSchoolingFish getHandle() {
-        return (AbstractSchoolingFish) super.getHandle();
+        return (AbstractSchoolingFish) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java
@@ -10,6 +10,11 @@ public abstract class AbstractProjectile extends CraftEntity implements Projecti
     }
 
     @Override
+    public net.minecraft.world.entity.projectile.Projectile getHandle() {
+        return (net.minecraft.world.entity.projectile.Projectile) this.entity;
+    }
+
+    @Override
     public boolean doesBounce() {
         return false;
     }
@@ -51,11 +56,6 @@ public abstract class AbstractProjectile extends CraftEntity implements Projecti
     @Override
     public void hitEntity(org.bukkit.entity.Entity entity, org.bukkit.util.Vector vector) {
         this.getHandle().preHitTargetOrDeflectSelf(new net.minecraft.world.phys.EntityHitResult(((CraftEntity) entity).getHandle(), new net.minecraft.world.phys.Vec3(vector.getX(), vector.getY(), vector.getZ())));
-    }
-
-    @Override
-    public net.minecraft.world.entity.projectile.Projectile getHandle() {
-        return (net.minecraft.world.entity.projectile.Projectile) entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractArrow.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractArrow.java
@@ -3,6 +3,7 @@ package org.bukkit.craftbukkit.entity;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import java.util.List;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.BlockCollisions;
@@ -13,12 +14,16 @@ import org.bukkit.craftbukkit.block.CraftBlock;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.AbstractArrow;
 import org.bukkit.inventory.ItemStack;
-import java.util.List;
 
 public abstract class CraftAbstractArrow extends AbstractProjectile implements AbstractArrow {
 
     public CraftAbstractArrow(CraftServer server, net.minecraft.world.entity.projectile.AbstractArrow entity) {
         super(server, entity);
+    }
+
+    @Override
+    public net.minecraft.world.entity.projectile.AbstractArrow getHandle() {
+        return (net.minecraft.world.entity.projectile.AbstractArrow) this.entity;
     }
 
     @Override
@@ -62,8 +67,6 @@ public abstract class CraftAbstractArrow extends AbstractProjectile implements A
     public void setCritical(boolean critical) {
         this.getHandle().setCritArrow(critical);
     }
-
-    // Paper - moved to AbstractProjectile
 
     @Override
     public boolean isInBlock() {
@@ -137,16 +140,6 @@ public abstract class CraftAbstractArrow extends AbstractProjectile implements A
         Preconditions.checkArgument(item != null, "ItemStack cannot be null");
 
         this.getHandle().firedFromWeapon = CraftItemStack.asNMSCopy(item);
-    }
-
-    @Override
-    public net.minecraft.world.entity.projectile.AbstractArrow getHandle() {
-        return (net.minecraft.world.entity.projectile.AbstractArrow) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftAbstractArrow";
     }
 
     // Paper start

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractCow.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractCow.java
@@ -15,5 +15,4 @@ public abstract class CraftAbstractCow extends CraftAnimals implements AbstractC
     public net.minecraft.world.entity.animal.AbstractCow getHandle() {
         return (net.minecraft.world.entity.animal.AbstractCow) this.entity;
     }
-
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractSkeleton.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractSkeleton.java
@@ -11,13 +11,13 @@ public abstract class CraftAbstractSkeleton extends CraftMonster implements Abst
     }
 
     @Override
-    public void setSkeletonType(Skeleton.SkeletonType type) {
-        throw new UnsupportedOperationException("Not supported.");
+    public net.minecraft.world.entity.monster.AbstractSkeleton getHandle() {
+        return (net.minecraft.world.entity.monster.AbstractSkeleton) this.entity;
     }
 
     @Override
-    public net.minecraft.world.entity.monster.AbstractSkeleton getHandle() {
-        return (net.minecraft.world.entity.monster.AbstractSkeleton) super.getHandle();
+    public void setSkeletonType(Skeleton.SkeletonType type) {
+        throw new UnsupportedOperationException("Not supported.");
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractVillager.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractVillager.java
@@ -26,11 +26,6 @@ public abstract class CraftAbstractVillager extends CraftAgeable implements Craf
     }
 
     @Override
-    public String toString() {
-        return "CraftAbstractVillager";
-    }
-
-    @Override
     public Inventory getInventory() {
         return new CraftInventory(this.getHandle().getInventory());
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractWindCharge.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractWindCharge.java
@@ -10,18 +10,13 @@ public abstract class CraftAbstractWindCharge extends CraftFireball implements A
     }
 
     @Override
-    public void explode() {
-        this.getHandle().explode(this.getHandle().position());
-        this.getHandle().discard(EntityRemoveEvent.Cause.EXPLODE); // SPIGOT-7577 - explode doesn't discard the entity, this happens only in tick and onHitBlock
-    }
-
-    @Override
     public net.minecraft.world.entity.projectile.windcharge.AbstractWindCharge getHandle() {
         return (net.minecraft.world.entity.projectile.windcharge.AbstractWindCharge) this.entity;
     }
 
     @Override
-    public String toString() {
-        return "CraftAbstractWindCharge";
+    public void explode() {
+        this.getHandle().explode(this.getHandle().position());
+        this.getHandle().discard(EntityRemoveEvent.Cause.EXPLODE); // SPIGOT-7577 - explode doesn't discard the entity, this happens only in tick and onHitBlock
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAgeable.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAgeable.java
@@ -10,6 +10,11 @@ public class CraftAgeable extends CraftCreature implements Ageable {
     }
 
     @Override
+    public AgeableMob getHandle() {
+        return (AgeableMob) this.entity;
+    }
+
+    @Override
     public int getAge() {
         return this.getHandle().getAge();
     }
@@ -61,15 +66,5 @@ public class CraftAgeable extends CraftCreature implements Ageable {
         } else if (this.isAdult()) {
             this.setAge(6000);
         }
-    }
-
-    @Override
-    public AgeableMob getHandle() {
-        return (AgeableMob) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftAgeable";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAllay.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAllay.java
@@ -22,11 +22,6 @@ public class CraftAllay extends CraftCreature implements org.bukkit.entity.Allay
     }
 
     @Override
-    public String toString() {
-        return "CraftAllay";
-    }
-
-    @Override
     public Inventory getInventory() {
         return new CraftInventory(this.getHandle().getInventory());
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAmbient.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAmbient.java
@@ -13,9 +13,4 @@ public class CraftAmbient extends CraftMob implements Ambient {
     public AmbientCreature getHandle() {
         return (AmbientCreature) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftAmbient";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAnimals.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAnimals.java
@@ -21,11 +21,6 @@ public class CraftAnimals extends CraftAgeable implements Animals {
     }
 
     @Override
-    public String toString() {
-        return "CraftAnimals";
-    }
-
-    @Override
     public UUID getBreedCause() {
         return this.getHandle().loveCause;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
@@ -30,12 +30,7 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
 
     @Override
     public net.minecraft.world.entity.AreaEffectCloud getHandle() {
-        return (net.minecraft.world.entity.AreaEffectCloud) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftAreaEffectCloud";
+        return (net.minecraft.world.entity.AreaEffectCloud) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftArmadillo.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftArmadillo.java
@@ -13,7 +13,7 @@ public class CraftArmadillo extends CraftAnimals implements Armadillo {
 
     @Override
     public net.minecraft.world.entity.animal.armadillo.Armadillo getHandle() {
-        return (net.minecraft.world.entity.animal.armadillo.Armadillo) super.getHandle();
+        return (net.minecraft.world.entity.animal.armadillo.Armadillo) this.entity;
     }
 
     @Override
@@ -36,11 +36,6 @@ public class CraftArmadillo extends CraftAnimals implements Armadillo {
 
         this.getHandle().lastHurtByMob = null; // Clear this memory to not have the sensor trigger rollUp instantly for damaged armadillo
         this.getHandle().getBrain().setMemoryWithExpiry(MemoryModuleType.DANGER_DETECTED_RECENTLY, true, ArmadilloState.UNROLLING.animationDuration());
-    }
-
-    @Override
-    public String toString() {
-        return "CraftArmadillo";
     }
 
     public static State stateToBukkit(ArmadilloState state) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
@@ -16,13 +16,8 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
     }
 
     @Override
-    public String toString() {
-        return "CraftArmorStand";
-    }
-
-    @Override
     public net.minecraft.world.entity.decoration.ArmorStand getHandle() {
-        return (net.minecraft.world.entity.decoration.ArmorStand) super.getHandle();
+        return (net.minecraft.world.entity.decoration.ArmorStand) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
@@ -30,11 +30,6 @@ public class CraftArrow extends CraftAbstractArrow implements Arrow {
     }
 
     @Override
-    public String toString() {
-        return "CraftArrow";
-    }
-
-    @Override
     public boolean addCustomEffect(PotionEffect effect, boolean override) {
         if (this.hasCustomEffect(effect.getType())) {
             if (!override) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAxolotl.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAxolotl.java
@@ -12,12 +12,7 @@ public class CraftAxolotl extends CraftAnimals implements Axolotl, io.papermc.pa
 
     @Override
     public net.minecraft.world.entity.animal.axolotl.Axolotl getHandle() {
-        return (net.minecraft.world.entity.animal.axolotl.Axolotl) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftAxolotl";
+        return (net.minecraft.world.entity.animal.axolotl.Axolotl) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBat.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBat.java
@@ -15,11 +15,6 @@ public class CraftBat extends CraftAmbient implements Bat {
     }
 
     @Override
-    public String toString() {
-        return "CraftBat";
-    }
-
-    @Override
     public boolean isAwake() {
         return !this.getHandle().isResting();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
@@ -19,11 +19,6 @@ public class CraftBee extends CraftAnimals implements Bee {
     }
 
     @Override
-    public String toString() {
-        return "CraftBee";
-    }
-
-    @Override
     public Location getHive() {
         BlockPos hive = this.getHandle().getHivePos();
         return (hive == null) ? null : CraftLocation.toBukkit(hive, this.getWorld());

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBlaze.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBlaze.java
@@ -12,9 +12,4 @@ public class CraftBlaze extends CraftMonster implements Blaze {
     public net.minecraft.world.entity.monster.Blaze getHandle() {
         return (net.minecraft.world.entity.monster.Blaze) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftBlaze";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBlockAttachedEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBlockAttachedEntity.java
@@ -12,9 +12,4 @@ public class CraftBlockAttachedEntity extends CraftEntity {
     public BlockAttachedEntity getHandle() {
         return (BlockAttachedEntity) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftBlockAttachedEntity";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBlockDisplay.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBlockDisplay.java
@@ -14,12 +14,7 @@ public class CraftBlockDisplay extends CraftDisplay implements BlockDisplay {
 
     @Override
     public net.minecraft.world.entity.Display.BlockDisplay getHandle() {
-        return (net.minecraft.world.entity.Display.BlockDisplay) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftBlockDisplay";
+        return (net.minecraft.world.entity.Display.BlockDisplay) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
@@ -1,17 +1,20 @@
 package org.bukkit.craftbukkit.entity;
 
-import java.util.stream.Collectors;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.vehicle.AbstractBoat;
 import org.bukkit.TreeSpecies;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Boat;
-import org.bukkit.entity.Entity;
 
 public abstract class CraftBoat extends CraftVehicle implements Boat, io.papermc.paper.entity.PaperLeashable { // Paper - Leashable API
 
     public CraftBoat(CraftServer server, AbstractBoat entity) {
         super(server, entity);
+    }
+
+    @Override
+    public AbstractBoat getHandle() {
+        return (AbstractBoat) this.entity;
     }
 
     @Override
@@ -97,16 +100,6 @@ public abstract class CraftBoat extends CraftVehicle implements Boat, io.papermc
         }
         // Paper end - Fix NPE on Boat getStatus
         return CraftBoat.boatStatusFromNms(this.getHandle().status);
-    }
-
-    @Override
-    public AbstractBoat getHandle() {
-        return (AbstractBoat) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftBoat{boatType=" + this.getBoatType() + ",status=" + this.getStatus() + ",passengers=" + this.getPassengers().stream().map(Entity::toString).collect(Collectors.joining("-", "{", "}")) + "}";
     }
 
     public static Boat.Type boatTypeFromNms(EntityType<?> boatType) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBogged.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBogged.java
@@ -16,11 +16,6 @@ public class CraftBogged extends CraftAbstractSkeleton implements Bogged, io.pap
     }
 
     @Override
-    public String toString() {
-        return "CraftBogged";
-    }
-
-    @Override
     public Skeleton.SkeletonType getSkeletonType() {
         return Skeleton.SkeletonType.BOGGED;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBreeze.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBreeze.java
@@ -22,9 +22,4 @@ public class CraftBreeze extends CraftMonster implements Breeze {
         net.minecraft.world.entity.LivingEntity entityLivingTarget = (target instanceof CraftLivingEntity craftLivingEntity) ? craftLivingEntity.getHandle() : null;
         this.getHandle().getBrain().setMemory(MemoryModuleType.ATTACK_TARGET, entityLivingTarget); // SPIGOT-7957: We need override memory for set target and trigger attack behaviours
     }
-
-    @Override
-    public String toString() {
-        return "CraftBreeze";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBreezeWindCharge.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBreezeWindCharge.java
@@ -12,9 +12,4 @@ public class CraftBreezeWindCharge extends CraftAbstractWindCharge implements Br
     public net.minecraft.world.entity.projectile.windcharge.BreezeWindCharge getHandle() {
         return (net.minecraft.world.entity.projectile.windcharge.BreezeWindCharge) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftBreezeWindCharge";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCamel.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCamel.java
@@ -13,12 +13,7 @@ public class CraftCamel extends CraftAbstractHorse implements Camel {
 
     @Override
     public net.minecraft.world.entity.animal.camel.Camel getHandle() {
-        return (net.minecraft.world.entity.animal.camel.Camel) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftCamel";
+        return (net.minecraft.world.entity.animal.camel.Camel) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCat.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCat.java
@@ -20,12 +20,7 @@ public class CraftCat extends CraftTameableAnimal implements Cat {
 
     @Override
     public net.minecraft.world.entity.animal.Cat getHandle() {
-        return (net.minecraft.world.entity.animal.Cat) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftCat";
+        return (net.minecraft.world.entity.animal.Cat) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCaveSpider.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCaveSpider.java
@@ -12,9 +12,4 @@ public class CraftCaveSpider extends CraftSpider implements CaveSpider {
     public net.minecraft.world.entity.monster.CaveSpider getHandle() {
         return (net.minecraft.world.entity.monster.CaveSpider) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftCaveSpider";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftChestBoat.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftChestBoat.java
@@ -19,11 +19,6 @@ public abstract class CraftChestBoat extends CraftBoat implements org.bukkit.ent
     }
 
     @Override
-    public String toString() {
-        return "CraftChestBoat";
-    }
-
-    @Override
     public Inventory getInventory() {
         return this.inventory;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftChestedHorse.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftChestedHorse.java
@@ -12,7 +12,7 @@ public abstract class CraftChestedHorse extends CraftAbstractHorse implements Ch
 
     @Override
     public AbstractChestedHorse getHandle() {
-        return (AbstractChestedHorse) super.getHandle();
+        return (AbstractChestedHorse) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftChicken.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftChicken.java
@@ -23,11 +23,6 @@ public class CraftChicken extends CraftAnimals implements Chicken {
     }
 
     @Override
-    public String toString() {
-        return "CraftChicken";
-    }
-
-    @Override
     public Variant getVariant() {
         return CraftVariant.minecraftHolderToBukkit(this.getHandle().getVariant());
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCod.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCod.java
@@ -11,11 +11,6 @@ public class CraftCod extends io.papermc.paper.entity.PaperSchoolableFish implem
 
     @Override
     public net.minecraft.world.entity.animal.Cod getHandle() {
-        return (net.minecraft.world.entity.animal.Cod) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftCod";
+        return (net.minecraft.world.entity.animal.Cod) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftComplexPart.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftComplexPart.java
@@ -1,20 +1,25 @@
 package org.bukkit.craftbukkit.entity;
 
 import net.minecraft.world.entity.boss.EnderDragonPart;
-import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.ComplexEntityPart;
 import org.bukkit.entity.ComplexLivingEntity;
 import org.bukkit.event.entity.EntityDamageEvent;
 
 public class CraftComplexPart extends CraftEntity implements ComplexEntityPart {
+
     public CraftComplexPart(CraftServer server, EnderDragonPart entity) {
         super(server, entity);
     }
 
     @Override
+    public EnderDragonPart getHandle() {
+        return (EnderDragonPart) this.entity;
+    }
+
+    @Override
     public ComplexLivingEntity getParent() {
-        return (ComplexLivingEntity) ((EnderDragon) this.getHandle().parentMob).getBukkitEntity();
+        return (ComplexLivingEntity) this.getHandle().parentMob.getBukkitEntity();
     }
 
     @Override
@@ -30,15 +35,5 @@ public class CraftComplexPart extends CraftEntity implements ComplexEntityPart {
     @Override
     public boolean isValid() {
         return this.getParent().isValid();
-    }
-
-    @Override
-    public EnderDragonPart getHandle() {
-        return (EnderDragonPart) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftComplexPart";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCow.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCow.java
@@ -23,11 +23,6 @@ public class CraftCow extends CraftAbstractCow implements Cow {
     }
 
     @Override
-    public String toString() {
-        return "CraftCow";
-    }
-
-    @Override
     public Variant getVariant() {
         return CraftVariant.minecraftHolderToBukkit(this.getHandle().getVariant());
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCreaking.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCreaking.java
@@ -43,9 +43,4 @@ public class CraftCreaking extends CraftMonster implements org.bukkit.entity.Cre
     public boolean isActive() {
         return this.getHandle().isActive();
     }
-
-    @Override
-    public String toString() {
-        return "CraftCreaking";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCreature.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCreature.java
@@ -13,9 +13,4 @@ public class CraftCreature extends CraftMob implements Creature {
     public PathfinderMob getHandle() {
         return (PathfinderMob) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftCreature";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCreeper.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftCreeper.java
@@ -13,6 +13,11 @@ public class CraftCreeper extends CraftMonster implements Creeper {
     }
 
     @Override
+    public net.minecraft.world.entity.monster.Creeper getHandle() {
+        return (net.minecraft.world.entity.monster.Creeper) this.entity;
+    }
+
+    @Override
     public boolean isPowered() {
         return this.getHandle().isPowered();
     }
@@ -90,16 +95,6 @@ public class CraftCreeper extends CraftMonster implements Creeper {
     @Override
     public Entity getIgniter() {
         return (this.getHandle().entityIgniter != null) ? this.getHandle().entityIgniter.getBukkitEntity() : null;
-    }
-
-    @Override
-    public net.minecraft.world.entity.monster.Creeper getHandle() {
-        return (net.minecraft.world.entity.monster.Creeper) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftCreeper";
     }
 
     // Paper start

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftDisplay.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftDisplay.java
@@ -14,12 +14,7 @@ public class CraftDisplay extends CraftEntity implements Display {
 
     @Override
     public net.minecraft.world.entity.Display getHandle() {
-        return (net.minecraft.world.entity.Display) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftDisplay";
+        return (net.minecraft.world.entity.Display) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftDolphin.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftDolphin.java
@@ -13,12 +13,7 @@ public class CraftDolphin extends CraftAgeable implements Dolphin {
 
     @Override
     public net.minecraft.world.entity.animal.Dolphin getHandle() {
-        return (net.minecraft.world.entity.animal.Dolphin) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftDolphin";
+        return (net.minecraft.world.entity.animal.Dolphin) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftDonkey.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftDonkey.java
@@ -11,11 +11,6 @@ public class CraftDonkey extends CraftChestedHorse implements Donkey {
     }
 
     @Override
-    public String toString() {
-        return "CraftDonkey";
-    }
-
-    @Override
     public Variant getVariant() {
         return Variant.DONKEY;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftDragonFireball.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftDragonFireball.java
@@ -4,12 +4,8 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.DragonFireball;
 
 public class CraftDragonFireball extends CraftFireball implements DragonFireball {
+
     public CraftDragonFireball(CraftServer server, net.minecraft.world.entity.projectile.DragonFireball entity) {
         super(server, entity);
-    }
-
-    @Override
-    public String toString() {
-        return "CraftDragonFireball";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftDrowned.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftDrowned.java
@@ -13,9 +13,4 @@ public class CraftDrowned extends CraftZombie implements Drowned, com.destroysto
     public net.minecraft.world.entity.monster.Drowned getHandle() {
         return (net.minecraft.world.entity.monster.Drowned) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftDrowned";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEgg.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEgg.java
@@ -5,6 +5,7 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Egg;
 
 public class CraftEgg extends CraftThrowableProjectile implements Egg {
+
     public CraftEgg(CraftServer server, ThrownEgg entity) {
         super(server, entity);
     }
@@ -12,10 +13,5 @@ public class CraftEgg extends CraftThrowableProjectile implements Egg {
     @Override
     public ThrownEgg getHandle() {
         return (ThrownEgg) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftEgg";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftElderGuardian.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftElderGuardian.java
@@ -10,11 +10,6 @@ public class CraftElderGuardian extends CraftGuardian implements ElderGuardian {
     }
 
     @Override
-    public String toString() {
-        return "CraftElderGuardian";
-    }
-
-    @Override
     public boolean isElder() {
         return true;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderCrystal.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderCrystal.java
@@ -8,8 +8,14 @@ import org.bukkit.craftbukkit.util.CraftLocation;
 import org.bukkit.entity.EnderCrystal;
 
 public class CraftEnderCrystal extends CraftEntity implements EnderCrystal {
+
     public CraftEnderCrystal(CraftServer server, EndCrystal entity) {
         super(server, entity);
+    }
+
+    @Override
+    public EndCrystal getHandle() {
+        return (EndCrystal) this.entity;
     }
 
     @Override
@@ -37,15 +43,5 @@ public class CraftEnderCrystal extends CraftEntity implements EnderCrystal {
         } else {
             this.getHandle().setBeamTarget(CraftLocation.toBlockPosition(location));
         }
-    }
-
-    @Override
-    public EndCrystal getHandle() {
-        return (EndCrystal) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftEnderCrystal";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderDragon.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderDragon.java
@@ -21,6 +21,11 @@ public class CraftEnderDragon extends CraftMob implements EnderDragon, CraftEnem
     }
 
     @Override
+    public net.minecraft.world.entity.boss.enderdragon.EnderDragon getHandle() {
+        return (net.minecraft.world.entity.boss.enderdragon.EnderDragon) this.entity;
+    }
+
+    @Override
     public Set<ComplexEntityPart> getParts() {
         Builder<ComplexEntityPart> builder = ImmutableSet.builder();
 
@@ -29,16 +34,6 @@ public class CraftEnderDragon extends CraftMob implements EnderDragon, CraftEnem
         }
 
         return builder.build();
-    }
-
-    @Override
-    public net.minecraft.world.entity.boss.enderdragon.EnderDragon getHandle() {
-        return (net.minecraft.world.entity.boss.enderdragon.EnderDragon) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftEnderDragon";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderDragonPart.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderDragonPart.java
@@ -17,16 +17,6 @@ public class CraftEnderDragonPart extends CraftComplexPart implements EnderDrago
     }
 
     @Override
-    public net.minecraft.world.entity.boss.EnderDragonPart getHandle() {
-        return (net.minecraft.world.entity.boss.EnderDragonPart) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftEnderDragonPart";
-    }
-
-    @Override
     public void damage(double amount, DamageSource damageSource) {
         this.getParent().damage(amount, damageSource);
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderPearl.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderPearl.java
@@ -13,9 +13,4 @@ public class CraftEnderPearl extends CraftThrowableProjectile implements EnderPe
     public ThrownEnderpearl getHandle() {
         return (ThrownEnderpearl) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftEnderPearl";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderSignal.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderSignal.java
@@ -21,11 +21,6 @@ public class CraftEnderSignal extends CraftEntity implements EnderSignal {
     }
 
     @Override
-    public String toString() {
-        return "CraftEnderSignal";
-    }
-
-    @Override
     public Location getTargetLocation() {
         return new Location(this.getWorld(), this.getHandle().tx, this.getHandle().ty, this.getHandle().tz, this.getHandle().getYRot(), this.getHandle().getXRot());
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderman.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderman.java
@@ -13,11 +13,21 @@ import org.bukkit.entity.Entity;
 import org.bukkit.material.MaterialData;
 
 public class CraftEnderman extends CraftMonster implements Enderman {
+
     public CraftEnderman(CraftServer server, EnderMan entity) {
         super(server, entity);
     }
 
-    @Override public boolean teleportRandomly() { return getHandle().teleport(); } // Paper
+    @Override
+    public EnderMan getHandle() {
+        return (EnderMan) this.entity;
+    }
+
+    @Override
+    public boolean teleportRandomly() {
+        return getHandle().teleport();
+    }
+
     @Override
     public MaterialData getCarriedMaterial() {
         BlockState blockData = this.getHandle().getCarriedBlock();
@@ -58,16 +68,6 @@ public class CraftEnderman extends CraftMonster implements Enderman {
     @Override
     public void setHasBeenStaredAt(boolean hasBeenStaredAt) {
         this.getHandle().setHasBeenStaredAt(hasBeenStaredAt);
-    }
-
-    @Override
-    public EnderMan getHandle() {
-        return (EnderMan) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftEnderman";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEndermite.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEndermite.java
@@ -11,12 +11,7 @@ public class CraftEndermite extends CraftMonster implements Endermite {
 
     @Override
     public net.minecraft.world.entity.monster.Endermite getHandle() {
-        return (net.minecraft.world.entity.monster.Endermite) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftEndermite";
+        return (net.minecraft.world.entity.monster.Endermite) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -124,6 +124,38 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
         throw new AssertionError("Unknown entity " + (entity == null ? null : entity.getClass()));
     }
 
+    public Entity getHandle() {
+        return this.entity;
+    }
+
+    public Entity getHandleRaw() {
+        return this.entity;
+    }
+
+    public void setHandle(final Entity entity) {
+        this.entity = entity;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "{uuid=" + this.getUniqueId() + '}';
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+
+        final CraftEntity other = (CraftEntity) obj;
+        return this.entity == other.entity; // There should never be duplicate entities with differing references
+    }
+
+    @Override
+    public int hashCode() {
+        // The UUID and thus hash code should never change (unlike the entity id)
+        return this.getUniqueId().hashCode();
+    }
+
     @Override
     public Location getLocation() {
         return CraftLocation.toBukkit(this.entity.position(), this.getWorld(), this.entity.getBukkitYaw(), this.entity.getXRot());
@@ -524,14 +556,6 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
         this.getHandle().totalEntityAge = value;
     }
 
-    public Entity getHandle() {
-        return this.entity;
-    }
-
-    public Entity getHandleRaw() {
-        return this.entity;
-    }
-
     @Override
     public final EntityType getType() {
         return this.entityType;
@@ -559,30 +583,6 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     @Override
     public Sound getSwimHighSpeedSplashSound() {
         return CraftSound.minecraftToBukkit(this.getHandle().getSwimHighSpeedSplashSound());
-    }
-
-    public void setHandle(final Entity entity) {
-        this.entity = entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftEntity{" + "id=" + this.getEntityId() + '}';
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
-
-        final CraftEntity other = (CraftEntity) obj;
-        return this.entity == other.entity; // There should never be duplicate entities with differing references
-    }
-
-    @Override
-    public int hashCode() {
-        // The UUID and thus hash code should never change (unlike the entity id)
-        return this.getUniqueId().hashCode();
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEvoker.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEvoker.java
@@ -13,12 +13,7 @@ public class CraftEvoker extends CraftSpellcaster implements Evoker {
 
     @Override
     public net.minecraft.world.entity.monster.Evoker getHandle() {
-        return (net.minecraft.world.entity.monster.Evoker) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftEvoker";
+        return (net.minecraft.world.entity.monster.Evoker) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEvokerFangs.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEvokerFangs.java
@@ -13,12 +13,7 @@ public class CraftEvokerFangs extends CraftEntity implements EvokerFangs {
 
     @Override
     public net.minecraft.world.entity.projectile.EvokerFangs getHandle() {
-        return (net.minecraft.world.entity.projectile.EvokerFangs) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftEvokerFangs";
+        return (net.minecraft.world.entity.projectile.EvokerFangs) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftExperienceOrb.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftExperienceOrb.java
@@ -5,8 +5,14 @@ import org.bukkit.entity.ExperienceOrb;
 import java.util.UUID;
 
 public class CraftExperienceOrb extends CraftEntity implements ExperienceOrb {
+
     public CraftExperienceOrb(CraftServer server, net.minecraft.world.entity.ExperienceOrb entity) {
         super(server, entity);
+    }
+
+    @Override
+    public net.minecraft.world.entity.ExperienceOrb getHandle() {
+        return (net.minecraft.world.entity.ExperienceOrb) this.entity;
     }
 
     @Override
@@ -42,15 +48,5 @@ public class CraftExperienceOrb extends CraftEntity implements ExperienceOrb {
     @Override
     public SpawnReason getSpawnReason() {
         return this.getHandle().spawnReason;
-    }
-
-    @Override
-    public net.minecraft.world.entity.ExperienceOrb getHandle() {
-        return (net.minecraft.world.entity.ExperienceOrb) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftExperienceOrb";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFallingBlock.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFallingBlock.java
@@ -20,11 +20,6 @@ public class CraftFallingBlock extends CraftEntity implements FallingBlock {
     }
 
     @Override
-    public String toString() {
-        return "CraftFallingBlock";
-    }
-
-    @Override
     public Material getMaterial() {
         return this.getBlockData().getMaterial();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
@@ -9,8 +9,14 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 public class CraftFireball extends AbstractProjectile implements Fireball {
+
     public CraftFireball(CraftServer server, AbstractHurtingProjectile entity) {
         super(server, entity);
+    }
+
+    @Override
+    public AbstractHurtingProjectile getHandle() {
+        return (AbstractHurtingProjectile) this.entity;
     }
 
     @Override
@@ -78,14 +84,4 @@ public class CraftFireball extends AbstractProjectile implements Fireball {
         return this.getAcceleration();
     }
     // Paper end - Expose power on fireball projectiles
-
-    @Override
-    public AbstractHurtingProjectile getHandle() {
-        return (AbstractHurtingProjectile) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftFireball";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFirework.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFirework.java
@@ -24,11 +24,6 @@ public class CraftFirework extends CraftProjectile implements Firework {
     }
 
     @Override
-    public String toString() {
-        return "CraftFirework";
-    }
-
-    @Override
     public FireworkMeta getFireworkMeta() {
         return (FireworkMeta) CraftItemStack.getItemMeta(this.getHandle().getEntityData().get(FireworkRocketEntity.DATA_ID_FIREWORKS_ITEM), org.bukkit.inventory.ItemType.FIREWORK_ROCKET); // Paper - Expose firework item directly
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFish.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFish.java
@@ -14,9 +14,4 @@ public class CraftFish extends CraftWaterMob implements Fish, io.papermc.paper.e
     public AbstractFish getHandle() {
         return (AbstractFish) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftFish";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.FishHook;
 import org.bukkit.inventory.EquipmentSlot;
 
 public class CraftFishHook extends CraftProjectile implements FishHook {
+
     private double biteChance = -1;
 
     public CraftFishHook(CraftServer server, FishingHook entity) {
@@ -23,11 +24,6 @@ public class CraftFishHook extends CraftProjectile implements FishHook {
     @Override
     public FishingHook getHandle() {
         return (FishingHook) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftFishingHook";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFlying.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFlying.java
@@ -14,9 +14,4 @@ public class CraftFlying extends CraftMob implements Flying {
     public FlyingMob getHandle() {
         return (FlyingMob) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftFlying";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFox.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFox.java
@@ -17,12 +17,7 @@ public class CraftFox extends CraftAnimals implements Fox {
 
     @Override
     public net.minecraft.world.entity.animal.Fox getHandle() {
-        return (net.minecraft.world.entity.animal.Fox) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftFox";
+        return (net.minecraft.world.entity.animal.Fox) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFrog.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFrog.java
@@ -24,11 +24,6 @@ public class CraftFrog extends CraftAnimals implements org.bukkit.entity.Frog {
     }
 
     @Override
-    public String toString() {
-        return "CraftFrog";
-    }
-
-    @Override
     public Entity getTongueTarget() {
         return this.getHandle().getTongueTarget().map(net.minecraft.world.entity.Entity::getBukkitEntity).orElse(null);
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGhast.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGhast.java
@@ -15,11 +15,6 @@ public class CraftGhast extends CraftFlying implements Ghast, CraftEnemy {
     }
 
     @Override
-    public String toString() {
-        return "CraftGhast";
-    }
-
-    @Override
     public boolean isCharging() {
         return this.getHandle().isCharging();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGiant.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGiant.java
@@ -13,9 +13,4 @@ public class CraftGiant extends CraftMonster implements Giant {
     public net.minecraft.world.entity.monster.Giant getHandle() {
         return (net.minecraft.world.entity.monster.Giant) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftGiant";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGlowItemFrame.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGlowItemFrame.java
@@ -11,11 +11,6 @@ public class CraftGlowItemFrame extends CraftItemFrame implements GlowItemFrame 
 
     @Override
     public net.minecraft.world.entity.decoration.GlowItemFrame getHandle() {
-        return (net.minecraft.world.entity.decoration.GlowItemFrame) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftGlowItemFrame{item=" + this.getItem() + ", rotation=" + this.getRotation() + "}";
+        return (net.minecraft.world.entity.decoration.GlowItemFrame) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGlowSquid.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGlowSquid.java
@@ -12,12 +12,7 @@ public class CraftGlowSquid extends CraftSquid implements GlowSquid {
 
     @Override
     public net.minecraft.world.entity.GlowSquid getHandle() {
-        return (net.minecraft.world.entity.GlowSquid) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftGlowSquid";
+        return (net.minecraft.world.entity.GlowSquid) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGoat.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGoat.java
@@ -11,12 +11,7 @@ public class CraftGoat extends CraftAnimals implements Goat {
 
     @Override
     public net.minecraft.world.entity.animal.goat.Goat getHandle() {
-        return (net.minecraft.world.entity.animal.goat.Goat) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftGoat";
+        return (net.minecraft.world.entity.animal.goat.Goat) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGolem.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGolem.java
@@ -5,6 +5,7 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Golem;
 
 public class CraftGolem extends CraftCreature implements Golem {
+
     public CraftGolem(CraftServer server, AbstractGolem entity) {
         super(server, entity);
     }
@@ -12,10 +13,5 @@ public class CraftGolem extends CraftCreature implements Golem {
     @Override
     public AbstractGolem getHandle() {
         return (AbstractGolem) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftGolem";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGuardian.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftGuardian.java
@@ -15,12 +15,7 @@ public class CraftGuardian extends CraftMonster implements Guardian {
 
     @Override
     public net.minecraft.world.entity.monster.Guardian getHandle() {
-        return (net.minecraft.world.entity.monster.Guardian) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftGuardian";
+        return (net.minecraft.world.entity.monster.Guardian) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHanging.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHanging.java
@@ -8,6 +8,7 @@ import org.bukkit.craftbukkit.block.CraftBlock;
 import org.bukkit.entity.Hanging;
 
 public class CraftHanging extends CraftBlockAttachedEntity implements Hanging {
+
     public CraftHanging(CraftServer server, HangingEntity entity) {
         super(server, entity);
     }
@@ -60,10 +61,5 @@ public class CraftHanging extends CraftBlockAttachedEntity implements Hanging {
     @Override
     public HangingEntity getHandle() {
         return (HangingEntity) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftHanging";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHoglin.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHoglin.java
@@ -11,6 +11,11 @@ public class CraftHoglin extends CraftAnimals implements Hoglin, CraftEnemy {
     }
 
     @Override
+    public net.minecraft.world.entity.monster.hoglin.Hoglin getHandle() {
+        return (net.minecraft.world.entity.monster.hoglin.Hoglin) this.entity;
+    }
+
+    @Override
     public boolean isImmuneToZombification() {
         return this.getHandle().isImmuneToZombification();
     }
@@ -49,15 +54,5 @@ public class CraftHoglin extends CraftAnimals implements Hoglin, CraftEnemy {
     @Override
     public boolean isConverting() {
         return this.getHandle().isConverting();
-    }
-
-    @Override
-    public net.minecraft.world.entity.monster.hoglin.Hoglin getHandle() {
-        return (net.minecraft.world.entity.monster.hoglin.Hoglin) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftHoglin";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHorse.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHorse.java
@@ -16,7 +16,7 @@ public class CraftHorse extends CraftAbstractHorse implements Horse {
 
     @Override
     public net.minecraft.world.entity.animal.horse.Horse getHandle() {
-        return (net.minecraft.world.entity.animal.horse.Horse) super.getHandle();
+        return (net.minecraft.world.entity.animal.horse.Horse) this.entity;
     }
 
     @Override
@@ -62,10 +62,5 @@ public class CraftHorse extends CraftAbstractHorse implements Horse {
             this.getHandle().createEquipmentSlotContainer(EquipmentSlot.BODY),
             this.getHandle().createEquipmentSlotContainer(EquipmentSlot.SADDLE)
         );
-    }
-
-    @Override
-    public String toString() {
-        return "CraftHorse{variant=" + this.getVariant() + ", owner=" + this.getOwner() + '}';
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -80,6 +80,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+
     private CraftInventoryPlayer inventory;
     private final CraftInventory enderChest;
     protected final PermissibleBase perm = new PermissibleBase(this);
@@ -91,6 +92,21 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         this.mode = server.getDefaultGameMode();
         this.inventory = new CraftInventoryPlayer(entity.getInventory());
         this.enderChest = new CraftInventory(entity.getEnderChestInventory());
+    }
+
+    @Override
+    public Player getHandle() {
+        return (Player) this.entity;
+    }
+
+    public void setHandle(final Player entity) {
+        super.setHandle(entity);
+        this.inventory = new CraftInventoryPlayer(entity.getInventory());
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "{name=" + this.getName() + ", uuid=" + this.getUniqueId() + '}';
     }
 
     @Override
@@ -302,21 +318,6 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         Preconditions.checkArgument(mode != null, "GameMode cannot be null");
 
         this.mode = mode;
-    }
-
-    @Override
-    public Player getHandle() {
-        return (Player) this.entity;
-    }
-
-    public void setHandle(final Player entity) {
-        super.setHandle(entity);
-        this.inventory = new CraftInventoryPlayer(entity.getInventory());
-    }
-
-    @Override
-    public String toString() {
-        return "CraftHumanEntity{" + "id=" + this.getEntityId() + "name=" + this.getName() + '}';
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHusk.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHusk.java
@@ -8,9 +8,4 @@ public class CraftHusk extends CraftZombie implements Husk {
     public CraftHusk(CraftServer server, net.minecraft.world.entity.monster.Husk entity) {
         super(server, entity);
     }
-
-    @Override
-    public String toString() {
-        return "CraftHusk";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftIllager.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftIllager.java
@@ -12,11 +12,6 @@ public class CraftIllager extends CraftRaider implements Illager {
 
     @Override
     public AbstractIllager getHandle() {
-        return (AbstractIllager) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftIllager";
+        return (AbstractIllager) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftIllusioner.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftIllusioner.java
@@ -11,11 +11,6 @@ public class CraftIllusioner extends CraftSpellcaster implements Illusioner, com
 
     @Override
     public net.minecraft.world.entity.monster.Illusioner getHandle() {
-        return (net.minecraft.world.entity.monster.Illusioner) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftIllusioner";
+        return (net.minecraft.world.entity.monster.Illusioner) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftInteraction.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftInteraction.java
@@ -14,12 +14,7 @@ public class CraftInteraction extends CraftEntity implements Interaction {
 
     @Override
     public net.minecraft.world.entity.Interaction getHandle() {
-        return (net.minecraft.world.entity.Interaction) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftInteraction";
+        return (net.minecraft.world.entity.Interaction) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftIronGolem.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftIronGolem.java
@@ -14,11 +14,6 @@ public class CraftIronGolem extends CraftGolem implements IronGolem {
     }
 
     @Override
-    public String toString() {
-        return "CraftIronGolem";
-    }
-
-    @Override
     public boolean isPlayerCreated() {
         return this.getHandle().isPlayerCreated();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
@@ -143,9 +143,4 @@ public class CraftItem extends CraftEntity implements Item {
     public UUID getThrower() {
         return this.getHandle().thrower;
     }
-
-    @Override
-    public String toString() {
-        return "CraftItem";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftItemDisplay.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftItemDisplay.java
@@ -15,12 +15,7 @@ public class CraftItemDisplay extends CraftDisplay implements ItemDisplay {
 
     @Override
     public net.minecraft.world.entity.Display.ItemDisplay getHandle() {
-        return (net.minecraft.world.entity.Display.ItemDisplay) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftItemDisplay";
+        return (net.minecraft.world.entity.Display.ItemDisplay) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftItemFrame.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftItemFrame.java
@@ -12,8 +12,14 @@ import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.ItemFrame;
 
 public class CraftItemFrame extends CraftHanging implements ItemFrame {
+
     public CraftItemFrame(CraftServer server, net.minecraft.world.entity.decoration.ItemFrame entity) {
         super(server, entity);
+    }
+
+    @Override
+    public net.minecraft.world.entity.decoration.ItemFrame getHandle() {
+        return (net.minecraft.world.entity.decoration.ItemFrame) this.entity;
     }
 
     @Override
@@ -149,15 +155,5 @@ public class CraftItemFrame extends CraftHanging implements ItemFrame {
     @Override
     public void setFixed(boolean fixed) {
         this.getHandle().fixed = fixed;
-    }
-
-    @Override
-    public net.minecraft.world.entity.decoration.ItemFrame getHandle() {
-        return (net.minecraft.world.entity.decoration.ItemFrame) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftItemFrame{item=" + this.getItem() + ", rotation=" + this.getRotation() + "}";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLargeFireball.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLargeFireball.java
@@ -4,14 +4,9 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.LargeFireball;
 
 public class CraftLargeFireball extends CraftSizedFireball implements LargeFireball {
+
     public CraftLargeFireball(CraftServer server, net.minecraft.world.entity.projectile.LargeFireball entity) {
         super(server, entity);
-    }
-
-    @Override
-    public void setYield(float yield) {
-        super.setYield(yield);
-        this.getHandle().explosionPower = (int) yield;
     }
 
     @Override
@@ -20,7 +15,8 @@ public class CraftLargeFireball extends CraftSizedFireball implements LargeFireb
     }
 
     @Override
-    public String toString() {
-        return "CraftLargeFireball";
+    public void setYield(float yield) {
+        super.setYield(yield);
+        this.getHandle().explosionPower = (int) yield;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLeash.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLeash.java
@@ -7,8 +7,14 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.LeashHitch;
 
 public class CraftLeash extends CraftBlockAttachedEntity implements LeashHitch {
+
     public CraftLeash(CraftServer server, LeashFenceKnotEntity entity) {
         super(server, entity);
+    }
+
+    @Override
+    public LeashFenceKnotEntity getHandle() {
+        return (LeashFenceKnotEntity) this.entity;
     }
 
     @Override
@@ -33,15 +39,5 @@ public class CraftLeash extends CraftBlockAttachedEntity implements LeashHitch {
     @Override
     public void setFacingDirection(BlockFace face) {
         // Leash hitch has no facing direction
-    }
-
-    @Override
-    public LeashFenceKnotEntity getHandle() {
-        return (LeashFenceKnotEntity) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftLeash";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLightningStrike.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLightningStrike.java
@@ -7,8 +7,14 @@ import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.Player;
 
 public class CraftLightningStrike extends CraftEntity implements LightningStrike {
+
     public CraftLightningStrike(final CraftServer server, final LightningBolt entity) {
         super(server, entity);
+    }
+
+    @Override
+    public LightningBolt getHandle() {
+        return (LightningBolt) this.entity;
     }
 
     @Override
@@ -39,16 +45,6 @@ public class CraftLightningStrike extends CraftEntity implements LightningStrike
 
     public void setCausingPlayer(Player player) {
         this.getHandle().setCause((player != null) ? ((CraftPlayer) player).getHandle() : null);
-    }
-
-    @Override
-    public LightningBolt getHandle() {
-        return (LightningBolt) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftLightningStrike";
     }
 
     // Spigot start

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
@@ -108,6 +108,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
     }
 
     @Override
+    public net.minecraft.world.entity.LivingEntity getHandle() {
+        return (net.minecraft.world.entity.LivingEntity) this.entity;
+    }
+
+    @Override
     public double getHealth() {
         return Math.min(Math.max(0, this.getHandle().getHealth()), this.getMaxHealth());
     }
@@ -501,20 +506,6 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
     public void setNoActionTicks(int ticks) {
         Preconditions.checkArgument(ticks >= 0, "ticks must be >= 0");
         this.getHandle().setNoActionTime(ticks);
-    }
-
-    @Override
-    public net.minecraft.world.entity.LivingEntity getHandle() {
-        return (net.minecraft.world.entity.LivingEntity) this.entity;
-    }
-
-    public void setHandle(final net.minecraft.world.entity.LivingEntity entity) {
-        super.setHandle(entity);
-    }
-
-    @Override
-    public String toString() {
-        return "CraftLivingEntity{" + "id=" + this.getEntityId() + '}';
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLlama.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLlama.java
@@ -6,7 +6,6 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.inventory.CraftInventoryLlama;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Llama;
-import org.bukkit.entity.Llama.Color;
 import org.bukkit.inventory.LlamaInventory;
 
 public class CraftLlama extends CraftChestedHorse implements Llama, com.destroystokyo.paper.entity.CraftRangedEntity<net.minecraft.world.entity.animal.horse.Llama> { // Paper
@@ -17,7 +16,7 @@ public class CraftLlama extends CraftChestedHorse implements Llama, com.destroys
 
     @Override
     public net.minecraft.world.entity.animal.horse.Llama getHandle() {
-        return (net.minecraft.world.entity.animal.horse.Llama) super.getHandle();
+        return (net.minecraft.world.entity.animal.horse.Llama) this.entity;
     }
 
     @Override
@@ -56,11 +55,6 @@ public class CraftLlama extends CraftChestedHorse implements Llama, com.destroys
     @Override
     public Horse.Variant getVariant() {
         return Horse.Variant.LLAMA;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftLlama";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLlamaSpit.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLlamaSpit.java
@@ -11,11 +11,6 @@ public class CraftLlamaSpit extends AbstractProjectile implements LlamaSpit {
 
     @Override
     public net.minecraft.world.entity.projectile.LlamaSpit getHandle() {
-        return (net.minecraft.world.entity.projectile.LlamaSpit) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftLlamaSpit";
+        return (net.minecraft.world.entity.projectile.LlamaSpit) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMagmaCube.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMagmaCube.java
@@ -13,9 +13,4 @@ public class CraftMagmaCube extends CraftSlime implements MagmaCube {
     public net.minecraft.world.entity.monster.MagmaCube getHandle() {
         return (net.minecraft.world.entity.monster.MagmaCube) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftMagmaCube";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMarker.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMarker.java
@@ -11,11 +11,6 @@ public class CraftMarker extends CraftEntity implements Marker {
 
     @Override
     public net.minecraft.world.entity.Marker getHandle() {
-        return (net.minecraft.world.entity.Marker) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftMarker";
+        return (net.minecraft.world.entity.Marker) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java
@@ -3,7 +3,6 @@ package org.bukkit.craftbukkit.entity;
 import com.google.common.base.Preconditions;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.vehicle.AbstractMinecart;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
@@ -16,8 +15,14 @@ import org.bukkit.util.Vector;
 import java.util.Optional;
 
 public abstract class CraftMinecart extends CraftVehicle implements Minecart {
+
     public CraftMinecart(CraftServer server, AbstractMinecart entity) {
         super(server, entity);
+    }
+
+    @Override
+    public AbstractMinecart getHandle() {
+        return (AbstractMinecart) this.entity;
     }
 
     @Override
@@ -78,11 +83,6 @@ public abstract class CraftMinecart extends CraftVehicle implements Minecart {
         return CraftMagicNumbers.getMaterial(this.getHandle().getDropItem());
     }
     // Paper end
-
-    @Override
-    public AbstractMinecart getHandle() {
-        return (AbstractMinecart) this.entity;
-    }
 
     @Override
     public void setDisplayBlock(MaterialData material) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.minecart.StorageMinecart;
 import org.bukkit.inventory.Inventory;
 
 public class CraftMinecartChest extends CraftMinecartContainer implements StorageMinecart, com.destroystokyo.paper.loottable.PaperLootableEntityInventory { // Paper
+
     private final CraftInventory inventory;
 
     public CraftMinecartChest(CraftServer server, MinecartChest entity) {
@@ -17,10 +18,5 @@ public class CraftMinecartChest extends CraftMinecartContainer implements Storag
     @Override
     public Inventory getInventory() {
         return this.inventory;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftMinecartChest{" + "inventory=" + this.inventory + '}';
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java
@@ -14,6 +14,7 @@ import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.plugin.Plugin;
 
 public class CraftMinecartCommand extends CraftMinecart implements CommandMinecart, io.papermc.paper.commands.PaperCommandBlockHolder {
+
     private final PermissibleBase perm = new PermissibleBase(this);
 
     public CraftMinecartCommand(CraftServer server, MinecartCommandBlock entity) {
@@ -39,11 +40,6 @@ public class CraftMinecartCommand extends CraftMinecart implements CommandMineca
     @Override
     public void setName(String name) {
         this.getHandle().getCommandBlock().setCustomName(CraftChatMessage.fromStringOrNull(name));
-    }
-
-    @Override
-    public String toString() {
-        return "CraftMinecartCommand";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartFurnace.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartFurnace.java
@@ -6,6 +6,7 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.minecart.PoweredMinecart;
 
 public class CraftMinecartFurnace extends CraftMinecart implements PoweredMinecart {
+
     public CraftMinecartFurnace(CraftServer server, MinecartFurnace entity) {
         super(server, entity);
     }
@@ -46,10 +47,5 @@ public class CraftMinecartFurnace extends CraftMinecart implements PoweredMineca
     public void setPushZ(double zPush) {
         final net.minecraft.world.phys.Vec3 push = this.getHandle().push;
         this.getHandle().push = new net.minecraft.world.phys.Vec3(push.x, push.y, zPush);
-    }
-
-    @Override
-    public String toString() {
-        return "CraftMinecartFurnace";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartHopper.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartHopper.java
@@ -6,7 +6,8 @@ import org.bukkit.craftbukkit.inventory.CraftInventory;
 import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.inventory.Inventory;
 
-public final class CraftMinecartHopper extends CraftMinecartContainer implements HopperMinecart, com.destroystokyo.paper.loottable.PaperLootableEntityInventory { // Paper
+public class CraftMinecartHopper extends CraftMinecartContainer implements HopperMinecart, com.destroystokyo.paper.loottable.PaperLootableEntityInventory { // Paper
+
     private final CraftInventory inventory;
 
     public CraftMinecartHopper(CraftServer server, MinecartHopper entity) {
@@ -15,8 +16,8 @@ public final class CraftMinecartHopper extends CraftMinecartContainer implements
     }
 
     @Override
-    public String toString() {
-        return "CraftMinecartHopper{" + "inventory=" + this.inventory + '}';
+    public net.minecraft.world.entity.vehicle.MinecartHopper getHandle() {
+        return (net.minecraft.world.entity.vehicle.MinecartHopper) this.entity;
     }
 
     @Override
@@ -32,11 +33,6 @@ public final class CraftMinecartHopper extends CraftMinecartContainer implements
     @Override
     public void setEnabled(boolean enabled) {
         this.getHandle().setEnabled(enabled);
-    }
-
-    @Override
-    public net.minecraft.world.entity.vehicle.MinecartHopper getHandle() {
-        return (net.minecraft.world.entity.vehicle.MinecartHopper) super.getHandle();
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartMobSpawner.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartMobSpawner.java
@@ -16,9 +16,15 @@ import org.bukkit.entity.EntitySnapshot;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.minecart.SpawnerMinecart;
 
-final class CraftMinecartMobSpawner extends CraftMinecart implements SpawnerMinecart, org.bukkit.craftbukkit.spawner.PaperSharedSpawnerLogic { // Paper - more spawner API
-    CraftMinecartMobSpawner(CraftServer server, MinecartSpawner entity) {
+public class CraftMinecartMobSpawner extends CraftMinecart implements SpawnerMinecart, org.bukkit.craftbukkit.spawner.PaperSharedSpawnerLogic { // Paper - more spawner API
+
+    public CraftMinecartMobSpawner(CraftServer server, MinecartSpawner entity) {
         super(server, entity);
+    }
+
+    @Override
+    public MinecartSpawner getHandle() {
+        return (MinecartSpawner) this.entity;
     }
 
     @Override
@@ -160,16 +166,6 @@ final class CraftMinecartMobSpawner extends CraftMinecart implements SpawnerMine
     @Override
     public void setSpawnRange(int spawnRange) {
         this.getHandle().getSpawner().spawnRange = spawnRange;
-    }
-
-    @Override
-    public MinecartSpawner getHandle() {
-        return (MinecartSpawner) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftMinecartMobSpawner";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartRideable.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartRideable.java
@@ -1,16 +1,12 @@
 package org.bukkit.craftbukkit.entity;
 
-import net.minecraft.world.entity.vehicle.AbstractMinecart;
+import net.minecraft.world.entity.vehicle.Minecart;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.minecart.RideableMinecart;
 
 public class CraftMinecartRideable extends CraftMinecart implements RideableMinecart {
-    public CraftMinecartRideable(CraftServer server, AbstractMinecart entity) {
-        super(server, entity);
-    }
 
-    @Override
-    public String toString() {
-        return "CraftMinecartRideable";
+    public CraftMinecartRideable(CraftServer server, Minecart entity) {
+        super(server, entity);
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartTNT.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartTNT.java
@@ -6,9 +6,15 @@ import net.minecraft.world.entity.vehicle.MinecartTNT;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
 
-public final class CraftMinecartTNT extends CraftMinecart implements ExplosiveMinecart {
-    CraftMinecartTNT(CraftServer server, MinecartTNT entity) {
+public class CraftMinecartTNT extends CraftMinecart implements ExplosiveMinecart {
+
+    public CraftMinecartTNT(CraftServer server, MinecartTNT entity) {
         super(server, entity);
+    }
+
+    @Override
+    public MinecartTNT getHandle() {
+        return (MinecartTNT) this.entity;
     }
 
     @Override
@@ -71,15 +77,5 @@ public final class CraftMinecartTNT extends CraftMinecart implements ExplosiveMi
         Preconditions.checkArgument(0 <= power && power <= Mth.square(5), "Power must be in range [0, 25] (got %s)", power);
 
         this.getHandle().explode(power);
-    }
-
-    @Override
-    public MinecartTNT getHandle() {
-        return (MinecartTNT) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftMinecartTNT";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
@@ -12,13 +12,30 @@ import org.bukkit.entity.Mob;
 import org.bukkit.loot.LootTable;
 
 public abstract class CraftMob extends CraftLivingEntity implements Mob, io.papermc.paper.entity.PaperLeashable { // Paper - Leashable API
-    public CraftMob(CraftServer server, net.minecraft.world.entity.Mob entity) {
-        super(server, entity);
-         paperPathfinder = new com.destroystokyo.paper.entity.PaperPathfinder(entity); // Paper - Mob Pathfinding API
-    }
 
     private final com.destroystokyo.paper.entity.PaperPathfinder paperPathfinder; // Paper - Mob Pathfinding API
-    @Override public com.destroystokyo.paper.entity.Pathfinder getPathfinder() { return paperPathfinder; } // Paper - Mob Pathfinding API
+
+    public CraftMob(CraftServer server, net.minecraft.world.entity.Mob entity) {
+        super(server, entity);
+        this.paperPathfinder = new com.destroystokyo.paper.entity.PaperPathfinder(entity); // Paper - Mob Pathfinding API
+    }
+
+    @Override
+    public net.minecraft.world.entity.Mob getHandle() {
+        return (net.minecraft.world.entity.Mob) this.entity;
+    }
+
+    @Override
+    public void setHandle(net.minecraft.world.entity.Entity entity) {
+        super.setHandle(entity);
+        this.paperPathfinder.setHandle(getHandle());
+    }
+
+    @Override
+    public com.destroystokyo.paper.entity.Pathfinder getPathfinder() {
+        return this.paperPathfinder;
+    }
+
     @Override
     public void setTarget(LivingEntity target) {
         Preconditions.checkState(!this.getHandle().generation, "Cannot set target during world generation");
@@ -52,24 +69,6 @@ public abstract class CraftMob extends CraftLivingEntity implements Mob, io.pape
     public Sound getAmbientSound() {
         SoundEvent sound = this.getHandle().getAmbientSound();
         return (sound != null) ? CraftSound.minecraftToBukkit(sound) : null;
-    }
-
-    @Override
-    public net.minecraft.world.entity.Mob getHandle() {
-        return (net.minecraft.world.entity.Mob) this.entity;
-    }
-
-    // Paper start - Mob Pathfinding API
-    @Override
-    public void setHandle(net.minecraft.world.entity.Entity entity) {
-        super.setHandle(entity);
-        paperPathfinder.setHandle(getHandle());
-    }
-    // Paper end - Mob Pathfinding API
-
-    @Override
-    public String toString() {
-        return "CraftMob";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMonster.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMonster.java
@@ -13,9 +13,4 @@ public class CraftMonster extends CraftCreature implements Monster, CraftEnemy {
     public net.minecraft.world.entity.monster.Monster getHandle() {
         return (net.minecraft.world.entity.monster.Monster) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftMonster";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMule.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMule.java
@@ -11,11 +11,6 @@ public class CraftMule extends CraftChestedHorse implements Mule {
     }
 
     @Override
-    public String toString() {
-        return "CraftMule";
-    }
-
-    @Override
     public Variant getVariant() {
         return Variant.MULE;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMushroomCow.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMushroomCow.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import net.minecraft.core.Holder;
 import net.minecraft.world.effect.MobEffect;
-import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.item.component.SuspiciousStewEffects;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.potion.CraftPotionEffectType;
@@ -15,8 +14,14 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 public class CraftMushroomCow extends CraftAbstractCow implements MushroomCow, io.papermc.paper.entity.PaperShearable { // Paper
+
     public CraftMushroomCow(CraftServer server, net.minecraft.world.entity.animal.MushroomCow entity) {
         super(server, entity);
+    }
+
+    @Override
+    public net.minecraft.world.entity.animal.MushroomCow getHandle() {
+        return (net.minecraft.world.entity.animal.MushroomCow) this.entity;
     }
 
     @Override
@@ -93,11 +98,6 @@ public class CraftMushroomCow extends CraftAbstractCow implements MushroomCow, i
     }
 
     @Override
-    public net.minecraft.world.entity.animal.MushroomCow getHandle() {
-        return (net.minecraft.world.entity.animal.MushroomCow) this.entity;
-    }
-
-    @Override
     public Variant getVariant() {
         return Variant.values()[this.getHandle().getVariant().ordinal()];
     }
@@ -145,9 +145,4 @@ public class CraftMushroomCow extends CraftAbstractCow implements MushroomCow, i
         this.getHandle().stewEffects = new SuspiciousStewEffects(nmsPairs);
     }
     // Paper end
-
-    @Override
-    public String toString() {
-        return "CraftMushroomCow";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftOcelot.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftOcelot.java
@@ -4,6 +4,7 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Ocelot;
 
 public class CraftOcelot extends CraftAnimals implements Ocelot {
+
     public CraftOcelot(CraftServer server, net.minecraft.world.entity.animal.Ocelot ocelot) {
         super(server, ocelot);
     }
@@ -31,10 +32,5 @@ public class CraftOcelot extends CraftAnimals implements Ocelot {
     @Override
     public void setCatType(Type type) {
         throw new UnsupportedOperationException("Cats are now a different entity!");
-    }
-
-    @Override
-    public String toString() {
-        return "CraftOcelot";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftOminousItemSpawner.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftOminousItemSpawner.java
@@ -17,11 +17,6 @@ public class CraftOminousItemSpawner extends CraftEntity implements OminousItemS
     }
 
     @Override
-    public String toString() {
-        return "CraftOminousItemSpawner";
-    }
-
-    @Override
     public ItemStack getItem() {
         return CraftItemStack.asBukkitCopy(this.getHandle().getItem());
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPainting.java
@@ -15,6 +15,11 @@ public class CraftPainting extends CraftHanging implements Painting {
     }
 
     @Override
+    public net.minecraft.world.entity.decoration.Painting getHandle() {
+        return (net.minecraft.world.entity.decoration.Painting) this.entity;
+    }
+
+    @Override
     public Art getArt() {
         return CraftArt.minecraftHolderToBukkit(this.getHandle().getVariant());
     }
@@ -48,15 +53,5 @@ public class CraftPainting extends CraftHanging implements Painting {
         }
 
         return false;
-    }
-
-    @Override
-    public net.minecraft.world.entity.decoration.Painting getHandle() {
-        return (net.minecraft.world.entity.decoration.Painting) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftPainting{art=" + this.getArt() + "}";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java
@@ -12,12 +12,7 @@ public class CraftPanda extends CraftAnimals implements Panda {
 
     @Override
     public net.minecraft.world.entity.animal.Panda getHandle() {
-        return (net.minecraft.world.entity.animal.Panda) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftPanda";
+        return (net.minecraft.world.entity.animal.Panda) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftParrot.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftParrot.java
@@ -3,7 +3,6 @@ package org.bukkit.craftbukkit.entity;
 import com.google.common.base.Preconditions;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Parrot;
-import org.bukkit.entity.Parrot.Variant;
 
 public class CraftParrot extends CraftTameableAnimal implements Parrot {
 
@@ -26,11 +25,6 @@ public class CraftParrot extends CraftTameableAnimal implements Parrot {
         Preconditions.checkArgument(variant != null, "variant cannot be null");
 
         this.getHandle().setVariant(net.minecraft.world.entity.animal.Parrot.Variant.byId(variant.ordinal()));
-    }
-
-    @Override
-    public String toString() {
-        return "CraftParrot";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPhantom.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPhantom.java
@@ -15,7 +15,7 @@ public class CraftPhantom extends CraftFlying implements Phantom, CraftEnemy {
 
     @Override
     public net.minecraft.world.entity.monster.Phantom getHandle() {
-        return (net.minecraft.world.entity.monster.Phantom) super.getHandle();
+        return (net.minecraft.world.entity.monster.Phantom) this.entity;
     }
 
     @Override
@@ -26,11 +26,6 @@ public class CraftPhantom extends CraftFlying implements Phantom, CraftEnemy {
     @Override
     public void setSize(int size) {
         this.getHandle().setPhantomSize(size);
-    }
-
-    @Override
-    public String toString() {
-        return "CraftPhantom";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPig.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPig.java
@@ -9,10 +9,8 @@ import net.minecraft.world.entity.animal.PigVariant;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.craftbukkit.CraftRegistry;
 import org.bukkit.craftbukkit.CraftServer;
-import org.bukkit.craftbukkit.util.Handleable;
 import org.bukkit.entity.Pig;
 import org.jspecify.annotations.NullMarked;
 
@@ -21,6 +19,11 @@ public class CraftPig extends CraftAnimals implements Pig {
 
     public CraftPig(CraftServer server, net.minecraft.world.entity.animal.Pig entity) {
         super(server, entity);
+    }
+
+    @Override
+    public net.minecraft.world.entity.animal.Pig getHandle() {
+        return (net.minecraft.world.entity.animal.Pig) this.entity;
     }
 
     @Override
@@ -100,15 +103,5 @@ public class CraftPig extends CraftAnimals implements Pig {
         public CraftVariant(final Holder<PigVariant> holder) {
             super(holder);
         }
-    }
-
-    @Override
-    public net.minecraft.world.entity.animal.Pig getHandle() {
-        return (net.minecraft.world.entity.animal.Pig) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftPig";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPigZombie.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPigZombie.java
@@ -11,6 +11,11 @@ public class CraftPigZombie extends CraftZombie implements PigZombie {
     }
 
     @Override
+    public ZombifiedPiglin getHandle() {
+        return (ZombifiedPiglin) this.entity;
+    }
+
+    @Override
     public int getAnger() {
         return this.getHandle().getRemainingPersistentAngerTime();
     }
@@ -28,16 +33,6 @@ public class CraftPigZombie extends CraftZombie implements PigZombie {
     @Override
     public boolean isAngry() {
         return this.getAnger() > 0;
-    }
-
-    @Override
-    public ZombifiedPiglin getHandle() {
-        return (ZombifiedPiglin) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftPigZombie";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java
@@ -19,6 +19,11 @@ public class CraftPiglin extends CraftPiglinAbstract implements Piglin, com.dest
     }
 
     @Override
+    public net.minecraft.world.entity.monster.piglin.Piglin getHandle() {
+        return (net.minecraft.world.entity.monster.piglin.Piglin) this.entity;
+    }
+
+    @Override
     public boolean isAbleToHunt() {
         return this.getHandle().cannotHunt;
     }
@@ -73,16 +78,6 @@ public class CraftPiglin extends CraftPiglinAbstract implements Piglin, com.dest
     @Override
     public Inventory getInventory() {
         return new CraftInventory(this.getHandle().inventory);
-    }
-
-    @Override
-    public net.minecraft.world.entity.monster.piglin.Piglin getHandle() {
-        return (net.minecraft.world.entity.monster.piglin.Piglin) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftPiglin";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglinAbstract.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglinAbstract.java
@@ -12,6 +12,11 @@ public class CraftPiglinAbstract extends CraftMonster implements PiglinAbstract 
     }
 
     @Override
+    public AbstractPiglin getHandle() {
+        return (AbstractPiglin) this.entity;
+    }
+
+    @Override
     public boolean isImmuneToZombification() {
         return this.getHandle().isImmuneToZombification();
     }
@@ -93,10 +98,5 @@ public class CraftPiglinAbstract extends CraftMonster implements PiglinAbstract 
 
     @Override
     public void setBreed(boolean b) {
-    }
-
-    @Override
-    public AbstractPiglin getHandle() {
-        return (AbstractPiglin) super.getHandle();
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglinBrute.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglinBrute.java
@@ -11,11 +11,6 @@ public class CraftPiglinBrute extends CraftPiglinAbstract implements PiglinBrute
 
     @Override
     public net.minecraft.world.entity.monster.piglin.PiglinBrute getHandle() {
-        return (net.minecraft.world.entity.monster.piglin.PiglinBrute) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftPiglinBrute";
+        return (net.minecraft.world.entity.monster.piglin.PiglinBrute) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPillager.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPillager.java
@@ -13,12 +13,7 @@ public class CraftPillager extends CraftIllager implements Pillager, com.destroy
 
     @Override
     public net.minecraft.world.entity.monster.Pillager getHandle() {
-        return (net.minecraft.world.entity.monster.Pillager) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftPillager";
+        return (net.minecraft.world.entity.monster.Pillager) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -43,6 +43,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import net.md_5.bungee.api.chat.BaseComponent;
 import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
@@ -203,10 +204,9 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.Scoreboard;
 import org.jetbrains.annotations.NotNull;
 
-import net.md_5.bungee.api.chat.BaseComponent; // Spigot
-
 @DelegateDeserialization(CraftOfflinePlayer.class)
 public class CraftPlayer extends CraftHumanEntity implements Player {
+
     private long firstPlayed = 0;
     private long lastPlayed = 0;
     private boolean hasPlayedBefore = false;
@@ -230,6 +230,27 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
         super(server, entity);
 
         this.firstPlayed = System.currentTimeMillis();
+    }
+
+    @Override
+    public ServerPlayer getHandle() {
+        return (ServerPlayer) this.entity;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        // Long-term, this should just use the super equals... for now, check the UUID
+        if (obj == this) return true;
+        if (!(obj instanceof OfflinePlayer other)) return false;
+        return this.getUniqueId().equals(other.getUniqueId());
+    }
+
+    @Override
+    public int hashCode() {
+        if (this.hash == 0 || this.hash == 485) {
+            this.hash = 97 * 5 + this.getUniqueId().hashCode();
+        }
+        return this.hash;
     }
 
     public GameProfile getProfile() {
@@ -660,14 +681,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
 
         ClientboundTabListPacket packet = new ClientboundTabListPacket(io.papermc.paper.adventure.PaperAdventure.asVanillaNullToEmpty(this.playerListHeader), io.papermc.paper.adventure.PaperAdventure.asVanillaNullToEmpty(this.playerListFooter)); // Paper - adventure
         this.getHandle().connection.send(packet);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        // Long-term, this should just use the super equals... for now, check the UUID
-        if (obj == this) return true;
-        if (!(obj instanceof OfflinePlayer other)) return false;
-        return this.getUniqueId().equals(other.getUniqueId());
     }
 
     @Override
@@ -2304,28 +2317,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     @Override
     public Player getPlayer() {
         return this;
-    }
-
-    @Override
-    public ServerPlayer getHandle() {
-        return (ServerPlayer) this.entity;
-    }
-
-    public void setHandle(final ServerPlayer entity) {
-        super.setHandle(entity);
-    }
-
-    @Override
-    public String toString() {
-        return "CraftPlayer{" + "name=" + this.getName() + '}';
-    }
-
-    @Override
-    public int hashCode() {
-        if (this.hash == 0 || this.hash == 485) {
-            this.hash = 97 * 5 + this.getUniqueId().hashCode();
-        }
-        return this.hash;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPolarBear.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPolarBear.java
@@ -8,14 +8,10 @@ public class CraftPolarBear extends CraftAnimals implements PolarBear {
     public CraftPolarBear(CraftServer server, net.minecraft.world.entity.animal.PolarBear entity) {
         super(server, entity);
     }
+
     @Override
     public net.minecraft.world.entity.animal.PolarBear getHandle() {
         return (net.minecraft.world.entity.animal.PolarBear) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftPolarBear";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftProjectile.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftProjectile.java
@@ -4,6 +4,7 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Projectile;
 
 public abstract class CraftProjectile extends AbstractProjectile implements Projectile {
+
     public CraftProjectile(CraftServer server, net.minecraft.world.entity.projectile.Projectile entity) {
         super(server, entity);
     }
@@ -11,10 +12,5 @@ public abstract class CraftProjectile extends AbstractProjectile implements Proj
     @Override
     public net.minecraft.world.entity.projectile.Projectile getHandle() {
         return (net.minecraft.world.entity.projectile.Projectile) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftProjectile";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPufferFish.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPufferFish.java
@@ -12,7 +12,7 @@ public class CraftPufferFish extends CraftFish implements PufferFish {
 
     @Override
     public Pufferfish getHandle() {
-        return (Pufferfish) super.getHandle();
+        return (Pufferfish) this.entity;
     }
 
     @Override
@@ -23,10 +23,5 @@ public class CraftPufferFish extends CraftFish implements PufferFish {
     @Override
     public void setPuffState(int state) {
         this.getHandle().setPuffState(state);
-    }
-
-    @Override
-    public String toString() {
-        return "CraftPufferFish";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftRabbit.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftRabbit.java
@@ -15,11 +15,6 @@ public class CraftRabbit extends CraftAnimals implements Rabbit {
     }
 
     @Override
-    public String toString() {
-        return "CraftRabbit{RabbitType=" + this.getRabbitType() + "}";
-    }
-
-    @Override
     public Type getRabbitType() {
         return Type.values()[this.getHandle().getVariant().ordinal()];
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftRaider.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftRaider.java
@@ -18,12 +18,7 @@ public abstract class CraftRaider extends CraftMonster implements Raider {
 
     @Override
     public net.minecraft.world.entity.raid.Raider getHandle() {
-        return (net.minecraft.world.entity.raid.Raider) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftRaider";
+        return (net.minecraft.world.entity.raid.Raider) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftRavager.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftRavager.java
@@ -11,12 +11,7 @@ public class CraftRavager extends CraftRaider implements Ravager {
 
     @Override
     public net.minecraft.world.entity.monster.Ravager getHandle() {
-        return (net.minecraft.world.entity.monster.Ravager) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftRavager";
+        return (net.minecraft.world.entity.monster.Ravager) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSalmon.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSalmon.java
@@ -12,12 +12,7 @@ public class CraftSalmon extends io.papermc.paper.entity.PaperSchoolableFish imp
 
     @Override
     public net.minecraft.world.entity.animal.Salmon getHandle() {
-        return (net.minecraft.world.entity.animal.Salmon) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftSalmon";
+        return (net.minecraft.world.entity.animal.Salmon) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSheep.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSheep.java
@@ -5,8 +5,14 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Sheep;
 
 public class CraftSheep extends CraftAnimals implements Sheep, io.papermc.paper.entity.PaperShearable { // Paper
+
     public CraftSheep(CraftServer server, net.minecraft.world.entity.animal.sheep.Sheep entity) {
         super(server, entity);
+    }
+
+    @Override
+    public net.minecraft.world.entity.animal.sheep.Sheep getHandle() {
+        return (net.minecraft.world.entity.animal.sheep.Sheep) this.entity;
     }
 
     @Override
@@ -27,15 +33,5 @@ public class CraftSheep extends CraftAnimals implements Sheep, io.papermc.paper.
     @Override
     public void setSheared(boolean flag) {
         this.getHandle().setSheared(flag);
-    }
-
-    @Override
-    public net.minecraft.world.entity.animal.sheep.Sheep getHandle() {
-        return (net.minecraft.world.entity.animal.sheep.Sheep) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftSheep";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftShulker.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftShulker.java
@@ -14,11 +14,6 @@ public class CraftShulker extends CraftGolem implements Shulker, CraftEnemy {
     }
 
     @Override
-    public String toString() {
-        return "CraftShulker";
-    }
-
-    @Override
     public net.minecraft.world.entity.monster.Shulker getHandle() {
         return (net.minecraft.world.entity.monster.Shulker) this.entity;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftShulkerBullet.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftShulkerBullet.java
@@ -11,6 +11,11 @@ public class CraftShulkerBullet extends AbstractProjectile implements ShulkerBul
     }
 
     @Override
+    public net.minecraft.world.entity.projectile.ShulkerBullet getHandle() {
+        return (net.minecraft.world.entity.projectile.ShulkerBullet) this.entity;
+    }
+
+    @Override
     public org.bukkit.entity.Entity getTarget() {
         return this.getHandle().getTarget() != null ? this.getHandle().getTarget().getBukkitEntity() : null;
     }
@@ -58,15 +63,5 @@ public class CraftShulkerBullet extends AbstractProjectile implements ShulkerBul
     @Override
     public void setFlightSteps(int steps) {
         this.getHandle().flightSteps = steps;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftShulkerBullet";
-    }
-
-    @Override
-    public net.minecraft.world.entity.projectile.ShulkerBullet getHandle() {
-        return (net.minecraft.world.entity.projectile.ShulkerBullet) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSilverfish.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSilverfish.java
@@ -4,6 +4,7 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Silverfish;
 
 public class CraftSilverfish extends CraftMonster implements Silverfish {
+
     public CraftSilverfish(CraftServer server, net.minecraft.world.entity.monster.Silverfish entity) {
         super(server, entity);
     }
@@ -11,10 +12,5 @@ public class CraftSilverfish extends CraftMonster implements Silverfish {
     @Override
     public net.minecraft.world.entity.monster.Silverfish getHandle() {
         return (net.minecraft.world.entity.monster.Silverfish) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftSilverfish";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSizedFireball.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSizedFireball.java
@@ -14,6 +14,11 @@ public class CraftSizedFireball extends CraftFireball implements SizedFireball {
     }
 
     @Override
+    public Fireball getHandle() {
+        return (Fireball) this.entity;
+    }
+
+    @Override
     public ItemStack getDisplayItem() {
         if (this.getHandle().getItem().isEmpty()) {
             return new ItemStack(Material.FIRE_CHARGE);
@@ -25,10 +30,5 @@ public class CraftSizedFireball extends CraftFireball implements SizedFireball {
     @Override
     public void setDisplayItem(ItemStack item) {
         this.getHandle().setItem(CraftItemStack.asNMSCopy(item));
-    }
-
-    @Override
-    public Fireball getHandle() {
-        return (Fireball) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
@@ -11,6 +11,11 @@ public class CraftSkeleton extends CraftAbstractSkeleton implements Skeleton {
     }
 
     @Override
+    public net.minecraft.world.entity.monster.Skeleton getHandle() {
+        return (net.minecraft.world.entity.monster.Skeleton) this.entity;
+    }
+
+    @Override
     public boolean isConverting() {
         return this.getHandle().isFreezeConverting();
     }
@@ -29,16 +34,6 @@ public class CraftSkeleton extends CraftAbstractSkeleton implements Skeleton {
         } else {
             this.getHandle().startFreezeConversion(time);
         }
-    }
-
-    @Override
-    public net.minecraft.world.entity.monster.Skeleton getHandle() {
-        return (net.minecraft.world.entity.monster.Skeleton) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftSkeleton";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeletonHorse.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeletonHorse.java
@@ -11,18 +11,13 @@ public class CraftSkeletonHorse extends CraftAbstractHorse implements SkeletonHo
     }
 
     @Override
-    public String toString() {
-        return "CraftSkeletonHorse";
+    public net.minecraft.world.entity.animal.horse.SkeletonHorse getHandle() {
+        return (net.minecraft.world.entity.animal.horse.SkeletonHorse) this.entity;
     }
 
     @Override
     public Variant getVariant() {
         return Variant.SKELETON_HORSE;
-    }
-
-    @Override
-    public net.minecraft.world.entity.animal.horse.SkeletonHorse getHandle() {
-        return (net.minecraft.world.entity.animal.horse.SkeletonHorse) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSlime.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSlime.java
@@ -10,6 +10,11 @@ public class CraftSlime extends CraftMob implements Slime, CraftEnemy {
     }
 
     @Override
+    public net.minecraft.world.entity.monster.Slime getHandle() {
+        return (net.minecraft.world.entity.monster.Slime) this.entity;
+    }
+
+    @Override
     public int getSize() {
         return this.getHandle().getSize();
     }
@@ -17,16 +22,6 @@ public class CraftSlime extends CraftMob implements Slime, CraftEnemy {
     @Override
     public void setSize(int size) {
         this.getHandle().setSize(size, /* true */ getHandle().isAlive()); // Paper - fix dead slime setSize invincibility
-    }
-
-    @Override
-    public net.minecraft.world.entity.monster.Slime getHandle() {
-        return (net.minecraft.world.entity.monster.Slime) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftSlime";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSmallFireball.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSmallFireball.java
@@ -4,6 +4,7 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.SmallFireball;
 
 public class CraftSmallFireball extends CraftSizedFireball implements SmallFireball {
+
     public CraftSmallFireball(CraftServer server, net.minecraft.world.entity.projectile.SmallFireball entity) {
         super(server, entity);
     }
@@ -11,10 +12,5 @@ public class CraftSmallFireball extends CraftSizedFireball implements SmallFireb
     @Override
     public net.minecraft.world.entity.projectile.SmallFireball getHandle() {
         return (net.minecraft.world.entity.projectile.SmallFireball) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftSmallFireball";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSniffer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSniffer.java
@@ -18,12 +18,7 @@ public class CraftSniffer extends CraftAnimals implements Sniffer {
 
     @Override
     public net.minecraft.world.entity.animal.sniffer.Sniffer getHandle() {
-        return (net.minecraft.world.entity.animal.sniffer.Sniffer) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftSniffer";
+        return (net.minecraft.world.entity.animal.sniffer.Sniffer) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSnowball.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSnowball.java
@@ -4,6 +4,7 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Snowball;
 
 public class CraftSnowball extends CraftThrowableProjectile implements Snowball {
+
     public CraftSnowball(CraftServer server, net.minecraft.world.entity.projectile.Snowball entity) {
         super(server, entity);
     }
@@ -11,10 +12,5 @@ public class CraftSnowball extends CraftThrowableProjectile implements Snowball 
     @Override
     public net.minecraft.world.entity.projectile.Snowball getHandle() {
         return (net.minecraft.world.entity.projectile.Snowball) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftSnowball";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSnowman.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSnowman.java
@@ -5,8 +5,14 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Snowman;
 
 public class CraftSnowman extends CraftGolem implements Snowman, com.destroystokyo.paper.entity.CraftRangedEntity<SnowGolem>, io.papermc.paper.entity.PaperShearable { // Paper
+
     public CraftSnowman(CraftServer server, SnowGolem entity) {
         super(server, entity);
+    }
+
+    @Override
+    public SnowGolem getHandle() {
+        return (SnowGolem) this.entity;
     }
 
     @Override
@@ -17,15 +23,5 @@ public class CraftSnowman extends CraftGolem implements Snowman, com.destroystok
     @Override
     public void setDerp(boolean derpMode) {
         this.getHandle().setPumpkin(!derpMode);
-    }
-
-    @Override
-    public SnowGolem getHandle() {
-        return (SnowGolem) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftSnowman";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSpectralArrow.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSpectralArrow.java
@@ -15,11 +15,6 @@ public class CraftSpectralArrow extends CraftAbstractArrow implements SpectralAr
     }
 
     @Override
-    public String toString() {
-        return "CraftSpectralArrow";
-    }
-
-    @Override
     public int getGlowingTicks() {
         return this.getHandle().duration;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSpellcaster.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSpellcaster.java
@@ -4,7 +4,6 @@ import com.google.common.base.Preconditions;
 import net.minecraft.world.entity.monster.SpellcasterIllager;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Spellcaster;
-import org.bukkit.entity.Spellcaster.Spell;
 
 public class CraftSpellcaster extends CraftIllager implements Spellcaster {
 
@@ -14,12 +13,7 @@ public class CraftSpellcaster extends CraftIllager implements Spellcaster {
 
     @Override
     public SpellcasterIllager getHandle() {
-        return (SpellcasterIllager) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftSpellcaster";
+        return (SpellcasterIllager) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSpider.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSpider.java
@@ -13,9 +13,4 @@ public class CraftSpider extends CraftMonster implements Spider {
     public net.minecraft.world.entity.monster.Spider getHandle() {
         return (net.minecraft.world.entity.monster.Spider) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftSpider";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSquid.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSquid.java
@@ -13,9 +13,4 @@ public class CraftSquid extends CraftAgeable implements Squid {
     public net.minecraft.world.entity.animal.Squid getHandle() {
         return (net.minecraft.world.entity.animal.Squid) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftSquid";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftStray.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftStray.java
@@ -11,11 +11,6 @@ public class CraftStray extends CraftAbstractSkeleton implements Stray {
     }
 
     @Override
-    public String toString() {
-        return "CraftStray";
-    }
-
-    @Override
     public SkeletonType getSkeletonType() {
         return SkeletonType.STRAY;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftStrider.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftStrider.java
@@ -15,6 +15,11 @@ public class CraftStrider extends CraftAnimals implements Strider {
     }
 
     @Override
+    public net.minecraft.world.entity.monster.Strider getHandle() {
+        return (net.minecraft.world.entity.monster.Strider) this.entity;
+    }
+
+    @Override
     public boolean isShivering() {
         return this.getHandle().isSuffocating();
     }
@@ -66,15 +71,5 @@ public class CraftStrider extends CraftAnimals implements Strider {
     @Override
     public Material getSteerMaterial() {
         return Material.WARPED_FUNGUS_ON_A_STICK;
-    }
-
-    @Override
-    public net.minecraft.world.entity.monster.Strider getHandle() {
-        return (net.minecraft.world.entity.monster.Strider) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftStrider";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTNTPrimed.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTNTPrimed.java
@@ -13,6 +13,11 @@ public class CraftTNTPrimed extends CraftEntity implements TNTPrimed {
     }
 
     @Override
+    public PrimedTnt getHandle() {
+        return (PrimedTnt) this.entity;
+    }
+
+    @Override
     public float getYield() {
         return this.getHandle().explosionPower;
     }
@@ -40,16 +45,6 @@ public class CraftTNTPrimed extends CraftEntity implements TNTPrimed {
     @Override
     public void setFuseTicks(int fuseTicks) {
         this.getHandle().setFuse(fuseTicks);
-    }
-
-    @Override
-    public PrimedTnt getHandle() {
-        return (PrimedTnt) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftTNTPrimed";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTadpole.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTadpole.java
@@ -15,11 +15,6 @@ public class CraftTadpole extends CraftFish implements org.bukkit.entity.Tadpole
     }
 
     @Override
-    public String toString() {
-        return "CraftTadpole";
-    }
-
-    @Override
     public int getAge() {
         return this.getHandle().age;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTameableAnimal.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTameableAnimal.java
@@ -10,13 +10,14 @@ import org.bukkit.entity.Creature;
 import org.bukkit.entity.Tameable;
 
 public class CraftTameableAnimal extends CraftAnimals implements Tameable, Creature {
+
     public CraftTameableAnimal(CraftServer server, TamableAnimal entity) {
         super(server, entity);
     }
 
     @Override
     public TamableAnimal getHandle() {
-        return (TamableAnimal) super.getHandle();
+        return (TamableAnimal) this.entity;
     }
 
     @Override
@@ -78,10 +79,5 @@ public class CraftTameableAnimal extends CraftAnimals implements Tameable, Creat
     public void setSitting(boolean sitting) {
         this.getHandle().setInSittingPose(sitting);
         this.getHandle().setOrderedToSit(sitting);
-    }
-
-    @Override
-    public String toString() {
-        return this.getClass().getSimpleName() + "{owner=" + this.getOwner() + ",tamed=" + this.isTamed() + "}";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTextDisplay.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTextDisplay.java
@@ -15,12 +15,7 @@ public class CraftTextDisplay extends CraftDisplay implements TextDisplay {
 
     @Override
     public net.minecraft.world.entity.Display.TextDisplay getHandle() {
-        return (net.minecraft.world.entity.Display.TextDisplay) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftTextDisplay";
+        return (net.minecraft.world.entity.Display.TextDisplay) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftThrowableProjectile.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftThrowableProjectile.java
@@ -13,6 +13,11 @@ public abstract class CraftThrowableProjectile extends CraftProjectile implement
     }
 
     @Override
+    public ThrowableItemProjectile getHandle() {
+        return (ThrowableItemProjectile) this.entity;
+    }
+
+    @Override
     public ItemStack getItem() {
         if (this.getHandle().getItem().isEmpty()) {
             return CraftItemStack.asBukkitCopy(new net.minecraft.world.item.ItemStack(this.getHandle().getDefaultItem()));
@@ -24,10 +29,5 @@ public abstract class CraftThrowableProjectile extends CraftProjectile implement
     @Override
     public void setItem(ItemStack item) {
         this.getHandle().setItem(CraftItemStack.asNMSCopy(item));
-    }
-
-    @Override
-    public ThrowableItemProjectile getHandle() {
-        return (ThrowableItemProjectile) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownExpBottle.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownExpBottle.java
@@ -5,6 +5,7 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.ThrownExpBottle;
 
 public class CraftThrownExpBottle extends CraftThrowableProjectile implements ThrownExpBottle {
+
     public CraftThrownExpBottle(CraftServer server, ThrownExperienceBottle entity) {
         super(server, entity);
     }
@@ -12,10 +13,5 @@ public class CraftThrownExpBottle extends CraftThrowableProjectile implements Th
     @Override
     public ThrownExperienceBottle getHandle() {
         return (ThrownExperienceBottle) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "EntityThrownExpBottle";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownLingeringPotion.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownLingeringPotion.java
@@ -17,6 +17,11 @@ public class CraftThrownLingeringPotion extends CraftThrownPotion implements Lin
     }
 
     @Override
+    public ThrownLingeringPotion getHandle() {
+        return (ThrownLingeringPotion) this.entity;
+    }
+
+    @Override
     public void setItem(final ItemStack item) {
         Preconditions.checkArgument(item != null, "ItemStack cannot be null");
         final PotionMeta meta = item.getType() == Material.LINGERING_POTION ? null : this.getPotionMeta();
@@ -29,10 +34,5 @@ public class CraftThrownLingeringPotion extends CraftThrownPotion implements Lin
     @Override
     public PotionMeta getPotionMeta() {
         return (PotionMeta) CraftItemStack.getItemMeta(this.getHandle().getItem(), ItemType.LINGERING_POTION);
-    }
-
-    @Override
-    public ThrownLingeringPotion getHandle() {
-        return (ThrownLingeringPotion) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownPotion.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownPotion.java
@@ -20,6 +20,11 @@ public abstract class CraftThrownPotion extends CraftThrowableProjectile impleme
     }
 
     @Override
+    public AbstractThrownPotion getHandle() {
+        return (AbstractThrownPotion) this.entity;
+    }
+
+    @Override
     public Collection<PotionEffect> getEffects() {
         ImmutableList.Builder<PotionEffect> builder = ImmutableList.builder();
         for (MobEffectInstance effect : this.getHandle().getItem().getOrDefault(DataComponents.POTION_CONTENTS, PotionContents.EMPTY).getAllEffects()) {
@@ -43,10 +48,5 @@ public abstract class CraftThrownPotion extends CraftThrowableProjectile impleme
     @Override
     public void splash() {
         this.getHandle().splash(null);
-    }
-
-    @Override
-    public AbstractThrownPotion getHandle() {
-        return (AbstractThrownPotion) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownSplashPotion.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownSplashPotion.java
@@ -17,6 +17,11 @@ public class CraftThrownSplashPotion extends CraftThrownPotion implements Splash
     }
 
     @Override
+    public ThrownSplashPotion getHandle() {
+        return (ThrownSplashPotion) this.entity;
+    }
+
+    @Override
     public void setItem(final ItemStack item) {
         Preconditions.checkArgument(item != null, "ItemStack cannot be null");
         final PotionMeta meta = item.getType() == Material.SPLASH_POTION ? null : this.getPotionMeta();
@@ -29,10 +34,5 @@ public class CraftThrownSplashPotion extends CraftThrownPotion implements Splash
     @Override
     public PotionMeta getPotionMeta() {
         return (PotionMeta) CraftItemStack.getItemMeta(this.getHandle().getItem(), ItemType.SPLASH_POTION);
-    }
-
-    @Override
-    public ThrownSplashPotion getHandle() {
-        return (ThrownSplashPotion) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTraderLlama.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTraderLlama.java
@@ -11,11 +11,6 @@ public class CraftTraderLlama extends CraftLlama implements TraderLlama {
 
     @Override
     public net.minecraft.world.entity.animal.horse.TraderLlama getHandle() {
-        return (net.minecraft.world.entity.animal.horse.TraderLlama) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftTraderLlama";
+        return (net.minecraft.world.entity.animal.horse.TraderLlama) this.entity;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTrident.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTrident.java
@@ -14,7 +14,7 @@ public class CraftTrident extends CraftAbstractArrow implements Trident {
 
     @Override
     public ThrownTrident getHandle() {
-        return (ThrownTrident) super.getHandle();
+        return (ThrownTrident) this.entity;
     }
 
     @Override
@@ -25,11 +25,6 @@ public class CraftTrident extends CraftAbstractArrow implements Trident {
     @Override
     public void setItem(ItemStack itemStack) {
         this.getHandle().pickupItemStack = CraftItemStack.asNMSCopy(itemStack);
-    }
-
-    @Override
-    public String toString() {
-        return "CraftTrident";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTropicalFish.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTropicalFish.java
@@ -16,11 +16,6 @@ public class CraftTropicalFish extends io.papermc.paper.entity.PaperSchoolableFi
     }
 
     @Override
-    public String toString() {
-        return "CraftTropicalFish";
-    }
-
-    @Override
     public DyeColor getPatternColor() {
         return CraftTropicalFish.getPatternColor(this.getHandle().getPackedVariant());
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTurtle.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftTurtle.java
@@ -12,12 +12,7 @@ public class CraftTurtle extends CraftAnimals implements Turtle {
 
     @Override
     public net.minecraft.world.entity.animal.Turtle getHandle() {
-        return (net.minecraft.world.entity.animal.Turtle) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftTurtle";
+        return (net.minecraft.world.entity.animal.Turtle) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVehicle.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVehicle.java
@@ -4,12 +4,8 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Vehicle;
 
 public abstract class CraftVehicle extends CraftEntity implements Vehicle {
+
     public CraftVehicle(CraftServer server, net.minecraft.world.entity.Entity entity) {
         super(server, entity);
-    }
-
-    @Override
-    public String toString() {
-        return "CraftVehicle{passenger=" + this.getPassenger() + '}';
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java
@@ -15,7 +15,7 @@ public class CraftVex extends CraftMonster implements Vex {
 
     @Override
     public net.minecraft.world.entity.monster.Vex getHandle() {
-        return (net.minecraft.world.entity.monster.Vex) super.getHandle();
+        return (net.minecraft.world.entity.monster.Vex) this.entity;
     }
 
     @Override
@@ -47,11 +47,6 @@ public class CraftVex extends CraftMonster implements Vex {
     @Override
     public void setLimitedLifetimeTicks(int ticks) {
         this.getHandle().limitedLifeTicks = ticks;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftVex";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
@@ -36,11 +36,6 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
     }
 
     @Override
-    public String toString() {
-        return "CraftVillager";
-    }
-
-    @Override
     public void remove() {
         this.getHandle().releaseAllPois();
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVillagerZombie.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVillagerZombie.java
@@ -16,12 +16,7 @@ public class CraftVillagerZombie extends CraftZombie implements ZombieVillager {
 
     @Override
     public net.minecraft.world.entity.monster.ZombieVillager getHandle() {
-        return (net.minecraft.world.entity.monster.ZombieVillager) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftVillagerZombie";
+        return (net.minecraft.world.entity.monster.ZombieVillager) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVindicator.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVindicator.java
@@ -11,12 +11,7 @@ public class CraftVindicator extends CraftIllager implements Vindicator {
 
     @Override
     public net.minecraft.world.entity.monster.Vindicator getHandle() {
-        return (net.minecraft.world.entity.monster.Vindicator) super.getHandle();
-    }
-
-    @Override
-    public String toString() {
-        return "CraftVindicator";
+        return (net.minecraft.world.entity.monster.Vindicator) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWanderingTrader.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWanderingTrader.java
@@ -16,11 +16,6 @@ public class CraftWanderingTrader extends CraftAbstractVillager implements Wande
     }
 
     @Override
-    public String toString() {
-        return "CraftWanderingTrader";
-    }
-
-    @Override
     public int getDespawnDelay() {
         return this.getHandle().getDespawnDelay();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWarden.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWarden.java
@@ -21,11 +21,6 @@ public class CraftWarden extends CraftMonster implements org.bukkit.entity.Warde
     }
 
     @Override
-    public String toString() {
-        return "CraftWarden";
-    }
-
-    @Override
     public int getAnger() {
         return this.getHandle().getAngerManagement().getActiveAnger(this.getHandle().getTarget());
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWaterMob.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWaterMob.java
@@ -14,9 +14,4 @@ public class CraftWaterMob extends CraftCreature implements WaterMob {
     public WaterAnimal getHandle() {
         return (WaterAnimal) this.entity;
     }
-
-    @Override
-    public String toString() {
-        return "CraftWaterMob";
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWindCharge.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWindCharge.java
@@ -4,6 +4,7 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.WindCharge;
 
 public class CraftWindCharge extends CraftAbstractWindCharge implements WindCharge {
+
     public CraftWindCharge(CraftServer server, net.minecraft.world.entity.projectile.windcharge.WindCharge entity) {
         super(server, entity);
     }
@@ -11,10 +12,5 @@ public class CraftWindCharge extends CraftAbstractWindCharge implements WindChar
     @Override
     public net.minecraft.world.entity.projectile.windcharge.WindCharge getHandle() {
         return (net.minecraft.world.entity.projectile.windcharge.WindCharge) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftWindCharge";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWitch.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWitch.java
@@ -1,13 +1,14 @@
 package org.bukkit.craftbukkit.entity;
 
 import com.google.common.base.Preconditions;
+import org.bukkit.Material;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.Witch;
-import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 public class CraftWitch extends CraftRaider implements Witch, com.destroystokyo.paper.entity.CraftRangedEntity<net.minecraft.world.entity.monster.Witch> { // Paper
+
     public CraftWitch(CraftServer server, net.minecraft.world.entity.monster.Witch entity) {
         super(server, entity);
     }
@@ -15,11 +16,6 @@ public class CraftWitch extends CraftRaider implements Witch, com.destroystokyo.
     @Override
     public net.minecraft.world.entity.monster.Witch getHandle() {
         return (net.minecraft.world.entity.monster.Witch) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftWitch";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
@@ -27,11 +27,6 @@ public class CraftWither extends CraftMonster implements Wither, com.destroystok
     }
 
     @Override
-    public String toString() {
-        return "CraftWither";
-    }
-
-    @Override
     public BossBar getBossBar() {
         return this.bossBar;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWitherSkeleton.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWitherSkeleton.java
@@ -11,11 +11,6 @@ public class CraftWitherSkeleton extends CraftAbstractSkeleton implements Wither
     }
 
     @Override
-    public String toString() {
-        return "CraftWitherSkeleton";
-    }
-
-    @Override
     public SkeletonType getSkeletonType() {
         return SkeletonType.WITHER;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWitherSkull.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWitherSkull.java
@@ -4,8 +4,14 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.WitherSkull;
 
 public class CraftWitherSkull extends CraftFireball implements WitherSkull {
+
     public CraftWitherSkull(CraftServer server, net.minecraft.world.entity.projectile.WitherSkull entity) {
         super(server, entity);
+    }
+
+    @Override
+    public net.minecraft.world.entity.projectile.WitherSkull getHandle() {
+        return (net.minecraft.world.entity.projectile.WitherSkull) this.entity;
     }
 
     @Override
@@ -16,15 +22,5 @@ public class CraftWitherSkull extends CraftFireball implements WitherSkull {
     @Override
     public boolean isCharged() {
         return this.getHandle().isDangerous();
-    }
-
-    @Override
-    public net.minecraft.world.entity.projectile.WitherSkull getHandle() {
-        return (net.minecraft.world.entity.projectile.WitherSkull) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftWitherSkull";
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWolf.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWolf.java
@@ -13,8 +13,14 @@ import org.bukkit.craftbukkit.util.Handleable;
 import org.bukkit.entity.Wolf;
 
 public class CraftWolf extends CraftTameableAnimal implements Wolf {
+
     public CraftWolf(CraftServer server, net.minecraft.world.entity.animal.wolf.Wolf wolf) {
         super(server, wolf);
+    }
+
+    @Override
+    public net.minecraft.world.entity.animal.wolf.Wolf getHandle() {
+        return (net.minecraft.world.entity.animal.wolf.Wolf) this.entity;
     }
 
     @Override
@@ -29,11 +35,6 @@ public class CraftWolf extends CraftTameableAnimal implements Wolf {
         } else {
             this.getHandle().stopBeingAngry();
         }
-    }
-
-    @Override
-    public net.minecraft.world.entity.animal.wolf.Wolf getHandle() {
-        return (net.minecraft.world.entity.animal.wolf.Wolf) this.entity;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftZoglin.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftZoglin.java
@@ -10,6 +10,11 @@ public class CraftZoglin extends CraftMonster implements Zoglin {
     }
 
     @Override
+    public net.minecraft.world.entity.monster.Zoglin getHandle() {
+        return (net.minecraft.world.entity.monster.Zoglin) this.entity;
+    }
+
+    @Override
     public boolean isBaby() {
         return this.getHandle().isBaby();
     }
@@ -17,16 +22,6 @@ public class CraftZoglin extends CraftMonster implements Zoglin {
     @Override
     public void setBaby(boolean flag) {
         this.getHandle().setBaby(flag);
-    }
-
-    @Override
-    public net.minecraft.world.entity.monster.Zoglin getHandle() {
-        return (net.minecraft.world.entity.monster.Zoglin) this.entity;
-    }
-
-    @Override
-    public String toString() {
-        return "CraftZoglin";
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java
@@ -18,11 +18,6 @@ public class CraftZombie extends CraftMonster implements Zombie {
     }
 
     @Override
-    public String toString() {
-        return "CraftZombie";
-    }
-
-    @Override
     public boolean isBaby() {
         return this.getHandle().isBaby();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftZombieHorse.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftZombieHorse.java
@@ -11,11 +11,6 @@ public class CraftZombieHorse extends CraftAbstractHorse implements ZombieHorse 
     }
 
     @Override
-    public String toString() {
-        return "CraftZombieHorse";
-    }
-
-    @Override
     public Variant getVariant() {
         return Variant.UNDEAD_HORSE;
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchantCustom.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchantCustom.java
@@ -34,11 +34,6 @@ public class CraftMerchantCustom implements CraftMerchant {
     // Paper end
 
     @Override
-    public String toString() {
-        return "CraftMerchantCustom";
-    }
-
-    @Override
     public MinecraftMerchant getMerchant() {
         return this.merchant;
     }


### PR DESCRIPTION
Instead of hardcoding the class name, fetch it dynamically and show more useful info to distinguish the instances