### PR TITLE
Properly save level data async

### DIFF
--- a/paper-server/patches/features/0023-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0023-Incremental-chunk-and-player-saving.patch
@@ -50,7 +50,7 @@ index 094ef7f54ad71795a2d8c2a8d03a32bef6ff2164..79bc1b7d9f640d2322814177eb3e921d
          ProfilerFiller profilerFiller = Profiler.get();
          this.runAllTasks(); // Paper - move runAllTasks() into full server tick (previously for timings)
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 32c8d4675de341d5edad7dbd9c0bf4bce5037733..3c8a1fe9831d6cf9e622e3ac2aede4e5c657c18f 100644
+index 32c8d4675de341d5edad7dbd9c0bf4bce5037733..bfbfbaa9660d21071c420b60b10be0a02a1bc87e 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -1317,6 +1317,28 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -64,7 +64,7 @@ index 32c8d4675de341d5edad7dbd9c0bf4bce5037733..3c8a1fe9831d6cf9e622e3ac2aede4e5
 +        }
 +
 +        if (doFull) {
-+            this.saveLevelData(true);
++            this.saveLevelData(false);
 +        }
 +        // chunk autosave is already called by the ChunkSystem during unload processing (ChunkMap#processUnloads)
 +        // Copied from save()


### PR DESCRIPTION
Previously we added a parameter allowing for level data to be saved asynchronously which was then overriden by a vanilla parameter which does the opposite.

This reverts back to the previous behavior that we were doing before.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-12530.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/3074197394.zip)