### PR TITLE
Add BlockDataChangeEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/block/BlockDataChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/block/BlockDataChangeEvent.java
@@ -35,7 +35,7 @@ public class BlockDataChangeEvent extends BlockEvent implements Cancellable {
      * @return The new {@link BlockData}
      */
     public BlockData getNewData() {
-        return newData;
+        return newData.clone();
     }
 
     /**
@@ -44,7 +44,7 @@ public class BlockDataChangeEvent extends BlockEvent implements Cancellable {
      * @param newData The new {@link BlockData}
      */
     public void setNewData(final BlockData newData) {
-        this.newData = newData;
+        this.newData = newData.clone();
     }
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/event/block/BlockDataChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/block/BlockDataChangeEvent.java
@@ -1,0 +1,78 @@
+package io.papermc.paper.event.block;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.block.BlockEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Called when a blocks {@link BlockData} gets changed.
+ * <p>
+ * Examples include placing a block or modifying one using commands such as the setblock command.
+ */
+@NullMarked
+public class BlockDataChangeEvent extends BlockEvent implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private BlockData newData;
+
+    private boolean cancelled;
+
+    @ApiStatus.Internal
+    public BlockDataChangeEvent(final Block block, final BlockData newData) {
+        super(block);
+        this.newData = newData;
+    }
+
+    /**
+     * Gets the new {@link BlockData} of the block.
+     *
+     * @return The new {@link BlockData}
+     */
+    public BlockData getNewData() {
+        return newData;
+    }
+
+    /**
+     * Sets the new {@link BlockData} of the block.
+     *
+     * @param newData The new {@link BlockData}
+     */
+    public void setNewData(final BlockData newData) {
+        this.newData = newData;
+    }
+
+    /**
+     * Gets whether the changing of the block data should be cancelled or not.
+     *
+     * @return Whether the changing of the block data should be cancelled or not.
+     */
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    /**
+     * Sets whether the changing of the block data should be cancelled or not.
+     *
+     * @param cancel whether the changing of the block data should be cancelled or not.
+     */
+    @Override
+    public void setCancelled(final boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/paper-server/patches/features/0004-Anti-Xray.patch
+++ b/paper-server/patches/features/0004-Anti-Xray.patch
@@ -199,7 +199,7 @@ index a2a4dbcfb77d44657b3dfbe97cb629de215c29eb..73717609fccd9af12e2cc39824106f49
          }
          // Paper end - Send empty chunk
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 1f26826b2161cfeb27e5b2060e178b493e9142d9..63f8b0c47e3321b74f4b6bcbc1e28cd751911198 100644
+index e423b4597e39d96294ed7e042c400d9d5e5c5e81..98da698c34d54d4f58f232ea57cd978ccbc64f91 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -132,6 +132,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
@@ -228,7 +228,7 @@ index 1f26826b2161cfeb27e5b2060e178b493e9142d9..63f8b0c47e3321b74f4b6bcbc1e28cd7
      }
  
      // Paper start - Cancel hit for vanished players
-@@ -483,6 +486,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -492,6 +495,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
                  snapshot.setFlags(flags); // Paper - always set the flag of the most recent call to mitigate issues with multiple update at the same pos with different flags
              }
              BlockState blockState = chunkAt.setBlockState(pos, state, flags);

