### PR TITLE
Fix ItemDespawnEvent not firing when "despawn-time" has been configured for items.

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -358,6 +358,13 @@
      public void tick() {
 +        // Paper start - entity despawn time limit
 +        if (this.despawnTime >= 0 && this.totalEntityAge >= this.despawnTime) {
++            // Fire ItemDespawnEvent for items, allow cancellation
++            if (this instanceof net.minecraft.world.entity.item.ItemEntity itemEntity) {
++                if (org.bukkit.craftbukkit.event.CraftEventFactory.callItemDespawnEvent(itemEntity).isCancelled()) {
++                    itemEntity.age = 0; // Reset age as in vanilla logic
++                    return;
++                }
++            }
 +            this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN);
 +            return;
 +        }


### PR DESCRIPTION
While working on [this](https://github.com/kcbleeker/RecoveryMod) plugin, I found that if I had a `despawn-time` value configured for "items" other than the default 5 minutes, it would not fire the [ItemDespawnEvent](https://jd.papermc.io/paper/1.21.5/org/bukkit/event/entity/ItemDespawnEvent.html), and I could not hook into it.

I have built this locally and tested that the fix works, but I'm no expert on the impact to performance or if there's a better way to achieve this.