### PR TITLE
Properly grow plants with growth modifier

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/CactusBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/CactusBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/CactusBlock.java
 +++ b/net/minecraft/world/level/block/CactusBlock.java
-@@ -56,14 +_,16 @@
+@@ -56,15 +_,24 @@
                  i++;
              }
  
@@ -9,18 +9,27 @@
                  int ageValue = state.getValue(AGE);
 -                if (ageValue == 15) {
 -                    level.setBlockAndUpdate(blockPos, this.defaultBlockState());
++                // Paper start - Properly grow plants with growth modifier
++                final int ageToProgress = level.spigotConfig.computeBlockGrowingAgeProgression(
++                    random,
++                    level.spigotConfig.cactusModifier);
 +
-+                int modifier = level.spigotConfig.cactusModifier; // Spigot - SPIGOT-7159: Better modifier resolution
-+                if (ageValue >= 15 || (modifier != 100 && random.nextFloat() < (modifier / (100.0f * 16)))) { // Spigot - SPIGOT-7159: Better modifier
++                if (ageToProgress > 0 && ageValue < CactusBlock.MAX_AGE) {
++                    // Moved up from below's if, now deleted, else.
++                    level.setBlock(pos, state.setValue(CactusBlock.AGE, Math.min(CactusBlock.MAX_AGE, ageValue + ageToProgress)), 4);
++                }
++
++                if (ageValue + ageToProgress > 15) {
++                    // Paper end - Properly grow plants with growth modifier
 +                    org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockGrowEvent(level, blockPos, this.defaultBlockState()); // CraftBukkit
                      BlockState blockState = state.setValue(AGE, Integer.valueOf(0));
                      level.setBlock(pos, blockState, 4);
                      level.neighborChanged(blockState, blockPos, this, null, false);
 -                } else {
-+                } else if (modifier == 100 || random.nextFloat() < (modifier / (100.0f * 16))) { // Spigot - SPIGOT-7159: Better modifier resolution
-                     level.setBlock(pos, state.setValue(AGE, Integer.valueOf(ageValue + 1)), 4);
+-                    level.setBlock(pos, state.setValue(AGE, Integer.valueOf(ageValue + 1)), 4);
                  }
              }
+         }
 @@ -113,7 +_,8 @@
  
      @Override

--- a/paper-server/src/main/java/org/spigotmc/SpigotWorldConfig.java
+++ b/paper-server/src/main/java/org/spigotmc/SpigotWorldConfig.java
@@ -133,6 +133,16 @@ public class SpigotWorldConfig {
         this.pitcherPlantModifier = this.getAndValidateGrowth("PitcherPlant"); // Paper
     }
 
+    // Paper start - Properly grow plants with growth modifier
+    public int computeBlockGrowingAgeProgression(final net.minecraft.util.RandomSource random, final int modifier) {
+        final double modifierScaled = modifier / 100.0D;
+        final int baseGrowth = (int) modifierScaled;
+        final double chanceOfDoubleGrowth = modifierScaled - baseGrowth;
+
+        return baseGrowth + (random.nextFloat() < chanceOfDoubleGrowth ? 1 : 0);
+    }
+    // Paper end - Properly grow plants with growth modifier
+
     public double itemMerge;
     private void itemMerge() {
         this.itemMerge = this.getDouble("merge-radius.item", 0.5);


### PR DESCRIPTION
Post-softspoon version of #8564
Resolves: #8544 

Spigots implementation of the growth modifier boils down to a plain chance for a plant to either grow immediately or to grow a single age value towards its fully grown age.

This behaviour is specifically troubling for plants like the cactus or the sugar cane, as they change an unrelated block when growing up (the free air block above their tip). This blocks validity is checked during neighbour updated which are triggered by resetting the previous tip of the plant back to [age=0].

With spigots modifier implementation, blocks at the age of zero are able to grow a new block above them however, causing the block change of the previous tip to change a block of age zero to a block of age zero, which does not cause a neighbour update as nothing actually changed. This means that the about block is not updated and hence may remain in an otherwise invalid state. (E.g. a cactus block next to a solid block).

This commit rewrites the existing spigot growth modifier implementation specifically for the plants that grow new blocks like the cactus or the sugar can block.

The modifier provided for the plants is separated into two distinct values. One being the remains after a floored division by 100, e.g. the original modifier without its 10^0 and 10^1 digits, the other the modifier modulo 100.
The modifier 475 would, for example, be split into a base growth of 4 and a percentage chance of an additional age progression of 75%. This way, on average, the plant would grow 4.75 times as fast as a normal plant, which would only grow a single age per random tick.