### PR TITLE
Make fishing bobbers respect NoGravity

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
@@ -42,6 +42,15 @@
                      return;
                  }
              } else {
+@@ -222,7 +_,7 @@
+                 }
+             }
+ 
+-            if (!fluidState.is(FluidTags.WATER)) {
++            if (!fluidState.is(FluidTags.WATER) && !this.isNoGravity()) { // Paper - respect NoGravity
+                 this.setDeltaMovement(this.getDeltaMovement().add(0.0, -0.03, 0.0));
+             }
+ 
 @@ -247,14 +_,14 @@
          if (!player.isRemoved() && player.isAlive() && (isFishingRod || isFishingRod1) && !(this.distanceToSqr(player) > 1024.0)) {
              return false;


### PR DESCRIPTION
Normally NoGravity is checked in `getGravity` but fishing bobbers don't call or override it with an appropriate value.