### PR TITLE
Fix CombatTracker stale on death

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -1419,7 +1419,7 @@
          }
  
          private static float calculateLookAtYaw(Vec3 position, BlockPos towardsPos) {
-@@ -2123,4 +_,144 @@
+@@ -2123,4 +_,143 @@
              return (float)Mth.wrapDegrees(Mth.atan2(vec3.z, vec3.x) * 180.0F / (float)Math.PI - 90.0);
          }
      }
@@ -1546,7 +1546,6 @@
 +        this.lastHurtByPlayer = null;
 +        this.lastHurtByMob = null;
 +        this.combatTracker = new net.minecraft.world.damagesource.CombatTracker(this);
-+        this.getBukkitEntity().setCombatTracker(this.combatTracker); // Paper - save new CombatTracker
 +        this.lastSentExp = -1;
 +        if (this.keepLevel) { // CraftBukkit - SPIGOT-6687: Only use keepLevel (was pre-set with RULE_KEEPINVENTORY value in PlayerDeathEvent)
 +            this.experienceProgress = exp;

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -1419,7 +1419,7 @@
          }
  
          private static float calculateLookAtYaw(Vec3 position, BlockPos towardsPos) {
-@@ -2123,4 +_,143 @@
+@@ -2123,4 +_,144 @@
              return (float)Mth.wrapDegrees(Mth.atan2(vec3.z, vec3.x) * 180.0F / (float)Math.PI - 90.0);
          }
      }
@@ -1546,6 +1546,7 @@
 +        this.lastHurtByPlayer = null;
 +        this.lastHurtByMob = null;
 +        this.combatTracker = new net.minecraft.world.damagesource.CombatTracker(this);
++        this.getBukkitEntity().setCombatTracker(this.combatTracker); // Paper - save new CombatTracker
 +        this.lastSentExp = -1;
 +        if (this.keepLevel) { // CraftBukkit - SPIGOT-6687: Only use keepLevel (was pre-set with RULE_KEEPINVENTORY value in PlayerDeathEvent)
 +            this.experienceProgress = exp;

--- a/paper-server/patches/sources/net/minecraft/world/damagesource/CombatTracker.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/damagesource/CombatTracker.java.patch
@@ -1,6 +1,17 @@
 --- a/net/minecraft/world/damagesource/CombatTracker.java
 +++ b/net/minecraft/world/damagesource/CombatTracker.java
-@@ -38,6 +_,13 @@
+@@ -29,15 +_,24 @@
+     private int combatEndTime;
+     public boolean inCombat;
+     public boolean takingDamage;
++    public final io.papermc.paper.world.damagesource.PaperCombatTrackerWrapper paperCombatTracker; // Paper - Combat tracker API
+ 
+     public CombatTracker(LivingEntity mob) {
+         this.mob = mob;
++        this.paperCombatTracker = new io.papermc.paper.world.damagesource.PaperCombatTrackerWrapper(this); // Paper - Combat tracker API
+     }
+ 
+     public void recordDamage(DamageSource source, float damage) {
          this.recheckStatus();
          FallLocation currentFallLocation = FallLocation.getCurrentFallLocation(this.mob);
          CombatEntry combatEntry = new CombatEntry(source, damage, currentFallLocation, (float)this.mob.fallDistance);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
@@ -91,20 +91,26 @@ import org.bukkit.potion.PotionType;
 import org.bukkit.util.BlockIterator;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.ApiStatus;
 
 public class CraftLivingEntity extends CraftEntity implements LivingEntity {
 
-    private final PaperCombatTrackerWrapper combatTracker;
+    private PaperCombatTrackerWrapper combatTracker;
     private CraftEntityEquipment equipment;
 
     public CraftLivingEntity(final CraftServer server, final net.minecraft.world.entity.LivingEntity entity) {
         super(server, entity);
 
-        this.combatTracker = new PaperCombatTrackerWrapper(entity.getCombatTracker());
+        this.setCombatTracker(entity.getCombatTracker());
 
         if (entity instanceof Mob || entity instanceof ArmorStand) {
             this.equipment = new CraftEntityEquipment(this);
         }
+    }
+
+    @ApiStatus.Internal
+    public void setCombatTracker(final net.minecraft.world.damagesource.CombatTracker combatTracker) {
+        this.combatTracker = new PaperCombatTrackerWrapper(combatTracker);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
@@ -95,22 +95,14 @@ import org.jetbrains.annotations.ApiStatus;
 
 public class CraftLivingEntity extends CraftEntity implements LivingEntity {
 
-    private PaperCombatTrackerWrapper combatTracker;
     private CraftEntityEquipment equipment;
 
     public CraftLivingEntity(final CraftServer server, final net.minecraft.world.entity.LivingEntity entity) {
         super(server, entity);
 
-        this.setCombatTracker(entity.getCombatTracker());
-
         if (entity instanceof Mob || entity instanceof ArmorStand) {
             this.equipment = new CraftEntityEquipment(this);
         }
-    }
-
-    @ApiStatus.Internal
-    public void setCombatTracker(final net.minecraft.world.damagesource.CombatTracker combatTracker) {
-        this.combatTracker = new PaperCombatTrackerWrapper(combatTracker);
     }
 
     @Override
@@ -1174,6 +1166,6 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
 
     @Override
     public CombatTracker getCombatTracker() {
-        return this.combatTracker;
+        return this.getHandle().getCombatTracker().paperCombatTracker;
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
@@ -10,8 +10,6 @@ import java.util.Set;
 import java.util.UUID;
 import net.minecraft.Optionull;
 import io.papermc.paper.world.damagesource.CombatTracker;
-import io.papermc.paper.world.damagesource.PaperCombatTrackerWrapper;
-import io.papermc.paper.world.damagesource.FallLocationType;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.protocol.game.ClientboundHurtAnimationPacket;
 import net.minecraft.server.level.ServerLevel;
@@ -91,7 +89,6 @@ import org.bukkit.potion.PotionType;
 import org.bukkit.util.BlockIterator;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.ApiStatus;
 
 public class CraftLivingEntity extends CraftEntity implements LivingEntity {
 


### PR DESCRIPTION
Fix #12558 where player replace the combattracker on death, this PR make the PaperCombatTrackerWrapper part of the NMS CombatTracker for avoid stale instances.