### PR TITLE
Fix cancelling PlayerInteractEvent at (0, 0, 0)

### DIFF
--- a/paper-server/patches/features/0004-Anti-Xray.patch
+++ b/paper-server/patches/features/0004-Anti-Xray.patch
@@ -145,7 +145,7 @@ index 3a384175f8e7f204234bbaf3081bdc20c47a0d4b..5699bc15eba92e22433a20cb8326b59f
  
      private ClientboundLevelChunkWithLightPacket(RegistryFriendlyByteBuf buffer) {
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 40b799fd90b0db13bdaa8834c021f5ca8f25ce10..400b56657414177cd76a7b94c426dc7c886aa957 100644
+index da8848e2a3e3745949eb2356a049451d30f763a7..192977dd661ee795ada13db895db770293e9b402 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -348,7 +348,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -158,10 +158,10 @@ index 40b799fd90b0db13bdaa8834c021f5ca8f25ce10..400b56657414177cd76a7b94c426dc7c
          this.levelStorageAccess = levelStorageAccess;
          this.uuid = org.bukkit.craftbukkit.util.WorldUUID.getUUID(levelStorageAccess.levelDirectory.path().toFile());
 diff --git a/net/minecraft/server/level/ServerPlayerGameMode.java b/net/minecraft/server/level/ServerPlayerGameMode.java
-index 77cd7194c2b977f2295c316dca543d1060aac7d0..086874c0126711a404f93f01c3f52d9c933740b6 100644
+index 47ed3ad5c0b4753f58e0bafff5e5e70b2f0bb40b..623c069f1fe079e020c6391a3db1a3d95cd3dbf5 100644
 --- a/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -300,6 +300,7 @@ public class ServerPlayerGameMode {
+@@ -299,6 +299,7 @@ public class ServerPlayerGameMode {
                  org.bukkit.craftbukkit.event.CraftEventFactory.callBlockDamageAbortEvent(this.player, pos, this.player.getInventory().getSelected()); // CraftBukkit
              }
          }
@@ -188,7 +188,7 @@ index 342bc843c384761e883de861044f4f8930ae8763..14878690a88fd4de3e2c127086607e6c
          if (io.papermc.paper.event.packet.PlayerChunkLoadEvent.getHandlerList().getRegisteredListeners().length > 0) {
              new io.papermc.paper.event.packet.PlayerChunkLoadEvent(new org.bukkit.craftbukkit.CraftChunk(chunk), packetListener.getPlayer().getBukkitEntity()).callEvent();
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 2f2a7ba0d9a136d8ec707f86a383a07d91aaecb0..5d88b2790710a885957ffcffc02fb99c917123c5 100644
+index 600a08d6b45cb19dbe551cefbf726e68684a0837..ff0315cffdb282fdc0a1ffd15e2954caa76835c9 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -403,7 +403,7 @@ public abstract class PlayerList {

--- a/paper-server/patches/features/0004-Anti-Xray.patch
+++ b/paper-server/patches/features/0004-Anti-Xray.patch
@@ -145,7 +145,7 @@ index 3a384175f8e7f204234bbaf3081bdc20c47a0d4b..5699bc15eba92e22433a20cb8326b59f
  
      private ClientboundLevelChunkWithLightPacket(RegistryFriendlyByteBuf buffer) {
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index da8848e2a3e3745949eb2356a049451d30f763a7..192977dd661ee795ada13db895db770293e9b402 100644
+index 40b799fd90b0db13bdaa8834c021f5ca8f25ce10..400b56657414177cd76a7b94c426dc7c886aa957 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -348,7 +348,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -158,10 +158,10 @@ index da8848e2a3e3745949eb2356a049451d30f763a7..192977dd661ee795ada13db895db7702
          this.levelStorageAccess = levelStorageAccess;
          this.uuid = org.bukkit.craftbukkit.util.WorldUUID.getUUID(levelStorageAccess.levelDirectory.path().toFile());
 diff --git a/net/minecraft/server/level/ServerPlayerGameMode.java b/net/minecraft/server/level/ServerPlayerGameMode.java
-index 47ed3ad5c0b4753f58e0bafff5e5e70b2f0bb40b..623c069f1fe079e020c6391a3db1a3d95cd3dbf5 100644
+index 77cd7194c2b977f2295c316dca543d1060aac7d0..086874c0126711a404f93f01c3f52d9c933740b6 100644
 --- a/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -299,6 +299,7 @@ public class ServerPlayerGameMode {
+@@ -300,6 +300,7 @@ public class ServerPlayerGameMode {
                  org.bukkit.craftbukkit.event.CraftEventFactory.callBlockDamageAbortEvent(this.player, pos, this.player.getInventory().getSelected()); // CraftBukkit
              }
          }
@@ -188,7 +188,7 @@ index 342bc843c384761e883de861044f4f8930ae8763..14878690a88fd4de3e2c127086607e6c
          if (io.papermc.paper.event.packet.PlayerChunkLoadEvent.getHandlerList().getRegisteredListeners().length > 0) {
              new io.papermc.paper.event.packet.PlayerChunkLoadEvent(new org.bukkit.craftbukkit.CraftChunk(chunk), packetListener.getPlayer().getBukkitEntity()).callEvent();
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 600a08d6b45cb19dbe551cefbf726e68684a0837..ff0315cffdb282fdc0a1ffd15e2954caa76835c9 100644
+index 2f2a7ba0d9a136d8ec707f86a383a07d91aaecb0..5d88b2790710a885957ffcffc02fb99c917123c5 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -403,7 +403,7 @@ public abstract class PlayerList {

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -1,6 +1,13 @@
 --- a/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -41,28 +_,49 @@
+@@ -35,34 +_,55 @@
+     private GameType previousGameModeForPlayer;
+     private boolean isDestroyingBlock;
+     private int destroyProgressStart;
+-    private BlockPos destroyPos = BlockPos.ZERO;
++    @Nullable private BlockPos destroyPos; // Paper
+     private int gameTicks;
+     private boolean hasDelayedDestroy;
      private BlockPos delayedDestroyPos = BlockPos.ZERO;
      private int delayedTickStart;
      private int lastSentState = -1;
@@ -92,7 +99,7 @@
              this.debugLogging(pos, false, sequence, "too far");
          } else if (pos.getY() > maxBuildHeight) {
              this.player.connection.send(new ClientboundBlockUpdatePacket(pos, this.level.getBlockState(pos)));
-@@ -138,16 +_,39 @@
+@@ -138,16 +_,40 @@
          } else {
              if (action == ServerboundPlayerActionPacket.Action.START_DESTROY_BLOCK) {
                  if (!this.level.mayInteract(this.player, pos)) {
@@ -115,6 +122,7 @@
 +                    // this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos)); // Paper - Don't resync blocks
 +                    // Update any tile entity data for this block
 +                    this.capturedBlockEntity = true; // Paper - Send block entities after destroy prediction
++                    this.destroyPos = null; // Paper
 +                    return;
 +                }
 +                // CraftBukkit end
@@ -174,14 +182,14 @@
 -                if (!Objects.equals(this.destroyPos, pos)) {
 -                    LOGGER.warn("Mismatch in destroy block pos: {} {}", this.destroyPos, pos);
 +                // Paper start - Don't allow digging into unloaded chunks
-+                if (!Objects.equals(this.destroyPos, pos) && !BlockPos.ZERO.equals(this.destroyPos)) { // Paper
++                if (!Objects.equals(this.destroyPos, pos) && this.destroyPos != null) { // Paper
 +                    ServerPlayerGameMode.LOGGER.debug("Mismatch in destroy block pos: {} {}", this.destroyPos, pos); // CraftBukkit - SPIGOT-5457 sent by client when interact event cancelled
 +                    BlockState type = this.level.getBlockStateIfLoaded(this.destroyPos); // Don't load unloaded chunks for stale records here
 +                    if (type != null) {
                      this.level.destroyBlockProgress(this.player.getId(), this.destroyPos, -1);
                      this.debugLogging(pos, true, sequence, "aborted mismatched destroying");
 +                    }
-+                    this.destroyPos = BlockPos.ZERO;
++                    this.destroyPos = null;
 +                    // Paper end - Don't allow digging into unloaded chunks
                  }
  

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -1,13 +1,6 @@
 --- a/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -35,34 +_,55 @@
-     private GameType previousGameModeForPlayer;
-     private boolean isDestroyingBlock;
-     private int destroyProgressStart;
--    private BlockPos destroyPos = BlockPos.ZERO;
-+    @Nullable private BlockPos destroyPos; // Paper
-     private int gameTicks;
-     private boolean hasDelayedDestroy;
+@@ -41,28 +_,49 @@
      private BlockPos delayedDestroyPos = BlockPos.ZERO;
      private int delayedTickStart;
      private int lastSentState = -1;
@@ -99,7 +92,7 @@
              this.debugLogging(pos, false, sequence, "too far");
          } else if (pos.getY() > maxBuildHeight) {
              this.player.connection.send(new ClientboundBlockUpdatePacket(pos, this.level.getBlockState(pos)));
-@@ -138,16 +_,40 @@
+@@ -138,16 +_,39 @@
          } else {
              if (action == ServerboundPlayerActionPacket.Action.START_DESTROY_BLOCK) {
                  if (!this.level.mayInteract(this.player, pos)) {
@@ -122,7 +115,6 @@
 +                    // this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos)); // Paper - Don't resync blocks
 +                    // Update any tile entity data for this block
 +                    this.capturedBlockEntity = true; // Paper - Send block entities after destroy prediction
-+                    this.destroyPos = null; // Paper
 +                    return;
 +                }
 +                // CraftBukkit end
@@ -182,14 +174,14 @@
 -                if (!Objects.equals(this.destroyPos, pos)) {
 -                    LOGGER.warn("Mismatch in destroy block pos: {} {}", this.destroyPos, pos);
 +                // Paper start - Don't allow digging into unloaded chunks
-+                if (!Objects.equals(this.destroyPos, pos) && this.destroyPos != null) { // Paper
++                if (!Objects.equals(this.destroyPos, pos) && !BlockPos.ZERO.equals(this.destroyPos)) { // Paper
 +                    ServerPlayerGameMode.LOGGER.debug("Mismatch in destroy block pos: {} {}", this.destroyPos, pos); // CraftBukkit - SPIGOT-5457 sent by client when interact event cancelled
 +                    BlockState type = this.level.getBlockStateIfLoaded(this.destroyPos); // Don't load unloaded chunks for stale records here
 +                    if (type != null) {
                      this.level.destroyBlockProgress(this.player.getId(), this.destroyPos, -1);
                      this.debugLogging(pos, true, sequence, "aborted mismatched destroying");
 +                    }
-+                    this.destroyPos = null;
++                    this.destroyPos = BlockPos.ZERO;
 +                    // Paper end - Don't allow digging into unloaded chunks
                  }
  

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -167,6 +167,15 @@
                  if (!blockState.isAir() && f >= 1.0F) {
                      this.destroyAndAck(pos, sequence, "insta mine");
                  } else {
+@@ -188,7 +_,7 @@
+                     this.lastSentState = i;
+                 }
+             } else if (action == ServerboundPlayerActionPacket.Action.STOP_DESTROY_BLOCK) {
+-                if (pos.equals(this.destroyPos)) {
++                if (this.isDestroyingBlock && pos.equals(this.destroyPos)) { // Paper - require isDestroyingBlock to be true (special condition for when destroy pos is 0,0,0 and the event is cancelled)
+                     int i1 = this.gameTicks - this.destroyProgressStart;
+                     BlockState blockStatex = this.level.getBlockState(pos);
+                     if (!blockStatex.isAir()) {
 @@ -212,14 +_,22 @@
                  this.debugLogging(pos, true, sequence, "stopped destroying");
              } else if (action == ServerboundPlayerActionPacket.Action.ABORT_DESTROY_BLOCK) {


### PR DESCRIPTION
When the PlayerInteractEvent gets canceled, the destroyPos field won't be updated, meaning the block won't get broken because the position doesn't match in the check at ServerPlayerGamemode line 261. However, the default value for destroyPos is BlockPos.ZERO.

This leads to the condition returning to true if the player has not mined any blocks before, even if the interactevent was denied. The issue also happens if someone is allowed to break a block the first time, but is denied the second time, since the destroyPos will stay the same

 This commit fixes #12196 by making the destroyPos nullable instead of using BlockPos.ZERO as a null value.