### PR TITLE
Fix reobf mappings regression in GameRules.Type

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/GameRules.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/GameRules.java.patch
@@ -225,12 +225,8 @@
          final String id;
          private final GameRules.Category category;
  
-@@ -572,10 +_,10 @@
-         }
-     }
- 
--    public static class Type<T extends GameRules.Value<T>> {
-+    public static class Type<T extends GameRules.Value<T>> implements net.minecraft.world.flag.FeatureElement { // Paper - FeatureDependant for GameRule
+@@ -575,7 +_,7 @@
+     public static class Type<T extends GameRules.Value<T>> {
          final Supplier<ArgumentType<?>> argument;
          private final Function<GameRules.Type<T>, T> constructor;
 -        final BiConsumer<MinecraftServer, T> callback;
@@ -247,6 +243,19 @@
              GameRules.VisitorCaller<T> visitorCaller,
              Class<T> valueClass,
              FeatureFlagSet requiredFeatures
+@@ -611,6 +_,12 @@
+         public FeatureFlagSet requiredFeatures() {
+             return this.requiredFeatures;
+         }
++        // Paper start - expose FeatureElement wrapper for GameRules.Type.
++        // Chosen over simply adding this to the inheritance to avoid reobf issues with spigot...
++        public net.minecraft.world.flag.FeatureElement asFeatureElement() {
++            return net.minecraft.world.level.GameRules.Type.this::requiredFeatures;
++        }
++        // Paper end - expose FeatureElement wrapper for GameRules.Type.
+     }
+ 
+     public abstract static class Value<T extends GameRules.Value<T>> {
 @@ -620,16 +_,16 @@
              this.type = type;
          }

--- a/paper-server/src/main/java/io/papermc/paper/world/flag/PaperFeatureFlagProviderImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/flag/PaperFeatureFlagProviderImpl.java
@@ -52,7 +52,7 @@ public class PaperFeatureFlagProviderImpl implements FeatureFlagProvider {
         } else if (dependant instanceof final PotionType potionType) {
             return CraftPotionType.bukkitToMinecraft(potionType);
         } else if (dependant instanceof final GameRule<?> gameRule) {
-            return getGameRuleType(gameRule.getName());
+            return getGameRuleType(gameRule.getName()).asFeatureElement();
         } else {
             throw new IllegalArgumentException(dependant + " is not a valid feature dependant");
         }


### PR DESCRIPTION
The recent commit 121a7bf4ebd42beb9285a694039c2868b4148b07 added
the interface FeatureElement to the GameRules.Type class to expose the
stored feature flags of gamerules.
This however messed with the reobf mappings spigot uses, as the now
overridden method requiredFeatures needs to be mapped to the same
obfuscated name as FeatureElement#requiredFeatures.

To avoid having this in the mappings patch, the commit removes the
inheritance again and instead exposes a wrapper method.
