### PR TITLE
Add Registry#getTagValues

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/registry/set/RegistryKeySet.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/set/RegistryKeySet.java
@@ -3,6 +3,7 @@ package io.papermc.paper.registry.set;
 import io.papermc.paper.registry.TypedKey;
 import java.util.Collection;
 import java.util.Iterator;
+import io.papermc.paper.registry.tag.TagKey;
 import org.bukkit.Keyed;
 import org.bukkit.Registry;
 import org.jetbrains.annotations.ApiStatus;
@@ -33,6 +34,7 @@ public non-sealed interface RegistryKeySet<T extends Keyed> extends Iterable<Typ
      * @param registry the registry to resolve the values from (must match {@link #registryKey()})
      * @return the resolved values
      * @see RegistryKeySet#values()
+     * @see Registry#getTagValues(TagKey) 
      */
     @Unmodifiable Collection<T> resolve(final Registry<T> registry);
 

--- a/paper-api/src/main/java/org/bukkit/Registry.java
+++ b/paper-api/src/main/java/org/bukkit/Registry.java
@@ -496,6 +496,22 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
     Tag<T> getTag(TagKey<T> key);
 
     /**
+     * Gets the named registry set (tag) for the given key and resolves it with this registry.
+     *
+     * @param key the key to get the tag for
+     * @return the resolved values
+     * @throws NoSuchElementException        if no tag with the given key is found
+     * @throws UnsupportedOperationException if this registry doesn't have or support tags
+     * @see #getTag(TagKey)
+     * @see Tag#resolve(Registry)
+     */
+    @ApiStatus.Experimental
+    default Collection<T> getTagAndResolve(TagKey<T> key) {
+        Tag<T> tag = getTag(key);
+        return tag.resolve(this);
+    }
+
+    /**
      * Gets all the tags in this registry.
      *
      * @return a stream of all tags in this registry

--- a/paper-api/src/main/java/org/bukkit/Registry.java
+++ b/paper-api/src/main/java/org/bukkit/Registry.java
@@ -491,6 +491,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      * @throws NoSuchElementException if no tag with the given key is found
      * @throws UnsupportedOperationException    if this registry doesn't have or support tags
      * @see #hasTag(TagKey)
+     * @see #getTagValues(TagKey) 
      */
     @ApiStatus.Experimental
     Tag<T> getTag(TagKey<T> key);
@@ -506,7 +507,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      * @see Tag#resolve(Registry)
      */
     @ApiStatus.Experimental
-    default Collection<T> getTagAndResolve(TagKey<T> key) {
+    default Collection<T> getTagValues(TagKey<T> key) {
         Tag<T> tag = getTag(key);
         return tag.resolve(this);
     }


### PR DESCRIPTION
Currently, if you want to retrieve all entries from a registry with a tag, you have to do these steps:
- Retrieve the `Registry`.
- Retrieve the `TagKey` using `Registry#getTag(...)`.
- Resolve the `TagKey` using the same `Registry`.

This double-use of the registry feels counter-intuitive. Therefore, I have added a new method, `#getTagValues(...)`, which does the last two steps automatically, resulting in the following, new steps:
- Retrieve the `Registry`.
- Retrieve all tagged entries using `Registry#getTagValues(...)`

```java
// The current way
Collection<ItemType> manualResolve = Registry.ITEM
    .getTag(ItemTypeTagKeys.LOGS_THAT_BURN)
    .resolve(Registry.ITEM);

// The new way
Collection<ItemType> quickResolve = Registry.ITEM
    .getTagValues(ItemTypeTagKeys.LOGS_THAT_BURN);
```