### PR TITLE
Allow `getAsString()`-ing non-persistent entities

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -948,7 +948,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     @Override
     public String getAsString() {
         CompoundTag tag = new CompoundTag();
-        if (!this.getHandle().saveAsPassenger(tag, false, false, false)) {
+        if (!this.getHandle().saveAsPassenger(tag, false, true, true)) {
             return null;
         }
 


### PR DESCRIPTION
`Entity#getAsString` allows dumping entity's snbt and can be used to create entity snapshots.

However, the method currently fails if used on unsaveable entity, e.g., non-persistent (`entity.setPersistent(false)`) ones.

While this API is not exactly supported, I don't see a reason to keep the restriction either.