### PR TITLE
Add plugin details to zip file errors

### DIFF
--- a/paper-api/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
@@ -206,7 +206,16 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
 
         if (result == null) {
             String path = name.replace('.', '/').concat(".class");
-            JarEntry entry = jar.getJarEntry(path);
+            // Add details to zip file errors - help debug classloading
+            JarEntry entry;
+            try {
+                entry = jar.getJarEntry(path);
+            } catch (IllegalStateException zipFileClosed) {
+                if (plugin == null) {
+                    throw zipFileClosed;
+                }
+                throw new IllegalStateException("The plugin classloader for " + plugin.getName() + " has thrown a zip file error.", zipFileClosed);
+            }
 
             if (entry != null) {
                 byte[] classBytes;


### PR DESCRIPTION
Recently, some users began reporting an annoying classloading bug, where "IllegalStateException: zip file closed" would travel **across** plugin boundaries. Here are some examples:

* https://pastebin.com/cCzr98sa
* https://pastebin.com/dSAfLcYK

This PR does **NOT** solve any bugs itself. It merely makes it easier to determine which plugin was the source of "zip file closed" in a complex plugin environment where bugs happen sporadically.

That such bugs can cross plugin boundaries at all is reason for this PR