### PR TITLE
Update component flattening to work properly with Adventure 4.20.0

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
@@ -35,7 +35,7 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.kyori.adventure.translation.GlobalTranslator;
-import net.kyori.adventure.translation.TranslationRegistry;
+import net.kyori.adventure.translation.TranslationStore;
 import net.kyori.adventure.translation.Translator;
 import net.kyori.adventure.util.Codec;
 import net.minecraft.ChatFormatting;
@@ -81,7 +81,7 @@ public final class PaperAdventure {
         .complexMapper(TranslatableComponent.class, (translatable, consumer) -> {
             if (!Language.getInstance().has(translatable.key())) {
                 for (final Translator source : GlobalTranslator.translator().sources()) {
-                    if (source instanceof TranslationRegistry registry && registry.contains(translatable.key())) {
+                    if (source instanceof TranslationStore<?> store && store.contains(translatable.key())) {
                         consumer.accept(GlobalTranslator.render(translatable, Locale.US));
                         return;
                     }

--- a/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
@@ -35,8 +35,6 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.kyori.adventure.translation.GlobalTranslator;
-import net.kyori.adventure.translation.TranslationStore;
-import net.kyori.adventure.translation.Translator;
 import net.kyori.adventure.util.Codec;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;


### PR DESCRIPTION
Adventure v4.20.0 has introduced `TranslationStore` interface as a replacement for the old `TranslationRegistry`, so Paper's platform flattener needs to account for that as well to render translatable components properly.

`TranslationRegistry` now extends `TranslationStore`, so this change is fully backwards-compitable with plugins that still use `TranslationRegistry`.