### PR TITLE
Add missing forname rewrite rules

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/pluginremap/reflect/ReflectionRemapper.java
+++ b/paper-server/src/main/java/io/papermc/paper/pluginremap/reflect/ReflectionRemapper.java
@@ -22,6 +22,12 @@ public final class ReflectionRemapper {
     private static final RewriteRuleVisitorFactory VISITOR_FACTORY = RewriteRuleVisitorFactory.create(
         Opcodes.ASM9,
         chain -> chain.then(new BaseReflectionRules(PAPER_REFLECTION_HOLDER).rules())
+            .then(
+                io.papermc.asm.rules.RewriteRule.forOwnerClass(Class.class, rf -> {
+                    rf.plainStaticRewrite(java.lang.constant.ClassDesc.of(PAPER_REFLECTION_HOLDER), b -> b
+                        .match("forName").desc("(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;", "(Ljava/lang/Module;Ljava/lang/String;)Ljava/lang/Class;"));
+                })
+            )
             .then(DefineClassRule.create(PAPER_REFLECTION_HOLDER_DESC, true)),
         ClassInfoProvider.basic()
     );

--- a/paper-server/src/main/java/io/papermc/paper/pluginremap/reflect/ReflectionRemapper.java
+++ b/paper-server/src/main/java/io/papermc/paper/pluginremap/reflect/ReflectionRemapper.java
@@ -2,10 +2,12 @@ package io.papermc.paper.pluginremap.reflect;
 
 import io.papermc.asm.ClassInfoProvider;
 import io.papermc.asm.RewriteRuleVisitorFactory;
+import io.papermc.asm.rules.RewriteRule;
 import io.papermc.paper.util.MappingEnvironment;
 import io.papermc.reflectionrewriter.BaseReflectionRules;
 import io.papermc.reflectionrewriter.DefineClassRule;
 import io.papermc.reflectionrewriter.proxygenerator.ProxyGenerator;
+import java.lang.constant.ClassDesc;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -23,8 +25,8 @@ public final class ReflectionRemapper {
         Opcodes.ASM9,
         chain -> chain.then(new BaseReflectionRules(PAPER_REFLECTION_HOLDER).rules())
             .then(
-                io.papermc.asm.rules.RewriteRule.forOwnerClass(Class.class, rf -> {
-                    rf.plainStaticRewrite(java.lang.constant.ClassDesc.of(PAPER_REFLECTION_HOLDER), b -> b
+                RewriteRule.forOwnerClass(Class.class, rf -> {
+                    rf.plainStaticRewrite(ClassDesc.of(PAPER_REFLECTION_HOLDER), b -> b
                         .match("forName").desc("(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;", "(Ljava/lang/Module;Ljava/lang/String;)Ljava/lang/Class;"));
                 })
             )


### PR DESCRIPTION
A fix before [PaperMC/asm-utils#48](https://github.com/PaperMC/asm-utils/pull/48) is merged and Paper update asm-utils to 0.0.4.

Added missing reflection rewrite rules for overloaded `Class.forName` methods:
- `Class.forName(String, boolean, ClassLoader)`
- `Class.forName(Module, String)`

The redirected methods are existed in [AbstractDefaultRulesReflectionProxy](https://github.com/PaperMC/asm-utils/blob/main/reflection-rewriter/runtime/src/main/java/io/papermc/reflectionrewriter/runtime/AbstractDefaultRulesReflectionProxy.java) as of 0.0.3, but rules are not added yet.