### PR TITLE
Remove unnecesary Item check for ServerboundPlayerActionPacket RELEASE_USE_ITEM

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1149,8 +1149,7 @@
  
                      return;
                  case RELEASE_USE_ITEM:
--                    this.player.releaseUsingItem();
-+                    if (this.player.getUseItem().getItem() == this.player.getItemInHand(this.player.getUsedItemHand()).getItem()) this.player.releaseUsingItem(); // Paper - validate use item before processing release
+                     this.player.releaseUsingItem();
 +                    if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.updateEquipmentOnPlayerActions) this.player.detectEquipmentUpdates(); // Paper - Force update attributes.
                      return;
                  case START_DESTROY_BLOCK:

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1150,7 +1150,7 @@
                      return;
                  case RELEASE_USE_ITEM:
 -                    this.player.releaseUsingItem();
-+                    if (this.player.getUseItem() == this.player.getItemInHand(this.player.getUsedItemHand())) this.player.releaseUsingItem(); // Paper - validate use item before processing release
++                    if (this.player.getUseItem().getItem() == this.player.getItemInHand(this.player.getUsedItemHand()).getItem()) this.player.releaseUsingItem(); // Paper - validate use item before processing release
 +                    if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.updateEquipmentOnPlayerActions) this.player.detectEquipmentUpdates(); // Paper - Force update attributes.
                      return;
                  case START_DESTROY_BLOCK:


### PR DESCRIPTION
Try to fix #12667 by change the check currently this check the item is the same what cause an ignore for every change in item being released.. im sure this was added for a reason but not sure the impact of this change or is even necesary that check.