### PR TITLE
Add keyStream() API to registries

### DIFF
--- a/paper-api/src/main/java/org/bukkit/Registry.java
+++ b/paper-api/src/main/java/org/bukkit/Registry.java
@@ -526,6 +526,13 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
     Stream<T> stream();
 
     /**
+     * Returns a new stream, which contains all registry keys, which are registered to the registry.
+     *
+     * @return a stream of all registry keys
+     */
+    Stream<NamespacedKey> keyStream();
+
+    /**
      * Attempts to match the registered object with the given key.
      * <p>
      * This will attempt to find a reasonable match based on the provided input
@@ -591,6 +598,11 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
             return this.map.values().iterator();
         }
 
+        @Override
+        public Stream<NamespacedKey> keyStream() {
+            return this.map.keySet().stream();
+        }
+
         @ApiStatus.Internal
         @Deprecated(since = "1.20.6", forRemoval = true)
         public Class<T> getType() {
@@ -604,6 +616,11 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
         @Override
         public Stream<A> stream() {
             return StreamSupport.stream(this.spliterator(), false);
+        }
+
+        @Override
+        public Stream<NamespacedKey> keyStream() {
+            return stream().map(this::getKey);
         }
 
         @Override

--- a/paper-server/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistry.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistry.java
@@ -50,6 +50,11 @@ public final class DelayedRegistry<T extends Keyed, R extends Registry<T>> imple
     }
 
     @Override
+    public Stream<NamespacedKey> keyStream() {
+        return this.delegate().keyStream();
+    }
+
+    @Override
     public int size() {
         return this.delegate().size();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
@@ -233,6 +233,12 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
         return this.minecraftRegistry.keySet().stream().map(minecraftKey -> this.get(CraftNamespacedKey.fromMinecraft(minecraftKey)));
     }
 
+    @NotNull
+    @Override
+    public Stream<NamespacedKey> keyStream() {
+        return this.minecraftRegistry.keySet().stream().map(CraftNamespacedKey::fromMinecraft);
+    }
+
     @Override
     public int size() {
         return this.minecraftRegistry.size();


### PR DESCRIPTION
This PR adds a `keyStream()` API to registries, to stream the registered keys, rather than the registered values.

While it's theoretically possible to map the existing Stream back to the key, having this in API is more direct/performant, and generally just more convenient due to not needing a local variable storing the registry.

Eg, if I wanted to get all the painting keys in a Stream prior to this, it'd be:

```java
Registry<Art> paintingRegistry = RegistryAccess.registryAccess().getRegistry(RegistryKey.PAINTING_VARIANT);

paintingRegistry.stream().map(paintingRegistry::getKey).toList();
```

With this PR, it'd be:

```java
RegistryAccess.registryAccess().getRegistry(RegistryKey.PAINTING_VARIANT).keyStream().toList();
```

`toList` being used as a simple example method so that it's not just creating a stream.