### PR TITLE
Added function to empty an entity's loot table.

### DIFF
--- a/paper-api/src/main/java/org/bukkit/loot/Lootable.java
+++ b/paper-api/src/main/java/org/bukkit/loot/Lootable.java
@@ -61,6 +61,15 @@ public interface Lootable {
     default void clearLootTable() {
         this.setLootTable(null);
     }
+
+    /**
+     * Empties the Loot Table of this object, making it not generate any Loot
+     * This uses the PLAYER Loot Table since it is, by default, empty and there is no EMPTY Table
+     * Possible edges cases may appear if the PLAYER Table is changed.
+     */
+    default void emptyLootTable() {
+        this.setLootTable(Bukkit.getLootTable(LootTables.PLAYER.getKey()));
+    }
     // Paper end
 
     /**


### PR DESCRIPTION
Fix #11849

By replacing the entity's loot table with an empty one, we ensure that the entity will not drop any items when killed, fixing the issue related to "clearLootTable" not working as expected.

Signed-off-by: Tiago Ferreira <tiago.a.p.ferreira@tecnico.ulisboa.pt>