### PR TITLE
Inventory Support on InventoryViewBuilders

### DIFF
--- a/menu-support.txt
+++ b/menu-support.txt
@@ -1,0 +1,30 @@
+AnvilMenu -> No
+BeaconMenu -> No
+BlastFurnaceMenu -> Yes
+BrewingStandMenu -> Yes
+CartographyTableMenu -> No
+ChestMenu -> Yes
+CrafterMenu -> No
+CraftingMenu -> No
+DispenserMenu -> Yes
+EnchantmentMenu -> No
+FuranceMenu -> Yes
+GrindstoneMenu -> No
+HopperMenu -> Yes
+LecternMenu -> No (Possible)
+LoomMenu -> No
+MerchantMenu -> No
+ShulkerBoxMenu -> Yes
+SmithingMenu -> No
+SmokerMenu -> Yes
+StonecutterMenu -> No
+
+--- Possible ---
+BlastFuranceMenu  | BlockEntity | Implemented
+BrewingStandMenu | BlockEntity | Implemented
+ChestMenu | DoubleChest, BlockEntity, Standard | partial impl
+DispenserMenu | BlockEntity | Implemented
+FurnaceMenu | BlockEntity | Implemented
+HopperMenu | BlockEntity | Implemented
+ShulkerBoxMenu | BlockEntity | Implemented
+SmokerMenu | BlockEntity | Implemented

--- a/paper-api/src/main/java/org/bukkit/inventory/view/builder/InventorySupport.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/view/builder/InventorySupport.java
@@ -1,0 +1,22 @@
+package org.bukkit.inventory.view.builder;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+
+/**
+ * Capability for InventoryViewBuilders to support adding Inventories directly.
+ *
+ * @param <V> the type of view produced by the builder
+ */
+public interface InventorySupport<V extends InventoryView> {
+
+    /**
+     * Sets the inventory to be used by the inventory supporting builder
+     * <p>
+     * Note setting an Inventory will clear all other settings besides the title.
+     *
+     * @param inventory the inventory
+     * @return the builder instance
+     */
+    InventoryViewBuilder<V> inventory(Inventory inventory);
+}

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -468,7 +468,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         }
 
         // Now open the window
