### PR TITLE
Add Entity#isTrackedBy

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -699,6 +699,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
     Set<Player> getTrackedBy();
 
     /**
+     * Checks to see if a player is currently tracking this entity.
+     *
+     * @param player the player to check
+     * @return if the player is currently tracking this entity
+     * @see #getTrackedBy()
+     */
+    boolean isTrackedBy(@NotNull Player player);
+
+    /**
      * Sets whether the entity has a team colored (default: white) glow.
      *
      * <b>nb: this refers to the 'Glowing' entity property, not whether a

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -726,6 +726,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     }
 
     @Override
+    public boolean isTrackedBy(final Player player) {
+        Preconditions.checkState(!this.entity.generation, "Cannot check tracking players during world generation");
+        Preconditions.checkArgument(player != null, "Player cannot be null");
+
+        ServerLevel world = ((CraftWorld) this.getWorld()).getHandle();
+        ChunkMap.TrackedEntity entityTracker = world.getChunkSource().chunkMap.entityMap.get(this.getEntityId());
+        if (entityTracker == null) return false;
+
+        return entityTracker.seenBy.contains(((CraftPlayer) player).getHandle().connection);
+    }
+
+    @Override
     public void sendMessage(String message) {
 
     }


### PR DESCRIPTION
Adds `Entity#isTrackedBy`, allowing for checking if a player is currently tracking an entity without having to get the set of all tracking players.