### PR TITLE
Properly grow plants with growth modifier

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/BeetrootBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/BeetrootBlock.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/world/level/block/BeetrootBlock.java
++++ b/net/minecraft/world/level/block/BeetrootBlock.java
+@@ -53,9 +_,9 @@
+ 
+     @Override
+     protected void randomTick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+-        if (random.nextInt(3) != 0) {
+-            super.randomTick(state, level, pos, random);
+-        }
++        // Paper - Properly grow plants with growth modifier
++        // Offloaded reduced (2/3) chance of growth to superclass
++        super.randomTick(state, level, pos, random);
+     }
+ 
+     @Override

--- a/paper-server/patches/sources/net/minecraft/world/level/block/CactusBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/CactusBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/CactusBlock.java
 +++ b/net/minecraft/world/level/block/CactusBlock.java
-@@ -56,14 +_,16 @@
+@@ -56,15 +_,24 @@
                  i++;
              }
  
@@ -9,18 +9,27 @@
                  int ageValue = state.getValue(AGE);
 -                if (ageValue == 15) {
 -                    level.setBlockAndUpdate(blockPos, this.defaultBlockState());
++                // Paper start - Properly grow plants with growth modifier
++                final int ageToProgress = level.spigotConfig.computeBlockGrowingAgeProgression(
++                    random,
++                    level.spigotConfig.cactusModifier);
 +
-+                int modifier = level.spigotConfig.cactusModifier; // Spigot - SPIGOT-7159: Better modifier resolution
-+                if (ageValue >= 15 || (modifier != 100 && random.nextFloat() < (modifier / (100.0f * 16)))) { // Spigot - SPIGOT-7159: Better modifier
++                if (ageToProgress > 0 && ageValue < CactusBlock.MAX_AGE) {
++                    // Moved up from below's if, now deleted, else.
++                    level.setBlock(pos, state.setValue(CactusBlock.AGE, Math.min(CactusBlock.MAX_AGE, ageValue + ageToProgress)), 4);
++                }
++
++                if (ageValue + ageToProgress > 15) {
++                    // Paper end - Properly grow plants with growth modifier
 +                    org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockGrowEvent(level, blockPos, this.defaultBlockState()); // CraftBukkit
                      BlockState blockState = state.setValue(AGE, Integer.valueOf(0));
                      level.setBlock(pos, blockState, 4);
                      level.neighborChanged(blockState, blockPos, this, null, false);
 -                } else {
-+                } else if (modifier == 100 || random.nextFloat() < (modifier / (100.0f * 16))) { // Spigot - SPIGOT-7159: Better modifier resolution
-                     level.setBlock(pos, state.setValue(AGE, Integer.valueOf(ageValue + 1)), 4);
+-                    level.setBlock(pos, state.setValue(AGE, Integer.valueOf(ageValue + 1)), 4);
                  }
              }
+         }
 @@ -113,7 +_,8 @@
  
      @Override

