### PR TITLE
Fix invulnerability damage and armour

### DIFF
--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -533,10 +533,10 @@ index 54cf80831372d102e8d2966ac104678caebdf336..d89c3949e16ff6cb0374da29ec6731d8
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index ff57fdb7b113041fc75523ec40365da685db7996..779f16a67ef8fda57dc1c85e13ef132fe18e3f20 100644
+index bf5fd2a6c8630ea2bb06881d4d365dda9a4e90ea..4713c29cc2add476f568163a29cb297f5d1049df 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3101,6 +3101,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3103,6 +3103,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return false;
      }
  

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -366,7 +366,7 @@ index d95413af04121fe91ca0f3b0c70025b9808acef9..ad665c7535c615d2b03a3e7864be435f
  import org.slf4j.Logger;
  
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 8204528c26456929fdec0d8ba7a5a52128409097..01bc2d1639be9f04afc63e5841c5c99730ea37d8 100644
+index cdb4d313eb33c049c8467fe5d31fb0d671737768..40b799fd90b0db13bdaa8834c021f5ca8f25ce10 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -551,6 +551,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -476,7 +476,7 @@ index 24735284fda151414d99faad401d25ba60995f9a..23b342cc31c7e72ade0e1ccad86a9ccf
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index b15420ffa1432d49aec8e91e917598bde4e94337..054ece1d539d69a4b7eec57e681179343c7e75c3 100644
+index 54cf80831372d102e8d2966ac104678caebdf336..d89c3949e16ff6cb0374da29ec6731d854b5f105 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -381,6 +381,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -533,10 +533,10 @@ index b15420ffa1432d49aec8e91e917598bde4e94337..054ece1d539d69a4b7eec57e68117934
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index ff513e8c87bf42be756e46f4dbfec8dda2b8cb60..239c443ddc9bacc08a39a8ef2ab17016a2480549 100644
+index ff57fdb7b113041fc75523ec40365da685db7996..779f16a67ef8fda57dc1c85e13ef132fe18e3f20 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3096,6 +3096,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3101,6 +3101,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return false;
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -971,7 +971,7 @@
                  int i = (this.getEffect(MobEffects.DAMAGE_RESISTANCE).getAmplifier() + 1) * 5;
                  int i1 = 25 - i;
                  float f = damageAmount * i1;
-@@ -1768,24 +_,217 @@
+@@ -1768,24 +_,219 @@
          }
      }
  
@@ -984,6 +984,10 @@
 +            if (invulnerabilityRelatedLastDamage == 0) return 0D; // no last damage, no reduction
 +            // last damage existed, this means the reduction *technically* is (new damage - last damage).
 +            // If the event damage was changed to something less than invul damage, hard lock it at 0.
++            //
++            // Cast the passed in double down to a float as double -> float -> double is lossly.
++            // If last damage is a (float) 3.2D (given spigot events use doubles), we cannot compare
++            // the new damage value of this damage instance by upcasting it again to a double as 3.2D != (double) (float) 3.2D.
 +            if (d.floatValue() < invulnerabilityRelatedLastDamage) return 0D;
 +            return (double) -invulnerabilityRelatedLastDamage;
 +        };
@@ -1118,12 +1122,10 @@
 +
 +            // Apply damage to armor
 +            if (!damageSource.is(DamageTypeTags.BYPASSES_ARMOR)) {
-+                // Paper start - fix invulnerability reduction in EntityDamageEvent
 +                float armorDamage = (float) event.getDamage();
 +                armorDamage += (float) event.getDamage(DamageModifier.INVULNERABILITY_REDUCTION);
 +                armorDamage += (float) event.getDamage(DamageModifier.BLOCKING);
 +                armorDamage += (float) event.getDamage(DamageModifier.HARD_HAT);
-+                // Paper end - fix invulnerability reduction in EntityDamageEvent
 +                this.hurtArmor(damageSource, armorDamage);
 +            }
 +

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -984,7 +984,7 @@
 +            if (invulnerabilityRelatedLastDamage == 0) return 0D; // no last damage, no reduction
 +            // last damage existed, this means the reduction *technically* is (new damage - last damage).
 +            // If the event damage was changed to something less than invul damage, hard lock it at 0.
-+            if (d < invulnerabilityRelatedLastDamage) return 0D;
++            if (d.floatValue() < invulnerabilityRelatedLastDamage) return 0D;
 +            return (double) -invulnerabilityRelatedLastDamage;
 +        };
 +        final float originalInvulnerabilityReduction = invulnerabilityReductionEquation.apply((double) amount).floatValue();

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -985,8 +985,8 @@
 +            // last damage existed, this means the reduction *technically* is (new damage - last damage).
 +            // If the event damage was changed to something less than invul damage, hard lock it at 0.
 +            //
