### PR TITLE
Avoid and discourage use of Maven Central as a CDN

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/plugin/loader/library/impl/MavenLibraryResolver.java
+++ b/paper-api/src/main/java/io/papermc/paper/plugin/loader/library/impl/MavenLibraryResolver.java
@@ -59,9 +59,12 @@ public class MavenLibraryResolver implements ClassPathLibrary {
      * <p>This repository is also used by the legacy {@link org.bukkit.plugin.java.LibraryLoader}.</p>
      */
     public static final String MAVEN_CENTRAL_DEFAULT_MIRROR = getDefaultMavenCentralMirror();
-    private static final String MAVEN_CENTRAL_HOSTNAME_PATH = "repo.maven.apache.org/maven2";
-    private static final String MAVEN_CENTRAL_URL_HTTPS = "https://" + MAVEN_CENTRAL_HOSTNAME_PATH;
-    private static final String MAVEN_CENTRAL_URL_HTTP = "http://" + MAVEN_CENTRAL_HOSTNAME_PATH;
+    private static final List<String> MAVEN_CENTRAL_URLS = List.of(
+        "https://repo1.maven.org/maven2",
+        "http://repo1.maven.org/maven2",
+        "https://repo.maven.apache.org/maven2",
+        "http://repo.maven.apache.org/maven2"
+    );
     private static final Logger LOGGER = LoggerFactory.getLogger("MavenLibraryResolver");
 
     private final RepositorySystem repository;
@@ -117,7 +120,7 @@ public class MavenLibraryResolver implements ClassPathLibrary {
      * dependencies from
      */
     public void addRepository(final RemoteRepository remoteRepository) {
-        if (remoteRepository.getUrl().startsWith(MAVEN_CENTRAL_URL_HTTPS) || remoteRepository.getUrl().startsWith(MAVEN_CENTRAL_URL_HTTP)) {
+        if (MAVEN_CENTRAL_URLS.stream().anyMatch(remoteRepository.getUrl()::startsWith)) {
             LOGGER.warn(
                 "Use of Maven Central as a CDN is against the Maven Central Terms of Service. Use MavenLibraryResolver.MAVEN_CENTRAL_DEFAULT_MIRROR instead.",
                 new RuntimeException("Plugin used Maven Central for library resolution")

--- a/paper-api/src/main/java/io/papermc/paper/plugin/loader/library/impl/MavenLibraryResolver.java
+++ b/paper-api/src/main/java/io/papermc/paper/plugin/loader/library/impl/MavenLibraryResolver.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * MavenLibraryResolver resolver = new MavenLibraryResolver();
  * resolver.addDependency(new Dependency(new DefaultArtifact("org.jooq:jooq:3.17.7"), null));
  * resolver.addRepository(new RemoteRepository.Builder(
- *     "central", "default", "https://repo1.maven.org/maven2/"
+ *     "central", "default", MavenLibraryResolver.MAVEN_CENTRAL_DEFAULT_MIRROR
  * ).build());
  * }</pre>
  * <p>

--- a/paper-api/src/main/java/org/bukkit/plugin/java/LibraryLoader.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/java/LibraryLoader.java
@@ -1,11 +1,11 @@
 package org.bukkit.plugin.java;
 
+import io.papermc.paper.plugin.loader.library.impl.MavenLibraryResolver;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -29,7 +29,6 @@ import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transfer.AbstractTransferListener;
-import org.eclipse.aether.transfer.TransferCancelledException;
 import org.eclipse.aether.transfer.TransferEvent;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.jetbrains.annotations.NotNull;
@@ -47,18 +46,8 @@ public class LibraryLoader {
     public static java.util.function.BiFunction<URL[], ClassLoader, URLClassLoader> LIBRARY_LOADER_FACTORY; // Paper - rewrite reflection in libraries
     public static java.util.function.Function<List<java.nio.file.Path>, List<java.nio.file.Path>> REMAPPER; // Paper - remap libraries
 
-    // TODO: Consider moving this and adding per plugin support for defining repositories
     private static List<RemoteRepository> getRepositories() {
-        String central = System.getenv("PAPER_DEFAULT_CENTRAL_REPOSITORY");
-        if (central == null) {
-            central = System.getProperty("org.bukkit.plugin.java.LibraryLoader.centralURL");
-        }
-        if (central == null) {
-            central = "https://repo.maven.apache.org/maven2";
-        }
-
-        return Arrays.asList(new RemoteRepository.Builder("central", "default", central).build());
-
+        return List.of(new RemoteRepository.Builder("central", "default", MavenLibraryResolver.MAVEN_CENTRAL_DEFAULT_MIRROR).build());
     }
 
     public LibraryLoader(@NotNull Logger logger) {


### PR DESCRIPTION
Default LibraryLoader to Google's Maven Central mirror, add MavenLibraryResolver.MAVEN_CENTRAL_DEFAULT_MIRROR, and warn on use of Maven Central with MavenLibraryResolver

https://www.sonatype.com/blog/maven-central-and-the-tragedy-of-the-commons
https://www.sonatype.com/blog/beyond-ips-addressing-organizational-overconsumption-in-maven-central