### PR TITLE
RideCommand - config to remove player as vehicle restriction

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/commands/RideCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/RideCommand.java.patch
@@ -5,7 +5,7 @@
          if (vehicle1 != null) {
              throw ERROR_ALREADY_RIDING.create(target.getDisplayName(), vehicle1.getDisplayName());
 -        } else if (vehicle.getType() == EntityType.PLAYER) {
-+        } else if (vehicle.getType() == EntityType.PLAYER && !io.papermc.paper.configuration.GlobalConfiguration.get().commands.rideCommandSkipPlayerAsVehicleRestriction) { // Paper - allow player as vehicle
++        } else if (vehicle.getType() == EntityType.PLAYER && !io.papermc.paper.configuration.GlobalConfiguration.get().commands.rideCommandAllowPlayerAsVehicle) { // Paper - allow player as vehicle
              throw ERROR_MOUNTING_PLAYER.create();
          } else if (target.getSelfAndPassengers().anyMatch(passenger -> passenger == vehicle)) {
              throw ERROR_MOUNTING_LOOP.create();

--- a/paper-server/patches/sources/net/minecraft/server/commands/RideCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/RideCommand.java.patch
@@ -1,15 +1,11 @@
 --- a/net/minecraft/server/commands/RideCommand.java
 +++ b/net/minecraft/server/commands/RideCommand.java
-@@ -58,8 +_,10 @@
+@@ -58,7 +_,7 @@
          Entity vehicle1 = target.getVehicle();
          if (vehicle1 != null) {
              throw ERROR_ALREADY_RIDING.create(target.getDisplayName(), vehicle1.getDisplayName());
 -        } else if (vehicle.getType() == EntityType.PLAYER) {
--            throw ERROR_MOUNTING_PLAYER.create();
-+        // Paper start - Remove player as vehicle restriction
-+        //} else if (vehicle.getType() == EntityType.PLAYER) {
-+        //    throw ERROR_MOUNTING_PLAYER.create();
-+        // Paper start - Remove player as vehicle restriction
++        } else if (vehicle.getType() == EntityType.PLAYER && !io.papermc.paper.configuration.GlobalConfiguration.get().commands.rideCommandSkipPlayerAsVehicleRestriction) { // Paper - allow player as vehicle
+             throw ERROR_MOUNTING_PLAYER.create();
          } else if (target.getSelfAndPassengers().anyMatch(passenger -> passenger == vehicle)) {
              throw ERROR_MOUNTING_LOOP.create();
-         } else if (target.level() != vehicle.level()) {

--- a/paper-server/patches/sources/net/minecraft/server/commands/RideCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/RideCommand.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/server/commands/RideCommand.java
++++ b/net/minecraft/server/commands/RideCommand.java
+@@ -58,8 +_,10 @@
+         Entity vehicle1 = target.getVehicle();
+         if (vehicle1 != null) {
+             throw ERROR_ALREADY_RIDING.create(target.getDisplayName(), vehicle1.getDisplayName());
+-        } else if (vehicle.getType() == EntityType.PLAYER) {
+-            throw ERROR_MOUNTING_PLAYER.create();
++        // Paper start - Remove player as vehicle restriction
++        //} else if (vehicle.getType() == EntityType.PLAYER) {
++        //    throw ERROR_MOUNTING_PLAYER.create();
++        // Paper start - Remove player as vehicle restriction
+         } else if (target.getSelfAndPassengers().anyMatch(passenger -> passenger == vehicle)) {
+             throw ERROR_MOUNTING_LOOP.create();
+         } else if (target.level() != vehicle.level()) {

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -202,6 +202,8 @@ public class GlobalConfiguration extends ConfigurationPart {
     public class Commands extends ConfigurationPart {
         public boolean suggestPlayerNamesWhenNullTabCompletions = true;
         public boolean timeCommandAffectsAllWorlds = false;
+        @Comment("Allow mounting entities to a player in the vanilla '/ride' command.")
+        public boolean rideCommandSkipPlayerAsVehicleRestriction = false;
     }
 
     public Logging logging;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -12,7 +12,6 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ServerboundPlaceRecipePacket;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Items;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
@@ -203,7 +202,7 @@ public class GlobalConfiguration extends ConfigurationPart {
         public boolean suggestPlayerNamesWhenNullTabCompletions = true;
         public boolean timeCommandAffectsAllWorlds = false;
         @Comment("Allow mounting entities to a player in the vanilla '/ride' command.")
-        public boolean rideCommandSkipPlayerAsVehicleRestriction = false;
+        public boolean rideCommandAllowPlayerAsVehicle = false;
     }
 
     public Logging logging;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -201,7 +201,7 @@ public class GlobalConfiguration extends ConfigurationPart {
     public class Commands extends ConfigurationPart {
         public boolean suggestPlayerNamesWhenNullTabCompletions = true;
         public boolean timeCommandAffectsAllWorlds = false;
-        @Comment("Allow mounting entities to a player in the vanilla '/ride' command.")
+        @Comment("Allow mounting entities to a player in the Vanilla '/ride' command.")
         public boolean rideCommandAllowPlayerAsVehicle = false;
     }
 


### PR DESCRIPTION
This PR aims to remove the player as vehicle restriction in the vanilla `/ride` command.
Its well know that the API allows mounting any entity to the player as a passenger, so it seems fitting to allow this in the ride command as well.
Unfortunately Mojang imposed a restriction here.
Some people may often rely on this command for funsies, or possibly even for debugging/testing when writing code.

Doc PR: https://github.com/PaperMC/docs/pull/552