### PR TITLE
Allow empty paths in namespaced keys

### DIFF
--- a/paper-api/src/test/java/org/bukkit/NamespacedKeyTest.java
+++ b/paper-api/src/test/java/org/bukkit/NamespacedKeyTest.java
@@ -35,16 +35,6 @@ public class NamespacedKeyTest {
     }
 
     @Test
-    public void testEmptyNamespace() {
-        assertThrows(IllegalArgumentException.class, () -> new NamespacedKey("", "foo").toString());
-    }
-
-    @Test
-    public void testEmptyKey() {
-        assertThrows(IllegalArgumentException.class, () -> new NamespacedKey("minecraft", "").toString());
-    }
-
-    @Test
     public void testInvalidNamespace() {
         assertThrows(IllegalArgumentException.class, () -> new NamespacedKey("minecraft/test", "foo").toString());
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
@@ -39,7 +39,7 @@ public class CraftLootTable implements org.bukkit.loot.LootTable {
     }
 
     public static org.bukkit.loot.LootTable minecraftToBukkit(ResourceKey<LootTable> minecraft) {
-        return (minecraft == null || minecraft.location().getPath().isEmpty()) ? null : Bukkit.getLootTable(CraftLootTable.minecraftToBukkitKey(minecraft)); // Paper - fix some NamespacedKey parsing
+        return (minecraft == null) ? null : Bukkit.getLootTable(CraftLootTable.minecraftToBukkitKey(minecraft));
     }
 
     public static NamespacedKey minecraftToBukkitKey(ResourceKey<LootTable> minecraft) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftNamespacedKey.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftNamespacedKey.java
@@ -3,20 +3,11 @@ package org.bukkit.craftbukkit.util;
 import net.minecraft.resources.ResourceLocation;
 import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public final class CraftNamespacedKey {
 
     public CraftNamespacedKey() {
-    }
-
-    public static @Nullable NamespacedKey fromStringOrNull(@Nullable String string) {
-        if (string == null || string.isEmpty()) {
-            return null;
-        }
-        ResourceLocation minecraft = ResourceLocation.tryParse(string);
-        return (minecraft == null || minecraft.getPath().isEmpty()) ? null : CraftNamespacedKey.fromMinecraft(minecraft); // Paper - Bukkit's parser does not match Vanilla for empty paths
     }
 
     public static NamespacedKey fromString(String string) {


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/12325

This makes it consistent with vanilla and adventure, it's weird that it's allowed by the game but i think it's easier to do that
rather than cover all the place and just ignore some data. And with adventure there's no justification that a key couldn't be converted to a namespaced key in method like Registry#get.
The implementation is roughly based on adventure (minus one bug).