### PR TITLE
Drop fix for MC-125757

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/AbstractArrow.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/AbstractArrow.java.patch
@@ -26,14 +26,6 @@
      }
  
      public void setSoundEvent(SoundEvent soundEvent) {
-@@ -214,6 +_,7 @@
-                 this.setSharedFlagOnFire(this.getRemainingFireTicks() > 0);
-             }
-         } else {
-+            if (this.tickCount > 200) this.tickDespawn(); // Paper - tick life regardless after 10 seconds
-             this.inGroundTime = 0;
-             Vec3 vec31 = this.position();
-             if (this.isInWater()) {
 @@ -280,12 +_,12 @@
  
              if (entityHitResult == null) {


### PR DESCRIPTION
MC-125757 has been marked as works-as-intended, meaning paper's changes to
forcefully despawn arrows are breaking vanilla behaviour.
Given paper also now implements entity-based time to live options, this
kind of behaviour can be replicated by server admins anyway.

See: #3859
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-12544.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/3101236784.zip)