### PR TITLE
Port callback command to brigadier

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/command/CallbackCommand.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/CallbackCommand.java
@@ -7,6 +7,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import java.util.UUID;
 
+@Deprecated(forRemoval = true)
 @DefaultQualifier(NonNull.class)
 public class CallbackCommand extends Command {
 

--- a/paper-server/src/main/java/io/papermc/paper/command/PaperCallbackCommand.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/PaperCallbackCommand.java
@@ -1,0 +1,32 @@
+package io.papermc.paper.command;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import io.papermc.paper.adventure.providers.ClickCallbackProviderImpl;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.Commands;
+import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
+import java.util.UUID;
+import org.bukkit.command.CommandSender;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class PaperCallbackCommand {
+    public static final String DESCRIPTION = "ClickEvent callback";
+
+    public static LiteralCommandNode<CommandSourceStack> create() {
+        final PaperCallbackCommand command = new PaperCallbackCommand();
+        return Commands.literal("callback")
+            .then(Commands.argument("uuid", ArgumentTypes.uuid())
+                .executes(command::execute))
+            .build();
+    }
+
+    private int execute(final CommandContext<CommandSourceStack> context) {
+        final CommandSender sender = context.getSource().getSender();
+        final UUID id = context.getArgument("uuid", UUID.class);
+        ClickCallbackProviderImpl.CALLBACK_MANAGER.runCallback(sender, id);
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/command/PaperCommands.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/PaperCommands.java
@@ -23,7 +23,6 @@ public final class PaperCommands {
 
     public static void registerCommands(final MinecraftServer server) {
         COMMANDS.put("paper", new PaperCommand("paper"));
-        COMMANDS.put("callback", new CallbackCommand("callback"));
         COMMANDS.put("mspt", new MSPTCommand("mspt"));
 
         COMMANDS.forEach((s, command) -> {

--- a/paper-server/src/main/java/io/papermc/paper/command/PaperCommands.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/PaperCommands.java
@@ -35,6 +35,7 @@ public final class PaperCommands {
     public static void registerCommands() {
         // Paper commands go here
         registerInternalCommand(PaperVersionCommand.create(), "bukkit", PaperVersionCommand.DESCRIPTION, List.of("ver", "about"), Set.of());
+        registerInternalCommand(PaperCallbackCommand.create(), "paper", PaperCallbackCommand.DESCRIPTION, List.of(), Set.of(CommandRegistrationFlag.SERVER_ONLY));
     }
 
     private static void registerInternalCommand(final LiteralCommandNode<CommandSourceStack> node, final String namespace, final String description, final List<String> aliases, final Set<CommandRegistrationFlag> flags) {


### PR DESCRIPTION
The brigadier version also makes use of the SERVER_ONLY command flag, which doesn't send the command to the client.