### PR TITLE
Fix #10323: Inefficient Ender Dragon Respawn 

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/dimension/end/EndDragonFight.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/dimension/end/EndDragonFight.java.patch
@@ -37,6 +37,76 @@
                  this.dragonUUID = null;
              }
          }
+@@ -268,21 +_,40 @@
+         return false;
+     }
+ 
++    // Paper start - Fix inefficient Ender Dragon respawn sequence
+     @Nullable
+     public BlockPattern.BlockPatternMatch findExitPortal() {
++
++        BlockPos location = EndPodiumFeature.getLocation(this.origin);
++        LevelChunk chunk = this.level.getChunk(location.getX(), location.getZ());
++
++        
++        for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
++            if (blockEntity instanceof TheEndPortalBlockEntity) {
++                BlockPattern.BlockPatternMatch blockPatternMatch1 = this.exitPortalPattern.find(this.level, blockEntity.getBlockPos());
++                if (blockPatternMatch1 != null) {
++                    if (this.portalLocation == null) {
++                        this.portalLocation = blockPatternMatch1.getBlock(3, 3, 3).getPos();
++                    }
++    
++                    return blockPatternMatch1;
++                }
++            }
++
++        }
++
+         ChunkPos chunkPos = new ChunkPos(this.origin);
+ 
+-        for (int i = -8 + chunkPos.x; i <= 8 + chunkPos.x; i++) {
+-            for (int i1 = -8 + chunkPos.z; i1 <= 8 + chunkPos.z; i1++) {
+-                LevelChunk chunk = this.level.getChunk(i, i1);
++        for (int i = -8 + chunkPos.x; i <= 8 + chunkPos.x; i+=16) {
++            for (int i1 = -8 + chunkPos.z; i1 <= 8 + chunkPos.z; i1+=16) {
++                chunk = this.level.getChunk(i, i1);
+ 
+                 for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
+                     if (blockEntity instanceof TheEndPortalBlockEntity) {
+                         BlockPattern.BlockPatternMatch blockPatternMatch = this.exitPortalPattern.find(this.level, blockEntity.getBlockPos());
+                         if (blockPatternMatch != null) {
+-                            BlockPos pos = blockPatternMatch.getBlock(3, 3, 3).getPos();
+                             if (this.portalLocation == null) {
+-                                this.portalLocation = pos;
++                                this.portalLocation = blockPatternMatch.getBlock(3, 3, 3).getPos();
+                             }
+ 
+                             return blockPatternMatch;
+@@ -292,22 +_,9 @@
+             }
+         }
+ 
+-        BlockPos location = EndPodiumFeature.getLocation(this.origin);
+-        int i1 = this.level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, location).getY();
+-
+-        for (int i2 = i1; i2 >= this.level.getMinY(); i2--) {
+-            BlockPattern.BlockPatternMatch blockPatternMatch1 = this.exitPortalPattern.find(this.level, new BlockPos(location.getX(), i2, location.getZ()));
+-            if (blockPatternMatch1 != null) {
+-                if (this.portalLocation == null) {
+-                    this.portalLocation = blockPatternMatch1.getBlock(3, 3, 3).getPos();
+-                }
+-
+-                return blockPatternMatch1;
+-            }
+-        }
+-
+         return null;
+     }
++    // Paper end - Fix inefficient Ender Dragon respawn sequence
+ 
+     private boolean isArenaLoaded() {
+         if (this.skipArenaLoadedCheck) {
 @@ -366,12 +_,22 @@
              this.dragonEvent.setVisible(false);
              this.spawnExitPortal(true);


### PR DESCRIPTION
This fixes issue #10323. Currently, the respawn sequence of the Ender Dragon has a noticeable lag spike, likely caused by the method findExitPortal() being poorly optimized, and calling the method find() (which is an expensive method, in terms of server execution time) multiple times, unnecessarily.

Solution: fix index incrementation and direct the search to the most likely spot first, instead of iterating over various blocks, calling find() without first checking whether it makes sense to call it for the instance of the block considered. Also, pre-fetching the relevant chunk does improve following computations.

Profiler links
under stress original version: https://spark.lucko.me/4gqvxg7QBt?hl=9025
under stress with modification: https://spark.lucko.me/tyLvsstn9J?hl=4886

As you can see, the method findExitPortal() is nowhere to be seen, in the second profile report, indicating little impact on server performance. Also, the execution time of the method scanState() went from 5360ms to 60ms.