### PR TITLE
Force update attributes

### DIFF
--- a/paper-server/patches/features/0029-Optimise-collision-checking-in-player-move-packet-ha.patch
+++ b/paper-server/patches/features/0029-Optimise-collision-checking-in-player-move-packet-ha.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Optimise collision checking in player move packet handling
 Move collision logic to just the hasNewCollision call instead of getCubes + hasNewCollision
 
 diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index addeb449904ec9a2ef59b99022787bee689b83cf..27718a20666a3edc0b036e4cdeda5d7901f814ce 100644
+index 12c83cb084563a4e3f7f357d8b600941544ef2b0..90e582ca30851857add5e2d830e9876667fd1807 100644
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -563,7 +563,7 @@ public class ServerGamePacketListenerImpl
@@ -88,7 +88,7 @@ index addeb449904ec9a2ef59b99022787bee689b83cf..27718a20666a3edc0b036e4cdeda5d79
      }
  
      @Override
-@@ -1370,7 +1402,7 @@ public class ServerGamePacketListenerImpl
+@@ -1371,7 +1403,7 @@ public class ServerGamePacketListenerImpl
                                  }
                              }
  
@@ -97,7 +97,7 @@ index addeb449904ec9a2ef59b99022787bee689b83cf..27718a20666a3edc0b036e4cdeda5d79
                              d3 = d - this.lastGoodX; // Paper - diff on change, used for checking large move vectors above
                              d4 = d1 - this.lastGoodY; // Paper - diff on change, used for checking large move vectors above
                              d5 = d2 - this.lastGoodZ; // Paper - diff on change, used for checking large move vectors above
-@@ -1409,6 +1441,7 @@ public class ServerGamePacketListenerImpl
+@@ -1410,6 +1442,7 @@ public class ServerGamePacketListenerImpl
                              boolean flag1 = this.player.verticalCollisionBelow;
                              this.player.move(MoverType.PLAYER, new Vec3(d3, d4, d5));
                              this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move
@@ -105,7 +105,7 @@ index addeb449904ec9a2ef59b99022787bee689b83cf..27718a20666a3edc0b036e4cdeda5d79
                              // Paper start - prevent position desync
                              if (this.awaitingPositionFromClient != null) {
                                  return; // ... thanks Mojang for letting move calls teleport across dimensions.
-@@ -1441,7 +1474,17 @@ public class ServerGamePacketListenerImpl
+@@ -1442,7 +1475,17 @@ public class ServerGamePacketListenerImpl
                              }
  
                              // Paper start - Add fail move event
@@ -124,7 +124,7 @@ index addeb449904ec9a2ef59b99022787bee689b83cf..27718a20666a3edc0b036e4cdeda5d79
                              if (teleportBack) {
                                  io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.CLIPPED_INTO_BLOCK,
                                      toX, toY, toZ, toYaw, toPitch, false);
