### PR TITLE
Don't resync all attributes when updating scaled health

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -2828,15 +2828,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
 
     public void updateScaledHealth(boolean sendHealth) {
         AttributeMap attributemapserver = this.getHandle().getAttributes();
-        Collection<AttributeInstance> set = new HashSet<>(1);
-
-        this.injectScaledMaxHealth(set, true);
 
         // SPIGOT-3813: Attributes before health
         if (this.getHandle().connection != null) {
-            if (!set.isEmpty()) {
-                this.getHandle().connection.send(new ClientboundUpdateAttributesPacket(this.getHandle().getId(), set));
-            }
+            this.getHandle().connection.send(new ClientboundUpdateAttributesPacket(this.getHandle().getId(), Set.of(getScaledMaxHealth())));
             if (sendHealth) {
                 this.sendHealthUpdate();
             }
@@ -2876,8 +2871,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                 break;
             }
         }
+        collection.add(getScaledMaxHealth());
+    }
+
+    public AttributeInstance getScaledMaxHealth() {
         AttributeInstance dummy = new AttributeInstance(Attributes.MAX_HEALTH, (attribute) -> { });
-        // Spigot start
         double healthMod = this.scaledHealth ? this.healthScale : this.getMaxHealth();
         if ( healthMod >= Float.MAX_VALUE || healthMod <= 0 )
         {
@@ -2885,8 +2883,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
             this.getServer().getLogger().warning( this.getName() + " tried to crash the server with a large health attribute" );
         }
         dummy.setBaseValue(healthMod);
-        // Spigot end
-        collection.add(dummy);
+        return dummy;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -2828,13 +2828,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
 
     public void updateScaledHealth(boolean sendHealth) {
         AttributeMap attributemapserver = this.getHandle().getAttributes();
-        Collection<AttributeInstance> set = attributemapserver.getSyncableAttributes();
+        Collection<AttributeInstance> set = new HashSet<>(1);
 
         this.injectScaledMaxHealth(set, true);
 
         // SPIGOT-3813: Attributes before health
         if (this.getHandle().connection != null) {
-            this.getHandle().connection.send(new ClientboundUpdateAttributesPacket(this.getHandle().getId(), set));
+            if (!set.isEmpty()) {
+                this.getHandle().connection.send(new ClientboundUpdateAttributesPacket(this.getHandle().getId(), set));
+            }
             if (sendHealth) {
                 this.sendHealthUpdate();
             }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -2827,11 +2827,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     }
 
     public void updateScaledHealth(boolean sendHealth) {
-        AttributeMap attributemapserver = this.getHandle().getAttributes();
-
         // SPIGOT-3813: Attributes before health
         if (this.getHandle().connection != null) {
-            this.getHandle().connection.send(new ClientboundUpdateAttributesPacket(this.getHandle().getId(), Set.of(getScaledMaxHealth())));
+            this.getHandle().connection.send(new ClientboundUpdateAttributesPacket(this.getHandle().getId(), Set.of(this.getScaledMaxHealth())));
             if (sendHealth) {
                 this.sendHealthUpdate();
             }


### PR DESCRIPTION
fixes #11997 
When a player is damaged cb needs to send max health to the player to ensure the client has the correct health data incase scaled health is being used. Instead they are sending all attributes including the movement speed to the client which causes it to slow down.