### PR TITLE
Fix ItemStack amount issues with Chat Components

### DIFF
--- a/paper-api/src/main/java/org/bukkit/inventory/ItemFactory.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemFactory.java
@@ -210,12 +210,12 @@ public interface ItemFactory {
     @Deprecated(since = "1.19.3") // Paper
     ItemStack enchantItem(@NotNull final ItemStack item, final int level, final boolean allowTreasures);
 
-    // Paper start - Adventure
     /**
      * Creates a hover event for the given item.
      *
      * @param item The item
      * @return A hover event
+     * @throws IllegalArgumentException if the {@link ItemStack#getAmount()} is not between 1 and 99
      */
     @NotNull
     net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowItem> asHoverEvent(final @NotNull ItemStack item, final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowItem> op);
@@ -223,12 +223,13 @@ public interface ItemFactory {
     /**
      * Get the formatted display name of the {@link ItemStack}.
      *
+     * @apiNote this component include a {@link net.kyori.adventure.text.event.HoverEvent item hover event}.
+     * When used in chat, make sure to follow the ItemStack rules regarding amount, type, and other properties.
      * @param itemStack the {@link ItemStack}
      * @return display name of the {@link ItemStack}
      */
     @NotNull
     net.kyori.adventure.text.Component displayName(@NotNull ItemStack itemStack);
-    // Paper end - Adventure
 
     // Paper start - add getI18NDisplayName
     /**

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.HoverEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -713,6 +714,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
         return Bukkit.getItemFactory().enchantWithLevels(this, levels, keySet, random);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @param op transformation on value
+     * @return a hover event
+     * @throws IllegalArgumentException if the {@link ItemStack#getAmount()} is not between 1 and 99
+     */
     @NotNull
     @Override
     public net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowItem> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowItem> op) {
@@ -722,6 +730,8 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
     /**
      * Get the formatted display name of the {@link ItemStack}.
      *
+     * @apiNote this component include a {@link net.kyori.adventure.text.event.HoverEvent item hover event}.
+     * When used in chat, make sure to follow the ItemStack rules regarding amount, type, and other properties.
      * @return display name of the {@link ItemStack}
      */
     public net.kyori.adventure.text.@NotNull Component displayName() {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
@@ -213,9 +213,9 @@ public final class CraftItemFactory implements ItemFactory {
         return CraftItemStack.asCraftMirror(EnchantmentHelper.enchantItem(source, craft.handle, level, registry, optional));
     }
 
-    // Paper start - Adventure
     @Override
     public net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowItem> asHoverEvent(final ItemStack item, final java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowItem> op) {
+        Preconditions.checkArgument(item.getAmount() > 1 && item.getAmount() <= 99, "ItemStack amount must be between 1 and 99 but was " + item.getAmount());
         return net.kyori.adventure.text.event.HoverEvent.showItem(op.apply(
             net.kyori.adventure.text.event.HoverEvent.ShowItem.showItem(
                 item.getType().getKey(),
@@ -228,7 +228,6 @@ public final class CraftItemFactory implements ItemFactory {
     public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component displayName(@org.jetbrains.annotations.NotNull ItemStack itemStack) {
         return io.papermc.paper.adventure.PaperAdventure.asAdventure(CraftItemStack.asNMSCopy(itemStack).getDisplayName());
     }
-    // Paper end - Adventure
 
     // Paper start - ensure server conversions API
     // TODO: DO WE NEED THIS?

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
@@ -215,7 +215,7 @@ public final class CraftItemFactory implements ItemFactory {
 
     @Override
     public net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowItem> asHoverEvent(final ItemStack item, final java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowItem> op) {
-        Preconditions.checkArgument(item.getAmount() > 1 && item.getAmount() <= 99, "ItemStack amount must be between 1 and 99 but was " + item.getAmount());
+        Preconditions.checkArgument(item.getAmount() > 1 && item.getAmount() <= 99, "ItemStack amount must be between 1 and 99 but was %s", item.getAmount());
         return net.kyori.adventure.text.event.HoverEvent.showItem(op.apply(
             net.kyori.adventure.text.event.HoverEvent.ShowItem.showItem(
                 item.getType().getKey(),


### PR DESCRIPTION
Close #12213 by handle two cases where this can happen.
- You try pass the displayname to a component for chat
```java
ItemStack itemStack = new ItemStack(Material.STICK, 200);
player.sendMessage(Component.text("Item1").appendSpace().append(itemStack.displayName()));
```
- You try to pass an item for the hover event
```java
ItemStack itemStack = new ItemStack(Material.STICK, 200);
player.sendMessage(Component.text("Item2").hoverEvent(itemStack));
```

for the first case the only "easy" way is just mention in javadocs about how use this for chat messages can cause issues because mess with precontitions breaks others "normal" behaviours, the second case is more easy add a Precondition and the mention in javadocs about this.