--- a/paper-server/patches/features/0015-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0015-Moonrise-optimisation-patches.patch
@@ -29725,7 +29725,7 @@ index 300f3ed58109219d97846082941b860585f66fed..892a7c1eb1b321ca6d5ca709142e7fea
  
      // Paper start - Affects Spawning API
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 98da698c34d54d4f58f232ea57cd978ccbc64f91..2cb3f4df82858b4f92936d1b658b4be1f8d0db8d 100644
+index a6a2cf4e9c5dbc4cc1fa5c738c6503e9867494cd..cbe2e0ef02dd347753e7a240cb227a596f3863c6 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -81,6 +81,7 @@ import net.minecraft.world.level.storage.LevelData;
@@ -31481,10 +31481,10 @@ index 8d98cba3830dc5dfb5cae9a6f5fedfffee0d2cd8..73962e79a0f3d892e3155443a1b84508
  
      public interface NoiseBiomeSource {
 diff --git a/net/minecraft/world/level/block/Block.java b/net/minecraft/world/level/block/Block.java
-index 95bd1139401d49ddf443a64faca8cd30ca3b1a1d..ae3e6e31171b1bcfba1ae51a0941b52dda270acd 100644
+index c5dd301b791bf81dc4b8c4b8b7a3e266ab89957d..33eb2b5d753b1d21ced76c6e0245fe69bf86078b 100644
 --- a/net/minecraft/world/level/block/Block.java
 +++ b/net/minecraft/world/level/block/Block.java
-@@ -305,7 +305,7 @@ public class Block extends BlockBehaviour implements ItemLike {
+@@ -306,7 +306,7 @@ public class Block extends BlockBehaviour implements ItemLike {
      }
  
      public static boolean isShapeFullBlock(VoxelShape shape) {

--- a/paper-server/patches/features/0015-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0015-Moonrise-optimisation-patches.patch
@@ -27565,7 +27565,7 @@ index fe9b4484d683fe48f435a053c9c90557fdf80e7b..8afe96bfdc37e57129f1bb4af5b6d5cc
      }
  
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index a8c73bdf8fb130eed8922cb537a35cda07e66da5..3e73c69c9db8cbded28a001b20d9989acb11c638 100644
+index a11591ea5e8aa1861d202db49ab200d814308c6d..31032beb40105b287e51206de2f68c9a070e8bdd 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -187,7 +187,7 @@ import net.minecraft.world.scores.Team;
@@ -29725,7 +29725,7 @@ index 300f3ed58109219d97846082941b860585f66fed..892a7c1eb1b321ca6d5ca709142e7fea
  
      // Paper start - Affects Spawning API
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d5be9e876 100644
+index 98da698c34d54d4f58f232ea57cd978ccbc64f91..2cb3f4df82858b4f92936d1b658b4be1f8d0db8d 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -81,6 +81,7 @@ import net.minecraft.world.level.storage.LevelData;
@@ -30408,7 +30408,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
      }
  
      // Paper start - Cancel hit for vanished players
-@@ -555,7 +1189,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -564,7 +1198,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
                  this.setBlocksDirty(pos, blockState, blockState1);
              }
  
@@ -30417,7 +30417,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
                  this.sendBlockUpdated(pos, blockState, state, flags);
              }
  
-@@ -820,6 +1454,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -829,6 +1463,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
          // Spigot start
          boolean runsNormally = this.tickRateManager().runsNormally();
  
@@ -30425,7 +30425,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
          var toRemove = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<TickingBlockEntity>(); // Paper - Fix MC-117075; use removeAll
          toRemove.add(null); // Paper - Fix MC-117075
          for (this.tileTickPosition = 0; this.tileTickPosition < this.blockEntityTickers.size(); this.tileTickPosition++) { // Paper - Disable tick limiters
-@@ -829,6 +1464,11 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -838,6 +1473,11 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
                  toRemove.add(tickingBlockEntity); // Paper - Fix MC-117075; use removeAll
              } else if (runsNormally && this.shouldTickBlocksAt(tickingBlockEntity.getPos())) {
                  tickingBlockEntity.tick();
@@ -30437,7 +30437,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
              }
          }
          this.blockEntityTickers.removeAll(toRemove); // Paper - Fix MC-117075
-@@ -849,6 +1489,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -858,6 +1498,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
              entity.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DISCARD);
              // Paper end - Prevent block entity and entity crashes
          }
@@ -30445,7 +30445,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
      }
  
      // Paper start - Option to prevent armor stands from doing entity lookups
-@@ -856,7 +1497,14 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -865,7 +1506,14 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
      public boolean noCollision(@Nullable Entity entity, AABB box) {
          if (entity instanceof net.minecraft.world.entity.decoration.ArmorStand && !entity.level().paperConfig().entities.armorStands.doCollisionEntityLookups)
              return false;
@@ -30461,7 +30461,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
      }
      // Paper end - Option to prevent armor stands from doing entity lookups
  
-@@ -994,7 +1642,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -1003,7 +1651,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
          if (this.isOutsideBuildHeight(pos)) {
              return null;
          } else {
@@ -30470,7 +30470,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
                  ? null
                  : this.getChunkAt(pos).getBlockEntity(pos, LevelChunk.EntityCreationType.IMMEDIATE);
          }
