### PR TITLE
Added a config option to enable/disable sending transfer packets

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
@@ -230,7 +230,7 @@
              }
  
              return false;
-@@ -149,6 +_,13 @@
+@@ -149,6 +_,15 @@
      }
  
      public void send(Packet<?> packet, @Nullable PacketSendListener listener) {
@@ -239,7 +239,9 @@
 +            return;
 +        } else if (packet instanceof net.minecraft.network.protocol.game.ClientboundSetDefaultSpawnPositionPacket defaultSpawnPositionPacket) {
 +            this.player.compassTarget = org.bukkit.craftbukkit.util.CraftLocation.toBukkit(defaultSpawnPositionPacket.getPos(), this.getCraftPlayer().getWorld());
-+        }
++        } else if (packet instanceof net.minecraft.network.protocol.common.ClientboundTransferPacket && !io.papermc.paper.configuration.GlobalConfiguration.get().misc.allowServerTransfers) { // Paper start - check if server allows sending transfer packets
++            return;
++        } // Paper end - check if server allows sending transfer packets
 +        // CraftBukkit end
          if (packet.isTerminal()) {
              this.close();

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -351,6 +351,8 @@ public class GlobalConfiguration extends ConfigurationPart {
         public IntOr.Default compressionLevel = IntOr.Default.USE_DEFAULT;
         @Comment("Defines the leniency distance added on the server to the interaction range of a player when validating interact packets.")
         public DoubleOr.Default clientInteractionLeniencyDistance = DoubleOr.Default.USE_DEFAULT;
+        @Comment("Allows the use of transfer packets in commands like /transfer")
+        public boolean allowServerTransfers = true;
     }
 
     public BlockUpdates blockUpdates;


### PR DESCRIPTION
Transferring a player will require both sender and receiver to have transfers enabled in paper-global.yml and server.properties respectively.

This increases security as server staff with elevated permissions can send players to self-hosted servers to ip-grab them without having console access in the "sender" server.
This also breaks attack vectors where server staff is tricked into transferring players directly via command or clicking a sign.