### PR TITLE
Prevent keep inventory deaths from dropping open container/cursor items

### DIFF
--- a/paper-server/patches/features/0015-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0015-Moonrise-optimisation-patches.patch
@@ -27565,7 +27565,7 @@ index 085040aa98704f2874bcd95b751b0a81dcdb15ad..cd72273468f596b640bd2d10d846fbe8
      }
  
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 8bbbd1d64df1f4f4aecdbb1d1d65e258af018ca9..9eff33c3f552da794370d48a6ef526eecd2b131c 100644
+index 4fc1e74ab98b61c9f95caa7f4ca7756b6d1c440a..d380bb90436ebd5992dad5de27a6d65803cb7c00 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -187,7 +187,7 @@ import net.minecraft.world.scores.Team;
@@ -27577,7 +27577,7 @@ index 8bbbd1d64df1f4f4aecdbb1d1d65e258af018ca9..9eff33c3f552da794370d48a6ef526ee
      private static final Logger LOGGER = LogUtils.getLogger();
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_XZ = 32;
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
-@@ -423,6 +423,36 @@ public class ServerPlayer extends Player {
+@@ -424,6 +424,36 @@ public class ServerPlayer extends Player {
      public @Nullable String clientBrandName = null; // Paper - Brand support
      public @Nullable org.bukkit.event.player.PlayerQuitEvent.QuitReason quitReason = null; // Paper - Add API for quit reason; there are a lot of changes to do if we change all methods leading to the event
  
@@ -28597,7 +28597,7 @@ index 8cc5c0716392ba06501542ff5cbe71ee43979e5d..09fd99c9cbd23b5f3c899bfb00c9b896
 +    // Paper end - block counting
  }
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 609b52150aab93b0bed3b41632c19a00e372fc64..f6cb7754e865b9df3f2e204a7ea9b522fb01851b 100644
+index be8213fa58e8305976c5ce16c9ff32130a26d42c..ace6c77be333e839b679b5cf3cd7c080df422be7 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -140,7 +140,7 @@ import net.minecraft.world.scores.ScoreHolder;
@@ -29576,7 +29576,7 @@ index b766b4281aecb3b96e2c263664d81da3425e3653..c3bcb494afe464207e805f8c40b03c70
          this(setDirty, true, ImmutableList.of());
      }
 diff --git a/net/minecraft/world/entity/decoration/ArmorStand.java b/net/minecraft/world/entity/decoration/ArmorStand.java
-index 75bf15ccd8a12153951f886ed87be9f3bece3133..6f601a0a300bbf01f77d835576d15e25c8ba10b8 100644
+index f5ce8151bb1bae9be638ced7f74899d452d517e1..5248f3c22abb608d7d7b338f169f13bfbf4cd2d6 100644
 --- a/net/minecraft/world/entity/decoration/ArmorStand.java
 +++ b/net/minecraft/world/entity/decoration/ArmorStand.java
 @@ -245,7 +245,7 @@ public class ArmorStand extends LivingEntity {

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -73,7 +73,7 @@
          @Override
          public void dataChanged(AbstractContainerMenu containerMenu, int dataSlotIndex, int value) {
          }
-@@ -344,9 +_,43 @@
+@@ -344,9 +_,44 @@
          public void sendSystemMessage(Component component) {
              ServerPlayer.this.sendSystemMessage(component);
          }
@@ -105,6 +105,7 @@
 +    public int newLevel = 0;
 +    public int newTotalExp = 0;
 +    public boolean keepLevel = false;
++    public boolean keepInventory = false; // Paper - Keep inventory tracking
 +    public double maxHealthCache;
 +    public boolean joining = true;
 +    public boolean sentListPacket = false;
@@ -1397,7 +1398,7 @@
          }
  
          private static float calculateLookAtYaw(Vec3 position, BlockPos towardsPos) {
-@@ -2123,4 +_,143 @@
+@@ -2123,4 +_,144 @@
              return (float)Mth.wrapDegrees(Mth.atan2(vec3.z, vec3.x) * 180.0F / (float)Math.PI - 90.0);
          }
      }
@@ -1531,6 +1532,7 @@
 +            this.giveExperiencePoints(this.newExp);
 +        }
 +        this.keepLevel = false;
++        this.keepInventory = false; // Paper - Keep inventory tracking
 +        this.setDeltaMovement(0, 0, 0); // CraftBukkit - SPIGOT-6948: Reset velocity on death
 +        this.skipDropExperience = false; // CraftBukkit - SPIGOT-7462: Reset experience drop skip, so that further deaths drop xp
 +    }

