### PR TITLE
Fix unnecessary map data saves (#12295)

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java.patch
@@ -96,6 +96,20 @@
      }
  
      public static void addTargetDecoration(ItemStack stack, BlockPos pos, String type, Holder<MapDecorationType> mapDecorationType) {
+@@ -354,7 +_,12 @@
+     }
+ 
+     public void setColorsDirty(int x, int z) {
+-        this.setDirty();
++    // Paper start - Fix unnecessary map data saves
++        this.setColorsDirty(x, z, true);
++    }
++    public void setColorsDirty(int x, int z, boolean markFileDirty) {
++        if (markFileDirty) this.setDirty();
++    // Paper end - Fix unnecessary map data saves
+ 
+         for (MapItemSavedData.HoldingPlayer holdingPlayer : this.carriedBy) {
+             holdingPlayer.markColorsDirty(x, z);
 @@ -395,7 +_,7 @@
                  return true;
              }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/map/CraftMapCanvas.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/map/CraftMapCanvas.java
@@ -64,7 +64,7 @@ public class CraftMapCanvas implements MapCanvas {
             return;
         if (this.buffer[y * 128 + x] != color) {
             this.buffer[y * 128 + x] = color;
-            this.mapView.worldMap.setColorsDirty(x, y);
+            this.mapView.worldMap.setColorsDirty(x, y, false); // Paper - Fix unnecessary map data saves
         }
     }
 
@@ -141,8 +141,8 @@ public class CraftMapCanvas implements MapCanvas {
         }
 
         // Mark all colors within the image as dirty
-        this.mapView.worldMap.setColorsDirty(destX, destY);
-        this.mapView.worldMap.setColorsDirty(destX + effectiveWidth - 1, destY + effectiveHeight - 1);
+        this.mapView.worldMap.setColorsDirty(destX, destY, false);
+        this.mapView.worldMap.setColorsDirty(destX + effectiveWidth - 1, destY + effectiveHeight - 1, false);
         // Paper end
     }
 


### PR DESCRIPTION
Fixes #12295 

Currently, MapCanvas API unnecessarily causes map data file to save.

The API calls `this.mapView.worldMap.setColorsDirty()` to mark colors dirty for players, however this has the side-effect of saving the map .dat files as well:
```java
public void setColorsDirty(int x, int z) {
    this.setDirty(); // This saves the data file! 

    for (MapItemSavedData.HoldingPlayer holdingPlayer : this.carriedBy) {
        holdingPlayer.markColorsDirty(x, z); // This is what the API wants to do!
    }
}
```

This causes unnecessary lag during world saves, which scales with the amount of maps handled with API since last save. On servers that heavily rely on imageonmap-like plugins, it can cause lag spikes of dozens of seconds.

This PR changes this method to add a boolean argument to the method that determines whether the file is saved or not, which is used by the API. An overload is added for compatibility, and for vanilla.