### PR TITLE
Fix EntityTeleportEvent triggering twice

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/commands/TeleportCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/TeleportCommand.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/commands/TeleportCommand.java
 +++ b/net/minecraft/server/commands/TeleportCommand.java
-@@ -290,7 +_,31 @@
+@@ -290,7 +_,16 @@
              float f1 = relatives.contains(Relative.X_ROT) ? xRot - target.getXRot() : xRot;
              float f2 = Mth.wrapDegrees(f);
              float f3 = Mth.wrapDegrees(f1);
@@ -10,21 +10,6 @@
 +            if (target instanceof final net.minecraft.server.level.ServerPlayer player) {
 +                result = player.teleportTo(level, d, d1, d2, relatives, f2, f3, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.COMMAND);
 +            } else {
-+                org.bukkit.Location to = new org.bukkit.Location(level.getWorld(), d, d1, d2, f2, f3);
-+                org.bukkit.event.entity.EntityTeleportEvent event = new org.bukkit.event.entity.EntityTeleportEvent(target.getBukkitEntity(), target.getBukkitEntity().getLocation(), to);
-+                level.getCraftServer().getPluginManager().callEvent(event);
-+                if (event.isCancelled() || event.getTo() == null) { // Paper
-+                    return;
-+                }
-+                to = event.getTo(); // Paper - actually track new location
-+
-+                d = to.getX();
-+                d1 = to.getY();
-+                d2 = to.getZ();
-+                f2 = to.getYaw();
-+                f3 = to.getPitch();
-+                level = ((org.bukkit.craftbukkit.CraftWorld) to.getWorld()).getHandle();
-+
 +                result = target.teleportTo(level, d, d1, d2, relatives, f2, f3, true);
 +            }
 +

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -263,7 +263,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
         }
 
         // Paper start - fix teleport event not being called
-        if (location.getWorld() == this.getWorld()) { // Don't call event for cross world teleports
+        if (location.getWorld() == this.getWorld() || location.getWorld() == null) { // Don't call event for cross world teleports
+            if (location.getWorld() == null) {
+                location.setWorld(this.getWorld());
+            }
             org.bukkit.event.entity.EntityTeleportEvent event = new org.bukkit.event.entity.EntityTeleportEvent(
                 this, this.getLocation(), location);
             // cancelling the event is handled differently for players and entities,

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -263,14 +263,16 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
         }
 
         // Paper start - fix teleport event not being called
-        org.bukkit.event.entity.EntityTeleportEvent event = new org.bukkit.event.entity.EntityTeleportEvent(
-            this, this.getLocation(), location);
-        // cancelling the event is handled differently for players and entities,
-        // entities just stop teleporting, players will still teleport to the "from" location of the event
-        if (!event.callEvent() || event.getTo() == null) {
-            return false;
+        if (location.getWorld() == this.getWorld()) { // Don't call event for cross world teleports
+            org.bukkit.event.entity.EntityTeleportEvent event = new org.bukkit.event.entity.EntityTeleportEvent(
+                this, this.getLocation(), location);
+            // cancelling the event is handled differently for players and entities,
+            // entities just stop teleporting, players will still teleport to the "from" location of the event
+            if (!event.callEvent() || event.getTo() == null) {
+                return false;
+            }
+            location = event.getTo();
         }
-        location = event.getTo();
         // Paper end
 
         // If this entity is riding another entity, we must dismount before teleporting.


### PR DESCRIPTION
fixes #12317 

fix vanilla tp command firing the EntityTeleportEvent twice and CraftEntity#teleport firing the EntityTeleportEvent twice for cross world teleports.