### PR TITLE
Add allow-remote-ender-dragon-respawning setting

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/dimension/end/EndDragonFight.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/dimension/end/EndDragonFight.java.patch
@@ -137,13 +137,12 @@
          if (this.dragonKilled && this.respawnStage == null) {
              BlockPos blockPos = this.portalLocation;
              if (blockPos == null) {
-@@ -486,6 +_,23 @@
+@@ -486,6 +_,22 @@
  
                  blockPos = this.portalLocation;
              }
 +            // Paper start - Perf: Do crystal-portal proximity check before entity lookup
-+            // Paper - add option to disable try-dragon-spawn performance improvement
-+            if (placedEndCrystalPos != null && level.paperConfig().misc.dragonSpawnAttemptPerformanceImprovements) {
++            if (placedEndCrystalPos != null && !level.paperConfig().misc.allowRemoteEnderDragonRespawning) {
 +                // The end crystal must be 0 or 1 higher than the portal origin
 +                int dy = placedEndCrystalPos.getY() - blockPos.getY();
 +                if (dy != 0 && dy != 1) {

--- a/paper-server/patches/sources/net/minecraft/world/level/dimension/end/EndDragonFight.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/dimension/end/EndDragonFight.java.patch
@@ -137,12 +137,13 @@
          if (this.dragonKilled && this.respawnStage == null) {
              BlockPos blockPos = this.portalLocation;
              if (blockPos == null) {
-@@ -486,6 +_,22 @@
+@@ -486,6 +_,23 @@
  
                  blockPos = this.portalLocation;
              }
 +            // Paper start - Perf: Do crystal-portal proximity check before entity lookup
-+            if (placedEndCrystalPos != null) {
++            // Paper - add option to disable try-dragon-spawn performance improvement
++            if (placedEndCrystalPos != null && level.paperConfig().misc.dragonSpawnAttemptPerformanceImprovements) {
 +                // The end crystal must be 0 or 1 higher than the portal origin
 +                int dy = placedEndCrystalPos.getY() - blockPos.getY();
 +                if (dy != 0 && dy != 1) {

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -574,6 +574,7 @@ public class WorldConfiguration extends ConfigurationPart {
         public int shieldBlockingDelay = 5;
         public boolean disableRelativeProjectileVelocity = false;
         public boolean legacyEnderPearlBehavior = false;
+        public boolean dragonSpawnAttemptPerformanceImprovements = true;
 
         public enum RedstoneImplementation {
             VANILLA, EIGENCRAFT, ALTERNATE_CURRENT

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -574,7 +574,7 @@ public class WorldConfiguration extends ConfigurationPart {
         public int shieldBlockingDelay = 5;
         public boolean disableRelativeProjectileVelocity = false;
         public boolean legacyEnderPearlBehavior = false;
-        public boolean dragonSpawnAttemptPerformanceImprovements = true;
+        public boolean allowRemoteEnderDragonRespawning = false;
 
         public enum RedstoneImplementation {
             VANILLA, EIGENCRAFT, ALTERNATE_CURRENT


### PR DESCRIPTION
When making an semi-automatic dragon farm, it is common to push end crystals into place and trigger the end spawn sequence with a fifth end crystal, which isn't placed on the portal. Paper changes this behavior by checking the location of any end crystal, resulting in the breakage of certain farms which rely on that mechanic.

This PR adds a new option to the `paper-world(-defaults).yml` file:
```yml
misc:
  allow-remote-ender-dragon-respawning: false
```

If this value is set to false, which is the default, the performance improvement takes effect and causes dragons to not spawn in the above mentioned scenario:

<details>
<summary><code>allow-remote-ender-dragon-respawning: false</code></summary>

https://github.com/user-attachments/assets/40b73521-5646-482b-920b-52b49823b74d

</details>

When setting this value to true, it returns to Vanilla behavior, causing remote dragon-spawning to be possible:

<details>
<summary><code>allow-remote-ender-dragon-respawning: true</code></summary>

https://github.com/user-attachments/assets/22cd1d26-d5fb-45f7-aea0-5462b774a0a5

</details>