### PR TITLE
Player - Expose player score

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -3902,4 +3902,28 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      * @return the result of this method, holding leftovers and spawned items.
      */
     PlayerGiveResult give(Collection<ItemStack> items, boolean dropIfFull);
+
+    /**
+     * Get the score that shows in the death screen of the player.
+     * <p>This amount is added to when the player gains experience.</p>
+     *
+     * @return Death screen score of player
+     */
+    int getDeathScreenScore();
+
+    /**
+     * Get the score that shows in the death screen of the player.
+     * <p>This amount is added to when the player gains experience.</p>
+     *
+     * @param score New death screen score of player
+     */
+    void setDeathScreenScore(int score);
+
+    /**
+     * Increase the death screen score of the player.
+     * <p>This amount is added to when the player gains experience.</p>
+     *
+     * @param score Amount to add to death screen score of player
+     */
+    void increaseDeathScreenScore(int score);
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -3912,7 +3912,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
     int getDeathScreenScore();
 
     /**
-     * Get the score that shows in the death screen of the player.
+     * Set the score that shows in the death screen of the player.
      * <p>This amount is added to when the player gains experience.</p>
      *
      * @param score New death screen score of player

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -3918,12 +3918,4 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      * @param score New death screen score of player
      */
     void setDeathScreenScore(int score);
-
-    /**
-     * Increase the death screen score of the player.
-     * <p>This amount is added to when the player gains experience.</p>
-     *
-     * @param score Amount to add to death screen score of player
-     */
-    void increaseDeathScreenScore(int score);
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -3599,4 +3599,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
 
         return forwardMovement == backwardMovement ? 0 : forwardMovement ? 1 : -1;
     }
+
+    @Override
+    public int getDeathScreenScore() {
+        return getHandle().getScore();
+    }
+
+    @Override
+    public void setDeathScreenScore(final int score) {
+        getHandle().setScore(score);
+    }
+
+    @Override
+    public void increaseDeathScreenScore(int score) {
+        getHandle().increaseScore(score);
+    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -3609,9 +3609,4 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     public void setDeathScreenScore(final int score) {
         getHandle().setScore(score);
     }
-
-    @Override
-    public void increaseDeathScreenScore(int score) {
-        getHandle().increaseScore(score);
-    }
 }


### PR DESCRIPTION
This PR aims to expose NMS `Player#getScore()` and its derivatives.

This score is show in the death screen of the player.   
The name was suggested/discussed with @Owen1212055 on discord.
Chose to use `get/setDeathScreenScore` to prevent confusion/collision with Scoreboard/Objective `getScore()`

Credit goes to Owen for the idea.
(Could have sworn this was already in the API, but nope)