### PR TITLE
Structure - Create PlacementOptions

### DIFF
--- a/paper-api/src/main/java/org/bukkit/structure/PlacementOptions.java
+++ b/paper-api/src/main/java/org/bukkit/structure/PlacementOptions.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import java.util.Random;
 import org.bukkit.block.structure.Mirror;
 import org.bukkit.block.structure.StructureRotation;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents options for placing a {@link Structure}.
@@ -25,17 +26,18 @@ public class PlacementOptions {
      * @param random The randomizer used for setting the structure's
      *               {@link org.bukkit.loot.LootTable LootTables} and integrity.
      */
-    public PlacementOptions(Random random) {
+    public PlacementOptions(@NotNull Random random) {
         this.random = random;
     }
 
     /**
-     * Whether to include entities when the structure is placed.
+     * Set whether to include entities when the structure is placed.
+     * <p>Will default to true if not set.</p>
      *
      * @param includeEntities Whether to include entities.
      * @return This PlacementOptions.
      */
-    public PlacementOptions includeEntities(boolean includeEntities) {
+    public @NotNull PlacementOptions includeEntities(boolean includeEntities) {
         this.includeEntities = includeEntities;
         return this;
     }
@@ -51,11 +53,12 @@ public class PlacementOptions {
 
     /**
      * Set the rotation a structure will place with.
+     * <p>Will default to {@link StructureRotation#NONE} if not set.</p>
      *
      * @param structureRotation Rotation to place with.
      * @return This PlacementOptions.
      */
-    public PlacementOptions structureRotation(StructureRotation structureRotation) {
+    public @NotNull PlacementOptions structureRotation(@NotNull StructureRotation structureRotation) {
         this.structureRotation = structureRotation;
         return this;
     }
@@ -65,17 +68,18 @@ public class PlacementOptions {
      *
      * @return Rotation to place with.
      */
-    public StructureRotation getStructureRotation() {
+    public @NotNull StructureRotation getStructureRotation() {
         return structureRotation;
     }
 
     /**
      * Set the mirror a structure will place with.
+     * <p>Will default to {@link Mirror#NONE} if not set</p>
      *
      * @param mirror Mirror to place with.
      * @return This PlacementOptions.
      */
-    public PlacementOptions mirror(Mirror mirror) {
+    public @NotNull PlacementOptions mirror(@NotNull Mirror mirror) {
         this.mirror = mirror;
         return this;
     }
@@ -85,18 +89,19 @@ public class PlacementOptions {
      *
      * @return Mirror to place with.
      */
-    public Mirror getMirror() {
+    public @NotNull Mirror getMirror() {
         return mirror;
     }
 
     /**
      * Set the palette used for placing a structure.
+     * <p>Will default to {@code -1} if not set.</p>
      *
      * @param palette The palette index of the structure to use, starting at
      *                {@code 0}, or {@code -1} to pick a random palette.
      * @return This PlacementOptions.
      */
-    public PlacementOptions palette(int palette) {
+    public @NotNull PlacementOptions palette(int palette) {
         this.palette = palette;
         return this;
     }
@@ -112,13 +117,14 @@ public class PlacementOptions {
 
     /**
      * Set the integrity used for placing a structure.
+     * <p>Will default to 1 if not set</p>
      *
      * @param integrity Determines how damaged the building should look by
      *                  randomly skipping blocks to place. This value can range from 0 to 1. With
      *                  0 removing all blocks and 1 spawning the structure in pristine condition.
      * @return This PlacementOptions
      */
-    public PlacementOptions integrity(float integrity) {
+    public @NotNull PlacementOptions integrity(float integrity) {
         Preconditions.checkArgument(integrity >= 0F && integrity <= 1F, "Integrity value (%S) must be between 0 and 1 inclusive", integrity);
         this.integrity = integrity;
         return this;
@@ -137,11 +143,12 @@ public class PlacementOptions {
      * Set whether the structure will place with strict block placement.
      * <p>When true, blocks placed in the structure will not perform block updates.
      * ie: Water won't spread, fences won't connect to blocks.</p>
+     * <p>Will default to false if not set.</p>
      *
      * @param strict Whether to restrict block updates.
      * @return This PlacementOptions
      */
-    public PlacementOptions strict(boolean strict) {
+    public @NotNull PlacementOptions strict(boolean strict) {
         this.strict = strict;
         return this;
     }
@@ -157,11 +164,12 @@ public class PlacementOptions {
 
     /**
      * Set whether to apply waterlogging when placing a structure.
+     * <p>Will default to true if not set.</p>
      *
      * @param applyWaterlogging Whether to apply waterlogging.
      * @return This PlacementOptions
      */
-    public PlacementOptions applyWaterlogging(boolean applyWaterlogging) {
+    public @NotNull PlacementOptions applyWaterlogging(boolean applyWaterlogging) {
         this.applyWaterlogging = applyWaterlogging;
         return this;
     }
@@ -180,7 +188,7 @@ public class PlacementOptions {
      *
      * @return Random assigned.
      */
-    public Random getRandom() {
+    public @NotNull Random getRandom() {
         return random;
     }
 

--- a/paper-api/src/main/java/org/bukkit/structure/PlacementOptions.java
+++ b/paper-api/src/main/java/org/bukkit/structure/PlacementOptions.java
@@ -1,0 +1,81 @@
+package org.bukkit.structure;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.block.structure.Mirror;
+import org.bukkit.block.structure.StructureRotation;
+import java.util.Random;
+
+public class PlacementOptions {
+
+    private boolean includeEntities = true;
+    private StructureRotation structureRotation = StructureRotation.NONE;
+    private Mirror mirror = Mirror.NONE;
+    private int palette = 0;
+    private float integrity = 1;
+    private final Random random;
+    private boolean strict = false;
+
+    public PlacementOptions(Random random) {
+        this.random = random;
+    }
+
+    public PlacementOptions includeEntities(boolean includeEntities) {
+        this.includeEntities = includeEntities;
+        return this;
+    }
+
+    public PlacementOptions structureRotation(StructureRotation structureRotation) {
+        this.structureRotation = structureRotation;
+        return this;
+    }
+
+    public PlacementOptions mirror(Mirror mirror) {
+        this.mirror = mirror;
+        return this;
+    }
+
+    public PlacementOptions palette(int palette) {
+        this.palette = palette;
+        return this;
+    }
+
+    public PlacementOptions integrity(float integrity) {
+        Preconditions.checkArgument(integrity >= 0F && integrity <= 1F, "Integrity value (%S) must be between 0 and 1 inclusive", integrity);
+        this.integrity = integrity;
+        return this;
+    }
+
+    public PlacementOptions strict(boolean strict) {
+        this.strict = strict;
+        return this;
+    }
+
+    public boolean isIncludeEntities() {
+        return includeEntities;
+    }
+
+    public StructureRotation getStructureRotation() {
+        return structureRotation;
+    }
+
+    public Mirror getMirror() {
+        return mirror;
+    }
+
+    public int getPalette() {
+        return palette;
+    }
+
+    public float getIntegrity() {
+        return integrity;
+    }
+
+    public Random getRandom() {
+        return random;
+    }
+
+    public boolean isStrict() {
+        return strict;
+    }
+
+}

--- a/paper-api/src/main/java/org/bukkit/structure/PlacementOptions.java
+++ b/paper-api/src/main/java/org/bukkit/structure/PlacementOptions.java
@@ -10,7 +10,7 @@ public class PlacementOptions {
     private boolean includeEntities = true;
     private StructureRotation structureRotation = StructureRotation.NONE;
     private Mirror mirror = Mirror.NONE;
-    private int palette = 0;
+    private int palette = -1;
     private float integrity = 1;
     private final Random random;
     private boolean strict = false;

--- a/paper-api/src/main/java/org/bukkit/structure/PlacementOptions.java
+++ b/paper-api/src/main/java/org/bukkit/structure/PlacementOptions.java
@@ -1,9 +1,13 @@
 package org.bukkit.structure;
 
 import com.google.common.base.Preconditions;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Random;
 import org.bukkit.block.structure.Mirror;
 import org.bukkit.block.structure.StructureRotation;
+import org.bukkit.util.BlockTransformer;
+import org.bukkit.util.EntityTransformer;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -19,6 +23,8 @@ public class PlacementOptions {
     private final Random random;
     private boolean strict = false;
     private boolean applyWaterlogging = true;
+    private Collection<BlockTransformer> blockTransformers = Collections.emptyList();
+    private Collection<EntityTransformer> entityTransformers = Collections.emptyList();
 
     /**
      * Create a new set of placement options for placing a {@link Structure}.
@@ -181,6 +187,71 @@ public class PlacementOptions {
      */
     public boolean isApplyWaterlogging() {
         return applyWaterlogging;
+    }
+
+    /**
+     * Set the collection of {@link BlockTransformer BlockTransformers} to apply to the structure.
+     *
+     * @param blockTransformers Collection of BlockTransformers.
+     * @return This PlacementOptions.
+     */
+    public @NotNull PlacementOptions blockTransformers(@NotNull Collection<BlockTransformer> blockTransformers) {
+        this.blockTransformers = blockTransformers;
+        return this;
+    }
+
+    /**
+     * Add a {@link BlockTransformer} to apply to the structure.
+     * <p>Will default to an empty list if not included.</p>
+     *
+     * @param blockTransformer BlockTransformer to apply.
+     * @return This PlacementOptions.
+     */
+    public @NotNull PlacementOptions addBlockTransformer(@NotNull BlockTransformer blockTransformer) {
+        this.blockTransformers.add(blockTransformer);
+        return this;
+    }
+
+    /**
+     * Collection of {@link BlockTransformer BlockTransformers} to apply to the structure.
+     *
+     * @return BlockTransformers to apply.
+     */
+    public @NotNull Collection<BlockTransformer> getBlockTransformers() {
+        return blockTransformers;
+    }
+
+    /**
+     * Set the collection of {@link EntityTransformer EntityTransformers} to apply to the structure.
+     * <p>Will default to an empty list if not included.</p>
+     *
+     * @param entityTransformers EntityTransformers to apply.
+     * @return This PlacementOptions.
+     */
+    public @NotNull PlacementOptions entityTransformers(@NotNull Collection<EntityTransformer> entityTransformers) {
+        this.entityTransformers = entityTransformers;
+        return this;
+    }
+
+    /**
+     * Add an {@link EntityTransformer} to apply to the structure.
+     * <p>Will default to an empty list if not included.</p>
+     *
+     * @param entityTransformer EntityTransformer to apply.
+     * @return This PlacementOptions.
+     */
+    public @NotNull PlacementOptions addEntityTransformer(@NotNull EntityTransformer entityTransformer) {
+        this.entityTransformers.add(entityTransformer);
+        return this;
+    }
+
+    /**
+     * Collection of {@link EntityTransformer EntityTransformers} to apply to the structure.
+     *
+     * @return EntityTransformers to apply.
+     */
+    public @NotNull Collection<EntityTransformer> getEntityTransformers() {
+        return entityTransformers;
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/structure/PlacementOptions.java
+++ b/paper-api/src/main/java/org/bukkit/structure/PlacementOptions.java
@@ -1,10 +1,13 @@
 package org.bukkit.structure;
 
 import com.google.common.base.Preconditions;
+import java.util.Random;
 import org.bukkit.block.structure.Mirror;
 import org.bukkit.block.structure.StructureRotation;
-import java.util.Random;
 
+/**
+ * Represents options for placing a {@link Structure}.
+ */
 public class PlacementOptions {
 
     private boolean includeEntities = true;
@@ -16,76 +19,169 @@ public class PlacementOptions {
     private boolean strict = false;
     private boolean applyWaterlogging = true;
 
+    /**
+     * Create a new set of placement options for placing a {@link Structure}.
+     *
+     * @param random The randomizer used for setting the structure's
+     *               {@link org.bukkit.loot.LootTable LootTables} and integrity.
+     */
     public PlacementOptions(Random random) {
         this.random = random;
     }
 
+    /**
+     * Whether to include entities when the structure is placed.
+     *
+     * @param includeEntities Whether to include entities.
+     * @return This PlacementOptions.
+     */
     public PlacementOptions includeEntities(boolean includeEntities) {
         this.includeEntities = includeEntities;
         return this;
     }
 
+    /**
+     * Whether to include entities when the structure is placed.
+     *
+     * @return Whether to include entities.
+     */
+    public boolean isIncludeEntities() {
+        return includeEntities;
+    }
+
+    /**
+     * Set the rotation a structure will place with.
+     *
+     * @param structureRotation Rotation to place with.
+     * @return This PlacementOptions.
+     */
     public PlacementOptions structureRotation(StructureRotation structureRotation) {
         this.structureRotation = structureRotation;
         return this;
     }
 
+    /**
+     * The rotation a structure will place with.
+     *
+     * @return Rotation to place with.
+     */
+    public StructureRotation getStructureRotation() {
+        return structureRotation;
+    }
+
+    /**
+     * Set the mirror a structure will place with.
+     *
+     * @param mirror Mirror to place with.
+     * @return This PlacementOptions.
+     */
     public PlacementOptions mirror(Mirror mirror) {
         this.mirror = mirror;
         return this;
     }
 
+    /**
+     * The mirror a structure will place with.
+     *
+     * @return Mirror to place with.
+     */
+    public Mirror getMirror() {
+        return mirror;
+    }
+
+    /**
+     * Set the palette used for placing a structure.
+     *
+     * @param palette The palette index of the structure to use, starting at
+     *                {@code 0}, or {@code -1} to pick a random palette.
+     * @return This PlacementOptions.
+     */
     public PlacementOptions palette(int palette) {
         this.palette = palette;
         return this;
     }
 
+    /**
+     * The palette used for placing a structure.
+     *
+     * @return Palette used for placing a structure.
+     */
+    public int getPalette() {
+        return palette;
+    }
+
+    /**
+     * Set the integrity used for placing a structure.
+     *
+     * @param integrity Determines how damaged the building should look by
+     *                  randomly skipping blocks to place. This value can range from 0 to 1. With
+     *                  0 removing all blocks and 1 spawning the structure in pristine condition.
+     * @return This PlacementOptions
+     */
     public PlacementOptions integrity(float integrity) {
         Preconditions.checkArgument(integrity >= 0F && integrity <= 1F, "Integrity value (%S) must be between 0 and 1 inclusive", integrity);
         this.integrity = integrity;
         return this;
     }
 
+    /**
+     * The integrity used for placing a structure.
+     *
+     * @return Integrity used for placing a structure.
+     */
+    public float getIntegrity() {
+        return integrity;
+    }
+
+    /**
+     * Set whether the structure will place with strict block placement.
+     * <p>When true, blocks placed in the structure will not perform block updates.
+     * ie: Water won't spread, fences won't connect to blocks.</p>
+     *
+     * @param strict Whether to restrict block updates.
+     * @return This PlacementOptions
+     */
     public PlacementOptions strict(boolean strict) {
         this.strict = strict;
         return this;
     }
 
+    /**
+     * Whether the structure will place with strict block placement.
+     *
+     * @return Will place with strict block placement.
+     */
+    public boolean isStrict() {
+        return strict;
+    }
+
+    /**
+     * Set whether to apply waterlogging when placing a structure.
+     *
+     * @param applyWaterlogging Whether to apply waterlogging.
+     * @return This PlacementOptions
+     */
     public PlacementOptions applyWaterlogging(boolean applyWaterlogging) {
         this.applyWaterlogging = applyWaterlogging;
         return this;
     }
 
-    public boolean isIncludeEntities() {
-        return includeEntities;
-    }
-
-    public StructureRotation getStructureRotation() {
-        return structureRotation;
-    }
-
-    public Mirror getMirror() {
-        return mirror;
-    }
-
-    public int getPalette() {
-        return palette;
-    }
-
-    public float getIntegrity() {
-        return integrity;
-    }
-
-    public Random getRandom() {
-        return random;
-    }
-
-    public boolean isStrict() {
-        return strict;
-    }
-
+    /**
+     * Whether waterlogging will be applied when placing a structure.
+     *
+     * @return Waterlogging will apply.
+     */
     public boolean isApplyWaterlogging() {
         return applyWaterlogging;
+    }
+
+    /**
+     * The random assigned to this PlacementOptions.
+     *
+     * @return Random assigned.
+     */
+    public Random getRandom() {
+        return random;
     }
 
 }

--- a/paper-api/src/main/java/org/bukkit/structure/PlacementOptions.java
+++ b/paper-api/src/main/java/org/bukkit/structure/PlacementOptions.java
@@ -14,6 +14,7 @@ public class PlacementOptions {
     private float integrity = 1;
     private final Random random;
     private boolean strict = false;
+    private boolean applyWaterlogging = true;
 
     public PlacementOptions(Random random) {
         this.random = random;
@@ -50,6 +51,11 @@ public class PlacementOptions {
         return this;
     }
 
+    public PlacementOptions applyWaterlogging(boolean applyWaterlogging) {
+        this.applyWaterlogging = applyWaterlogging;
+        return this;
+    }
+
     public boolean isIncludeEntities() {
         return includeEntities;
     }
@@ -76,6 +82,10 @@ public class PlacementOptions {
 
     public boolean isStrict() {
         return strict;
+    }
+
+    public boolean isApplyWaterlogging() {
+        return applyWaterlogging;
     }
 
 }

--- a/paper-api/src/main/java/org/bukkit/structure/Structure.java
+++ b/paper-api/src/main/java/org/bukkit/structure/Structure.java
@@ -107,54 +107,12 @@ public interface Structure extends PersistentDataHolder {
      * randomly skipping blocks to place. This value can range from 0 to 1. With
      * 0 removing all blocks and 1 spawning the structure in pristine condition.
      * @param random The randomizer used for setting the structure's
-     * @param strict Whether to prevent block updates (ie: prevent flowing water or fence connections)
-     * {@link org.bukkit.loot.LootTable}s and integrity.
-     */
-    @ApiStatus.Experimental
-    void place(@NotNull Location location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, boolean strict);
-
-    /**
-     * Place a structure in the world.
-     *
-     * @param location The location to place the structure at.
-     * @param includeEntities If the entities present in the structure should be
-     * spawned.
-     * @param structureRotation The rotation of the structure.
-     * @param mirror The mirror settings of the structure.
-     * @param palette The palette index of the structure to use, starting at
-     * {@code 0}, or {@code -1} to pick a random palette.
-     * @param integrity Determines how damaged the building should look by
-     * randomly skipping blocks to place. This value can range from 0 to 1. With
-     * 0 removing all blocks and 1 spawning the structure in pristine condition.
-     * @param random The randomizer used for setting the structure's
      * {@link org.bukkit.loot.LootTable}s and integrity.
      * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
      * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
      */
     @ApiStatus.Experimental
     void place(@NotNull Location location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
-
-    /**
-     * Place a structure in the world.
-     *
-     * @param location The location to place the structure at.
-     * @param includeEntities If the entities present in the structure should be
-     * spawned.
-     * @param structureRotation The rotation of the structure.
-     * @param mirror The mirror settings of the structure.
-     * @param palette The palette index of the structure to use, starting at
-     * {@code 0}, or {@code -1} to pick a random palette.
-     * @param integrity Determines how damaged the building should look by
-     * randomly skipping blocks to place. This value can range from 0 to 1. With
-     * 0 removing all blocks and 1 spawning the structure in pristine condition.
-     * @param random The randomizer used for setting the structure's
-     * @param strict Whether to prevent block updates (ie: prevent flowing water or fence connections)
-     * {@link org.bukkit.loot.LootTable}s and integrity.
-     * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
-     * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
-     */
-    @ApiStatus.Experimental
-    void place(@NotNull Location location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, boolean strict, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
 
     /**
      * Place a structure in the world.
@@ -190,56 +148,12 @@ public interface Structure extends PersistentDataHolder {
      * randomly skipping blocks to place. This value can range from 0 to 1. With
      * 0 removing all blocks and 1 spawning the structure in pristine condition.
      * @param random The randomizer used for setting the structure's
-     * @param strict Whether to prevent block updates (ie: prevent flowing water or fence connections)
-     * {@link org.bukkit.loot.LootTable}s and integrity.
-     */
-    @ApiStatus.Experimental
-    void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, boolean strict);
-
-    /**
-     * Place a structure in the world.
-     *
-     * @param regionAccessor The world to place the structure in.
-     * @param location The location to place the structure at.
-     * @param includeEntities If the entities present in the structure should be
-     * spawned.
-     * @param structureRotation The rotation of the structure.
-     * @param mirror The mirror settings of the structure.
-     * @param palette The palette index of the structure to use, starting at
-     * {@code 0}, or {@code -1} to pick a random palette.
-     * @param integrity Determines how damaged the building should look by
-     * randomly skipping blocks to place. This value can range from 0 to 1. With
-     * 0 removing all blocks and 1 spawning the structure in pristine condition.
-     * @param random The randomizer used for setting the structure's
      * {@link org.bukkit.loot.LootTable}s and integrity.
      * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
      * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
      */
     @ApiStatus.Experimental
     void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
-
-    /**
-     * Place a structure in the world.
-     *
-     * @param regionAccessor The world to place the structure in.
-     * @param location The location to place the structure at.
-     * @param includeEntities If the entities present in the structure should be
-     * spawned.
-     * @param structureRotation The rotation of the structure.
-     * @param mirror The mirror settings of the structure.
-     * @param palette The palette index of the structure to use, starting at
-     * {@code 0}, or {@code -1} to pick a random palette.
-     * @param integrity Determines how damaged the building should look by
-     * randomly skipping blocks to place. This value can range from 0 to 1. With
-     * 0 removing all blocks and 1 spawning the structure in pristine condition.
-     * @param random The randomizer used for setting the structure's
-     * @param strict Whether to prevent block updates (ie: prevent flowing water or fence connections)
-     * {@link org.bukkit.loot.LootTable}s and integrity.
-     * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
-     * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
-     */
-    @ApiStatus.Experimental
-    void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, boolean strict, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
 
     /**
      * Fills the structure from an area in a world. The origin and size will be

--- a/paper-api/src/main/java/org/bukkit/structure/Structure.java
+++ b/paper-api/src/main/java/org/bukkit/structure/Structure.java
@@ -155,9 +155,27 @@ public interface Structure extends PersistentDataHolder {
     @ApiStatus.Experimental
     void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
 
+    /**
+     * Place a structure in the world.
+     *
+     * @param location The location to place the structure at.
+     * @param placementOptions Options used to determine different settings applied to the structure.
+     * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
+     * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
+     */
     @ApiStatus.Experimental
     void place(@NotNull Location location, @NotNull PlacementOptions placementOptions, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
 
+    /**
+     * Place a structure in the world.
+     *
+     * @param regionAccessor The world to place the structure in.
+     * @param location The location to place the structure at.
+     * @param placementOptions Options used to determine different settings applied to the structure.
+     * {@link org.bukkit.loot.LootTable}s and integrity.
+     * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
+     * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
+     */
     @ApiStatus.Experimental
     void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, @NotNull PlacementOptions placementOptions, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
 

--- a/paper-api/src/main/java/org/bukkit/structure/Structure.java
+++ b/paper-api/src/main/java/org/bukkit/structure/Structure.java
@@ -172,12 +172,9 @@ public interface Structure extends PersistentDataHolder {
      * @param regionAccessor The world to place the structure in.
      * @param location The location to place the structure at.
      * @param placementOptions Options used to determine different settings applied to the structure.
-     * {@link org.bukkit.loot.LootTable}s and integrity.
-     * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
-     * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
      */
     @ApiStatus.Experimental
-    void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, @NotNull PlacementOptions placementOptions, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
+    void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, @NotNull PlacementOptions placementOptions);
 
     /**
      * Fills the structure from an area in a world. The origin and size will be

--- a/paper-api/src/main/java/org/bukkit/structure/Structure.java
+++ b/paper-api/src/main/java/org/bukkit/structure/Structure.java
@@ -155,6 +155,12 @@ public interface Structure extends PersistentDataHolder {
     @ApiStatus.Experimental
     void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
 
+    @ApiStatus.Experimental
+    void place(@NotNull Location location, @NotNull PlacementOptions placementOptions, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
+
+    @ApiStatus.Experimental
+    void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, @NotNull PlacementOptions placementOptions, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
+
     /**
      * Fills the structure from an area in a world. The origin and size will be
      * calculated automatically from the two corners provided.

--- a/paper-api/src/main/java/org/bukkit/structure/Structure.java
+++ b/paper-api/src/main/java/org/bukkit/structure/Structure.java
@@ -107,12 +107,54 @@ public interface Structure extends PersistentDataHolder {
      * randomly skipping blocks to place. This value can range from 0 to 1. With
      * 0 removing all blocks and 1 spawning the structure in pristine condition.
      * @param random The randomizer used for setting the structure's
+     * @param strict Whether to prevent block updates (ie: prevent flowing water or fence connections)
+     * {@link org.bukkit.loot.LootTable}s and integrity.
+     */
+    @ApiStatus.Experimental
+    void place(@NotNull Location location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, boolean strict);
+
+    /**
+     * Place a structure in the world.
+     *
+     * @param location The location to place the structure at.
+     * @param includeEntities If the entities present in the structure should be
+     * spawned.
+     * @param structureRotation The rotation of the structure.
+     * @param mirror The mirror settings of the structure.
+     * @param palette The palette index of the structure to use, starting at
+     * {@code 0}, or {@code -1} to pick a random palette.
+     * @param integrity Determines how damaged the building should look by
+     * randomly skipping blocks to place. This value can range from 0 to 1. With
+     * 0 removing all blocks and 1 spawning the structure in pristine condition.
+     * @param random The randomizer used for setting the structure's
      * {@link org.bukkit.loot.LootTable}s and integrity.
      * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
      * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
      */
     @ApiStatus.Experimental
     void place(@NotNull Location location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
+
+    /**
+     * Place a structure in the world.
+     *
+     * @param location The location to place the structure at.
+     * @param includeEntities If the entities present in the structure should be
+     * spawned.
+     * @param structureRotation The rotation of the structure.
+     * @param mirror The mirror settings of the structure.
+     * @param palette The palette index of the structure to use, starting at
+     * {@code 0}, or {@code -1} to pick a random palette.
+     * @param integrity Determines how damaged the building should look by
+     * randomly skipping blocks to place. This value can range from 0 to 1. With
+     * 0 removing all blocks and 1 spawning the structure in pristine condition.
+     * @param random The randomizer used for setting the structure's
+     * @param strict Whether to prevent block updates (ie: prevent flowing water or fence connections)
+     * {@link org.bukkit.loot.LootTable}s and integrity.
+     * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
+     * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
+     */
+    @ApiStatus.Experimental
+    void place(@NotNull Location location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, boolean strict, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
 
     /**
      * Place a structure in the world.
@@ -148,12 +190,56 @@ public interface Structure extends PersistentDataHolder {
      * randomly skipping blocks to place. This value can range from 0 to 1. With
      * 0 removing all blocks and 1 spawning the structure in pristine condition.
      * @param random The randomizer used for setting the structure's
+     * @param strict Whether to prevent block updates (ie: prevent flowing water or fence connections)
+     * {@link org.bukkit.loot.LootTable}s and integrity.
+     */
+    @ApiStatus.Experimental
+    void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, boolean strict);
+
+    /**
+     * Place a structure in the world.
+     *
+     * @param regionAccessor The world to place the structure in.
+     * @param location The location to place the structure at.
+     * @param includeEntities If the entities present in the structure should be
+     * spawned.
+     * @param structureRotation The rotation of the structure.
+     * @param mirror The mirror settings of the structure.
+     * @param palette The palette index of the structure to use, starting at
+     * {@code 0}, or {@code -1} to pick a random palette.
+     * @param integrity Determines how damaged the building should look by
+     * randomly skipping blocks to place. This value can range from 0 to 1. With
+     * 0 removing all blocks and 1 spawning the structure in pristine condition.
+     * @param random The randomizer used for setting the structure's
      * {@link org.bukkit.loot.LootTable}s and integrity.
      * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
      * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
      */
     @ApiStatus.Experimental
     void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
+
+    /**
+     * Place a structure in the world.
+     *
+     * @param regionAccessor The world to place the structure in.
+     * @param location The location to place the structure at.
+     * @param includeEntities If the entities present in the structure should be
+     * spawned.
+     * @param structureRotation The rotation of the structure.
+     * @param mirror The mirror settings of the structure.
+     * @param palette The palette index of the structure to use, starting at
+     * {@code 0}, or {@code -1} to pick a random palette.
+     * @param integrity Determines how damaged the building should look by
+     * randomly skipping blocks to place. This value can range from 0 to 1. With
+     * 0 removing all blocks and 1 spawning the structure in pristine condition.
+     * @param random The randomizer used for setting the structure's
+     * @param strict Whether to prevent block updates (ie: prevent flowing water or fence connections)
+     * {@link org.bukkit.loot.LootTable}s and integrity.
+     * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
+     * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
+     */
+    @ApiStatus.Experimental
+    void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, boolean strict, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
 
     /**
      * Fills the structure from an area in a world. The origin and size will be

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/structure/CraftStructure.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/structure/CraftStructure.java
@@ -52,47 +52,27 @@ public class CraftStructure implements Structure {
 
     @Override
     public void place(Location location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random) {
-        this.place(location, includeEntities, structureRotation, mirror, palette, integrity, random, false);
-    }
-
-    @Override
-    public void place(Location location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, boolean strict) {
-        this.place(location, includeEntities, structureRotation, mirror, palette, integrity, random, strict, Collections.emptyList(), Collections.emptyList());
+        this.place(location, includeEntities, structureRotation, mirror, palette, integrity, random, Collections.emptyList(), Collections.emptyList());
     }
 
     @Override
     public void place(Location location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
-        this.place(location, includeEntities, structureRotation, mirror, palette, integrity, random, false, blockTransformers, entityTransformers);
-    }
-
-    @Override
-    public void place(Location location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, boolean strict, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
         Preconditions.checkArgument(location != null, "Location cannot be null");
         location.checkFinite();
         World world = location.getWorld();
         Preconditions.checkArgument(world != null, "The World of Location cannot be null");
 
         BlockVector blockVector = new BlockVector(location.getBlockX(), location.getBlockY(), location.getBlockZ());
-        this.place(world, blockVector, includeEntities, structureRotation, mirror, palette, integrity, random, strict, blockTransformers, entityTransformers);
+        this.place(world, blockVector, includeEntities, structureRotation, mirror, palette, integrity, random, blockTransformers, entityTransformers);
     }
 
     @Override
     public void place(RegionAccessor regionAccessor, BlockVector location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random) {
-       this.place(regionAccessor, location, includeEntities, structureRotation, mirror, palette, integrity, random, false);
-    }
-
-    @Override
-    public void place(RegionAccessor regionAccessor, BlockVector location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, boolean strict) {
-        this.place(regionAccessor, location, includeEntities, structureRotation, mirror, palette, integrity, random, strict, Collections.emptyList(), Collections.emptyList());
+       this.place(regionAccessor, location, includeEntities, structureRotation, mirror, palette, integrity, random, Collections.emptyList(), Collections.emptyList());
     }
 
     @Override
     public void place(RegionAccessor regionAccessor, BlockVector location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
-        this.place(regionAccessor, location, includeEntities, structureRotation, mirror, palette, integrity, random,false, blockTransformers, entityTransformers);
-    }
-
-    @Override
-    public void place(RegionAccessor regionAccessor, BlockVector location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, boolean strict, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
         Preconditions.checkArgument(location != null, "Location cannot be null");
         Preconditions.checkArgument(regionAccessor != null, "RegionAccessor cannot be null");
         Preconditions.checkArgument(blockTransformers != null, "BlockTransformers cannot be null");
@@ -107,8 +87,7 @@ public class CraftStructure implements Structure {
                 .setRotation(Rotation.valueOf(structureRotation.name()))
                 .setIgnoreEntities(!includeEntities)
                 .addProcessor(new BlockRotProcessor(integrity))
-                .setRandom(randomSource)
-                .setKnownShape(strict);
+                .setRandom(randomSource);
         definedstructureinfo.palette = palette;
 
         BlockPos pos = CraftBlockVector.toBlockPosition(location);
@@ -118,7 +97,7 @@ public class CraftStructure implements Structure {
         access.setDelegate(handle);
         access.setStructureTransformer(new CraftStructureTransformer(handle, new ChunkPos(pos), blockTransformers, entityTransformers));
 
-        this.structure.placeInWorld(access, pos, pos, definedstructureinfo, randomSource, 2 | (strict ? 816 : 0));
+        this.structure.placeInWorld(access, pos, pos, definedstructureinfo, randomSource, 2);
         access.getStructureTransformer().discard();
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/structure/CraftStructure.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/structure/CraftStructure.java
@@ -35,6 +35,7 @@ import org.bukkit.craftbukkit.util.TransformerGeneratorAccess;
 import org.bukkit.entity.Entity;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.structure.Palette;
+import org.bukkit.structure.PlacementOptions;
 import org.bukkit.structure.Structure;
 import org.bukkit.util.BlockTransformer;
 import org.bukkit.util.BlockVector;
@@ -57,13 +58,8 @@ public class CraftStructure implements Structure {
 
     @Override
     public void place(Location location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
-        Preconditions.checkArgument(location != null, "Location cannot be null");
-        location.checkFinite();
-        World world = location.getWorld();
-        Preconditions.checkArgument(world != null, "The World of Location cannot be null");
-
-        BlockVector blockVector = new BlockVector(location.getBlockX(), location.getBlockY(), location.getBlockZ());
-        this.place(world, blockVector, includeEntities, structureRotation, mirror, palette, integrity, random, blockTransformers, entityTransformers);
+        PlacementOptions placementOptions = new PlacementOptions(random).includeEntities(includeEntities).structureRotation(structureRotation).mirror(mirror).palette(palette).integrity(integrity);
+        this.place(location, placementOptions, blockTransformers, entityTransformers);
     }
 
     @Override
@@ -72,23 +68,39 @@ public class CraftStructure implements Structure {
     }
 
     @Override
+    public void place(Location location, PlacementOptions placementOptions, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
+        Preconditions.checkArgument(location != null, "Location cannot be null");
+        location.checkFinite();
+        World world = location.getWorld();
+        Preconditions.checkArgument(world != null, "The World of Location cannot be null");
+
+        BlockVector blockVector = new BlockVector(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+        this.place(world, blockVector, placementOptions, blockTransformers, entityTransformers);
+    }
+
+    @Override
     public void place(RegionAccessor regionAccessor, BlockVector location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
+        PlacementOptions placementOptions = new PlacementOptions(random).includeEntities(includeEntities).structureRotation(structureRotation).mirror(mirror).palette(palette).integrity(integrity);
+        this.place(regionAccessor, location, placementOptions, blockTransformers, entityTransformers);
+    }
+
+    @Override
+    public void place(RegionAccessor regionAccessor, BlockVector location, PlacementOptions placementOptions, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
         Preconditions.checkArgument(location != null, "Location cannot be null");
         Preconditions.checkArgument(regionAccessor != null, "RegionAccessor cannot be null");
         Preconditions.checkArgument(blockTransformers != null, "BlockTransformers cannot be null");
         Preconditions.checkArgument(entityTransformers != null, "EntityTransformers cannot be null");
         location.checkFinite();
 
-        Preconditions.checkArgument(integrity >= 0F && integrity <= 1F, "Integrity value (%S) must be between 0 and 1 inclusive", integrity);
-
-        RandomSource randomSource = new RandomSourceWrapper(random);
+        RandomSource randomSource = new RandomSourceWrapper(placementOptions.getRandom());
         StructurePlaceSettings definedstructureinfo = new StructurePlaceSettings()
-                .setMirror(net.minecraft.world.level.block.Mirror.valueOf(mirror.name()))
-                .setRotation(Rotation.valueOf(structureRotation.name()))
-                .setIgnoreEntities(!includeEntities)
-                .addProcessor(new BlockRotProcessor(integrity))
+                .setMirror(net.minecraft.world.level.block.Mirror.valueOf(placementOptions.getMirror().name()))
+                .setRotation(Rotation.valueOf(placementOptions.getStructureRotation().name()))
+                .setIgnoreEntities(!placementOptions.isIncludeEntities())
+                .addProcessor(new BlockRotProcessor(placementOptions.getIntegrity()))
+                .setKnownShape(placementOptions.isStrict())
                 .setRandom(randomSource);
-        definedstructureinfo.palette = palette;
+        definedstructureinfo.palette = placementOptions.getPalette();
 
         BlockPos pos = CraftBlockVector.toBlockPosition(location);
         WorldGenLevel handle = ((CraftRegionAccessor) regionAccessor).getHandle();
@@ -97,7 +109,7 @@ public class CraftStructure implements Structure {
         access.setDelegate(handle);
         access.setStructureTransformer(new CraftStructureTransformer(handle, new ChunkPos(pos), blockTransformers, entityTransformers));
 
-        this.structure.placeInWorld(access, pos, pos, definedstructureinfo, randomSource, 2);
+        this.structure.placeInWorld(access, pos, pos, definedstructureinfo, randomSource, 2 | (placementOptions.isStrict() ? 816 : 0));
         access.getStructureTransformer().discard();
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/structure/CraftStructure.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/structure/CraftStructure.java
@@ -76,21 +76,24 @@ public class CraftStructure implements Structure {
         Preconditions.checkArgument(world != null, "The World of Location cannot be null");
 
         BlockVector blockVector = new BlockVector(location.getBlockX(), location.getBlockY(), location.getBlockZ());
-        this.place(world, blockVector, placementOptions, blockTransformers, entityTransformers);
+        this.place(world, blockVector, placementOptions);
     }
 
     @Override
     public void place(RegionAccessor regionAccessor, BlockVector location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
-        PlacementOptions placementOptions = new PlacementOptions(random).includeEntities(includeEntities).structureRotation(structureRotation).mirror(mirror).palette(palette).integrity(integrity);
-        this.place(regionAccessor, location, placementOptions, blockTransformers, entityTransformers);
+        PlacementOptions placementOptions = new PlacementOptions(random).includeEntities(includeEntities).structureRotation(structureRotation).mirror(mirror).palette(palette).integrity(integrity)
+            .blockTransformers(blockTransformers).entityTransformers(entityTransformers);
+        this.place(regionAccessor, location, placementOptions);
     }
 
     @Override
-    public void place(RegionAccessor regionAccessor, BlockVector location, PlacementOptions placementOptions, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
+    public void place(RegionAccessor regionAccessor, BlockVector location, PlacementOptions placementOptions) {
         Preconditions.checkArgument(location != null, "Location cannot be null");
         Preconditions.checkArgument(regionAccessor != null, "RegionAccessor cannot be null");
-        Preconditions.checkArgument(blockTransformers != null, "BlockTransformers cannot be null");
-        Preconditions.checkArgument(entityTransformers != null, "EntityTransformers cannot be null");
+        Collection<BlockTransformer> blockTransformers = placementOptions.getBlockTransformers();
+        Preconditions.checkState(blockTransformers != null, "BlockTransformers cannot be null");
+        Collection<EntityTransformer> entityTransformers = placementOptions.getEntityTransformers();
+        Preconditions.checkState(entityTransformers != null, "EntityTransformers cannot be null");
         location.checkFinite();
 
         RandomSource randomSource = new RandomSourceWrapper(placementOptions.getRandom());

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/structure/CraftStructure.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/structure/CraftStructure.java
@@ -52,27 +52,47 @@ public class CraftStructure implements Structure {
 
     @Override
     public void place(Location location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random) {
-        this.place(location, includeEntities, structureRotation, mirror, palette, integrity, random, Collections.emptyList(), Collections.emptyList());
+        this.place(location, includeEntities, structureRotation, mirror, palette, integrity, random, false);
+    }
+
+    @Override
+    public void place(Location location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, boolean strict) {
+        this.place(location, includeEntities, structureRotation, mirror, palette, integrity, random, strict, Collections.emptyList(), Collections.emptyList());
     }
 
     @Override
     public void place(Location location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
+        this.place(location, includeEntities, structureRotation, mirror, palette, integrity, random, false, blockTransformers, entityTransformers);
+    }
+
+    @Override
+    public void place(Location location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, boolean strict, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
         Preconditions.checkArgument(location != null, "Location cannot be null");
         location.checkFinite();
         World world = location.getWorld();
         Preconditions.checkArgument(world != null, "The World of Location cannot be null");
 
         BlockVector blockVector = new BlockVector(location.getBlockX(), location.getBlockY(), location.getBlockZ());
-        this.place(world, blockVector, includeEntities, structureRotation, mirror, palette, integrity, random, blockTransformers, entityTransformers);
+        this.place(world, blockVector, includeEntities, structureRotation, mirror, palette, integrity, random, strict, blockTransformers, entityTransformers);
     }
 
     @Override
     public void place(RegionAccessor regionAccessor, BlockVector location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random) {
-       this.place(regionAccessor, location, includeEntities, structureRotation, mirror, palette, integrity, random, Collections.emptyList(), Collections.emptyList());
+       this.place(regionAccessor, location, includeEntities, structureRotation, mirror, palette, integrity, random, false);
+    }
+
+    @Override
+    public void place(RegionAccessor regionAccessor, BlockVector location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, boolean strict) {
+        this.place(regionAccessor, location, includeEntities, structureRotation, mirror, palette, integrity, random, strict, Collections.emptyList(), Collections.emptyList());
     }
 
     @Override
     public void place(RegionAccessor regionAccessor, BlockVector location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
+        this.place(regionAccessor, location, includeEntities, structureRotation, mirror, palette, integrity, random,false, blockTransformers, entityTransformers);
+    }
+
+    @Override
+    public void place(RegionAccessor regionAccessor, BlockVector location, boolean includeEntities, StructureRotation structureRotation, Mirror mirror, int palette, float integrity, Random random, boolean strict, Collection<BlockTransformer> blockTransformers, Collection<EntityTransformer> entityTransformers) {
         Preconditions.checkArgument(location != null, "Location cannot be null");
         Preconditions.checkArgument(regionAccessor != null, "RegionAccessor cannot be null");
         Preconditions.checkArgument(blockTransformers != null, "BlockTransformers cannot be null");
@@ -87,7 +107,8 @@ public class CraftStructure implements Structure {
                 .setRotation(Rotation.valueOf(structureRotation.name()))
                 .setIgnoreEntities(!includeEntities)
                 .addProcessor(new BlockRotProcessor(integrity))
-                .setRandom(randomSource);
+                .setRandom(randomSource)
+                .setKnownShape(strict);
         definedstructureinfo.palette = palette;
 
         BlockPos pos = CraftBlockVector.toBlockPosition(location);
@@ -97,7 +118,7 @@ public class CraftStructure implements Structure {
         access.setDelegate(handle);
         access.setStructureTransformer(new CraftStructureTransformer(handle, new ChunkPos(pos), blockTransformers, entityTransformers));
 
-        this.structure.placeInWorld(access, pos, pos, definedstructureinfo, randomSource, 2);
+        this.structure.placeInWorld(access, pos, pos, definedstructureinfo, randomSource, 2 | (strict ? 816 : 0));
         access.getStructureTransformer().discard();
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/structure/CraftStructure.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/structure/CraftStructure.java
@@ -17,6 +17,7 @@ import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.levelgen.structure.templatesystem.BlockRotProcessor;
+import net.minecraft.world.level.levelgen.structure.templatesystem.LiquidSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import org.bukkit.Bukkit;
@@ -99,6 +100,7 @@ public class CraftStructure implements Structure {
                 .setIgnoreEntities(!placementOptions.isIncludeEntities())
                 .addProcessor(new BlockRotProcessor(placementOptions.getIntegrity()))
                 .setKnownShape(placementOptions.isStrict())
+                .setLiquidSettings(placementOptions.isApplyWaterlogging() ? LiquidSettings.APPLY_WATERLOGGING : LiquidSettings.IGNORE_WATERLOGGING)
                 .setRandom(randomSource);
         definedstructureinfo.palette = placementOptions.getPalette();
 


### PR DESCRIPTION
This PR originally aimed to add an option to place structures without doing block updates.
This was something Minecraft added in 1.21.5 to Structure Blocks as well as the `/place template` command.

After a great suggestion from Kashike, this PR changed to add a new PlacementOptions class.
This will allow for deciding which options you want to add, or fallback to defaults.
This will also be great in the future if Mojang adds more options for placement, won't need to create more methods in the structure class.

While I understand the team is not wanting PRs for 1.21.5 yet, I just wanted to get this done as early as possible.
I'm ok with the PR sitting here til the team accepts 1.21.5 PRs.

This feature (the earlier mentioned strict option) has been requested by users of my plugin for over a year now, so Im super excited to have this.
I did test with my plugin locally and it works like a charm :) 

Side note (re: Strict placement):
I did a test on 1.21.4 for this, it technically works as well, but only like 50/50.
For example:
- Fences didn't connect as expected (yay)
- Water still flowed (boo)
- I didn't test other blocks but it felt a bit unstable, so I didn't want to do the PR for 1.21.4 due to instability.

Closes #12381 