### PR TITLE
Improve error messages when PluginRemapper fails to initialize

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/pluginremap/PluginRemapper.java
+++ b/paper-server/src/main/java/io/papermc/paper/pluginremap/PluginRemapper.java
@@ -75,7 +75,11 @@ public final class PluginRemapper {
             return null;
         }
 
-        return new PluginRemapper(pluginsDir);
+        try {
+            return new PluginRemapper(pluginsDir);
+        } catch (final Exception e) {
+            throw new RuntimeException("Failed to create PluginRemapper, try deleting the '" + pluginsDir.resolve(PAPER_REMAPPED) + "' directory", e);
+        }
     }
 
     public void shutdown() {

--- a/paper-server/src/main/java/io/papermc/paper/pluginremap/RemappedPluginIndex.java
+++ b/paper-server/src/main/java/io/papermc/paper/pluginremap/RemappedPluginIndex.java
@@ -8,6 +8,7 @@ import io.papermc.paper.util.MappingEnvironment;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -58,26 +59,29 @@ class RemappedPluginIndex {
 
         this.indexFile = dir.resolve(INDEX_FILE_NAME);
         if (Files.isRegularFile(this.indexFile)) {
-            try {
-                this.state = this.readIndex();
-            } catch (final IOException e) {
-                throw new RuntimeException(e);
-            }
+            this.state = this.readIndex();
         } else {
             this.state = new State();
         }
     }
 
-    private State readIndex() throws IOException {
+    private State readIndex() {
         final State state;
         try (final BufferedReader reader = Files.newBufferedReader(this.indexFile)) {
             state = GSON.fromJson(reader, State.class);
+        } catch (final IOException ex) {
+            throw new UncheckedIOException("Failed to read index file '" + this.indexFile + "'", ex);
         }
 
         // If mappings have changed, delete all cached files and create a new index
         if (!state.mappingsHash.equals(MappingEnvironment.mappingsHash())) {
             for (final String fileName : state.hashes.values()) {
-                Files.deleteIfExists(this.dir.resolve(fileName));
+                final Path path = this.dir.resolve(fileName);
+                try  {
+                    Files.deleteIfExists(path);
+                } catch (final IOException ex) {
+                    throw new UncheckedIOException("Failed to delete no longer needed file '" + path + "'", ex);
+                }
             }
             return new State();
         }
@@ -111,10 +115,11 @@ class RemappedPluginIndex {
             }
 
             iterator.remove();
+            final Path filePath = this.dir.resolve(fileName);
             try {
-                Files.deleteIfExists(this.dir.resolve(fileName));
+                Files.deleteIfExists(filePath);
             } catch (final IOException ex) {
-                throw new RuntimeException(ex);
+                throw new UncheckedIOException("Failed to delete no longer needed file '" + filePath + "'", ex);
             }
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/pluginremap/RemappedPluginIndex.java
+++ b/paper-server/src/main/java/io/papermc/paper/pluginremap/RemappedPluginIndex.java
@@ -2,6 +2,7 @@ package io.papermc.paper.pluginremap;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import com.mojang.logging.LogUtils;
 import io.papermc.paper.util.Hashing;
 import io.papermc.paper.util.MappingEnvironment;
@@ -69,7 +70,7 @@ class RemappedPluginIndex {
         final State state;
         try (final BufferedReader reader = Files.newBufferedReader(this.indexFile)) {
             state = GSON.fromJson(reader, State.class);
-        } catch (final IOException ex) {
+        } catch (final IOException | JsonSyntaxException ex) {
             throw new UncheckedIOException("Failed to read index file '" + this.indexFile + "'", ex);
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/pluginremap/RemappedPluginIndex.java
+++ b/paper-server/src/main/java/io/papermc/paper/pluginremap/RemappedPluginIndex.java
@@ -2,8 +2,6 @@ package io.papermc.paper.pluginremap;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonIOException;
-import com.google.gson.JsonSyntaxException;
 import com.mojang.logging.LogUtils;
 import io.papermc.paper.util.Hashing;
 import io.papermc.paper.util.MappingEnvironment;
@@ -55,7 +53,7 @@ class RemappedPluginIndex {
             try {
                 Files.createDirectories(this.dir);
             } catch (final IOException ex) {
-                throw new RuntimeException(ex);
+                throw new UncheckedIOException(ex);
             }
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/pluginremap/RemappedPluginIndex.java
+++ b/paper-server/src/main/java/io/papermc/paper/pluginremap/RemappedPluginIndex.java
@@ -2,6 +2,7 @@ package io.papermc.paper.pluginremap;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
 import com.mojang.logging.LogUtils;
 import io.papermc.paper.util.Hashing;
@@ -70,8 +71,8 @@ class RemappedPluginIndex {
         final State state;
         try (final BufferedReader reader = Files.newBufferedReader(this.indexFile)) {
             state = GSON.fromJson(reader, State.class);
-        } catch (final IOException | JsonSyntaxException ex) {
-            throw new UncheckedIOException("Failed to read index file '" + this.indexFile + "'", ex);
+        } catch (final Exception ex) {
+            throw new RuntimeException("Failed to read index file '" + this.indexFile + "'", ex);
         }
 
         // If mappings have changed, delete all cached files and create a new index


### PR DESCRIPTION
```
[12:23:15 INFO]: [PluginInitializerManager] Initializing plugins...
[12:23:15 ERROR]: Failed to start the minecraft server
java.lang.RuntimeException: Failed to create PluginRemapper, try deleting the 'plugins/.paper-remapped' directory
	at io.papermc.paper.pluginremap.PluginRemapper.create(PluginRemapper.java:81) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.plugin.PluginInitializerManager.<init>(PluginInitializerManager.java:40) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.plugin.PluginInitializerManager.parse(PluginInitializerManager.java:64) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.plugin.PluginInitializerManager.init(PluginInitializerManager.java:88) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.plugin.PluginInitializerManager.load(PluginInitializerManager.java:109) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at net.minecraft.server.Main.main(Main.java:111) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.PaperBootstrap.boot(PaperBootstrap.java:21) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at org.bukkit.craftbukkit.Main.main(Main.java:243) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paperclip.Paperclip.lambda$main$0(Paperclip.java:42) ~[app:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.lang.RuntimeException: Failed to read index file 'plugins/.paper-remapped/index.json'
	at io.papermc.paper.pluginremap.RemappedPluginIndex.readIndex(RemappedPluginIndex.java:75) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.pluginremap.RemappedPluginIndex.<init>(RemappedPluginIndex.java:64) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.pluginremap.PluginRemapper.<init>(PluginRemapper.java:67) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.pluginremap.PluginRemapper.create(PluginRemapper.java:79) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	... 9 more
Caused by: com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $
See https://github.com/google/gson/blob/main/Troubleshooting.md#unexpected-json-structure
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:520) ~[gson-2.11.0.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:1361) ~[gson-2.11.0.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:1262) ~[gson-2.11.0.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:1199) ~[gson-2.11.0.jar:?]
	at io.papermc.paper.pluginremap.RemappedPluginIndex.readIndex(RemappedPluginIndex.java:73) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.pluginremap.RemappedPluginIndex.<init>(RemappedPluginIndex.java:64) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.pluginremap.PluginRemapper.<init>(PluginRemapper.java:67) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.pluginremap.PluginRemapper.create(PluginRemapper.java:79) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	... 9 more
Caused by: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $
See https://github.com/google/gson/blob/main/Troubleshooting.md#unexpected-json-structure
	at com.google.gson.stream.JsonReader.unexpectedTokenError(JsonReader.java:1768) ~[gson-2.11.0.jar:?]
	at com.google.gson.stream.JsonReader.beginObject(JsonReader.java:469) ~[gson-2.11.0.jar:?]
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:509) ~[gson-2.11.0.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:1361) ~[gson-2.11.0.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:1262) ~[gson-2.11.0.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:1199) ~[gson-2.11.0.jar:?]
	at io.papermc.paper.pluginremap.RemappedPluginIndex.readIndex(RemappedPluginIndex.java:73) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.pluginremap.RemappedPluginIndex.<init>(RemappedPluginIndex.java:64) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.pluginremap.PluginRemapper.<init>(PluginRemapper.java:67) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	at io.papermc.paper.pluginremap.PluginRemapper.create(PluginRemapper.java:79) ~[paper-1.21.5.jar:1.21.5-DEV-925b073]
	... 9 more

```