### PR TITLE
feat: xp orb merge percentage

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -208,6 +208,7 @@ public net.minecraft.world.entity.Entity setSharedFlag(IZ)V
 public net.minecraft.world.entity.Entity teleportPassengers()V
 public net.minecraft.world.entity.Entity unsetRemoved()V
 public net.minecraft.world.entity.Entity wasTouchingWater
+public net.minecraft.world.entity.ExperienceOrb ORB_GROUPS_PER_AREA
 public net.minecraft.world.entity.ExperienceOrb count
 public net.minecraft.world.entity.ExperienceOrb setValue(I)V
 public net.minecraft.world.entity.GlowSquid setDarkTicks(I)V
@@ -788,4 +789,3 @@ public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData locked
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData scale
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData trackingPosition
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData unlimitedTracking
-public net.minecraft.world.entity.ExperienceOrb ORB_GROUPS_PER_AREA

--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -788,3 +788,4 @@ public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData locked
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData scale
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData trackingPosition
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData unlimitedTracking
+public net.minecraft.world.entity.ExperienceOrb ORB_GROUPS_PER_AREA

--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -208,7 +208,6 @@ public net.minecraft.world.entity.Entity setSharedFlag(IZ)V
 public net.minecraft.world.entity.Entity teleportPassengers()V
 public net.minecraft.world.entity.Entity unsetRemoved()V
 public net.minecraft.world.entity.Entity wasTouchingWater
-public net.minecraft.world.entity.ExperienceOrb ORB_GROUPS_PER_AREA
 public net.minecraft.world.entity.ExperienceOrb count
 public net.minecraft.world.entity.ExperienceOrb setValue(I)V
 public net.minecraft.world.entity.GlowSquid setDarkTicks(I)V

--- a/paper-server/patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
@@ -126,7 +126,12 @@
          AABB aabb = AABB.ofSize(pos, 1.0, 1.0, 1.0);
          int randomInt = level.getRandom().nextInt(40);
          List<ExperienceOrb> entities = level.getEntities(EntityTypeTest.forClass(ExperienceOrb.class), aabb, orb -> canMerge(orb, randomInt, amount));
-@@ -193,9 +_,14 @@
+@@ -189,13 +_,18 @@
+     }
+ 
+     private static boolean canMerge(ExperienceOrb orb, int amount, int other) {
+-        return !orb.isRemoved() && (orb.getId() - amount) % 40 == 0 && orb.getValue() == other;
++        return !orb.isRemoved() && (orb.getId() - amount) % io.papermc.paper.configuration.GlobalConfiguration.get().misc.xpMergePercentage == 0 && orb.getValue() == other; // Paper - Configure how many orbs will merge together
      }
  
      private void merge(ExperienceOrb orb) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
@@ -125,7 +125,7 @@
 +        // Paper - TODO some other event for this kind of merge
          AABB aabb = AABB.ofSize(pos, 1.0, 1.0, 1.0);
 -        int randomInt = level.getRandom().nextInt(40);
-+        int randomInt = level.getRandom().nextInt(io.papermc.paper.configuration.GlobalConfiguration.get().misc.xpOrbGroupsPerArea.or(ORB_GROUPS_PER_AREA));
++        int randomInt = level.getRandom().nextInt(io.papermc.paper.configuration.GlobalConfiguration.get().misc.xpOrbGroupsPerArea.or(ORB_GROUPS_PER_AREA)); // Paper - Configure how many orb groups per area
          List<ExperienceOrb> entities = level.getEntities(EntityTypeTest.forClass(ExperienceOrb.class), aabb, orb -> canMerge(orb, randomInt, amount));
          if (!entities.isEmpty()) {
              ExperienceOrb experienceOrb = entities.get(0);

--- a/paper-server/patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
@@ -126,12 +126,31 @@
          AABB aabb = AABB.ofSize(pos, 1.0, 1.0, 1.0);
          int randomInt = level.getRandom().nextInt(40);
          List<ExperienceOrb> entities = level.getEntities(EntityTypeTest.forClass(ExperienceOrb.class), aabb, orb -> canMerge(orb, randomInt, amount));
-@@ -189,13 +_,18 @@
+@@ -189,13 +_,37 @@
      }
  
      private static boolean canMerge(ExperienceOrb orb, int amount, int other) {
 -        return !orb.isRemoved() && (orb.getId() - amount) % 40 == 0 && orb.getValue() == other;
-+        return !orb.isRemoved() && (orb.getId() - amount) % io.papermc.paper.configuration.GlobalConfiguration.get().misc.xpMergePercentage == 0 && orb.getValue() == other; // Paper - Configure how many orbs will merge together
++        // Paper start - Configure how many orbs will merge together
++        // We want to interpolate the percentage (where 100 maps to 1 and 2.5 maps to 40)
++        double orbPercentage = io.papermc.paper.configuration.GlobalConfiguration.get().misc.xpMergePercentage;
++        int mergeModulo;
++        
++        if (orbPercentage >= 100.0) {
++            mergeModulo = 1;
++        } else if (orbPercentage <= 2.5) {
++            mergeModulo = 40;
++        } else {
++            // Linear interpolation: y = mx + b
++            // Where x is orbPercentage, y is the result
++            // For (2.5, 40) and (100, 1): m = (1-40)/(100-2.5) = -39/97.5 = -0.4
++            double interpolated = 40 - 0.4 * (orbPercentage - 2.5);
++            mergeModulo = (int) Math.ceil(interpolated);
++        }
++        System.out.println("mergeModulo: " + mergeModulo);
++        
++        return !orb.isRemoved() && (orb.getId() - amount) % mergeModulo == 0 && orb.getValue() == other;
++        // Paper end - Configure how many orbs will merge together
      }
  
      private void merge(ExperienceOrb orb) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
