### PR TITLE
Bump to adventure 4.20.0

### DIFF
--- a/paper-api/build.gradle.kts
+++ b/paper-api/build.gradle.kts
@@ -11,7 +11,7 @@ java {
 
 val annotationsVersion = "26.0.1"
 val bungeeCordChatVersion = "1.20-R0.2"
-val adventureVersion = "4.18.0"
+val adventureVersion = "4.19.0"
 val slf4jVersion = "2.0.9"
 val log4jVersion = "2.17.1"
 

--- a/paper-api/build.gradle.kts
+++ b/paper-api/build.gradle.kts
@@ -11,7 +11,7 @@ java {
 
 val annotationsVersion = "26.0.1"
 val bungeeCordChatVersion = "1.20-R0.2"
-val adventureVersion = "4.19.0"
+val adventureVersion = "4.20.0"
 val slf4jVersion = "2.0.9"
 val log4jVersion = "2.17.1"
 

--- a/paper-server/src/main/java/io/papermc/paper/adventure/providers/MiniMessageProviderImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/providers/MiniMessageProviderImpl.java
@@ -10,7 +10,7 @@ public class MiniMessageProviderImpl implements MiniMessage.Provider {
 
     @Override
     public @NotNull MiniMessage miniMessage() {
-        return MiniMessage.builder().build();
+        return MiniMessage.builder().emitVirtuals(false).build();
     }
 
     @Override


### PR DESCRIPTION
The update only includes a new configuration for MiniMessage,
specifically one to prevent it from emitting virtual components.
As virtual components break the generated component tree, items quickly
become unstackable with items generated before adventure 4.18.

Plugin developers may construct their own mini message instance which
will emit virtual components if they so choose.