### PR TITLE
[ci skip] Clarify BlockFadeEvent#getNewState javadocs

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/block/BlockFadeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/BlockFadeEvent.java
@@ -33,9 +33,11 @@ public class BlockFadeEvent extends BlockEvent implements Cancellable {
     }
 
     /**
-     * Gets the state of the new block that will replace the block fading, melting or disappearing.
+     * Gets the state of the new block that will replace the block
+     * fading, melting or disappearing.
      *
-     * @return The block state of the new block that replaces the block fading, melting or disappearing.
+     * @return The block state of the new block that replaces the block
+     *     fading, melting or disappearing
      */
     @NotNull
     public BlockState getNewState() {

--- a/paper-api/src/main/java/org/bukkit/event/block/BlockFadeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/BlockFadeEvent.java
@@ -33,11 +33,9 @@ public class BlockFadeEvent extends BlockEvent implements Cancellable {
     }
 
     /**
-     * Gets the state of the block that will be fading, melting or
-     * disappearing.
+     * Gets the state of the new block that will replace the block fading, melting or disappearing.
      *
-     * @return The block state of the block that will be fading, melting or
-     *     disappearing
+     * @return The block state of the new block that replaces the block fading, melting or disappearing.
      */
     @NotNull
     public BlockState getNewState() {


### PR DESCRIPTION
Old wording of:

"Gets the state of the block that will be fading, melting or disappearing"

Sounds as if it will return the same block as .getBlock()

For example, Ice melts and become water. Current wording of "Gets ... the block that will be ... melting" would mean ice. But the method would return water.