### PR TITLE
Call BlockRedstoneEvent for more interactions

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/block/BlockRedstoneEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/BlockRedstoneEvent.java
@@ -1,13 +1,22 @@
 package org.bukkit.event.block;
 
+import com.google.common.base.Preconditions;
 import org.bukkit.block.Block;
 import org.bukkit.event.HandlerList;
+import org.checkerframework.common.value.qual.IntRange;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 
 /**
- * Called when a redstone current changes
+ * Called when a redstone current changes.
+ * <p>
+ * It includes the relevant mutation of the {@code powered} and {@code power}
+ * properties even if the block is not able to produce a redstone signal.
+ * For the {@code powered} property, a high state will be considered as
+ * a current of 15 and a low state as 0. Setting the new current to a different
+ * value will prevent most action in this case.
  */
+@NullMarked
 public class BlockRedstoneEvent extends BlockEvent {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
@@ -16,46 +25,45 @@ public class BlockRedstoneEvent extends BlockEvent {
     private int newCurrent;
 
     @ApiStatus.Internal
-    public BlockRedstoneEvent(@NotNull final Block block, final int oldCurrent, final int newCurrent) {
+    public BlockRedstoneEvent(final Block block, final int oldCurrent, final int newCurrent) {
         super(block);
         this.oldCurrent = oldCurrent;
         this.newCurrent = newCurrent;
     }
 
     /**
-     * Gets the old current of this block
+     * Gets the old current of this block.
      *
-     * @return The previous current
+     * @return the previous current
      */
-    public int getOldCurrent() {
+    public @IntRange(from = 0, to = 15) int getOldCurrent() {
         return this.oldCurrent;
     }
 
     /**
-     * Gets the new current of this block
+     * Gets the new current of this block.
      *
-     * @return The new current
+     * @return the new current
      */
-    public int getNewCurrent() {
+    public @IntRange(from = 0, to = 15) int getNewCurrent() {
         return this.newCurrent;
     }
 
     /**
-     * Sets the new current of this block
+     * Sets the new current of this block.
      *
-     * @param newCurrent The new current to set
+     * @param newCurrent the new current to set
      */
-    public void setNewCurrent(int newCurrent) {
+    public void setNewCurrent(@IntRange(from = 0, to = 15) int newCurrent) {
+        Preconditions.checkArgument(newCurrent >= 0 && newCurrent <= 15, "New current must be a redstone signal between 0 and 15 (was %s)", newCurrent);
         this.newCurrent = newCurrent;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
 
-    @NotNull
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/paper-server/patches/features/0015-Eigencraft-redstone-implementation.patch
+++ b/paper-server/patches/features/0015-Eigencraft-redstone-implementation.patch
@@ -19,12 +19,14 @@ Co-authored-by: egg82 <eggys82@gmail.com>
 
 diff --git a/io/papermc/paper/redstone/RedstoneWireTurbo.java b/io/papermc/paper/redstone/RedstoneWireTurbo.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ff747a1ecdf3c888bca0d69de4f85dcd810b6139
+index 0000000000000000000000000000000000000000..8e03419df1469c6fecfaa82fcb319a58635b39f3
 --- /dev/null
 +++ b/io/papermc/paper/redstone/RedstoneWireTurbo.java
-@@ -0,0 +1,954 @@
+@@ -0,0 +1,949 @@
 +package io.papermc.paper.redstone;
 +
++import com.google.common.collect.Lists;
++import com.google.common.collect.Maps;
 +import java.util.List;
 +import java.util.Map;
 +import java.util.concurrent.ThreadLocalRandom;
@@ -36,11 +38,7 @@ index 0000000000000000000000000000000000000000..ff747a1ecdf3c888bca0d69de4f85dcd
 +import net.minecraft.world.level.block.Block;
 +import net.minecraft.world.level.block.RedStoneWireBlock;
 +import net.minecraft.world.level.block.state.BlockState;
-+import org.bukkit.craftbukkit.block.CraftBlock;
-+import org.bukkit.event.block.BlockRedstoneEvent;
-+
-+import com.google.common.collect.Lists;
-+import com.google.common.collect.Maps;
++import org.bukkit.craftbukkit.event.CraftEventFactory;
 +
 +public final class RedstoneWireTurbo {
 +    /*
@@ -914,12 +912,9 @@ index 0000000000000000000000000000000000000000..ff747a1ecdf3c888bca0d69de4f85dcd
 +        // always be in the range of 0 to 15, the following if will correct that.
 +        if (k > j) j = k;
 +
-+        // egg82's amendment
-+        // Adding Bukkit's BlockRedstoneEvent - er.. event.
++        // [egg82] Adding Bukkit's BlockRedstoneEvent.
 +        if (i != j) {
-+            BlockRedstoneEvent event = new BlockRedstoneEvent(CraftBlock.at(worldIn, upd.self), i, j);
-+            worldIn.getCraftServer().getPluginManager().callEvent(event);
-+            j = event.getNewCurrent();
++            j = CraftEventFactory.callRedstoneChange(worldIn, upd.self, i, j).getNewCurrent();
 +        }
 +
 +        if (i != j) {
@@ -978,10 +973,10 @@ index 0000000000000000000000000000000000000000..ff747a1ecdf3c888bca0d69de4f85dcd
 +    }
 +}
 diff --git a/net/minecraft/world/level/block/RedStoneWireBlock.java b/net/minecraft/world/level/block/RedStoneWireBlock.java
-index 0ee7bc3a10896a4f59fa94df158bce741aea0464..a677c3bfddfa0b7947394a3975ec43794be07d7e 100644
+index 0ee7bc3a10896a4f59fa94df158bce741aea0464..a00002774755eb90a0b772fe742b30a5e09452cf 100644
 --- a/net/minecraft/world/level/block/RedStoneWireBlock.java
 +++ b/net/minecraft/world/level/block/RedStoneWireBlock.java
-@@ -269,6 +269,60 @@ public class RedStoneWireBlock extends Block {
+@@ -269,6 +269,56 @@ public class RedStoneWireBlock extends Block {
          return relativeState.isFaceSturdy(level, relativePos, Direction.UP) || relativeState.is(Blocks.HOPPER);
      }
  
@@ -1021,12 +1016,8 @@ index 0ee7bc3a10896a4f59fa94df158bce741aea0464..a677c3bfddfa0b7947394a3975ec4379
 +        int oldPower = state.getValue(POWER);
 +        int newPower = ((DefaultRedstoneWireEvaluator) evaluator).calculateTargetStrength(level, pos);
 +        if (oldPower != newPower) {
-+            org.bukkit.event.block.BlockRedstoneEvent event = new org.bukkit.event.block.BlockRedstoneEvent(org.bukkit.craftbukkit.block.CraftBlock.at(level, pos), oldPower, newPower);
-+            level.getCraftServer().getPluginManager().callEvent(event);
-+
-+            newPower = event.getNewCurrent();
-+
 +            if (level.getBlockState(pos) == state) {
++                newPower = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldPower, newPower).getNewCurrent();
 +                state = state.setValue(POWER, newPower);
 +                // [Space Walker] suppress shape updates and emit those manually to
 +                // bypass the new neighbor update stack.
@@ -1042,7 +1033,7 @@ index 0ee7bc3a10896a4f59fa94df158bce741aea0464..a677c3bfddfa0b7947394a3975ec4379
      private void updatePowerStrength(
          final Level level,
          final BlockPos pos,
-@@ -303,7 +357,7 @@ public class RedStoneWireBlock extends Block {
+@@ -303,7 +353,7 @@ public class RedStoneWireBlock extends Block {
      @Override
      protected void onPlace(final BlockState state, final Level level, final BlockPos pos, final BlockState oldState, final boolean movedByPiston) {
          if (!oldState.is(state.getBlock()) && !level.isClientSide()) {
@@ -1051,7 +1042,7 @@ index 0ee7bc3a10896a4f59fa94df158bce741aea0464..a677c3bfddfa0b7947394a3975ec4379
  
              for (Direction direction : Direction.Plane.VERTICAL) {
                  level.updateNeighborsAt(pos.relative(direction), this);
-@@ -320,7 +374,7 @@ public class RedStoneWireBlock extends Block {
+@@ -320,7 +370,7 @@ public class RedStoneWireBlock extends Block {
                  level.updateNeighborsAt(pos.relative(direction), this);
              }
  
@@ -1060,7 +1051,7 @@ index 0ee7bc3a10896a4f59fa94df158bce741aea0464..a677c3bfddfa0b7947394a3975ec4379
              this.updateNeighborsOfNeighboringWires(level, pos);
          }
      }
-@@ -347,7 +401,7 @@ public class RedStoneWireBlock extends Block {
+@@ -347,7 +397,7 @@ public class RedStoneWireBlock extends Block {
          if (!level.isClientSide()) {
              if (block != this || !useExperimentalEvaluator(level)) {
                  if (state.canSurvive(level, pos)) {
@@ -1070,10 +1061,10 @@ index 0ee7bc3a10896a4f59fa94df158bce741aea0464..a677c3bfddfa0b7947394a3975ec4379
                      dropResources(state, level, pos);
                      level.removeBlock(pos, false);
 diff --git a/net/minecraft/world/level/redstone/DefaultRedstoneWireEvaluator.java b/net/minecraft/world/level/redstone/DefaultRedstoneWireEvaluator.java
-index fe52dd304bc03b172654b89acb382c7f410d7946..afdcbb9e5a4c859d82bfb33a1d253514c17eed39 100644
+index 45c3586a653f4ec22b9fb859b2869503d0b6c5b3..81b7b625dbfe69f2a9d74dac000a0e60a75db839 100644
 --- a/net/minecraft/world/level/redstone/DefaultRedstoneWireEvaluator.java
 +++ b/net/minecraft/world/level/redstone/DefaultRedstoneWireEvaluator.java
-@@ -47,7 +47,7 @@ public class DefaultRedstoneWireEvaluator extends RedstoneWireEvaluator {
+@@ -44,7 +44,7 @@ public class DefaultRedstoneWireEvaluator extends RedstoneWireEvaluator {
          }
      }
  

--- a/paper-server/patches/features/0016-Add-Alternate-Current-redstone-implementation.patch
+++ b/paper-server/patches/features/0016-Add-Alternate-Current-redstone-implementation.patch
@@ -22,30 +22,25 @@ Alternate Current's wire handler.
 
 diff --git a/alternate/current/wire/LevelHelper.java b/alternate/current/wire/LevelHelper.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ff663d3089627e75221aa128aff4bf5cc459addb
+index 0000000000000000000000000000000000000000..dd533953f33aacfc91a8acad6c9a9d601df0bd86
 --- /dev/null
 +++ b/alternate/current/wire/LevelHelper.java
-@@ -0,0 +1,66 @@
+@@ -0,0 +1,61 @@
 +package alternate.current.wire;
-+
-+import org.bukkit.craftbukkit.block.CraftBlock;
-+import org.bukkit.event.block.BlockRedstoneEvent;
 +
 +import net.minecraft.core.BlockPos;
 +import net.minecraft.server.level.ServerLevel;
 +import net.minecraft.world.level.block.Block;
 +import net.minecraft.world.level.block.state.BlockState;
 +import net.minecraft.world.level.chunk.ChunkAccess;
-+import net.minecraft.world.level.chunk.status.ChunkStatus;
 +import net.minecraft.world.level.chunk.LevelChunkSection;
++import net.minecraft.world.level.chunk.status.ChunkStatus;
++import org.bukkit.craftbukkit.event.CraftEventFactory;
 +
 +class LevelHelper {
 +
 +    static int doRedstoneEvent(ServerLevel level, BlockPos pos, int prevPower, int newPower) {
-+        BlockRedstoneEvent event = new BlockRedstoneEvent(CraftBlock.at(level, pos), prevPower, newPower);
-+        level.getCraftServer().getPluginManager().callEvent(event);
-+
-+        return event.getNewCurrent();
++        return CraftEventFactory.callRedstoneChange(level, pos, prevPower, newPower).getNewCurrent();
 +    }
 +
 +    /**
@@ -2352,7 +2347,7 @@ index f4bbccee849ee3711a3b838884e4bcf4e24da039..0b9fbf0ae658f0b3e9c6106a42fb7094
          return toLevel.dimension() != Level.NETHER || this.getGameRules().get(GameRules.ALLOW_ENTERING_NETHER_USING_PORTALS);
      }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 2b3ec0a012918815ed0eda8b40647c2274a5b418..e60717b486756f66660e88055eea0f4735f351ef 100644
+index 07c301ba02c7f2c032a29a0ae3bdf95fc522c03b..7e4cf8a13e0ff2198cb7b6d80fb3fa343339943b 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -2153,6 +2153,17 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
@@ -2374,7 +2369,7 @@ index 2b3ec0a012918815ed0eda8b40647c2274a5b418..e60717b486756f66660e88055eea0f47
          NONE("none"),
          BLOCK("block"),
 diff --git a/net/minecraft/world/level/block/RedStoneWireBlock.java b/net/minecraft/world/level/block/RedStoneWireBlock.java
-index a677c3bfddfa0b7947394a3975ec43794be07d7e..ed471efa3ab705de62aec81c3940c1b9c5acdbc5 100644
+index a00002774755eb90a0b772fe742b30a5e09452cf..1e863e97bd1dc99ed6e2c0602f78f457ac618965 100644
 --- a/net/minecraft/world/level/block/RedStoneWireBlock.java
 +++ b/net/minecraft/world/level/block/RedStoneWireBlock.java
 @@ -269,7 +269,7 @@ public class RedStoneWireBlock extends Block {
@@ -2386,7 +2381,7 @@ index a677c3bfddfa0b7947394a3975ec43794be07d7e..ed471efa3ab705de62aec81c3940c1b9
      // The bulk of the new functionality is found in RedstoneWireTurbo.java
      io.papermc.paper.redstone.RedstoneWireTurbo turbo = new io.papermc.paper.redstone.RedstoneWireTurbo(this);
  
-@@ -357,7 +357,13 @@ public class RedStoneWireBlock extends Block {
+@@ -353,7 +353,13 @@ public class RedStoneWireBlock extends Block {
      @Override
      protected void onPlace(final BlockState state, final Level level, final BlockPos pos, final BlockState oldState, final boolean movedByPiston) {
          if (!oldState.is(state.getBlock()) && !level.isClientSide()) {
@@ -2401,7 +2396,7 @@ index a677c3bfddfa0b7947394a3975ec43794be07d7e..ed471efa3ab705de62aec81c3940c1b9
  
              for (Direction direction : Direction.Plane.VERTICAL) {
                  level.updateNeighborsAt(pos.relative(direction), this);
-@@ -374,7 +380,13 @@ public class RedStoneWireBlock extends Block {
+@@ -370,7 +376,13 @@ public class RedStoneWireBlock extends Block {
                  level.updateNeighborsAt(pos.relative(direction), this);
              }
  
@@ -2416,7 +2411,7 @@ index a677c3bfddfa0b7947394a3975ec43794be07d7e..ed471efa3ab705de62aec81c3940c1b9
              this.updateNeighborsOfNeighboringWires(level, pos);
          }
      }
-@@ -399,9 +411,15 @@ public class RedStoneWireBlock extends Block {
+@@ -395,9 +407,15 @@ public class RedStoneWireBlock extends Block {
          final BlockState state, final Level level, final BlockPos pos, final Block block, final @Nullable Orientation orientation, final boolean movedByPiston
      ) {
          if (!level.isClientSide()) {

--- a/paper-server/patches/features/0031-Delay-open-close-callbacks-for-chests.patch
+++ b/paper-server/patches/features/0031-Delay-open-close-callbacks-for-chests.patch
@@ -46,7 +46,7 @@ index 81a293cc13653a9a0336cb25d75273969fee4d16..8ebcce4c4971a11d367fb39e9c7fd280
          protected void onOpen(final Level level, final BlockPos pos, final BlockState blockState) {
              if (blockState.getBlock() instanceof ChestBlock chestBlock) {
 diff --git a/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java b/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
-index 9af046cbe2c5024040057118a0e9ecd539815781..aa8b384b05738139fa3492b3c09084cda09448ce 100644
+index baa8b5aba0500981a191626553d66650c7304b88..52737172ccfa0c7c977e4f2fe1db242e0bb92d25 100644
 --- a/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
 +++ b/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
 @@ -37,11 +37,23 @@ public abstract class ContainerOpenersCounter {
@@ -70,9 +70,9 @@ index 9af046cbe2c5024040057118a0e9ecd539815781..aa8b384b05738139fa3492b3c09084cd
 +            return;
 +        }
 +        // Paper end - delay open/close callbacks
-         int oldPower = Math.max(0, Math.min(15, this.openCount)); // CraftBukkit - Get power before new viewer is added
          int previous = this.openCount++;
  
+         // Paper start - Call BlockRedstoneEvent
 @@ -66,6 +78,12 @@ public abstract class ContainerOpenersCounter {
      }
  
@@ -83,9 +83,9 @@ index 9af046cbe2c5024040057118a0e9ecd539815781..aa8b384b05738139fa3492b3c09084cd
 +            return;
 +        }
 +        // Paper end - delay open/close callbacks
-         int oldPower = Math.max(0, Math.min(15, this.openCount)); // CraftBukkit - Get power before new viewer is added
          if (this.openCount == 0) return; // Paper - Prevent ContainerOpenersCounter openCount from going negative
          int previous = this.openCount--;
+ 
 @@ -151,6 +169,11 @@ public abstract class ContainerOpenersCounter {
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/level/block/AbstractSkullBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/AbstractSkullBlock.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/level/block/AbstractSkullBlock.java
++++ b/net/minecraft/world/level/block/AbstractSkullBlock.java
+@@ -76,6 +_,11 @@
+         if (!level.isClientSide()) {
+             boolean signal = level.hasNeighborSignal(pos);
+             if (signal != state.getValue(POWERED)) {
++                // Paper start - Call BlockRedstoneEvent
++                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, signal)) {
++                    return;
++                }
++                // Paper end - Call BlockRedstoneEvent
+                 level.setBlock(pos, state.setValue(POWERED, signal), Block.UPDATE_CLIENTS);
+             }
+         }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/BasePressurePlateBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/BasePressurePlateBlock.java.patch
@@ -13,15 +13,15 @@
          boolean wasPressed = oldSignal > 0;
          boolean isPressed = signal > 0;
 +
-+        // CraftBukkit start - Interact Pressure Plate
-+        if (wasPressed != isPressed) {
-+            org.bukkit.event.block.BlockRedstoneEvent eventRedstone = new org.bukkit.event.block.BlockRedstoneEvent(org.bukkit.craftbukkit.block.CraftBlock.at(level, pos), oldSignal, signal);
-+            eventRedstone.callEvent();
++        // Paper start - Call BlockRedstoneEvent
++        if (oldSignal != signal) {
++            org.bukkit.event.block.BlockRedstoneEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldSignal, signal);
 +
-+            isPressed = eventRedstone.getNewCurrent() > 0;
-+            signal = eventRedstone.getNewCurrent();
++            signal = event.getNewCurrent();
++            isPressed = signal > 0;
 +        }
-+        // CraftBukkit end
++        // Paper end - Call BlockRedstoneEvent
++
          if (oldSignal != signal) {
              BlockState newState = this.setSignalForState(state, signal);
              level.setBlock(pos, newState, Block.UPDATE_CLIENTS);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/BellBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/BellBlock.java.patch
@@ -1,5 +1,17 @@
 --- a/net/minecraft/world/level/block/BellBlock.java
 +++ b/net/minecraft/world/level/block/BellBlock.java
+@@ -73,6 +_,11 @@
+     ) {
+         boolean signal = level.hasNeighborSignal(pos);
+         if (signal != state.getValue(POWERED)) {
++            // Paper start - Call BlockRedstoneEvent
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, signal)) {
++                return;
++            }
++            // Paper end - Call BlockRedstoneEvent
+             if (signal) {
+                 this.attemptToRing(level, pos, null);
+             }
 @@ -143,6 +_,11 @@
                  direction = level.getBlockState(pos).getValue(FACING);
              }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/ButtonBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/ButtonBlock.java.patch
@@ -1,25 +1,27 @@
 --- a/net/minecraft/world/level/block/ButtonBlock.java
 +++ b/net/minecraft/world/level/block/ButtonBlock.java
-@@ -92,6 +_,19 @@
+@@ -92,6 +_,11 @@
          if (state.getValue(POWERED)) {
              return InteractionResult.CONSUME;
          } else {
-+            // CraftBukkit start
-+            boolean powered = state.getValue(ButtonBlock.POWERED);
-+            org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
-+            int old = (powered) ? 15 : 0;
-+            int current = (!powered) ? 15 : 0;
-+
-+            org.bukkit.event.block.BlockRedstoneEvent eventRedstone = new org.bukkit.event.block.BlockRedstoneEvent(block, old, current);
-+            level.getCraftServer().getPluginManager().callEvent(eventRedstone);
-+
-+            if ((eventRedstone.getNewCurrent() > 0) != (!powered)) {
++            // Paper start - Call BlockRedstoneEvent
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, true)) {
 +                return InteractionResult.SUCCESS;
 +            }
-+            // CraftBukkit end
++            // Paper end - Call BlockRedstoneEvent
              this.press(state, level, pos, player);
              return InteractionResult.SUCCESS;
          }
+@@ -102,7 +_,9 @@
+         final BlockState state, final ServerLevel level, final BlockPos pos, final Explosion explosion, final BiConsumer<ItemStack, BlockPos> onHit
+     ) {
+         if (explosion.canTriggerBlocks() && !state.getValue(POWERED)) {
++            if (org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, true)) { // Paper - Call BlockRedstoneEvent
+             this.press(state, level, pos, null);
++            } // Paper - Call BlockRedstoneEvent
+         }
+ 
+         super.onExplosionHit(state, level, pos, explosion, onHit);
 @@ -162,6 +_,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
@@ -28,7 +30,7 @@
          if (!level.isClientSide() && this.type.canButtonBeActivatedByArrows() && !state.getValue(POWERED)) {
              this.checkPressed(state, level, pos);
          }
-@@ -173,7 +_,31 @@
+@@ -173,7 +_,21 @@
              : null;
          boolean shouldBePressed = firstArrow != null;
          boolean wasPressed = state.getValue(POWERED);
@@ -36,27 +38,17 @@
 +        if (wasPressed != shouldBePressed && shouldBePressed) {
 +            org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
 +            org.bukkit.event.entity.EntityInteractEvent event = new org.bukkit.event.entity.EntityInteractEvent(firstArrow.getBukkitEntity(), block);
-+            level.getCraftServer().getPluginManager().callEvent(event);
-+
-+            if (event.isCancelled()) {
++            if (!event.callEvent()) {
 +                return;
 +            }
 +        }
 +        // CraftBukkit end
          if (shouldBePressed != wasPressed) {
-+            // CraftBukkit start
-+            boolean powered = wasPressed;
-+            org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
-+            int old = (powered) ? 15 : 0;
-+            int current = (!powered) ? 15 : 0;
-+
-+            org.bukkit.event.block.BlockRedstoneEvent eventRedstone = new org.bukkit.event.block.BlockRedstoneEvent(block, old, current);
-+            level.getCraftServer().getPluginManager().callEvent(eventRedstone);
-+
-+            if ((shouldBePressed && eventRedstone.getNewCurrent() <= 0) || (!shouldBePressed && eventRedstone.getNewCurrent() > 0)) {
++            // Paper start - Call BlockRedstoneEvent
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, shouldBePressed)) {
 +                return;
 +            }
-+            // CraftBukkit end
++            // Paper end - Call BlockRedstoneEvent
              level.setBlock(pos, state.setValue(POWERED, shouldBePressed), Block.UPDATE_ALL);
              this.updateNeighbours(state, level, pos);
              this.playSound(null, level, pos, shouldBePressed);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/CommandBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/CommandBlock.java.patch
@@ -1,24 +1,21 @@
 --- a/net/minecraft/world/level/block/CommandBlock.java
 +++ b/net/minecraft/world/level/block/CommandBlock.java
-@@ -69,8 +_,17 @@
+@@ -69,9 +_,14 @@
          }
      }
  
 -    private void setPoweredAndUpdate(final Level level, final BlockPos pos, final CommandBlockEntity commandBlock, final boolean isPowered) {
 +    private void setPoweredAndUpdate(final Level level, final BlockPos pos, final CommandBlockEntity commandBlock, boolean isPowered) { // Paper - remove final from isPowered
          boolean wasPowered = commandBlock.isPowered();
-+        // CraftBukkit start
-+        org.bukkit.block.Block bukkitBlock = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
-+        int old = wasPowered ? 15 : 0;
-+        int current = isPowered ? 15 : 0;
-+
-+        org.bukkit.event.block.BlockRedstoneEvent eventRedstone = new org.bukkit.event.block.BlockRedstoneEvent(bukkitBlock, old, current);
-+        level.getCraftServer().getPluginManager().callEvent(eventRedstone);
-+        isPowered = eventRedstone.getNewCurrent() > 0;
-+        // CraftBukkit end
          if (isPowered != wasPowered) {
++            // Paper start - Call BlockRedstoneEvent
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, isPowered)) {
++                return;
++            }
++            // Paper end - Call BlockRedstoneEvent
              commandBlock.setPowered(isPowered);
              if (isPowered) {
+                 if (commandBlock.isAutomatic() || commandBlock.getMode() == CommandBlockEntity.Mode.SEQUENCE) {
 @@ -129,7 +_,7 @@
          final BlockState state, final Level level, final BlockPos pos, final Player player, final BlockHitResult hitResult
      ) {

--- a/paper-server/patches/sources/net/minecraft/world/level/block/ComparatorBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/ComparatorBlock.java.patch
@@ -13,18 +13,18 @@
              boolean sourceOn = this.shouldTurnOn(level, pos, state);
              boolean isOn = state.getValue(POWERED);
              if (isOn && !sourceOn) {
-+                // CraftBukkit start
-+                if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 15, 0).getNewCurrent() != 0) {
++                // Paper start - Call BlockRedstoneEvent
++                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, false)) {
 +                    return;
 +                }
-+                // CraftBukkit end
++                // Paper end - Call BlockRedstoneEvent
                  level.setBlock(pos, state.setValue(POWERED, false), Block.UPDATE_CLIENTS);
              } else if (!isOn && sourceOn) {
-+                // CraftBukkit start
-+                if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 0, 15).getNewCurrent() != 15) {
++                // Paper start - Call BlockRedstoneEvent
++                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, true)) {
 +                    return;
 +                }
-+                // CraftBukkit end
++                // Paper end - Call BlockRedstoneEvent
                  level.setBlock(pos, state.setValue(POWERED, true), Block.UPDATE_CLIENTS);
              }
  

--- a/paper-server/patches/sources/net/minecraft/world/level/block/CopperBulbBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/CopperBulbBlock.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/level/block/CopperBulbBlock.java
++++ b/net/minecraft/world/level/block/CopperBulbBlock.java
+@@ -49,6 +_,11 @@
+     public void checkAndFlip(final BlockState state, final ServerLevel level, final BlockPos pos) {
+         boolean signal = level.hasNeighborSignal(pos);
+         if (signal != state.getValue(POWERED)) {
++            // Paper start - Call BlockRedstoneEvent
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, signal)) {
++                return;
++            }
++            // Paper end - Call BlockRedstoneEvent
+             BlockState newState = state;
+             if (!state.getValue(POWERED)) {
+                 newState = state.cycle(LIT);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/DaylightDetectorBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/DaylightDetectorBlock.java.patch
@@ -4,7 +4,7 @@
  
          target = Mth.clamp(target, 0, 15);
          if (state.getValue(POWER) != target) {
-+            target = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, state.getValue(DaylightDetectorBlock.POWER), target).getNewCurrent(); // CraftBukkit - Call BlockRedstoneEvent
++            target = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, state.getValue(POWER), target).getNewCurrent(); // Paper - Call BlockRedstoneEvent
              level.setBlock(pos, state.setValue(POWER, target), Block.UPDATE_ALL);
          }
      }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/DetectorRailBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/DetectorRailBlock.java.patch
@@ -8,7 +8,7 @@
          if (!level.isClientSide()) {
              if (!state.getValue(POWERED)) {
                  this.checkPressed(level, pos, state);
-@@ -87,6 +_,7 @@
+@@ -87,12 +_,21 @@
  
      private void checkPressed(final Level level, final BlockPos pos, final BlockState state) {
          if (this.canSurvive(state, level, pos)) {
@@ -16,20 +16,17 @@
              boolean wasPressed = state.getValue(POWERED);
              boolean shouldBePressed = false;
              List<AbstractMinecart> entities = this.getInteractingMinecartOfType(level, pos, AbstractMinecart.class, e -> true);
-@@ -94,6 +_,16 @@
+             if (!entities.isEmpty()) {
                  shouldBePressed = true;
              }
- 
-+            // CraftBukkit start
++
++            // Paper start - Call BlockRedstoneEvent
 +            if (wasPressed != shouldBePressed) {
-+                org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
-+
-+                org.bukkit.event.block.BlockRedstoneEvent eventRedstone = new org.bukkit.event.block.BlockRedstoneEvent(block, shouldBePressed ? 15 : 0, shouldBePressed ? 15 : 0);
-+                level.getCraftServer().getPluginManager().callEvent(eventRedstone);
-+
-+                shouldBePressed = eventRedstone.getNewCurrent() > 0;
++                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, shouldBePressed)) {
++                    return;
++                }
 +            }
-+            // CraftBukkit end
++            // Paper end - Call BlockRedstoneEvent
+ 
              if (shouldBePressed && !wasPressed) {
                  BlockState newState = state.setValue(POWERED, true);
-                 level.setBlock(pos, newState, Block.UPDATE_ALL);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/DiodeBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/DiodeBlock.java.patch
@@ -4,18 +4,18 @@
              boolean on = state.getValue(POWERED);
              boolean shouldTurnOn = this.shouldTurnOn(level, pos, state);
              if (on && !shouldTurnOn) {
-+                // CraftBukkit start
-+                if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 15, 0).getNewCurrent() != 0) {
++                // Paper start - Call BlockRedstoneEvent
++                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, false)) {
 +                    return;
 +                }
-+                // CraftBukkit end
++                // Paper end - Call BlockRedstoneEvent
                  level.setBlock(pos, state.setValue(POWERED, false), Block.UPDATE_CLIENTS);
              } else if (!on) {
-+                // CraftBukkit start
-+                if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 0, 15).getNewCurrent() != 15) {
++                // Paper start - Call BlockRedstoneEvent
++                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, true)) {
 +                    return;
 +                }
-+                // CraftBukkit end
++                // Paper end - Call BlockRedstoneEvent
                  level.setBlock(pos, state.setValue(POWERED, true), Block.UPDATE_CLIENTS);
                  if (!shouldTurnOn) {
                      level.scheduleTick(pos, this, this.getDelay(state), TickPriority.VERY_HIGH);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/DoorBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/DoorBlock.java.patch
@@ -1,28 +1,14 @@
 --- a/net/minecraft/world/level/block/DoorBlock.java
 +++ b/net/minecraft/world/level/block/DoorBlock.java
-@@ -225,9 +_,22 @@
-     protected void neighborChanged(
-         final BlockState state, final Level level, final BlockPos pos, final Block block, final @Nullable Orientation orientation, final boolean movedByPiston
-     ) {
--        boolean signal = level.hasNeighborSignal(pos)
--            || level.hasNeighborSignal(pos.relative(state.getValue(HALF) == DoubleBlockHalf.LOWER ? Direction.UP : Direction.DOWN));
--        if (!this.defaultBlockState().is(block) && signal != state.getValue(POWERED)) {
-+        // CraftBukkit start
-+        BlockPos otherHalf = pos.relative(state.getValue(DoorBlock.HALF) == DoubleBlockHalf.LOWER ? Direction.UP : Direction.DOWN);
-+        org.bukkit.block.Block bukkitBlock = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
-+        org.bukkit.block.Block blockTop = org.bukkit.craftbukkit.block.CraftBlock.at(level, otherHalf);
-+
-+        int power = bukkitBlock.getBlockPower();
-+        int powerTop = blockTop.getBlockPower();
-+        if (powerTop > power) power = powerTop;
-+        int oldPower = state.getValue(DoorBlock.POWERED) ? net.minecraft.world.level.redstone.Redstone.SIGNAL_MAX : net.minecraft.world.level.redstone.Redstone.SIGNAL_MIN;
-+
-+        if (oldPower == 0 ^ power == 0) {
-+            org.bukkit.event.block.BlockRedstoneEvent event = new org.bukkit.event.block.BlockRedstoneEvent(bukkitBlock, oldPower, power);
-+            event.callEvent();
-+
-+            boolean signal = event.getNewCurrent() > 0;
-+            // CraftBukkit end
+@@ -228,6 +_,11 @@
+         boolean signal = level.hasNeighborSignal(pos)
+             || level.hasNeighborSignal(pos.relative(state.getValue(HALF) == DoubleBlockHalf.LOWER ? Direction.UP : Direction.DOWN));
+         if (!this.defaultBlockState().is(block) && signal != state.getValue(POWERED)) {
++            // Paper start - Call BlockRedstoneEvent
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, signal)) {
++                return;
++            }
++            // Paper end - Call BlockRedstoneEvent
              if (signal != state.getValue(OPEN)) {
                  this.playSound(null, level, pos, signal);
                  level.gameEvent(null, signal ? GameEvent.BLOCK_OPEN : GameEvent.BLOCK_CLOSE, pos);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/FenceGateBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/FenceGateBlock.java.patch
@@ -1,20 +1,14 @@
 --- a/net/minecraft/world/level/block/FenceGateBlock.java
 +++ b/net/minecraft/world/level/block/FenceGateBlock.java
-@@ -188,6 +_,17 @@
-     ) {
+@@ -189,6 +_,11 @@
          if (!level.isClientSide()) {
              boolean hasPower = level.hasNeighborSignal(pos);
-+            // CraftBukkit start
-+            boolean oldPowered = state.getValue(FenceGateBlock.POWERED);
-+            if (oldPowered != hasPower) {
-+                int newPower = hasPower ? 15 : 0;
-+                int oldPower = oldPowered ? 15 : 0;
-+                org.bukkit.block.Block bukkitBlock = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
-+                org.bukkit.event.block.BlockRedstoneEvent eventRedstone = new org.bukkit.event.block.BlockRedstoneEvent(bukkitBlock, oldPower, newPower);
-+                level.getCraftServer().getPluginManager().callEvent(eventRedstone);
-+                hasPower = eventRedstone.getNewCurrent() > 0;
-+            }
-+            // CraftBukkit end
              if (state.getValue(POWERED) != hasPower) {
++                // Paper start - Call BlockRedstoneEvent
++                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, hasPower)) {
++                    return;
++                }
++                // Paper end - Call BlockRedstoneEvent
                  level.setBlock(pos, state.setValue(POWERED, hasPower).setValue(OPEN, hasPower), Block.UPDATE_CLIENTS);
                  if (state.getValue(OPEN) != hasPower) {
+                     level.playSound(

--- a/paper-server/patches/sources/net/minecraft/world/level/block/LecternBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/LecternBlock.java.patch
@@ -26,20 +26,17 @@
              resetBookState(sourceEntity, level, pos, state, true);
              level.playSound(null, pos, SoundEvents.BOOK_PUT, SoundSource.BLOCKS, 1.0F, 1.0F);
          }
-@@ -162,6 +_,16 @@
+@@ -162,6 +_,13 @@
      }
  
      private static void changePowered(final Level level, final BlockPos pos, final BlockState state, final boolean isPowered) {
-+        // Paper start - Call BlockRedstoneEvent properly
-+        final int currentRedstoneLevel = state.getValue(LecternBlock.POWERED) ? 15 : 0, targetRedstoneLevel = isPowered ? 15 : 0;
-+        if (currentRedstoneLevel != targetRedstoneLevel) {
-+            final org.bukkit.event.block.BlockRedstoneEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, currentRedstoneLevel, targetRedstoneLevel);
-+
-+            if (event.getNewCurrent() != targetRedstoneLevel) {
++        // Paper start - Call BlockRedstoneEvent
++        if (state.getValue(POWERED) != isPowered) {
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, isPowered)) {
 +                return;
 +            }
 +        }
-+        // Paper end - Call BlockRedstoneEvent properly
++        // Paper end - Call BlockRedstoneEvent
          level.setBlock(pos, state.setValue(POWERED, isPowered), Block.UPDATE_ALL);
          updateBelow(level, pos, state);
      }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/LeverBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/LeverBlock.java.patch
@@ -1,22 +1,28 @@
 --- a/net/minecraft/world/level/block/LeverBlock.java
 +++ b/net/minecraft/world/level/block/LeverBlock.java
-@@ -70,6 +_,19 @@
+@@ -70,6 +_,12 @@
                  makeParticle(stateAfter, level, pos, 1.0F);
              }
          } else {
-+            // CraftBukkit start - Interact Lever
-+            boolean powered = stateBefore.getValue(LeverBlock.POWERED); // Old powered state
-+            org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
-+            int old = (powered) ? 15 : 0;
-+            int current = (!powered) ? 15 : 0;
-+
-+            org.bukkit.event.block.BlockRedstoneEvent eventRedstone = new org.bukkit.event.block.BlockRedstoneEvent(block, old, current);
-+            level.getCraftServer().getPluginManager().callEvent(eventRedstone);
-+
-+            if ((eventRedstone.getNewCurrent() > 0) != (!powered)) {
++            // Paper start - Call BlockRedstoneEvent
++            boolean wasPowered = stateBefore.getValue(POWERED);
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, !wasPowered)) {
 +                return InteractionResult.SUCCESS;
 +            }
-+            // CraftBukkit end
++            // Paper end - Call BlockRedstoneEvent
              this.pull(stateBefore, level, pos, null);
          }
  
+@@ -81,7 +_,12 @@
+         final BlockState state, final ServerLevel level, final BlockPos pos, final Explosion explosion, final BiConsumer<ItemStack, BlockPos> onHit
+     ) {
+         if (explosion.canTriggerBlocks()) {
++            // Paper start - Call BlockRedstoneEvent
++            boolean wasPowered = state.getValue(POWERED);
++            if (org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, !wasPowered)) {
++            // Paper end - Call BlockRedstoneEvent
+             this.pull(state, level, pos, null);
++            } // Paper - Call BlockRedstoneEvent
+         }
+ 
+         super.onExplosionHit(state, level, pos, explosion, onHit);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/LightningRodBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/LightningRodBlock.java.patch
@@ -1,21 +1,30 @@
 --- a/net/minecraft/world/level/block/LightningRodBlock.java
 +++ b/net/minecraft/world/level/block/LightningRodBlock.java
-@@ -83,6 +_,18 @@
+@@ -83,6 +_,13 @@
      }
  
      public void onLightningStrike(final BlockState state, final Level level, final BlockPos pos) {
-+        // CraftBukkit start
-+        boolean powered = state.getValue(LightningRodBlock.POWERED);
-+        int old = (powered) ? 15 : 0;
-+        int current = (!powered) ? 15 : 0;
-+
-+        org.bukkit.event.block.BlockRedstoneEvent eventRedstone = new org.bukkit.event.block.BlockRedstoneEvent(org.bukkit.craftbukkit.block.CraftBlock.at(level, pos), old, current);
-+        level.getCraftServer().getPluginManager().callEvent(eventRedstone);
-+
-+        if (eventRedstone.getNewCurrent() <= 0) {
-+            return;
++        // Paper start - Call BlockRedstoneEvent
++        if (!state.getValue(POWERED)) {
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, true)) {
++                return;
++            }
 +        }
-+        // CraftBukkit end
++        // Paper end - Call BlockRedstoneEvent
          level.setBlock(pos, state.setValue(POWERED, true), Block.UPDATE_ALL);
          this.updateNeighbours(state, level, pos);
          level.scheduleTick(pos, this, 8);
+@@ -96,6 +_,13 @@
+ 
+     @Override
+     protected void tick(final BlockState state, final ServerLevel level, final BlockPos pos, final RandomSource random) {
++        // Paper start - Call BlockRedstoneEvent
++        if (state.getValue(POWERED)) {
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, false)) {
++                return;
++            }
++        }
++        // Paper end - Call BlockRedstoneEvent
+         level.setBlock(pos, state.setValue(POWERED, false), Block.UPDATE_ALL);
+         this.updateNeighbours(state, level, pos);
+     }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/NoteBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/NoteBlock.java.patch
@@ -16,7 +16,7 @@
          boolean neighborDirectionSetsInstrument = directionToNeighbour.getAxis() == Direction.Axis.Y;
          return neighborDirectionSetsInstrument
              ? this.setInstrument(level, pos, state)
-@@ -86,12 +_,14 @@
+@@ -86,12 +_,19 @@
  
      @Override
      protected void neighborChanged(
@@ -26,6 +26,11 @@
 +        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableNoteblockUpdates) return; // Paper - prevent noteblock powered-state from updating
          boolean signal = level.hasNeighborSignal(pos);
          if (signal != state.getValue(POWERED)) {
++            // Paper start - Call BlockRedstoneEvent
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, signal)) {
++                return;
++            }
++            // Paper end - Call BlockRedstoneEvent
              if (signal) {
                  this.playNote(null, state, level, pos);
 +                state = level.getBlockState(pos); // CraftBukkit - SPIGOT-5617: update in case changed in event

--- a/paper-server/patches/sources/net/minecraft/world/level/block/ObserverBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/ObserverBlock.java.patch
@@ -4,18 +4,18 @@
      @Override
      protected void tick(final BlockState state, final ServerLevel level, final BlockPos pos, final RandomSource random) {
          if (state.getValue(POWERED)) {
-+            // CraftBukkit start
-+            if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 15, 0).getNewCurrent() != 0) {
++            // Paper start - Call BlockRedstoneEvent
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, false)) {
 +                return;
 +            }
-+            // CraftBukkit end
++            // Paper end - Call BlockRedstoneEvent
              level.setBlock(pos, state.setValue(POWERED, false), Block.UPDATE_CLIENTS);
          } else {
-+            // CraftBukkit start
-+            if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 0, 15).getNewCurrent() != 15) {
++            // Paper start - Call BlockRedstoneEvent
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, true)) {
 +                return;
 +            }
-+            // CraftBukkit end
++            // Paper end - Call BlockRedstoneEvent
              level.setBlock(pos, state.setValue(POWERED, true), Block.UPDATE_CLIENTS);
              level.scheduleTick(pos, this, 2);
          }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/PoweredRailBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/PoweredRailBlock.java.patch
@@ -1,16 +1,14 @@
 --- a/net/minecraft/world/level/block/PoweredRailBlock.java
 +++ b/net/minecraft/world/level/block/PoweredRailBlock.java
-@@ -127,6 +_,13 @@
+@@ -127,6 +_,11 @@
              || this.findPoweredRailSignal(level, pos, state, true, 0)
              || this.findPoweredRailSignal(level, pos, state, false, 0);
          if (shouldPower != isPowered) {
-+            // CraftBukkit start
-+            int power = shouldPower ? 15 : 0;
-+            int newPower = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, power, 15 - power).getNewCurrent();
-+            if (newPower == power) {
++            // Paper start - Call BlockRedstoneEvent
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, shouldPower)) {
 +                return;
 +            }
-+            // CraftBukkit end
++            // Paper end - Call BlockRedstoneEvent
              level.setBlock(pos, state.setValue(POWERED, shouldPower), Block.UPDATE_ALL);
              level.updateNeighborsAt(pos.below(), this);
              if (state.getValue(SHAPE).isSlope()) {

--- a/paper-server/patches/sources/net/minecraft/world/level/block/RedstoneLampBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/RedstoneLampBlock.java.patch
@@ -4,11 +4,11 @@
                  if (isLit) {
                      level.scheduleTick(pos, this, 4);
                  } else {
-+                    // CraftBukkit start
-+                    if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 0, 15).getNewCurrent() != 15) {
++                    // Paper start - Call BlockRedstoneEvent
++                    if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, true)) {
 +                        return;
 +                    }
-+                    // CraftBukkit end
++                    // Paper end - Call BlockRedstoneEvent
                      level.setBlock(pos, state.cycle(LIT), Block.UPDATE_CLIENTS);
                  }
              }
@@ -16,11 +16,11 @@
      @Override
      protected void tick(final BlockState state, final ServerLevel level, final BlockPos pos, final RandomSource random) {
          if (state.getValue(LIT) && !level.hasNeighborSignal(pos)) {
-+            // CraftBukkit start
-+            if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 15, 0).getNewCurrent() != 0) {
++            // Paper start - Call BlockRedstoneEvent
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, false)) {
 +                return;
 +            }
-+            // CraftBukkit end
++            // Paper end - Call BlockRedstoneEvent
              level.setBlock(pos, state.cycle(LIT), Block.UPDATE_CLIENTS);
          }
      }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/RedstoneTorchBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/RedstoneTorchBlock.java.patch
@@ -9,7 +9,7 @@
      public static final int RECENT_TOGGLE_TIMER = 60;
      public static final int MAX_RECENT_TOGGLES = 8;
      public static final int RESTART_DELAY = 160;
-@@ -73,14 +_,22 @@
+@@ -73,14 +_,23 @@
      @Override
      protected void tick(final BlockState state, final ServerLevel level, final BlockPos pos, final RandomSource random) {
          boolean neighborSignal = this.hasNeighborSignal(level, pos, state);
@@ -25,8 +25,8 @@
 +                toggles.poll();
 +            }
          }
--
 +        // Paper end - Faster redstone torch rapid clock removal
+ 
          if (state.getValue(LIT)) {
              if (neighborSignal) {
 +                // Paper start - Call BlockRedstoneEvent

--- a/paper-server/patches/sources/net/minecraft/world/level/block/RedstoneTorchBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/RedstoneTorchBlock.java.patch
@@ -9,7 +9,7 @@
      public static final int RECENT_TOGGLE_TIMER = 60;
      public static final int MAX_RECENT_TOGGLES = 8;
      public static final int RESTART_DELAY = 160;
-@@ -73,14 +_,32 @@
+@@ -73,14 +_,22 @@
      @Override
      protected void tick(final BlockState state, final ServerLevel level, final BlockPos pos, final RandomSource random) {
          boolean neighborSignal = this.hasNeighborSignal(level, pos, state);
@@ -25,40 +25,27 @@
 +                toggles.poll();
 +            }
          }
+-
 +        // Paper end - Faster redstone torch rapid clock removal
-+        // CraftBukkit start
-+        org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
-+        int oldCurrent = state.getValue(LIT) ? 15 : 0;
- 
-+        org.bukkit.event.block.BlockRedstoneEvent event = new org.bukkit.event.block.BlockRedstoneEvent(block, oldCurrent, oldCurrent);
-+        // CraftBukkit end
          if (state.getValue(LIT)) {
              if (neighborSignal) {
-+                // CraftBukkit start
-+                if (oldCurrent != 0) {
-+                    event.setNewCurrent(0);
-+                    event.callEvent();
-+                    if (event.getNewCurrent() != 0) {
-+                        return;
-+                    }
++                // Paper start - Call BlockRedstoneEvent
++                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, false)) {
++                    return;
 +                }
-+                // CraftBukkit end
++                // Paper end - Call BlockRedstoneEvent
                  level.setBlock(pos, state.setValue(LIT, false), Block.UPDATE_ALL);
                  if (isToggledTooFrequently(level, pos, true)) {
                      level.levelEvent(LevelEvent.REDSTONE_TORCH_BURNOUT, pos, 0);
-@@ -88,6 +_,15 @@
+@@ -88,6 +_,11 @@
                  }
              }
          } else if (!neighborSignal && !isToggledTooFrequently(level, pos, false)) {
-+            // CraftBukkit start
-+            if (oldCurrent != 15) {
-+                event.setNewCurrent(15);
-+                event.callEvent();
-+                if (event.getNewCurrent() != 15) {
-+                    return;
-+                }
++            // Paper start - Call BlockRedstoneEvent
++            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, true)) {
++                return;
 +            }
-+            // CraftBukkit end
++            // Paper end - Call BlockRedstoneEvent
              level.setBlock(pos, state.setValue(LIT, true), Block.UPDATE_ALL);
          }
      }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/SculkSensorBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/SculkSensorBlock.java.patch
@@ -43,7 +43,7 @@
          final BlockPos pos,
          final BlockState state,
 -        final int calculatedPower,
-+        int calculatedPower, // CraftBukkit
++        int calculatedPower, // Paper - remove final
          final int vibrationFrequency
      ) {
 +        // Paper start - Call BlockRedstoneEvent

--- a/paper-server/patches/sources/net/minecraft/world/level/block/SculkSensorBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/SculkSensorBlock.java.patch
@@ -19,7 +19,7 @@
              sculkSensor.getListener().forceScheduleVibration(serverLevel, GameEvent.STEP, GameEvent.Context.of(entity), entity.position());
          }
  
-@@ -189,10 +_,19 @@
+@@ -189,10 +_,17 @@
      }
  
      public static boolean canActivate(final BlockState state) {
@@ -28,19 +28,17 @@
      }
  
      public static void deactivate(final Level level, final BlockPos pos, final BlockState state) {
-+        // CraftBukkit start
-+        org.bukkit.event.block.BlockRedstoneEvent eventRedstone = new org.bukkit.event.block.BlockRedstoneEvent(org.bukkit.craftbukkit.block.CraftBlock.at(level, pos), state.getValue(SculkSensorBlock.POWER), 0);
-+        level.getCraftServer().getPluginManager().callEvent(eventRedstone);
-+
-+        if (eventRedstone.getNewCurrent() > 0) {
-+            level.setBlock(pos, state.setValue(SculkSensorBlock.POWER, eventRedstone.getNewCurrent()), Block.UPDATE_ALL);
++        // Paper start - Call BlockRedstoneEvent
++        int newCurrent = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, state.getValue(POWER), 0).getNewCurrent();
++        if (newCurrent > 0) {
++            level.setBlock(pos, state.setValue(POWER, newCurrent), Block.UPDATE_ALL);
 +            return;
 +        }
-+        // CraftBukkit end
++        // Paper end - Call BlockRedstoneEvent
          level.setBlock(pos, state.setValue(PHASE, SculkSensorPhase.COOLDOWN).setValue(POWER, 0), Block.UPDATE_ALL);
          level.scheduleTick(pos, state.getBlock(), 10);
          updateNeighbours(level, pos, state);
-@@ -208,9 +_,18 @@
+@@ -208,9 +_,15 @@
          final Level level,
          final BlockPos pos,
          final BlockState state,
@@ -48,15 +46,12 @@
 +        int calculatedPower, // CraftBukkit
          final int vibrationFrequency
      ) {
-+        // CraftBukkit start
-+        org.bukkit.event.block.BlockRedstoneEvent eventRedstone = new org.bukkit.event.block.BlockRedstoneEvent(org.bukkit.craftbukkit.block.CraftBlock.at(level, pos), state.getValue(SculkSensorBlock.POWER), calculatedPower);
-+        level.getCraftServer().getPluginManager().callEvent(eventRedstone);
-+
-+        if (eventRedstone.getNewCurrent() <= 0) {
++        // Paper start - Call BlockRedstoneEvent
++        calculatedPower = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, state.getValue(POWER), calculatedPower).getNewCurrent();
++        if (calculatedPower == 0) {
 +            return;
 +        }
-+        calculatedPower = eventRedstone.getNewCurrent();
-+        // CraftBukkit end
++        // Paper end - Call BlockRedstoneEvent
          level.setBlock(pos, state.setValue(PHASE, SculkSensorPhase.ACTIVE).setValue(POWER, calculatedPower), Block.UPDATE_ALL);
          level.scheduleTick(pos, state.getBlock(), this.getActiveTicks());
          updateNeighbours(level, pos, state);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/TargetBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TargetBlock.java.patch
@@ -11,7 +11,7 @@
          if (projectile.getOwner() instanceof ServerPlayer playerOwner) {
              playerOwner.awardStat(Stats.TARGET_HIT);
              CriteriaTriggers.TARGET_BLOCK_HIT.trigger(playerOwner, projectile, hitResult.getLocation(), outputStrength);
-@@ -51,10 +_,30 @@
+@@ -51,10 +_,29 @@
      private static int updateRedstoneOutput(final LevelAccessor level, final BlockState state, final BlockHitResult hitResult, final Entity entity) {
          int redstoneStrength = getRedstoneStrength(hitResult, hitResult.getLocation());
          int duration = entity instanceof AbstractArrow ? 20 : 8;
@@ -38,7 +38,6 @@
 +            awardTargetHitCriteria((Projectile) entity, hitResult, redstoneStrength);
 +        }
 +        // Paper end - Award Hit Criteria after Block Update
-+
          return redstoneStrength;
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/level/block/TargetBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TargetBlock.java.patch
@@ -11,7 +11,7 @@
          if (projectile.getOwner() instanceof ServerPlayer playerOwner) {
              playerOwner.awardStat(Stats.TARGET_HIT);
              CriteriaTriggers.TARGET_BLOCK_HIT.trigger(playerOwner, projectile, hitResult.getLocation(), outputStrength);
-@@ -51,9 +_,29 @@
+@@ -51,10 +_,30 @@
      private static int updateRedstoneOutput(final LevelAccessor level, final BlockState state, final BlockHitResult hitResult, final Entity entity) {
          int redstoneStrength = getRedstoneStrength(hitResult, hitResult.getLocation());
          int duration = entity instanceof AbstractArrow ? 20 : 8;
@@ -32,12 +32,40 @@
          if (!level.getBlockTicks().hasScheduledTick(hitResult.getBlockPos(), state.getBlock())) {
              setOutputPower(level, state, redstoneStrength, hitResult.getBlockPos(), duration);
          }
-+
+ 
 +        // Paper start - Award Hit Criteria after Block Update
 +        if (shouldAward) {
 +            awardTargetHitCriteria((Projectile) entity, hitResult, redstoneStrength);
 +        }
 +        // Paper end - Award Hit Criteria after Block Update
- 
++
          return redstoneStrength;
+     }
+ 
+@@ -76,7 +_,12 @@
+         return Math.max(1, Mth.ceil(15.0 * Mth.clamp((0.5 - distance) / 0.5, 0.0, 1.0)));
+     }
+ 
+-    private static void setOutputPower(final LevelAccessor level, final BlockState state, final int outputStrength, final BlockPos pos, final int duration) {
++    private static void setOutputPower(final LevelAccessor level, final BlockState state, int outputStrength, final BlockPos pos, final int duration) { // Paper - remove final
++        // Paper start - Call BlockRedstoneEvent
++        if (state.getValue(OUTPUT_POWER) != outputStrength) {
++            outputStrength = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, state.getValue(OUTPUT_POWER), outputStrength).getNewCurrent();
++        }
++        // Paper end - Call BlockRedstoneEvent
+         level.setBlock(pos, state.setValue(OUTPUT_POWER, outputStrength), Block.UPDATE_ALL);
+         level.scheduleTick(pos, state.getBlock(), duration);
+     }
+@@ -84,6 +_,12 @@
+     @Override
+     protected void tick(final BlockState state, final ServerLevel level, final BlockPos pos, final RandomSource random) {
+         if (state.getValue(OUTPUT_POWER) != 0) {
++            // Paper start - Call BlockRedstoneEvent
++            org.bukkit.event.block.BlockRedstoneEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, state.getValue(OUTPUT_POWER), 0);
++            if (event.getNewCurrent() > 0) {
++                return;
++            }
++            // Paper end - Call BlockRedstoneEvent
+             level.setBlock(pos, state.setValue(OUTPUT_POWER, 0), Block.UPDATE_ALL);
+         }
      }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/TrapDoorBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TrapDoorBlock.java.patch
@@ -1,21 +1,15 @@
 --- a/net/minecraft/world/level/block/TrapDoorBlock.java
 +++ b/net/minecraft/world/level/block/TrapDoorBlock.java
-@@ -133,7 +_,37 @@
+@@ -133,7 +_,31 @@
          if (!level.isClientSide()) {
              boolean signal = level.hasNeighborSignal(pos);
              if (signal != state.getValue(POWERED)) {
 -                if (state.getValue(OPEN) != signal) {
-+                // CraftBukkit start
-+                org.bukkit.block.Block bblock = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
-+                int power = bblock.getBlockPower();
-+                int oldPower = state.getValue(TrapDoorBlock.OPEN) ? 15 : 0;
-+
-+                if (oldPower == 0 ^ power == 0 || block.defaultBlockState().isSignalSource()) {
-+                    org.bukkit.event.block.BlockRedstoneEvent eventRedstone = new org.bukkit.event.block.BlockRedstoneEvent(bblock, oldPower, power);
-+                    level.getCraftServer().getPluginManager().callEvent(eventRedstone);
-+                    signal = eventRedstone.getNewCurrent() > 0;
++                // Paper start - Call BlockRedstoneEvent
++                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, signal)) {
++                    return;
 +                }
-+                // CraftBukkit end
++                // Paper end - Call BlockRedstoneEvent
 +                // Paper start - break redstone on trapdoors early
 +                boolean open = state.getValue(TrapDoorBlock.OPEN) != signal;
 +                // note: this must run before any state for this block/its neighbours are written to the world
@@ -26,7 +20,7 @@
 +                    BlockState above = level.getBlockState(abovePos);
 +                    if (above.getBlock() instanceof RedStoneWireBlock) {
 +                        level.setBlock(abovePos, Blocks.AIR.defaultBlockState(), Block.UPDATE_CLIENTS | Block.UPDATE_NEIGHBORS);
-+                        Block.popResource(level, abovePos, new net.minecraft.world.item.ItemStack(net.minecraft.world.item.Items.REDSTONE));
++                        Block.popResource(level, abovePos, new ItemStack(net.minecraft.world.item.Items.REDSTONE));
 +                        // now check that this didn't change our state
 +                        if (level.getBlockState(pos) != state) {
 +                            // our state was changed, so we cannot propagate this update

--- a/paper-server/patches/sources/net/minecraft/world/level/block/TripWireHookBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TripWireHookBlock.java.patch
@@ -13,7 +13,7 @@
              int receiverPos = 0;
              BlockState[] wireStates = new BlockState[42];
  
-@@ -158,8 +_,20 @@
+@@ -158,8 +_,15 @@
              attached &= receiverPos > 1;
              powered &= attached;
              BlockState newState = block.defaultBlockState().trySetValue(ATTACHED, attached).trySetValue(POWERED, powered);
@@ -22,19 +22,14 @@
                  BlockPos testPosx = pos.relative(direction, receiverPos);
 +                // Paper start - Call BlockRedstoneEvent
 +                if (wasPowered != powered) {
-+                    int newCurrent = powered ? 15 : 0;
-+                    org.bukkit.event.block.BlockRedstoneEvent event = new org.bukkit.event.block.BlockRedstoneEvent(
-+                        org.bukkit.craftbukkit.block.CraftBlock.at(level, testPosx), wasPowered ? 15 : 0, newCurrent
-+                    );
-+                    event.callEvent();
-+                    cancelledReceiverHook = event.getNewCurrent() != newCurrent;
++                    cancelledReceiverHook = !org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, testPosx, powered);
 +                }
 +                if (!cancelledReceiverHook) { // always trigger two events even when the first hook current change is cancelled
 +                // Paper end - Call BlockRedstoneEvent
                  Direction opposite = direction.getOpposite();
                  level.setBlock(testPosx, newState.setValue(FACING, opposite), Block.UPDATE_ALL);
                  notifyNeighbors(block, level, testPosx, opposite);
-@@ -169,15 +_,29 @@
+@@ -169,15 +_,24 @@
                  }
  
                  emitState(level, testPosx, attached, powered, wasAttached, wasPowered);
@@ -43,12 +38,7 @@
 +            }
 +            // Paper start - Call BlockRedstoneEvent
 +            if (wasPowered != powered) {
-+                int newCurrent = powered ? 15 : 0;
-+                org.bukkit.event.block.BlockRedstoneEvent event = new org.bukkit.event.block.BlockRedstoneEvent(
-+                    org.bukkit.craftbukkit.block.CraftBlock.at(level, pos), wasPowered ? 15 : 0, newCurrent
-+                );
-+                event.callEvent();
-+                cancelledEmitterHook = event.getNewCurrent() != newCurrent;
++                cancelledEmitterHook = !org.bukkit.craftbukkit.event.CraftEventFactory.callBinaryRedstoneChange(level, pos, powered);
 +            }
 +            // Paper end - Call BlockRedstoneEvent
  

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java.patch
@@ -21,22 +21,21 @@
  
      protected abstract void onOpen(final Level level, final BlockPos pos, final BlockState blockState);
  
-@@ -28,7 +_,19 @@
-     public void incrementOpeners(
+@@ -29,6 +_,18 @@
          final LivingEntity entity, final Level level, final BlockPos pos, final BlockState blockState, final double maxInteractionRange
      ) {
-+        int oldPower = Math.max(0, Math.min(15, this.openCount)); // CraftBukkit - Get power before new viewer is added
          int previous = this.openCount++;
 +
-+        // CraftBukkit start - Call redstone event
-+        if (level.getBlockState(pos).is(net.minecraft.world.level.block.Blocks.TRAPPED_CHEST)) {
-+            int newPower = Math.max(0, Math.min(15, this.openCount));
++        // Paper start - Call BlockRedstoneEvent
++        if (blockState.is(net.minecraft.world.level.block.Blocks.TRAPPED_CHEST)) {
++            int oldCurrent = Math.clamp(previous, 0, 15);
++            int newCurrent = Math.clamp(this.openCount, 0, 15);
 +
-+            if (oldPower != newPower) {
-+                org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldPower, newPower);
++            if (oldCurrent != newCurrent) {
++                org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldCurrent, newCurrent);
 +            }
 +        }
-+        // CraftBukkit end
++        // Paper end - Call BlockRedstoneEvent
 +
          if (previous == 0) {
              this.onOpen(level, pos, blockState);
@@ -45,19 +44,19 @@
      }
  
      public void decrementOpeners(final LivingEntity entity, final Level level, final BlockPos pos, final BlockState blockState) {
-+        int oldPower = Math.max(0, Math.min(15, this.openCount)); // CraftBukkit - Get power before new viewer is added
 +        if (this.openCount == 0) return; // Paper - Prevent ContainerOpenersCounter openCount from going negative
          int previous = this.openCount--;
 +
-+        // CraftBukkit start - Call redstone event
-+        if (level.getBlockState(pos).is(net.minecraft.world.level.block.Blocks.TRAPPED_CHEST)) {
-+            int newPower = Math.max(0, Math.min(15, this.openCount));
++        // Paper start - Call BlockRedstoneEvent
++        if (blockState.is(net.minecraft.world.level.block.Blocks.TRAPPED_CHEST)) {
++            int oldCurrent = Math.clamp(previous, 0, 15);
++            int newCurrent = Math.clamp(this.openCount, 0, 15);
 +
-+            if (oldPower != newPower) {
-+                org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldPower, newPower);
++            if (oldCurrent != newCurrent) {
++                org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldCurrent, newCurrent);
 +            }
 +        }
-+        // CraftBukkit end
++        // Paper end - Call BlockRedstoneEvent
 +
          if (this.openCount == 0) {
              this.onClose(level, pos, blockState);
@@ -69,16 +68,16 @@
 +        if (this.opened) openCount++; // CraftBukkit - add dummy count from API
          int prevCount = this.openCount;
          if (prevCount != openCount) {
-+            // CraftBukkit start - Call redstone event
-+            if (level.getBlockState(pos).is(net.minecraft.world.level.block.Blocks.TRAPPED_CHEST)) {
-+                int oldPower = net.minecraft.util.Mth.clamp(prevCount, 0, 15);
-+                int newPower = net.minecraft.util.Mth.clamp(openCount, 0, 15);
++            // Paper start - Call BlockRedstoneEvent
++            if (blockState.is(net.minecraft.world.level.block.Blocks.TRAPPED_CHEST)) {
++                int oldCurrent = Math.clamp(prevCount, 0, 15);
++                int newCurrent = Math.clamp(openCount, 0, 15);
 +
-+                if (oldPower != newPower) {
-+                    org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldPower, newPower);
++                if (oldCurrent != newCurrent) {
++                    org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldCurrent, newCurrent);
 +                }
 +            }
-+            // CraftBukkit end
++            // Paper end - Call BlockRedstoneEvent
 +
              boolean isOpen = openCount != 0;
              boolean wasOpen = prevCount != 0;

--- a/paper-server/patches/sources/net/minecraft/world/level/redstone/DefaultRedstoneWireEvaluator.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/redstone/DefaultRedstoneWireEvaluator.java.patch
@@ -1,20 +1,17 @@
 --- a/net/minecraft/world/level/redstone/DefaultRedstoneWireEvaluator.java
 +++ b/net/minecraft/world/level/redstone/DefaultRedstoneWireEvaluator.java
-@@ -20,7 +_,16 @@
+@@ -20,7 +_,13 @@
          final Level level, final BlockPos pos, final BlockState state, final @Nullable Orientation orientation, final boolean skipShapeUpdates
      ) {
          int targetStrength = this.calculateTargetStrength(level, pos);
 -        if (state.getValue(RedStoneWireBlock.POWER) != targetStrength) {
-+        // CraftBukkit start
++        // Paper start - Call BlockRedstoneEvent
 +        int oldPower = state.getValue(RedStoneWireBlock.POWER);
-+        if (oldPower != targetStrength) {
-+            org.bukkit.event.block.BlockRedstoneEvent event = new org.bukkit.event.block.BlockRedstoneEvent(org.bukkit.craftbukkit.block.CraftBlock.at(level, pos), oldPower, targetStrength);
-+            level.getCraftServer().getPluginManager().callEvent(event);
-+
-+            targetStrength = event.getNewCurrent();
++        if (oldPower != targetStrength && level.getBlockState(pos) == state) {
++            targetStrength = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldPower, targetStrength).getNewCurrent();
 +        }
 +        if (oldPower != targetStrength) {
-+            // CraftBukkit end
++            // Paper end - Call BlockRedstoneEvent
              if (level.getBlockState(pos) == state) {
                  level.setBlock(pos, state.setValue(RedStoneWireBlock.POWER, targetStrength), Block.UPDATE_CLIENTS);
              }

--- a/paper-server/patches/sources/net/minecraft/world/level/redstone/DefaultRedstoneWireEvaluator.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/redstone/DefaultRedstoneWireEvaluator.java.patch
@@ -6,11 +6,11 @@
          int targetStrength = this.calculateTargetStrength(level, pos);
 -        if (state.getValue(RedStoneWireBlock.POWER) != targetStrength) {
 +        // Paper start - Call BlockRedstoneEvent
-+        int oldPower = state.getValue(RedStoneWireBlock.POWER);
-+        if (oldPower != targetStrength && level.getBlockState(pos) == state) {
-+            targetStrength = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldPower, targetStrength).getNewCurrent();
++        int previousStrength = state.getValue(RedStoneWireBlock.POWER);
++        if (previousStrength != targetStrength && level.getBlockState(pos) == state) {
++            targetStrength = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, previousStrength, targetStrength).getNewCurrent();
 +        }
-+        if (oldPower != targetStrength) {
++        if (previousStrength != targetStrength) {
 +            // Paper end - Call BlockRedstoneEvent
              if (level.getBlockState(pos) == state) {
                  level.setBlock(pos, state.setValue(RedStoneWireBlock.POWER, targetStrength), Block.UPDATE_CLIENTS);

--- a/paper-server/patches/sources/net/minecraft/world/level/redstone/ExperimentalRedstoneWireEvaluator.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/redstone/ExperimentalRedstoneWireEvaluator.java.patch
@@ -1,20 +1,14 @@
 --- a/net/minecraft/world/level/redstone/ExperimentalRedstoneWireEvaluator.java
 +++ b/net/minecraft/world/level/redstone/ExperimentalRedstoneWireEvaluator.java
-@@ -45,7 +_,16 @@
+@@ -45,6 +_,11 @@
              int packed = next.getIntValue();
              int newLevel = unpackPower(packed);
              BlockState state = level.getBlockState(pos);
--            if (state.is(this.wireBlock) && !state.getValue(RedStoneWireBlock.POWER).equals(newLevel)) {
-+            // CraftBukkit start
-+            int oldPower = state.getValue(RedStoneWireBlock.POWER); // Paper - Call BlockRedstoneEvent properly; get the previous power from the right state
-+            if (oldPower != newLevel) {
-+                org.bukkit.event.block.BlockRedstoneEvent event = new org.bukkit.event.block.BlockRedstoneEvent(org.bukkit.craftbukkit.block.CraftBlock.at(level, pos), oldPower, newLevel);
-+                level.getCraftServer().getPluginManager().callEvent(event);
-+
-+                newLevel = event.getNewCurrent();
++            // Paper start - Call BlockRedstoneEvent
++            if (state.is(this.wireBlock) && !state.getValue(RedStoneWireBlock.POWER).equals(newLevel)) {
++                newLevel = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, state.getValue(RedStoneWireBlock.POWER), newLevel).getNewCurrent();
 +            }
-+            if (state.is(this.wireBlock) && oldPower != newLevel) {
-+                // CraftBukkit end
++            // Paper end - Call BlockRedstoneEvent
+             if (state.is(this.wireBlock) && !state.getValue(RedStoneWireBlock.POWER).equals(newLevel)) {
                  int updateFlags = Block.UPDATE_CLIENTS;
                  if (!shapeUpdateWiresAroundInitialPosition || !initialWire) {
-                     updateFlags |= Block.UPDATE_SKIP_SHAPE_UPDATE_ON_WIRE;


### PR DESCRIPTION
Handle more case that would change the powered/power property once a block is placed:
- skull, copper bulb, bell, target block, note block
- wind charge on button/lever

Fixes some other problems:
- lighting strike on lightning rod only called the event for the transition 0 -> 15 and not 15 -> 0
- command block called the event even for non redstone change (for example when placed/already powered)
- detector rail called the event with wrong arguments (oldCurrent always equals to newCurrent)
- trapdoor didn't call the event when already opened then powered
- door and trapdoor had the real power received instead of its two states (0/15) unlike similar blocks (lever/fence gate)
- iron/gold pressure plates power change was not accounted properly