--- a/paper-server/patches/sources/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -171,7 +171,7 @@
              ItemStack item = inventory.getItem(button);
              Slot slot = this.slots.get(slotId);
              ItemStack carried = slot.getItem();
-@@ -590,8 +_,9 @@
+@@ -590,14 +_,18 @@
          if (player instanceof ServerPlayer) {
              ItemStack carried = this.getCarried();
              if (!carried.isEmpty()) {
@@ -182,6 +182,16 @@
              }
          }
      }
+ 
+     private static void dropOrPlaceInInventory(Player player, ItemStack stack) {
+-        boolean flag = player.isRemoved() && player.getRemovalReason() != Entity.RemovalReason.CHANGED_DIMENSION;
++        // Paper start - config for not dropping menu items with keep inventory
++        boolean shouldPutBackIntoInventory = ((ServerPlayer) player).keepInventory && io.papermc.paper.configuration.GlobalConfiguration.get().misc.returnItemsToInventoryUponKeepInventoryDeath;
++        boolean flag = player.isRemoved() && player.getRemovalReason() != Entity.RemovalReason.CHANGED_DIMENSION && !shouldPutBackIntoInventory;
++        // Paper end - config for not dropping menu items with keep inventory
+         boolean flag1 = player instanceof ServerPlayer serverPlayer && serverPlayer.hasDisconnected();
+         if (flag || flag1) {
+             player.drop(stack, false);
 @@ -637,6 +_,14 @@
      public abstract boolean stillValid(Player player);
  

--- a/paper-server/patches/sources/net/minecraft/world/inventory/MerchantMenu.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/MerchantMenu.java.patch
@@ -89,3 +89,15 @@
              Entity entity = (Entity)this.trader;
              entity.level()
                  .playLocalSound(entity.getX(), entity.getY(), entity.getZ(), this.trader.getNotifyTradeSound(), SoundSource.NEUTRAL, 1.0F, 1.0F, false);
+@@ -152,7 +_,10 @@
+         super.removed(player);
+         this.trader.setTradingPlayer(null);
+         if (!this.trader.isClientSide()) {
+-            if (!player.isAlive() || player instanceof ServerPlayer && ((ServerPlayer)player).hasDisconnected()) {
++            // Paper start - config for not dropping menu items with keep inventory
++            boolean shouldPutBackIntoInventory = ((ServerPlayer) player).keepInventory && io.papermc.paper.configuration.GlobalConfiguration.get().misc.returnItemsToInventoryUponKeepInventoryDeath;
++            if ((!player.isAlive() && !shouldPutBackIntoInventory) || (player instanceof ServerPlayer && ((ServerPlayer)player).hasDisconnected())) {
++            // Paper start - config for not dropping menu items with keep inventory
+                 ItemStack itemStack = this.tradeContainer.removeItemNoUpdate(0);
+                 if (!itemStack.isEmpty()) {
+                     player.drop(itemStack, false);

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -356,6 +356,8 @@ public class GlobalConfiguration extends ConfigurationPart {
         public IntOr.Default compressionLevel = IntOr.Default.USE_DEFAULT;
         @Comment("Defines the leniency distance added on the server to the interaction range of a player when validating interact packets.")
         public DoubleOr.Default clientInteractionLeniencyDistance = DoubleOr.Default.USE_DEFAULT;
+        @Comment("If true, items in open inventory slots and the cursor item return to the player's inventory on death with keep-inventory; otherwise, they drop.")
+        public boolean returnItemsToInventoryUponKeepInventoryDeath = false;
     }
 
     public BlockUpdates blockUpdates;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -894,6 +894,7 @@ public class CraftEventFactory {
         // Paper end
 
         victim.keepLevel = event.getKeepLevel();
+        victim.keepInventory = event.getKeepInventory();
         victim.newLevel = event.getNewLevel();
         victim.newTotalExp = event.getNewTotalExp();
         victim.expToDrop = event.getDroppedExp();


### PR DESCRIPTION
When a player has an open inventory—such as with a merchant or anvil—and
places items in it, or has an item on their cursor, closing the inventory typically 
returns those items to the player's main inventory. However, if the player dies with
the inventory still open, the items are dropped onto the ground.

This usually isn't a problem, as their entire inventory would be dropped anyway.
But when keep inventory is enabled, these items should return directly to the player's inventory
to prevent valuable items from being accidentally dropped—especially
in spawn areas where keep inventory is active.

Rebased version of: #11533