### PR TITLE
Fix SignChangeEvent NPE (& external list mutability)

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/SignChangeEvent.java
@@ -59,7 +59,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
         this.player = thePlayer;
         this.adventure$lines = new ArrayList<>(4);
         for (String theLine : theLines) {
-            this.adventure$lines.add(theLine == null ? null : LegacyComponentSerializer.legacySection().deserialize(theLine));
+            this.adventure$lines.add(LegacyComponentSerializer.legacySection().deserializeOrNull(theLine));
         }
         this.side = side;
     }
@@ -128,7 +128,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
      */
     @Deprecated
     public @Nullable String[] getLines() {
-        return this.adventure$lines.stream().map(line -> line == null ? null : LegacyComponentSerializer.legacySection().serialize(line)).toArray(String[]::new);
+        return this.adventure$lines.stream().map(LegacyComponentSerializer.legacySection()::serializeOrNull).toArray(String[]::new);
     }
 
     /**
@@ -144,8 +144,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
     @Nullable
     @Deprecated
     public String getLine(int index) throws IndexOutOfBoundsException {
-        Component line = line(index);
-        return line == null ? null : LegacyComponentSerializer.legacySection().serialize(line);
+        return LegacyComponentSerializer.legacySection().serializeOrNull(this.adventure$lines.get(index));
     }
 
     /**
@@ -159,7 +158,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
      */
     @Deprecated
     public void setLine(int index, @Nullable String line) throws IndexOutOfBoundsException {
-        this.adventure$lines.set(index, line != null ? LegacyComponentSerializer.legacySection().deserialize(line) : null);
+        this.adventure$lines.set(index, LegacyComponentSerializer.legacySection().deserializeOrNull(line));
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/SignChangeEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.block;
 
+import com.google.common.base.Preconditions;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.block.Block;
@@ -24,7 +25,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final Player player;
-    private final List<@Nullable Component> adventure$lines;
+    private List<@Nullable Component> adventure$lines;
     private final Side side;
 
     private boolean cancelled;
@@ -32,8 +33,9 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
     @ApiStatus.Internal
     public SignChangeEvent(final Block sign, final Player player, final List<@Nullable Component> adventure$lines, Side side) {
         super(sign);
+        Preconditions.checkArgument(adventure$lines != null && adventure$lines.size() == 4, "Signs must contain exactly 4 lines of text");
         this.player = player;
-        this.adventure$lines = adventure$lines;
+        this.adventure$lines = new ArrayList<>(adventure$lines);
         this.side = side;
     }
 
@@ -53,8 +55,9 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
     @Deprecated(forRemoval = true)
     public SignChangeEvent(final Block sign, final Player thePlayer, final @Nullable String[] theLines, Side side) {
         super(sign);
+        Preconditions.checkArgument(theLines != null && theLines.length == 4, "Signs must contain exactly 4 lines of text");
         this.player = thePlayer;
-        this.adventure$lines = new ArrayList<>();
+        this.adventure$lines = new ArrayList<>(4);
         for (String theLine : theLines) {
             this.adventure$lines.add(theLine == null ? null : LegacyComponentSerializer.legacySection().deserialize(theLine));
         }
@@ -72,11 +75,23 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
 
     /**
      * Gets all the lines of text from the sign involved in this event.
+     * <p>Changes to the list won't affect the sign's lines of text.
      *
      * @return the String array for the sign's lines new text
      */
     public List<@Nullable Component> lines() {
-        return this.adventure$lines;
+        return new ArrayList<>(this.adventure$lines);
+    }
+
+    /**
+     * Sets all the lines of text for the sign involved in this event.
+     *
+     * @param lines lines
+     * @throws IllegalArgumentException if there aren't exactly 4 lines of text
+     */
+    public void lines(List<@Nullable Component> lines) {
+        Preconditions.checkArgument(lines != null && lines.size() == 4, "Signs must contain exactly 4 lines of text");
+        this.adventure$lines = new ArrayList<>(lines);
     }
 
     /**
@@ -106,6 +121,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
 
     /**
      * Gets all the lines of text from the sign involved in this event.
+     * <p>Changes to the array won't affect the sign's lines of text.
      *
      * @return the String array for the sign's lines new text
      * @deprecated in favour of {@link #lines()}

--- a/paper-api/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/SignChangeEvent.java
@@ -1,14 +1,16 @@
 package org.bukkit.event.block;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.block.Block;
 import org.bukkit.block.sign.Side;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -16,18 +18,19 @@ import java.util.List;
  * <p>
  * If this event is cancelled, the sign will not be changed.
  */
+@NullMarked
 public class SignChangeEvent extends BlockEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final Player player;
-    private final List<Component> adventure$lines;
+    private final List<@Nullable Component> adventure$lines;
     private final Side side;
 
     private boolean cancelled;
 
     @ApiStatus.Internal
-    public SignChangeEvent(@NotNull final Block sign, @NotNull final Player player, @NotNull final java.util.List<net.kyori.adventure.text.Component> adventure$lines, @NotNull Side side) {
+    public SignChangeEvent(final Block sign, final Player player, final List<@Nullable Component> adventure$lines, Side side) {
         super(sign);
         this.player = player;
         this.adventure$lines = adventure$lines;
@@ -36,24 +39,24 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
 
     @ApiStatus.Internal
     @Deprecated(forRemoval = true)
-    public SignChangeEvent(@NotNull final Block sign, @NotNull final Player player, @NotNull final java.util.List<net.kyori.adventure.text.Component> adventure$lines) {
+    public SignChangeEvent(final Block sign, final Player player, final List<@Nullable Component> adventure$lines) {
         this(sign, player, adventure$lines, Side.FRONT);
     }
 
     @ApiStatus.Internal
     @Deprecated(since = "1.19.4", forRemoval = true)
-    public SignChangeEvent(@NotNull final Block sign, @NotNull final Player thePlayer, @NotNull final String[] theLines) {
+    public SignChangeEvent(final Block sign, final Player thePlayer, final @Nullable String[] theLines) {
         this(sign, thePlayer, theLines, Side.FRONT);
     }
 
     @ApiStatus.Internal
     @Deprecated(forRemoval = true)
-    public SignChangeEvent(@NotNull final Block sign, @NotNull final Player thePlayer, @NotNull final String[] theLines, @NotNull Side side) {
+    public SignChangeEvent(final Block sign, final Player thePlayer, final @Nullable String[] theLines, Side side) {
         super(sign);
         this.player = thePlayer;
-        this.adventure$lines = new java.util.ArrayList<>();
+        this.adventure$lines = new ArrayList<>();
         for (String theLine : theLines) {
-            this.adventure$lines.add(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(theLine));
+            this.adventure$lines.add(theLine == null ? null : LegacyComponentSerializer.legacySection().deserialize(theLine));
         }
         this.side = side;
     }
@@ -63,17 +66,16 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
      *
      * @return the Player involved in this event
      */
-    @NotNull
     public Player getPlayer() {
         return this.player;
     }
 
     /**
-     * Gets all of the lines of text from the sign involved in this event.
+     * Gets all the lines of text from the sign involved in this event.
      *
      * @return the String array for the sign's lines new text
      */
-    public @NotNull java.util.List<net.kyori.adventure.text.Component> lines() {
+    public List<@Nullable Component> lines() {
         return this.adventure$lines;
     }
 
@@ -86,7 +88,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
      * @throws IndexOutOfBoundsException thrown when the provided index is {@literal > 3
      *     or < 0}
      */
-    public net.kyori.adventure.text.@Nullable Component line(int index) throws IndexOutOfBoundsException {
+    public @Nullable Component line(int index) throws IndexOutOfBoundsException {
         return this.adventure$lines.get(index);
     }
 
@@ -98,20 +100,19 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
      * @throws IndexOutOfBoundsException thrown when the provided index is {@literal > 3
      *     or < 0}
      */
-    public void line(int index, net.kyori.adventure.text.@Nullable Component line) throws IndexOutOfBoundsException {
+    public void line(int index, @Nullable Component line) throws IndexOutOfBoundsException {
         this.adventure$lines.set(index, line);
     }
 
     /**
-     * Gets all of the lines of text from the sign involved in this event.
+     * Gets all the lines of text from the sign involved in this event.
      *
      * @return the String array for the sign's lines new text
      * @deprecated in favour of {@link #lines()}
      */
-    @NotNull
-    @Deprecated // Paper
-    public String[] getLines() {
-        return this.adventure$lines.stream().map(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection()::serialize).toArray(String[]::new); // Paper
+    @Deprecated
+    public @Nullable String[] getLines() {
+        return this.adventure$lines.stream().map(line -> line == null ? null : LegacyComponentSerializer.legacySection().serialize(line)).toArray(String[]::new);
     }
 
     /**
@@ -125,9 +126,10 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
      * @deprecated in favour of {@link #line(int)}
      */
     @Nullable
-    @Deprecated // Paper
+    @Deprecated
     public String getLine(int index) throws IndexOutOfBoundsException {
-        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.adventure$lines.get(index)); // Paper
+        Component line = line(index);
+        return line == null ? null : LegacyComponentSerializer.legacySection().serialize(line);
     }
 
     /**
@@ -137,11 +139,11 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
      * @param line text to set
      * @throws IndexOutOfBoundsException thrown when the provided index is {@literal > 3
      *     or < 0}
-     * @deprecated in favour of {@link #line(int, net.kyori.adventure.text.Component)}
+     * @deprecated in favour of {@link #line(int, Component)}
      */
-    @Deprecated // Paper
+    @Deprecated
     public void setLine(int index, @Nullable String line) throws IndexOutOfBoundsException {
-        this.adventure$lines.set(index, line != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(line) : null); // Paper
+        this.adventure$lines.set(index, line != null ? LegacyComponentSerializer.legacySection().deserialize(line) : null);
     }
 
     /**
@@ -149,7 +151,6 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
      *
      * @return the affected side of the sign
      */
-    @NotNull
     public Side getSide() {
         return this.side;
     }
@@ -164,13 +165,11 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
         this.cancelled = cancel;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
 
-    @NotNull
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/SignBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/SignBlockEntity.java.patch
@@ -62,7 +62,7 @@
 +            lines.add(io.papermc.paper.adventure.PaperAdventure.asAdventure(text.getMessage(i, player.isTextFilteringEnabled()))); // Paper - Adventure
 +        }
 +
-+        org.bukkit.event.block.SignChangeEvent event = new org.bukkit.event.block.SignChangeEvent(org.bukkit.craftbukkit.block.CraftBlock.at(this.level, this.worldPosition), apiPlayer, new java.util.ArrayList<>(lines), (front) ? org.bukkit.block.sign.Side.FRONT : org.bukkit.block.sign.Side.BACK); // Paper - Adventure
++        org.bukkit.event.block.SignChangeEvent event = new org.bukkit.event.block.SignChangeEvent(org.bukkit.craftbukkit.block.CraftBlock.at(this.level, this.worldPosition), apiPlayer, lines, (front) ? org.bukkit.block.sign.Side.FRONT : org.bukkit.block.sign.Side.BACK); // Paper - Adventure
 +        if (!event.callEvent()) {
 +            return originalText;
 +        }


### PR DESCRIPTION
- Updated SignChangeEvent class
	- Fix NPE on `getLine()` / `getLines()` / legacy String[] constructor
	- Updated the annotations to JSpecify, removed Paper comments and fully qualified imports as it's quite a small class & change
	- `getLine()` / `line()` / constructor now correctly show nullability
		- To clarify, this PR does not break the null contract, but simply adds a missing nullability annotations for those
	- Change lines handling to not allow external modifications (otherwise iffy things are possible like passing an immutable list, changing the amount of elements) and mandate 4 elements. Adds a method to set all the lines at once as an alternative.
		- That's changing behavior (updating the list won't affect event anymore), but I personally wasn't expecting this in the first place (it's not mentioned in javadoc, and differs from other similar places within API), and it's not a major break. The legacy getter didn't allow mutability already.

---

~~I'm sorry this grew a liiiiiiiiiitle bigger than initially planned as changes just snowballed 🫠
Can be easily split if any of the changes are debatable.~~
Edit: split into https://github.com/PaperMC/Paper/pull/12462