### PR TITLE
[Fix] Prevent dupe via PlayerDropItemEvent when using /give

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
@@ -8,7 +8,31 @@
          int maxStackSize = itemStack.getMaxStackSize();
          int i = maxStackSize * 100;
          if (count > i) {
-@@ -95,11 +_,11 @@
+@@ -65,8 +_,10 @@
+                     i1 -= min;
+                     ItemStack itemStack1 = item.createItemStack(min, false);
+                     boolean flag = serverPlayer.getInventory().add(itemStack1);
++
++                    // Paper start - Fix PlayerDropItemEvent dupe on /give
++                    ItemEntity itemEntity = serverPlayer.drop(itemStack1, false, false, false, null);
+                     if (flag && itemStack1.isEmpty()) {
+-                        ItemEntity itemEntity = serverPlayer.drop(itemStack, false);
+                         if (itemEntity != null) {
+                             itemEntity.makeFakeItem();
+                         }
+@@ -84,22 +_,22 @@
+                             );
+                         serverPlayer.containerMenu.broadcastChanges();
+                     } else {
+-                        ItemEntity itemEntity = serverPlayer.drop(itemStack1, false);
+                         if (itemEntity != null) {
+                             itemEntity.setNoPickUpDelay();
+                             itemEntity.setTarget(serverPlayer.getUUID());
+                         }
+                     }
++                    // Paper end - Fix PlayerDropItemEvent dupe on /give
+                 }
+             }
  
              if (targets.size() == 1) {
                  source.sendSuccess(


### PR DESCRIPTION
Fixes #12609 

Cancelling PlayerDropItemEvent would cause items from /give to be duplicated