### PR TITLE
Add a method on InventoryView to get the MenuType

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -479,6 +479,7 @@ public net.minecraft.world.flag.FeatureFlagRegistry names
 public net.minecraft.world.food.FoodData exhaustionLevel
 public net.minecraft.world.food.FoodData foodLevel
 public net.minecraft.world.food.FoodData saturationLevel
+public net.minecraft.world.inventory.AbstractContainerMenu menuType
 public net.minecraft.world.inventory.AbstractContainerMenu quickcraftSlots
 public net.minecraft.world.inventory.AbstractContainerMenu quickcraftStatus
 public net.minecraft.world.inventory.AbstractContainerMenu quickcraftType

--- a/paper-api/src/main/java/org/bukkit/inventory/InventoryView.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/InventoryView.java
@@ -321,8 +321,8 @@ public interface InventoryView {
     /**
      * Gets the menu type of the inventory view.
      *
-     * @return the menu type of the inventory view
+     * @return the menu type of the inventory view or null if not applicable
      */
     @ApiStatus.Experimental
-    @NotNull MenuType getMenuType();
+    @Nullable MenuType getMenuType();
 }

--- a/paper-api/src/main/java/org/bukkit/inventory/InventoryView.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/InventoryView.java
@@ -319,7 +319,11 @@ public interface InventoryView {
     public void setTitle(@NotNull String title);
 
     /**
-     * Gets the menu type of the inventory view.
+     * Gets the menu type of the inventory view if applicable.
+     * <p>
+     * Some inventory types do not support a menu type. In such cases, this method
+     * returns null. This typically applies to inventories belonging to entities
+     * like players or animals (e.g., a horse).
      *
      * @return the menu type of the inventory view or null if not applicable
      */

--- a/paper-api/src/main/java/org/bukkit/inventory/InventoryView.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/InventoryView.java
@@ -2,6 +2,7 @@ package org.bukkit.inventory;
 
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryType;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -316,4 +317,12 @@ public interface InventoryView {
      */
     @Deprecated(since = "1.21.1") // Paper
     public void setTitle(@NotNull String title);
+
+    /**
+     * Gets the menu type of the inventory view.
+     *
+     * @return the menu type of the inventory view
+     */
+    @ApiStatus.Experimental
+    @NotNull MenuType getMenuType();
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
@@ -95,6 +95,11 @@ public class CraftContainer extends AbstractContainerMenu {
                 this.title = title;
             }
 
+            @Override
+            public MenuType getMenuType() {
+                return CraftMenuType.minecraftToBukkit(getNotchInventoryType(inventory));
+            }
+
         }, player, id);
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryView.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryView.java
@@ -96,6 +96,11 @@ public class CraftInventoryView<T extends AbstractContainerMenu, I extends Inven
         this.title = title;
     }
 
+    @Override
+    public org.bukkit.inventory.MenuType getMenuType() {
+        return CraftMenuType.minecraftToBukkit(container.getType());
+    }
+
     public boolean isInTop(int rawSlot) {
         return rawSlot < this.viewing.getSize();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryView.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryView.java
@@ -98,7 +98,8 @@ public class CraftInventoryView<T extends AbstractContainerMenu, I extends Inven
 
     @Override
     public org.bukkit.inventory.MenuType getMenuType() {
-        return CraftMenuType.minecraftToBukkit(container.getType());
+        MenuType<?> menuType = container.menuType;
+        return menuType != null ? CraftMenuType.minecraftToBukkit(menuType) : null;
     }
 
     public boolean isInTop(int rawSlot) {


### PR DESCRIPTION
It is possible to get the `InventoryType`, but not `MenuType`.
Since there is a new (better) way to create views for players using `MenuType`, it would be nice to also be able to get it back from `InventoryView` after creating.