### PR TITLE
Fixs and Improvements for EndermanEscapeEvent

### DIFF
--- a/paper-api/src/main/java/com/destroystokyo/paper/event/entity/EndermanEscapeEvent.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/event/entity/EndermanEscapeEvent.java
@@ -27,7 +27,9 @@ public class EndermanEscapeEvent extends EntityEvent implements Cancellable {
     }
 
     /**
-     * @return The reason the enderman is trying to escape
+     * Gets the reason the enderman is trying to escape.
+     *
+     * @return The reason
      */
     public Reason getReason() {
         return this.reason;
@@ -42,7 +44,8 @@ public class EndermanEscapeEvent extends EntityEvent implements Cancellable {
      * Cancels the escape.
      * <p>
      * If this escape normally had resulted in damage avoidance such as indirect,
-     * the enderman will now take damage.
+     * the enderman will now take damage. However, this does not change the Enderman's
+     * innate immunities or damage behavior like arrows where the damage never happen.
      */
     @Override
     public void setCancelled(final boolean cancel) {
@@ -76,7 +79,7 @@ public class EndermanEscapeEvent extends EntityEvent implements Cancellable {
          */
         STARE,
         /**
-         * Specific case for {@link #CRITICAL_HIT} where the enderman is taking rain damage
+         * Specific case for {@link #CRITICAL_HIT} where the enderman is taking damage by drowning (ex: rain)
          */
         DROWN
     }

--- a/paper-api/src/main/java/com/destroystokyo/paper/event/entity/EndermanEscapeEvent.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/event/entity/EndermanEscapeEvent.java
@@ -45,7 +45,7 @@ public class EndermanEscapeEvent extends EntityEvent implements Cancellable {
      * <p>
      * If this escape normally had resulted in damage avoidance such as indirect,
      * the enderman will now take damage. However, this does not change the Enderman's
-     * innate immunities or damage behavior like arrows where the damage never happen.
+     * innate immunities or damage behavior like arrows where the damage never happens.
      */
     @Override
     public void setCancelled(final boolean cancel) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/EnderMan.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/EnderMan.java.patch
@@ -61,7 +61,7 @@
                  ? abstractThrownPotion
                  : null;
 -            if (!damageSource.is(DamageTypeTags.IS_PROJECTILE) && abstractThrownPotion1 == null) {
-+            if (!damageSource.is(DamageTypeTags.IS_PROJECTILE) && abstractThrownPotion1 == null) { // Paper - EndermanEscapeEvent - below logic relies on this path covering non-projectile damage.
++            if (!damageSource.is(DamageTypeTags.IS_PROJECTILE) && abstractThrownPotion1 == null) { // Paper - EndermanEscapeEvent - diff on change - below logic relies on this path covering non-projectile damage.
                  boolean flag = super.hurtServer(level, damageSource, amount);
                  if (!(damageSource.getEntity() instanceof LivingEntity) && this.random.nextInt(10) != 0) {
 +                    if (this.tryEscape(damageSource.is(net.minecraft.tags.DamageTypeTags.IS_DROWNING) ? com.destroystokyo.paper.event.entity.EndermanEscapeEvent.Reason.DROWN : com.destroystokyo.paper.event.entity.EndermanEscapeEvent.Reason.CRITICAL_HIT)) { // Paper - EndermanEscapeEvent

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/EnderMan.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/EnderMan.java.patch
@@ -56,8 +56,12 @@
                  this.setTarget(null);
                  this.teleport();
              }
-@@ -362,18 +_,22 @@
-             if (!damageSource.is(DamageTypeTags.IS_PROJECTILE) && abstractThrownPotion1 == null) {
+@@ -359,21 +_,25 @@
+             AbstractThrownPotion abstractThrownPotion1 = damageSource.getDirectEntity() instanceof AbstractThrownPotion abstractThrownPotion
+                 ? abstractThrownPotion
+                 : null;
+-            if (!damageSource.is(DamageTypeTags.IS_PROJECTILE) && abstractThrownPotion1 == null) {
++            if (!damageSource.is(DamageTypeTags.IS_PROJECTILE) && abstractThrownPotion1 == null) { // Paper - EndermanEscapeEvent - below logic relies on this path covering non-projectile damage.
                  boolean flag = super.hurtServer(level, damageSource, amount);
                  if (!(damageSource.getEntity() instanceof LivingEntity) && this.random.nextInt(10) != 0) {
 +                    if (this.tryEscape(damageSource.is(net.minecraft.tags.DamageTypeTags.IS_DROWNING) ? com.destroystokyo.paper.event.entity.EndermanEscapeEvent.Reason.DROWN : com.destroystokyo.paper.event.entity.EndermanEscapeEvent.Reason.CRITICAL_HIT)) { // Paper - EndermanEscapeEvent

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/EnderMan.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/EnderMan.java.patch
@@ -56,7 +56,16 @@
                  this.setTarget(null);
                  this.teleport();
              }
-@@ -369,11 +_,13 @@
+@@ -362,18 +_,22 @@
+             if (!damageSource.is(DamageTypeTags.IS_PROJECTILE) && abstractThrownPotion1 == null) {
+                 boolean flag = super.hurtServer(level, damageSource, amount);
+                 if (!(damageSource.getEntity() instanceof LivingEntity) && this.random.nextInt(10) != 0) {
++                    if (this.tryEscape(damageSource.is(net.minecraft.tags.DamageTypeTags.IS_DROWNING) ? com.destroystokyo.paper.event.entity.EndermanEscapeEvent.Reason.DROWN : com.destroystokyo.paper.event.entity.EndermanEscapeEvent.Reason.CRITICAL_HIT)) { // Paper - EndermanEscapeEvent
+                     this.teleport();
++                    } // Paper - EndermanEscapeEvent
+                 }
+ 
+                 return flag;
              } else {
                  boolean flag = abstractThrownPotion1 != null && this.hurtWithCleanWater(level, damageSource, abstractThrownPotion1, amount);
  


### PR DESCRIPTION
Related to fix https://github.com/PaperMC/Paper/issues/12500 this PR handle two things.

- Improvement docs for mention the vanilla behaviour for arrows where the damage are not apply in any case
- Add support for two reasons ignored by damage not related to projectiles like rain