-@@ -1087,22 +1735,16 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -1096,22 +1744,16 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
      public List<Entity> getEntities(@Nullable Entity entity, AABB boundingBox, Predicate<? super Entity> predicate) {
          Profiler.get().incrementCounter("getEntities");
          List<Entity> list = Lists.newArrayList();
@@ -30501,7 +30501,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
      }
  
      @Override
-@@ -1116,33 +1758,94 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -1125,33 +1767,94 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
          this.getEntities(entityTypeTest, bounds, predicate, output, Integer.MAX_VALUE);
      }
  

--- a/paper-server/patches/features/0018-Add-Alternate-Current-redstone-implementation.patch
+++ b/paper-server/patches/features/0018-Add-Alternate-Current-redstone-implementation.patch
@@ -2352,10 +2352,10 @@ index 8afe96bfdc37e57129f1bb4af5b6d5cc22c11aee..32db2b9e375c12cbf7abab69cc01e8ac
          @Override
          public void onCreated(Entity entity) {
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index eb4d03cfdb34243901cfba832d35559d5be9e876..013ed7dbe2309f562f63e66203179a90566e8115 100644
+index 2cb3f4df82858b4f92936d1b658b4be1f8d0db8d..9c3e4b6cfb09725897998daa6f9d8b0f643b7908 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
-@@ -2096,6 +2096,17 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -2105,6 +2105,17 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
          return 0;
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
@@ -334,7 +334,7 @@
          if (this.isOutsideBuildHeight(pos)) {
              return false;
          } else if (!this.isClientSide && this.isDebug()) {
-@@ -221,11 +_,31 @@
+@@ -221,11 +_,40 @@
          } else {
              LevelChunk chunkAt = this.getChunkAt(pos);
              Block block = state.getBlock();

--- a/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
@@ -338,6 +338,15 @@
          } else {
              LevelChunk chunkAt = this.getChunkAt(pos);
              Block block = state.getBlock();
++            // Paper start - BlockDataChangeEvent
++            if (io.papermc.paper.event.block.BlockDataChangeEvent.getHandlerList().getRegisteredListeners().length > 0) {
++                io.papermc.paper.event.block.BlockDataChangeEvent event = new io.papermc.paper.event.block.BlockDataChangeEvent(org.bukkit.craftbukkit.block.CraftBlock.at(this, pos), CraftBlockData.fromData(state));
++                if(!event.callEvent()) {
++                    return false;
++                }
++                state = ((CraftBlockData) event.getNewData()).getState();
++            }
++            // Paper end - BlockDataChangeEvent
 +            // CraftBukkit start - capture blockstates
 +            boolean captured = false;
 +            if (this.captureBlockStates) {

--- a/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
@@ -339,7 +339,7 @@
              LevelChunk chunkAt = this.getChunkAt(pos);
              Block block = state.getBlock();
 +            // Paper start - BlockDataChangeEvent
-+            if (io.papermc.paper.event.block.BlockDataChangeEvent.getHandlerList().getRegisteredListeners().length > 0) {
++            if ((flags & Block.UPDATE_SKIP_DATA_CHANGE_EVENT) == 0 && io.papermc.paper.event.block.BlockDataChangeEvent.getHandlerList().getRegisteredListeners().length > 0) {
 +                io.papermc.paper.event.block.BlockDataChangeEvent event = new io.papermc.paper.event.block.BlockDataChangeEvent(org.bukkit.craftbukkit.block.CraftBlock.at(this, pos), CraftBlockData.fromData(state));
 +                if(!event.callEvent()) {
 +                    return false;

--- a/paper-server/patches/sources/net/minecraft/world/level/block/Block.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/Block.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/world/level/block/Block.java
 +++ b/net/minecraft/world/level/block/Block.java
+@@ -90,6 +_,7 @@
+     public static final int UPDATE_SKIP_SHAPE_UPDATE_ON_WIRE = 128;
+     public static final int UPDATE_SKIP_BLOCK_ENTITY_SIDEEFFECTS = 256;
+     public static final int UPDATE_SKIP_ON_PLACE = 512;
++    public static final int UPDATE_SKIP_DATA_CHANGE_EVENT = 1024;
+     public static final int UPDATE_NONE = 260;
+     public static final int UPDATE_ALL = 3;
+     public static final int UPDATE_ALL_IMMEDIATE = 11;
 @@ -99,6 +_,21 @@
      public static final int UPDATE_LIMIT = 512;
      protected final StateDefinition<Block, BlockState> stateDefinition;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
@@ -155,7 +155,7 @@ public class CraftBlock implements Block {
     }
 
     private void setData(final byte data, int flags) {
-        this.world.setBlock(this.position, CraftMagicNumbers.getBlock(this.getType(), data), flags);
+        this.world.setBlock(this.position, CraftMagicNumbers.getBlock(this.getType(), data), flags | net.minecraft.world.level.block.Block.UPDATE_SKIP_DATA_CHANGE_EVENT);
     }
 
     @Override
@@ -202,17 +202,18 @@ public class CraftBlock implements Block {
             if (world instanceof net.minecraft.world.level.Level) {
                 ((net.minecraft.world.level.Level) world).removeBlockEntity(pos);
             } else {
-                world.setBlock(pos, Blocks.AIR.defaultBlockState(), 0);
+                world.setBlock(pos, Blocks.AIR.defaultBlockState(), net.minecraft.world.level.block.Block.UPDATE_SKIP_DATA_CHANGE_EVENT);
             }
         }
 
         if (applyPhysics) {
-            return world.setBlock(pos, newState, net.minecraft.world.level.block.Block.UPDATE_ALL);
+            return world.setBlock(pos, newState, net.minecraft.world.level.block.Block.UPDATE_ALL | net.minecraft.world.level.block.Block.UPDATE_SKIP_DATA_CHANGE_EVENT);
         } else {
             boolean success = world.setBlock(pos, newState,
                 net.minecraft.world.level.block.Block.UPDATE_CLIENTS |
                     net.minecraft.world.level.block.Block.UPDATE_KNOWN_SHAPE |
-                    net.minecraft.world.level.block.Block.UPDATE_SKIP_ON_PLACE);
+                    net.minecraft.world.level.block.Block.UPDATE_SKIP_ON_PLACE |
+                    net.minecraft.world.level.block.Block.UPDATE_SKIP_DATA_CHANGE_EVENT);
             if (success && world instanceof net.minecraft.world.level.Level) {
                 world.getMinecraftWorld().sendBlockUpdated(
                     pos,

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -817,7 +817,7 @@ public class CraftEventFactory {
     public static boolean handleBlockSpreadEvent(LevelAccessor world, BlockPos source, BlockPos target, net.minecraft.world.level.block.state.BlockState state, int flags, boolean checkSetResult) {
         // Suppress during worldgen
         if (!(world instanceof Level)) {
-            boolean result = world.setBlock(target, state, flags);
+            boolean result = world.setBlock(target, state, flags | net.minecraft.world.level.block.Block.UPDATE_SKIP_DATA_CHANGE_EVENT);
             return !checkSetResult || result;
         }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -817,7 +817,7 @@ public class CraftEventFactory {
     public static boolean handleBlockSpreadEvent(LevelAccessor world, BlockPos source, BlockPos target, net.minecraft.world.level.block.state.BlockState state, int flags, boolean checkSetResult) {
         // Suppress during worldgen
         if (!(world instanceof Level)) {
-            boolean result = world.setBlock(target, state, flags | net.minecraft.world.level.block.Block.UPDATE_SKIP_DATA_CHANGE_EVENT);
+            boolean result = world.setBlock(target, state, flags);
             return !checkSetResult || result;
         }
 


### PR DESCRIPTION
Currently, when wanting to prevent or modify all or certain `BlockData` changes, you have to listen to numerous different BlockEvents to try and catch every one, and even then you don't catch cases like changes made by commands.

This PR adds a `BlockDataChangeEvent` which gets called whenever a `BlockState` gets changed in `net.minecraft.world.level.Level#setBlock`. To stay more consistent with Bukkit's Naming Scheme, `BlockData` has been chosen instead of `BlockState` for the Event Name.

Another benefit of this method is that commands like setblock return a sensible message that the block changes could not be made, instead of not notifying the user like with other workarounds.