### PR TITLE
Fix data conversion mapping for raid HeroesOfTheVillage field

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/legacy/FieldRename.java
@@ -114,6 +114,7 @@ public class FieldRename {
             .change("LUCK", "LUCK_OF_THE_SEA")
             .withKeyRename()
             .change("SWEEPING", "SWEEPING_EDGE")
+            .change("HeroesOfTheVillage", "heroes_of_the_village")  // Paper - Fix raid data conversion 
             .build();
 
     public static final BiFunction<NamespacedKey, ApiVersion, NamespacedKey> ENCHANTMENT_RENAME = ENCHANTMENT_DATA::getReplacement;


### PR DESCRIPTION
This resolves an issue where raid data containing the legacy `HeroesOfTheVillage` field fails to convert properly to the modern `heroes_of_the_village` field name during world loading.

**What's happening**  
When loading raid data from older worlds/saves, the data converter misses the field rename from:
`HeroesOfTheVillage` to `heroes_of_the_village`

This results in errors like:
```java
No key heroes_of_the_village in MapLike[{HeroesOfTheVillage:[[I;-1184423578,...]]]
Verified fixed conversion using test world saves with legacy raid data
Confirmed error no longer appears in server logs during world loading
```
this PR fix is also connected to the issue 12515