### PR TITLE
Fix player messages edited by plugins not showing in console

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
@@ -82,8 +82,8 @@ public final class PaperAdventure {
             if (!language.has(translatable.key()) && (fallback == null || !language.has(fallback))) {
                 if (GlobalTranslator.translator().canTranslate(translatable.key(), Locale.US)) {
                     consumer.accept(GlobalTranslator.render(translatable, Locale.US));
+                    return;
                 }
-                return;
             }
             final @NotNull String translated = language.getOrDefault(translatable.key(), fallback != null ? fallback : translatable.key());
 


### PR DESCRIPTION
Chat plugins that use AsyncChatEvent didn't displayed messages in console
jmp mentioned in discord it might've been a misplaced return, seems like it was

Before:
![image](https://github.com/user-attachments/assets/16c059e7-aa7c-4687-a812-cb9a1dc3665c)

After:
![image](https://github.com/user-attachments/assets/f56efa4c-c88d-47ab-8625-e99357fb4b99)
