### PR TITLE
Correctly handle events for end portal

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/EndPortalBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/EndPortalBlock.java.patch
@@ -34,7 +34,7 @@
                  f = Direction.WEST.toYRot();
                  set = Relative.union(Relative.DELTA, Set.of(Relative.X_ROT));
                  if (entity instanceof ServerPlayer) {
-@@ -88,15 +_,21 @@
+@@ -88,15 +_,23 @@
                  f = 0.0F;
                  set = Relative.union(Relative.DELTA, Relative.ROTATION);
                  if (entity instanceof ServerPlayer serverPlayer) {
@@ -49,13 +49,15 @@
 -                level1, bottomCenter, Vec3.ZERO, f, 0.0F, set, TeleportTransition.PLAY_PORTAL_SOUND.then(TeleportTransition.PLACE_PORTAL_TICKET)
 -            );
 +            // CraftBukkit start
-+            org.bukkit.craftbukkit.event.CraftPortalEvent event = entity.callPortalEvent(entity, org.bukkit.craftbukkit.util.CraftLocation.toBukkit(bottomCenter, level1.getWorld(), f, entity.getXRot()), org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.END_PORTAL, 0, 0);
++            set.removeAll(Relative.ROTATION); // remove relative rotation flags to simplify event mutation
++            float absoluteYaw = flag ? f : entity.getYRot() + f;
++            org.bukkit.craftbukkit.event.CraftPortalEvent event = entity.callPortalEvent(entity, org.bukkit.craftbukkit.util.CraftLocation.toBukkit(bottomCenter, level1.getWorld(), absoluteYaw, entity.getXRot()), org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.END_PORTAL, 0, 0);
 +            if (event == null) {
 +                return null;
 +            }
 +            org.bukkit.Location to = event.getTo();
 +
-+            return new TeleportTransition(((org.bukkit.craftbukkit.CraftWorld) to.getWorld()).getHandle(), org.bukkit.craftbukkit.util.CraftLocation.toVec3D(to), entity.getDeltaMovement(), to.getYaw(), to.getPitch(), set, TeleportTransition.PLAY_PORTAL_SOUND.then(TeleportTransition.PLACE_PORTAL_TICKET), org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.END_PORTAL);
++            return new TeleportTransition(((org.bukkit.craftbukkit.CraftWorld) to.getWorld()).getHandle(), org.bukkit.craftbukkit.util.CraftLocation.toVec3D(to), Vec3.ZERO, to.getYaw(), to.getPitch(), set, TeleportTransition.PLAY_PORTAL_SOUND.then(TeleportTransition.PLACE_PORTAL_TICKET), org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.END_PORTAL);
 +            // CraftBukkit end
          }
      }


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/12234

It seems this part wasn't properly updated when the game used more specific relative flags. This now restore the velocity and rotation to match vanilla. Rotation flags are removed to fix/simplify mutation of the event location.