### PR TITLE
Fix bukkit brig forwarding map; Invert isEmpty method

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitBrigForwardingMap.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/bukkit/BukkitBrigForwardingMap.java
@@ -47,7 +47,7 @@ public class BukkitBrigForwardingMap extends HashMap<String, Command> {
 
     @Override
     public boolean isEmpty() {
-        return this.size() != 0;
+        return this.size() == 0;
     }
 
     @Override


### PR DESCRIPTION
Doesn't seem like this method is used anyways now. Might as well do it correctly though