### PR TITLE
Fix unnecessary player info remove packets being sent when hiding players

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1872,7 +1872,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         // Remove the hidden entity from this player user list, if they're on it
         if (other instanceof ServerPlayer) {
             ServerPlayer otherPlayer = (ServerPlayer) other;
-            if (otherPlayer.sentListPacket) {
+            if (this.getHandle().sentListPacket && otherPlayer.sentListPacket) {
                 this.getHandle().connection.send(new ClientboundPlayerInfoRemovePacket(List.of(otherPlayer.getUUID())));
             }
         }


### PR DESCRIPTION
When `CraftPlayer.unregisterEntity` is given a player, it will check to see if it should send a player info remove packet. However this check is only for whether the player being unregistered has received the player list. 

This check is not sufficient; when a player is hidden from a newly joining player in `PlayerJoinEvent` a remove packet will be sent to the joining player, even though they have not yet received the player list. This will reveal the presence of the hidden player on the server.

Changing the check to require both players to have received the player list resolves this.