### PR TITLE
Remove ItemFactory#enchantWithLevels range check for vanilla parity

### DIFF
--- a/paper-api/src/main/java/org/bukkit/inventory/ItemFactory.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemFactory.java
@@ -327,6 +327,10 @@ public interface ItemFactory {
      *
      * <p>If the provided ItemStack is already enchanted, the existing enchants will be removed before enchanting.</p>
      *
+     * <p>Enchantment tables use levels in the range {@code [1, 30]}.</p>
+     *
+     * <p>Non-positive or too high values of {@code levels} will result in no enchantments being applied.</p>
+     *
      * @param itemStack ItemStack to enchant
      * @param levels levels to use for enchanting
      * @param allowTreasure whether to allow enchantments where {@link org.bukkit.enchantments.Enchantment#isTreasure()} returns true
@@ -341,6 +345,10 @@ public interface ItemFactory {
      * Randomly enchants a copy of the provided {@link ItemStack} using the given experience levels.
      *
      * <p>If the provided ItemStack is already enchanted, the existing enchants will be removed before enchanting.</p>
+     *
+     * <p>Enchantment tables use levels in the range {@code [1, 30]}.</p>
+     *
+     * <p>Non-positive or too high values of {@code levels} will result in no enchantments being applied.</p>
      *
      * @param itemStack ItemStack to enchant
      * @param levels levels to use for enchanting

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemFactory.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemFactory.java
@@ -329,8 +329,6 @@ public interface ItemFactory {
      *
      * <p>Enchantment tables use levels in the range {@code [1, 30]}.</p>
      *
-     * <p>Non-positive or too high values of {@code levels} will result in no enchantments being applied.</p>
-     *
      * @param itemStack ItemStack to enchant
      * @param levels levels to use for enchanting
      * @param allowTreasure whether to allow enchantments where {@link org.bukkit.enchantments.Enchantment#isTreasure()} returns true
@@ -347,8 +345,6 @@ public interface ItemFactory {
      * <p>If the provided ItemStack is already enchanted, the existing enchants will be removed before enchanting.</p>
      *
      * <p>Enchantment tables use levels in the range {@code [1, 30]}.</p>
-     *
-     * <p>Non-positive or too high values of {@code levels} will result in no enchantments being applied.</p>
      *
      * @param itemStack ItemStack to enchant
      * @param levels levels to use for enchanting

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemFactory.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemFactory.java
@@ -327,8 +327,6 @@ public interface ItemFactory {
      *
      * <p>If the provided ItemStack is already enchanted, the existing enchants will be removed before enchanting.</p>
      *
-     * <p>Levels must be in range {@code [1, 30]}.</p>
-     *
      * @param itemStack ItemStack to enchant
      * @param levels levels to use for enchanting
      * @param allowTreasure whether to allow enchantments where {@link org.bukkit.enchantments.Enchantment#isTreasure()} returns true
@@ -336,15 +334,13 @@ public interface ItemFactory {
      * @return enchanted copy of the provided ItemStack
      * @throws IllegalArgumentException on bad arguments
      */
-    @NotNull ItemStack enchantWithLevels(@NotNull ItemStack itemStack, @org.jetbrains.annotations.Range(from = 1, to = 30) int levels, boolean allowTreasure, @NotNull java.util.Random random);
+    @NotNull ItemStack enchantWithLevels(@NotNull ItemStack itemStack, int levels, boolean allowTreasure, @NotNull java.util.Random random);
     // Paper end - enchantWithLevels API
     // Paper start - enchantWithLevels with tag specification
     /**
      * Randomly enchants a copy of the provided {@link ItemStack} using the given experience levels.
      *
      * <p>If the provided ItemStack is already enchanted, the existing enchants will be removed before enchanting.</p>
-     *
-     * <p>Levels must be in range {@code [1, 30]}.</p>
      *
      * @param itemStack ItemStack to enchant
      * @param levels levels to use for enchanting
@@ -353,6 +349,6 @@ public interface ItemFactory {
      * @return enchanted copy of the provided ItemStack
      * @throws IllegalArgumentException on bad arguments
      */
-    @NotNull ItemStack enchantWithLevels(@NotNull ItemStack itemStack, @org.jetbrains.annotations.Range(from = 1, to = 30) int levels, @NotNull io.papermc.paper.registry.set.RegistryKeySet<@NotNull Enchantment> keySet, @NotNull java.util.Random random);
+    @NotNull ItemStack enchantWithLevels(@NotNull ItemStack itemStack, int levels, @NotNull io.papermc.paper.registry.set.RegistryKeySet<@NotNull Enchantment> keySet, @NotNull java.util.Random random);
     // Paper end - enchantWithLevels with tag specification
 }

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -683,6 +683,10 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      *
      * <p>If this ItemStack is already enchanted, the existing enchants will be removed before enchanting.</p>
      *
+     * <p>Enchantment tables use levels in the range {@code [1, 30]}.</p>
+     *
+     * <p>Non-positive or too high values of {@code levels} will result in no enchantments being applied.</p>
+     *
      * @param levels levels to use for enchanting
      * @param allowTreasure whether to allow enchantments where {@link org.bukkit.enchantments.Enchantment#isTreasure()} returns true
      * @param random {@link java.util.Random} instance to use for enchanting
@@ -698,6 +702,10 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      * Randomly enchants a copy of this {@link ItemStack} using the given experience levels.
      *
      * <p>If the provided ItemStack is already enchanted, the existing enchants will be removed before enchanting.</p>
+     *
+     * <p>Enchantment tables use levels in the range {@code [1, 30]}.</p>
+     *
+     * <p>Non-positive or too high values of {@code levels} will result in no enchantments being applied.</p>
      *
      * @param levels levels to use for enchanting
      * @param keySet registry key set defining the set of possible enchantments, e.g. {@link io.papermc.paper.registry.keys.tags.EnchantmentTagKeys#IN_ENCHANTING_TABLE}.

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -685,8 +685,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      *
      * <p>Enchantment tables use levels in the range {@code [1, 30]}.</p>
      *
-     * <p>Non-positive or too high values of {@code levels} will result in no enchantments being applied.</p>
-     *
      * @param levels levels to use for enchanting
      * @param allowTreasure whether to allow enchantments where {@link org.bukkit.enchantments.Enchantment#isTreasure()} returns true
      * @param random {@link java.util.Random} instance to use for enchanting
@@ -704,8 +702,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      * <p>If the provided ItemStack is already enchanted, the existing enchants will be removed before enchanting.</p>
      *
      * <p>Enchantment tables use levels in the range {@code [1, 30]}.</p>
-     *
-     * <p>Non-positive or too high values of {@code levels} will result in no enchantments being applied.</p>
      *
      * @param levels levels to use for enchanting
      * @param keySet registry key set defining the set of possible enchantments, e.g. {@link io.papermc.paper.registry.keys.tags.EnchantmentTagKeys#IN_ENCHANTING_TABLE}.

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -683,8 +683,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      *
      * <p>If this ItemStack is already enchanted, the existing enchants will be removed before enchanting.</p>
      *
-     * <p>Levels must be in range {@code [1, 30]}.</p>
-     *
      * @param levels levels to use for enchanting
      * @param allowTreasure whether to allow enchantments where {@link org.bukkit.enchantments.Enchantment#isTreasure()} returns true
      * @param random {@link java.util.Random} instance to use for enchanting
@@ -692,7 +690,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      * @throws IllegalArgumentException on bad arguments
      */
     @NotNull
-    public ItemStack enchantWithLevels(final @org.jetbrains.annotations.Range(from = 1, to = 30) int levels, final boolean allowTreasure, final @NotNull java.util.Random random) {
+    public ItemStack enchantWithLevels(final int levels, final boolean allowTreasure, final @NotNull java.util.Random random) {
         return Bukkit.getServer().getItemFactory().enchantWithLevels(this, levels, allowTreasure, random);
     }
 
@@ -701,15 +699,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      *
      * <p>If the provided ItemStack is already enchanted, the existing enchants will be removed before enchanting.</p>
      *
-     * <p>Levels must be in range {@code [1, 30]}.</p>
-     *
      * @param levels levels to use for enchanting
      * @param keySet registry key set defining the set of possible enchantments, e.g. {@link io.papermc.paper.registry.keys.tags.EnchantmentTagKeys#IN_ENCHANTING_TABLE}.
      * @param random {@link java.util.Random} instance to use for enchanting
      * @return enchanted copy of the provided ItemStack
      * @throws IllegalArgumentException on bad arguments
      */
-    public @NotNull ItemStack enchantWithLevels(final @org.jetbrains.annotations.Range(from = 1, to = 30) int levels, final @NotNull io.papermc.paper.registry.set.RegistryKeySet<@NotNull Enchantment> keySet, final @NotNull java.util.Random random) {
+    public @NotNull ItemStack enchantWithLevels(final int levels, final @NotNull io.papermc.paper.registry.set.RegistryKeySet<@NotNull Enchantment> keySet, final @NotNull java.util.Random random) {
         return Bukkit.getItemFactory().enchantWithLevels(this, levels, keySet, random);
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
@@ -349,7 +349,6 @@ public final class CraftItemFactory implements ItemFactory {
     ) {
         Preconditions.checkArgument(itemStack != null, "Argument 'itemStack' must not be null");
         Preconditions.checkArgument(!itemStack.isEmpty(), "Argument 'itemStack' cannot be empty");
-        Preconditions.checkArgument(levels > 0 && levels <= 30, "Argument 'levels' must be in range [1, 30] (attempted " + levels + ")");
         Preconditions.checkArgument(random != null, "Argument 'random' must not be null");
         final net.minecraft.world.item.ItemStack internalStack = CraftItemStack.asNMSCopy(itemStack);
         if (internalStack.isEnchanted()) {


### PR DESCRIPTION
Resolves #12208 by removing the level range check on ItemFactory#enchantWithLevels. The old ItemFactory#enchantItem did not have a level range, and the vanilla method does not have a level range either. There isn't really any reason to have this. If desired, it could be capped with a lower bound of 1, but it doesn't seem necessary.

Vanilla has at least one loot table that uses a level above 30, see the end city treasure table.