### PR TITLE
Pass correct draw strength for EntityShootBowEvent

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
@@ -48,7 +48,7 @@
          double squareRoot = Math.sqrt(d * d + d2 * d2);
          if (this.level() instanceof ServerLevel serverLevel) {
 +            // CraftBukkit start
-+            org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(this, this.getMainHandItem(), arrow.getPickupItem(), arrow, net.minecraft.world.InteractionHand.MAIN_HAND, 0.8F, true); // Paper - improve entity shoot bow event, add arrow stack to event
++            org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(this, this.getMainHandItem(), arrow.getPickupItem(), arrow, net.minecraft.world.InteractionHand.MAIN_HAND, distanceFactor, true); // Paper - improve entity shoot bow event, add arrow stack to event
 +            if (event.isCancelled()) {
 +                event.getProjectile().remove();
 +                return;

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/Illusioner.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/Illusioner.java.patch
@@ -5,7 +5,7 @@
          double squareRoot = Math.sqrt(d * d + d2 * d2);
          if (this.level() instanceof ServerLevel serverLevel) {
 +            // Paper start - EntityShootBowEvent
-+            org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(this, this.getMainHandItem(), mobArrow.getPickupItem(), mobArrow, target.getUsedItemHand(), 0.8F, true);
++            org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(this, this.getMainHandItem(), mobArrow.getPickupItem(), mobArrow, target.getUsedItemHand(), distanceFactor, true);
 +            if (event.isCancelled()) {
 +                event.getProjectile().remove();
 +                return;

--- a/paper-server/patches/sources/net/minecraft/world/item/BowItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/BowItem.java.patch
@@ -5,7 +5,7 @@
                      List<ItemStack> list = draw(stack, projectile, player);
                      if (level instanceof ServerLevel serverLevel && !list.isEmpty()) {
 -                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, powerForTime * 3.0F, 1.0F, powerForTime == 1.0F, null);
-+                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, 1.0F, powerForTime * 3.0F,powerForTime == 1.0F, null, powerForTime); // Paper - Pass draw strength
++                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, powerForTime * 3.0F, 1.0F, powerForTime == 1.0F, null, powerForTime); // Paper - Pass draw strength
                      }
  
                      level.playSound(

--- a/paper-server/patches/sources/net/minecraft/world/item/BowItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/BowItem.java.patch
@@ -5,7 +5,7 @@
                      List<ItemStack> list = draw(stack, projectile, player);
                      if (level instanceof ServerLevel serverLevel && !list.isEmpty()) {
 -                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, powerForTime * 3.0F, 1.0F, powerForTime == 1.0F, null);
-+                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, powerForTime, powerForTime * 3.0F, 1.0F, powerForTime == 1.0F, null); // Paper
++                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, powerForTime, powerForTime * 3.0F,powerForTime == 1.0F, null, 1.0F); // Paper - Pass draw strength
                      }
  
                      level.playSound(

--- a/paper-server/patches/sources/net/minecraft/world/item/BowItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/BowItem.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/item/BowItem.java
++++ b/net/minecraft/world/item/BowItem.java
+@@ -38,7 +_,7 @@
+                 } else {
+                     List<ItemStack> list = draw(stack, projectile, player);
+                     if (level instanceof ServerLevel serverLevel && !list.isEmpty()) {
+-                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, powerForTime * 3.0F, 1.0F, powerForTime == 1.0F, null);
++                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, powerForTime, powerForTime * 3.0F, 1.0F, powerForTime == 1.0F, null);
+                     }
+ 
+                     level.playSound(

--- a/paper-server/patches/sources/net/minecraft/world/item/BowItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/BowItem.java.patch
@@ -5,7 +5,7 @@
                      List<ItemStack> list = draw(stack, projectile, player);
                      if (level instanceof ServerLevel serverLevel && !list.isEmpty()) {
 -                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, powerForTime * 3.0F, 1.0F, powerForTime == 1.0F, null);
-+                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, powerForTime, powerForTime * 3.0F, 1.0F, powerForTime == 1.0F, null);
++                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, powerForTime, powerForTime * 3.0F, 1.0F, powerForTime == 1.0F, null); // Paper
                      }
  
                      level.playSound(

--- a/paper-server/patches/sources/net/minecraft/world/item/BowItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/BowItem.java.patch
@@ -5,7 +5,7 @@
                      List<ItemStack> list = draw(stack, projectile, player);
                      if (level instanceof ServerLevel serverLevel && !list.isEmpty()) {
 -                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, powerForTime * 3.0F, 1.0F, powerForTime == 1.0F, null);
-+                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, powerForTime, powerForTime * 3.0F,powerForTime == 1.0F, null, 1.0F); // Paper - Pass draw strength
++                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, 1.0F, powerForTime * 3.0F,powerForTime == 1.0F, null, powerForTime); // Paper - Pass draw strength
                      }
  
                      level.playSound(

--- a/paper-server/patches/sources/net/minecraft/world/item/CrossbowItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/CrossbowItem.java.patch
@@ -30,6 +30,15 @@
          } else {
              Projectile projectile = super.createProjectile(level, shooter, weapon, ammo, isCrit);
              if (projectile instanceof AbstractArrow abstractArrow) {
+@@ -163,7 +_,7 @@
+         if (level instanceof ServerLevel serverLevel) {
+             ChargedProjectiles chargedProjectiles = weapon.set(DataComponents.CHARGED_PROJECTILES, ChargedProjectiles.EMPTY);
+             if (chargedProjectiles != null && !chargedProjectiles.isEmpty()) {
+-                this.shoot(serverLevel, shooter, hand, weapon, chargedProjectiles.getItems(), velocity, inaccuracy, shooter instanceof Player, target);
++                this.shoot(serverLevel, shooter, hand, weapon, chargedProjectiles.getItems(), 1, velocity, inaccuracy, shooter instanceof Player, target);
+                 if (shooter instanceof ServerPlayer serverPlayer) {
+                     CriteriaTriggers.SHOT_CROSSBOW.trigger(serverPlayer, weapon);
+                     serverPlayer.awardStat(Stats.ITEM_USED.get(weapon.getItem()));
 @@ -211,7 +_,14 @@
                      );
              }

--- a/paper-server/patches/sources/net/minecraft/world/item/CrossbowItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/CrossbowItem.java.patch
@@ -35,7 +35,7 @@
              ChargedProjectiles chargedProjectiles = weapon.set(DataComponents.CHARGED_PROJECTILES, ChargedProjectiles.EMPTY);
              if (chargedProjectiles != null && !chargedProjectiles.isEmpty()) {
 -                this.shoot(serverLevel, shooter, hand, weapon, chargedProjectiles.getItems(), velocity, inaccuracy, shooter instanceof Player, target);
-+                this.shoot(serverLevel, shooter, hand, weapon, chargedProjectiles.getItems(), 1, velocity, inaccuracy, shooter instanceof Player, target); // Paper
++                this.shoot(serverLevel, shooter, hand, weapon, chargedProjectiles.getItems(), velocity, inaccuracy, shooter instanceof Player, target, 1); // Paper - Pass draw strength
                  if (shooter instanceof ServerPlayer serverPlayer) {
                      CriteriaTriggers.SHOT_CROSSBOW.trigger(serverPlayer, weapon);
                      serverPlayer.awardStat(Stats.ITEM_USED.get(weapon.getItem()));

--- a/paper-server/patches/sources/net/minecraft/world/item/CrossbowItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/CrossbowItem.java.patch
@@ -35,7 +35,7 @@
              ChargedProjectiles chargedProjectiles = weapon.set(DataComponents.CHARGED_PROJECTILES, ChargedProjectiles.EMPTY);
              if (chargedProjectiles != null && !chargedProjectiles.isEmpty()) {
 -                this.shoot(serverLevel, shooter, hand, weapon, chargedProjectiles.getItems(), velocity, inaccuracy, shooter instanceof Player, target);
-+                this.shoot(serverLevel, shooter, hand, weapon, chargedProjectiles.getItems(), 1, velocity, inaccuracy, shooter instanceof Player, target);
++                this.shoot(serverLevel, shooter, hand, weapon, chargedProjectiles.getItems(), 1, velocity, inaccuracy, shooter instanceof Player, target); // Paper
                  if (shooter instanceof ServerPlayer serverPlayer) {
                      CriteriaTriggers.SHOT_CROSSBOW.trigger(serverPlayer, weapon);
                      serverPlayer.awardStat(Stats.ITEM_USED.get(weapon.getItem()));

--- a/paper-server/patches/sources/net/minecraft/world/item/ProjectileWeaponItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/ProjectileWeaponItem.java.patch
@@ -1,13 +1,13 @@
 --- a/net/minecraft/world/item/ProjectileWeaponItem.java
 +++ b/net/minecraft/world/item/ProjectileWeaponItem.java
-@@ -46,6 +_,7 @@
-         InteractionHand hand,
-         ItemStack weapon,
-         List<ItemStack> projectileItems,
-+        float drawStrength,
-         float velocity,
+@@ -50,6 +_,7 @@
          float inaccuracy,
          boolean isCrit,
+         @Nullable LivingEntity target
++        ,float drawStrength // Paper
+     ) {
+         float f = EnchantmentHelper.processProjectileSpread(level, weapon, shooter, 0.0F);
+         float f1 = projectileItems.size() == 1 ? 0.0F : 2.0F * f / (projectileItems.size() - 1);
 @@ -62,12 +_,29 @@
                  float f4 = f2 + f3 * ((i + 1) / 2) * f1;
                  f3 = -f3;

--- a/paper-server/patches/sources/net/minecraft/world/item/ProjectileWeaponItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/ProjectileWeaponItem.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/world/item/ProjectileWeaponItem.java
 +++ b/net/minecraft/world/item/ProjectileWeaponItem.java
+@@ -46,6 +_,7 @@
+         InteractionHand hand,
+         ItemStack weapon,
+         List<ItemStack> projectileItems,
++        float drawStrength,
+         float velocity,
+         float inaccuracy,
+         boolean isCrit,
 @@ -62,12 +_,29 @@
                  float f4 = f2 + f3 * ((i + 1) / 2) * f1;
                  f3 = -f3;
@@ -14,7 +22,7 @@
 +                Projectile projectile = this.createProjectile(level, shooter, weapon, itemStack, isCrit);
 +                this.shootProjectile(shooter, projectile, i1, velocity, inaccuracy, f4, target);
 +
-+                org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(shooter, weapon, itemStack, projectile, hand, velocity, true);
++                org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(shooter, weapon, itemStack, projectile, hand, drawStrength, true);
 +                if (event.isCancelled()) {
 +                    event.getProjectile().remove();
 +                    return;

--- a/paper-server/patches/sources/net/minecraft/world/item/ProjectileWeaponItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/ProjectileWeaponItem.java.patch
@@ -4,7 +4,7 @@
          float inaccuracy,
          boolean isCrit,
          @Nullable LivingEntity target
-+        ,float drawStrength // Paper
++        ,float drawStrength // Paper - Pass draw strength
      ) {
          float f = EnchantmentHelper.processProjectileSpread(level, weapon, shooter, 0.0F);
          float f1 = projectileItems.size() == 1 ? 0.0F : 2.0F * f / (projectileItems.size() - 1);


### PR DESCRIPTION
Fixes #10640.

After testing, the broken behavior started in 1.20.5. In 1.20.4, `EntityShootBowEvent#getForce` worked as expected, returning a draw strength of `[0, 1]` for bows, and `1` for crossbows.

Additionally, a constant `0.8` was passed for force in `AbstractSkeleton#performRangedAttack` and `Illusioner#performRangedAttack`. After checking `RangedBowAttackGoal`, which calls the method with:

```java
this.mob.performRangedAttack(target, BowItem.getPowerForTime(ticksUsingItem));
```

Which prompted changing it to passing the `distanceFactor` parameter as the force.