### PR TITLE
Don't promote checking enchantment by legacy lore

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -264,19 +264,18 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      * <br>
      * You <b>MUST</b> remove the item from the .getDrops() collection too or it will duplicate!
      * <pre>{@code
-     *    {@literal @EventHandler(ignoreCancelled = true)}
-     *     public void onPlayerDeath(PlayerDeathEvent event) {
-     *         for (Iterator<ItemStack> iterator = event.getDrops().iterator(); iterator.hasNext(); ) {
-     *             ItemStack drop = iterator.next();
-     *             List<String> lore = drop.getLore();
-     *             if (lore != null && !lore.isEmpty()) {
-     *                 if (lore.get(0).contains("(SOULBOUND)")) {
-     *                     iterator.remove();
-     *                     event.getItemsToKeep().add(drop);
-     *                 }
-     *             }
+     * private static final NamespacedKey soulboundKey = new NamespacedKey("testplugin", "soulbound");
+     *
+     * @EventHandler(ignoreCancelled = true)
+     * public void onPlayerDeath(PlayerDeathEvent event) {
+     *     for (Iterator<ItemStack> iterator = event.getDrops().iterator(); iterator.hasNext(); ) {
+     *         ItemStack drop = iterator.next();
+     *         if (drop.getPersistentDataContainer().getOrDefault(soulboundKey, PersistentDataType.BOOLEAN, false)) {
+     *             iterator.remove();
+     *             event.getItemsToKeep().add(drop);
      *         }
      *     }
+     * }
      * }</pre>
      * <p>
      * Adding an item to this list that the player did not previously have will give them the item on death.

--- a/paper-api/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -264,13 +264,13 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      * <br>
      * You <b>MUST</b> remove the item from the .getDrops() collection too or it will duplicate!
      * <pre>{@code
-     * private static final NamespacedKey soulboundKey = new NamespacedKey("testplugin", "soulbound");
+     * private static final NamespacedKey SOULBOUND_KEY = new NamespacedKey("testplugin", "soulbound");
      *
      * @EventHandler(ignoreCancelled = true)
      * public void onPlayerDeath(PlayerDeathEvent event) {
      *     for (Iterator<ItemStack> iterator = event.getDrops().iterator(); iterator.hasNext(); ) {
      *         ItemStack drop = iterator.next();
-     *         if (drop.getPersistentDataContainer().getOrDefault(soulboundKey, PersistentDataType.BOOLEAN, false)) {
+     *         if (drop.getPersistentDataContainer().getOrDefault(SOULBOUND_KEY, PersistentDataType.BOOLEAN, false)) {
      *             iterator.remove();
      *             event.getItemsToKeep().add(drop);
      *         }


### PR DESCRIPTION
Replaces the example code in https://jd.papermc.io/paper/1.21.5/org/bukkit/event/entity/PlayerDeathEvent.html#getItemsToKeep() with a more up to date versions that doesn't depend on magic values in lore for important checks and doesn't promote legacy color codes over adventure components.