### PR TITLE
Vanilla Chat Rendering API

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/InternalAPIBridge.java
+++ b/paper-api/src/main/java/io/papermc/paper/InternalAPIBridge.java
@@ -1,7 +1,12 @@
 package io.papermc.paper;
 
+import io.papermc.paper.chat.ChatRenderer;
+import io.papermc.paper.chat.ChatTypeParameter;
+import io.papermc.paper.chat.vanilla.ChatTypeRenderer;
 import io.papermc.paper.world.damagesource.CombatEntry;
 import io.papermc.paper.world.damagesource.FallLocationType;
+import net.kyori.adventure.chat.ChatType;
+import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.util.Services;
 import org.bukkit.block.Biome;
 import org.bukkit.damage.DamageEffect;
@@ -10,6 +15,7 @@ import org.bukkit.entity.LivingEntity;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import java.util.List;
 
 /**
  * Static bridge to the server internals.
@@ -73,5 +79,9 @@ public interface InternalAPIBridge {
      * @return combat entry
      */
     CombatEntry createCombatEntry(DamageSource damageSource, float damage, @Nullable FallLocationType fallLocationType, float fallDistance);
+
+    ChatType createAdventureChatType(String format, String narration, Style style, List<ChatTypeParameter> parameters);
+
+    ChatRenderer createVanillaChatRenderer(ChatTypeRenderer renderer);
 }
 

--- a/paper-api/src/main/java/io/papermc/paper/chat/ChatRenderer.java
+++ b/paper-api/src/main/java/io/papermc/paper/chat/ChatRenderer.java
@@ -1,5 +1,7 @@
 package io.papermc.paper.chat;
 
+import io.papermc.paper.InternalAPIBridge;
+import io.papermc.paper.chat.vanilla.ChatTypeRenderer;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
@@ -67,4 +69,27 @@ public interface ChatRenderer {
         @ApiStatus.OverrideOnly
         Component render(Player source, Component sourceDisplayName, Component message);
     }
+
+    /**
+     * Creates a {@link ChatRenderer} that renders using the vanilla chat renderer that is
+     * viewer aware.
+     *
+     * @param renderer the custom provided {@link ChatTypeRenderer.ViewerAware} implementation
+     * @return a {@link ChatRenderer} that delegates to the given viewer‐aware renderer
+     */
+    static ChatRenderer chatTypeRenderer(final ChatTypeRenderer.ViewerAware renderer) {
+        return InternalAPIBridge.get().createVanillaChatRenderer(renderer);
+    }
+
+    /**
+     * Creates a {@link ChatRenderer} that renders using the vanilla chat renderer that is
+     * viewer unaware.
+     *
+     * @param renderer the custom provided {@link ChatTypeRenderer.ViewerUnaware} implementation
+     * @return a {@link ChatRenderer} that delegates to the given viewer‐unaware renderer
+     */
+    static ChatRenderer chatTypeRendererViewerUnaware(final ChatTypeRenderer.ViewerUnaware renderer) {
+        return InternalAPIBridge.get().createVanillaChatRenderer(renderer);
+    }
+
 }

--- a/paper-api/src/main/java/io/papermc/paper/chat/ChatTypeParameter.java
+++ b/paper-api/src/main/java/io/papermc/paper/chat/ChatTypeParameter.java
@@ -1,0 +1,16 @@
+package io.papermc.paper.chat;
+
+import net.kyori.adventure.text.format.Style;
+import java.util.List;
+
+/**
+ * The available parameters for vanilla chat formatting.
+ * This used to determine the order of how chat content is rendered.
+ *
+ * @see io.papermc.paper.chat.vanilla.ChatTypeRenderer#vanillaChatType(String, String, Style, List)
+ */
+public enum ChatTypeParameter {
+    SENDER,
+    TARGET,
+    CONTENT
+}

