### PR TITLE
[ci skip] CONTRIBUTING.md use latest Java 21 version for Docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,12 +36,13 @@ If you're compiling with Docker, you can use Adoptium's
 [`eclipse-temurin`](https://hub.docker.com/_/eclipse-temurin/) images like so:
 
 ```console
-# docker run -it -v "$(pwd)":/data --rm eclipse-temurin:21.0.5_11-jdk bash
+# docker run -it -v "$(pwd)":/data --rm eclipse-temurin:21-jdk bash
 Pulling image...
 
 root@abcdefg1234:/# javac -version
-javac 21.0.5
+javac 21.0.6
 ```
+*The version show in javac can be different based in latest version of 21 in Docker*
 
 ## Understanding Patches
 


### PR DESCRIPTION
Based in discord a few mentions about early versions of Java 21 this PR just replace the version used in the Docker example for just use the latest of Java 21.