### PR TITLE
Replace legacy Maven resolver dependencies with maven-resolver-supplier-mvn3

### DIFF
--- a/paper-api/build.gradle.kts
+++ b/paper-api/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     api("org.apache.logging.log4j:log4j-api:$log4jVersion")
     api("org.slf4j:slf4j-api:$slf4jVersion")
     api("com.mojang:brigadier:1.3.10")
+    api("org.apache.commons:commons-lang3:3.17.0")
 
     // Deprecate bungeecord-chat in favor of adventure
     api("net.md-5:bungeecord-chat:$bungeeCordChatVersion") {
@@ -65,9 +66,8 @@ dependencies {
     apiAndDocs("net.kyori:adventure-text-serializer-plain")
     apiAndDocs("net.kyori:adventure-text-logger-slf4j")
 
-    api("org.apache.maven:maven-resolver-provider:3.9.6") // make API dependency for Paper Plugins
-    compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.9.18")
-    compileOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.9.18")
+    api("org.apache.maven:maven-resolver-provider:3.9.9") // make API dependency for Paper Plugins
+    compileOnly("org.apache.maven.resolver:maven-resolver-supplier-mvn3:2.0.8")
 
     // Annotations - Slowly migrate to jspecify
     val annotations = "org.jetbrains:annotations:$annotationsVersion"

--- a/paper-api/src/main/java/io/papermc/paper/plugin/loader/library/impl/MavenLibraryResolver.java
+++ b/paper-api/src/main/java/io/papermc/paper/plugin/loader/library/impl/MavenLibraryResolver.java
@@ -10,9 +10,7 @@ import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.collection.CollectRequest;
-import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.graph.Dependency;
-import org.eclipse.aether.impl.DefaultServiceLocator;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
@@ -20,12 +18,10 @@ import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
-import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
-import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.supplier.RepositorySystemSupplier;
 import org.eclipse.aether.transfer.AbstractTransferListener;
 import org.eclipse.aether.transfer.TransferCancelledException;
 import org.eclipse.aether.transfer.TransferEvent;
-import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,11 +62,7 @@ public class MavenLibraryResolver implements ClassPathLibrary {
      * submitting the {@link MavenLibraryResolver} to the {@link io.papermc.paper.plugin.loader.PluginClasspathBuilder}.
      */
     public MavenLibraryResolver() {
-        final DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
-        locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
-        locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
-
-        this.repository = locator.getService(RepositorySystem.class);
+        this.repository = new RepositorySystemSupplier().get();
         this.session = MavenRepositorySystemUtils.newSession();
 
         this.session.setSystemProperties(System.getProperties());

--- a/paper-api/src/main/java/org/bukkit/plugin/java/LibraryLoader.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/java/LibraryLoader.java
@@ -16,9 +16,7 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
-import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.graph.Dependency;
-import org.eclipse.aether.impl.DefaultServiceLocator;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
@@ -26,12 +24,9 @@ import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
-import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
-import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.supplier.RepositorySystemSupplier;
 import org.eclipse.aether.transfer.AbstractTransferListener;
-import org.eclipse.aether.transfer.TransferCancelledException;
 import org.eclipse.aether.transfer.TransferEvent;
-import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -50,11 +45,7 @@ public class LibraryLoader {
     public LibraryLoader(@NotNull Logger logger) {
         this.logger = logger;
 
-        DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
-        locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
-        locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
-
-        this.repository = locator.getService(RepositorySystem.class);
+        this.repository = new RepositorySystemSupplier().get();
         this.session = MavenRepositorySystemUtils.newSession();
 
         session.setSystemProperties(System.getProperties()); // Paper - paper plugins, backport system properties fix for transitive dependency parsing, see #10116

--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -167,9 +167,8 @@ dependencies {
         isTransitive = false // includes junit
     }
 
-    runtimeOnly("org.apache.maven:maven-resolver-provider:3.9.6")
-    runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.9.18")
-    runtimeOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.9.18")
+    runtimeOnly("org.apache.maven:maven-resolver-provider:3.9.9")
+    runtimeOnly("org.apache.maven.resolver:maven-resolver-supplier-mvn3:2.0.8")
 
     testImplementation("io.github.classgraph:classgraph:4.8.179") // For mob goal test
     testImplementation("org.junit.jupiter:junit-jupiter:5.12.2")


### PR DESCRIPTION
This PR replaces the following deprecated Maven resolver dependencies:

```kotlin
compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.9.18")
compileOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.9.18")
```
with:


```kotlin
compileOnly("org.apache.maven.resolver:maven-resolver-supplier-mvn3:2.0.8")
```

Rationale:
The new maven-resolver-supplier-mvn3 module encapsulates the default resolver setup for Maven environments and provides a cleaner and more modern way to integrate Maven resolution logic.

Code changes:
- Dependencies updated
- Internal resolver setup adjusted to use the MavenResolverSupplier from the new dependency
- Add the commons-lang3 dependency because this where transitive from the removed

This simplifies dependency management and reduces direct reliance on individual connector/transport components.

Let me know if additional adjustments are needed.