@@ -126,31 +126,12 @@
          AABB aabb = AABB.ofSize(pos, 1.0, 1.0, 1.0);
          int randomInt = level.getRandom().nextInt(40);
          List<ExperienceOrb> entities = level.getEntities(EntityTypeTest.forClass(ExperienceOrb.class), aabb, orb -> canMerge(orb, randomInt, amount));
-@@ -189,13 +_,37 @@
+@@ -189,13 +_,18 @@
      }
  
      private static boolean canMerge(ExperienceOrb orb, int amount, int other) {
 -        return !orb.isRemoved() && (orb.getId() - amount) % 40 == 0 && orb.getValue() == other;
-+        // Paper start - Configure how many orbs will merge together
-+        // We want to interpolate the percentage (where 100 maps to 1 and 2.5 maps to 40)
-+        double orbPercentage = io.papermc.paper.configuration.GlobalConfiguration.get().misc.xpMergePercentage;
-+        int mergeModulo;
-+        
-+        if (orbPercentage >= 100.0) {
-+            mergeModulo = 1;
-+        } else if (orbPercentage <= 2.5) {
-+            mergeModulo = 40;
-+        } else {
-+            // Linear interpolation: y = mx + b
-+            // Where x is orbPercentage, y is the result
-+            // For (2.5, 40) and (100, 1): m = (1-40)/(100-2.5) = -39/97.5 = -0.4
-+            double interpolated = 40 - 0.4 * (orbPercentage - 2.5);
-+            mergeModulo = (int) Math.ceil(interpolated);
-+        }
-+        System.out.println("mergeModulo: " + mergeModulo);
-+        
-+        return !orb.isRemoved() && (orb.getId() - amount) % mergeModulo == 0 && orb.getValue() == other;
-+        // Paper end - Configure how many orbs will merge together
++        return !orb.isRemoved() && (orb.getId() - amount) % io.papermc.paper.configuration.GlobalConfiguration.get().misc.xpMergeModulo == 0 && orb.getValue() == other; // Paper - Configure how many orbs will merge together
      }
  
      private void merge(ExperienceOrb orb) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
