### PR TITLE
Deprecate TeleportCause CHORUS_FRUIT for CONSUMABLE_EFFECT

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -122,7 +122,7 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
          */
         END_GATEWAY,
         /**
-         * Indicates the teleportation was caused by a player consuming an item with Component {@link ConsumeEffect.TeleportRandomly}
+         * Indicates the teleportation was caused by a player consuming an item with a {@link ConsumeEffect.TeleportRandomly} effect
          */
         CONSUMABLE_TELEPORT,
         /**

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -124,7 +124,7 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
         /**
          * Indicates the teleportation was caused by a player consuming an item with a {@link ConsumeEffect.TeleportRandomly} effect
          */
-        CONSUMABLE_TELEPORT,
+        CONSUMABLE_EFFECT,
         /**
          * Indicates the teleportation was caused by a player exiting a vehicle
          */
@@ -142,9 +142,9 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
         /**
          * Indicates the teleportation was caused by a player consuming chorus
          * fruit
-         * @deprecated in favor of {@link #CONSUMABLE_TELEPORT}
+         * @deprecated in favor of {@link #CONSUMABLE_EFFECT}
          */
         @Deprecated(since = "1.21.5", forRemoval = true)
-        public static final TeleportCause CHORUS_FRUIT = CONSUMABLE_TELEPORT;
+        public static final TeleportCause CHORUS_FRUIT = CONSUMABLE_EFFECT;
     }
 }

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.player;
 
+import io.papermc.paper.datacomponent.item.consumable.ConsumeEffect;
 import io.papermc.paper.entity.TeleportFlag;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -123,8 +124,14 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
         /**
          * Indicates the teleportation was caused by a player consuming chorus
          * fruit
+         * @deprecated in favor of {@link #CONSUMABLE_TELEPORT}
          */
+        @Deprecated(since = "1.21.4")
         CHORUS_FRUIT,
+        /**
+         * Indicates the teleportation was caused by a player consuming an item with Component {@link ConsumeEffect.TeleportRandomly}
+         */
+        CONSUMABLE_TELEPORT,
         /**
          * Indicates the teleportation was caused by a player exiting a vehicle
          */

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -122,12 +122,9 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
          */
         END_GATEWAY,
         /**
-         * Indicates the teleportation was caused by a player consuming chorus
-         * fruit
-         * @deprecated in favor of {@link #CONSUMABLE_TELEPORT}
+         * Indicates the teleportation was caused by a player consuming an item with Component {@link ConsumeEffect.TeleportRandomly}
          */
-        @Deprecated(since = "1.21.5", forRemoval = true)
-        CHORUS_FRUIT,
+        CONSUMABLE_TELEPORT,
         /**
          * Indicates the teleportation was caused by a player exiting a vehicle
          */
@@ -143,8 +140,11 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
         UNKNOWN;
 
         /**
-         * Indicates the teleportation was caused by a player consuming an item with Component {@link ConsumeEffect.TeleportRandomly}
+         * Indicates the teleportation was caused by a player consuming chorus
+         * fruit
+         * @deprecated in favor of {@link #CONSUMABLE_TELEPORT}
          */
-        public static TeleportCause CONSUMABLE_TELEPORT = CHORUS_FRUIT;
+        @Deprecated(since = "1.21.5", forRemoval = true)
+        public static final TeleportCause CHORUS_FRUIT = CONSUMABLE_TELEPORT;
     }
 }

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -126,7 +126,7 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
          * fruit
          * @deprecated in favor of {@link #CONSUMABLE_TELEPORT}
          */
-        @Deprecated(since = "1.21.4")
+        @Deprecated(since = "1.21.5", forRemoval = true)
         CHORUS_FRUIT,
         /**
          * Indicates the teleportation was caused by a player consuming an item with Component {@link ConsumeEffect.TeleportRandomly}

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -129,10 +129,6 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
         @Deprecated(since = "1.21.5", forRemoval = true)
         CHORUS_FRUIT,
         /**
-         * Indicates the teleportation was caused by a player consuming an item with Component {@link ConsumeEffect.TeleportRandomly}
-         */
-        CONSUMABLE_TELEPORT,
-        /**
          * Indicates the teleportation was caused by a player exiting a vehicle
          */
         DISMOUNT,
@@ -144,6 +140,11 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
          * Indicates the teleportation was caused by an event not covered by
          * this enum
          */
-        UNKNOWN
+        UNKNOWN;
+
+        /**
+         * Indicates the teleportation was caused by a player consuming an item with Component {@link ConsumeEffect.TeleportRandomly}
+         */
+        public static TeleportCause CONSUMABLE_TELEPORT = CHORUS_FRUIT;
     }
 }

--- a/paper-server/patches/sources/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
@@ -1,13 +1,14 @@
 --- a/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java
 +++ b/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java
