### PR TITLE
Add ItemType#getBurnDuration()

### DIFF
--- a/paper-api/src/main/java/org/bukkit/inventory/ItemType.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemType.java
@@ -3021,8 +3021,17 @@ public interface ItemType extends Keyed, Translatable, net.kyori.adventure.trans
      * Checks if this item type can be used as fuel in a Furnace
      *
      * @return true if this item type can be used as fuel.
+     * @see #getBurnDuration() 
      */
     boolean isFuel();
+
+    /**
+     * Retrieve the item's burn duration in a Furnace
+     * 
+     * @return the burn duration, in ticks or 0 if the item is not fuel
+     * @see #isFuel()
+     */
+    int getBurnDuration();
 
     /**
      * Checks whether this item type is compostable (can be inserted into a

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
@@ -15,6 +15,7 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.level.block.ComposterBlock;
+import net.minecraft.world.level.block.entity.FuelValues;
 import org.bukkit.Material;
 import org.bukkit.Registry;
 import org.bukkit.World;
@@ -153,6 +154,18 @@ public class CraftItemType<M extends ItemMeta> extends HolderableBase<Item> impl
     @Override
     public boolean isFuel() {
         return MinecraftServer.getServer().fuelValues().isFuel(new net.minecraft.world.item.ItemStack(this.getHandle()));
+    }
+
+    @Override
+    public int getBurnDuration() {
+        FuelValues fuelValues = MinecraftServer.getServer().fuelValues();
+        net.minecraft.world.item.ItemStack stack = new net.minecraft.world.item.ItemStack(this.getHandle());
+        
+        if (!fuelValues.isFuel(stack)) {
+            return 0;
+        }
+        
+        return fuelValues.burnDuration(stack);
     }
 
     @Override


### PR DESCRIPTION
Adds a new method to `ItemType` which allows for retrieving an item's burn duration in a furnace.

The following prints out all burnable item's burn durations:
```java
String burnTimes = String.join("\n- ", Registry.ITEM.stream()
    .filter(ItemType::isFuel)
    .map(type -> type.key().value() + ": " + type.getBurnDuration())
    .toList());
getComponentLogger().info("All items' burn times: \n- {}", burnTimes);
```

Output (truncated):
```
[15:40:24 INFO]: [Paper-Test-Plugin] Enabling Paper-Test-Plugin v1.0.0-SNAPSHOT
[15:40:24 INFO]: [Paper-Test-Plugin] All items' burn times: 
- charcoal: 1600
- dark_oak_button: 100
- cherry_sapling: 100
- pale_oak_door: 200
- red_wool: 100
- stripped_dark_oak_wood: 300
- ...
```