### PR TITLE
Require isDestroyingBlock for block destruction

### DIFF
--- a/paper-server/patches/features/0004-Anti-Xray.patch
+++ b/paper-server/patches/features/0004-Anti-Xray.patch
@@ -145,7 +145,7 @@ index 3a384175f8e7f204234bbaf3081bdc20c47a0d4b..5699bc15eba92e22433a20cb8326b59f
  
      private ClientboundLevelChunkWithLightPacket(RegistryFriendlyByteBuf buffer) {
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index da8848e2a3e3745949eb2356a049451d30f763a7..192977dd661ee795ada13db895db770293e9b402 100644
+index 12f0dc36c5adcdbd9e1dad5f8512ac184da3960f..d1f235ebd835f58cf0c703c3a64d29825d98e183 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -348,7 +348,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -158,7 +158,7 @@ index da8848e2a3e3745949eb2356a049451d30f763a7..192977dd661ee795ada13db895db7702
          this.levelStorageAccess = levelStorageAccess;
          this.uuid = org.bukkit.craftbukkit.util.WorldUUID.getUUID(levelStorageAccess.levelDirectory.path().toFile());
 diff --git a/net/minecraft/server/level/ServerPlayerGameMode.java b/net/minecraft/server/level/ServerPlayerGameMode.java
-index 47ed3ad5c0b4753f58e0bafff5e5e70b2f0bb40b..623c069f1fe079e020c6391a3db1a3d95cd3dbf5 100644
+index 02b9aefbcd0b1fbe0fae39a7055cdd9f077aaad3..621c0ec6670e223f032cfe47e2638597e3eadcd0 100644
 --- a/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -299,6 +299,7 @@ public class ServerPlayerGameMode {
@@ -168,7 +168,7 @@ index 47ed3ad5c0b4753f58e0bafff5e5e70b2f0bb40b..623c069f1fe079e020c6391a3db1a3d9
 +        this.level.chunkPacketBlockController.onPlayerLeftClickBlock(this, pos, action, face, maxBuildHeight, sequence); // Paper - Anti-Xray
      }
  
-     public void destroyAndAck(BlockPos pos, int sequence, String message) {
+     public boolean destroyAndAck(BlockPos pos, int sequence, String message) { // Paper - block break event - correctly restore isDestroyingBlock if destroyBlock fails
 diff --git a/net/minecraft/server/network/PlayerChunkSender.java b/net/minecraft/server/network/PlayerChunkSender.java
 index 342bc843c384761e883de861044f4f8930ae8763..14878690a88fd4de3e2c127086607e6c819c636c 100644
 --- a/net/minecraft/server/network/PlayerChunkSender.java
@@ -188,7 +188,7 @@ index 342bc843c384761e883de861044f4f8930ae8763..14878690a88fd4de3e2c127086607e6c
          if (io.papermc.paper.event.packet.PlayerChunkLoadEvent.getHandlerList().getRegisteredListeners().length > 0) {
              new io.papermc.paper.event.packet.PlayerChunkLoadEvent(new org.bukkit.craftbukkit.CraftChunk(chunk), packetListener.getPlayer().getBukkitEntity()).callEvent();
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 600a08d6b45cb19dbe551cefbf726e68684a0837..ff0315cffdb282fdc0a1ffd15e2954caa76835c9 100644
+index 2f2a7ba0d9a136d8ec707f86a383a07d91aaecb0..5d88b2790710a885957ffcffc02fb99c917123c5 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -403,7 +403,7 @@ public abstract class PlayerList {

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -167,7 +167,25 @@
                  if (!blockState.isAir() && f >= 1.0F) {
                      this.destroyAndAck(pos, sequence, "insta mine");
                  } else {
-@@ -212,14 +_,22 @@
+@@ -188,7 +_,7 @@
+                     this.lastSentState = i;
+                 }
+             } else if (action == ServerboundPlayerActionPacket.Action.STOP_DESTROY_BLOCK) {
+-                if (pos.equals(this.destroyPos)) {
++                if (this.isDestroyingBlock && pos.equals(this.destroyPos)) { // Paper - require isDestroyingBlock to be true (special condition for when destroy pos is 0,0,0 and the event is cancelled)
+                     int i1 = this.gameTicks - this.destroyProgressStart;
+                     BlockState blockStatex = this.level.getBlockState(pos);
+                     if (!blockStatex.isAir()) {
+@@ -196,7 +_,7 @@
+                         if (f1 >= 0.7F) {
+                             this.isDestroyingBlock = false;
+                             this.level.destroyBlockProgress(this.player.getId(), pos, -1);
+-                            this.destroyAndAck(pos, sequence, "destroyed");
++                            this.isDestroyingBlock = !this.destroyAndAck(pos, sequence, "destroyed"); // Paper - block break event - correctly restore isDestroyingBlock if destroyBlock fails
+                             return;
+                         }
+ 
+@@ -212,59 +_,141 @@
                  this.debugLogging(pos, true, sequence, "stopped destroying");
              } else if (action == ServerboundPlayerActionPacket.Action.ABORT_DESTROY_BLOCK) {
                  this.isDestroyingBlock = false;
@@ -192,7 +210,18 @@
              }
          }
      }
-@@ -235,36 +_,108 @@
+ 
+-    public void destroyAndAck(BlockPos pos, int sequence, String message) {
++    public boolean destroyAndAck(BlockPos pos, int sequence, String message) { // Paper - block break event - correctly restore isDestroyingBlock if destroyBlock fails
+         if (this.destroyBlock(pos)) {
+             this.debugLogging(pos, true, sequence, message);
++            return true; // Paper - block break event - correctly restore isDestroyingBlock if destroyBlock fails
+         } else {
+             this.player.connection.send(new ClientboundBlockUpdatePacket(pos, this.level.getBlockState(pos)));
+             this.debugLogging(pos, false, sequence, message);
++            return false; // Paper - block break event - correctly restore isDestroyingBlock if destroyBlock fails
+         }
+     }
  
      public boolean destroyBlock(BlockPos pos) {
          BlockState blockState = this.level.getBlockState(pos);


### PR DESCRIPTION
Reimplementation of a previous attempt at ensuring cancelled
PlayerInteractEvent would prevent block breaking.
Ensures that the now checked isDestroyingBlock is not set to false if
the actual block destruction failed.

See: #12254
See: a2b0ff0644e76fb4a644d870bc335bf81bc6a109
Resolves: #12196
