### PR TITLE
Expose arrow velocity in EntityShootBowEvent for mobs

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
@@ -43,23 +43,36 @@
          if (this.getItemBySlot(EquipmentSlot.HEAD).isEmpty()) {
              LocalDate localDate = LocalDate.now();
              int i = localDate.get(ChronoField.DAY_OF_MONTH);
-@@ -196,9 +_,19 @@
+@@ -188,7 +_,8 @@
+ 
+     @Override
+     public void performRangedAttack(LivingEntity target, float distanceFactor) {
+-        ItemStack itemInHand = this.getItemInHand(ProjectileUtil.getWeaponHoldingHand(this, Items.BOW));
++        net.minecraft.world.InteractionHand hand = ProjectileUtil.getWeaponHoldingHand(this, Items.BOW); // Paper - call EntityShootBowEvent
++        ItemStack itemInHand = this.getItemInHand(hand); // Paper - call EntityShootBowEvent
+         ItemStack projectile = this.getProjectile(itemInHand);
+         AbstractArrow arrow = this.getArrow(projectile, distanceFactor, itemInHand);
+         double d = target.getX() - this.getX();
+@@ -196,9 +_,21 @@
          double d2 = target.getZ() - this.getZ();
          double squareRoot = Math.sqrt(d * d + d2 * d2);
          if (this.level() instanceof ServerLevel serverLevel) {
-+            // CraftBukkit start
-+            org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(this, this.getMainHandItem(), arrow.getPickupItem(), arrow, net.minecraft.world.InteractionHand.MAIN_HAND, distanceFactor, true); // Paper - improve entity shoot bow event, add arrow stack to event
+-            Projectile.spawnProjectileUsingShoot(
++            Projectile.Delayed<AbstractArrow> delayedEntity = Projectile.spawnProjectileUsingShootDelayed( // Paper - delayed
+                 arrow, serverLevel, projectile, d, d1 + squareRoot * 0.2F, d2, 1.6F, 14 - serverLevel.getDifficulty().getId() * 4
+             );
++
++            // Paper start - call EntityShootBowEvent
++            org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(this, itemInHand, arrow.getPickupItem(), arrow, hand, distanceFactor, true);
 +            if (event.isCancelled()) {
 +                event.getProjectile().remove();
 +                return;
 +            }
 +
 +            if (event.getProjectile() == arrow.getBukkitEntity()) {
-+            // CraftBukkit end
-             Projectile.spawnProjectileUsingShoot(
-                 arrow, serverLevel, projectile, d, d1 + squareRoot * 0.2F, d2, 1.6F, 14 - serverLevel.getDifficulty().getId() * 4
-             );
-+            } // CraftBukkit
++                delayedEntity.spawn();
++            }
++            // Paper end - call EntityShootBowEvent
          }
  
          this.playSound(SoundEvents.SKELETON_SHOOT, 1.0F, 1.0F / (this.getRandom().nextFloat() * 0.4F + 0.8F));

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/Illusioner.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/Illusioner.java.patch
@@ -1,22 +1,35 @@
 --- a/net/minecraft/world/entity/monster/Illusioner.java
 +++ b/net/minecraft/world/entity/monster/Illusioner.java
-@@ -180,9 +_,19 @@
+@@ -172,7 +_,8 @@
+ 
+     @Override
+     public void performRangedAttack(LivingEntity target, float distanceFactor) {
+-        ItemStack itemInHand = this.getItemInHand(ProjectileUtil.getWeaponHoldingHand(this, Items.BOW));
++        net.minecraft.world.InteractionHand hand = ProjectileUtil.getWeaponHoldingHand(this, Items.BOW); // Paper - call EntityShootBowEvent
++        ItemStack itemInHand = this.getItemInHand(hand); // Paper - call EntityShootBowEvent
+         ItemStack projectile = this.getProjectile(itemInHand);
+         AbstractArrow mobArrow = ProjectileUtil.getMobArrow(this, projectile, distanceFactor, itemInHand);
+         double d = target.getX() - this.getX();
+@@ -180,9 +_,21 @@
          double d2 = target.getZ() - this.getZ();
          double squareRoot = Math.sqrt(d * d + d2 * d2);
          if (this.level() instanceof ServerLevel serverLevel) {
-+            // Paper start - EntityShootBowEvent
-+            org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(this, this.getMainHandItem(), mobArrow.getPickupItem(), mobArrow, target.getUsedItemHand(), distanceFactor, true);
+-            Projectile.spawnProjectileUsingShoot(
++            Projectile.Delayed<AbstractArrow> delayedEntity = Projectile.spawnProjectileUsingShootDelayed( // Paper - delayed
+                 mobArrow, serverLevel, projectile, d, d1 + squareRoot * 0.2F, d2, 1.6F, 14 - serverLevel.getDifficulty().getId() * 4
+             );
++
++            // Paper start - call EntityShootBowEvent
++            org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(this, itemInHand, mobArrow.getPickupItem(), mobArrow, hand, distanceFactor, true);
 +            if (event.isCancelled()) {
 +                event.getProjectile().remove();
 +                return;
 +            }
 +
 +            if (event.getProjectile() == mobArrow.getBukkitEntity()) {
-             Projectile.spawnProjectileUsingShoot(
-                 mobArrow, serverLevel, projectile, d, d1 + squareRoot * 0.2F, d2, 1.6F, 14 - serverLevel.getDifficulty().getId() * 4
-             );
++                delayedEntity.spawn();
 +            }
-+            // Paper end - EntityShootBowEvent
++            // Paper end - call EntityShootBowEvent
          }
  
          this.playSound(SoundEvents.SKELETON_SHOOT, 1.0F, 1.0F / (this.getRandom().nextFloat() * 0.4F + 0.8F));


### PR DESCRIPTION
Closes #12675
This is a regression since 1.21.2, also fix the wrong hand/used item by those event calls.