### PR TITLE
Mace was not included in the ENCHANTABLE MaterialSetTag

### DIFF
--- a/paper-api/src/main/java/com/destroystokyo/paper/MaterialTags.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/MaterialTags.java
@@ -568,8 +568,8 @@ public class MaterialTags {
             Material.FLINT_AND_STEEL, Material.CARROT_ON_A_STICK, Material.WARPED_FUNGUS_ON_A_STICK,
             Material.BRUSH, Material.CARVED_PUMPKIN, Material.COMPASS, Material.SKELETON_SKULL,
             Material.WITHER_SKELETON_SKULL, Material.PLAYER_HEAD, Material.ZOMBIE_HEAD,
-            Material.CREEPER_HEAD, Material.DRAGON_HEAD, Material.PIGLIN_HEAD)
-        .ensureSize("ENCHANTABLE", 75).lock();
+            Material.CREEPER_HEAD, Material.DRAGON_HEAD, Material.PIGLIN_HEAD, Material.MACE)
+        .ensureSize("ENCHANTABLE", 76).lock();
 
     /**
      * Covers the variants of raw ores.


### PR DESCRIPTION
Added the new-ish Mace item to the Enchantable MaterialSetTag list as it was missing