### PR TITLE
Support DamagePerBlock for Virtual WorldBorder

### DIFF
--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -358,7 +358,7 @@ index 88b81a5fbc88e6240f86c1e780d80eb4b601df8c..00a5ed09caa2689543bd47bcd93d5a61
  import java.io.Writer;
  import java.nio.file.Path;
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 156f7ddc2fdc96b762598bad2a2b21f433518dc0..ef201f4add358fbf1818f3b2ec9e75fe2cce4c8b 100644
+index 81c615d00323bdf86bdb76db17bb47288cf3feba..6b67cc939851745718f919488c997eb6719a16fc 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -544,6 +544,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -527,10 +527,10 @@ index fd0cc1bf9e4425a0924ed77854907deec1a7348e..1c9e5f61d182cf60caa885135abddc87
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 4123354a660f85905c8c2db1c5377201c2b8267e..7ba7a00b8dee651ca7a3cab5b64b4ae11aa66da9 100644
+index 17139bfb7fa50e9968008d696d9eb348179360d3..027d6605d483baebecb8dad5ab859543dbe393ef 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3163,6 +3163,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3172,6 +3172,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return false;
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -60,6 +60,36 @@
              }
          }
  
+@@ -394,10 +_,10 @@
+             boolean flag = this instanceof Player;
+             if (this.isInWall()) {
+                 this.hurtServer(serverLevel1, this.damageSources().inWall(), 1.0F);
+-            } else if (flag && !serverLevel1.getWorldBorder().isWithinBounds(this.getBoundingBox())) {
+-                double d = serverLevel1.getWorldBorder().getDistanceToBorder(this) + serverLevel1.getWorldBorder().getDamageSafeZone();
++            } else if (flag && !this.getWorldBorder().isWithinBounds(this.getBoundingBox())) { // Paper - use the first WorldBorder available
++                double d = this.getWorldBorder().getDistanceToBorder(this) + serverLevel1.getWorldBorder().getDamageSafeZone(); // Paper - use the first WorldBorder available
+                 if (d < 0.0) {
+-                    double damagePerBlock = serverLevel1.getWorldBorder().getDamagePerBlock();
++                    double damagePerBlock = this.getWorldBorder().getDamagePerBlock(); // Paper - use the first WorldBorder available
+                     if (damagePerBlock > 0.0) {
+                         this.hurtServer(serverLevel1, this.damageSources().outOfBorder(), Math.max(1, Mth.floor(-d * damagePerBlock)));
+                     }
+@@ -478,6 +_,15 @@
+         return Mth.lerp((float)this.getAttributeValue(Attributes.MOVEMENT_EFFICIENCY), super.getBlockSpeedFactor(), 1.0F);
+     }
+ 
++    // Paper start - helper for WorldBorder
++    private net.minecraft.world.level.border.WorldBorder getWorldBorder() {
++        if (this instanceof ServerPlayer serverPlayer && serverPlayer.getBukkitEntity().hasClientWorldBorder()) {
++            return ((org.bukkit.craftbukkit.CraftWorldBorder)serverPlayer.getBukkitEntity().getWorldBorder()).getHandle();
++        }
++        return this.level().getWorldBorder();
++    }
++    // Paper end
++
+     public float getLuck() {
+         return 0.0F;
+     }
 @@ -535,7 +_,7 @@
          this.deathTime++;
          if (this.deathTime >= 20 && !this.level().isClientSide() && !this.isRemoved()) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -1522,7 +1522,9 @@ public final class CraftServer implements Server {
 
     @Override
     public WorldBorder createWorldBorder() {
-        return new CraftWorldBorder(new net.minecraft.world.level.border.WorldBorder());
+        net.minecraft.world.level.border.WorldBorder worldBorder = new net.minecraft.world.level.border.WorldBorder();
+        worldBorder.setDamagePerBlock(0);
+        return new CraftWorldBorder(worldBorder);
     }
 
     @Override


### PR DESCRIPTION
This PR close https://github.com/PaperMC/Paper/issues/12372 by adding the support for server to consider the damage, this make the break change where the WorldBorder created by Server/Bukkit set the damage in zero.