-        MenuType<?> windowType = CraftContainer.getNotchInventoryType(inventory.getTopInventory());
+        MenuType<?> windowType = container.getType();
         // we can open these now, delegate for now
         if (windowType == MenuType.MERCHANT) {
             CraftMenus.openMerchantMenu(player, (MerchantMenu) container);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftMenus.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftMenus.java
@@ -3,7 +3,16 @@ package org.bukkit.craftbukkit.inventory.util;
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.npc.Villager;
+import net.minecraft.world.inventory.BlastFurnaceMenu;
+import net.minecraft.world.inventory.BrewingStandMenu;
+import net.minecraft.world.inventory.ChestMenu;
+import net.minecraft.world.inventory.DispenserMenu;
+import net.minecraft.world.inventory.FurnaceMenu;
+import net.minecraft.world.inventory.HopperMenu;
 import net.minecraft.world.inventory.MerchantMenu;
+import net.minecraft.world.inventory.ShulkerBoxMenu;
+import net.minecraft.world.inventory.SimpleContainerData;
+import net.minecraft.world.inventory.SmokerMenu;
 import net.minecraft.world.item.trading.Merchant;
 import net.minecraft.world.item.trading.MerchantOffers;
 import net.minecraft.world.level.block.Blocks;
@@ -24,6 +33,7 @@ import org.bukkit.craftbukkit.inventory.view.builder.CraftAccessLocationInventor
 import org.bukkit.craftbukkit.inventory.view.builder.CraftBlockEntityInventoryViewBuilder;
 import org.bukkit.craftbukkit.inventory.view.builder.CraftDoubleChestInventoryViewBuilder;
 import org.bukkit.craftbukkit.inventory.view.builder.CraftEnchantmentInventoryViewBuilder;
+import org.bukkit.craftbukkit.inventory.view.builder.CraftInventorySupportBlockEntityInventoryViewBuilder;
 import org.bukkit.craftbukkit.inventory.view.builder.CraftMerchantInventoryViewBuilder;
 import org.bukkit.craftbukkit.inventory.view.builder.CraftStandardInventoryViewBuilder;
 import org.bukkit.inventory.InventoryView;
@@ -42,6 +52,8 @@ import org.bukkit.inventory.view.builder.InventoryViewBuilder;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.function.Supplier;
+
+import static org.bukkit.craftbukkit.inventory.view.builder.CraftInventorySupportBlockEntityInventoryViewBuilder.SimpleMenuBuilder.chest;
 
 @NullMarked
 public final class CraftMenus {
@@ -78,16 +90,28 @@ public final class CraftMenus {
     public static <V extends InventoryView, B extends InventoryViewBuilder<V>> MenuTypeData<V, B> getMenuTypeData(final CraftMenuType<?, ?> menuType) {
         final net.minecraft.world.inventory.MenuType<?> handle = menuType.getHandle();
         // this sucks horribly but it should work for now
-        if (menuType == MenuType.GENERIC_9X6) {
-            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftDoubleChestInventoryViewBuilder<>(handle)));
+        if (menuType == MenuType.GENERIC_9X1) {
+            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftStandardInventoryViewBuilder<>(handle, chest(1, handle))));
+        }
+        if (menuType == MenuType.GENERIC_9X2) {
+            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftStandardInventoryViewBuilder<>(handle, chest(2, handle))));
         }
         if (menuType == MenuType.GENERIC_9X3) {
-            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftBlockEntityInventoryViewBuilder<>(handle, Blocks.CHEST, ChestBlockEntity::new, false)));
+            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftInventorySupportBlockEntityInventoryViewBuilder<>(handle, Blocks.CHEST, ChestBlockEntity::new, (id, pi, container) -> new ChestMenu(net.minecraft.world.inventory.MenuType.GENERIC_9x3, id, pi, container, 3), false)));
+        }
+        if (menuType == MenuType.GENERIC_9X4) {
+            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftStandardInventoryViewBuilder<>(handle, chest(4, handle))));
+        }
+        if (menuType == MenuType.GENERIC_9X5) {
+            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftStandardInventoryViewBuilder<>(handle, chest(5, handle))));
+        }
+        if (menuType == MenuType.GENERIC_9X6) {
+            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftDoubleChestInventoryViewBuilder<>(handle)));
         }
         // this isn't ideal as both dispenser and dropper are 3x3, InventoryType can't currently handle generic 3x3s with size 9
         // this needs to be removed when inventory creation is overhauled
         if (menuType == MenuType.GENERIC_3X3) {
-            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftBlockEntityInventoryViewBuilder<>(handle, Blocks.DISPENSER, DispenserBlockEntity::new)));
+            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftInventorySupportBlockEntityInventoryViewBuilder<>(handle, Blocks.DISPENSER, DispenserBlockEntity::new, DispenserMenu::new)));
         }
         if (menuType == MenuType.CRAFTER_3X3) {
             return asType(new MenuTypeData<>(CrafterView.class, () -> new CraftBlockEntityInventoryViewBuilder<>(handle, Blocks.CRAFTER, CrafterBlockEntity::new)));
@@ -99,10 +123,10 @@ public final class CraftMenus {
             return asType(new MenuTypeData<>(BeaconView.class, () -> new CraftBlockEntityInventoryViewBuilder<>(handle, Blocks.BEACON, BeaconBlockEntity::new)));
         }
         if (menuType == MenuType.BLAST_FURNACE) {
-            return asType(new MenuTypeData<>(FurnaceView.class, () -> new CraftBlockEntityInventoryViewBuilder<>(handle, Blocks.BLAST_FURNACE, BlastFurnaceBlockEntity::new)));
+            return asType(new MenuTypeData<>(FurnaceView.class, () -> new CraftInventorySupportBlockEntityInventoryViewBuilder<>(handle, Blocks.BLAST_FURNACE, BlastFurnaceBlockEntity::new, (id, pi, container) -> new BlastFurnaceMenu(id ,pi ,container, new SimpleContainerData(4)))));
         }
         if (menuType == MenuType.BREWING_STAND) {
-            return asType(new MenuTypeData<>(BrewingStandView.class, () -> new CraftBlockEntityInventoryViewBuilder<>(handle, Blocks.BREWING_STAND, BrewingStandBlockEntity::new)));
+            return asType(new MenuTypeData<>(BrewingStandView.class, () -> new CraftInventorySupportBlockEntityInventoryViewBuilder<>(handle, Blocks.BREWING_STAND, BrewingStandBlockEntity::new, (id, pi, c) -> new BrewingStandMenu(id, pi, c, new SimpleContainerData(5)))));
         }
         if (menuType == MenuType.CRAFTING) {
             return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftAccessLocationInventoryViewBuilder<>(handle, Blocks.CRAFTING_TABLE)));
