### PR TITLE
Add ItemCraftedEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/inventory/ItemCraftedEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/inventory/ItemCraftedEvent.java
@@ -1,4 +1,4 @@
-package org.bukkit.event.inventory;
+package io.papermc.paper.event.inventory;
 
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -6,24 +6,37 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Called when a player picks up a crafted item from the result slot of a crafting grid.
+ */
 public class ItemCraftedEvent extends Event{
     private static final HandlerList HANDLERS = new HandlerList();
     private final Player player;
-    private final ItemStack craftedItem;
+    private final ItemStack craftedItemStack;
 
-    public ItemCraftedEvent(@NotNull Player player, @NotNull ItemStack craftedItem) {
+    public ItemCraftedEvent(@NotNull Player player, @NotNull ItemStack craftedItemStack) {
         this.player = player;
-        this.craftedItem = craftedItem;
+        this.craftedItemStack = craftedItemStack;
     }
 
+    /**
+     * Gets the Player who triggered the event by picking up the crafted item.
+     *
+     * @return Player
+     */
     @NotNull
     public Player getPlayer() {
         return player;
     }
 
+    /**
+     * Gets the ItemStack that was crafted and picked up by the Player.
+     *
+     * @return ItemStack
+     */
     @NotNull
-    public ItemStack getCraftedItem() {
-        return craftedItem;
+    public ItemStack getCraftedItemStack() {
+        return craftedItemStack;
     }
 
     @NotNull

--- a/paper-api/src/main/java/io/papermc/paper/event/inventory/ItemCraftedEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/inventory/ItemCraftedEvent.java
@@ -1,0 +1,39 @@
+package org.bukkit.event.inventory;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public class ItemCraftedEvent extends Event{
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final Player player;
+    private final ItemStack craftedItem;
+
+    public ItemCraftedEvent(@NotNull Player player, @NotNull ItemStack craftedItem) {
+        this.player = player;
+        this.craftedItem = craftedItem;
+    }
+
+    @NotNull
+    public Player getPlayer() {
+        return player;
+    }
+
+    @NotNull
+    public ItemStack getCraftedItem() {
+        return craftedItem;
+    }
+
+    @NotNull
+    @Override
+    public  HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/event/inventory/ItemCraftedEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/inventory/ItemCraftedEvent.java
@@ -1,4 +1,4 @@
-package io.papermc.paper.event.inventory;
+package org.bukkit.event.inventory;
 
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -6,37 +6,24 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-/**
- * Called when a player picks up a crafted item from the result slot of a crafting grid.
- */
 public class ItemCraftedEvent extends Event{
     private static final HandlerList HANDLERS = new HandlerList();
     private final Player player;
-    private final ItemStack craftedItemStack;
+    private final ItemStack craftedItem;
 
-    public ItemCraftedEvent(@NotNull Player player, @NotNull ItemStack craftedItemStack) {
+    public ItemCraftedEvent(@NotNull Player player, @NotNull ItemStack craftedItem) {
         this.player = player;
-        this.craftedItemStack = craftedItemStack;
+        this.craftedItem = craftedItem;
     }
 
-    /**
-     * Gets the Player who triggered the event by picking up the crafted item.
-     *
-     * @return Player
-     */
     @NotNull
     public Player getPlayer() {
         return player;
     }
 
-    /**
-     * Gets the ItemStack that was crafted and picked up by the Player.
-     *
-     * @return ItemStack
-     */
     @NotNull
-    public ItemStack getCraftedItemStack() {
-        return craftedItemStack;
+    public ItemStack getCraftedItem() {
+        return craftedItem;
     }
 
     @NotNull

--- a/paper-api/src/main/java/org/bukkit/event/inventory/ItemCraftedEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/inventory/ItemCraftedEvent.java
@@ -1,4 +1,0 @@
-package org.bukkit.event.inventory;
-
-public class ItemCraftedEvent {
-}

--- a/paper-api/src/main/java/org/bukkit/event/inventory/ItemCraftedEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/inventory/ItemCraftedEvent.java
@@ -1,0 +1,4 @@
+package org.bukkit.event.inventory;
+
+public class ItemCraftedEvent {
+}

--- a/paper-server/patches/sources/net/minecraft/world/inventory/ResultSlot.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/ResultSlot.java.patch
@@ -9,3 +9,17 @@
                  .map(recipe -> recipe.value().getRemainingItems(input))
                  .orElseGet(() -> copyAllInputItems(input))
              : CraftingRecipe.defaultCraftingReminder(input);
+@@ -80,6 +_,13 @@
+ 
+     @Override
+     public void onTake(Player player, ItemStack stack) {
++        //Paper start
++        org.bukkit.event.inventory.ItemCraftedEvent event = new org.bukkit.event.inventory.ItemCraftedEvent((org.bukkit.entity.Player) player.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(stack));
++        org.bukkit.Bukkit.getPluginManager().callEvent(event);
++        if (event.isCancelled()) {
++            return; // Stop crafting if event is cancelled
++        }
++        //Paper end
+         this.checkTakeAchievements(stack);
+         CraftingInput.Positioned positionedCraftInput = this.craftSlots.asPositionedCraftInput();
+         CraftingInput craftingInput = positionedCraftInput.input();

--- a/paper-server/patches/sources/net/minecraft/world/inventory/ResultSlot.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/ResultSlot.java.patch
@@ -1,19 +1,5 @@
 --- a/net/minecraft/world/inventory/ResultSlot.java
 +++ b/net/minecraft/world/inventory/ResultSlot.java
-@@ -39,6 +_,13 @@
-     protected void onQuickCraft(ItemStack stack, int amount) {
-         this.removeCount += amount;
-         this.checkTakeAchievements(stack);
-+        //Paper start - Trigger ItemCraftedEvent
-+        if (!stack.isEmpty()) {
-+            org.bukkit.entity.Player bukkitPlayer = (org.bukkit.entity.Player) this.player.getBukkitEntity();
-+            io.papermc.paper.event.inventory.ItemCraftedEvent event = new io.papermc.paper.event.inventory.ItemCraftedEvent(bukkitPlayer, org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(stack));
-+            org.bukkit.Bukkit.getPluginManager().callEvent(event);
-+        }
-+        //Paper end
-     }
- 
-     @Override
 @@ -72,7 +_,7 @@
      private NonNullList<ItemStack> getRemainingItems(CraftingInput input, Level level) {
          return level instanceof ServerLevel serverLevel
@@ -27,11 +13,11 @@
  
      @Override
      public void onTake(Player player, ItemStack stack) {
-+        //Paper start - Trigger ItemCraftedEvent
-+        if (!stack.isEmpty()) {
-+            player.containerMenu.broadcastChanges();
-+            io.papermc.paper.event.inventory.ItemCraftedEvent event = new io.papermc.paper.event.inventory.ItemCraftedEvent((org.bukkit.entity.Player) player.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(stack));
-+            org.bukkit.Bukkit.getPluginManager().callEvent(event);
++        //Paper start
++        org.bukkit.event.inventory.ItemCraftedEvent event = new org.bukkit.event.inventory.ItemCraftedEvent((org.bukkit.entity.Player) player.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(stack));
++        org.bukkit.Bukkit.getPluginManager().callEvent(event);
++        if (event.isCancelled()) {
++            return; // Stop crafting if event is cancelled
 +        }
 +        //Paper end
          this.checkTakeAchievements(stack);

--- a/paper-server/patches/sources/net/minecraft/world/inventory/ResultSlot.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/ResultSlot.java.patch
@@ -1,5 +1,19 @@
 --- a/net/minecraft/world/inventory/ResultSlot.java
 +++ b/net/minecraft/world/inventory/ResultSlot.java
+@@ -39,6 +_,13 @@
+     protected void onQuickCraft(ItemStack stack, int amount) {
+         this.removeCount += amount;
+         this.checkTakeAchievements(stack);
++        //Paper start - Trigger ItemCraftedEvent
++        if (!stack.isEmpty()) {
++            org.bukkit.entity.Player bukkitPlayer = (org.bukkit.entity.Player) this.player.getBukkitEntity();
++            io.papermc.paper.event.inventory.ItemCraftedEvent event = new io.papermc.paper.event.inventory.ItemCraftedEvent(bukkitPlayer, org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(stack));
++            org.bukkit.Bukkit.getPluginManager().callEvent(event);
++        }
++        //Paper end
+     }
+ 
+     @Override
 @@ -72,7 +_,7 @@
      private NonNullList<ItemStack> getRemainingItems(CraftingInput input, Level level) {
          return level instanceof ServerLevel serverLevel
@@ -13,11 +27,11 @@
  
      @Override
      public void onTake(Player player, ItemStack stack) {
-+        //Paper start
-+        org.bukkit.event.inventory.ItemCraftedEvent event = new org.bukkit.event.inventory.ItemCraftedEvent((org.bukkit.entity.Player) player.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(stack));
-+        org.bukkit.Bukkit.getPluginManager().callEvent(event);
-+        if (event.isCancelled()) {
-+            return; // Stop crafting if event is cancelled
++        //Paper start - Trigger ItemCraftedEvent
++        if (!stack.isEmpty()) {
++            player.containerMenu.broadcastChanges();
++            io.papermc.paper.event.inventory.ItemCraftedEvent event = new io.papermc.paper.event.inventory.ItemCraftedEvent((org.bukkit.entity.Player) player.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(stack));
++            org.bukkit.Bukkit.getPluginManager().callEvent(event);
 +        }
 +        //Paper end
          this.checkTakeAchievements(stack);


### PR DESCRIPTION
- Currently we do not have an event which fires when the cursor actually picks up the crafted item from result slot. 
- 
- ItemCraftedEvent is an event which fires only when the ItemStack is picked up.
- 
- This event differs from CraftItemEvent which fires even if the cursor doesn't pick up the ItemStack (Eg. when the cursor has max stack of items.) 