### PR TITLE
Add support for bonus chest configuration in WorldCreator

### DIFF
--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2871,6 +2871,13 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
     public boolean canGenerateStructures();
 
     /**
+     * Checks if the bonus chest is enabled.
+     *
+     * @return true if the bonus chest is enabled, false otherwise
+     */
+    boolean hasBonusChest();
+
+    /**
      * Gets whether the world is hardcore or not.
      *
      * In a hardcore world the difficulty is locked to hard.

--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2873,7 +2873,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
     /**
      * Checks if the bonus chest is enabled.
      *
-     * @return true if the bonus chest is enabled, false otherwise
+     * @return {@code true} if the bonus chest is enabled, {@code false} otherwise
      */
     boolean hasBonusChest();
 

--- a/paper-api/src/main/java/org/bukkit/WorldCreator.java
+++ b/paper-api/src/main/java/org/bukkit/WorldCreator.java
@@ -454,7 +454,7 @@ public class WorldCreator {
 
     /**
      * Gets whether the world will be hardcore or not.
-     *
+     * <p>
      * In a hardcore world the difficulty will be locked to hard.
      *
      * @return hardcore status
@@ -466,11 +466,11 @@ public class WorldCreator {
     /**
      * Sets whether a bonus chest should be generated or not.
      *
-     * @param bonusChest Indicating whether the bonus chest should be generated
+     * @param bonusChest indicating whether the bonus chest should be generated
      * @return This object, for chaining
      */
     @NotNull
-    public WorldCreator bonusChest(boolean bonusChest) {
+    public WorldCreator bonusChest(final boolean bonusChest) {
         this.bonusChest = bonusChest;
         return this;
     }

--- a/paper-api/src/main/java/org/bukkit/WorldCreator.java
+++ b/paper-api/src/main/java/org/bukkit/WorldCreator.java
@@ -23,6 +23,7 @@ public class WorldCreator {
     private boolean generateStructures = true;
     private String generatorSettings = "";
     private boolean hardcore = false;
+    private boolean bonusChest = false;
     private net.kyori.adventure.util.TriState keepSpawnLoaded = net.kyori.adventure.util.TriState.NOT_SET; // Paper
 
     /**
@@ -123,6 +124,7 @@ public class WorldCreator {
         type = world.getWorldType();
         generateStructures = world.canGenerateStructures();
         hardcore = world.isHardcore();
+        bonusChest = world.hasBonusChest();
         this.keepSpawnLoaded = net.kyori.adventure.util.TriState.byBoolean(world.getKeepSpawnInMemory()); // Paper
 
         return this;
@@ -146,6 +148,7 @@ public class WorldCreator {
         generateStructures = creator.generateStructures();
         generatorSettings = creator.generatorSettings();
         hardcore = creator.hardcore();
+        bonusChest = creator.bonusChest();
         keepSpawnLoaded = creator.keepSpawnLoaded(); // Paper
 
         return this;
@@ -458,6 +461,27 @@ public class WorldCreator {
      */
     public boolean hardcore() {
         return hardcore;
+    }
+
+    /**
+     * Sets whether a bonus chest should be generated or not.
+     *
+     * @param bonusChest Indicating whether the bonus chest should be generated
+     * @return This object, for chaining
+     */
+    @NotNull
+    public WorldCreator bonusChest(boolean bonusChest) {
+        this.bonusChest = bonusChest;
+        return this;
+    }
+
+    /**
+     * Gets whether the bonus chest feature is enabled.
+     *
+     * @return true if the bonus chest is enabled, false otherwise.
+     */
+    public boolean bonusChest() {
+        return bonusChest;
     }
 
     /**

--- a/paper-server/patches/sources/net/minecraft/world/level/GameRules.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/GameRules.java.patch
@@ -250,7 +250,7 @@
 +        // Paper start - expose FeatureElement wrapper for GameRules.Type.
 +        // Chosen over simply adding this to the inheritance to avoid reobf issues with spigot...
 +        public net.minecraft.world.flag.FeatureElement asFeatureElement() {
-+            return net.minecraft.world.level.GameRules.Type.this::requiredFeatures;
++            return GameRules.Type.this::requiredFeatures;
 +        }
 +        // Paper end - expose FeatureElement wrapper for GameRules.Type.
      }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -1345,7 +1345,7 @@ public final class CraftServer implements Server {
             registryAccess = levelDataAndDimensions.dimensions().dimensionsRegistryAccess();
         } else {
             LevelSettings levelSettings;
-            WorldOptions worldOptions = new WorldOptions(creator.seed(), creator.generateStructures(), false);
+            WorldOptions worldOptions = new WorldOptions(creator.seed(), creator.generateStructures(), creator.bonusChest());
             WorldDimensions worldDimensions;
 
             DedicatedServerProperties.WorldDimensionData properties = new DedicatedServerProperties.WorldDimensionData(GsonHelper.parse((creator.generatorSettings().isEmpty()) ? "{}" : creator.generatorSettings()), creator.type().name().toLowerCase(Locale.ROOT));

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1621,6 +1621,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
     }
 
     @Override
+    public boolean hasBonusChest() {
+        return this.world.serverLevelData.worldGenOptions().generateBonusChest();
+    }
+
+    @Override
     public boolean isHardcore() {
         return this.world.getLevelData().isHardcore();
     }


### PR DESCRIPTION
Introduces a new option in WorldCreator to enable or disable bonus chest generation.