### PR TITLE
CraftBlock - fix applyBoneMeal false result

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
@@ -577,7 +577,7 @@ public class CraftBlock implements Block {
             }
         }
 
-        return result == InteractionResult.CONSUME && (event == null || !event.isCancelled()); // Paper - CONSUME is returned on success server-side (see BoneMealItem.applyBoneMeal and InteractionResult.sidedSuccess(boolean))
+        return result == InteractionResult.SUCCESS && (event == null || !event.isCancelled());
     }
 
     @Override


### PR DESCRIPTION
This PR aims to fix the `Block#applyBoneMeal` method always returning false.

I'm assuming the NMS method used here was probably changed at one point from CONSUME to SUCCESS

For context:
This is the method used in `CraftBlock#applyBoneMeal` for getting the `result`
<img width="682" alt="Screenshot 2025-04-11 at 2 20 11 PM" src="https://github.com/user-attachments/assets/4f28c379-67d8-43df-b9fc-963897a81133" />
