### PR TITLE
ServerTickManager#requestGameToSprint - Silence command like feedback

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/ServerTickRateManager.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/ServerTickRateManager.java.patch
@@ -17,7 +17,7 @@
 +    }
 +
 +    public boolean requestGameToSprint(int sprintTime, boolean silent) {
-+        this.silent = silent;
++        if (!isSprinting()) this.silent = silent;
 +        // Paper end - silence feedback when API requests sprint
          boolean flag = this.remainingSprintTicks > 0L;
          this.sprintTimeSpend = 0L;

--- a/paper-server/patches/sources/net/minecraft/server/ServerTickRateManager.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/ServerTickRateManager.java.patch
@@ -1,0 +1,34 @@
+--- a/net/minecraft/server/ServerTickRateManager.java
++++ b/net/minecraft/server/ServerTickRateManager.java
+@@ -14,6 +_,7 @@
+     private long scheduledCurrentSprintTicks = 0L;
+     private boolean previousIsFrozen = false;
+     private final MinecraftServer server;
++    private boolean silent; // Paper - silence feedback when API requests sprint
+ 
+     public ServerTickRateManager(MinecraftServer server) {
+         this.server = server;
+@@ -67,6 +_,13 @@
+     }
+ 
+     public boolean requestGameToSprint(int sprintTime) {
++        // Paper start - silence feedback when API requests sprint
++        return requestGameToSprint(sprintTime, false);
++    }
++
++    public boolean requestGameToSprint(int sprintTime, boolean silent) {
++        this.silent = silent;
++        // Paper end - silence feedback when API requests sprint
+         boolean flag = this.remainingSprintTicks > 0L;
+         this.sprintTimeSpend = 0L;
+         this.scheduledCurrentSprintTicks = sprintTime;
+@@ -83,7 +_,8 @@
+         String string = String.format("%.2f", l == 0L ? this.millisecondsPerTick() : d / l);
+         this.scheduledCurrentSprintTicks = 0L;
+         this.sprintTimeSpend = 0L;
+-        this.server.createCommandSourceStack().sendSuccess(() -> Component.translatable("commands.tick.sprint.report", i, string), true);
++        if (!this.silent) this.server.createCommandSourceStack().sendSuccess(() -> Component.translatable("commands.tick.sprint.report", i, string), true);
++        this.silent = false;
+         this.remainingSprintTicks = 0L;
+         this.setFrozen(this.previousIsFrozen);
+         this.server.onTickRateChanged();

--- a/paper-server/patches/sources/net/minecraft/server/ServerTickRateManager.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/ServerTickRateManager.java.patch
@@ -22,13 +22,15 @@
          boolean flag = this.remainingSprintTicks > 0L;
          this.sprintTimeSpend = 0L;
          this.scheduledCurrentSprintTicks = sprintTime;
-@@ -83,7 +_,8 @@
+@@ -83,7 +_,10 @@
          String string = String.format("%.2f", l == 0L ? this.millisecondsPerTick() : d / l);
          this.scheduledCurrentSprintTicks = 0L;
          this.sprintTimeSpend = 0L;
 -        this.server.createCommandSourceStack().sendSuccess(() -> Component.translatable("commands.tick.sprint.report", i, string), true);
++        // Paper start - silence feedback when API requests sprint
 +        if (!this.silent) this.server.createCommandSourceStack().sendSuccess(() -> Component.translatable("commands.tick.sprint.report", i, string), true);
 +        this.silent = false;
++        // Paper end - silence feedback when API requests sprint
          this.remainingSprintTicks = 0L;
          this.setFrozen(this.previousIsFrozen);
          this.server.onTickRateChanged();

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServerTickManager.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServerTickManager.java
@@ -72,7 +72,7 @@ final class CraftServerTickManager implements ServerTickManager {
 
     @Override
     public boolean requestGameToSprint(final int ticks) {
-        return this.manager.requestGameToSprint(ticks);
+        return this.manager.requestGameToSprint(ticks, true);
     }
 
     @Override


### PR DESCRIPTION
This PR aims to silence the feedback from server sprinting via the API.

When using the API to request the server to sprint:
<https://jd.papermc.io/paper/1.21.4/org/bukkit/ServerTickManager.html#requestGameToSprint(int)>

The tick manager still provides feedback as if the vanilla `/tick sprint` command were run:
<img width="520" alt="Screenshot 2025-03-02 at 10 45 31 PM" src="https://github.com/user-attachments/assets/f16344a5-fa5a-4b89-9f70-3aa88a160655" />

When using the API to do this task, the server shouldn't be responding as if a command were run.

This has driven me nuts since Bukkit added this, I just kept forgetting to report it and/or actually do something about it.
But nows my chance.

One thing I did think was someone out there using this API might actually like this feedback?!?!?
So I was thinking, should I make another `ServerTickManager#requestGameToSprint` method with an option to silence?
Looking for feedback!
