### PR TITLE
Fix cursor item being lost when PlayerDropItemEvent is cancelled and …

### DIFF
--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -527,10 +527,10 @@ index fd0cc1bf9e4425a0924ed77854907deec1a7348e..1c9e5f61d182cf60caa885135abddc87
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 8e4bcd599b25d0aa8b58f102291c5d44972c52b2..e7671d595f703ef4f11d71eee7bc064161a4d9d4 100644
+index f7d8bfe57c183ae87803236825f02c9d892f0a5e..1a493d7c36dcf8559cd3764ee8bc4202468067d8 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3183,6 +3183,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3186,6 +3186,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return false;
      }
  

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -358,7 +358,7 @@ index 88b81a5fbc88e6240f86c1e780d80eb4b601df8c..00a5ed09caa2689543bd47bcd93d5a61
  import java.io.Writer;
  import java.nio.file.Path;
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 156f7ddc2fdc96b762598bad2a2b21f433518dc0..ef201f4add358fbf1818f3b2ec9e75fe2cce4c8b 100644
+index 81c615d00323bdf86bdb76db17bb47288cf3feba..6b67cc939851745718f919488c997eb6719a16fc 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -544,6 +544,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -527,10 +527,10 @@ index fd0cc1bf9e4425a0924ed77854907deec1a7348e..1c9e5f61d182cf60caa885135abddc87
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 4123354a660f85905c8c2db1c5377201c2b8267e..7ba7a00b8dee651ca7a3cab5b64b4ae11aa66da9 100644
+index 8cd0336158e72580b3ab9ed8e9ac251f69d94408..bb7a5e2fb783282c2af44d6915e217ae67aff26e 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3163,6 +3163,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3168,6 +3168,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return false;
      }
  

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -527,10 +527,10 @@ index fd0cc1bf9e4425a0924ed77854907deec1a7348e..1c9e5f61d182cf60caa885135abddc87
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 8cd0336158e72580b3ab9ed8e9ac251f69d94408..bb7a5e2fb783282c2af44d6915e217ae67aff26e 100644
+index 8e4bcd599b25d0aa8b58f102291c5d44972c52b2..e7671d595f703ef4f11d71eee7bc064161a4d9d4 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3168,6 +3168,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3183,6 +3183,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return false;
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -146,7 +146,7 @@
          if (stack.isEmpty()) {
              return null;
          } else if (this.level().isClientSide) {
-@@ -741,6 +_,31 @@
+@@ -741,6 +_,36 @@
          } else {
              ItemEntity itemEntity = this.createItemStackToDrop(stack, randomizeMotion, includeThrower);
              if (itemEntity != null) {
@@ -169,7 +169,12 @@
 +                            player.getInventory().setItemInMainHand(inHandItem);
 +                        } else {
 +                            // Fallback
-+                            player.getInventory().addItem(drop.getItemStack());
++                            java.util.Map<Integer, org.bukkit.inventory.ItemStack> failed = player.getInventory().addItem(drop.getItemStack());
++                            if (!failed.isEmpty()) {
++                                net.minecraft.server.level.ServerPlayer serverPlayer = (net.minecraft.server.level.ServerPlayer) this;
++                                serverPlayer.containerMenu.setCarried(CraftItemStack.asNMSCopy(drop.getItemStack()));
++                                serverPlayer.containerMenu.broadcastFullState();
++                            }
 +                        }
 +                        return null;
 +                    }

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -146,7 +146,7 @@
          if (stack.isEmpty()) {
              return null;
          } else if (this.level().isClientSide) {
-@@ -741,6 +_,36 @@
+@@ -741,6 +_,51 @@
          } else {
              ItemEntity itemEntity = this.createItemStackToDrop(stack, randomizeMotion, includeThrower);
              if (itemEntity != null) {
@@ -170,10 +170,25 @@
 +                        } else {
 +                            // Fallback
 +                            java.util.Map<Integer, org.bukkit.inventory.ItemStack> failed = player.getInventory().addItem(drop.getItemStack());
-+                            if (!failed.isEmpty()) {
-+                                net.minecraft.server.level.ServerPlayer serverPlayer = (net.minecraft.server.level.ServerPlayer) this;
-+                                serverPlayer.containerMenu.setCarried(CraftItemStack.asNMSCopy(drop.getItemStack()));
-+                                serverPlayer.containerMenu.broadcastFullState();
++
++                            // The item could not be added to the inventory.
++                            // We can attempt to set/merge it into the cursor now.
++                            if (failed.containsKey(0) && this instanceof final ServerPlayer serverPlayer) {
++                                final ItemStack itemNotAddedToInventory = CraftItemStack.asNMSCopy(failed.get(0));
++                                final ItemStack carriedAfterDropping = serverPlayer.containerMenu.getCarried();
++                                final boolean stackable = net.minecraft.world.item.ItemStack.isSameItemSameComponents(carriedAfterDropping, itemNotAddedToInventory);
++                                if (carriedAfterDropping.isEmpty() || stackable) {
++                                    if (carriedAfterDropping.isEmpty()) {
++                                        serverPlayer.containerMenu.setCarried(itemNotAddedToInventory);
++                                    } else {
++                                        // We can merge, if there *is* any overflow, there is nothing we can do.
++                                        // Those items will be lost.
++                                        carriedAfterDropping.grow(itemNotAddedToInventory.getCount());
++                                        carriedAfterDropping.limitSize(carriedAfterDropping.getMaxStackSize());
++                                        serverPlayer.containerMenu.setCarried(carriedAfterDropping);
++                                    }
++                                    serverPlayer.containerMenu.broadcastFullState();
++                                }
 +                            }
 +                        }
 +                        return null;

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -146,7 +146,7 @@
          if (stack.isEmpty()) {
              return null;
          } else if (this.level().isClientSide) {
-@@ -741,6 +_,51 @@
+@@ -741,6 +_,54 @@
          } else {
              ItemEntity itemEntity = this.createItemStackToDrop(stack, randomizeMotion, includeThrower);
              if (itemEntity != null) {
@@ -169,11 +169,14 @@
 +                            player.getInventory().setItemInMainHand(inHandItem);
 +                        } else {
 +                            // Fallback
-+                            java.util.Map<Integer, org.bukkit.inventory.ItemStack> failed = player.getInventory().addItem(drop.getItemStack());
++                            final java.util.Map<Integer, org.bukkit.inventory.ItemStack> failed = player.getInventory().addItem(drop.getItemStack());
 +
 +                            // The item could not be added to the inventory.
 +                            // We can attempt to set/merge it into the cursor now.
-+                            if (failed.containsKey(0) && this instanceof final ServerPlayer serverPlayer) {
++                            // This cursor level logic is only applicable to non-creative mode users.
++                            // The creative client does not share its cursor with the server in most cases.
++                            // Setting the cursor to something while the player is in creative mode results in buggy behaviour.
++                            if (failed.containsKey(0) && this instanceof final ServerPlayer serverPlayer && !serverPlayer.hasInfiniteMaterials()) {
 +                                final ItemStack itemNotAddedToInventory = CraftItemStack.asNMSCopy(failed.get(0));
 +                                final ItemStack carriedAfterDropping = serverPlayer.containerMenu.getCarried();
 +                                final boolean stackable = net.minecraft.world.item.ItemStack.isSameItemSameComponents(carriedAfterDropping, itemNotAddedToInventory);
@@ -181,7 +184,7 @@
 +                                    if (carriedAfterDropping.isEmpty()) {
 +                                        serverPlayer.containerMenu.setCarried(itemNotAddedToInventory);
 +                                    } else {
-+                                        // We can merge, if there *is* any overflow, there is nothing we can do.
++                                        // We can merge, if there is any overflow, there is nothing we can do.
 +                                        // Those items will be lost.
 +                                        carriedAfterDropping.grow(itemNotAddedToInventory.getCount());
 +                                        carriedAfterDropping.limitSize(carriedAfterDropping.getMaxStackSize());


### PR DESCRIPTION
…the player inventory is full

See this video for a tutorial on how to reproduce this issue: https://youtu.be/xonJe2S7jQ8. Note that you also need to have the PlayerDropItemEvent cancelled in the test plugin.