### PR TITLE
feat: expose updateDemand and restock on Villager

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -419,6 +419,7 @@ public net.minecraft.world.entity.npc.Villager increaseMerchantCareer()V
 public net.minecraft.world.entity.npc.Villager numberOfRestocksToday
 public net.minecraft.world.entity.npc.Villager releaseAllPois()V
 public net.minecraft.world.entity.npc.Villager setUnhappy()V
+public net.minecraft.world.entity.npc.Villager updateDemand()V
 public net.minecraft.world.entity.npc.WanderingTrader getWanderTarget()Lnet/minecraft/core/BlockPos;
 public net.minecraft.world.entity.player.Abilities flyingSpeed
 public net.minecraft.world.entity.player.Abilities walkingSpeed

--- a/paper-api/src/main/java/org/bukkit/entity/Villager.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Villager.java
@@ -394,12 +394,18 @@ public interface Villager extends AbstractVillager {
 
     /**
      * Updates the demand for Villager offers.
-     * This is used to calculate price changes for regularly traded offers.
+     * Demand can rise and fall based on how often offers are traded.
+     * They can fall when an item is not traded for a while, or rise when the item is resupplied next.
+     * Demand is used to calculate the price of items in the Villager's offers.
+     * <br>
+     * <b>Note: Demand is stored per item and not per Villager.</b>
      */
     public void updateDemand();
 
     /**
-     * Restocks all offers for the Villager.
+     * Resets uses of all offers for the Villager. This also internally calls {@link #updateDemand()}.
+     * Calling this will trigger a {@link org.bukkit.event.entity.VillagerReplenishTradeEvent} for each offer that is restocked.
+     * Demand is still updated even if all events are canceled.
      */
     public void restock();
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Villager.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Villager.java
@@ -391,4 +391,15 @@ public interface Villager extends AbstractVillager {
      * reputation regardless of its impact and the player associated.
      */
     public void clearReputations();
+
+    /**
+     * Updates the demand for Villager offers.
+     * This is used to calculate price changes for regularly traded offers.
+     */
+    public void updateDemand();
+
+    /**
+     * Restocks all offers for the Villager.
+     */
+    public void restock();
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
@@ -383,8 +383,12 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
     }
 
     @Override
-    public void updateDemand() { getHandle().updateDemand(); }
+    public void updateDemand() {
+        getHandle().updateDemand();
+    }
 
     @Override
-    public void restock() { getHandle().restock(); }
+    public void restock() {
+        getHandle().restock();
+    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
@@ -11,7 +11,6 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.world.entity.monster.Zombie;
 import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.entity.npc.VillagerType;
-import net.minecraft.world.item.trading.MerchantOffer;
 import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import org.bukkit.Location;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
@@ -11,6 +11,7 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.world.entity.monster.Zombie;
 import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.entity.npc.VillagerType;
+import net.minecraft.world.item.trading.MerchantOffer;
 import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import org.bukkit.Location;
@@ -380,4 +381,10 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
     public void clearReputations() {
         getHandle().getGossips().gossips.clear();
     }
+
+    @Override
+    public void updateDemand() { getHandle().updateDemand(); }
+
+    @Override
+    public void restock() { getHandle().restock(); }
 }


### PR DESCRIPTION
These functions are super helpful when creating a plugin to disable the AI of the Villager as they're needed to ensure stock and demand are still calculated like Vanilla. 

Restock could always be done manually through the API but demand wasn't possible before this. Tested it with my lobotomizing plugin and it works :) 

First time doing an API PR so let me know if it's wrong lol