### PR TITLE
[Fix] Prevent dupe via PlayerDropItemEvent when using /give

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
@@ -8,31 +8,29 @@
          int maxStackSize = itemStack.getMaxStackSize();
          int i = maxStackSize * 100;
          if (count > i) {
-@@ -65,8 +_,10 @@
-                     i1 -= min;
+@@ -66,7 +_,9 @@
                      ItemStack itemStack1 = item.createItemStack(min, false);
                      boolean flag = serverPlayer.getInventory().add(itemStack1);
-+
-+                    // Paper start - Fix PlayerDropItemEvent dupe on /give
-+                    ItemEntity itemEntity = serverPlayer.drop(itemStack1, false, false, false, null);
                      if (flag && itemStack1.isEmpty()) {
 -                        ItemEntity itemEntity = serverPlayer.drop(itemStack, false);
++                        // Paper start - Fix PlayerDropItemEvent dupe on /give
++                        ItemEntity itemEntity = serverPlayer.drop(itemStack, false, false, false, null);
++                        // Paper end - Fix PlayerDropItemEvent dupe on /give
                          if (itemEntity != null) {
                              itemEntity.makeFakeItem();
                          }
-@@ -84,22 +_,22 @@
+@@ -84,7 +_,9 @@
                              );
                          serverPlayer.containerMenu.broadcastChanges();
                      } else {
 -                        ItemEntity itemEntity = serverPlayer.drop(itemStack1, false);
++                        // Paper start - Fix PlayerDropItemEvent dupe on /give
++                        ItemEntity itemEntity = serverPlayer.drop(itemStack1, false, false, false, null);
++                        // Paper end - Fix PlayerDropItemEvent dupe on /give
                          if (itemEntity != null) {
                              itemEntity.setNoPickUpDelay();
                              itemEntity.setTarget(serverPlayer.getUUID());
-                         }
-                     }
-+                    // Paper end - Fix PlayerDropItemEvent dupe on /give
-                 }
-             }
+@@ -95,11 +_,11 @@
  
              if (targets.size() == 1) {
                  source.sendSuccess(

--- a/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
@@ -8,7 +8,31 @@
          int maxStackSize = itemStack.getMaxStackSize();
          int i = maxStackSize * 100;
          if (count > i) {
-@@ -95,11 +_,11 @@
+@@ -65,8 +_,10 @@
+                     i1 -= min;
+                     ItemStack itemStack1 = item.createItemStack(min, false);
+                     boolean flag = serverPlayer.getInventory().add(itemStack1);
++
++                    // Paper start - Fix PlayerDropItemEvent dupe on /give
++                    ItemEntity itemEntity = serverPlayer.drop(itemStack1, false, false, false, null);
+                     if (flag && itemStack1.isEmpty()) {
+-                        ItemEntity itemEntity = serverPlayer.drop(itemStack, false);
+                         if (itemEntity != null) {
+                             itemEntity.makeFakeItem();
+                         }
+@@ -84,22 +_,22 @@
+                             );
+                         serverPlayer.containerMenu.broadcastChanges();
+                     } else {
+-                        ItemEntity itemEntity = serverPlayer.drop(itemStack1, false);
+                         if (itemEntity != null) {
+                             itemEntity.setNoPickUpDelay();
+                             itemEntity.setTarget(serverPlayer.getUUID());
+                         }
+                     }
++                    // Paper end - Fix PlayerDropItemEvent dupe on /give
+                 }
+             }
  
              if (targets.size() == 1) {
                  source.sendSuccess(

--- a/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
@@ -8,25 +8,21 @@
          int maxStackSize = itemStack.getMaxStackSize();
          int i = maxStackSize * 100;
          if (count > i) {
-@@ -66,7 +_,9 @@
+@@ -66,7 +_,7 @@
                      ItemStack itemStack1 = item.createItemStack(min, false);
                      boolean flag = serverPlayer.getInventory().add(itemStack1);
                      if (flag && itemStack1.isEmpty()) {
 -                        ItemEntity itemEntity = serverPlayer.drop(itemStack, false);
-+                        // Paper start - Fix PlayerDropItemEvent dupe on /give
-+                        ItemEntity itemEntity = serverPlayer.drop(itemStack, false, false, false, null);
-+                        // Paper end - Fix PlayerDropItemEvent dupe on /give
++                        ItemEntity itemEntity = serverPlayer.drop(itemStack, false, false, false, null); // Paper - do not fire PlayerDropItemEvent for /give command
                          if (itemEntity != null) {
                              itemEntity.makeFakeItem();
                          }
-@@ -84,7 +_,9 @@
+@@ -84,7 +_,7 @@
                              );
                          serverPlayer.containerMenu.broadcastChanges();
                      } else {
 -                        ItemEntity itemEntity = serverPlayer.drop(itemStack1, false);
-+                        // Paper start - Fix PlayerDropItemEvent dupe on /give
-+                        ItemEntity itemEntity = serverPlayer.drop(itemStack1, false, false, false, null);
-+                        // Paper end - Fix PlayerDropItemEvent dupe on /give
++                        ItemEntity itemEntity = serverPlayer.drop(itemStack1, false, false, false, null); // Paper - do not fire PlayerDropItemEvent for /give command
                          if (itemEntity != null) {
                              itemEntity.setNoPickUpDelay();
                              itemEntity.setTarget(serverPlayer.getUUID());


### PR DESCRIPTION
Fixes #12609 

Cancelling PlayerDropItemEvent would cause items from /give to be duplicated