### PR TITLE
Skull - get/set customName

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -605,6 +605,7 @@ public net.minecraft.world.level.block.entity.SculkSensorBlockEntity lastVibrati
 public net.minecraft.world.level.block.entity.SculkShriekerBlockEntity warningLevel
 public net.minecraft.world.level.block.entity.ShulkerBoxBlockEntity openCount
 public net.minecraft.world.level.block.entity.SignBlockEntity playerWhoMayEdit
+public net.minecraft.world.level.block.entity.SkullBlockEntity customName
 public net.minecraft.world.level.block.entity.SkullBlockEntity noteBlockSound
 public net.minecraft.world.level.block.entity.SkullBlockEntity owner
 public net.minecraft.world.level.block.entity.StructureBlockEntity author

--- a/paper-api/src/main/java/org/bukkit/block/Skull.java
+++ b/paper-api/src/main/java/org/bukkit/block/Skull.java
@@ -1,5 +1,6 @@
 package org.bukkit.block;
 
+import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
@@ -168,4 +169,20 @@ public interface Skull extends TileState {
     @Deprecated(since = "1.13")
     @Contract("_ -> fail")
     public void setSkullType(SkullType skullType);
+
+    /**
+     * Get the custom name of skull.
+     * <p>This name is set when placing a skull item that has a custom name.</p>
+     *
+     * @return Custom name of skull
+     */
+    public @Nullable Component customName();
+
+    /**
+     * Set the custom name of skull.
+     * <p>This name is set when placing a skull item that has a custom name.</p>
+     *
+     * @param customName Custom name of skull
+     */
+    public void customName(@Nullable Component customName);
 }

--- a/paper-api/src/main/java/org/bukkit/block/Skull.java
+++ b/paper-api/src/main/java/org/bukkit/block/Skull.java
@@ -172,7 +172,9 @@ public interface Skull extends TileState {
 
     /**
      * Get the custom name of skull.
-     * <p>This name is set when placing a skull item that has a custom name.</p>
+     * <p>This name is set when placing a skull item that has a custom name.
+     * This name is only carried back to the item when broken for player heads
+     * (skeleton/creeper heads will not retain the name).</p>
      *
      * @return Custom name of skull
      */
@@ -180,7 +182,9 @@ public interface Skull extends TileState {
 
     /**
      * Set the custom name of skull.
-     * <p>This name is set when placing a skull item that has a custom name.</p>
+     * <p>This name is set when placing a skull item that has a custom name.
+     * This name is only carried back to the item when broken for player heads
+     * (skeleton/creeper heads will not retain the name).</p>
      *
      * @param customName Custom name of skull
      */

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
@@ -2,6 +2,8 @@ package org.bukkit.craftbukkit.block;
 
 import com.google.common.base.Preconditions;
 import com.mojang.authlib.GameProfile;
+import io.papermc.paper.adventure.PaperAdventure;
+import net.kyori.adventure.text.Component;
 import net.minecraft.Util;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
@@ -28,6 +30,7 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
 
     private static final int MAX_OWNER_LENGTH = 16;
     private ResolvableProfile profile;
+    private Component customName;
 
     public CraftSkull(World world, SkullBlockEntity tileEntity) {
         super(world, tileEntity);
@@ -45,6 +48,7 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
         if (owner != null) {
             this.profile = owner;
         }
+        this.customName = PaperAdventure.asAdventure(skull.customName);
     }
 
     @Override
@@ -205,6 +209,7 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
         if (this.getSkullType() == SkullType.PLAYER) {
             skull.setOwner(this.hasOwner() ? this.profile : null);
         }
+        skull.customName = PaperAdventure.asVanilla(customName);
     }
 
     @Override
@@ -215,5 +220,15 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
     @Override
     public CraftSkull copy(Location location) {
         return new CraftSkull(this, location);
+    }
+
+    @Override
+    public @Nullable Component customName() {
+        return this.customName;
+    }
+
+    @Override
+    public void customName(@Nullable Component customName) {
+        this.customName = customName;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
@@ -30,7 +30,6 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
 
     private static final int MAX_OWNER_LENGTH = 16;
     private ResolvableProfile profile;
-    private Component customName;
 
     public CraftSkull(World world, SkullBlockEntity tileEntity) {
         super(world, tileEntity);
@@ -48,7 +47,6 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
         if (owner != null) {
             this.profile = owner;
         }
-        this.customName = PaperAdventure.asAdventure(skull.customName);
     }
 
     @Override
@@ -209,7 +207,6 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
         if (this.getSkullType() == SkullType.PLAYER) {
             skull.setOwner(this.hasOwner() ? this.profile : null);
         }
-        skull.customName = PaperAdventure.asVanilla(customName);
     }
 
     @Override
@@ -224,11 +221,13 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
 
     @Override
     public @Nullable Component customName() {
-        return this.customName;
+        SkullBlockEntity snapshot = getSnapshot();
+        return snapshot.customName == null ? null : PaperAdventure.asAdventure(snapshot.customName);
     }
 
     @Override
     public void customName(@Nullable Component customName) {
-        this.customName = customName;
+        SkullBlockEntity snapshot = getSnapshot();
+        snapshot.customName = customName == null ? null : PaperAdventure.asVanilla(customName);
     }
 }


### PR DESCRIPTION
This PR aims to add a getter/setter for the custom name of a Skull (tile entity) block.
I believe Minecraft added this fairly recently?

We were talking about this over at [Skript](https://github.com/SkriptLang/Skript/issues/6826) recently, and realized Paper didn't have API for this. 

I've never touched BlockState stuff with CraftBukkit before, so I'm hoping I did this correctly.
I was basically going off how the profile was done.... 🤞 