### PR TITLE
Add a tile entity tick limit based on wallclock time

### DIFF
--- a/paper-server/patches/features/0015-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0015-Moonrise-optimisation-patches.patch
@@ -29729,7 +29729,7 @@ index 300f3ed58109219d97846082941b860585f66fed..892a7c1eb1b321ca6d5ca709142e7fea
  
      // Paper start - Affects Spawning API
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d5be9e876 100644
+index 30be2f5bf5c6d0086bb636ade02ca878fefd10ec..0fa0f09b6a2b6cd0aacac705e7a751364e467daf 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -81,6 +81,7 @@ import net.minecraft.world.level.storage.LevelData;
@@ -30428,8 +30428,8 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
 +        int tickedEntities = 0; // Paper - rewrite chunk system
          var toRemove = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<TickingBlockEntity>(); // Paper - Fix MC-117075; use removeAll
          toRemove.add(null); // Paper - Fix MC-117075
-         for (this.tileTickPosition = 0; this.tileTickPosition < this.blockEntityTickers.size(); this.tileTickPosition++) { // Paper - Disable tick limiters
-@@ -829,6 +1464,11 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+ 
+@@ -853,6 +1488,11 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
                  toRemove.add(tickingBlockEntity); // Paper - Fix MC-117075; use removeAll
              } else if (runsNormally && this.shouldTickBlocksAt(tickingBlockEntity.getPos())) {
                  tickingBlockEntity.tick();
@@ -30441,7 +30441,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
              }
          }
          this.blockEntityTickers.removeAll(toRemove); // Paper - Fix MC-117075
-@@ -849,6 +1489,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -873,6 +1513,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
              entity.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DISCARD);
              // Paper end - Prevent block entity and entity crashes
          }
@@ -30449,7 +30449,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
      }
  
      // Paper start - Option to prevent armor stands from doing entity lookups
-@@ -856,7 +1497,14 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -880,7 +1521,14 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
      public boolean noCollision(@Nullable Entity entity, AABB box) {
          if (entity instanceof net.minecraft.world.entity.decoration.ArmorStand && !entity.level().paperConfig().entities.armorStands.doCollisionEntityLookups)
              return false;
@@ -30465,7 +30465,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
      }
      // Paper end - Option to prevent armor stands from doing entity lookups
  
-@@ -994,7 +1642,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -1018,7 +1666,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
          if (this.isOutsideBuildHeight(pos)) {
              return null;
          } else {
@@ -30474,7 +30474,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
                  ? null
                  : this.getChunkAt(pos).getBlockEntity(pos, LevelChunk.EntityCreationType.IMMEDIATE);
          }
-@@ -1087,22 +1735,16 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -1111,22 +1759,16 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
      public List<Entity> getEntities(@Nullable Entity entity, AABB boundingBox, Predicate<? super Entity> predicate) {
          Profiler.get().incrementCounter("getEntities");
          List<Entity> list = Lists.newArrayList();
@@ -30505,7 +30505,7 @@ index 63f8b0c47e3321b74f4b6bcbc1e28cd751911198..eb4d03cfdb34243901cfba832d35559d
      }
  
      @Override
-@@ -1116,33 +1758,94 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -1140,33 +1782,94 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
          this.getEntities(entityTypeTest, bounds, predicate, output, Integer.MAX_VALUE);
      }
  

