### PR TITLE
Use correct placed block position for sound

### DIFF
--- a/paper-server/patches/features/0027-Optimize-Hoppers.patch
+++ b/paper-server/patches/features/0027-Optimize-Hoppers.patch
@@ -48,7 +48,7 @@ index 0000000000000000000000000000000000000000..24a2090e068ad3c0d08705050944abdf
 +    }
 +}
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index ea85cac4a41075efe8525c40755e7ebac6ca9dea..7af29d3dc7b337d74cee5df7cbca35c420643370 100644
+index 79bc1b7d9f640d2322814177eb3e921da8671e87..f1373fd5fdebb9f4600ba7f32a5df6188de3a0e9 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -1706,6 +1706,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -60,10 +60,10 @@ index ea85cac4a41075efe8525c40755e7ebac6ca9dea..7af29d3dc7b337d74cee5df7cbca35c4
              /* Drop global time updates
              if (this.tickCount % 20 == 0) {
 diff --git a/net/minecraft/world/item/ItemStack.java b/net/minecraft/world/item/ItemStack.java
-index 5329dc9259f30011d277336bfc76da18c15d5d81..8391f51b7dd584dd346bda5dccbee900d4fa9c2d 100644
+index 72cd623a1a3ce4b7a570a853456b067cd93736b1..ad7852a19ff73368ec9e7e63dcb7a064f78eefa0 100644
 --- a/net/minecraft/world/item/ItemStack.java
 +++ b/net/minecraft/world/item/ItemStack.java
-@@ -832,10 +832,16 @@ public final class ItemStack implements DataComponentHolder {
+@@ -831,10 +831,16 @@ public final class ItemStack implements DataComponentHolder {
      }
  
      public ItemStack copy() {

--- a/paper-server/patches/sources/net/minecraft/world/InteractionResult.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/InteractionResult.java.patch
@@ -1,0 +1,40 @@
+--- a/net/minecraft/world/InteractionResult.java
++++ b/net/minecraft/world/InteractionResult.java
+@@ -30,18 +_,34 @@
+     public record Pass() implements InteractionResult {
+     }
+ 
+-    public record Success(InteractionResult.SwingSource swingSource, InteractionResult.ItemContext itemContext) implements InteractionResult {
++    // Paper start - track more context in interaction result
++    public record PaperSuccessContext(net.minecraft.core.@org.jspecify.annotations.Nullable BlockPos placedBlockPosition) {
++        static PaperSuccessContext DEFAULT = new PaperSuccessContext(null);
++
++        public PaperSuccessContext placedBlockAt(final net.minecraft.core.BlockPos blockPos) {
++            return new PaperSuccessContext(blockPos);
++        }
++    }
++    public record Success(InteractionResult.SwingSource swingSource, InteractionResult.ItemContext itemContext, PaperSuccessContext paperSuccessContext) implements InteractionResult {
++        public InteractionResult.Success configurePaper(final java.util.function.UnaryOperator<PaperSuccessContext> edit) {
++            return new InteractionResult.Success(this.swingSource, this.itemContext, edit.apply(this.paperSuccessContext));
++        }
++
++        public Success(final net.minecraft.world.InteractionResult.SwingSource swingSource, final net.minecraft.world.InteractionResult.ItemContext itemContext) {
++            this(swingSource, itemContext, PaperSuccessContext.DEFAULT);
++        }
++    // Paper end - track more context in interaction result
+         @Override
+         public boolean consumesAction() {
+             return true;
+         }
+ 
+         public InteractionResult.Success heldItemTransformedTo(ItemStack stack) {
+-            return new InteractionResult.Success(this.swingSource, new InteractionResult.ItemContext(true, stack));
++            return new InteractionResult.Success(this.swingSource, new InteractionResult.ItemContext(true, stack), this.paperSuccessContext); // Paper - track more context in interaction result
+         }
+ 
+         public InteractionResult.Success withoutItem() {
+-            return new InteractionResult.Success(this.swingSource, InteractionResult.ItemContext.NONE);
++            return new InteractionResult.Success(this.swingSource, InteractionResult.ItemContext.NONE, this.paperSuccessContext); // Paper - track more context in interaction result
+         }
+ 
+         public boolean wasItemInteraction() {

--- a/paper-server/patches/sources/net/minecraft/world/item/BlockItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/BlockItem.java.patch
@@ -56,6 +56,15 @@
                      level.playSound(
                          player,
                          clickedPos,
+@@ -88,7 +_,7 @@
+                     );
+                     level.gameEvent(GameEvent.BLOCK_PLACE, clickedPos, GameEvent.Context.of(player, blockState));
+                     itemInHand.consume(1, player);
+-                    return InteractionResult.SUCCESS;
++                    return InteractionResult.SUCCESS.configurePaper(e -> e.placedBlockAt(clickedPos.immutable())); // Paper - track placed block position from block item
+                 }
+             }
+         }
 @@ -137,8 +_,19 @@
  
      protected boolean canPlace(BlockPlaceContext context, BlockState state) {

--- a/paper-server/patches/sources/net/minecraft/world/item/ItemStack.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/ItemStack.java.patch
@@ -23,7 +23,7 @@
                  }
              }
          };
-@@ -373,10 +_,167 @@
+@@ -373,10 +_,166 @@
              return InteractionResult.PASS;
          } else {
              Item item = this.getItem();
@@ -177,8 +177,7 @@
 +                    // SPIGOT-1288 - play sound stripped from BlockItem
 +                    if (this.item instanceof BlockItem) {
 +                        // Paper start - Fix spigot sound playing for BlockItem ItemStacks
-+                        BlockPos pos = new net.minecraft.world.item.context.BlockPlaceContext(context).getClickedPos();
-+                        net.minecraft.world.level.block.state.BlockState state = serverLevel.getBlockState(pos);
++                        net.minecraft.world.level.block.state.BlockState state = serverLevel.getBlockState(Objects.requireNonNull(success.paperSuccessContext().placedBlockPosition(), "BlockItem yielded InteractionResult without attached placedBlockPosition context. This is a bug!!"));
 +                        net.minecraft.world.level.block.SoundType soundType = state.getSoundType();
 +                        // Paper end - Fix spigot sound playing for BlockItem ItemStacks
 +                        serverLevel.playSound(player, clickedPos, soundType.getPlaceSound(), net.minecraft.sounds.SoundSource.BLOCKS, (soundType.getVolume() + 1.0F) / 2.0F, soundType.getPitch() * 0.8F);


### PR DESCRIPTION
Previously the server attempted to compute the block placed by using the
BlockPlaceContext. This approach however fails on replacable blocks, as
the BlockPlaceContext computes this during its construction, which
happened after the actual world modification.

The commit reworks this approach and now stores metadata in the
InteractionResult which can later be read.
The diff is structured to allow for easy future expansion of the tracked
metadata.

Resolves: #12399
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-12400.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/2915418526.zip)