### PR TITLE
Fix handling of resultant crafting container from craftItemResult

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -1722,29 +1722,26 @@ public final class CraftServer implements Server {
         final CraftingInput.Positioned positionedCraftInput = inventoryCrafting.asPositionedCraftInput();
         final CraftingInput craftingInput = positionedCraftInput.input();
         recipe.map((holder) -> holder.value().getRemainingItems(craftingInput)).ifPresent((remainingItems) -> {
-
-
-            System.out.println(remainingItems.stream().map(Object::toString).toList());
             // Set the resulting matrix items and overflow items
-            for (int h = 0; h < craftingInput.height(); h++) {
-                for (int w = 0; w < craftingInput.width(); w++) {
-                    final int inventorySlot = w + positionedCraftInput.left() + (h + positionedCraftInput.top()) * inventoryCrafting.getWidth();
-                    net.minecraft.world.item.ItemStack itemstack1 = inventoryCrafting.getItem(inventorySlot);
-                    net.minecraft.world.item.ItemStack itemstack2 = remainingItems.get(w + h * craftingInput.width());
+            for (int height = 0; height < craftingInput.height(); height++) {
+                for (int width = 0; width < craftingInput.width(); width++) {
+                    final int inventorySlot = width + positionedCraftInput.left() + (height + positionedCraftInput.top()) * inventoryCrafting.getWidth();
+                    net.minecraft.world.item.ItemStack itemInMenu = inventoryCrafting.getItem(inventorySlot);
+                    net.minecraft.world.item.ItemStack remainingItem = remainingItems.get(width + height * craftingInput.width());
 
-                    if (!itemstack1.isEmpty()) {
+                    if (!itemInMenu.isEmpty()) {
                         inventoryCrafting.removeItem(inventorySlot, 1);
-                        itemstack1 = inventoryCrafting.getItem(inventorySlot);
+                        itemInMenu = inventoryCrafting.getItem(inventorySlot);
                     }
 
-                    if (!itemstack2.isEmpty()) {
-                        if (itemstack1.isEmpty()) {
-                            inventoryCrafting.setItem(inventorySlot, itemstack2);
-                        } else if (net.minecraft.world.item.ItemStack.isSameItemSameComponents(itemstack1, itemstack2)) {
-                            itemstack2.grow(itemstack1.getCount());
-                            inventoryCrafting.setItem(inventorySlot, itemstack2);
+                    if (!remainingItem.isEmpty()) {
+                        if (itemInMenu.isEmpty()) {
+                            inventoryCrafting.setItem(inventorySlot, remainingItem);
+                        } else if (net.minecraft.world.item.ItemStack.isSameItemSameComponents(itemInMenu, remainingItem)) {
+                            remainingItem.grow(itemInMenu.getCount());
+                            inventoryCrafting.setItem(inventorySlot, remainingItem);
                         } else {
-                            craftItemResult.getOverflowItems().add(CraftItemStack.asBukkitCopy(itemstack2));
+                            craftItemResult.getOverflowItems().add(CraftItemStack.asBukkitCopy(remainingItem));
                         }
                     }
                 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -87,6 +87,7 @@ import net.minecraft.world.inventory.ResultContainer;
 import net.minecraft.world.inventory.TransientCraftingContainer;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.MapItem;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -1717,25 +1718,34 @@ public final class CraftServer implements Server {
 
     private CraftItemCraftResult createItemCraftResult(Optional<RecipeHolder<CraftingRecipe>> recipe, ItemStack itemStack, CraftingContainer inventoryCrafting) {
         CraftItemCraftResult craftItemResult = new CraftItemCraftResult(itemStack);
-        recipe.map((holder) -> holder.value().getRemainingItems(inventoryCrafting.asCraftInput())).ifPresent((remainingItems) -> {
+        // tl;dr: this is an API adopted implementation of ResultSlot#onTake
+        final CraftingInput.Positioned positionedCraftInput = inventoryCrafting.asPositionedCraftInput();
+        final CraftingInput craftingInput = positionedCraftInput.input();
+        recipe.map((holder) -> holder.value().getRemainingItems(craftingInput)).ifPresent((remainingItems) -> {
+
+
+            System.out.println(remainingItems.stream().map(Object::toString).toList());
             // Set the resulting matrix items and overflow items
-            for (int i = 0; i < remainingItems.size(); ++i) {
-                net.minecraft.world.item.ItemStack itemstack1 = inventoryCrafting.getItem(i);
-                net.minecraft.world.item.ItemStack itemstack2 = remainingItems.get(i);
+            for (int h = 0; h < craftingInput.height(); h++) {
+                for (int w = 0; w < craftingInput.width(); w++) {
+                    final int inventorySlot = w + positionedCraftInput.left() + (h + positionedCraftInput.top()) * inventoryCrafting.getWidth();
+                    net.minecraft.world.item.ItemStack itemstack1 = inventoryCrafting.getItem(inventorySlot);
+                    net.minecraft.world.item.ItemStack itemstack2 = remainingItems.get(w + h * craftingInput.width());
 
-                if (!itemstack1.isEmpty()) {
-                    inventoryCrafting.removeItem(i, 1);
-                    itemstack1 = inventoryCrafting.getItem(i);
-                }
+                    if (!itemstack1.isEmpty()) {
+                        inventoryCrafting.removeItem(inventorySlot, 1);
+                        itemstack1 = inventoryCrafting.getItem(inventorySlot);
+                    }
 
-                if (!itemstack2.isEmpty()) {
-                    if (itemstack1.isEmpty()) {
-                        inventoryCrafting.setItem(i, itemstack2);
-                    } else if (net.minecraft.world.item.ItemStack.isSameItemSameComponents(itemstack1, itemstack2)) {
-                        itemstack2.grow(itemstack1.getCount());
-                        inventoryCrafting.setItem(i, itemstack2);
-                    } else {
-                        craftItemResult.getOverflowItems().add(CraftItemStack.asBukkitCopy(itemstack2));
+                    if (!itemstack2.isEmpty()) {
+                        if (itemstack1.isEmpty()) {
+                            inventoryCrafting.setItem(inventorySlot, itemstack2);
+                        } else if (net.minecraft.world.item.ItemStack.isSameItemSameComponents(itemstack1, itemstack2)) {
+                            itemstack2.grow(itemstack1.getCount());
+                            inventoryCrafting.setItem(inventorySlot, itemstack2);
+                        } else {
+                            craftItemResult.getOverflowItems().add(CraftItemStack.asBukkitCopy(itemstack2));
+                        }
                     }
                 }
             }

--- a/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
+++ b/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
@@ -1,14 +1,53 @@
 package io.papermc.testplugin;
 
+import io.papermc.paper.command.brigadier.Commands;
+import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
+import net.kyori.adventure.text.Component;
+import org.apache.logging.log4j.util.Strings;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemCraftResult;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
+import java.util.Arrays;
 
 public final class TestPlugin extends JavaPlugin implements Listener {
 
     @Override
     public void onEnable() {
         this.getServer().getPluginManager().registerEvents(this, this);
-
+        Bukkit.getLogger().info("TestPlugin enabled");
         // io.papermc.testplugin.brigtests.Registration.registerViaOnEnable(this);
+
+        this.getLifecycleManager().registerEventHandler(
+            LifecycleEvents.COMMANDS.newHandler((handler) -> {
+                handler.registrar().register(Commands.literal("testcraft").executes(context -> {
+                    if (context.getSource().getSender() instanceof Player player) {
+                        ItemStack bottle = ItemStack.of(Material.HONEY_BOTTLE);
+                        ItemStack air = ItemStack.empty();
+
+                        ItemStack[] craftingGrid = {
+                            air.clone(), bottle.clone(), bottle.clone(),
+                            air.clone(), bottle.clone(), bottle.clone(),
+                            air.clone(),    air.clone(),    air.clone()
+                        };
+
+                        ItemCraftResult result = Bukkit.craftItemResult(
+                            craftingGrid,
+                            player.getWorld(),
+                            player
+                        );
+                        ItemStack[] resultingMatrix = result.getResultingMatrix();
+                        player.sendMessage(Component.text(Arrays.toString(resultingMatrix)));
+                    }
+                    return 1;
+                }).build());
+            })
+        );
+
+
+
     }
 }

--- a/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
+++ b/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
@@ -1,53 +1,14 @@
 package io.papermc.testplugin;
 
-import io.papermc.paper.command.brigadier.Commands;
-import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import net.kyori.adventure.text.Component;
-import org.apache.logging.log4j.util.Strings;
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
-import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
-import org.bukkit.inventory.ItemCraftResult;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
-import java.util.Arrays;
 
 public final class TestPlugin extends JavaPlugin implements Listener {
 
     @Override
     public void onEnable() {
         this.getServer().getPluginManager().registerEvents(this, this);
-        Bukkit.getLogger().info("TestPlugin enabled");
+
         // io.papermc.testplugin.brigtests.Registration.registerViaOnEnable(this);
-
-        this.getLifecycleManager().registerEventHandler(
-            LifecycleEvents.COMMANDS.newHandler((handler) -> {
-                handler.registrar().register(Commands.literal("testcraft").executes(context -> {
-                    if (context.getSource().getSender() instanceof Player player) {
-                        ItemStack bottle = ItemStack.of(Material.HONEY_BOTTLE);
-                        ItemStack air = ItemStack.empty();
-
-                        ItemStack[] craftingGrid = {
-                            air.clone(), bottle.clone(), bottle.clone(),
-                            air.clone(), bottle.clone(), bottle.clone(),
-                            air.clone(),    air.clone(),    air.clone()
-                        };
-
-                        ItemCraftResult result = Bukkit.craftItemResult(
-                            craftingGrid,
-                            player.getWorld(),
-                            player
-                        );
-                        ItemStack[] resultingMatrix = result.getResultingMatrix();
-                        player.sendMessage(Component.text(Arrays.toString(resultingMatrix)));
-                    }
-                    return 1;
-                }).build());
-            })
-        );
-
-
-
     }
 }


### PR DESCRIPTION
The result object of overhanging items is based upon a derived view
of the provided crafting slots, meaning that we need to consider this
when handing back the resultant slots
