### PR TITLE
Use MiniMessage#deserialize(String, Pointered) for send messages

### DIFF
--- a/paper-api/src/main/java/org/bukkit/Server.java
+++ b/paper-api/src/main/java/org/bukkit/Server.java
@@ -422,7 +422,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      * @param message MiniMessage content
      */
     default void sendRichMessage(final @NotNull String message) {
-        this.sendMessage(MiniMessage.miniMessage().deserialize(message));
+        this.sendMessage(MiniMessage.miniMessage().deserialize(message, this));
     }
 
     /**
@@ -435,7 +435,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      * @param resolvers resolvers to use
      */
     default void sendRichMessage(final @NotNull String message, final @NotNull TagResolver... resolvers) {
-        this.sendMessage(MiniMessage.miniMessage().deserialize(message, resolvers));
+        this.sendMessage(MiniMessage.miniMessage().deserialize(message, this, resolvers));
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/command/CommandSender.java
+++ b/paper-api/src/main/java/org/bukkit/command/CommandSender.java
@@ -147,7 +147,7 @@ public interface CommandSender extends net.kyori.adventure.audience.Audience, Pe
      * @param message MiniMessage content
      */
     default void sendRichMessage(final @NotNull String message) {
-        this.sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message));
+        this.sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message, this));
     }
 
     /**
@@ -160,7 +160,7 @@ public interface CommandSender extends net.kyori.adventure.audience.Audience, Pe
      * @param resolvers resolvers to use
      */
     default void sendRichMessage(final @NotNull String message, final net.kyori.adventure.text.minimessage.tag.resolver.@NotNull TagResolver... resolvers) {
-        this.sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message, resolvers));
+        this.sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message, this, resolvers));
     }
 
     /**


### PR DESCRIPTION
This small change allows to use recent changes from Adventure 4.17.0. Passing `Pointered` to `MiniMessage#deserialize(String, Pointered)` method allows to take Pointered from MiniMessage context (`net.kyori.adventure.text.minimessage.Context`) using `Context#target` method.

Usage example:
```java
static TagResolver DISPLAY_NAME_TAG_RESOLVER = TagResolver.resolver("display_name", new BiFunction<ArgumentQueue, Context, Tag>() { // without the use of lambda for clarity
            @Override
            public Tag apply(final ArgumentQueue argumentQueue, final Context context) {
                Audience target = context.targetAsType(Audience.class); // Or CommandSender, Player, etc.

                return Tag.inserting(target.get(Identity.DISPLAY_NAME).orElseThrow());
            }
        });

...

player.sendRichMessage("You display name is: <display_name>", DISPLAY_NAME_TAG_RESOLVER);
```

The simplest testing:
![image](https://github.com/user-attachments/assets/f68e851f-c387-4965-862a-de0fd675cac8)
![image](https://github.com/user-attachments/assets/ece57abf-17b8-4c21-ac38-f6c7d8af3f75)
