### PR TITLE
Reinclude Log4j Javadocs

### DIFF
--- a/paper-api/build.gradle.kts
+++ b/paper-api/build.gradle.kts
@@ -184,7 +184,7 @@ tasks.withType<Javadoc> {
         "https://jd.advntr.dev/text-serializer-plain/$adventureVersion/",
         "https://jd.advntr.dev/text-logger-slf4j/$adventureVersion/",
         "https://javadoc.io/doc/org.slf4j/slf4j-api/$slf4jVersion/",
-        // "https://logging.apache.org/log4j/2.x/javadoc/log4j-api/", // TODO: Broken
+        "https://logging.apache.org/log4j/2.x/javadoc/log4j-api/",
         "https://javadoc.io/doc/org.apache.maven.resolver/maven-resolver-api/1.7.3",
     )
     options.tags("apiNote:a:API Note:")


### PR DESCRIPTION
Log4j Javadocs were recently fixed (https://github.com/apache/logging-log4j2/issues/3753), so they can be included in generation again.