### PR TITLE
Send the pong response packet immediately.

### DIFF
--- a/paper-server/patches/features/0001-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
+++ b/paper-server/patches/features/0001-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
@@ -28,7 +28,7 @@ and then catch exceptions and close if they fire.
 Part of this commit was authored by: Spottedleaf, sandtechnology
 
 diff --git a/net/minecraft/network/Connection.java b/net/minecraft/network/Connection.java
-index 42f44c7cb0bd55ddfacd18acb0e596e7a953870e..161ee86d67b9a23368a18481fde9768c022d913d 100644
+index 42f44c7cb0bd55ddfacd18acb0e596e7a953870e..2040b9555c430420a8a8697cc131d42eafb96fa1 100644
 --- a/net/minecraft/network/Connection.java
 +++ b/net/minecraft/network/Connection.java
 @@ -85,7 +85,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -232,7 +232,7 @@ index 42f44c7cb0bd55ddfacd18acb0e596e7a953870e..161ee86d67b9a23368a18481fde9768c
                  // Paper start - Add PlayerConnectionCloseEvent
                  if (packetListener instanceof net.minecraft.server.network.ServerCommonPacketListenerImpl commonPacketListener) {
                      /* Player was logged in, either game listener or configuration listener */
-@@ -797,4 +888,96 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -797,4 +888,97 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      public void setBandwidthLogger(LocalSampleLogger bandwithLogger) {
          this.bandwidthDebugMonitor = new BandwidthDebugMonitor(bandwithLogger);
      }
@@ -293,7 +293,8 @@ index 42f44c7cb0bd55ddfacd18acb0e596e7a953870e..161ee86d67b9a23368a18481fde9768c
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket ||
-+                packet instanceof net.minecraft.network.protocol.game.ClientboundBossEventPacket;
++                packet instanceof net.minecraft.network.protocol.game.ClientboundBossEventPacket ||
++                packet instanceof net.minecraft.network.protocol.ping.ClientboundPongResponsePacket;
 +        }
 +    }
 +


### PR DESCRIPTION
This fixes the F3+3 ping graph in the Minecraft client being offset by 25-50ms.