@@ -111,7 +135,7 @@ public final class CraftMenus {
             return asType(new MenuTypeData<>(EnchantmentView.class, () -> new CraftEnchantmentInventoryViewBuilder(handle)));
         }
         if (menuType == MenuType.FURNACE) {
-            return asType(new MenuTypeData<>(FurnaceView.class, () -> new CraftBlockEntityInventoryViewBuilder<>(handle, Blocks.FURNACE, FurnaceBlockEntity::new)));
+            return asType(new MenuTypeData<>(FurnaceView.class, () -> new CraftInventorySupportBlockEntityInventoryViewBuilder<>(handle, Blocks.FURNACE, FurnaceBlockEntity::new, (id, pi ,c) -> new FurnaceMenu(id, pi, c, new SimpleContainerData(4)))));
         }
         if (menuType == MenuType.GRINDSTONE) {
             return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftAccessLocationInventoryViewBuilder<>(handle, Blocks.GRINDSTONE)));
@@ -119,7 +143,7 @@ public final class CraftMenus {
         // We really don't need to be creating a block entity for hopper but currently InventoryType doesn't have capacity
         // to understand otherwise
         if (menuType == MenuType.HOPPER) {
-            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftBlockEntityInventoryViewBuilder<>(handle, Blocks.HOPPER, HopperBlockEntity::new)));
+            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftInventorySupportBlockEntityInventoryViewBuilder<>(handle, Blocks.HOPPER, HopperBlockEntity::new, HopperMenu::new)));
         }
         // We also don't need to create a block entity for lectern, but again InventoryType isn't smart enough to know any better
         if (menuType == MenuType.LECTERN) {
@@ -132,13 +156,13 @@ public final class CraftMenus {
             return asType(new MenuTypeData<>(MerchantView.class, () -> new CraftMerchantInventoryViewBuilder<>(handle)));
         }
         if (menuType == MenuType.SHULKER_BOX) {
-            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftBlockEntityInventoryViewBuilder<>(handle, Blocks.SHULKER_BOX, ShulkerBoxBlockEntity::new)));
+            return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftInventorySupportBlockEntityInventoryViewBuilder<>(handle, Blocks.SHULKER_BOX, ShulkerBoxBlockEntity::new, ShulkerBoxMenu::new)));
         }
         if (menuType == MenuType.SMITHING) {
             return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftAccessLocationInventoryViewBuilder<>(handle, Blocks.SMITHING_TABLE)));
         }
         if (menuType == MenuType.SMOKER) {
-            return asType(new MenuTypeData<>(FurnaceView.class, () -> new CraftBlockEntityInventoryViewBuilder<>(handle, Blocks.SMOKER, SmokerBlockEntity::new)));
+            return asType(new MenuTypeData<>(FurnaceView.class, () -> new CraftInventorySupportBlockEntityInventoryViewBuilder<>(handle, Blocks.SMOKER, SmokerBlockEntity::new, (id, pi, c) -> new SmokerMenu(id, pi, c, new SimpleContainerData(4)))));
         }
         if (menuType == MenuType.CARTOGRAPHY_TABLE) {
             return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftAccessLocationInventoryViewBuilder<>(handle, Blocks.CARTOGRAPHY_TABLE)));
@@ -147,7 +171,7 @@ public final class CraftMenus {
             return asType(new MenuTypeData<>(StonecutterView.class, () -> new CraftAccessLocationInventoryViewBuilder<>(handle, Blocks.STONECUTTER)));
         }
 
