### PR TITLE
Update player chat session sync

### DIFF
--- a/paper-server/patches/features/0015-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0015-Moonrise-optimisation-patches.patch
@@ -28202,10 +28202,10 @@ index b30f56fbc1fd17259a1d05dc9155fffcab292ca1..11fed81a4696ba18440e755c3b8a5ca3
          this.generatingStep = generatingStep;
          this.cache = cache;
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 73717609fccd9af12e2cc39824106f49426b581c..72524ff3399a4477dfa3db2f4e79bb14f6519a8b 100644
+index 5ec9e3b37e575e9805bf9f0ce5cae5c1284461d8..78201407a37eced73998b97d5d5c412eaba69af1 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
-@@ -1321,7 +1321,7 @@ public abstract class PlayerList {
+@@ -1320,7 +1320,7 @@ public abstract class PlayerList {
  
      public void setViewDistance(int viewDistance) {
          this.viewDistance = viewDistance;
@@ -28214,7 +28214,7 @@ index 73717609fccd9af12e2cc39824106f49426b581c..72524ff3399a4477dfa3db2f4e79bb14
  
          for (ServerLevel serverLevel : this.server.getAllLevels()) {
              if (serverLevel != null) {
-@@ -1332,7 +1332,7 @@ public abstract class PlayerList {
+@@ -1331,7 +1331,7 @@ public abstract class PlayerList {
  
      public void setSimulationDistance(int simulationDistance) {
          this.simulationDistance = simulationDistance;

--- a/paper-server/patches/features/0023-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0023-Incremental-chunk-and-player-saving.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Incremental chunk and player saving
 
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 00f7f4356d6bffdd31f58b9d798c755edd9cd3ff..ea85cac4a41075efe8525c40755e7ebac6ca9dea 100644
+index 094ef7f54ad71795a2d8c2a8d03a32bef6ff2164..79bc1b7d9f640d2322814177eb3e921da8671e87 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -952,7 +952,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -50,7 +50,7 @@ index 00f7f4356d6bffdd31f58b9d798c755edd9cd3ff..ea85cac4a41075efe8525c40755e7eba
          ProfilerFiller profilerFiller = Profiler.get();
          this.runAllTasks(); // Paper - move runAllTasks() into full server tick (previously for timings)
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index debc511cf18d0be813803c200bd1cf0b07ba7974..2a4a40976215ea858c562c3f530db378896c6fcb 100644
+index 32db2b9e375c12cbf7abab69cc01e8ac2c7c3b6e..d50d2928ad9f8b34a14621b1fe5c188547e04bd1 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -1317,6 +1317,28 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -83,7 +83,7 @@ index debc511cf18d0be813803c200bd1cf0b07ba7974..2a4a40976215ea858c562c3f530db378
          // Paper start - add close param
          this.save(progress, flush, skipSave, false);
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index bc901bc689c2690ac19e590bff1ae612b7071ee9..8e7ee4dc951eb53ccf65ab71214a0b89bd932ba0 100644
+index 3e73c69c9db8cbded28a001b20d9989acb11c638..d1de5aff81da465be79f2f747466734e80ec50dc 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -189,6 +189,7 @@ import org.slf4j.Logger;
@@ -95,7 +95,7 @@ index bc901bc689c2690ac19e590bff1ae612b7071ee9..8e7ee4dc951eb53ccf65ab71214a0b89
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      private static final int FLY_STAT_RECORDING_SPEED = 25;
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 72524ff3399a4477dfa3db2f4e79bb14f6519a8b..6e22aedd36add8e39a82248193f324b36dfa27b5 100644
+index 78201407a37eced73998b97d5d5c412eaba69af1..f057e682ccd378f11710dc2e7129cba95788bb18 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -486,6 +486,7 @@ public abstract class PlayerList {
@@ -106,7 +106,7 @@ index 72524ff3399a4477dfa3db2f4e79bb14f6519a8b..6e22aedd36add8e39a82248193f324b3
          this.playerIo.save(player);
          ServerStatsCounter serverStatsCounter = player.getStats(); // CraftBukkit
          if (serverStatsCounter != null) {
-@@ -1068,9 +1069,23 @@ public abstract class PlayerList {
+@@ -1067,9 +1068,23 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -2555,7 +2555,7 @@
                  );
          }
      }
-@@ -1997,6 +_,7 @@
+@@ -1997,27 +_,32 @@
  
      private void resetPlayerChatState(RemoteChatSession chatSession) {
          this.chatSession = chatSession;
@@ -2563,16 +2563,19 @@
          this.signedMessageDecoder = chatSession.createMessageDecoder(this.player.getUUID());
          this.chatMessageChain
              .append(
-@@ -2005,7 +_,7 @@
+                 () -> {
++                    server.executeBlocking(() -> { // Paper - Broadcast chat session update sync
+                     this.player.setChatSession(chatSession);
                      this.server
                          .getPlayerList()
                          .broadcastAll(
 -                            new ClientboundPlayerInfoUpdatePacket(EnumSet.of(ClientboundPlayerInfoUpdatePacket.Action.INITIALIZE_CHAT), List.of(this.player))
 +                            new ClientboundPlayerInfoUpdatePacket(EnumSet.of(ClientboundPlayerInfoUpdatePacket.Action.INITIALIZE_CHAT), List.of(this.player)), this.player // Paper - Use single player info update packet on join
                          );
++                    });
                  }
              );
-@@ -2013,11 +_,13 @@
+     }
  
      @Override
      public void handleCustomPayload(ServerboundCustomPayloadPacket packet) {

--- a/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -756,7 +756,7 @@
  
          return serverPlayer;
      }
-@@ -488,24 +_,60 @@
+@@ -488,24 +_,59 @@
      }
  
      public void sendActiveEffects(LivingEntity entity, ServerGamePacketListenerImpl connection) {
@@ -800,12 +800,11 @@
  
 +    // CraftBukkit start - add a world/entity limited version
 +    public void broadcastAll(Packet packet, net.minecraft.world.entity.player.Player entityhuman) {
-+        for (int i = 0; i < this.players.size(); ++i) {
-+            ServerPlayer entityplayer =  this.players.get(i);
++        for (ServerPlayer entityplayer : this.players) { // Paper - replace for i with for each for thread safety
 +            if (entityhuman != null && !entityplayer.getBukkitEntity().canSee(entityhuman.getBukkitEntity())) {
 +                continue;
 +            }
-+            ((ServerPlayer) this.players.get(i)).connection.send(packet);
++            ((ServerPlayer) entityplayer).connection.send(packet); // Paper - replace for i with for each for thread safety
 +        }
 +    }
 +


### PR DESCRIPTION
``PlayerList#broadcastAll(Packet, Player)`` is not thread safe and can result in errors like this:
```
[15:04:46] [Async Chat Thread - #91/ERROR]: Chain link failed, continuing to next one
java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
	at java.base/java.util.concurrent.CopyOnWriteArrayList.elementAt(CopyOnWriteArrayList.java:390) ~[?:?]
	at java.base/java.util.concurrent.CopyOnWriteArrayList.get(CopyOnWriteArrayList.java:403) ~[?:?]
	at net.minecraft.server.players.PlayerList.broadcastAll(PlayerList.java:982) ~[spigot.jar:1.21.3-DEV-020e886]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$resetPlayerChatState$16(ServerGamePacketListenerImpl.java:3667) ~[spigot.jar:1.21.3-DEV-020e886]
	at net.minecraft.util.TaskChainer.lambda$append$0(TaskChainer.java:26) ~[spigot.jar:1.21.3-DEV-020e886]
	at net.minecraft.util.FutureChain.lambda$append$1(FutureChain.java:25) ~[spigot.jar:1.21.3-DEV-020e886]
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:718) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```

My first approach was updating the ``PlayerList#broadcastAll`` to make it thread safe. For some reason CraftBukkit explicitly replaced the ``PlayerList#players`` list with an CopyOnWriteArrayList, but then uses an for i loop (not thread safe) instead of an iterator (thread safe):
``public final List<ServerPlayer> players = new java.util.concurrent.CopyOnWriteArrayList(); // CraftBukkit - ArrayList -> CopyOnWriteArrayList: Iterator safety``
```
// CraftBukkit start - add a world/entity limited version
public void broadcastAll(Packet packet, net.minecraft.world.entity.player.Player entityhuman) {
    for (int i = 0; i < this.players.size(); ++i) {
        ServerPlayer entityplayer =  this.players.get(i);
        if (entityhuman != null && !entityplayer.getBukkitEntity().canSee(entityhuman.getBukkitEntity())) {
            continue;
        }
        ((ServerPlayer) this.players.get(i)).connection.send(packet);
    }
}
```
However I think ``Player#canSee`` also isn't thread safe and this could still lead to players receiving the chat session update for hidden players.
So just posting the chat session update to the main thread should be the safest option.