### PR TITLE
Force update attributes

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1049,7 +1049,7 @@
          this.awaitingTeleportTime = this.tickCount;
          if (++this.awaitingTeleport == Integer.MAX_VALUE) {
              this.awaitingTeleport = 0;
-@@ -1087,12 +_,20 @@
+@@ -1087,28 +_,69 @@
  
          this.player.teleportSetPosition(posMoveRotation, relatives);
          this.awaitingPositionFromClient = this.player.position();
@@ -1070,7 +1070,9 @@
          if (this.player.hasClientLoaded()) {
              BlockPos pos = packet.getPos();
              this.player.resetLastActionTime();
-@@ -1101,14 +_,46 @@
++            this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
+             ServerboundPlayerActionPacket.Action action = packet.getAction();
+             switch (action) {
                  case SWAP_ITEM_WITH_OFFHAND:
                      if (!this.player.isSpectator()) {
                          ItemStack itemInHand = this.player.getItemInHand(InteractionHand.OFF_HAND);
@@ -1838,7 +1840,7 @@
      public void switchToConfig() {
          this.waitingForSwitchToConfig = true;
          this.removePlayerFromWorld();
-@@ -1594,9 +_,16 @@
+@@ -1594,27 +_,74 @@
      @Override
      public void handleInteract(ServerboundInteractPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
@@ -1854,8 +1856,10 @@
 +            // Spigot end
              this.player.resetLastActionTime();
              this.player.setShiftKeyDown(packet.isUsingSecondaryAction());
++            this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
              if (target != null) {
-@@ -1605,16 +_,55 @@
+                 if (!serverLevel.getWorldBorder().isWithinBounds(target.blockPosition())) {
+                     return;
                  }
  
                  AABB boundingBox = target.getBoundingBox();


### PR DESCRIPTION
Fixes attribute swap exploit: https://www.youtube.com/watch?v=jL98SsqfdvU
TLDR: You can swap an item right before using it and the new item will contain the same attributes as the first item: attack speed, attack damage, dig speed, etc.

This exploit allows you to use the attributes from the previous weapon/tool right before swapping. Could you let me know if I missed any easily abusable actions other than attack/intract? Let me know if anyone also finds issues with this patch. It should work perfectly with my limited testing, but it would be nice to know if this causes new exploits.