### PR TITLE
Add support for private constructors in plugin main classes

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/plugin/provider/util/ProviderUtil.java
+++ b/paper-api/src/main/java/io/papermc/paper/plugin/provider/util/ProviderUtil.java
@@ -4,6 +4,7 @@ import com.destroystokyo.paper.util.SneakyThrow;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InaccessibleObjectException;
 
 /**

--- a/paper-api/src/main/java/io/papermc/paper/plugin/provider/util/ProviderUtil.java
+++ b/paper-api/src/main/java/io/papermc/paper/plugin/provider/util/ProviderUtil.java
@@ -4,6 +4,7 @@ import com.destroystokyo.paper.util.SneakyThrow;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import java.lang.reflect.InaccessibleObjectException;
 
 /**
  * An <b>internal</b> utility type that holds logic for loading a provider-like type from a classloaders.
@@ -56,7 +57,14 @@ public final class ProviderUtil {
                     throw new ClassCastException("class '%s' does not extend '%s'".formatted(clazz, classType));
                 }
 
-                clazzInstance = pluginClass.getDeclaredConstructor().newInstance();
+                final Constructor<? extends T> constructor = pluginClass.getDeclaredConstructor();
+                try {
+                    constructor.setAccessible(true); // Allow non-public constructors
+                } catch (final InaccessibleObjectException | SecurityException ex) {
+                    throw new RuntimeException("Inaccessible constructor");
+                }
+
+                clazzInstance = constructor.newInstance();
             } catch (final IllegalAccessException exception) {
                 throw new RuntimeException("No public constructor");
             } catch (final InstantiationException exception) {


### PR DESCRIPTION
Adds support for private constructors in plugin main classes, using `Constructor#setAccessible(boolean)`, allowing for better encapsulation.