### PR TITLE
fix writing headers, and update to be more papery

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
@@ -101,6 +101,7 @@ public class PaperConfigurations extends Configurations<GlobalConfiguration, Wor
             The world configuration options have been moved inside
             their respective world folder. The files are named %s
 
+            File Reference: https://docs.papermc.io/paper/reference/global-configuration/
             Docs: https://docs.papermc.io/
             Discord: https://discord.gg/papermc
             Website: https://papermc.io/""", WORLD_CONFIG_FILE_NAME);
@@ -116,6 +117,7 @@ public class PaperConfigurations extends Configurations<GlobalConfiguration, Wor
             Configuration options here apply to all worlds, unless you specify overrides inside
             the world-specific config file inside each world folder.
 
+            File Reference: https://docs.papermc.io/paper/reference/world-configuration/
             Docs: https://docs.papermc.io/
             Discord: https://discord.gg/papermc
             Website: https://papermc.io/""";
@@ -123,6 +125,8 @@ public class PaperConfigurations extends Configurations<GlobalConfiguration, Wor
     private static final Function<ContextMap, String> WORLD_HEADER = map -> String.format("""
         This is a world configuration file for Paper.
         This file may start empty but can be filled with settings to override ones in the %s/%s
+        
+        For more information, see https://docs.papermc.io/paper/reference/configuration/#per-world-configuration
         
         World: %s (%s)""",
         PaperConfigurations.CONFIG_DIR,

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -432,7 +432,9 @@ public final class CraftServer implements Server {
 
         this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
         this.configuration.options().copyDefaults(true);
-        this.configuration.setDefaults(YamlConfiguration.loadConfiguration(new InputStreamReader(this.getClass().getClassLoader().getResourceAsStream("configurations/bukkit.yml"), StandardCharsets.UTF_8)));
+        YamlConfiguration configurationDefaults = YamlConfiguration.loadConfiguration(new InputStreamReader(this.getClass().getClassLoader().getResourceAsStream("configurations/bukkit.yml"), StandardCharsets.UTF_8));
+        this.configuration.setDefaults(configurationDefaults);
+        this.configuration.options().setHeader(configurationDefaults.options().getHeader());
         ConfigurationSection legacyAlias = null;
         if (!this.configuration.isString("aliases")) {
             legacyAlias = this.configuration.getConfigurationSection("aliases");

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -451,6 +451,7 @@ public final class CraftServer implements Server {
         if (this.commandsConfiguration.contains("aliases")) commandsDefaults.set("aliases", null);
         this.commandsConfiguration.setDefaults(commandsDefaults);
         // Paper end - don't enforce icanhasbukkit default if alias block exists
+        this.commandsConfiguration.options().setHeader(commandsDefaults.options().getHeader());
         this.saveCommandsConfig();
 
         // Migrate aliases from old file and add previously implicit $1- to pass all arguments

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/help/HelpYamlReader.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/help/HelpYamlReader.java
@@ -32,11 +32,10 @@ public class HelpYamlReader {
             this.helpYaml = YamlConfiguration.loadConfiguration(helpYamlFile);
             this.helpYaml.options().copyDefaults(true);
             this.helpYaml.setDefaults(defaultConfig);
+            this.helpYaml.options().setHeader(defaultConfig.options().getHeader());
 
             try {
-                if (!helpYamlFile.exists()) {
-                    this.helpYaml.save(helpYamlFile);
-                }
+                this.helpYaml.save(helpYamlFile);
             } catch (IOException ex) {
                 server.getLogger().log(Level.SEVERE, "Could not save " + helpYamlFile, ex);
             }

--- a/paper-server/src/main/java/org/spigotmc/SpigotConfig.java
+++ b/paper-server/src/main/java/org/spigotmc/SpigotConfig.java
@@ -33,17 +33,17 @@ public class SpigotConfig {
 
     private static File CONFIG_FILE;
     private static final String HEADER = """
-        This is the main configuration file for Spigot.
+        This is the Spigot configuration file for Paper.
         As you can see, there's tons to configure. Some options may impact gameplay, so use
         with caution, and make sure you know what each option does before configuring.
-        For a reference for any variable inside this file, check out the Spigot wiki at
-        http://www.spigotmc.org/wiki/spigot-configuration/
         
-        If you need help with the configuration or have any questions related to Spigot,
-        join us at the Discord or drop by our forums and leave a post.
+        If you need help with the configuration or have any questions related to Paper,
+        join us in our Discord or check the docs page.
         
-        Discord: https://www.spigotmc.org/go/discord
-        Forums: http://www.spigotmc.org/
+        File Reference: https://docs.papermc.io/paper/reference/spigot-configuration/
+        Docs: https://docs.papermc.io/
+        Discord: https://discord.gg/papermc
+        Website: https://papermc.io/
         """;
     /*========================================================================*/
     public static YamlConfiguration config;

--- a/paper-server/src/main/resources/configurations/bukkit.yml
+++ b/paper-server/src/main/resources/configurations/bukkit.yml
@@ -1,15 +1,13 @@
-# This is the main configuration file for Bukkit.
+# This is the Bukkit configuration file in Paper.
 # As you can see, there's actually not that much to configure without any plugins.
-# For a reference for any variable inside this file, check out the Bukkit Wiki at
-# https://www.spigotmc.org/go/bukkit-yml
-# 
-# If you need help on this file, feel free to join us on Discord or leave a message
-# on the forums asking for advice.
-# 
-# Discord: https://www.spigotmc.org/go/discord
-# Forums: https://www.spigotmc.org/
-# Bug tracker: https://www.spigotmc.org/go/bugs
-
+#
+# If you need help with the configuration or have any questions related to Paper,
+# join us in our Discord or check the docs page.
+#
+# File Reference: https://docs.papermc.io/paper/reference/bukkit-configuration/
+# Docs: https://docs.papermc.io/
+# Discord: https://discord.gg/papermc
+# Website: https://papermc.io/
 
 settings:
     allow-end: true

--- a/paper-server/src/main/resources/configurations/commands.yml
+++ b/paper-server/src/main/resources/configurations/commands.yml
@@ -1,13 +1,12 @@
-# This is the commands configuration file for Bukkit.
-# For documentation on how to make use of this file, check out the Bukkit Wiki at
-# https://www.spigotmc.org/go/commands-yml
-# 
-# If you need help on this file, feel free to join us on Discord or leave a message
-# on the forums asking for advice.
-# 
-# Discord: https://www.spigotmc.org/go/discord
-# Forums: https://www.spigotmc.org/
-# Bug tracker: https://www.spigotmc.org/go/bugs
+# This is the Bukkit commands configuration file for Paper.
+#
+# If you need help with the configuration or have any questions related to Paper,
+# join us in our Discord or check the docs page.
+#
+# File Reference: https://docs.papermc.io/paper/reference/bukkit-commands-configuration/
+# Docs: https://docs.papermc.io/
+# Discord: https://discord.gg/papermc
+# Website: https://papermc.io/
 
 command-block-overrides: []
 ignore-vanilla-permissions: false

--- a/paper-server/src/main/resources/configurations/help.yml
+++ b/paper-server/src/main/resources/configurations/help.yml
@@ -1,4 +1,4 @@
-# This is the help configuration file for Bukkit.
+# This is the Bukkit help configuration file for Paper.
 # 
 # By default you do not need to modify this file. Help topics for all plugin commands are automatically provided by
 # or extracted from your installed plugins. You only need to modify this file if you wish to add new help pages to
@@ -53,3 +53,10 @@
 #    - PluginNameOne
 #    - PluginNameTwo
 #    - PluginNameThree
+#
+# If you need help with the configuration or have any questions related to Paper,
+# join us in our Discord or check the docs page.
+#
+# Docs: https://docs.papermc.io/
+# Discord: https://discord.gg/papermc
+# Website: https://papermc.io/


### PR DESCRIPTION
no idea when these broke, but while testing / updating the paper-docs configuration stuff (incoming at somepoint :tm:),
I noticed that `bukkit.yml`, `commands.yml` and `help.yml` all had headers in their default files that werent being copied over.

Now, the behavior is that the headers are replaced on each start, matching `paper-*.yml` and `spigot.yml`
this replacement _may_ cause data loss if people put custom information in the headers of these files.
if this is unacceptable, this can be changed to only affect new servers/servers where the header is blank, 
by only setting the header if the current header is empty, but this means updating the header later becomes harder.

Also updated the headers to roughly match the format of paper-*.yml