### PR TITLE
[ci skip] Fix bad format for a few jd @link reference

### DIFF
--- a/paper-api/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java
@@ -119,7 +119,7 @@ public class AsyncTabCompleteEvent extends Event implements Cancellable {
      * the standard process of calling {@link Command#tabComplete(CommandSender, String, String[])}
      * or current player names will not be called.
      * <p>
-     * The passed collection will be cloned to a new {@code List}. You must call {{@link #getCompletions()}} to mutate from here
+     * The passed collection will be cloned to a new {@code List}. You must call {@link #getCompletions()} to mutate from here
      *
      * @param completions the new completions
      */

--- a/paper-api/src/main/java/org/bukkit/Location.java
+++ b/paper-api/src/main/java/org/bukkit/Location.java
@@ -732,7 +732,7 @@ public class Location implements Cloneable, ConfigurationSerializable, io.paperm
     /**
      * Returns a copy of this location except with y = getWorld().getHighestBlockYAt(this.getBlockX(), this.getBlockZ())
      * @return A copy of this location except with y = getWorld().getHighestBlockYAt(this.getBlockX(), this.getBlockZ())
-     * @throws NullPointerException if {{@link #getWorld()}} is {@code null}
+     * @throws NullPointerException if {@link #getWorld()} is {@code null}
      */
     @NotNull
     public Location toHighestLocation() {

--- a/paper-api/src/main/java/org/bukkit/entity/Zombie.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Zombie.java
@@ -71,7 +71,7 @@ public interface Zombie extends Monster, Ageable {
     /**
      * Gets the amount of ticks until this entity will be converted to a Drowned
      * as a result of being underwater.
-     *
+     * <br>
      * When this reaches 0, the entity will be converted.
      *
      * @return conversion time
@@ -82,7 +82,7 @@ public interface Zombie extends Monster, Ageable {
     /**
      * Sets the amount of ticks until this entity will be converted to a Drowned
      * as a result of being underwater.
-     *
+     * <br>
      * When this reaches 0, the entity will be converted. A value of less than 0
      * will stop the current conversion process without converting the current
      * entity.
@@ -121,7 +121,6 @@ public interface Zombie extends Monster, Ageable {
      * Make zombie start drowning
      *
      * @param drownedConversionTime Amount of time until zombie converts from drowning
-     *
      * @deprecated See {@link #setConversionTime(int)}
      */
     @Deprecated
@@ -136,7 +135,7 @@ public interface Zombie extends Monster, Ageable {
      * Set if zombie has its arms raised
      *
      * @param raised True to raise arms
-     * @deprecated use {{@link #setAggressive(boolean)}}
+     * @deprecated use {@link #setAggressive(boolean)}
      */
     @Deprecated
     void setArmsRaised(boolean raised);

--- a/paper-api/src/main/java/org/bukkit/event/server/TabCompleteEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/server/TabCompleteEvent.java
@@ -87,7 +87,7 @@ public class TabCompleteEvent extends Event implements Cancellable {
     /**
      * Set the completions offered, overriding any already set.
      * <br>
-     * The passed collection will be cloned to a new List. You must call {{@link #getCompletions()}} to mutate from here
+     * The passed collection will be cloned to a new List. You must call {@link #getCompletions()} to mutate from here
      *
      * @param completions the new completions
      */


### PR DESCRIPTION
This PR fix bad style in the use of link reference in javadocs adding extra `{}`