### PR TITLE
Fix #11919: Some Zombified Piglins don't forgive players after death

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/ZombifiedPiglin.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/ZombifiedPiglin.java.patch
@@ -1,22 +1,35 @@
 --- a/net/minecraft/world/entity/monster/ZombifiedPiglin.java
 +++ b/net/minecraft/world/entity/monster/ZombifiedPiglin.java
-@@ -57,6 +_,7 @@
+@@ -57,6 +_,8 @@
      private static final int ALERT_RANGE_Y = 10;
      private static final UniformInt ALERT_INTERVAL = TimeUtil.rangeOfSeconds(4, 6);
      private int ticksUntilNextAlert;
-+    private HurtByTargetGoal hurtByTargetGoal; // Paper - fix PigZombieAngerEvent cancellation
++    private HurtByTargetGoal pathfinderGoalHurtByTarget; // Paper - fix PigZombieAngerEvent cancellation
++    private ResetUniversalAngerTargetGoal<ZombifiedPiglin> resetUniversalTarget; // Paper - fix ZombifiedPiglin anger persistence after player death
  
      public ZombifiedPiglin(EntityType<? extends ZombifiedPiglin> entityType, Level level) {
          super(entityType, level);
-@@ -72,7 +_,7 @@
+@@ -72,9 +_,9 @@
      protected void addBehaviourGoals() {
          this.goalSelector.addGoal(2, new ZombieAttackGoal(this, 1.0, false));
          this.goalSelector.addGoal(7, new WaterAvoidingRandomStrollGoal(this, 1.0));
 -        this.targetSelector.addGoal(1, new HurtByTargetGoal(this).setAlertOthers());
-+        this.targetSelector.addGoal(1, this.hurtByTargetGoal = (new HurtByTargetGoal(this)).setAlertOthers()); // Paper - fix PigZombieAngerEvent cancellation
++        this.targetSelector.addGoal(1, this.pathfinderGoalHurtByTarget = (new HurtByTargetGoal(this)).setAlertOthers()); // Paper - fix PigZombieAngerEvent cancellation
          this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, 10, true, false, this::isAngryAt));
-         this.targetSelector.addGoal(3, new ResetUniversalAngerTargetGoal<>(this, true));
+-        this.targetSelector.addGoal(3, new ResetUniversalAngerTargetGoal<>(this, true));
++        this.targetSelector.addGoal(3,this.resetUniversalTarget = (new ResetUniversalAngerTargetGoal<ZombifiedPiglin>(this, true))); // Paper - fix ZombifiedPiglin anger persistence after player death
      }
+ 
+     public static AttributeSupplier.Builder createAttributes() {
+@@ -82,7 +_,7 @@
+             .add(Attributes.SPAWN_REINFORCEMENTS_CHANCE, 0.0)
+             .add(Attributes.MOVEMENT_SPEED, 0.23F)
+             .add(Attributes.ATTACK_DAMAGE, 5.0);
+-    }
++    }   
+ 
+     @Override
+     public EntityDimensions getDefaultDimensions(Pose pose) {
 @@ -145,7 +_,7 @@
              .filter(zombifiedPiglin -> zombifiedPiglin != this)
              .filter(zombifiedPiglin -> zombifiedPiglin.getTarget() == null)
@@ -26,7 +39,7 @@
      }
  
      private void playAngerSound() {
-@@ -153,18 +_,27 @@
+@@ -153,18 +_,43 @@
      }
  
      @Override
