### PR TITLE
Check for trailing input in ItemFactory#createItemStack

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
@@ -153,7 +153,9 @@ public final class CraftItemFactory implements ItemFactory {
     @Override
     public ItemStack createItemStack(String input) throws IllegalArgumentException {
         try {
-            ItemParser.ItemResult arg = new ItemParser(MinecraftServer.getDefaultRegistryAccess()).parse(new StringReader(input));
+            StringReader reader = new StringReader(input);
+            ItemParser.ItemResult arg = new ItemParser(MinecraftServer.getDefaultRegistryAccess()).parse(reader);
+            Preconditions.checkArgument(!reader.canRead(), "Trailing input found when parsing ItemStack: %s", input);
 
             Item item = arg.item().value();
             net.minecraft.world.item.ItemStack nmsItemStack = new net.minecraft.world.item.ItemStack(item);


### PR DESCRIPTION
Adds a check for trailing input in `ItemFactory#createItemStack`. Without the check, inputs such as `diamond[]extra` are accepted.