### PR TITLE
Call EntityDamageByBlockEvent for fire damage

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/BaseFireBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/BaseFireBlock.java.patch
@@ -1,13 +1,15 @@
 --- a/net/minecraft/world/level/block/BaseFireBlock.java
 +++ b/net/minecraft/world/level/block/BaseFireBlock.java
-@@ -136,12 +_,13 @@
+@@ -136,12 +_,14 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
 +        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        BlockPos savedPos = pos.immutable(); // Paper - track fire contact
          effectApplier.apply(InsideBlockEffectType.CLEAR_FREEZE);
          effectApplier.apply(InsideBlockEffectType.FIRE_IGNITE);
-         effectApplier.runAfter(InsideBlockEffectType.FIRE_IGNITE, e -> e.hurt(e.level().damageSources().inFire(), this.fireDamage));
+-        effectApplier.runAfter(InsideBlockEffectType.FIRE_IGNITE, e -> e.hurt(e.level().damageSources().inFire(), this.fireDamage));
++        effectApplier.runAfter(InsideBlockEffectType.FIRE_IGNITE, e -> e.hurt(e.level().damageSources().inFire().eventBlockDamager(level, savedPos), this.fireDamage)); // Paper
      }
  
 -    public static void fireIgnite(final Entity entity) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -1117,8 +1117,6 @@ public class CraftEventFactory {
         DamageCause cause;
         if (source.knownCause() != null) {
             cause = source.knownCause();
-        } else if (source.is(DamageTypes.IN_FIRE)) { // todo could be called above
-            cause = DamageCause.FIRE;
         } else if (source.is(DamageTypes.STARVE)) {
             cause = DamageCause.STARVATION;
         } else if (source.is(DamageTypes.WITHER)) {


### PR DESCRIPTION
I think it makes sense to have the more specific event called here since lava damage also called the event.
Also deprecated the unused dragon breath damage cause to warn listeners (it's only used for command or plugin but not for the dragon breath in a regular play) will probably be fixed in https://bugs.mojang.com/browse/MC/issues/MC-84595.