### PR TITLE
Add ability to disable Bukkit permissions handling

### DIFF
--- a/paper-server/patches/sources/net/minecraft/commands/CommandSourceStack.java.patch
+++ b/paper-server/patches/sources/net/minecraft/commands/CommandSourceStack.java.patch
@@ -74,7 +74,7 @@
 +    // CraftBukkit start
 +    public boolean hasPermission(int i, String bukkitPermission) {
 +        // Paper start - Fix permission levels for command blocks
-+        final java.util.function.BooleanSupplier hasBukkitPerm = () -> this.source == CommandSource.NULL /*treat NULL as having all bukkit perms*/ || this.getBukkitSender().hasPermission(bukkitPermission); // lazily check bukkit perms to the benefit of custom permission setups
++        final java.util.function.BooleanSupplier hasBukkitPerm = () -> !this.getServer().server.ignoreBukkitPermissions && (this.source == CommandSource.NULL /*treat NULL as having all bukkit perms*/ || this.getBukkitSender().hasPermission(bukkitPermission)); // lazily check bukkit perms to the benefit of custom permission setups
 +        // if the server is null, we must check the vanilla perm level system
 +        // if ignoreVanillaPermissions is true, we can skip vanilla perms and just run the bukkit perm check
 +        //noinspection ConstantValue

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -307,6 +307,7 @@ public final class CraftServer implements Server {
     private CraftIconCache icon;
     private boolean overrideAllCommandBlockCommands = false;
     public boolean ignoreVanillaPermissions = false;
+    public boolean ignoreBukkitPermissions = false; // Paper
     private final List<CraftPlayer> playerView;
     public int reloadCount;
     public Set<String> activeCompatibilities = Collections.emptySet();
@@ -477,6 +478,9 @@ public final class CraftServer implements Server {
         this.saveCommandsConfig();
         this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
         this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
+        // Paper start
+        this.ignoreBukkitPermissions = this.commandsConfiguration.getBoolean("ignore-bukkit-permissions");
+        // Paper end
         this.overrideSpawnLimits();
         console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
         this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -1122,6 +1126,9 @@ public final class CraftServer implements Server {
         this.spark.registerCommandBeforePlugins(this); // Paper - spark
         this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
         this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
+        // Paper start
+        this.ignoreBukkitPermissions = this.commandsConfiguration.getBoolean("ignore-bukkit-permissions");
+        // Paper end
 
         int pollCount = 0;
 


### PR DESCRIPTION
# PR Details

## Information

This PR intends to add the ability for server to disable Bukkit permissions checking for commands. With this will be able to fix some problems with permission levels checking in Bukkit.

## Technical comments

The `PermissibleBase#hasPermission(@NotNull String inName)` is a Bukkit method that checks the permissions of a property, from the comment of @zml2008 `permissions model predates the numbered op levels` we can assume it should be thought as a refactor in the future. Because the Bukkit implementation does not allow levels of permissions.

Note: The modifications are made in the less affecting way possible, we know this might induce into some configurations changes to unintended behavior. With this I want to ask: I should enhance the hole system or only change the minimum to fix the issues

## Why do not approach the full solution?

IMHO; this should be thought, when the project has fulfill all the major goals and all the important discussions has being fixed, by the contributors for having a nice permission handling without affecting vanilla implementation while containing all the features needed, Bukkit's and Paper's, 


## Why still in draft?

This PR is in draft because, me luisch444, have not completely tested this feature and neither added any test. Nevertheless, we would like to hear back by the contributors of project if any adjustment is needed.

As well, this modifications (with the config value active) might introduces some breaks into some plugins only supported in Bukkit.


## Fixed issues (Please update/comment on need)

- Workaround to #7369 