### PR TITLE
FishHook - add method to retrieve

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/FishHook.java
+++ b/paper-api/src/main/java/org/bukkit/entity/FishHook.java
@@ -377,5 +377,5 @@ public interface FishHook extends Projectile {
      * @param itemStack The fishing rod item currently cast out
      * @return The amount of damage which would be applied to the itemstack
      */
-    int retrieve(EquipmentSlot slot, ItemStack itemStack);
+    int retrieve(@NotNull EquipmentSlot slot, @NotNull ItemStack itemStack);
 }

--- a/paper-api/src/main/java/org/bukkit/entity/FishHook.java
+++ b/paper-api/src/main/java/org/bukkit/entity/FishHook.java
@@ -1,5 +1,7 @@
 package org.bukkit.entity;
 
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -323,7 +325,6 @@ public interface FishHook extends Projectile {
         BOBBING;
     }
 
-    // Paper start - More FishHook API
     /**
      * Get the number of ticks the hook needs to wait for a fish to bite.
      *
@@ -367,5 +368,14 @@ public interface FishHook extends Projectile {
      * enchantment.
      */
     void resetFishingState();
-    // Paper end
+
+    /**
+     * Retrieve this fishhook back to the casting player.
+     * <p>This will act the same as if the player manually reels in their fishhook.</p>
+     *
+     * @param slot Slot holding the fishing rod (must be HAND/OFF_HAND)
+     * @param itemStack The fishing rod item currently cast out
+     * @return The amount of damage which would be applied to the itemstack
+     */
+    int retrieve(EquipmentSlot slot, ItemStack itemStack);
 }

--- a/paper-api/src/main/java/org/bukkit/entity/FishHook.java
+++ b/paper-api/src/main/java/org/bukkit/entity/FishHook.java
@@ -1,7 +1,6 @@
 package org.bukkit.entity;
 
 import org.bukkit.inventory.EquipmentSlot;
-import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/paper-api/src/main/java/org/bukkit/entity/FishHook.java
+++ b/paper-api/src/main/java/org/bukkit/entity/FishHook.java
@@ -371,7 +371,7 @@ public interface FishHook extends Projectile {
     /**
      * Retrieve this fishhook back to the casting player.
      * <p>
-     * This method will trigger all normal bukkit events, which are subject to cancellation.
+     * This method will trigger and respect API events, which may be subject to cancellation.
      * Plugins listening to {@link org.bukkit.event.player.PlayerFishEvent} might for example cancel this action.
      *
      * @param slot Slot holding the fishing rod (must be HAND/OFF_HAND)

--- a/paper-api/src/main/java/org/bukkit/entity/FishHook.java
+++ b/paper-api/src/main/java/org/bukkit/entity/FishHook.java
@@ -370,9 +370,15 @@ public interface FishHook extends Projectile {
 
     /**
      * Retrieve this fishhook back to the casting player.
+     * <p>
+     * This method will trigger all normal bukkit events, which are subject to cancellation.
+     * Plugins listening to {@link org.bukkit.event.player.PlayerFishEvent} might for example cancel this action.
      *
      * @param slot Slot holding the fishing rod (must be HAND/OFF_HAND)
      * @return The amount of damage which would be applied to the itemstack
+     * @throws IllegalStateException if the fish hook does not have a player casting it.
+     * @throws IllegalStateException if the player casting it is not holding a
+     *                               {@link org.bukkit.inventory.ItemType#FISHING_ROD} in the specified equipment slot.
      */
     int retrieve(@NotNull EquipmentSlot slot);
 }

--- a/paper-api/src/main/java/org/bukkit/entity/FishHook.java
+++ b/paper-api/src/main/java/org/bukkit/entity/FishHook.java
@@ -374,8 +374,7 @@ public interface FishHook extends Projectile {
      * <p>This will act the same as if the player manually reels in their fishhook.</p>
      *
      * @param slot Slot holding the fishing rod (must be HAND/OFF_HAND)
-     * @param itemStack The fishing rod item currently cast out
      * @return The amount of damage which would be applied to the itemstack
      */
-    int retrieve(@NotNull EquipmentSlot slot, @NotNull ItemStack itemStack);
+    int retrieve(@NotNull EquipmentSlot slot);
 }

