### PR TITLE
Undeprecate Entity#isInWaterOrRain & correct some javadocs

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Tool.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Tool.java
@@ -1,6 +1,7 @@
 package io.papermc.paper.datacomponent.item;
 
 import io.papermc.paper.datacomponent.DataComponentBuilder;
+import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.registry.set.RegistryKeySet;
 import java.util.Collection;
 import java.util.List;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * Controls the behavior of the item as a tool.
- * @see io.papermc.paper.datacomponent.DataComponentTypes#TOOL
+ * @see DataComponentTypes#TOOL
  */
 @NullMarked
 @ApiStatus.Experimental
@@ -92,8 +93,6 @@ public interface Tool {
 
         /**
          * Overrides the mining speed if present and matched.
-         * <p>
-         * {@code true} will cause the block to mine at its most efficient speed, and drop items if the targeted block requires that.
          *
          * @return speed override
          */
@@ -101,6 +100,8 @@ public interface Tool {
 
         /**
          * Overrides whether this tool is considered 'correct' if present and matched.
+         * <p>
+         * {@code true} will cause the block to mine at its most efficient speed, and drop items if the targeted block requires that.
          *
          * @return a tri-state
          */

--- a/paper-api/src/main/java/org/bukkit/entity/AbstractArrow.java
+++ b/paper-api/src/main/java/org/bukkit/entity/AbstractArrow.java
@@ -165,7 +165,7 @@ public interface AbstractArrow extends Projectile {
      * Sets the ItemStack which will be picked up from this arrow.
      *
      * @param item ItemStack set to be picked up
-     * @deprecated use {@link #getItemStack()}
+     * @deprecated use {@link #setItemStack(ItemStack)}
      */
     @ApiStatus.Experimental
     @Deprecated(forRemoval = true, since = "1.20.4") // Paper

--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -1048,7 +1048,7 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
     /**
      * Check if entity is in water or rain
      *
-     * @deprecated use {@link #isInWater()}} and {@link #isInRain()}
+     * @deprecated use {@link #isInWater()} and {@link #isInRain()}
      */
     @Deprecated(since = "1.21.5")
     default boolean isInWaterOrRain() {
@@ -1068,7 +1068,7 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
     /**
      * Check if entity is in water or rain or bubble column
      *
-     * @deprecated use {@link #isInWaterOrRain()}, bubble column is considered as water
+     * @deprecated bubble column is considered as water, use {@link #isInWater()} and {@link #isInRain()}
      */
     @Deprecated(since = "1.21.5")
     default boolean isInWaterOrRainOrBubbleColumn() {

--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -1048,10 +1048,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
     /**
      * Check if entity is in water or rain
      *
-     * @see #isInWater()
-     * @see #isInRain()
+     * @deprecated use {@link #isInWater()}} and {@link #isInRain()}
      */
-    boolean isInWaterOrRain();
+    @Deprecated(since = "1.21.5")
+    default boolean isInWaterOrRain() {
+        return this.isInWater() || this.isInRain();
+    }
 
     /**
      * Check if entity is in water or bubble column

--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -1048,12 +1048,10 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
     /**
      * Check if entity is in water or rain
      *
-     * @deprecated use {@link #isInWater()}} and {@link #isInRain()}
+     * @see #isInWater()
+     * @see #isInRain()
      */
-    @Deprecated(since = "1.21.5")
-    default boolean isInWaterOrRain() {
-        return this.isInWater() || this.isInRain();
-    }
+    boolean isInWaterOrRain();
 
     /**
      * Check if entity is in water or bubble column

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -1162,6 +1162,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     }
 
     @Override
+    public boolean isInWaterOrRain() {
+        return this.getHandle().isInWaterOrRain();
+    }
+
+    @Override
     public boolean isInLava() {
         return this.getHandle().isInLava();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -1162,11 +1162,6 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     }
 
     @Override
-    public boolean isInWaterOrRain() {
-        return this.getHandle().isInWaterOrRain();
-    }
-
-    @Override
     public boolean isInLava() {
         return this.getHandle().isInLava();
     }


### PR DESCRIPTION
- Javadoc corrections
	- `Tool.Rule#speed()` had a description for `Tool.Rule#correctForDrops()`
	- `AbstractArrow#setItem` now points to `#setItemStack` instead of `#getItemStack`
- Undeprecate `Entity#isInWaterOrRain`
	- I've asked in Discord about this, there weren't any strong opinions for/against it.
	- Deprecating `BubbleColumn` overload in 1.21.5 makes sense, but the rain one still exists internally and is a neat way to check "is this entity wet?". I don't mind leaving it deprecated, but also I've used this method 34 times in just one codebase and my lazy kicked in.
		- <details>
			  <summary>Image</summary>
			  
			![image](https://github.com/user-attachments/assets/4c8c8bcb-4daf-4f56-a74d-cf2c4129b9b4)
			  
			</details>