### PR TITLE
Fix min ItemStack amount check for asHoverEvent

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
@@ -216,7 +216,7 @@ public final class CraftItemFactory implements ItemFactory {
 
     @Override
     public net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowItem> asHoverEvent(final ItemStack item, final java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowItem> op) {
-        Preconditions.checkArgument(item.getAmount() > 1 && item.getAmount() <= 99, "ItemStack amount must be between 1 and 99 but was %s", item.getAmount());
+        Preconditions.checkArgument(item.getAmount() > 0 && item.getAmount() <= Item.ABSOLUTE_MAX_STACK_SIZE, "ItemStack amount must be between 1 and %s but was %s", Item.ABSOLUTE_MAX_STACK_SIZE, item.getAmount());
         return net.kyori.adventure.text.event.HoverEvent.showItem(op.apply(
             net.kyori.adventure.text.event.HoverEvent.ShowItem.showItem(
                 item.getType().getKey(),


### PR DESCRIPTION
https://github.com/PaperMC/Paper/pull/12216#issuecomment-2844833747

This PR fix a bad check for min itemstack size, also modify the max value for use the NMS field declared for the max