### PR TITLE
Fix #10323: Inefficient Ender Dragon respawn sequence

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/dimension/end/EndDragonFight.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/dimension/end/EndDragonFight.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/world/level/dimension/end/EndDragonFight.java
 +++ b/net/minecraft/world/level/dimension/end/EndDragonFight.java
+@@ -48,6 +_,7 @@
+ import net.minecraft.world.level.block.state.pattern.BlockPattern;
+ import net.minecraft.world.level.block.state.pattern.BlockPatternBuilder;
+ import net.minecraft.world.level.block.state.predicate.BlockPredicate;
++import net.minecraft.world.level.block.state.BlockState;
+ import net.minecraft.world.level.chunk.ChunkAccess;
+ import net.minecraft.world.level.chunk.LevelChunk;
+ import net.minecraft.world.level.chunk.status.ChunkStatus;
 @@ -69,8 +_,9 @@
      private static final int GATEWAY_DISTANCE = 96;
      public static final int DRAGON_SPAWN_Y = 128;
@@ -37,6 +45,57 @@
                  this.dragonUUID = null;
              }
          }
+@@ -271,6 +_,12 @@
+     public BlockPattern.BlockPatternMatch findExitPortal() {
+         ChunkPos chunkPos = new ChunkPos(this.origin);
+ 
++        // Paper start
++        BlockPattern.BlockPatternMatch originSearch = findExitPortalExitAroundOrigin();
++        if (originSearch != null) {
++            return originSearch;
++        }
++        // Paper end
+         for (int i = -8 + chunkPos.x; i <= 8 + chunkPos.x; i++) {
+             for (int i1 = -8 + chunkPos.z; i1 <= 8 + chunkPos.z; i1++) {
+                 LevelChunk chunk = this.level.getChunk(i, i1);
+@@ -279,9 +_,9 @@
+                     if (blockEntity instanceof TheEndPortalBlockEntity) {
+                         BlockPattern.BlockPatternMatch blockPatternMatch = this.exitPortalPattern.find(this.level, blockEntity.getBlockPos());
+                         if (blockPatternMatch != null) {
+-                            BlockPos pos = blockPatternMatch.getBlock(3, 3, 3).getPos();
++                            // BlockPos pos = blockPatternMatch.getBlock(3, 3, 3).getPos(); // Paper - move down
+                             if (this.portalLocation == null) {
+-                                this.portalLocation = pos;
++                                this.portalLocation = blockPatternMatch.getBlock(3, 3, 3).getPos(); // Paper
+                             }
+ 
+                             return blockPatternMatch;
+@@ -291,11 +_,24 @@
+             }
+         }
+ 
++     // Paper start - exit portal optimization look around the origin first
++        return null;
++    }
++    public BlockPattern.@org.checkerframework.checker.nullness.qual.Nullable BlockPatternMatch findExitPortalExitAroundOrigin() {
++        BlockPos targetPos;
++    // Paper end - exit portal optimization look around the origin first
+         BlockPos location = EndPodiumFeature.getLocation(this.origin);
+         int i1 = this.level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, location).getY();
+ 
+         for (int i2 = i1; i2 >= this.level.getMinY(); i2--) {
+-            BlockPattern.BlockPatternMatch blockPatternMatch1 = this.exitPortalPattern.find(this.level, new BlockPos(location.getX(), i2, location.getZ()));
++            // Paper start
++            targetPos = new BlockPos(location.getX(), i2, location.getZ());
++            // Early exit if we encroached a non bedrock block because the middle column MUST be bedrock
++            if (!this.level.getBlockState(targetPos).is(net.minecraft.world.level.block.Blocks.BEDROCK)) {
++                continue;
++            }
++            BlockPattern.BlockPatternMatch blockPatternMatch1 = this.exitPortalPattern.find(this.level, targetPos);
++           // Paper end
+             if (blockPatternMatch1 != null) {
+                 if (this.portalLocation == null) {
+                     this.portalLocation = blockPatternMatch1.getBlock(3, 3, 3).getPos();
 @@ -365,12 +_,22 @@
              this.dragonEvent.setVisible(false);
              this.spawnExitPortal(true);

--- a/paper-server/patches/sources/net/minecraft/world/level/dimension/end/EndDragonFight.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/dimension/end/EndDragonFight.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/world/level/dimension/end/EndDragonFight.java
 +++ b/net/minecraft/world/level/dimension/end/EndDragonFight.java
-@@ -48,6 +_,7 @@
- import net.minecraft.world.level.block.state.pattern.BlockPattern;
- import net.minecraft.world.level.block.state.pattern.BlockPatternBuilder;
- import net.minecraft.world.level.block.state.predicate.BlockPredicate;
-+import net.minecraft.world.level.block.state.BlockState;
- import net.minecraft.world.level.chunk.ChunkAccess;
- import net.minecraft.world.level.chunk.LevelChunk;
- import net.minecraft.world.level.chunk.status.ChunkStatus;
 @@ -69,8 +_,9 @@
      private static final int GATEWAY_DISTANCE = 96;
      public static final int DRAGON_SPAWN_Y = 128;
@@ -50,7 +42,7 @@
          ChunkPos chunkPos = new ChunkPos(this.origin);
  
 +        // Paper start
-+        BlockPattern.BlockPatternMatch originSearch = findExitPortalExitAroundOrigin();
++        BlockPattern.BlockPatternMatch originSearch = this.findExitPortalAroundOrigin();
 +        if (originSearch != null) {
 +            return originSearch;
 +        }
@@ -70,15 +62,14 @@
                              }
  
                              return blockPatternMatch;
-@@ -291,11 +_,24 @@
+@@ -291,11 +_,23 @@
              }
          }
  
-+     // Paper start - exit portal optimization look around the origin first
++    // Paper start - exit portal optimization look around the origin first
 +        return null;
 +    }
-+    public BlockPattern.@org.checkerframework.checker.nullness.qual.Nullable BlockPatternMatch findExitPortalExitAroundOrigin() {
-+        BlockPos targetPos;
++    public @Nullable BlockPattern.BlockPatternMatch findExitPortalAroundOrigin() {
 +    // Paper end - exit portal optimization look around the origin first
          BlockPos location = EndPodiumFeature.getLocation(this.origin);
          int i1 = this.level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, location).getY();
@@ -86,13 +77,13 @@
          for (int i2 = i1; i2 >= this.level.getMinY(); i2--) {
 -            BlockPattern.BlockPatternMatch blockPatternMatch1 = this.exitPortalPattern.find(this.level, new BlockPos(location.getX(), i2, location.getZ()));
 +            // Paper start
-+            targetPos = new BlockPos(location.getX(), i2, location.getZ());
++            BlockPos targetPos = new BlockPos(location.getX(), i2, location.getZ());
 +            // Early exit if we encroached a non bedrock block because the middle column MUST be bedrock
-+            if (!this.level.getBlockState(targetPos).is(net.minecraft.world.level.block.Blocks.BEDROCK)) {
++            if (!this.level.getBlockState(targetPos).is(Blocks.BEDROCK)) {
 +                continue;
 +            }
 +            BlockPattern.BlockPatternMatch blockPatternMatch1 = this.exitPortalPattern.find(this.level, targetPos);
-+           // Paper end
++            // Paper end
              if (blockPatternMatch1 != null) {
                  if (this.portalLocation == null) {
                      this.portalLocation = blockPatternMatch1.getBlock(3, 3, 3).getPos();


### PR DESCRIPTION
This fixes issue https://github.com/PaperMC/Paper/issues/10323. Currently, the respawn sequence of the Ender Dragon has a noticeable lag spike, likely caused by the method findExitPortal() being poorly optimized, and calling the method find() (which is an expensive method, in terms of server execution time) multiple times, unnecessarily.

Solution: fix index incrementation and direct the search to the most likely spot first, instead of iterating over various blocks, calling find() without first checking whether it makes sense to call it for the instance of the block considered. Also, pre-fetching the relevant chunk does improve following computations.

Profiler links
under stress original version: https://spark.lucko.me/4gqvxg7QBt?hl=9025
under stress with modification: https://spark.lucko.me/tyLvsstn9J?hl=4886

As you can see, the method findExitPortal() is nowhere to be seen, in the second profile report, indicating little impact on server performance. Also, the execution time of the method scanState() went from 5360ms to 60ms.