--- a/paper-api/src/main/java/io/papermc/paper/chat/ViewerUnawareImpl.java
+++ b/paper-api/src/main/java/io/papermc/paper/chat/ViewerUnawareImpl.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 sealed class ViewerUnawareImpl implements ChatRenderer, ChatRenderer.ViewerUnaware permits ViewerUnawareImpl.Default {
     private final ViewerUnaware unaware;
-    private @Nullable Component message;
 
     ViewerUnawareImpl(final ViewerUnaware unaware) {
         this.unaware = unaware;
@@ -24,10 +23,7 @@ sealed class ViewerUnawareImpl implements ChatRenderer, ChatRenderer.ViewerUnawa
 
     @Override
     public Component render(final Player source, final Component sourceDisplayName, final Component message) {
-        if (this.message == null) {
-            this.message = this.unaware.render(source, sourceDisplayName, message);
-        }
-        return this.message;
+        return this.unaware.render(source, sourceDisplayName, message);
     }
 
     static final class Default extends ViewerUnawareImpl implements ChatRenderer.Default {

--- a/paper-api/src/main/java/io/papermc/paper/chat/vanilla/ChatTypeRenderResult.java
+++ b/paper-api/src/main/java/io/papermc/paper/chat/vanilla/ChatTypeRenderResult.java
@@ -1,0 +1,53 @@
+package io.papermc.paper.chat.vanilla;
+
+import net.kyori.adventure.chat.ChatType;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The result of rendering a chat message into a specific {@link ChatType}.
+ */
+@NullMarked
+@ApiStatus.NonExtendable
+public sealed interface ChatTypeRenderResult permits TypeRenderResultImpl {
+
+    /**
+     * Create a render result with no unsigned content component.
+     *
+     * @param bound the {@link ChatType.Bound} containing the formatted message
+     *              component and narration text
+     * @return a new {@link ChatTypeRenderResult}
+     */
+    static ChatTypeRenderResult of(ChatType.Bound bound) {
+        return new TypeRenderResultImpl(bound, null);
+    }
+
+    /**
+     * Create a render result including an unsigned content component.
+     *
+     * @param bound     the {@link ChatType.Bound}
+     * @param unsignedContent an optional {@link Component} representing unsigned content, or {@code null}
+     * @return a new {@link ChatTypeRenderResult}
+     */
+    static ChatTypeRenderResult of(ChatType.Bound bound, @Nullable Component unsignedContent) {
+        return new TypeRenderResultImpl(bound, unsignedContent);
+    }
+
+    /**
+     * Retrieves the optional unsigned content component.
+     *
+     * @return the unsigned {@link Component}, or {@code null} if none was provided
+     */
+    @Nullable
+    Component unsignedContent();
+
+    /**
+     * Retrieves the bound chat type result.
+     *
+     * @return the {@link ChatType.Bound} instance for this render
+     */
+    ChatType.Bound boundChat();
+
+}

--- a/paper-api/src/main/java/io/papermc/paper/chat/vanilla/ChatTypeRenderer.java
+++ b/paper-api/src/main/java/io/papermc/paper/chat/vanilla/ChatTypeRenderer.java
@@ -1,0 +1,80 @@
+package io.papermc.paper.chat.vanilla;
+
+import io.papermc.paper.InternalAPIBridge;
+import io.papermc.paper.chat.ChatTypeParameter;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.chat.ChatType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.Style;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.ApiStatus;
+import java.util.List;
+
+/**
+ * Represents a renderer implementation that utilizes Minecraft's {@link ChatType} system for
+ * rendering on the client.
+ * <p>
+ * Using this API allows additional flexibility such as configurable narration.
+ * <p>
+ * Implementations are either viewer-unaware or viewer-aware, depending on
+ * whether they need to know the audience when rendering.
+ * </p>
+ */
+@ApiStatus.NonExtendable
+public sealed interface ChatTypeRenderer permits ChatTypeRenderer.ViewerUnaware, ChatTypeRenderer.ViewerAware {
+
+    /**
+     * A chat type renderer that does not consider the viewer when rendering.
+     */
+    non-sealed interface ViewerUnaware extends ChatTypeRenderer {
+
+        /**
+         * Renders a chat message without regard to a recipient.
+         *
+         * @param source the player who sent the message
+         * @param sourceDisplayName the display name component of the sender
+         * @param message the message content component
+         * @return the rendering result
+         */
+        @ApiStatus.OverrideOnly
+        ChatTypeRenderResult render(Player source, Component sourceDisplayName, Component message);
+
+    }
+
+    /**
+     * A chat type renderer that may customize output based on the viewer.
+     */
+    non-sealed interface ViewerAware extends ChatTypeRenderer {
+
+        /**
+         * Render a chat message while taking into account who is receiving the message.
+         *
+         * @param source the player who sent the message
+         * @param sourceDisplayName the display name component of the sender
+         * @param message the message content component
+         * @param viewer the audience receiving the message
+         * @return the rendering result
+         */
+        @ApiStatus.OverrideOnly
+        ChatTypeRenderResult render(Player source, Component sourceDisplayName, Component message, Audience viewer);
+
+    }
+
+    /**
+     * Creates a vanilla {@link ChatType} with custom message formatting and narration.
+     * <p>
+     * The position of each {@link ChatTypeParameter} directly determines which
+     * placeholder it substitutes in both the chat message and the narration output.
+     *
+     * @param format     the pattern for rendering chat messages (e.g. "<%s> %s")
+     * @param narration  the pattern for the narration of  chat messages (e.g. "%s says %s")
+     * @param style      the {@link Style} to apply to the rendered message
+     * @param parameters an ordered list of {@link ChatTypeParameter}s
+     *
+     * @return a new {@link ChatType} instance with the specified format, narration,style, and parameters
+     */
+    static ChatType vanillaChatType(String format, String narration, Style style, List<ChatTypeParameter> parameters) {
+        return InternalAPIBridge.get().createAdventureChatType(format, narration, style, parameters);
+    }
+
+}

--- a/paper-api/src/main/java/io/papermc/paper/chat/vanilla/TypeRenderResultImpl.java
+++ b/paper-api/src/main/java/io/papermc/paper/chat/vanilla/TypeRenderResultImpl.java
@@ -1,0 +1,10 @@
+package io.papermc.paper.chat.vanilla;
+
+import net.kyori.adventure.chat.ChatType;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
+
+@ApiStatus.Internal
+record TypeRenderResultImpl(ChatType.Bound boundChat, @Nullable Component unsignedContent) implements ChatTypeRenderResult {
+}

--- a/paper-server/patches/features/0015-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0015-Moonrise-optimisation-patches.patch
@@ -28206,10 +28206,10 @@ index b30f56fbc1fd17259a1d05dc9155fffcab292ca1..11fed81a4696ba18440e755c3b8a5ca3
          this.generatingStep = generatingStep;
          this.cache = cache;
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index eda176c96bcf3d67650722ffce33863edfbdea9e..a7a07ebe6ceed99fa768b6834e350fe2f51a6950 100644
+index b80e6d91b8dafc9782bb7796f9855b360fd86f65..990945a9f23830f11bb1e07485fb81b0470dc2e8 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
-@@ -1332,7 +1332,7 @@ public abstract class PlayerList {
+@@ -1338,7 +1338,7 @@ public abstract class PlayerList {
  
      public void setViewDistance(int viewDistance) {
          this.viewDistance = viewDistance;
@@ -28218,7 +28218,7 @@ index eda176c96bcf3d67650722ffce33863edfbdea9e..a7a07ebe6ceed99fa768b6834e350fe2
  
          for (ServerLevel serverLevel : this.server.getAllLevels()) {
              if (serverLevel != null) {
-@@ -1343,7 +1343,7 @@ public abstract class PlayerList {
+@@ -1349,7 +1349,7 @@ public abstract class PlayerList {
  
      public void setSimulationDistance(int simulationDistance) {
          this.simulationDistance = simulationDistance;

--- a/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -1013,45 +1013,51 @@
  
      public void broadcastSystemMessage(Component message, boolean bypassHiddenChat) {
          this.broadcastSystemMessage(message, serverPlayer -> message, bypassHiddenChat);
-@@ -756,20 +_,39 @@
+@@ -756,20 +_,45 @@
      }
  
      public void broadcastChatMessage(PlayerChatMessage message, ServerPlayer sender, ChatType.Bound boundChatType) {
 -        this.broadcastChatMessage(message, sender::shouldFilterMessageTo, sender, boundChatType);
 +        // Paper start
-+        this.broadcastChatMessage(message, sender, boundChatType, null);
++        this.broadcastChatMessage(message, sender, io.papermc.paper.adventure.ChatProcessor.ChatContentProvider.ofStaticViewerUnaware(boundChatType, null));
 +    }
-+    public void broadcastChatMessage(PlayerChatMessage message, ServerPlayer sender, ChatType.Bound boundChatType, @Nullable Function<net.kyori.adventure.audience.Audience, Component> unsignedFunction) {
++    public void broadcastChatMessage(PlayerChatMessage message, ServerPlayer sender, io.papermc.paper.adventure.ChatProcessor.ChatContentProvider chatContentProvider) {
 +        // Paper end
-+        this.broadcastChatMessage(message, sender::shouldFilterMessageTo, sender, boundChatType, unsignedFunction); // Paper
++        this.broadcastChatMessage(message, sender::shouldFilterMessageTo, sender, chatContentProvider); // Paper
      }
  
      private void broadcastChatMessage(
          PlayerChatMessage message, Predicate<ServerPlayer> shouldFilterMessageTo, @Nullable ServerPlayer sender, ChatType.Bound boundChatType
      ) {
 +        // Paper start
-+        this.broadcastChatMessage(message, shouldFilterMessageTo, sender, boundChatType, null);
++        this.broadcastChatMessage(message, shouldFilterMessageTo, sender, io.papermc.paper.adventure.ChatProcessor.ChatContentProvider.ofStaticViewerUnaware(boundChatType, null));
 +    }
-+    public void broadcastChatMessage(PlayerChatMessage message, Predicate<ServerPlayer> shouldFilterMessageTo, @Nullable ServerPlayer sender, ChatType.Bound boundChatType, @Nullable Function<net.kyori.adventure.audience.Audience, Component> unsignedFunction) {
++    private void broadcastChatMessage(PlayerChatMessage message, Predicate<ServerPlayer> shouldFilterMessageTo, @Nullable ServerPlayer sender, io.papermc.paper.adventure.ChatProcessor.ChatContentProvider chatContentProvider) {
++        io.papermc.paper.adventure.ChatProcessor.RenderedResult consoleChat = chatContentProvider.render(this.server.console);
++        boolean isViewerUnaware = chatContentProvider.isViewerUnaware();
 +        // Paper end
          boolean flag = this.verifyChatTrusted(message);
 -        this.server.logChatMessage(message.decoratedContent(), boundChatType, flag ? null : "Not Secure");
-+        this.server.logChatMessage((unsignedFunction == null ? message.decoratedContent() : unsignedFunction.apply(this.server.console)), boundChatType, flag ? null : "Not Secure"); // Paper
++        this.server.logChatMessage(consoleChat.unsignedOrElse(message.decoratedContent()), consoleChat.bound(), flag ? null : "Not Secure"); // Paper
          OutgoingChatMessage outgoingChatMessage = OutgoingChatMessage.create(message);
          boolean flag1 = false;
  
-+        Packet<?> disguised = sender != null && unsignedFunction == null ? new net.minecraft.network.protocol.game.ClientboundDisguisedChatPacket(outgoingChatMessage.content(), boundChatType) : null; // Paper - don't send player chat packets from vanished players
++        Packet<?> disguised = sender != null && isViewerUnaware ? new net.minecraft.network.protocol.game.ClientboundDisguisedChatPacket(outgoingChatMessage.content(), consoleChat.bound()) : null; // Paper - don't send player chat packets from vanished players
          for (ServerPlayer serverPlayer : this.players) {
              boolean flag2 = shouldFilterMessageTo.test(serverPlayer);
 -            serverPlayer.sendChatMessage(outgoingChatMessage, flag2, boundChatType);
 +            // Paper start - don't send player chat packets from vanished players
 +            if (sender != null && !serverPlayer.getBukkitEntity().canSee(sender.getBukkitEntity())) {
-+                serverPlayer.connection.send(unsignedFunction != null
-+                    ? new net.minecraft.network.protocol.game.ClientboundDisguisedChatPacket(unsignedFunction.apply(serverPlayer.getBukkitEntity()), boundChatType)
-+                    : disguised);
++                if (isViewerUnaware) {
++                    serverPlayer.connection.send(disguised);
++                } else {
++                    io.papermc.paper.adventure.ChatProcessor.RenderedResult renderedFrame = chatContentProvider.render(serverPlayer.getBukkitEntity());
++                    serverPlayer.connection.send(new net.minecraft.network.protocol.game.ClientboundDisguisedChatPacket(renderedFrame.unsignedOrElse(outgoingChatMessage.content()), renderedFrame.bound()));
++                }
 +                continue;
 +            }
-+            serverPlayer.sendChatMessage(outgoingChatMessage, flag2, boundChatType, unsignedFunction == null ? null : unsignedFunction.apply(serverPlayer.getBukkitEntity()));
++            io.papermc.paper.adventure.ChatProcessor.RenderedResult playerChat = isViewerUnaware ? consoleChat : chatContentProvider.render(serverPlayer.getBukkitEntity());
++            serverPlayer.sendChatMessage(outgoingChatMessage, flag2, playerChat.bound(), playerChat.unsigned());
 +            // Paper end
              flag1 |= flag2 && message.isFullyFiltered();
          }

--- a/paper-server/src/main/java/io/papermc/paper/PaperServerInternalAPIBridge.java
+++ b/paper-server/src/main/java/io/papermc/paper/PaperServerInternalAPIBridge.java
@@ -1,10 +1,21 @@
 package io.papermc.paper;
 
+import io.papermc.paper.adventure.ChatProcessor;
+import io.papermc.paper.adventure.PaperAdventure;
+import io.papermc.paper.chat.ChatRenderer;
+import io.papermc.paper.chat.ChatTypeParameter;
+import io.papermc.paper.chat.vanilla.ChatTypeRenderer;
+import io.papermc.paper.util.MCUtil;
 import io.papermc.paper.world.damagesource.CombatEntry;
 import io.papermc.paper.world.damagesource.FallLocationType;
 import io.papermc.paper.world.damagesource.PaperCombatEntryWrapper;
 import io.papermc.paper.world.damagesource.PaperCombatTrackerWrapper;
+import net.kyori.adventure.chat.ChatType;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.format.Style;
 import net.minecraft.Optionull;
+import net.minecraft.core.Holder;
+import net.minecraft.network.chat.ChatTypeDecoration;
 import net.minecraft.world.damagesource.FallLocation;
 import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.block.CraftBiome;
@@ -14,8 +25,10 @@ import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.damage.DamageEffect;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.entity.LivingEntity;
+import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import java.util.List;
 
 @NullMarked
 public class PaperServerInternalAPIBridge implements InternalAPIBridge {
@@ -70,5 +83,30 @@ public class PaperServerInternalAPIBridge implements InternalAPIBridge {
         return new PaperCombatEntryWrapper(new net.minecraft.world.damagesource.CombatEntry(
             damageSource, damage, fallLocation, fallDistance
         ));
+    }
+
+    @Override
+    public ChatType createAdventureChatType(final String format, final String narration, final Style style, final List<ChatTypeParameter> parameters) {
+        List<ChatTypeDecoration.Parameter> parameterList = MCUtil.transformUnmodifiable(parameters, chatTypeParameter -> ChatTypeDecoration.Parameter.values()[chatTypeParameter.ordinal()]);
+        net.minecraft.network.chat.Style nmsType = PaperAdventure.asVanilla(style);
+
+        net.minecraft.network.chat.ChatType chatType = new net.minecraft.network.chat.ChatType(
+            new ChatTypeDecoration(format, parameterList, nmsType),
+            new ChatTypeDecoration(narration, parameterList, nmsType)
+        );
+        return new PaperInternalChatType(Holder.direct(chatType));
+    }
+
+    public record PaperInternalChatType(Holder<net.minecraft.network.chat.ChatType> chatType) implements ChatType {
+
+        @Override
+        public @NotNull Key key() {
+            throw new IllegalStateException("Cannot get key for this registry item, because it is not registered.");
+        }
+    }
+
+    @Override
+    public ChatRenderer createVanillaChatRenderer(final ChatTypeRenderer renderer) {
+        return ChatProcessor.PaperVanillaChatRenderer.of(renderer);
     }
 }

--- a/paper-server/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
@@ -431,7 +431,7 @@ public final class ChatProcessor {
             };
         }
 
-        // "legacy" compatability renderer
+        // api compatability renderer
         @Override
         public Component render(final Player source, final Component sourceDisplayName, final Component message, final Audience viewer) {
             ChatType.Bound nms = compute(source, sourceDisplayName, message, viewer).bound();


### PR DESCRIPTION
Allows to utilize the Vanilla ChatType rendering API to render chat messages natively on the client rather than using the RAW chat type. This most notably improves the experience for those using chat narration. This utilizes inlined ChatTypes, which we currently cannot nicely use our registry api due to adventure having its own implemented ChatType.

The ChatProcessor has also been refactored a bit to support per player bound chat types which is needed for this api.

```java
private static final ChatType BEE_TYPE = ChatTypeRenderer.vanillaChatType("%s: %s", "%s loudly exclaims %s", Style.style(NamedTextColor.WHITE), List.of(ChatTypeParameter.SENDER, ChatTypeParameter.CONTENT));
    private static final ChatRenderer renderer = ChatRenderer.chatTypeRendererViewerUnaware(new ChatTypeRenderer.ViewerUnaware() {
        @Override
        public ChatTypeRenderResult render(final Player source, final Component sourceDisplayName, final Component message) {
            return ChatTypeRenderResult.of(
                BEE_TYPE.bind(Component.text("[Owner] ", NamedTextColor.RED).append(sourceDisplayName))
            );
        }
    });

    @EventHandler
    public void test(AsyncChatEvent event) {
        event.renderer(renderer);
    }
```

This also includes a bug fix for viewer unaware renders which would break if you tried to reuse the same renderer.