-@@ -1577,7 +1620,7 @@ public class ServerGamePacketListenerImpl
+@@ -1578,7 +1621,7 @@ public class ServerGamePacketListenerImpl
  
      private boolean updateAwaitingTeleport() {
          if (this.awaitingPositionFromClient != null) {
@@ -133,7 +133,7 @@ index addeb449904ec9a2ef59b99022787bee689b83cf..27718a20666a3edc0b036e4cdeda5d79
                  this.awaitingTeleportTime = this.tickCount;
                  this.teleport(
                      this.awaitingPositionFromClient.x,
-@@ -1596,6 +1639,33 @@ public class ServerGamePacketListenerImpl
+@@ -1597,6 +1640,33 @@ public class ServerGamePacketListenerImpl
          }
      }
  

--- a/paper-server/patches/features/0031-Do-not-record-movement-for-vehicles-players-unaffect.patch
+++ b/paper-server/patches/features/0031-Do-not-record-movement-for-vehicles-players-unaffect.patch
@@ -11,7 +11,7 @@ a portal in spectator mode and then later switching to creative mode
 would portal the player.
 
 diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 27718a20666a3edc0b036e4cdeda5d7901f814ce..727792ca1a2c9044abb1d404fbf8420652e1507c 100644
+index 90e582ca30851857add5e2d830e9876667fd1807..c569cdfa4cba4f65892ffd4045c611837049f440 100644
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -659,7 +659,7 @@ public class ServerGamePacketListenerImpl
@@ -23,7 +23,7 @@ index 27718a20666a3edc0b036e4cdeda5d7901f814ce..727792ca1a2c9044abb1d404fbf84206
                  Vec3 vec3 = new Vec3(rootVehicle.getX() - x, rootVehicle.getY() - y, rootVehicle.getZ() - z);
                  this.handlePlayerKnownMovement(vec3);
                  rootVehicle.setOnGroundWithMovement(packet.onGround(), vec3);
-@@ -1576,7 +1576,7 @@ public class ServerGamePacketListenerImpl
+@@ -1577,7 +1577,7 @@ public class ServerGamePacketListenerImpl
                                  Vec3 vec3 = new Vec3(this.player.getX() - x, this.player.getY() - y, this.player.getZ() - z);
                                  this.player.setOnGroundWithMovement(packet.isOnGround(), packet.horizontalCollision(), vec3);
                                  this.player.doCheckFallDamage(vec3.x, vec3.y, vec3.z, packet.isOnGround());

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1145,7 +1145,7 @@
                  case ABORT_DESTROY_BLOCK:
                  case STOP_DESTROY_BLOCK:
 +                    // Paper start - Don't allow digging into unloaded chunks
-+                    if (this.player.level().getChunkIfLoadedImmediately(pos.getX() >> 4, pos.getZ() >> 4) == null) {
++                    if (this.player.level().getChunkIfLoadedImmediately(pos.getX() >> 4, pos.getZ() >> 4) == null || !this.player.canInteractWithBlock(pos, 1.0)) {
 +                        this.player.connection.ackBlockChangesUpTo(packet.getSequence());
 +                        return;
 +                    }

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -547,7 +547,7 @@
                          addBlockDataToItem(blockState, serverLevel, blockPos, cloneItemStack);
                      }
  
-@@ -685,14 +_,24 @@
+@@ -685,18 +_,29 @@
          if (stack.isItemEnabled(this.player.level().enabledFeatures())) {
              Inventory inventory = this.player.getInventory();
              int i = inventory.findSlotMatchingItem(stack);
@@ -576,6 +576,11 @@
              }
  
              this.player.connection.send(new ClientboundSetHeldSlotPacket(inventory.selected));
+             this.player.inventoryMenu.broadcastChanges();
++            this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
+         }
+     }
+ 
 @@ -814,6 +_,13 @@
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          int item = packet.getItem();
@@ -1072,7 +1077,7 @@
          if (this.player.hasClientLoaded()) {
              BlockPos pos = packet.getPos();
              this.player.resetLastActionTime();
-@@ -1101,14 +_,46 @@
+@@ -1101,32 +_,95 @@
                  case SWAP_ITEM_WITH_OFFHAND:
                      if (!this.player.isSpectator()) {
                          ItemStack itemInHand = this.player.getItemInHand(InteractionHand.OFF_HAND);
@@ -1098,6 +1103,7 @@
 +                        }
 +                        // CraftBukkit end
                          this.player.stopUsingItem();
++                        this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
                      }
  
                      return;
@@ -1119,14 +1125,21 @@
 +                        }
 +                        // CraftBukkit end
                          this.player.drop(false);
++                        this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
                      }
  
-@@ -1120,13 +_,39 @@
+                     return;
+                 case DROP_ALL_ITEMS:
+                     if (!this.player.isSpectator()) {
+                         this.player.drop(true);
++                        this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
+                     }
  
                      return;
                  case RELEASE_USE_ITEM:
 -                    this.player.releaseUsingItem();
 +                    if (this.player.getUseItem() == this.player.getItemInHand(this.player.getUsedItemHand())) this.player.releaseUsingItem(); // Paper - validate use item before processing release
++                    this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
                      return;
                  case START_DESTROY_BLOCK:
                  case ABORT_DESTROY_BLOCK:
@@ -1159,6 +1172,7 @@
 +                        }
 +                    }
 +                    // Paper end - Send block entities after destroy prediction
++                    this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
                      return;
                  default:
                      throw new IllegalArgumentException("Invalid player action");
