### PR TITLE
fix: Don't hardcode checks for translation registries

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
@@ -35,8 +35,6 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.kyori.adventure.translation.GlobalTranslator;
-import net.kyori.adventure.translation.TranslationRegistry;
-import net.kyori.adventure.translation.Translator;
 import net.kyori.adventure.util.Codec;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
@@ -79,16 +77,15 @@ public final class PaperAdventure {
     private static final Pattern LOCALIZATION_PATTERN = Pattern.compile("%(?:(\\d+)\\$)?s");
     public static final ComponentFlattener FLATTENER = ComponentFlattener.basic().toBuilder()
         .complexMapper(TranslatableComponent.class, (translatable, consumer) -> {
-            if (!Language.getInstance().has(translatable.key())) {
-                for (final Translator source : GlobalTranslator.translator().sources()) {
-                    if (source instanceof TranslationRegistry registry && registry.contains(translatable.key())) {
-                        consumer.accept(GlobalTranslator.render(translatable, Locale.US));
-                        return;
-                    }
-                }
-            }
+            final Language language = Language.getInstance();
             final @Nullable String fallback = translatable.fallback();
-            final @NotNull String translated = Language.getInstance().getOrDefault(translatable.key(), fallback != null ? fallback : translatable.key());
+            if (!language.has(translatable.key()) && (fallback == null || !language.has(fallback))) {
+                if (GlobalTranslator.translator().canTranslate(translatable.key(), Locale.US)) {
+                    consumer.accept(GlobalTranslator.render(translatable, Locale.US));
+                }
+                return;
+            }
+            final @NotNull String translated = language.getOrDefault(translatable.key(), fallback != null ? fallback : translatable.key());
 
             final Matcher matcher = LOCALIZATION_PATTERN.matcher(translated);
             final List<TranslationArgument> args = translatable.arguments();


### PR DESCRIPTION
Devs can register custom Translator instances, and we can use the new `#canTranslate` method to avoid having to iterate through the whole set of sources.