### PR TITLE
Allow Server#getDefaultGameMode before worlds are initialized

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -41,6 +41,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.imageio.ImageIO;
+import net.minecraft.Optionull;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -2262,9 +2263,11 @@ public final class CraftServer implements Server {
 
     @Override
     public GameMode getDefaultGameMode() {
-        ServerLevel level = this.console.getLevel(net.minecraft.world.level.Level.OVERWORLD);
-        GameType type = level != null ? level.serverLevelData.getGameType() : this.console.getProperties().gamemode;
-        return Objects.requireNonNull(GameMode.getByValue(type.getId()));
+        return GameMode.getByValue(Optionull.mapOrDefault(
+            this.console.getLevel(net.minecraft.world.level.Level.OVERWORLD),
+            l -> l.serverLevelData.getGameType(),
+            this.console.getProperties().gamemode
+        ).getId());
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -32,6 +32,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -2263,7 +2264,7 @@ public final class CraftServer implements Server {
     public GameMode getDefaultGameMode() {
         ServerLevel level = this.console.getLevel(net.minecraft.world.level.Level.OVERWORLD);
         GameType type = level != null ? level.serverLevelData.getGameType() : this.console.getProperties().gamemode;
-        return GameMode.getByValue(type.getId());
+        return Objects.requireNonNull(GameMode.getByValue(type.getId()));
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -32,7 +32,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -2261,7 +2261,9 @@ public final class CraftServer implements Server {
 
     @Override
     public GameMode getDefaultGameMode() {
-        return GameMode.getByValue(this.console.getLevel(net.minecraft.world.level.Level.OVERWORLD).serverLevelData.getGameType().getId());
+        ServerLevel level = this.console.getLevel(net.minecraft.world.level.Level.OVERWORLD);
+        GameType type = level != null ? level.serverLevelData.getGameType() : this.console.getProperties().gamemode;
+        return GameMode.getByValue(type.getId());
     }
 
     @Override


### PR DESCRIPTION
Instead of accessing the level directly we return the configured value from properties 

Without fix
![image](https://github.com/user-attachments/assets/5677f6a1-d17b-4c40-b6db-f103c7b43be3)


With fix
![image](https://github.com/user-attachments/assets/2905ed02-06e3-44ac-9b9b-7eced6bca248)
