### PR TITLE
Fix children copying when filling missing command redirects

### DIFF
--- a/paper-server/patches/sources/net/minecraft/commands/Commands.java.patch
+++ b/paper-server/patches/sources/net/minecraft/commands/Commands.java.patch
@@ -172,7 +172,7 @@
              }
  
              return null;
-@@ -359,26 +_,121 @@
+@@ -359,26 +_,131 @@
      }
  
      public void sendCommands(ServerPlayer player) {
@@ -245,6 +245,17 @@
          Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> commandNodeToSuggestionNode
      ) {
 -        for (CommandNode<CommandSourceStack> commandNode : rootCommandSource.getChildren()) {
++        // Paper start - support filling builders
++        this.fillUsableCommands(children, rootSuggestion::addChild, source, commandNodeToSuggestionNode);
++    }
++
++    private void fillUsableCommands(
++        java.util.Collection<CommandNode<CommandSourceStack>> children, // Paper - Perf: Async command map building; pass copy of children
++        Consumer<CommandNode<SharedSuggestionProvider>> rootSuggestion,
++        CommandSourceStack source,
++        Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> commandNodeToSuggestionNode
++    ) {
++        // Paper end - support filling builders
 +        for (CommandNode<CommandSourceStack> commandNode : children) { // Paper - Perf: Async command map building; pass copy of children
 +            // Paper start - Brigadier API
 +            if (commandNode.clientNode != null) {
@@ -282,10 +293,9 @@
 +                    if (redirect.getCommand() != null) {
 +                        builder.executes(redirect.getCommand());
 +                    }
-+                    // Diff copied from LiteralCommand#createBuilder
-+                    for (final CommandNode<SharedSuggestionProvider> child : redirect.getChildren()) {
-+                        builder.then(child);
-+                    }
++                    // don't blindly copy over children
++                    this.fillUsableCommands(commandNode.getRedirect().getChildren(),
++                            builder::then, source, commandNodeToSuggestionNode);
 +
 +                    argumentBuilder = builder;
 +                }
@@ -300,9 +310,12 @@
  
                  if (argumentBuilder instanceof RequiredArgumentBuilder requiredArgumentBuilder
                      && requiredArgumentBuilder.getSuggestionsProvider() != null) {
-@@ -393,7 +_,7 @@
+@@ -391,9 +_,9 @@
+ 
+                 CommandNode<SharedSuggestionProvider> commandNode1 = argumentBuilder.build();
                  commandNodeToSuggestionNode.put(commandNode, commandNode1);
-                 rootSuggestion.addChild(commandNode1);
+-                rootSuggestion.addChild(commandNode1);
++                rootSuggestion.accept(commandNode1); // Paper - support filling builders
                  if (!commandNode.getChildren().isEmpty()) {
 -                    this.fillUsableCommands(commandNode, commandNode1, source, commandNodeToSuggestionNode);
 +                    this.fillUsableCommands(commandNode.getChildren(), commandNode1, source, commandNodeToSuggestionNode); // Paper - Perf: Async command map building; pass copy of children

--- a/paper-server/patches/sources/net/minecraft/commands/Commands.java.patch
+++ b/paper-server/patches/sources/net/minecraft/commands/Commands.java.patch
@@ -246,14 +246,15 @@
      ) {
 -        for (CommandNode<CommandSourceStack> commandNode : rootCommandSource.getChildren()) {
 +        // Paper start - support filling builders
-+        this.fillUsableCommands(children, rootSuggestion::addChild, source, commandNodeToSuggestionNode);
++        this.fillUsableCommands(children, rootSuggestion::addChild, source, commandNodeToSuggestionNode, true);
 +    }
 +
 +    private void fillUsableCommands(
 +        java.util.Collection<CommandNode<CommandSourceStack>> children, // Paper - Perf: Async command map building; pass copy of children
 +        Consumer<CommandNode<SharedSuggestionProvider>> rootSuggestion,
 +        CommandSourceStack source,
-+        Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> commandNodeToSuggestionNode
++        Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> commandNodeToSuggestionNode,
++        boolean isRoot
 +    ) {
 +        // Paper end - support filling builders
 +        for (CommandNode<CommandSourceStack> commandNode : children) { // Paper - Perf: Async command map building; pass copy of children
@@ -262,7 +263,7 @@
 +                commandNode = commandNode.clientNode;
 +            }
 +            // Paper end - Brigadier API
-+            if (!org.spigotmc.SpigotConfig.sendNamespaced && commandNode.getName().contains(":")) continue; // Spigot
++            if (isRoot && !org.spigotmc.SpigotConfig.sendNamespaced && commandNode.getName().contains(":")) continue; // Spigot
 +            if (commandNode.wrappedCached != null && commandNode.wrappedCached.apiCommandMeta != null && commandNode.wrappedCached.apiCommandMeta.serverSideOnly()) continue; // Paper
              if (commandNode.canUse(source)) {
                  ArgumentBuilder<SharedSuggestionProvider, ?> argumentBuilder = (ArgumentBuilder) commandNode.createBuilder();
@@ -294,8 +295,7 @@
 +                        builder.executes(redirect.getCommand());
 +                    }
 +                    // don't blindly copy over children
-+                    this.fillUsableCommands(commandNode.getRedirect().getChildren(),
-+                            builder::then, source, commandNodeToSuggestionNode);
++                    this.fillUsableCommands(commandNode.getRedirect().getChildren(), builder::then, source, commandNodeToSuggestionNode, false);
 +
 +                    argumentBuilder = builder;
 +                }


### PR DESCRIPTION
The redirect flattening previously copied over children nodes without checking node requirements (e.g. permissions)

Before https://github.com/PaperMC/Paper/pull/11954, this caused node requirements to be ignored for second-level command nodes created using the brigadier api (if namespaced commands were prevented from being sent using the spigot config option), see https://github.com/PaperMC/Paper/pull/11953

Since https://github.com/PaperMC/Paper/pull/11954 is merged now, it's much less of an issue, but as https://github.com/PaperMC/Paper/pull/12136 has been merged, it still is an issue