### PR TITLE
Fix portal create event block list

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/portal/PortalShape.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/portal/PortalShape.java.patch
@@ -122,7 +122,7 @@
              }
 +            // CraftBukkit start - left and right
 +            blocks.setBlock(checkPos.set(pos).move(Direction.UP, i).move(direction, -1), level.getBlockState(checkPos), 18);
-+            blocks.setBlock(checkPos.set(pos).move(Direction.UP, i).move(direction, i), level.getBlockState(checkPos), 18);
++            blocks.setBlock(checkPos.set(pos).move(Direction.UP, i).move(direction, width), level.getBlockState(checkPos), 18); // Paper - fix block list
 +            // CraftBukkit end
          }
  


### PR DESCRIPTION
The current logic for the portal gets the portal blocks incorrectly. It retrieves blocks in a diagonal line, as seen below (the two lime wool are part of this incorrect line). This PR changes the variable used to correctly align the blocks retrieved.
![image](https://github.com/user-attachments/assets/596f90de-6fa0-4588-99a7-401ce1e0ffd4)