-        return asType(new MenuTypeData<>(InventoryView.class, () -> new CraftStandardInventoryViewBuilder<>(handle)));
+        throw new IllegalArgumentException("No menu type data allocated for " + menuType.getHandle());
     }
 
     @SuppressWarnings("unchecked")

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/view/builder/CraftBlockEntityInventoryViewBuilder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/view/builder/CraftBlockEntityInventoryViewBuilder.java
@@ -15,9 +15,9 @@ import org.jspecify.annotations.Nullable;
 
 public class CraftBlockEntityInventoryViewBuilder<V extends InventoryView> extends CraftAbstractLocationInventoryViewBuilder<V> {
 
-    private final Block block;
-    private final boolean useFakeBlockEntity;
-    private final @Nullable CraftBlockInventoryBuilder builder;
+    protected final Block block;
+    protected final boolean useFakeBlockEntity;
+    protected final @Nullable CraftBlockInventoryBuilder builder;
 
     public CraftBlockEntityInventoryViewBuilder(
         final MenuType<?> handle,
@@ -68,7 +68,7 @@ public class CraftBlockEntityInventoryViewBuilder<V extends InventoryView> exten
         return atBlock;
     }
 
-    private AbstractContainerMenu buildFakeBlockEntity(final ServerPlayer player) {
+    protected AbstractContainerMenu buildFakeBlockEntity(final ServerPlayer player) {
         final MenuProvider inventory = this.builder.build(this.position, this.block.defaultBlockState());
         if (inventory instanceof final BlockEntity blockEntity) {
             blockEntity.setLevel(this.world);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/view/builder/CraftDoubleChestInventoryViewBuilder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/view/builder/CraftDoubleChestInventoryViewBuilder.java
@@ -4,15 +4,22 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ChestMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ChestBlock;
 import net.minecraft.world.level.block.DoubleBlockCombiner;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import org.bukkit.craftbukkit.inventory.CraftInventory;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.view.builder.InventorySupport;
+import org.bukkit.inventory.view.builder.InventoryViewBuilder;
 import org.bukkit.inventory.view.builder.LocationInventoryViewBuilder;
 
-public class CraftDoubleChestInventoryViewBuilder<V extends InventoryView> extends CraftAbstractLocationInventoryViewBuilder<V> {
+public class CraftDoubleChestInventoryViewBuilder<V extends InventoryView> extends CraftAbstractLocationInventoryViewBuilder<V> implements InventorySupport<V> {
+
+    private Inventory inventory;
 
     public CraftDoubleChestInventoryViewBuilder(final MenuType<?> handle) {
         super(handle);
@@ -20,14 +27,24 @@ public class CraftDoubleChestInventoryViewBuilder<V extends InventoryView> exten
     }
 
     @Override
+    public InventoryViewBuilder<V> inventory(final Inventory inventory) {
+        this.inventory = inventory;
+        return this;
+    }
+
+    @Override
     protected AbstractContainerMenu buildContainer(final ServerPlayer player) {
+        if (inventory != null) {
+            return ChestMenu.sixRows(player.nextContainerCounter(), player.getInventory(), ((CraftInventory) this.inventory).getInventory());
+        }
+
         if (super.world == null) {
             return handle.create(player.nextContainerCounter(), player.getInventory());
         }
 
         final ChestBlock chest = (ChestBlock) Blocks.CHEST;
         final DoubleBlockCombiner.NeighborCombineResult<? extends ChestBlockEntity> result = chest.combine(
-            super.world.getBlockState(super.position), super.world, super.position, false
+                super.world.getBlockState(super.position), super.world, super.position, false
         );
         if (result instanceof DoubleBlockCombiner.NeighborCombineResult.Single<? extends ChestBlockEntity>) {
             return handle.create(player.nextContainerCounter(), player.getInventory());

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/view/builder/CraftInventorySupportBlockEntityInventoryViewBuilder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/view/builder/CraftInventorySupportBlockEntityInventoryViewBuilder.java
@@ -1,0 +1,81 @@
+package org.bukkit.craftbukkit.inventory.view.builder;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ChestMenu;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.bukkit.craftbukkit.inventory.CraftInventory;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.view.builder.InventorySupport;
+import org.bukkit.inventory.view.builder.LocationInventoryViewBuilder;
+import org.jspecify.annotations.Nullable;
+
+// This name SUCKS big time
+public class CraftInventorySupportBlockEntityInventoryViewBuilder<V extends InventoryView> extends CraftBlockEntityInventoryViewBuilder<V> implements InventorySupport<V> {
+    private final SimpleMenuBuilder smb;
+
+    private @Nullable Inventory inventory;
+
+    public CraftInventorySupportBlockEntityInventoryViewBuilder(final MenuType<?> handle, final Block block, final @Nullable CraftBlockInventoryBuilder builder, final SimpleMenuBuilder smb, final boolean useFakeBlockEntity) {
+        super(handle, block, builder, useFakeBlockEntity);
+        this.smb = smb;
+    }
+
+    public CraftInventorySupportBlockEntityInventoryViewBuilder(final MenuType<?> handle, final Block block, final @Nullable CraftBlockInventoryBuilder builder, final SimpleMenuBuilder smb) {
+        super(handle, block, builder);
+        this.smb = smb;
+    }
+
+    @Override
+    public LocationInventoryViewBuilder<V> inventory(final Inventory inventory) {
+        this.inventory = inventory;
+        return this;
+    }
+
+    @Override
+    protected AbstractContainerMenu buildContainer(final ServerPlayer player) {
+        if (inventory == null) {
+            return super.buildContainer(player);
+        }
+
+        if (this.world == null) {
+            this.world = player.level();
+        }
+
+        if (this.position == null) {
+            this.position = player.blockPosition();
+        }
+
+        // this is for default title
+        final MenuProvider provider = this.builder.build(this.position, this.block.defaultBlockState());
+        if (provider instanceof final BlockEntity blockEntity) {
+            blockEntity.setLevel(this.world);
+            super.defaultTitle = provider.getDisplayName();
+        }
+
+        return this.smb.build(player.nextContainerCounter(), player.getInventory(), ((CraftInventory) this.inventory).getInventory());
+    }
+
+    @Override
+    public LocationInventoryViewBuilder<V> copy() {
+        final CraftInventorySupportBlockEntityInventoryViewBuilder<V> copy = new CraftInventorySupportBlockEntityInventoryViewBuilder<>(super.handle, this.block, this.builder, this.smb, this.useFakeBlockEntity);
+        copy.world = this.world;
+        copy.position = this.position;
+        copy.checkReachable = super.checkReachable;
+        copy.title = title;
+        return copy;
+    }
+
+    public interface SimpleMenuBuilder {
+        static SimpleMenuBuilder chest(int rows, MenuType<?> type) {
+            return (id, pi, c) -> new ChestMenu(type, id, pi, c, rows);
+        }
+
+        AbstractContainerMenu build(int containerId, net.minecraft.world.entity.player.Inventory playerInventory, Container container);
+    }
+}

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/view/builder/CraftStandardInventoryViewBuilder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/view/builder/CraftStandardInventoryViewBuilder.java
@@ -4,24 +4,42 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
+import org.bukkit.craftbukkit.inventory.CraftInventory;
+import org.bukkit.craftbukkit.inventory.view.builder.CraftInventorySupportBlockEntityInventoryViewBuilder.SimpleMenuBuilder;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.view.builder.InventorySupport;
 import org.bukkit.inventory.view.builder.InventoryViewBuilder;
+import org.jspecify.annotations.Nullable;
 
-public class CraftStandardInventoryViewBuilder<V extends InventoryView> extends CraftAbstractInventoryViewBuilder<V> {
+public class CraftStandardInventoryViewBuilder<V extends InventoryView> extends CraftAbstractInventoryViewBuilder<V> implements InventorySupport<V> {
 
-    public CraftStandardInventoryViewBuilder(final MenuType<?> handle) {
+    private final SimpleMenuBuilder smb;
+
+    private @Nullable Inventory inventory;
+    public CraftStandardInventoryViewBuilder(final MenuType<?> handle, SimpleMenuBuilder smb) {
         super(handle);
+        this.smb = smb;
         super.defaultTitle = Component.translatable("container.chest");
     }
 
     @Override
+    public InventoryViewBuilder<V> inventory(final Inventory inventory) {
+        this.inventory = inventory;
+        return this;
+    }
+
+    @Override
     protected AbstractContainerMenu buildContainer(final ServerPlayer player) {
+        if (inventory != null) {
+            return smb.build(player.nextContainerCounter(), player.getInventory(), ((CraftInventory) inventory).getInventory());
+        }
         return super.handle.create(player.nextContainerCounter(), player.getInventory());
     }
 
     @Override
     public InventoryViewBuilder<V> copy() {
-        final CraftStandardInventoryViewBuilder<V> copy = new CraftStandardInventoryViewBuilder<>(handle);
+        final CraftStandardInventoryViewBuilder<V> copy = new CraftStandardInventoryViewBuilder<>(handle, smb);
         copy.title = this.title;
         return copy;
     }

--- a/test-plugin/build.gradle.kts
+++ b/test-plugin/build.gradle.kts
@@ -2,6 +2,7 @@ version = "1.0.0-SNAPSHOT"
 
 dependencies {
     compileOnly(project(":paper-api"))
+    compileOnly(project(":paper-server"))
 }
 
 tasks.processResources {

--- a/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
+++ b/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
@@ -1,14 +1,61 @@
 package io.papermc.testplugin;
 
+import com.destroystokyo.paper.event.player.PlayerJumpEvent;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.inventory.HopperMenu;
+import org.bukkit.craftbukkit.inventory.CraftInventory;
+import org.bukkit.craftbukkit.inventory.CraftInventoryView;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockDropItemEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MenuType;
+import org.bukkit.inventory.view.builder.InventorySupport;
+import org.bukkit.inventory.view.builder.LocationInventoryViewBuilder;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class TestPlugin extends JavaPlugin implements Listener {
+
+    private Inventory container;
 
     @Override
     public void onEnable() {
         this.getServer().getPluginManager().registerEvents(this, this);
 
         // io.papermc.testplugin.brigtests.Registration.registerViaOnEnable(this);
+        container = new CraftInventory(new SimpleContainer(18));
+    }
+
+    @EventHandler
+    public void event(PlayerJumpEvent event) {
+        final var builder = MenuType.GENERIC_9X2.builder();
+        if (builder instanceof InventorySupport<?> cast) {
+            cast.inventory(this.container)
+                    .build(event.getPlayer())
+                    .open();
+        }
+    }
+
+    @EventHandler
+    public void onOpen(InventoryOpenEvent event) {
+        final CraftInventoryView view = (CraftInventoryView) event.getView();
+        final var handle = view.getHandle();
+        if (handle instanceof HopperMenu menu) {
+            System.out.println(menu.hopper == ((CraftInventory) this.container).getInventory());
+        }
+        System.out.println(event.getView().getItem(0));
+    }
+
+    @EventHandler
+    public void bdie(BlockDropItemEvent event) {
+        final var iter = event.getItems().iterator();
+        while (iter.hasNext()) {
+            final var next = iter.next();
+            container.addItem(next.getItemStack());
+            iter.remove();
+        }
     }
 }


### PR DESCRIPTION
The end goal of this pull request is to address the need to put Inventory on a view builder during the build process. The goal is to completely replace `HumanEntity#openInvenotry(Inventory)`. and deprecate `Bukkit#createInventory(InventoryType, ...);` methods. 

When deciding what approach to take to do this I decided it'd be best to avoid
A. Intrusive insertion of Inventories into builders. (This is because Inventories are supported on only some menus and not others)
B. Adding more inheritance (Adding more inheritance while allowing for a more streamlined builder process also makes implementation and future maintenance a pain).

In this iteration I took the approach to instead add an InventorySupport class that allows for the api consumer to cast their builder and then add the inventory from there.

```java
final var builder = MenuType.GENERIC_9X2.builder();
if (builder instanceof InventorySupport<?> cast) {
    cast.inventory(this.container)
            .build(event.getPlayer())
             .open();
}
```

- [X] Add support for Inventories for applicable MenuType
- [ ] Add new Bukkit#createMenuInventory or refactor Bukkit#createInventory method to allow for more arbitrarily sized containers
- [ ] refactor opening logic to ensure "modern" inventories can not be opened outside of their use with InventoryViewBuilders
 
This is an early iterative draft I will take feedback and things may change a lot in between iterations based on feedback. I've opened it as I want feedback so I can continue to iterate on this API.