### PR TITLE
Added PlayerRequestStatsEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerRequestStatsEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerRequestStatsEvent.java
@@ -1,0 +1,44 @@
+package io.papermc.paper.event.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * This event is fired when a player opens the Statistics menu on the client
+ * Cancelling this event will send no stat changes.
+ * If the client has not received the stats before, all stats will be set to 0, otherwise the cached stats will be shown. 
+ */
+@NullMarked
+public class PlayerRequestStatsEvent extends PlayerEvent implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+    private boolean cancelled;
+
+    @ApiStatus.Internal
+    public PlayerRequestStatsEvent(final Player player) {
+        super(player);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(final boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1943,7 +1943,7 @@
                      this.resetPosition();
                      CriteriaTriggers.CHANGED_DIMENSION.trigger(this.player, Level.END, Level.OVERWORLD);
                  } else {
-@@ -1774,11 +_,11 @@
+@@ -1774,31 +_,49 @@
                          return;
                      }
  
@@ -1958,7 +1958,17 @@
                      }
                  }
                  break;
-@@ -1789,16 +_,27 @@
+             case REQUEST_STATS:
++                // Paper start - PlayerRequestStatsEvent
++                io.papermc.paper.event.player.PlayerRequestStatsEvent event = new io.papermc.paper.event.player.PlayerRequestStatsEvent(this.getCraftPlayer());
++                if (!event.callEvent()) {
++                    player.connection.send(new net.minecraft.network.protocol.game.ClientboundAwardStatsPacket(new it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap<>()));
++                    return;
++                }
++                // Paper end
+                 this.player.getStats().sendStats(this.player);
+         }
+     }
  
      @Override
      public void handleContainerClose(ServerboundContainerClosePacket packet) {


### PR DESCRIPTION
Introduced `PlayerRequestStatsEvent` to allow handling when a player opens the statistics menu.
Cancellable event prevents stat updates.