### PR TITLE
Make advancement ordering logical and consistent.

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/PlayerAdvancements.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/PlayerAdvancements.java.patch
@@ -67,3 +67,36 @@
                      }
                  });
              }
+@@ -246,25 +_,25 @@
+ 
+     public void flushDirty(ServerPlayer serverPlayer) {
+         if (this.isFirstPacket || !this.rootsToUpdate.isEmpty() || !this.progressChanged.isEmpty()) {
+-            Map<ResourceLocation, AdvancementProgress> map = new HashMap<>();
+-            Set<AdvancementHolder> set = new HashSet<>();
+-            Set<ResourceLocation> set1 = new HashSet<>();
++            Map<ResourceLocation, AdvancementProgress> progress = new HashMap<>();
++            Set<AdvancementHolder> added = new java.util.TreeSet<>(java.util.Comparator.comparing(AdvancementHolder::toString)); // Paper - Changed from HashSet to TreeSet ordered alphabetically.
++            Set<ResourceLocation> removed = new HashSet<>();
+ 
+             for (AdvancementNode advancementNode : this.rootsToUpdate) {
+-                this.updateTreeVisibility(advancementNode, set, set1);
++                this.updateTreeVisibility(advancementNode, added, removed);
+             }
+ 
+             this.rootsToUpdate.clear();
+ 
+             for (AdvancementHolder advancementHolder : this.progressChanged) {
+                 if (this.visible.contains(advancementHolder)) {
+-                    map.put(advancementHolder.id(), this.progress.get(advancementHolder));
++                    progress.put(advancementHolder.id(), this.progress.get(advancementHolder));
+                 }
+             }
+ 
+             this.progressChanged.clear();
+-            if (!map.isEmpty() || !set.isEmpty() || !set1.isEmpty()) {
+-                serverPlayer.connection.send(new ClientboundUpdateAdvancementsPacket(this.isFirstPacket, set, set1, map));
++            if (!progress.isEmpty() || !added.isEmpty() || !removed.isEmpty()) {
++                serverPlayer.connection.send(new ClientboundUpdateAdvancementsPacket(this.isFirstPacket, added, removed, progress));
+             }
+         }
+ 


### PR DESCRIPTION
When clients are sent packets about advancements, those advancements are stored in a HashMap. This makes the order in which those entries are read essentially random.

By switching to a TreeMap, which orders based upon the advancement namespacedkey, it ensures that tabs from the same namespace are grouped together, and that within a namespace, the tabs are alphabetical.

The client appears to read advancement data in the order that it is written to the packet. So by changing the order, the client will read the alphabetised order and display them accordingly.

## Existing code

Testing with two datapacks which add more advancements.

![image](https://github.com/user-attachments/assets/9c9ff260-17db-4d7f-a56e-e1a52c2df185)

The order of the tabs here is:

1. `diamond:building/root`
2. `diamond:husbandry/root`
3. `diamond:homestead/root`
4. `diamond:end/root`
5. `diamond:completionist/root`
6. `item_catalogue_page_8:root`
7. `item_catalogue_page_9:root`
8. `item_catalogue_page_6:root`
9. `item_catalogue_page_7:root`
10. `item_catalogue_page_4:root`
11. `item_catalogue_page_5:root`
12. `diamond:adventure/root`
13. `item_catalogue_page_2:root`
14. `item_catalogue_page_3:root`
15. `item_catalogue_page_1:root`
16. `diamond:story/root`
17. `diamond:enchanting/root`
18. `diamond:redstone/root`
19. `diamond:aquatic/root`
20. `diamond:nether/root`

## With Fix

![image](https://github.com/user-attachments/assets/99f32d0c-280e-469c-8b6d-3d0db2bc34bb)

1. `diamond:adventure/root`
2. `diamond:aquatic/root`
3. `diamond:building/root`
4. `diamond:completionist/root`
5. `diamond:enchanting/root`
6. `diamond:end/root`
7. `diamond:homestead/root`
8. `diamond:husbandry/root`
9. `diamond:nether/root`
10. `diamond:redstone/root`
11. `diamond:story/root`
12. `item_catalogue_page_1:root`
13. `item_catalogue_page_2:root`
14. `item_catalogue_page_3:root`
15. `item_catalogue_page_4:root`
16. `item_catalogue_page_5:root`
17. `item_catalogue_page_6:root`
18. `item_catalogue_page_7:root`
19. `item_catalogue_page_8:root`
20. `item_catalogue_page_9:root`