### PR TITLE
Fix ItemStack#addUnsafeEnchantment ignored for missing enchantment component

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -13,7 +13,7 @@
 +        // Paper end
          DataComponentType<ItemEnchantments> componentType = getComponentType(stack);
 -        ItemEnchantments itemEnchantments = stack.get(componentType);
-+        ItemEnchantments itemEnchantments = force ? stack.get(componentType) : stack.getOrDefault(componentType, ItemEnchantments.EMPTY); // Paper - force
++        ItemEnchantments itemEnchantments = force ? stack.getOrDefault(componentType, ItemEnchantments.EMPTY) : stack.get(componentType); // Paper - force
          if (itemEnchantments == null) {
              return ItemEnchantments.EMPTY;
          } else {

--- a/paper-server/patches/sources/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/world/item/enchantment/EnchantmentHelper.java
++++ b/net/minecraft/world/item/enchantment/EnchantmentHelper.java
+@@ -51,9 +_,15 @@
+         return itemEnchantments.getLevel(enchantment);
+     }
+ 
++    // Paper start - allow force in updateEnchantments
+     public static ItemEnchantments updateEnchantments(ItemStack stack, Consumer<ItemEnchantments.Mutable> updater) {
++        return updateEnchantments(stack, false, updater);
++    }
++
++    public static ItemEnchantments updateEnchantments(ItemStack stack, boolean force, Consumer<ItemEnchantments.Mutable> updater) {
++        // Paper end
+         DataComponentType<ItemEnchantments> componentType = getComponentType(stack);
+-        ItemEnchantments itemEnchantments = stack.get(componentType);
++        ItemEnchantments itemEnchantments = force ? stack.get(componentType) : stack.getOrDefault(componentType, ItemEnchantments.EMPTY); // Paper - force
+         if (itemEnchantments == null) {
+             return ItemEnchantments.EMPTY;
+         } else {

--- a/paper-server/patches/sources/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -1,19 +1,18 @@
 --- a/net/minecraft/world/item/enchantment/EnchantmentHelper.java
 +++ b/net/minecraft/world/item/enchantment/EnchantmentHelper.java
-@@ -51,9 +_,15 @@
-         return itemEnchantments.getLevel(enchantment);
+@@ -52,8 +_,14 @@
      }
  
-+    // Paper start - allow force in updateEnchantments
      public static ItemEnchantments updateEnchantments(ItemStack stack, Consumer<ItemEnchantments.Mutable> updater) {
-+        return updateEnchantments(stack, false, updater);
++        // Paper start - allow force in updateEnchantments
++        return updateEnchantments(stack, updater, false);
 +    }
 +
-+    public static ItemEnchantments updateEnchantments(ItemStack stack, boolean force, Consumer<ItemEnchantments.Mutable> updater) {
++    public static ItemEnchantments updateEnchantments(ItemStack stack, Consumer<ItemEnchantments.Mutable> updater, boolean force) {
 +        // Paper end
          DataComponentType<ItemEnchantments> componentType = getComponentType(stack);
 -        ItemEnchantments itemEnchantments = stack.get(componentType);
-+        ItemEnchantments itemEnchantments = force ? stack.getOrDefault(componentType, ItemEnchantments.EMPTY) : stack.get(componentType); // Paper - force
++        ItemEnchantments itemEnchantments = force ? stack.getOrDefault(componentType, ItemEnchantments.EMPTY) : stack.get(componentType); // Paper - if force then pass a default instance
          if (itemEnchantments == null) {
              return ItemEnchantments.EMPTY;
          } else {

--- a/paper-server/patches/sources/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -4,15 +4,15 @@
      }
  
      public static ItemEnchantments updateEnchantments(ItemStack stack, Consumer<ItemEnchantments.Mutable> updater) {
-+        // Paper start - allow force in updateEnchantments
++    // Paper start - allowing updating enchantments on items without component
 +        return updateEnchantments(stack, updater, false);
 +    }
 +
-+    public static ItemEnchantments updateEnchantments(ItemStack stack, Consumer<ItemEnchantments.Mutable> updater, boolean force) {
-+        // Paper end
++    public static ItemEnchantments updateEnchantments(ItemStack stack, Consumer<ItemEnchantments.Mutable> updater, final boolean createComponentIfMissing) {
++    // Paper end - allowing updating enchantments on items without component
          DataComponentType<ItemEnchantments> componentType = getComponentType(stack);
 -        ItemEnchantments itemEnchantments = stack.get(componentType);
-+        ItemEnchantments itemEnchantments = force ? stack.getOrDefault(componentType, ItemEnchantments.EMPTY) : stack.get(componentType); // Paper - if force then pass a default instance
++        ItemEnchantments itemEnchantments = createComponentIfMissing ? stack.getOrDefault(componentType, ItemEnchantments.EMPTY) : stack.get(componentType); // Paper - allowing updating enchantments on items without component
          if (itemEnchantments == null) {
              return ItemEnchantments.EMPTY;
          } else {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
@@ -268,15 +268,13 @@ public final class CraftItemStack extends ItemStack {
     public void addUnsafeEnchantment(Enchantment enchant, int level) {
         Preconditions.checkArgument(enchant != null, "Enchantment cannot be null");
 
-        // Paper start
         if (this.handle == null) {
             return;
         }
 
-        EnchantmentHelper.updateEnchantments(this.handle, true, mutable -> { // data component api doesn't really support mutable things once already set yet
+        EnchantmentHelper.updateEnchantments(this.handle, mutable -> { // data component api doesn't really support mutable things once already set yet
             mutable.set(CraftEnchantment.bukkitToMinecraftHolder(enchant), level);
-        });
-        // Paper end
+        }, true);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
@@ -273,7 +273,7 @@ public final class CraftItemStack extends ItemStack {
             return;
         }
 
-        EnchantmentHelper.updateEnchantments(this.handle, mutable -> { // data component api doesn't really support mutable things once already set yet
+        EnchantmentHelper.updateEnchantments(this.handle, true, mutable -> { // data component api doesn't really support mutable things once already set yet
             mutable.set(CraftEnchantment.bukkitToMinecraftHolder(enchant), level);
         });
         // Paper end


### PR DESCRIPTION
Mentioned by electroniccat in [discord](https://canary.discord.com/channels/289587909051416579/925530366192779286/1372636642845790358) the method addUnsafeEnchantment in itemstack not works if the enchantment component are not set, for fix this i just add a new parameter in the NMS method for allow set if that happen. 