@@ -97,7 +97,7 @@
              Vec3 vec3 = new Vec3(
                  this.followingPlayer.getX() - this.getX(),
                  this.followingPlayer.getY() + this.followingPlayer.getEyeHeight() / 2.0 - this.getY(),
-@@ -161,16 +_,27 @@
+@@ -161,18 +_,29 @@
      }
  
      public static void award(ServerLevel level, Vec3 pos, int amount) {
@@ -124,14 +124,17 @@
      private static boolean tryMergeToExisting(ServerLevel level, Vec3 pos, int amount) {
 +        // Paper - TODO some other event for this kind of merge
          AABB aabb = AABB.ofSize(pos, 1.0, 1.0, 1.0);
-         int randomInt = level.getRandom().nextInt(40);
+-        int randomInt = level.getRandom().nextInt(40);
++        int randomInt = level.getRandom().nextInt(io.papermc.paper.configuration.GlobalConfiguration.get().misc.xpOrbGroupsPerArea.or(ORB_GROUPS_PER_AREA));
          List<ExperienceOrb> entities = level.getEntities(EntityTypeTest.forClass(ExperienceOrb.class), aabb, orb -> canMerge(orb, randomInt, amount));
+         if (!entities.isEmpty()) {
+             ExperienceOrb experienceOrb = entities.get(0);
 @@ -189,13 +_,18 @@
      }
  
      private static boolean canMerge(ExperienceOrb orb, int amount, int other) {
 -        return !orb.isRemoved() && (orb.getId() - amount) % 40 == 0 && orb.getValue() == other;
-+        return !orb.isRemoved() && (orb.getId() - amount) % io.papermc.paper.configuration.GlobalConfiguration.get().misc.xpMergeModulo == 0 && orb.getValue() == other; // Paper - Configure how many orbs will merge together
++        return !orb.isRemoved() && (orb.getId() - amount) % io.papermc.paper.configuration.GlobalConfiguration.get().misc.xpOrbGroupsPerArea.or(ORB_GROUPS_PER_AREA) == 0 && orb.getValue() == other; // Paper - Configure how many orbs will merge together
      }
  
      private void merge(ExperienceOrb orb) {

--- a/paper-server/src/main/java/io/papermc/paper/configuration/Configurations.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/Configurations.java
@@ -62,7 +62,8 @@ public abstract class Configurations<G, W> {
     protected ObjectMapper.Factory.Builder createObjectMapper() {
         return ObjectMapper.factoryBuilder()
             .addConstraint(Constraint.class, new Constraint.Factory())
-            .addConstraint(Constraints.Min.class, Number.class, new Constraints.Min.Factory());
+            .addConstraint(Constraints.Min.class, Number.class, new Constraints.Min.Factory())
+            .addConstraint(Constraints.Max.class, Number.class, new Constraints.Max.Factory());
     }
 
     protected YamlConfigurationLoader.Builder createLoaderBuilder() {

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -12,7 +12,6 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ServerboundPlaceRecipePacket;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.ExperienceOrb;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
@@ -357,20 +356,9 @@ public class GlobalConfiguration extends ConfigurationPart {
         public IntOr.Default compressionLevel = IntOr.Default.USE_DEFAULT;
         @Comment("Defines the leniency distance added on the server to the interaction range of a player when validating interact packets.")
         public DoubleOr.Default clientInteractionLeniencyDistance = DoubleOr.Default.USE_DEFAULT;
-        @Comment("Defines percentage of how many orbs in an area will actually merge.")
+        @Comment("Defines how many orbs groups can exist in an area.")
         @Constraints.Min(1)
-        @Constraints.Max(100)
-        public DoubleOr.Default xpMergePercentage = DoubleOr.Default.USE_DEFAULT;
-        @PostProcess
-        private void postProcess() {
-            double xpMergePercentage = this.xpMergePercentage.or(102.5 - 2.5 * ExperienceOrb.ORB_GROUPS_PER_AREA);
-            // Linear interpolation: y = mx + b
-            // Where x is orbPercentage, y is the result
-            // For (2.5, 40) and (100, 1): m = (1-40)/(100-2.5) = -39/97.5 = -0.4
-            double interpolated = 41 - 0.4 * xpMergePercentage;
-            this.xpMergeModulo = (int) Math.ceil(Math.clamp(interpolated, 1, 40));
-        }
-        public transient int xpMergeModulo = ExperienceOrb.ORB_GROUPS_PER_AREA;
+        public IntOr.Default xpOrbGroupsPerArea = IntOr.Default.USE_DEFAULT;
     }
 
     public BlockUpdates blockUpdates;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -360,6 +360,22 @@ public class GlobalConfiguration extends ConfigurationPart {
         @Constraints.Min(1)
         @Constraints.Max(100)
         public double xpMergePercentage = 2.5;
+        @PostProcess
+        private void postProcess() {
+            if (this.xpMergePercentage >= 100.0) {
+                this.xpMergeModulo = 1;
+            } else if (xpMergePercentage <= 2.5) {
+                this.xpMergeModulo = 40;
+            } else {
+                // Linear interpolation: y = mx + b
+                // Where x is orbPercentage, y is the result
+                // For (2.5, 40) and (100, 1): m = (1-40)/(100-2.5) = -39/97.5 = -0.4
+                double interpolated = 40 - 0.4 * (xpMergePercentage - 2.5);
+                this.xpMergeModulo = (int) Math.ceil(interpolated);
+            }
+
+        }
+        public transient int xpMergeModulo = 40;
     }
 
     public BlockUpdates blockUpdates;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -12,6 +12,7 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ServerboundPlaceRecipePacket;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.ExperienceOrb;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
@@ -362,14 +363,14 @@ public class GlobalConfiguration extends ConfigurationPart {
         public DoubleOr.Default xpMergePercentage = DoubleOr.Default.USE_DEFAULT;
         @PostProcess
         private void postProcess() {
-            double xpMergePercentage = this.xpMergePercentage.or(2.5);
+            double xpMergePercentage = this.xpMergePercentage.or(102.5 - 2.5 * ExperienceOrb.ORB_GROUPS_PER_AREA);
             // Linear interpolation: y = mx + b
             // Where x is orbPercentage, y is the result
             // For (2.5, 40) and (100, 1): m = (1-40)/(100-2.5) = -39/97.5 = -0.4
             double interpolated = 41 - 0.4 * xpMergePercentage;
             this.xpMergeModulo = (int) Math.ceil(Math.clamp(interpolated, 1, 40));
         }
-        public transient int xpMergeModulo = 40;
+        public transient int xpMergeModulo = ExperienceOrb.ORB_GROUPS_PER_AREA;
     }
 
     public BlockUpdates blockUpdates;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -356,13 +356,10 @@ public class GlobalConfiguration extends ConfigurationPart {
         public IntOr.Default compressionLevel = IntOr.Default.USE_DEFAULT;
         @Comment("Defines the leniency distance added on the server to the interaction range of a player when validating interact packets.")
         public DoubleOr.Default clientInteractionLeniencyDistance = DoubleOr.Default.USE_DEFAULT;
-        @Comment(
-            "Defines how many orbs in an area will actually merge." +
-            "This is a percentage. Where 40 is 2.5% of the orbs will merge and 1 is 100% of the orbs will merge."
-        )
+        @Comment("Defines percentage of how many orbs in an area will actually merge.")
         @Constraints.Min(1)
-        @Constraints.Max(40)
-        public int xpMergePercentage = 40;
+        @Constraints.Max(100)
+        public double xpMergePercentage = 2.5;
     }
 
     public BlockUpdates blockUpdates;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -359,21 +359,15 @@ public class GlobalConfiguration extends ConfigurationPart {
         @Comment("Defines percentage of how many orbs in an area will actually merge.")
         @Constraints.Min(1)
         @Constraints.Max(100)
-        public double xpMergePercentage = 2.5;
+        public DoubleOr.Default xpMergePercentage = DoubleOr.Default.USE_DEFAULT;
         @PostProcess
         private void postProcess() {
-            if (this.xpMergePercentage >= 100.0) {
-                this.xpMergeModulo = 1;
-            } else if (xpMergePercentage <= 2.5) {
-                this.xpMergeModulo = 40;
-            } else {
-                // Linear interpolation: y = mx + b
-                // Where x is orbPercentage, y is the result
-                // For (2.5, 40) and (100, 1): m = (1-40)/(100-2.5) = -39/97.5 = -0.4
-                double interpolated = 40 - 0.4 * (xpMergePercentage - 2.5);
-                this.xpMergeModulo = (int) Math.ceil(interpolated);
-            }
-
+            double xpMergePercentage = this.xpMergePercentage.or(2.5);
+            // Linear interpolation: y = mx + b
+            // Where x is orbPercentage, y is the result
+            // For (2.5, 40) and (100, 1): m = (1-40)/(100-2.5) = -39/97.5 = -0.4
+            double interpolated = 41 - 0.4 * xpMergePercentage;
+            this.xpMergeModulo = (int) Math.ceil(Math.clamp(interpolated, 1, 40));
         }
         public transient int xpMergeModulo = 40;
     }

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -356,6 +356,13 @@ public class GlobalConfiguration extends ConfigurationPart {
         public IntOr.Default compressionLevel = IntOr.Default.USE_DEFAULT;
         @Comment("Defines the leniency distance added on the server to the interaction range of a player when validating interact packets.")
         public DoubleOr.Default clientInteractionLeniencyDistance = DoubleOr.Default.USE_DEFAULT;
+        @Comment(
+            "Defines how many orbs in an area will actually merge." +
+            "This is a percentage. Where 40 is 2.5% of the orbs will merge and 1 is 100% of the orbs will merge."
+        )
+        @Constraints.Min(1)
+        @Constraints.Max(40)
+        public int xpMergePercentage = 40;
     }
 
     public BlockUpdates blockUpdates;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/constraint/Constraints.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/constraint/Constraints.java
@@ -40,4 +40,22 @@ public final class Constraints {
             }
         }
     }
+
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface Max {
+        int value();
+
+        final class Factory implements Constraint.Factory<Max, Number> {
+            @Override
+            public Constraint<Number> make(Max data, Type type) {
+                return value -> {
+                    if (value != null && value.intValue() > data.value()) {
+                        throw new SerializationException(value + " is greater than the max " + data.value());
+                    }
+                };
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds a config setting that allows tweaking of the percentage of orbs in a given radius will merge. Vanilla will only merge 2.5% of orbs in the range.

Vanilla: 
![image](https://github.com/user-attachments/assets/a4d8b65b-db6a-44b6-94d6-d6e9bf8b506e)

Setting the config to 1 (which is 100%):
![image](https://github.com/user-attachments/assets/227f7589-40a5-4264-a320-9632444be5ee)

This'll help with farms that generate stupid amounts of XP orbs without needing to increase the merge radius. 
