### PR TITLE
Fix UOE when using generateTree with pale oak

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
@@ -86,6 +86,11 @@ public class BlockStateListPopulator extends DummyGeneratorAccess {
         return this.world.getMinecraftWorld();
     }
 
+    @Override
+    public ServerLevel getLevel() {
+        return this.getMinecraftWorld();
+    }
+
     public void refreshTiles() {
         for (CraftBlockState snapshot : this.blocks.values()) {
             if (snapshot instanceof CraftBlockEntityState) {


### PR DESCRIPTION
Fixes an UOE error when the consumer/predicate generateTree methods are used with the pale oak tree type. I'm not sure if there's something inherently wrong with implementing getLevel here, but otherwise it could be fixed by passing only the generator along to the PaleMossDecorator.

```
java.lang.UnsupportedOperationException: Not supported yet.
	at org.bukkit.craftbukkit.util.DummyGeneratorAccess.getLevel(DummyGeneratorAccess.java:58) ~[main/:?]
	at net.minecraft.world.level.levelgen.feature.treedecorators.PaleMossDecorator.lambda$place$6(PaleMossDecorator.java:61) ~[main/:?]
	at java.base/java.util.Optional.ifPresent(Optional.java:178) ~[?:?]
	at net.minecraft.world.level.levelgen.feature.treedecorators.PaleMossDecorator.place(PaleMossDecorator.java:59) ~[main/:?]
	at net.minecraft.world.level.levelgen.feature.TreeFeature.lambda$place$8(TreeFeature.java:155) ~[main/:?]
	at java.base/java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
	at net.minecraft.world.level.levelgen.feature.TreeFeature.place(TreeFeature.java:155) ~[main/:?]
	at net.minecraft.world.level.levelgen.feature.Feature.place(Feature.java:192) ~[main/:?]
	at net.minecraft.world.level.levelgen.feature.ConfiguredFeature.place(ConfiguredFeature.java:25) ~[main/:?]
	at org.bukkit.craftbukkit.CraftRegionAccessor.generateTree(CraftRegionAccessor.java:291) ~[main/:?]
	at org.bukkit.craftbukkit.CraftRegionAccessor.generateTree(CraftRegionAccessor.java:200) ~[main/:?]
```