### PR TITLE
Add type to represent unimplemented data component types

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/DataComponentAdapter.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/DataComponentAdapter.java
@@ -15,8 +15,16 @@ public record DataComponentAdapter<NMS, API>(
 ) {
     static final Function<Void, Unit> API_TO_UNIT_CONVERTER = $ -> Unit.INSTANCE;
 
+    static final Function API_TO_UNIMPLEMENTED_CONVERTER = $ -> {
+        throw new UnsupportedOperationException("Cannot convert an API value to an unimplemented type");
+    };
+
     public boolean isValued() {
         return this.apiToVanilla != API_TO_UNIT_CONVERTER;
+    }
+
+    public boolean isUnimplemented() {
+        return this.apiToVanilla == API_TO_UNIMPLEMENTED_CONVERTER;
     }
 
     public NMS toVanilla(final API value) {

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/DataComponentAdapters.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/DataComponentAdapters.java
@@ -63,6 +63,10 @@ public final class DataComponentAdapters {
         throw new UnsupportedOperationException("Cannot convert the Unit type to an API value");
     };
 
+    static final Function UNIMPLEMENTED_TO_API_CONVERTER = $ -> {
+        throw new UnsupportedOperationException("Cannot convert the an unimplemented type to an API value");
+    };
+
     static final Map<ResourceKey<DataComponentType<?>>, DataComponentAdapter<?, ?>> ADAPTERS = new HashMap<>();
 
     public static void bootstrap() {
@@ -136,10 +140,9 @@ public final class DataComponentAdapters {
         // register(DataComponents.LOCK, PaperLockCode::new);
         register(DataComponents.CONTAINER_LOOT, PaperSeededContainerLoot::new);
 
-        // TODO: REMOVE THIS... we want to build the PR... so lets just make things UNTYPED!
         for (final Map.Entry<ResourceKey<DataComponentType<?>>, DataComponentType<?>> componentType : BuiltInRegistries.DATA_COMPONENT_TYPE.entrySet()) {
             if (!ADAPTERS.containsKey(componentType.getKey())) {
-                registerUntyped((DataComponentType<Unit>) componentType.getValue());
+                registerUnimplemented(componentType.getValue());
             }
         }
     }
@@ -150,6 +153,10 @@ public final class DataComponentAdapters {
 
     private static <COMMON> void registerIdentity(final DataComponentType<COMMON> type) {
         registerInternal(type, Function.identity(), Function.identity(), true);
+    }
+
+    public static <NMS> void registerUnimplemented(final DataComponentType<NMS> type) {
+        registerInternal(type, UNIMPLEMENTED_TO_API_CONVERTER, DataComponentAdapter.API_TO_UNIMPLEMENTED_CONVERTER, false);
     }
 
     private static <NMS, API extends Handleable<NMS>> void register(final DataComponentType<NMS> type, final Function<NMS, API> vanillaToApi) {

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/PaperDataComponentType.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/PaperDataComponentType.java
@@ -77,7 +77,9 @@ public abstract class PaperDataComponentType<T, NMS> implements DataComponentTyp
         if (adapter == null) {
             throw new IllegalArgumentException("No adapter found for " + key);
         }
-        if (adapter.isValued()) {
+        if (adapter.isUnimplemented()) {
+            return new Unimplemented<>(key, type, adapter);
+        } else if (adapter.isValued()) {
             return new ValuedImpl<>(key, type, adapter);
         } else {
             return new NonValuedImpl<>(key, type, adapter);
@@ -98,6 +100,17 @@ public abstract class PaperDataComponentType<T, NMS> implements DataComponentTyp
     public static final class ValuedImpl<T, NMS> extends PaperDataComponentType<T, NMS> implements Valued<T> {
 
         ValuedImpl(
+            final NamespacedKey key,
+            final net.minecraft.core.component.DataComponentType<NMS> type,
+            final DataComponentAdapter<NMS, T> adapter
+        ) {
+            super(key, type, adapter);
+        }
+    }
+
+    public static final class Unimplemented<T, NMS> extends PaperDataComponentType<T, NMS> {
+
+        public Unimplemented(
             final NamespacedKey key,
             final net.minecraft.core.component.DataComponentType<NMS> type,
             final DataComponentAdapter<NMS, T> adapter


### PR DESCRIPTION
Adds an `Unimplemented` type for data component types that have yet to receive an API implementation. This replaces using `DataComponentType.NonValued` for such cases. Using `DataComponentType.NonValued` here causes issues as you're able to get instances of unimplemented data component types using methods like `Registry#get` and `ItemStack#getDataTypes`.

Tested with `ItemStack#hasData`, `ItemStack#resetData`, and `ItemStack#unsetData`.

Not a big fan of using raw types for the converters, but unsure of a better way to do it.