### PR TITLE
Do not call EntityRemoveEvent during worldgen

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -1065,10 +1065,11 @@
      @Override
      public CrashReportCategory fillReportDetails(CrashReport report) {
          CrashReportCategory crashReportCategory = super.fillReportDetails(report);
-@@ -1712,6 +_,7 @@
+@@ -1712,6 +_,8 @@
      final class EntityCallbacks implements LevelCallback<Entity> {
          @Override
          public void onCreated(Entity entity) {
++            entity.inWorld = true; // CraftBukkit - Mark entity as in world
 +            entity.setOldPosAndRot(); // Paper - update old pos / rot for new entities as it will default to Vec3.ZERO
          }
  
@@ -1108,11 +1109,10 @@
                      String string = "onTrackingStart called during navigation iteration";
                      Util.logAndPauseIfInIde(
                          "onTrackingStart called during navigation iteration", new IllegalStateException("onTrackingStart called during navigation iteration")
-@@ -1755,10 +_,52 @@
+@@ -1755,10 +_,51 @@
              }
  
              entity.updateDynamicGameEventListener(DynamicGameEventListener::add);
-+            entity.inWorld = true; // CraftBukkit - Mark entity as in world
 +            entity.valid = true; // CraftBukkit
 +            ServerLevel.this.getChunkSource().addEntity(entity); // Paper - ignore and warn about illegal addEntity calls instead of crashing server
 +            // Paper start - Entity origin API

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -1961,6 +1961,11 @@ public class CraftEventFactory {
             return;
         }
 
+        // SPIGOT-8041: Do not call event unless entity has been spawned into world
+        if (!entity.inWorld) {
+            return;
+        }
+
         Bukkit.getPluginManager().callEvent(new EntityRemoveEvent(entity.getBukkitEntity(), cause));
     }
 


### PR DESCRIPTION
Ports the follow commits from spigot to paper.
All credits to go the respective commit authors listed below.

CraftBukkit: 3b4fd5b321f4440a2b3a67f3945739b45e6e687f

By: md_5 <git@md-5.net>

Resolves: #12426
