### PR TITLE
Deprecate getPotentialRespawnLocation and add getRespawnBlock

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -7,6 +7,7 @@ import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
@@ -440,7 +441,6 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
     public int getSleepTicks();
 
 
-    // Paper start - Potential bed api
     /**
      * Gets the Location of the player's bed, null if they have not slept
      * in one. This method will not attempt to validate if the current bed
@@ -463,10 +463,26 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * to validate if the current respawn location is still valid.
      *
      * @return respawn location if exists, otherwise null.
+     * @see #getRespawnBlock()
+     * @deprecated Misleading name.
+     * This method returns the respawn point block location and not the player's respawn location
      */
     @Nullable
-    Location getPotentialRespawnLocation();
-    // Paper end
+    @Deprecated(since = "1.21.4")
+    default Location getPotentialRespawnLocation() {
+        Block block = this.getRespawnBlock();
+        return block != null ? block.getLocation() : null;
+    }
+
+    /**
+     * Retrieves the block located at the player's designated respawn point.
+     * This method will not attempt to validate if the current respawn point is still valid.
+     *
+     * @return The respawn point {@link Block}, or {@code null} if no respawn point is set.
+     */
+    @Nullable
+    Block getRespawnBlock();
+
     // Paper start
     /**
      * @return the player's fishing hook if they are fishing

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -562,6 +562,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      * Gets the Location where the player will spawn at, null if they
      * don't have a valid respawn point.
      *
+     * @see #getRespawnBlock()
      * @return respawn location if exists, otherwise null.
      */
     @Nullable

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -152,12 +152,12 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         return this.getHandle().sleepCounter;
     }
 
-    // Paper start - Potential bed api
+    // Paper start - respawn api
     @Override
-    public Location getPotentialRespawnLocation() {
+    public Block getRespawnBlock() {
         ServerPlayer handle = (ServerPlayer) getHandle();
-        BlockPos bed = handle.getRespawnPosition();
-        if (bed == null) {
+        BlockPos pos = handle.getRespawnPosition();
+        if (pos == null) {
             return null;
         }
 
@@ -165,7 +165,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         if (worldServer == null) {
             return null;
         }
-        return new Location(worldServer.getWorld(), bed.getX(), bed.getY(), bed.getZ());
+        return worldServer.getWorld().getBlockAt(pos.getX(), pos.getY(), pos.getZ());
     }
     // Paper end
     // Paper start


### PR DESCRIPTION
Introduced `getRespawnBlock` to retrieve the player's respawn block directly and deprecated `getPotentialRespawnLocation` due to its misleading name.
Updated documentation to clarify usage.