### PR TITLE
Bugfix for #11676 Riptide without calling PlayerRiptideEvent

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerRiptideEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerRiptideEvent.java
@@ -64,4 +64,14 @@ public class PlayerRiptideEvent extends PlayerEvent {
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }
+
+    /**
+     * prevent item switching during riptide
+     */
+    public void preventItemSwitching() {
+        Player player = getPlayer();
+        if (player.isRiptiding()) {
+            player.getInventory().setHeldItemSlot(player.getInventory().getHeldItemSlot());
+        }
+    }
 }

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerSwapHandItemsEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerSwapHandItemsEvent.java
@@ -69,6 +69,9 @@ public class PlayerSwapHandItemsEvent extends PlayerEvent implements Cancellable
 
     @Override
     public boolean isCancelled() {
+        if (isPlayerRiptiding(getPlayer())) {
+            return false;
+        }
         return this.cancelled;
     }
 
@@ -86,5 +89,15 @@ public class PlayerSwapHandItemsEvent extends PlayerEvent implements Cancellable
     @NotNull
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
+    }
+
+    /**
+     * Checks if the player is currently performing a riptide attack.
+     * 
+     * @param player the player to check
+     * @return true if the player is riptiding, false otherwise
+     */
+    private boolean isPlayerRiptiding(@NotNull Player player) {
+        return player.isRiptiding();
     }
 }


### PR DESCRIPTION
Players were able to Riptide without calling PlayerRiptideEvent, due to item switching Prevents the items from being switched if the player is using Riptide.
The proposed fix is stop item switching from happening on charge of a riptide trident.