### PR TITLE
Fix EquippableComponent fails to serialise when custom Sound does not have a key

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/components/CraftEquippableComponent.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/components/CraftEquippableComponent.java
@@ -81,7 +81,11 @@ public final class CraftEquippableComponent implements EquippableComponent {
     public Map<String, Object> serialize() {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("slot", this.getSlot().name());
-        result.put("equip-sound", this.getEquipSound().getKey().toString());
+
+        NamespacedKey sound = Registry.SOUNDS.getKey(this.getEquipSound());
+        if (sound != null) {
+            result.put("equip-sound", sound.toString());
+        }
 
         NamespacedKey model = this.getModel();
         if (model != null) {


### PR DESCRIPTION
It is possible for a Sound to be custom where it doesn't have a Minecraft NamespaceKey as a `Holder.Direct`. This will cause the serialization of CraftEquippableComponent to throw the following error:
```
java.lang.IllegalStateException: Cannot get key for this registry item, because it is not registered.
at io.papermc.paper.util.OldEnumHolderable.lambda$getKey$0(OldEnumHolderable.java:71) ~[purpur-1.21.4.jar:1.21.4-2406-4a3b139]
at java.base/java.util.Optional.orElseThrow(Optional.java:403) ~[?:?]
at io.papermc.paper.util.OldEnumHolderable.getKey(OldEnumHolderable.java:71) ~[purpur-1.21.4.jar:1.21.4-2406-4a3b139]
at org.bukkit.craftbukkit.inventory.components.CraftEquippableComponent.serialize(CraftEquippableComponent.java:84) ~[purpur-1.21.4.jar:1.21.4-2406-4a3b139]
```

I believe instead of failling is this manner, we should add a check the sound's NamespacedKey for null just like `model` and `camera-overlay` attributes.