--- a/paper-server/patches/sources/net/minecraft/world/level/block/CactusBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/CactusBlock.java.patch
@@ -9,18 +9,18 @@
                  int ageValue = state.getValue(AGE);
 -                if (ageValue == 15) {
 -                    level.setBlockAndUpdate(blockPos, this.defaultBlockState());
-+                // Paper start - Properly grow plants with growth modifier
-+                final int ageToProgress = level.spigotConfig.computeBlockGrowingAgeProgression(
++                // Paper start - Spigot growth modifier
++                final int ageToProgress = org.spigotmc.SpigotWorldConfig.computeBlockGrowingAgeProgression(
 +                    random,
 +                    level.spigotConfig.cactusModifier);
 +
-+                if (ageToProgress > 0 && ageValue < CactusBlock.MAX_AGE) {
++                if (ageToProgress > 0 && ageValue < MAX_AGE) {
 +                    // Moved up from below's if, now deleted, else.
-+                    level.setBlock(pos, state.setValue(CactusBlock.AGE, Math.min(CactusBlock.MAX_AGE, ageValue + ageToProgress)), 4);
++                    level.setBlock(pos, state.setValue(AGE, Math.min(MAX_AGE, ageValue + ageToProgress)), 4);
 +                }
 +
-+                if (ageValue + ageToProgress > 15) {
-+                    // Paper end - Properly grow plants with growth modifier
++                if (ageValue + ageToProgress > MAX_AGE) {
++                    // Paper end - Spigot growth modifier
 +                    org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockGrowEvent(level, blockPos, this.defaultBlockState()); // CraftBukkit
                      BlockState blockState = state.setValue(AGE, Integer.valueOf(0));
                      level.setBlock(pos, blockState, 4);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/CropBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/CropBlock.java.patch
@@ -1,23 +1,27 @@
 --- a/net/minecraft/world/level/block/CropBlock.java
 +++ b/net/minecraft/world/level/block/CropBlock.java
-@@ -88,8 +_,25 @@
+@@ -88,8 +_,29 @@
              int age = this.getAge(state);
              if (age < this.getMaxAge()) {
                  float growthSpeed = getGrowthSpeed(this, level, pos);
 -                if (random.nextInt((int)(25.0F / growthSpeed) + 1) == 0) {
 -                    level.setBlock(pos, this.getStateForAge(age + 1), 2);
 +                // Spigot start
-+                int modifier = 100;
++                // Paper start - Properly grow plants with growth modifier
++                float modifier = 100.0f;
 +                if (this == Blocks.BEETROOTS) {
-+                    modifier = level.spigotConfig.beetrootModifier;
++                    // Multiplied by 2/3 as beetroot typically only has a 2/3 chance to call this method on random tick
++                    modifier = level.spigotConfig.beetrootModifier * 2.0f/3.0f;
 +                } else if (this == Blocks.CARROTS) {
 +                    modifier = level.spigotConfig.carrotModifier;
 +                } else if (this == Blocks.POTATOES) {
 +                    modifier = level.spigotConfig.potatoModifier;
 +                // Paper start - Fix Spigot growth modifiers
 +                } else if (this == Blocks.TORCHFLOWER_CROP) {
-+                    modifier = level.spigotConfig.torchFlowerModifier;
++                    // Multiplied by 2/3 as torchflower typically only has a 2/3 chance to call this method on random tick
++                    modifier = level.spigotConfig.torchFlowerModifier * 2.0f/3.0f;
 +                // Paper end - Fix Spigot growth modifiers
++                // Paper end - Properly grow plants with growth modifier
 +                } else if (this == Blocks.WHEAT) {
 +                    modifier = level.spigotConfig.wheatModifier;
 +                }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/CropBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/CropBlock.java.patch
@@ -1,33 +1,29 @@
 --- a/net/minecraft/world/level/block/CropBlock.java
 +++ b/net/minecraft/world/level/block/CropBlock.java
-@@ -88,8 +_,29 @@
+@@ -88,8 +_,25 @@
              int age = this.getAge(state);
              if (age < this.getMaxAge()) {
                  float growthSpeed = getGrowthSpeed(this, level, pos);
 -                if (random.nextInt((int)(25.0F / growthSpeed) + 1) == 0) {
 -                    level.setBlock(pos, this.getStateForAge(age + 1), 2);
-+                // Spigot start
-+                // Paper start - Properly grow plants with growth modifier
-+                float modifier = 100.0f;
++                // Paper start - Spigot growth modifier
++                float modifier = 100.0F;
 +                if (this == Blocks.BEETROOTS) {
 +                    // Multiplied by 2/3 as beetroot typically only has a 2/3 chance to call this method on random tick
-+                    modifier = level.spigotConfig.beetrootModifier * 2.0f/3.0f;
++                    modifier = level.spigotConfig.beetrootModifier * 2.0F/3.0F;
 +                } else if (this == Blocks.CARROTS) {
 +                    modifier = level.spigotConfig.carrotModifier;
 +                } else if (this == Blocks.POTATOES) {
 +                    modifier = level.spigotConfig.potatoModifier;
-+                // Paper start - Fix Spigot growth modifiers
 +                } else if (this == Blocks.TORCHFLOWER_CROP) {
 +                    // Multiplied by 2/3 as torchflower typically only has a 2/3 chance to call this method on random tick
-+                    modifier = level.spigotConfig.torchFlowerModifier * 2.0f/3.0f;
-+                // Paper end - Fix Spigot growth modifiers
-+                // Paper end - Properly grow plants with growth modifier
++                    modifier = level.spigotConfig.torchFlowerModifier * 2.0F/3.0F;
 +                } else if (this == Blocks.WHEAT) {
 +                    modifier = level.spigotConfig.wheatModifier;
 +                }
 +
-+                if (random.nextFloat() < (modifier / (100.0f * (Math.floor((25.0F / growthSpeed) + 1))))) { // Spigot - SPIGOT-7159: Better modifier resolution
-+                    // Spigot end
++                if (random.nextFloat() < (modifier / (100.0F * (Math.floor((25.0F / growthSpeed) + 1))))) {
++                    // Paper end - Spigot growth modifier
 +                    org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockGrowEvent(level, pos, this.getStateForAge(age + 1), 2); // CraftBukkit
                  }
              }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/SugarCaneBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/SugarCaneBlock.java.patch
@@ -9,18 +9,18 @@
                  int ageValue = state.getValue(AGE);
 -                if (ageValue == 15) {
 -                    level.setBlockAndUpdate(pos.above(), this.defaultBlockState());
-+                // Paper start - Properly grow plants with growth modifier
-+                final int ageToProgress = level.spigotConfig.computeBlockGrowingAgeProgression(
++                // Paper start - Spigot growth modifier
++                final int ageToProgress = org.spigotmc.SpigotWorldConfig.computeBlockGrowingAgeProgression(
 +                    random,
 +                    level.spigotConfig.caneModifier);
 +
-+                if (ageToProgress > 0 && ageValue < 15) {
++                if (ageToProgress > 0 && ageValue < AGE.max) {
 +                    // Moved up from below's if, now deleted, else.
-+                    level.setBlock(pos, state.setValue(AGE, Math.min(15, ageValue + ageToProgress)), 4);
++                    level.setBlock(pos, state.setValue(AGE, Math.min(AGE.max, ageValue + ageToProgress)), 4);
 +                }
 +
-+                if (ageValue + ageToProgress > 15) {
-+                    // Paper end - Properly grow plants with growth modifier
++                if (ageValue + ageToProgress > AGE.max) {
++                    // Paper end - Spigot growth modifier
 +                    org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockGrowEvent(level, pos.above(), this.defaultBlockState()); // CraftBukkit
                      level.setBlock(pos, state.setValue(AGE, Integer.valueOf(0)), 4);
 -                } else {

--- a/paper-server/patches/sources/net/minecraft/world/level/block/SugarCaneBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/SugarCaneBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/SugarCaneBlock.java
 +++ b/net/minecraft/world/level/block/SugarCaneBlock.java
-@@ -56,12 +_,13 @@
+@@ -56,13 +_,22 @@
                  i++;
              }
  
@@ -9,12 +9,22 @@
                  int ageValue = state.getValue(AGE);
 -                if (ageValue == 15) {
 -                    level.setBlockAndUpdate(pos.above(), this.defaultBlockState());
-+                int modifier = level.spigotConfig.caneModifier; // Spigot - SPIGOT-7159: Better modifier resolution
-+                if (ageValue >= 15 || (modifier != 100 && random.nextFloat() < (modifier / (100.0f * 16)))) { // Spigot - SPIGOT-7159: Better modifier resolution
++                // Paper start - Properly grow plants with growth modifier
++                final int ageToProgress = level.spigotConfig.computeBlockGrowingAgeProgression(
++                    random,
++                    level.spigotConfig.caneModifier);
++
++                if (ageToProgress > 0 && ageValue < 15) {
++                    // Moved up from below's if, now deleted, else.
++                    level.setBlock(pos, state.setValue(AGE, Math.min(15, ageValue + ageToProgress)), 4);
++                }
++
++                if (ageValue + ageToProgress > 15) {
++                    // Paper end - Properly grow plants with growth modifier
 +                    org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockGrowEvent(level, pos.above(), this.defaultBlockState()); // CraftBukkit
                      level.setBlock(pos, state.setValue(AGE, Integer.valueOf(0)), 4);
 -                } else {
-+                } else if (modifier == 100 || random.nextFloat() < (modifier / (100.0f * 16))) { // Spigot - SPIGOT-7159: Better modifier resolution
-                     level.setBlock(pos, state.setValue(AGE, Integer.valueOf(ageValue + 1)), 4);
+-                    level.setBlock(pos, state.setValue(AGE, Integer.valueOf(ageValue + 1)), 4);
                  }
              }
+         }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/TorchflowerCropBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TorchflowerCropBlock.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/world/level/block/TorchflowerCropBlock.java
++++ b/net/minecraft/world/level/block/TorchflowerCropBlock.java
+@@ -65,9 +_,9 @@
+ 
+     @Override
+     public void randomTick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+-        if (random.nextInt(3) != 0) {
+-            super.randomTick(state, level, pos, random);
+-        }
++        // Paper - Properly grow plants with growth modifier
++        // Offloaded reduced (2/3) chance of growth to superclass
++        super.randomTick(state, level, pos, random);
+     }
+ 
+     @Override

--- a/paper-server/src/main/java/org/spigotmc/SpigotWorldConfig.java
+++ b/paper-server/src/main/java/org/spigotmc/SpigotWorldConfig.java
@@ -133,6 +133,14 @@ public class SpigotWorldConfig {
         this.pitcherPlantModifier = this.getAndValidateGrowth("PitcherPlant"); // Paper
     }
 
+    public int computeBlockGrowingAgeProgression(final net.minecraft.util.RandomSource random, final int modifier) {
+        final double modifierScaled = modifier / 100.0D;
+        final int baseGrowth = (int) modifierScaled;
+        final double chanceOfDoubleGrowth = modifierScaled - baseGrowth;
+
+        return baseGrowth + (random.nextFloat() < chanceOfDoubleGrowth ? 1 : 0);
+    }
+
     public double itemMerge;
     private void itemMerge() {
         this.itemMerge = this.getDouble("merge-radius.item", 0.5);

--- a/paper-server/src/main/java/org/spigotmc/SpigotWorldConfig.java
+++ b/paper-server/src/main/java/org/spigotmc/SpigotWorldConfig.java
@@ -83,7 +83,7 @@ public class SpigotWorldConfig {
     public int beetrootModifier;
     public int carrotModifier;
     public int potatoModifier;
-    public int torchFlowerModifier; // Paper
+    public int torchFlowerModifier;
     public int wheatModifier;
     public int wartModifier;
     public int vineModifier;
@@ -94,8 +94,8 @@ public class SpigotWorldConfig {
     public int twistingVinesModifier;
     public int weepingVinesModifier;
     public int caveVinesModifier;
-    public int glowBerryModifier; // Paper
-    public int pitcherPlantModifier; // Paper
+    public int glowBerryModifier;
+    public int pitcherPlantModifier;
 
     private int getAndValidateGrowth(String crop) {
         int modifier = this.getInt("growth." + crop.toLowerCase(java.util.Locale.ENGLISH) + "-modifier", 100);
@@ -118,7 +118,7 @@ public class SpigotWorldConfig {
         this.beetrootModifier = this.getAndValidateGrowth("Beetroot");
         this.carrotModifier = this.getAndValidateGrowth("Carrot");
         this.potatoModifier = this.getAndValidateGrowth("Potato");
-        this.torchFlowerModifier = this.getAndValidateGrowth("TorchFlower"); // Paper
+        this.torchFlowerModifier = this.getAndValidateGrowth("TorchFlower");
         this.wheatModifier = this.getAndValidateGrowth("Wheat");
         this.wartModifier = this.getAndValidateGrowth("NetherWart");
         this.vineModifier = this.getAndValidateGrowth("Vine");
@@ -129,11 +129,11 @@ public class SpigotWorldConfig {
         this.twistingVinesModifier = this.getAndValidateGrowth("TwistingVines");
         this.weepingVinesModifier = this.getAndValidateGrowth("WeepingVines");
         this.caveVinesModifier = this.getAndValidateGrowth("CaveVines");
-        this.glowBerryModifier = this.getAndValidateGrowth("GlowBerry"); // Paper
-        this.pitcherPlantModifier = this.getAndValidateGrowth("PitcherPlant"); // Paper
+        this.glowBerryModifier = this.getAndValidateGrowth("GlowBerry");
+        this.pitcherPlantModifier = this.getAndValidateGrowth("PitcherPlant");
     }
 
-    public int computeBlockGrowingAgeProgression(final net.minecraft.util.RandomSource random, final int modifier) {
+    public static int computeBlockGrowingAgeProgression(final net.minecraft.util.RandomSource random, final int modifier) {
         final double modifierScaled = modifier / 100.0D;
         final int baseGrowth = (int) modifierScaled;
         final double chanceOfDoubleGrowth = modifierScaled - baseGrowth;


### PR DESCRIPTION
Post-softspoon version of https://github.com/PaperMC/Paper/pull/8564
Resolves: https://github.com/PaperMC/Paper/issues/8544

Spigots implementation of the growth modifier boils down to a plain chance for a plant to either grow immediately or to grow a single age value towards its fully grown age.

This behaviour is specifically troubling for plants like the cactus or the sugar cane, as they change an unrelated block when growing up (the free air block above their tip). This blocks validity is checked during neighbour updated which are triggered by resetting the previous tip of the plant back to [age=0].

With spigots modifier implementation, blocks at the age of zero are able to grow a new block above them however, causing the block change of the previous tip to change a block of age zero to a block of age zero, which does not cause a neighbour update as nothing actually changed. This means that the about block is not updated and hence may remain in an otherwise invalid state. (E.g. a cactus block next to a solid block).

This commit rewrites the existing spigot growth modifier implementation specifically for the plants that grow new blocks like the cactus or the sugar can block.

The modifier provided for the plants is separated into two distinct values. One being the remains after a floored division by 100, e.g. the original modifier without its 10^0 and 10^1 digits, the other the modifier modulo 100.
The modifier 475 would, for example, be split into a base growth of 4 and a percentage chance of an additional age progression of 75%. This way, on average, the plant would grow 4.75 times as fast as a normal plant, which would only grow a single age per random tick.