### PR TITLE
ChunkGenerator - add getHeight to ChunkData

### DIFF
--- a/paper-api/src/main/java/org/bukkit/generator/ChunkGenerator.java
+++ b/paper-api/src/main/java/org/bukkit/generator/ChunkGenerator.java
@@ -14,6 +14,7 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.material.MaterialData;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
 
 /**
  * A chunk generator is responsible for the initial shaping of an entire
@@ -789,6 +790,6 @@ public abstract class ChunkGenerator {
          * @param z the z location in the chunk from 0-15 inclusive
          * @return Y coordinate at highest position
          */
-        public int getHeight(@NotNull HeightMap heightMap, int x, int z);
+        int getHeight(@NotNull HeightMap heightMap, @Range(from = 0L, to = 15L) int x, @Range(from = 0L, to = 15L) int z);
     }
 }

--- a/paper-api/src/main/java/org/bukkit/generator/ChunkGenerator.java
+++ b/paper-api/src/main/java/org/bukkit/generator/ChunkGenerator.java
@@ -779,7 +779,7 @@ public abstract class ChunkGenerator {
         public byte getData(int x, int y, int z);
 
         /**
-         * Get the current of the chunk data.
+         * Get the current height of a position in the chunk data.
          * <p>This will differ based on which state generation of the chunk is currently at.
          * If for example the chunk is in the generate surface stage,
          * this will return what was already generated in the noise stage.</p>

--- a/paper-api/src/main/java/org/bukkit/generator/ChunkGenerator.java
+++ b/paper-api/src/main/java/org/bukkit/generator/ChunkGenerator.java
@@ -777,5 +777,18 @@ public abstract class ChunkGenerator {
          */
         @Deprecated(since = "1.8.8")
         public byte getData(int x, int y, int z);
+
+        /**
+         * Get the current of the chunk data.
+         * <p>This will differ based on which state generation of the chunk is currently at.
+         * If for example the chunk is in the generate surface stage,
+         * this will return what was already generated in the noise stage.</p>
+         *
+         * @param heightMap Heightmap to determine where to grab height
+         * @param x the x location in the chunk from 0-15 inclusive
+         * @param z the z location in the chunk from 0-15 inclusive
+         * @return Y coordinate at highest position
+         */
+        public int getHeight(@NotNull HeightMap heightMap, int x, int z);
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
@@ -8,7 +8,6 @@ import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.levelgen.Heightmap;
 import org.bukkit.HeightMap;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -16,7 +15,6 @@ import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftHeightMap;
 import org.bukkit.craftbukkit.block.CraftBiome;
-import org.bukkit.craftbukkit.block.CraftBlockType;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.util.CraftMagicNumbers;
 import org.bukkit.generator.ChunkGenerator;
@@ -187,6 +185,6 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
     @Override
     public int getHeight(HeightMap heightMap, final int x, final int z) {
         Preconditions.checkNotNull(heightMap, "HeightMap cannot be null");
-        return getHandle().getHeight(CraftHeightMap.toNMS(heightMap),  x, z);
+        return getHandle().getHeight(CraftHeightMap.toNMS(heightMap), x, z);
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
@@ -8,10 +8,13 @@ import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.levelgen.Heightmap;
+import org.bukkit.HeightMap;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.craftbukkit.CraftHeightMap;
 import org.bukkit.craftbukkit.block.CraftBiome;
 import org.bukkit.craftbukkit.block.CraftBlockType;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
@@ -179,5 +182,11 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
         } else if (oldBlockData != null && oldBlockData.hasBlockEntity()) {
             access.removeBlockEntity(blockPosition);
         }
+    }
+
+    @Override
+    public int getHeight(HeightMap heightMap, final int x, final int z) {
+        Preconditions.checkNotNull(heightMap, "HeightMap cannot be null");
+        return getHandle().getHeight(CraftHeightMap.toNMS(heightMap),  x, z);
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
@@ -185,8 +185,8 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
     @Override
     public int getHeight(HeightMap heightMap, final int x, final int z) {
         Preconditions.checkArgument(heightMap != null, "HeightMap cannot be null");
-        if (x != (x & 0xf) || z != (z & 0xf)) {
-            return 0;
+        if (x < 0 || x > 15 || z < 0 || z > 15) {
+            throw new IllegalArgumentException("Cannot get height outside of a chunks bounds");
         }
         return getHandle().getHeight(CraftHeightMap.toNMS(heightMap), x, z);
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
@@ -186,7 +186,7 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
     public int getHeight(HeightMap heightMap, final int x, final int z) {
         Preconditions.checkArgument(heightMap != null, "HeightMap cannot be null");
         if (x < 0 || x > 15 || z < 0 || z > 15) {
-            throw new IllegalArgumentException("Cannot get height outside of a chunks bounds");
+            throw new IllegalArgumentException("Cannot get height outside of a chunks bounds, must be between 0 and 15, found: x: " + x + ", z: " + z);
         }
         return getHandle().getHeight(CraftHeightMap.toNMS(heightMap), x, z);
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
@@ -183,11 +183,10 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
     }
 
     @Override
-    public int getHeight(HeightMap heightMap, final int x, final int z) {
+    public int getHeight(final HeightMap heightMap, final int x, final int z) {
         Preconditions.checkArgument(heightMap != null, "HeightMap cannot be null");
-        if (x < 0 || x > 15 || z < 0 || z > 15) {
-            throw new IllegalArgumentException("Cannot get height outside of a chunks bounds, must be between 0 and 15, found: x: " + x + ", z: " + z);
-        }
+        Preconditions.checkArgument(x >= 0 && x <= 15 && z >= 0 && z <= 15, "Cannot get height outside of a chunks bounds, must be between 0 and 15, got x: %s, z: %s", x, z);
+
         return getHandle().getHeight(CraftHeightMap.toNMS(heightMap), x, z);
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
@@ -184,7 +184,7 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
 
     @Override
     public int getHeight(HeightMap heightMap, final int x, final int z) {
-        Preconditions.checkNotNull(heightMap, "HeightMap cannot be null");
+        Preconditions.checkArgument(heightMap != null, "HeightMap cannot be null");
         return getHandle().getHeight(CraftHeightMap.toNMS(heightMap), x, z);
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
@@ -185,6 +185,9 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
     @Override
     public int getHeight(HeightMap heightMap, final int x, final int z) {
         Preconditions.checkArgument(heightMap != null, "HeightMap cannot be null");
+        if (x != (x & 0xf) || z != (z & 0xf)) {
+            return 0;
+        }
         return getHandle().getHeight(CraftHeightMap.toNMS(heightMap), x, z);
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/generator/OldCraftChunkData.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/generator/OldCraftChunkData.java
@@ -8,6 +8,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunkSection;
+import org.bukkit.HeightMap;
 import org.bukkit.Material;
 import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
@@ -199,5 +200,10 @@ public final class OldCraftChunkData implements ChunkGenerator.ChunkData {
 
     Set<BlockPos> getLights() {
         return this.lights;
+    }
+
+    @Override
+    public int getHeight(HeightMap heightMap, final int x, final int z) {
+        throw new UnsupportedOperationException("Unsupported, in older chunk generator api");
     }
 }


### PR DESCRIPTION
This PR aims to add an option to ChunkGenerator.ChunkData to get the current height.
This allows to get the height generated in a previous step.
For example, let's say I have a generator where I allow Minecraft to generate the noise, but I want to generate the surface.
I can get the height that was previously generated in the noise step, and plop my surface block on top of that in the surface step.

Closes #12048 