### PR TITLE
Infer block entity data in brigadier blockstate argument

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
@@ -74,8 +74,6 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.GameMode;
@@ -88,6 +86,7 @@ import org.bukkit.block.structure.Mirror;
 import org.bukkit.block.structure.StructureRotation;
 import org.bukkit.craftbukkit.CraftHeightMap;
 import org.bukkit.craftbukkit.CraftRegistry;
+import org.bukkit.craftbukkit.block.CraftBlockEntityState;
 import org.bukkit.craftbukkit.block.CraftBlockStates;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.scoreboard.CraftCriteria;
@@ -174,15 +173,11 @@ public class VanillaArgumentProviderImpl implements VanillaArgumentProvider {
     @Override
     public ArgumentType<BlockState> blockState() {
         return this.wrap(BlockStateArgument.block(PaperCommands.INSTANCE.getBuildContext()), (result) -> {
-            if (!result.getState().hasBlockEntity()) {
-                return CraftBlockStates.getBlockState(CraftRegistry.getMinecraftRegistry(), BlockPos.ZERO, result.getState(), null);
+            final BlockState snapshot = CraftBlockStates.getBlockState(CraftRegistry.getMinecraftRegistry(), BlockPos.ZERO, result.getState(), null);
+            if (result.tag != null && snapshot instanceof final CraftBlockEntityState<?> blockEntitySnapshot) {
+                blockEntitySnapshot.loadData(result.tag);
             }
-
-            final BlockEntity blockEntity = ((EntityBlock) result.getState().getBlock()).newBlockEntity(BlockPos.ZERO, result.getState());
-            if (result != null) {
-                blockEntity.loadWithComponents(result.tag, CraftRegistry.getMinecraftRegistry());
-            }
-            return CraftBlockStates.getBlockState(null, BlockPos.ZERO, result.getState(), blockEntity);
+            return snapshot;
         });
     }
 

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
@@ -68,14 +68,14 @@ import net.minecraft.commands.arguments.coordinates.Vec3Argument;
 import net.minecraft.commands.arguments.item.ItemArgument;
 import net.minecraft.commands.arguments.item.ItemPredicateArgument;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.GameMode;
@@ -174,11 +174,13 @@ public class VanillaArgumentProviderImpl implements VanillaArgumentProvider {
     @Override
     public ArgumentType<BlockState> blockState() {
         return this.wrap(BlockStateArgument.block(PaperCommands.INSTANCE.getBuildContext()), (result) -> {
-            CompoundTag tag = result.tag;
-            if (tag != null && !tag.contains("id")) {
-                tag.putString("id", BuiltInRegistries.BLOCK.getKey(result.getState().getBlock()).toString());
+            if (!result.getState().hasBlockEntity()) {
+                return CraftBlockStates.getBlockState(CraftRegistry.getMinecraftRegistry(), BlockPos.ZERO, result.getState(), null);
             }
-            return CraftBlockStates.getBlockState(CraftRegistry.getMinecraftRegistry(), BlockPos.ZERO, result.getState(), tag);
+
+            final BlockEntity blockEntity = ((EntityBlock) result.getState().getBlock()).newBlockEntity(BlockPos.ZERO, result.getState());
+            blockEntity.loadWithComponents(result.tag, CraftRegistry.getMinecraftRegistry());
+            return CraftBlockStates.getBlockState(null, BlockPos.ZERO, result.getState(), blockEntity);
         });
     }
 

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
@@ -179,7 +179,9 @@ public class VanillaArgumentProviderImpl implements VanillaArgumentProvider {
             }
 
             final BlockEntity blockEntity = ((EntityBlock) result.getState().getBlock()).newBlockEntity(BlockPos.ZERO, result.getState());
-            blockEntity.loadWithComponents(result.tag, CraftRegistry.getMinecraftRegistry());
+            if (result != null) {
+                blockEntity.loadWithComponents(result.tag, CraftRegistry.getMinecraftRegistry());
+            }
             return CraftBlockStates.getBlockState(null, BlockPos.ZERO, result.getState(), blockEntity);
         });
     }

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
@@ -68,7 +68,9 @@ import net.minecraft.commands.arguments.coordinates.Vec3Argument;
 import net.minecraft.commands.arguments.item.ItemArgument;
 import net.minecraft.commands.arguments.item.ItemPredicateArgument;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -172,7 +174,11 @@ public class VanillaArgumentProviderImpl implements VanillaArgumentProvider {
     @Override
     public ArgumentType<BlockState> blockState() {
         return this.wrap(BlockStateArgument.block(PaperCommands.INSTANCE.getBuildContext()), (result) -> {
-            return CraftBlockStates.getBlockState(CraftRegistry.getMinecraftRegistry(), BlockPos.ZERO, result.getState(), result.tag);
+            CompoundTag tag = result.tag;
+            if (tag != null) {
+                tag.putString("id", BuiltInRegistries.BLOCK.getKey(result.getState().getBlock()).toString());
+            }
+            return CraftBlockStates.getBlockState(CraftRegistry.getMinecraftRegistry(), BlockPos.ZERO, result.getState(), tag);
         });
     }
 

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
@@ -175,7 +175,7 @@ public class VanillaArgumentProviderImpl implements VanillaArgumentProvider {
     public ArgumentType<BlockState> blockState() {
         return this.wrap(BlockStateArgument.block(PaperCommands.INSTANCE.getBuildContext()), (result) -> {
             CompoundTag tag = result.tag;
-            if (tag != null) {
+            if (tag != null && !tag.contains("id")) {
                 tag.putString("id", BuiltInRegistries.BLOCK.getKey(result.getState().getBlock()).toString());
             }
             return CraftBlockStates.getBlockState(CraftRegistry.getMinecraftRegistry(), BlockPos.ZERO, result.getState(), tag);


### PR DESCRIPTION
Applies id to blockstate tag when not provided, fixes #11700 