-@@ -55,7 +_,14 @@
+@@ -55,7 +_,15 @@
              }
  
              Vec3 vec3 = entity.position();
 -            if (entity.randomTeleport(d, d1, d2, true)) {
 +            // CraftBukkit start - handle canceled status of teleport event
-+            org.bukkit.event.player.PlayerTeleportEvent.TeleportCause teleportCause = stack.is(net.minecraft.world.item.Items.CHORUS_FRUIT) ? org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT : org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CONSUMABLE_TELEPORT;
-+            java.util.Optional<Boolean> status = entity.randomTeleport(d, d1, d2, true, teleportCause);
++            java.util.Optional<Boolean> statusDeprecated = entity.randomTeleport(d, d1, d2, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT);
++            if (statusDeprecated.orElse(false)) break;
++            java.util.Optional<Boolean> status = entity.randomTeleport(d, d1, d2, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CONSUMABLE_TELEPORT);
 +
 +            // teleport event was canceled, no more tries
 +            if (status.isEmpty()) break;

--- a/paper-server/patches/sources/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
@@ -4,7 +4,7 @@
      @Override
      public boolean apply(Level level, ItemStack stack, LivingEntity entity) {
          boolean flag = false;
-+        org.bukkit.event.player.PlayerTeleportEvent.TeleportCause teleportCause = (stack.is(net.minecraft.world.item.Items.CHORUS_FRUIT) ? org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT : org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CONSUMABLE_TELEPORT);
++        org.bukkit.event.player.PlayerTeleportEvent.TeleportCause teleportCause = (stack.is(net.minecraft.world.item.Items.CHORUS_FRUIT) ? org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT : org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CONSUMABLE_TELEPORT); // Paper
  
          for (int i = 0; i < 16; i++) {
              double d = entity.getX() + (entity.getRandom().nextDouble() - 0.5) * this.diameter;

--- a/paper-server/patches/sources/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
@@ -1,20 +1,12 @@
 --- a/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java
 +++ b/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java
-@@ -41,6 +_,7 @@
-     @Override
-     public boolean apply(Level level, ItemStack stack, LivingEntity entity) {
-         boolean flag = false;
-+        org.bukkit.event.player.PlayerTeleportEvent.TeleportCause teleportCause = (stack.is(net.minecraft.world.item.Items.CHORUS_FRUIT) ? org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT : org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CONSUMABLE_TELEPORT); // Paper
- 
-         for (int i = 0; i < 16; i++) {
-             double d = entity.getX() + (entity.getRandom().nextDouble() - 0.5) * this.diameter;
 @@ -55,7 +_,13 @@
              }
  
              Vec3 vec3 = entity.position();
 -            if (entity.randomTeleport(d, d1, d2, true)) {
 +            // CraftBukkit start - handle canceled status of teleport event
-+            java.util.Optional<Boolean> status = entity.randomTeleport(d, d1, d2, true, teleportCause);
++            java.util.Optional<Boolean> status = entity.randomTeleport(d, d1, d2, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CONSUMABLE_TELEPORT);
 +
 +            // teleport event was canceled, no more tries
 +            if (status.isEmpty()) break;

--- a/paper-server/patches/sources/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
@@ -1,12 +1,13 @@
 --- a/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java
 +++ b/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java
-@@ -55,7 +_,13 @@
+@@ -55,7 +_,14 @@
              }
  
              Vec3 vec3 = entity.position();
 -            if (entity.randomTeleport(d, d1, d2, true)) {
 +            // CraftBukkit start - handle canceled status of teleport event
-+            java.util.Optional<Boolean> status = entity.randomTeleport(d, d1, d2, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT);
++            org.bukkit.event.player.PlayerTeleportEvent.TeleportCause teleportCause = stack.is(net.minecraft.world.item.Items.CHORUS_FRUIT) ? org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT : org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CONSUMABLE_TELEPORT;
++            java.util.Optional<Boolean> status = entity.randomTeleport(d, d1, d2, true, teleportCause);
 +
 +            // teleport event was canceled, no more tries
 +            if (status.isEmpty()) break;

--- a/paper-server/patches/sources/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
@@ -1,14 +1,20 @@
 --- a/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java
 +++ b/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java
-@@ -55,7 +_,15 @@
+@@ -41,6 +_,7 @@
+     @Override
+     public boolean apply(Level level, ItemStack stack, LivingEntity entity) {
+         boolean flag = false;
++        org.bukkit.event.player.PlayerTeleportEvent.TeleportCause teleportCause = (stack.is(net.minecraft.world.item.Items.CHORUS_FRUIT) ? org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT : org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CONSUMABLE_TELEPORT);
+ 
+         for (int i = 0; i < 16; i++) {
+             double d = entity.getX() + (entity.getRandom().nextDouble() - 0.5) * this.diameter;
+@@ -55,7 +_,13 @@
              }
  
              Vec3 vec3 = entity.position();
 -            if (entity.randomTeleport(d, d1, d2, true)) {
 +            // CraftBukkit start - handle canceled status of teleport event
-+            java.util.Optional<Boolean> statusDeprecated = entity.randomTeleport(d, d1, d2, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT);
-+            if (statusDeprecated.orElse(false)) break;
-+            java.util.Optional<Boolean> status = entity.randomTeleport(d, d1, d2, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CONSUMABLE_TELEPORT);
++            java.util.Optional<Boolean> status = entity.randomTeleport(d, d1, d2, true, teleportCause);
 +
 +            // teleport event was canceled, no more tries
 +            if (status.isEmpty()) break;

--- a/paper-server/patches/sources/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
@@ -6,7 +6,7 @@
              Vec3 vec3 = entity.position();
 -            if (entity.randomTeleport(d, d1, d2, true)) {
 +            // CraftBukkit start - handle canceled status of teleport event
-+            java.util.Optional<Boolean> status = entity.randomTeleport(d, d1, d2, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CONSUMABLE_TELEPORT);
++            java.util.Optional<Boolean> status = entity.randomTeleport(d, d1, d2, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CONSUMABLE_EFFECT);
 +
 +            // teleport event was canceled, no more tries
 +            if (status.isEmpty()) break;


### PR DESCRIPTION
When `TeleportCause CHORUS_FRUIT` was added the teleport behaviour was hardcoded... now with components that teleport cause feels not make sense, this PR deprecate this and add a new one, for avoid breaks the event its called twice with the two causes.