### PR TITLE
Fix excess slot updates / inventory state id desync

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -157,7 +157,7 @@
  
                  slot.setChanged();
 +                // CraftBukkit start - Make sure the client has the right slot contents
-+                if (player instanceof ServerPlayer serverPlayer && slot.getMaxStackSize() != 64) {
++                if (player instanceof ServerPlayer serverPlayer && slot.getMaxStackSize() != net.minecraft.world.Container.MAX_STACK) {
 +                    serverPlayer.connection.send(new net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket(this.containerId, this.incrementStateId(), slot.index, slot.getItem()));
 +                    // Updating a crafting inventory makes the client reset the result slot, have to send it again
 +                    if (this.getBukkitView().getType() == org.bukkit.event.inventory.InventoryType.WORKBENCH || this.getBukkitView().getType() == org.bukkit.event.inventory.InventoryType.CRAFTING) {


### PR DESCRIPTION
Fixes inventory state id desync with high ping causing inventory to be "buggy" (ghost items, items jumping to/from cursor, etc)

Without patch: https://youtu.be/hOXt3Rpkgtg
With patch: https://youtu.be/MtOYD7uieS4

https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/df01cf867a2255024aacf9ac2ff6a56b2ffb7ce5#nms-patches/net/minecraft/world/inventory/Container.patch

https://discord.com/channels/289587909051416579/555462289851940864/1382165293308182699