--- a/paper-api/src/main/java/org/bukkit/entity/FishHook.java
+++ b/paper-api/src/main/java/org/bukkit/entity/FishHook.java
@@ -371,7 +371,6 @@ public interface FishHook extends Projectile {
 
     /**
      * Retrieve this fishhook back to the casting player.
-     * <p>This will act the same as if the player manually reels in their fishhook.</p>
      *
      * @param slot Slot holding the fishing rod (must be HAND/OFF_HAND)
      * @return The amount of damage which would be applied to the itemstack

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
@@ -241,7 +241,7 @@ public class CraftFishHook extends CraftProjectile implements FishHook {
 
     @Override
     public int retrieve(EquipmentSlot slot, ItemStack itemStack) {
-        Preconditions.checkArgument(slot != null, "Equipment slot cannot be null");
+        Preconditions.checkArgument(slot == EquipmentSlot.HAND || slot == EquipmentSlot.OFF_HAND, "Equipment slot must be HAND or OFF_HAND");
         Preconditions.checkArgument(itemStack != null, "ItemStack cannot be null");
         return getHandle().retrieve(CraftEquipmentSlot.getHand(slot), CraftItemStack.asNMSCopy(itemStack));
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.FishHook;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
 public class CraftFishHook extends CraftProjectile implements FishHook {
     private double biteChance = -1;
@@ -239,7 +240,9 @@ public class CraftFishHook extends CraftProjectile implements FishHook {
     }
 
     @Override
-    public int retrieve(final EquipmentSlot slot, final ItemStack itemStack) {
+    public int retrieve(EquipmentSlot slot, ItemStack itemStack) {
+        Preconditions.checkNotNull(slot, "Equipment slot cannot be null");
+        Preconditions.checkNotNull(itemStack, "ItemStack cannot be null");
         return getHandle().retrieve(CraftEquipmentSlot.getHand(slot), CraftItemStack.asNMSCopy(itemStack));
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
@@ -241,8 +241,8 @@ public class CraftFishHook extends CraftProjectile implements FishHook {
 
     @Override
     public int retrieve(EquipmentSlot slot, ItemStack itemStack) {
-        Preconditions.checkNotNull(slot, "Equipment slot cannot be null");
-        Preconditions.checkNotNull(itemStack, "ItemStack cannot be null");
+        Preconditions.checkArgument(slot != null, "Equipment slot cannot be null");
+        Preconditions.checkArgument(itemStack != null, "ItemStack cannot be null");
         return getHandle().retrieve(CraftEquipmentSlot.getHand(slot), CraftItemStack.asNMSCopy(itemStack));
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
@@ -2,15 +2,16 @@ package org.bukkit.craftbukkit.entity;
 
 import com.google.common.base.Preconditions;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.FishingHook;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import org.bukkit.craftbukkit.CraftEquipmentSlot;
 import org.bukkit.craftbukkit.CraftServer;
-import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.FishHook;
 import org.bukkit.inventory.EquipmentSlot;
-import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
 
 public class CraftFishHook extends CraftProjectile implements FishHook {
     private double biteChance = -1;
@@ -240,9 +241,16 @@ public class CraftFishHook extends CraftProjectile implements FishHook {
     }
 
     @Override
-    public int retrieve(EquipmentSlot slot, ItemStack itemStack) {
+    public int retrieve(EquipmentSlot slot) {
         Preconditions.checkArgument(slot == EquipmentSlot.HAND || slot == EquipmentSlot.OFF_HAND, "Equipment slot must be HAND or OFF_HAND");
-        Preconditions.checkArgument(itemStack != null, "ItemStack cannot be null");
-        return getHandle().retrieve(CraftEquipmentSlot.getHand(slot), CraftItemStack.asNMSCopy(itemStack));
+        FishingHook fishingHook = getHandle();
+        Player playerOwner = fishingHook.getPlayerOwner();
+        Preconditions.checkState(playerOwner != null, "Player owner cannot be null");
+
+        InteractionHand hand = CraftEquipmentSlot.getHand(slot);
+        ItemStack itemInHand = playerOwner.getItemInHand(hand);
+        Preconditions.checkState(itemInHand.is(Items.FISHING_ROD), "Item in slot is not a FISHING_ROD");
+
+        return fishingHook.retrieve(hand, itemInHand);
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
@@ -243,12 +243,12 @@ public class CraftFishHook extends CraftProjectile implements FishHook {
     @Override
     public int retrieve(EquipmentSlot slot) {
         Preconditions.checkArgument(slot == EquipmentSlot.HAND || slot == EquipmentSlot.OFF_HAND, "Equipment slot must be HAND or OFF_HAND");
-        FishingHook fishingHook = getHandle();
-        Player playerOwner = fishingHook.getPlayerOwner();
+        final FishingHook fishingHook = getHandle();
+        final Player playerOwner = fishingHook.getPlayerOwner();
         Preconditions.checkState(playerOwner != null, "Player owner cannot be null");
 
-        InteractionHand hand = CraftEquipmentSlot.getHand(slot);
-        ItemStack itemInHand = playerOwner.getItemInHand(hand);
+        final InteractionHand hand = CraftEquipmentSlot.getHand(slot);
+        final ItemStack itemInHand = playerOwner.getItemInHand(hand);
         Preconditions.checkState(itemInHand.is(Items.FISHING_ROD), "Item in slot is not a FISHING_ROD");
 
         return fishingHook.retrieve(itemInHand, hand);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
@@ -3,9 +3,13 @@ package org.bukkit.craftbukkit.entity;
 import com.google.common.base.Preconditions;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.projectile.FishingHook;
+import org.bukkit.craftbukkit.CraftEquipmentSlot;
 import org.bukkit.craftbukkit.CraftServer;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.FishHook;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
 
 public class CraftFishHook extends CraftProjectile implements FishHook {
     private double biteChance = -1;
@@ -232,5 +236,10 @@ public class CraftFishHook extends CraftProjectile implements FishHook {
         final FishingHook hook = this.getHandle();
         hook.resetTimeUntilLured();
         hook.timeUntilHooked = 0; // Reset time until hooked, will be repopulated once lured time is ticked down.
+    }
+
+    @Override
+    public int retrieve(final EquipmentSlot slot, final ItemStack itemStack) {
+        return getHandle().retrieve(CraftEquipmentSlot.getHand(slot), CraftItemStack.asNMSCopy(itemStack));
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
@@ -251,6 +251,6 @@ public class CraftFishHook extends CraftProjectile implements FishHook {
         ItemStack itemInHand = playerOwner.getItemInHand(hand);
         Preconditions.checkState(itemInHand.is(Items.FISHING_ROD), "Item in slot is not a FISHING_ROD");
 
-        return fishingHook.retrieve(hand, itemInHand);
+        return fishingHook.retrieve(itemInHand, hand);
     }
 }


### PR DESCRIPTION
This PR aims to add a method to retrieve the current fish hook casted by a player.
I've seen this asked for many times, so I think its my time to add this.

Looking for some feedback on a few things:
1) Javadocs = I think I described things well? But always looking for feedback. Especially with the return value
2) Using `CraftItemStack.asNMSCopy()` = I chose this method to prevent actually damaging the original ItemStack, allowing the dev to do the damage themselves, they may or may not want this. 
Opinions here would be appreciated. Should it be a copy? Should it be the original?
Another option could be nixing the ItemStack all together, and internally handle it (grab based on slot chosen), maybe a boolean like `shouldDamage`, where could then decide to use copy/original.
Actually nevermind nixing the itemstack, maybe the dev wants to pass thru some super powerful fishing rod. Ohhh the possibilities.
This could go so many different ways, so feedback would be nice :) 