### PR TITLE
Add GhastShootFireballEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/entity/GhastShootFireballEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/GhastShootFireballEvent.java
@@ -1,0 +1,41 @@
+package io.papermc.paper.event.entity;
+
+
+import com.google.common.base.Preconditions;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class GhastShootFireballEvent extends EntityEvent {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+    private int explosion_power = 1;
+
+
+    public GhastShootFireballEvent(@NotNull Entity ghast) {
+        super(ghast);
+    }
+
+    public static HandlerList getHandlerList(){
+        return HANDLER_LIST;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public @NotNull int getExplosionPower(){
+        return explosion_power;
+    }
+
+    public @NotNull void setExplosionPower(@NotNull int power){
+        Preconditions.checkArgument((power < 127), "Fatal error! Power can not be greater than 127");
+        Preconditions.checkArgument((power > 1), "Fatal error! Power can not be less than 1");
+
+        explosion_power = power;
+    }
+
+
+}

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/Ghast.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/Ghast.java.patch
@@ -13,9 +13,17 @@
      @Override
      protected boolean shouldDespawnInPeaceful() {
          return true;
-@@ -276,6 +_,7 @@
+@@ -275,7 +_,15 @@
+                             level.levelEvent(null, 1016, this.ghast.blockPosition(), 0);
                          }
  
++                        //Paper start - Call io.papermc.paper.event.entity.GhastShootFireballEvent
++                        io.papermc.paper.event.entity.GhastShootFireballEvent ghastFireballEventBackend = new io.papermc.paper.event.entity.GhastShootFireballEvent(this.ghast.getBukkitEntity());
++                        ghastFireballEventBackend.callEvent();
++                        this.ghast.explosionPower = ghastFireballEventBackend.getExplosionPower();
++                        org.bukkit.Bukkit.getServer().getPluginManager().callEvent(ghastFireballEventBackend);
++                        //Paper end
++
                          LargeFireball largeFireball = new LargeFireball(level, this.ghast, vec3.normalize(), this.ghast.getExplosionPower());
 +                        largeFireball.bukkitYield = largeFireball.explosionPower = this.ghast.getExplosionPower(); // CraftBukkit - set bukkitYield when setting explosionPower
                          largeFireball.setPos(this.ghast.getX() + viewVector.x * 4.0, this.ghast.getY(0.5) + 0.5, largeFireball.getZ() + viewVector.z * 4.0);


### PR DESCRIPTION
I've added a new event that fires when a Ghast fires a fireball, I've implemented some basic setExplosionPower and getExplosionPower methods to mimic those provided by net.minecraft.world.entity.monster.Ghast in the future (such as a method to modify the speed, etc). I opted to set the values directly, because I didn't want to use any weird casts within the event listener's method to get a bukkit ghast.