### PR TITLE
Allows servers to prevent chickens from laying eggs by setting EggLayTime to -1

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/Chicken.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/Chicken.java.patch
@@ -1,9 +1,11 @@
 --- a/net/minecraft/world/entity/animal/Chicken.java
 +++ b/net/minecraft/world/entity/animal/Chicken.java
-@@ -91,10 +_,12 @@
+@@ -90,11 +_,13 @@
+         }
  
          this.flap = this.flap + this.flapping * 2.0F;
-         if (this.level() instanceof ServerLevel serverLevel && this.isAlive() && !this.isBaby() && !this.isChickenJockey() && --this.eggTime <= 0) {
+-        if (this.level() instanceof ServerLevel serverLevel && this.isAlive() && !this.isBaby() && !this.isChickenJockey() && --this.eggTime <= 0) {
++        if (this.level() instanceof ServerLevel serverLevel && this.isAlive() && !this.isBaby() && !this.isChickenJockey() && this.eggTime > -1 && --this.eggTime <= 0) { // Paper - do not decrease eggTime when negative, allowing servers to disable egg laying without a plugin
 +            this.forceDrops = true; // CraftBukkit
              if (this.dropFromGiftLootTable(serverLevel, BuiltInLootTables.CHICKEN_LAY, this::spawnAtLocation)) {
                  this.playSound(SoundEvents.CHICKEN_EGG, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F);


### PR DESCRIPTION
I was surprised that NoAI:1 still causes eggs to be laid, but is a more flexible solution for servers that want both as -1 is never normally reached. 

-1 prevents ticking.
0 works as before for instant egg lay.

Try with `/data merge entity @n[type=chicken] {EggLayTime:-1}`