### PR TITLE
Fix NoSuchElementException in EntityTransformEvent for slimes

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityTransformEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityTransformEvent.java
@@ -6,11 +6,12 @@ import org.bukkit.entity.Entity;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Called when an entity is about to be replaced by another entity.
  */
+@NullMarked
 public class EntityTransformEvent extends EntityEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
@@ -22,10 +23,10 @@ public class EntityTransformEvent extends EntityEvent implements Cancellable {
     private boolean cancelled;
 
     @ApiStatus.Internal
-    public EntityTransformEvent(@NotNull Entity original, @NotNull List<Entity> convertedList, @NotNull TransformReason transformReason) {
+    public EntityTransformEvent(Entity original, List<Entity> convertedList, TransformReason transformReason) {
         super(original);
         this.convertedList = Collections.unmodifiableList(convertedList);
-        this.converted = convertedList.get(0);
+        this.converted = convertedList.getFirst();
         this.transformReason = transformReason;
     }
 
@@ -34,7 +35,6 @@ public class EntityTransformEvent extends EntityEvent implements Cancellable {
      *
      * @return The transformed entities.
      */
-    @NotNull
     public List<Entity> getTransformedEntities() {
         return this.convertedList;
     }
@@ -47,7 +47,6 @@ public class EntityTransformEvent extends EntityEvent implements Cancellable {
      * @return The transformed entity.
      * @see #getTransformedEntities()
      */
-    @NotNull
     public Entity getTransformedEntity() {
         return this.converted;
     }
@@ -57,7 +56,6 @@ public class EntityTransformEvent extends EntityEvent implements Cancellable {
      *
      * @return The reason for conversion that has occurred.
      */
-    @NotNull
     public TransformReason getTransformReason() {
         return this.transformReason;
     }
@@ -72,13 +70,11 @@ public class EntityTransformEvent extends EntityEvent implements Cancellable {
         this.cancelled = cancel;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
 
-    @NotNull
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/Slime.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/Slime.java.patch
@@ -33,7 +33,7 @@
          int size = this.getSize();
          if (!this.level().isClientSide && size > 1 && this.isDeadOrDying()) {
              float width = this.getDimensions(this.getPose()).width();
-@@ -205,18 +_,43 @@
+@@ -205,18 +_,44 @@
              int i = size / 2;
              int i1 = 2 + this.random.nextInt(3);
              PlayerTeam team = this.getTeam();
@@ -66,6 +66,7 @@
 +                // CraftBukkit end
 +            }
 +            // CraftBukkit start
++            if (slimes.isEmpty()) return; // Paper - avoid call transform with empty converted entities
 +            if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTransformEvent(this, slimes, org.bukkit.event.entity.EntityTransformEvent.TransformReason.SPLIT).isCancelled()) {
 +                super.remove(reason, eventCause); // add Bukkit remove cause
 +                return;

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/Slime.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/Slime.java.patch
@@ -33,7 +33,7 @@
          int size = this.getSize();
          if (!this.level().isClientSide && size > 1 && this.isDeadOrDying()) {
              float width = this.getDimensions(this.getPose()).width();
-@@ -205,18 +_,44 @@
+@@ -205,18 +_,43 @@
              int i = size / 2;
              int i1 = 2 + this.random.nextInt(3);
              PlayerTeam team = this.getTeam();
@@ -66,8 +66,7 @@
 +                // CraftBukkit end
 +            }
 +            // CraftBukkit start
-+            if (slimes.isEmpty()) return; // Paper - avoid call transform with empty converted entities
-+            if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTransformEvent(this, slimes, org.bukkit.event.entity.EntityTransformEvent.TransformReason.SPLIT).isCancelled()) {
++            if (slimes.isEmpty() || org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTransformEvent(this, slimes, org.bukkit.event.entity.EntityTransformEvent.TransformReason.SPLIT).isCancelled()) { // check for empty converted entities or cancel event
 +                super.remove(reason, eventCause); // add Bukkit remove cause
 +                return;
 +            }

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/Slime.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/Slime.java.patch
@@ -66,7 +66,7 @@
 +                // CraftBukkit end
 +            }
 +            // CraftBukkit start
-+            if (slimes.isEmpty() || org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTransformEvent(this, slimes, org.bukkit.event.entity.EntityTransformEvent.TransformReason.SPLIT).isCancelled()) { // check for empty converted entities or cancel event
++            if (!slimes.isEmpty() && org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTransformEvent(this, slimes, org.bukkit.event.entity.EntityTransformEvent.TransformReason.SPLIT).isCancelled()) { // check for empty converted entities or cancel event
 +                super.remove(reason, eventCause); // add Bukkit remove cause
 +                return;
 +            }


### PR DESCRIPTION
Related to #12509 the current code from NMS can have the edge case where the slimes from a convertion can be null and not added to the list causing later pass an empty list to the event and fails when try to get the first entity, this PR just skip the call if that happen.

~~also include a minor cleanup of the event class~~