-+            // Cast the passed in double down to a float as double -> float -> double is lossly.
-+            // If last damage is a (float) 3.2D (given spigot events use doubles), we cannot compare
++            // Cast the passed in double down to a float as double -> float -> double is lossy.
++            // If last damage is a (float) 3.2D (since the events use doubles), we cannot compare
 +            // the new damage value of this damage instance by upcasting it again to a double as 3.2D != (double) (float) 3.2D.
 +            if (d.floatValue() < invulnerabilityRelatedLastDamage) return 0D;
 +            return (double) -invulnerabilityRelatedLastDamage;

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -971,7 +971,7 @@
                  int i = (this.getEffect(MobEffects.DAMAGE_RESISTANCE).getAmplifier() + 1) * 5;
                  int i1 = 25 - i;
                  float f = damageAmount * i1;
-@@ -1768,24 +_,212 @@
+@@ -1768,24 +_,217 @@
          }
      }
  
@@ -1118,7 +1118,12 @@
 +
 +            // Apply damage to armor
 +            if (!damageSource.is(DamageTypeTags.BYPASSES_ARMOR)) {
-+                float armorDamage = (float) (event.getDamage() + event.getDamage(DamageModifier.BLOCKING) + event.getDamage(DamageModifier.HARD_HAT));
++                // Paper start - fix invulnerability reduction in EntityDamageEvent
++                float armorDamage = (float) event.getDamage();
++                armorDamage += (float) event.getDamage(DamageModifier.INVULNERABILITY_REDUCTION);
++                armorDamage += (float) event.getDamage(DamageModifier.BLOCKING);
++                armorDamage += (float) event.getDamage(DamageModifier.HARD_HAT);
++                // Paper end - fix invulnerability reduction in EntityDamageEvent
 +                this.hurtArmor(damageSource, armorDamage);
 +            }
 +


### PR DESCRIPTION
If a plugin changes the damage in `EntityDamageEvent`, it can cause the `INVULNERABILITY_REDUCTION` damage modifier to be set to 0 and render invulnerability damage reduction, added in https://github.com/PaperMC/Paper/pull/11599, ineffective.

This happens because a float (the `lastHurt` value in a Player) is being compared to a double (stored in the modifiers of EntityDamageEvent), and a float can be greater than a double, even if they are the same noiminal value:

```
jshell> 3.2 < (float) 3.2
$2 ==> true
```

Due to lossy floating point precision, 3.2 becomes 3.200000047683716, which indeed would be greater than 3.2.

`float lastHurt` is the result of casting the double from `EntityDamageEvent#getFinalDamage`, which causes this imprecision. The fix is to cast the doubles from `EntityDamageEvent` to floats when comparing them here. This ensures that if they are the same value, then one will not be less than the other, because they have both been cast from the same `double` value. The opposite approach, casting a `double` to a `float` and back to a `double` again, does not work, because is lossy. We cannot really convert `lastHurt` to a `double` without touching a lot of the damage processing code.

I have also taken the liberty of fixing how armour damage is calculated. In the #11599 PR, armour would still take damage even if the damage should have been blocked due to invulnerability. This change will now take that into account. It's also necessary to individual cast each component to a float, rather than adding the doubles like before, otherwise the armourDamage may be marginally greater than 0. I've done this in a similar way to the `LivingEntity#computeAmountFromEntityDamageEvent` function.

The BASE damage and INVULNERABILITY_DAMAGE modifers may be slightly different doubles, but represent the same float. The INVULNERABILITY_DAMAGE represents the BASE modifier, but casted to a float and back to a double. Therefore we must cast BASE and INVULNERABILITY_DAMAGE to floats before adding them.

To test this PR, you can use the following code and run the `/test` command (plugin.yml not included)

```java
public class TestPlugin extends JavaPlugin implements Listener, CommandExecutor {

    @Override
    public void onEnable() {
        getCommand("test").setExecutor(this);
        getServer().getPluginManager().registerEvents(this, this);
    }

    @Override
    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
        ServerPlayer handle = ((CraftPlayer) sender).getHandle();
        handle.hurtServer(handle.serverLevel(), handle.level().damageSources().cactus(), 4);
        handle.hurtServer(handle.serverLevel(), handle.level().damageSources().cactus(), 4);
        return true;
    }

    @EventHandler
    public void on(EntityDamageEvent event) {
        getLogger().info("Invulnerability reduction before: " + event.getDamage(EntityDamageEvent.DamageModifier.INVULNERABILITY_REDUCTION));
        event.setDamage(3.2);
        getLogger().info("Invulnerability reduction after: " + event.getDamage(EntityDamageEvent.DamageModifier.INVULNERABILITY_REDUCTION));
    }
}
```

Without this fix:

```
[TestPlugin] Invulnerability reduction before: 0.0
[TestPlugin] Invulnerability reduction after: 0.0
[TestPlugin] Invulnerability reduction before: -3.200000047683716
[TestPlugin] Invulnerability reduction after: 0.0
```

With this fix:

```
[TestPlugin] Invulnerability reduction before: 0.0
[TestPlugin] Invulnerability reduction after: 0.0
[TestPlugin] Invulnerability reduction before: -3.200000047683716
[TestPlugin] Invulnerability reduction after: -3.200000047683716
```

cc @lynxplay 