--- a/paper-server/patches/features/0018-Add-Alternate-Current-redstone-implementation.patch
+++ b/paper-server/patches/features/0018-Add-Alternate-Current-redstone-implementation.patch
@@ -2326,7 +2326,7 @@ index 0000000000000000000000000000000000000000..298076a0db4e6ee6e4775ac43bf749d9
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 8afe96bfdc37e57129f1bb4af5b6d5cc22c11aee..32db2b9e375c12cbf7abab69cc01e8ac2c7c3b6e 100644
+index cd72273468f596b640bd2d10d846fbe8813846a6..32c8d4675de341d5edad7dbd9c0bf4bce5037733 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -210,6 +210,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -2352,10 +2352,10 @@ index 8afe96bfdc37e57129f1bb4af5b6d5cc22c11aee..32db2b9e375c12cbf7abab69cc01e8ac
          @Override
          public void onCreated(Entity entity) {
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index eb4d03cfdb34243901cfba832d35559d5be9e876..013ed7dbe2309f562f63e66203179a90566e8115 100644
+index 0fa0f09b6a2b6cd0aacac705e7a751364e467daf..1db48b779ffeddedb3e73ec156b9096ddd0c236e 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
-@@ -2096,6 +2096,17 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -2120,6 +2120,17 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
          return 0;
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
@@ -490,7 +490,7 @@
              return chunk.getBlockState(pos);
          }
      }
-@@ -463,32 +_,48 @@
+@@ -463,32 +_,72 @@
              this.pendingBlockEntityTickers.clear();
          }
  
@@ -502,8 +502,32 @@
 -            TickingBlockEntity tickingBlockEntity = iterator.next();
 +        var toRemove = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<TickingBlockEntity>(); // Paper - Fix MC-117075; use removeAll
 +        toRemove.add(null); // Paper - Fix MC-117075
-+        for (this.tileTickPosition = 0; this.tileTickPosition < this.blockEntityTickers.size(); this.tileTickPosition++) { // Paper - Disable tick limiters
++
++        // Paper start - put wall clock limit on tile entity tick
++
++        if (this.tileTickPosition >= blockEntityTickers.size()) {
++            this.tileTickPosition = 0;
++        }
++
++        long start = System.nanoTime();
++        long limitMsToNano = paperConfig.misc.tileEntityMaxTickMs <= 0 ? 0 :
++            java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(paperConfig.misc.tileEntityMaxTickMs);
++
++        // Paper end
++
++        for (; this.tileTickPosition < this.blockEntityTickers.size(); this.tileTickPosition++) { // Paper - Disable tick limiters
 +            TickingBlockEntity tickingBlockEntity = this.blockEntityTickers.get(this.tileTickPosition);
++
++            // Paper start - put wall clock limit on tile entity tick
++
++            if (limitMsToNano != 0 && (tickedEntities & 31) == 0) {
++                if (System.nanoTime() - start >= limitMsToNano) {
++                    break;
++                }
++            }
++
++            // Paper end
++
 +            // Spigot end
              if (tickingBlockEntity.isRemoved()) {
 -                iterator.remove();

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -68,7 +68,7 @@ import org.spongepowered.configurate.serialize.SerializationException;
 @SuppressWarnings({"FieldCanBeLocal", "FieldMayBeFinal", "NotNullFieldNotInitialized", "InnerClassMayBeStatic"})
 public class WorldConfiguration extends ConfigurationPart {
     private static final Logger LOGGER = LogUtils.getClassLogger();
-    static final int CURRENT_VERSION = 31; // (when you change the version, change the comment, so it conflicts on rebases): migrate spawn loaded configs to gamerule
+    static final int CURRENT_VERSION = 32; // (when you change the version, change the comment, so it conflicts on rebases): tile entity wallclock limit
 
     private final transient SpigotWorldConfig spigotConfig;
     private final transient ResourceLocation worldKey;
@@ -569,6 +569,7 @@ public class WorldConfiguration extends ConfigurationPart {
         public int shieldBlockingDelay = 5;
         public boolean disableRelativeProjectileVelocity = false;
         public boolean legacyEnderPearlBehavior = false;
+        public long tileEntityMaxTickMs = 0; // anything > 0 means the feature is enabled
 
         public enum RedstoneImplementation {
             VANILLA, EIGENCRAFT, ALTERNATE_CURRENT


### PR DESCRIPTION
One of the biggest problems on large survival servers is a long tile entity tick loop, especially hoppers. By introducing a limit on the time tile entites are allowed to take, this can be alleviated.

A config option is added to configure the amount of milliseconds that a tile entitiy ticking may take in a single tick, setting it to 0 (which is also the default value) disables the feature.