### PR TITLE
Improve Fix MC-44654

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1832,17 +1832,17 @@
              int floor = Mth.floor(x);
              int floor1 = Mth.floor(y);
              int floor2 = Mth.floor(z);
-@@ -3684,8 +_,19 @@
-                 if (this instanceof ServerPlayer serverPlayer && serverPlayer.isReceivingWaypoints() && serverPlayer.connection != null) {
+@@ -3685,7 +_,18 @@
                      serverLevel.getWaypointManager().updatePlayer(serverPlayer);
                  }
-+                // Paper start - Fix MC-44654
-+                if (this.getType().updateInterval() == Integer.MAX_VALUE) {
-+                    this.hasImpulse = true;
-+                }
-+                // Paper end - Fix MC-44654
              }
-         }
+-        }
++            // Paper start - Fix MC-44654
++            if (this.getType().updateInterval() == Integer.MAX_VALUE) {
++                this.hasImpulse = true;
++            }
++            // Paper end - Fix MC-44654
++        }
 +        // Paper start - Block invalid positions and bounding box; don't allow desync of pos and AABB
 +        // hanging has its own special logic
 +        if (!(this instanceof net.minecraft.world.entity.decoration.HangingEntity) && (forceBoundingBoxUpdate || this.position.x != x || this.position.y != y || this.position.z != z)) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1832,8 +1832,15 @@
              int floor = Mth.floor(x);
              int floor1 = Mth.floor(y);
              int floor2 = Mth.floor(z);
-@@ -3686,6 +_,12 @@
+@@ -3684,8 +_,19 @@
+                 if (this instanceof ServerPlayer serverPlayer && serverPlayer.isReceivingWaypoints() && serverPlayer.connection != null) {
+                     serverLevel.getWaypointManager().updatePlayer(serverPlayer);
                  }
++                // Paper start - Fix MC-44654
++                if (this.getType().updateInterval() == Integer.MAX_VALUE) {
++                    this.hasImpulse = true;
++                }
++                // Paper end - Fix MC-44654
              }
          }
 +        // Paper start - Block invalid positions and bounding box; don't allow desync of pos and AABB

--- a/paper-server/patches/sources/net/minecraft/world/entity/EntityType.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/EntityType.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/world/entity/EntityType.java
 +++ b/net/minecraft/world/entity/EntityType.java
-@@ -217,7 +_,7 @@
-             .fireImmune()
-             .sized(6.0F, 0.5F)
-             .clientTrackingRange(10)
--            .updateInterval(Integer.MAX_VALUE)
-+            .updateInterval(10) // CraftBukkit - SPIGOT-3729: track area effect clouds
-     );
-     public static final EntityType<Armadillo> ARMADILLO = register(
-         "armadillo", EntityType.Builder.of(Armadillo::new, MobCategory.CREATURE).sized(0.7F, 0.65F).eyeHeight(0.26F).clientTrackingRange(10)
 @@ -1155,6 +_,22 @@
          boolean shouldOffsetY,
          boolean shouldOffsetYMore


### PR DESCRIPTION
This more properly implement spigot's fix for teleportation area effect clouds, now however supporting many other entity types specified in this bug report.

Currently, this is not an issue for hanging blocks since they have a fix identical to this inside of setPos.

(This fixes spigots fix to more properly include all the other entities and prevent erroneous updates)