### PR TITLE
Fix missing calls for Target in Warden

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/warden/Roar.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/warden/Roar.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/ai/behavior/warden/Roar.java
++++ b/net/minecraft/world/entity/ai/behavior/warden/Roar.java
+@@ -64,7 +_,7 @@
+             entity.setPose(Pose.STANDING);
+         }
+ 
+-        entity.getBrain().getMemory(MemoryModuleType.ROAR_TARGET).ifPresent(entity::setAttackTarget);
++        entity.getBrain().getMemory(MemoryModuleType.ROAR_TARGET).ifPresent(livingEntity -> entity.setAttackTarget(livingEntity, org.bukkit.event.entity.EntityTargetEvent.TargetReason.CLOSEST_ENTITY)); // Paper
+         entity.getBrain().eraseMemory(MemoryModuleType.ROAR_TARGET);
+     }
+ }

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/warden/Warden.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/warden/Warden.java.patch
@@ -9,7 +9,7 @@
      }
  
      @Override
-@@ -446,6 +_,15 @@
+@@ -446,11 +_,20 @@
      @VisibleForTesting
      public void increaseAngerAt(@Nullable Entity entity, int offset, boolean playListeningSound) {
          if (!this.isNoAi() && this.canTargetEntity(entity)) {
@@ -25,3 +25,73 @@
              WardenAi.setDigCooldown(this);
              boolean flag = !(this.getTarget() instanceof Player);
              int i = this.angerManagement.increaseAnger(entity, offset);
+             if (entity instanceof Player && flag && AngerLevel.byAnger(i).isAngry()) {
+-                this.getBrain().eraseMemory(MemoryModuleType.ATTACK_TARGET);
++                this.removeAttackTarget(org.bukkit.event.entity.EntityTargetEvent.TargetReason.FORGOT_TARGET); // Paper - handle remove target over "this.getBrain().eraseMemory(MemoryModuleType.ATTACK_TARGET);"
+             }
+ 
+             if (playListeningSound) {
+@@ -498,14 +_,62 @@
+             if (this.brain.getMemory(MemoryModuleType.ATTACK_TARGET).isEmpty()
+                 && entity instanceof LivingEntity livingEntity
+                 && (damageSource.isDirect() || this.closerThan(livingEntity, 5.0))) {
+-                this.setAttackTarget(livingEntity);
++                this.setAttackTarget(livingEntity, org.bukkit.event.entity.EntityTargetEvent.TargetReason.TARGET_ATTACKED_ENTITY); // Paper
+             }
+         }
+ 
+         return flag;
+     }
+ 
++    // Paper start - remove target
++    public void removeAttackTarget() {
++        this.removeAttackTarget(org.bukkit.event.entity.EntityTargetEvent.TargetReason.UNKNOWN);
++    }
++
++    public void removeAttackTarget(@Nullable org.bukkit.event.entity.EntityTargetEvent.TargetReason reason) {
++        if (reason != null) {
++            org.bukkit.event.entity.EntityTargetLivingEntityEvent event = new org.bukkit.event.entity.EntityTargetLivingEntityEvent(this.getBukkitEntity(), null, org.bukkit.event.entity.EntityTargetEvent.TargetReason.FORGOT_TARGET);
++            if (!event.callEvent()) {
++                return;
++            }
++
++            if (event.getTarget() != null) {
++                LivingEntity attackTarget = ((org.bukkit.craftbukkit.entity.CraftLivingEntity) event.getTarget()).getHandle();
++                this.getBrain().setMemory(MemoryModuleType.ATTACK_TARGET, attackTarget);
++                return;
++            }
++        }
++        this.getBrain().eraseMemory(net.minecraft.world.entity.ai.memory.MemoryModuleType.ATTACK_TARGET);
++    }
++    // Paper end - remove target
++
+     public void setAttackTarget(LivingEntity attackTarget) {
++        // Paper start - handle EntityTargetLivingEntityEvent
++        this.setAttackTarget(attackTarget, org.bukkit.event.entity.EntityTargetEvent.TargetReason.UNKNOWN);
++    }
++
++    public void setAttackTarget(LivingEntity attackTarget, @Nullable org.bukkit.event.entity.EntityTargetEvent.TargetReason reason) {
++        if (this.getTarget() == attackTarget) {
++            return;
++        }
++        if (reason != null) {
++            if (reason == org.bukkit.event.entity.EntityTargetEvent.TargetReason.UNKNOWN) {
++                this.level().getCraftServer().getLogger().log(java.util.logging.Level.WARNING, "Unknown target reason, please report on the issue tracker", new Exception());
++            }
++            org.bukkit.craftbukkit.entity.CraftLivingEntity ctarget = (org.bukkit.craftbukkit.entity.CraftLivingEntity) attackTarget.getBukkitEntity();
++            org.bukkit.event.entity.EntityTargetLivingEntityEvent event = new org.bukkit.event.entity.EntityTargetLivingEntityEvent(this.getBukkitEntity(), ctarget, reason);
++            if (!event.callEvent()) {
++                return;
++            }
++
++            if (event.getTarget() != null) {
++                attackTarget = ((org.bukkit.craftbukkit.entity.CraftLivingEntity) event.getTarget()).getHandle();
++            } else {
++                this.getBrain().eraseMemory(net.minecraft.world.entity.ai.memory.MemoryModuleType.ATTACK_TARGET);
++                return;
++            }
++        }
++        // Paper end - handle EntityTargetLivingEntityEvent
+         this.getBrain().eraseMemory(MemoryModuleType.ROAR_TARGET);
+         this.getBrain().setMemory(MemoryModuleType.ATTACK_TARGET, attackTarget);
+         this.getBrain().eraseMemory(MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWarden.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftWarden.java
@@ -8,6 +8,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityTargetEvent;
 
 public class CraftWarden extends CraftMonster implements org.bukkit.entity.Warden {
 
@@ -69,6 +70,11 @@ public class CraftWarden extends CraftMonster implements org.bukkit.entity.Warde
         Preconditions.checkArgument(location != null, "Location cannot be null");
 
         WardenAi.setDisturbanceLocation(this.getHandle(), BlockPos.containing(location.getX(), location.getY(), location.getZ()));
+    }
+
+    @Override
+    public void setTarget(LivingEntity livingEntity) {
+        this.getHandle().setAttackTarget(((CraftLivingEntity) livingEntity).getHandle(), EntityTargetEvent.TargetReason.CUSTOM);
     }
 
     @Override


### PR DESCRIPTION
This PR try to manage a few things related to the Warden and target (thanks memory)
- Call EntityTargetEvent when target is set
- Override the setTarget in Warden class to use the memory method and not the legacy field what its not used for this