### PR TITLE
Add config option for failed beehive release cooldowns

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/BeehiveBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/BeehiveBlockEntity.java.patch
@@ -163,7 +163,7 @@
                      iterator.remove();
                  }
 +                // Paper start - Fix bees aging inside; use exitTickCounter to keep actual bee life
-+                else {
++                else if (level.paperConfig().entities.behavior.cooldownFailedBeehiveReleases) {
 +                    beeData.exitTickCounter = beeData.occupant.minTicksInHive / 2;
 +                }
 +                // Paper end - Fix bees aging inside; use exitTickCounter to keep actual bee life

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -328,7 +328,7 @@ public class WorldConfiguration extends ConfigurationPart {
                 }
             }
 
-            @Comment("Adds a cooldown to bees being released after a failed release, which can occur if the hive is blocked or it is being night.")
+            @Comment("Adds a cooldown to bees being released after a failed release, which can occur if the hive is blocked or it being night.")
             public boolean cooldownFailedBeehiveReleases = true;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -327,6 +327,9 @@ public class WorldConfiguration extends ConfigurationPart {
                     public int day = 5;
                 }
             }
+
+            @Comment("Adds a cooldown to bees being released after a failed release, which can occur if the hive is blocked or it is being night.")
+            public boolean cooldownFailedBeehiveReleases = true;
         }
 
         public TrackingRangeY trackingRangeY;


### PR DESCRIPTION
Closes #12178

Adds a config to toggle the behavior of bees getting a cooldown for future release attempts when an attempt fails (such as the hive being blocked). Disabling this brings behavior back to how it is in vanilla, at the cost of reduced performance.