@@ -1229,6 +1243,14 @@
                          } else {
                              Component component1 = Component.translatable("build.tooHigh", maxY).withStyle(ChatFormatting.RED);
                              this.player.sendSystemMessage(component1, true);
+@@ -1187,6 +_,7 @@
+ 
+                         this.player.connection.send(new ClientboundBlockUpdatePacket(serverLevel, blockPos));
+                         this.player.connection.send(new ClientboundBlockUpdatePacket(serverLevel, blockPos.relative(direction)));
++                        this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
+                     } else {
+                         LOGGER.warn(
+                             "Rejecting UseItemOnPacket from {}: Location {} too far away from hit block {}.",
 @@ -1203,6 +_,8 @@
      @Override
      public void handleUseItem(ServerboundUseItemPacket packet) {
@@ -1354,7 +1376,7 @@
              throw new IllegalArgumentException("Expected packet sequence nr >= 0");
          } else {
              this.ackBlockChangesUpTo = Math.max(sequence, this.ackBlockChangesUpTo);
-@@ -1275,7 +_,17 @@
+@@ -1275,20 +_,38 @@
      @Override
      public void handleSetCarriedItem(ServerboundSetCarriedItemPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
@@ -1372,8 +1394,10 @@
              if (this.player.getInventory().selected != packet.getSlot() && this.player.getUsedItemHand() == InteractionHand.MAIN_HAND) {
                  this.player.stopUsingItem();
              }
-@@ -1284,11 +_,18 @@
+ 
+             this.player.getInventory().selected = packet.getSlot();
              this.player.resetLastActionTime();
++            this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
          } else {
              LOGGER.warn("{} tried to set an invalid carried item", this.player.getName().getString());
 +            this.disconnect(Component.literal("Invalid hotbar selection (Hacking?)"), org.bukkit.event.player.PlayerKickEvent.Cause.ILLEGAL_ACTION); // CraftBukkit // Paper - kick event cause
@@ -1956,7 +1980,7 @@
                                      ServerGamePacketListenerImpl.LOGGER
                                          .warn("Player {} tried to attack an invalid entity", ServerGamePacketListenerImpl.this.player.getName().getString());
                                  }
-@@ -1656,6 +_,26 @@
+@@ -1656,6 +_,27 @@
                      );
                  }
              }
@@ -1980,6 +2004,7 @@
 +                });
 +            }
 +            // Paper end - PlayerUseUnknownEntityEvent
++            this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
          }
      }
  
@@ -2381,6 +2406,14 @@
  
                      for (Entry<ItemStack> entry : Int2ObjectMaps.fastIterable(packet.getChangedSlots())) {
                          this.player.containerMenu.setRemoteSlotNoCopy(entry.getIntKey(), entry.getValue());
+@@ -1726,6 +_,7 @@
+                     } else {
+                         this.player.containerMenu.broadcastChanges();
+                     }
++                    this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
+                 }
+             }
+         }
 @@ -1733,6 +_,14 @@
  
      @Override
@@ -2450,7 +2483,15 @@
          this.player.resetLastActionTime();
          if (this.player.containerMenu.containerId == packet.containerId() && !this.player.isSpectator()) {
              if (!this.player.containerMenu.stillValid(this.player)) {
-@@ -1792,6 +_,43 @@
+@@ -1776,6 +_,7 @@
+                 if (flag) {
+                     this.player.containerMenu.broadcastChanges();
+                 }
++                this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
+             }
+         }
+     }
+@@ -1792,10 +_,48 @@
  
              boolean flag1 = packet.slotNum() >= 1 && packet.slotNum() <= 45;
              boolean flag2 = itemStack.isEmpty() || itemStack.getCount() <= itemStack.getMaxStackSize();
@@ -2494,6 +2535,11 @@
              if (flag1 && flag2) {
                  this.player.inventoryMenu.getSlot(packet.slotNum()).setByPlayer(itemStack);
                  this.player.inventoryMenu.setRemoteSlot(packet.slotNum(), itemStack);
+                 this.player.inventoryMenu.broadcastChanges();
++                this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
+             } else if (flag && flag2) {
+                 if (this.dropSpamThrottler.isUnderThreshold()) {
+                     this.dropSpamThrottler.increment();
 @@ -1809,11 +_,24 @@
  
      @Override


### PR DESCRIPTION
Fixes attribute swap exploit: https://www.youtube.com/watch?v=jL98SsqfdvU
TLDR: You can swap an item right before using it and the new item will contain the same attributes as the first item: attack speed, attack damage, dig speed, etc.

This exploit allows you to use the attributes from the previous weapon/tool right before swapping. Let me know if I missed any easily abusable actions other than attack/interact? Let me know if anyone also finds issues with this patch. It should work perfectly with my limited testing, but it would be nice to know if this causes new exploits.