@@ -44,16 +57,32 @@
      @Override
      public void startPersistentAngerTimer() {
 -        this.setRemainingPersistentAngerTime(PERSISTENT_ANGER_TIME.sample(this.random));
-+        // CraftBukkit start
++        // Paper start - PersistentAngerTimer 
++        if(this.level().paperConfig().entities.behavior.zombifiedPiglinsAggressiveBehavior){
 +        net.minecraft.world.entity.Entity entity = this.level().getEntity(this.getPersistentAngerTarget());
-+        org.bukkit.event.entity.PigZombieAngerEvent event = new org.bukkit.event.entity.PigZombieAngerEvent((org.bukkit.entity.PigZombie) this.getBukkitEntity(), (entity == null) ? null : entity.getBukkitEntity(), PERSISTENT_ANGER_TIME.sample(this.random));
-+        if (!event.callEvent()) {
-+            this.setPersistentAngerTarget(null);
-+            this.hurtByTargetGoal.stop();
-+            return;
-+        }
-+        this.setRemainingPersistentAngerTime(event.getNewAnger());
-+        // CraftBukkit end
++            org.bukkit.event.entity.PigZombieAngerEvent event = new org.bukkit.event.entity.PigZombieAngerEvent((org.bukkit.entity.PigZombie) this.getBukkitEntity(), (entity == null) ? null : entity.getBukkitEntity(), PERSISTENT_ANGER_TIME.sample(this.random));
++            if (!event.callEvent()) {
++                this.setPersistentAngerTarget(null);
++                this.pathfinderGoalHurtByTarget.stop();
++                return;
++            }
++            this.setRemainingPersistentAngerTime(event.getNewAnger());
++        }       
++
++        else{
++            net.minecraft.world.entity.Entity entity = ((ServerLevel) this.level()).getEntity(this.getPersistentAngerTarget());
++            org.bukkit.event.entity.PigZombieAngerEvent event = new org.bukkit.event.entity.PigZombieAngerEvent((org.bukkit.entity.PigZombie) this.getBukkitEntity(), (entity == null) ? null : entity.getBukkitEntity(), ZombifiedPiglin.PERSISTENT_ANGER_TIME.sample(this.random));
++            this.level().getCraftServer().getPluginManager().callEvent(event);
++            if (event.isCancelled()) {
++                this.setPersistentAngerTarget(null);
++                this.pathfinderGoalHurtByTarget.stop(); // Paper - fix PigZombieAngerEvent cancellation
++                this.resetUniversalTarget.start(); // Paper - fix ZombifiedPiglin anger persistence after player death
++                return;
++            }
++            this.setRemainingPersistentAngerTime(event.getNewAnger());
++
++        } 
++        // Paper end: PersistentAngerTimer
      }
  
      public static boolean checkZombifiedPiglinSpawnRules(

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/ZombifiedPiglin.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/ZombifiedPiglin.java.patch
@@ -39,7 +39,7 @@
      }
  
      private void playAngerSound() {
-@@ -153,18 +_,43 @@
+@@ -153,18 +_,65 @@
      }
  
      @Override
@@ -59,8 +59,30 @@
 -        this.setRemainingPersistentAngerTime(PERSISTENT_ANGER_TIME.sample(this.random));
 +        // Paper start - PersistentAngerTimer 
 +        if(this.level().paperConfig().entities.behavior.zombifiedPiglinsAggressiveBehavior){
-+        net.minecraft.world.entity.Entity entity = this.level().getEntity(this.getPersistentAngerTarget());
-+            org.bukkit.event.entity.PigZombieAngerEvent event = new org.bukkit.event.entity.PigZombieAngerEvent((org.bukkit.entity.PigZombie) this.getBukkitEntity(), (entity == null) ? null : entity.getBukkitEntity(), PERSISTENT_ANGER_TIME.sample(this.random));
++            int radiusX = 32;
++            int radiusY = 10;
++            int radiusZ = 12;
++
++            net.minecraft.world.entity.Entity entity = this.level().getEntity(this.getPersistentAngerTarget());
++            org.bukkit.event.entity.PigZombieAngerEvent event = new org.bukkit.event.entity.PigZombieAngerEvent(
++                (org.bukkit.entity.PigZombie) this.getBukkitEntity(),
++                (entity == null) ? null : entity.getBukkitEntity(),
++                PERSISTENT_ANGER_TIME.sample(this.random)
++            );
++
++            BlockPos piglinPos = this.blockPosition();
++            BlockPos targetPos = entity.blockPosition();
++
++            int dx = Math.abs(piglinPos.getX() - targetPos.getX());
++            int dy = Math.abs(piglinPos.getY() - targetPos.getY());
++            int dz = Math.abs(piglinPos.getZ() - targetPos.getZ());
++
++            if (entity != null && (dx <= radiusX && dy <= radiusY && dz <= radiusZ)) {
++                this.setPersistentAngerTarget(null);
++                this.pathfinderGoalHurtByTarget.stop();
++                return;
++            }
++
 +            if (!event.callEvent()) {
 +                this.setPersistentAngerTarget(null);
 +                this.pathfinderGoalHurtByTarget.stop();

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -280,6 +280,7 @@ public class WorldConfiguration extends ConfigurationPart {
             public boolean piglinsGuardChests = true;
             public double babyZombieMovementModifier = 0.5;
             public boolean allowSpiderWorldBorderClimbing = true;
+            public boolean zombifiedPiglinsAggressiveBehavior = true;
 
             private static final List<EntityType<?>> ZOMBIE_LIKE = List.of(EntityType.ZOMBIE, EntityType.HUSK, EntityType.ZOMBIE_VILLAGER, EntityType.ZOMBIFIED_PIGLIN);
             @MergeMap


### PR DESCRIPTION
Previously, Zombified Piglins did not properly reset their aggression after a player's death, causing some to remain hostile. To fix this, an instance of the ResetUniversalAngerTargetGoal class is now an attribute of the ZombifiedPiglin class and its start() method is called upon player death(in the startPersistentAngerTimer method). This ensures that only ZombifiedPiglin entities within a range are being reset. Additionally, the expected behavior of Zombified Piglins has been updated to consistently use this reset mechanism, ensuring proper forgiveness behavior.

Video showing the problem solved:
https://www.youtube.com/watch?v=LxUmljnKg40
The video is in Portuguese, due to the fact I am still in college and doing this for a course. Sorry for the inconvenience.