### PR TITLE
Fix CCE in LingeringPotionSplashEvent

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/entity/LingeringPotionSplashEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/LingeringPotionSplashEvent.java
@@ -38,7 +38,7 @@ public class LingeringPotionSplashEvent extends ProjectileHitEvent implements Ca
     @NotNull
     @Override
     public ThrownPotion getEntity() {
-        return (ThrownPotion) this.entity;
+        return (ThrownPotion) super.getEntity();
     }
 
     /**


### PR DESCRIPTION
Regression in 1.21.5 update ([ref](https://github.com/PaperMC/Paper/commit/f00727c57e564f3a8cb875183a54142feb693db7#diff-bd1c99844d4a4fbb8a38c4e3519004b029ab994dc325fbb513ccb62313ee7a0eR41), if it loads).

Might ultimately make more sense to rename the AoE cloud instead of having two things named `entity` in "scope" but that's a separate issue.