### PR TITLE
Cleanup Primed TNT Fix

### DIFF
--- a/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
@@ -28640,7 +28640,7 @@ index 8cc5c0716392ba06501542ff5cbe71ee43979e5d..09fd99c9cbd23b5f3c899bfb00c9b896
 +    // Paper end - block counting
  }
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index bd962b2a0f381ddc1c7251162531bdecf3c2706b..9344cdbad8415f6ff4d592d3f13390e85477a10d 100644
+index fa2ffc44336c3ddfe576b202154f14ef91a301b9..7546ff4c5ffc62d93a3f874519db8fef1e3bfbcb 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -147,7 +147,7 @@ import net.minecraft.world.waypoints.WaypointTransmitter;
@@ -29348,7 +29348,7 @@ index bd962b2a0f381ddc1c7251162531bdecf3c2706b..9344cdbad8415f6ff4d592d3f13390e8
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4823,6 +5130,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4828,6 +5135,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
      public final void setRemoved(Entity.RemovalReason removalReason, @Nullable org.bukkit.event.entity.EntityRemoveEvent.Cause cause) { // CraftBukkit - add Bukkit remove cause
@@ -29361,7 +29361,7 @@ index bd962b2a0f381ddc1c7251162531bdecf3c2706b..9344cdbad8415f6ff4d592d3f13390e8
          org.bukkit.craftbukkit.event.CraftEventFactory.callEntityRemoveEvent(this, cause); // CraftBukkit
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
          if (this.removalReason == null) {
-@@ -4833,7 +5146,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4838,7 +5151,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              this.stopRiding();
          }
  
@@ -29370,7 +29370,7 @@ index bd962b2a0f381ddc1c7251162531bdecf3c2706b..9344cdbad8415f6ff4d592d3f13390e8
          this.levelCallback.onRemove(removalReason);
          this.onRemoval(removalReason);
          // Paper start - Folia schedulers
-@@ -4867,7 +5180,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4872,7 +5185,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public boolean shouldBeSaved() {
          return (this.removalReason == null || this.removalReason.shouldSave())
              && !this.isPassenger()

--- a/paper-server/patches/sources/net/minecraft/world/entity/item/PrimedTnt.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/item/PrimedTnt.java.patch
@@ -48,7 +48,7 @@
          this.setDeltaMovement(this.getDeltaMovement().scale(0.98));
          if (this.onGround()) {
              this.setDeltaMovement(this.getDeltaMovement().multiply(0.7, -0.5, 0.7));
-@@ -105,20 +_,50 @@
+@@ -105,20 +_,35 @@
          int i = this.getFuse() - 1;
          this.setFuse(i);
          if (i <= 0) {
@@ -68,23 +68,8 @@
          }
 +        // Paper start - Option to prevent TNT from moving in water
 +        if (!this.isRemoved() && this.wasTouchingWater && this.level().paperConfig().fixes.preventTntFromMovingInWater) {
-+            /*
-+             * Author: Jedediah Smith <jedediah@silencegreys.com>
-+             */
-+            // Send position and velocity updates to nearby players on every tick while the TNT is in water.
-+            // This does pretty well at keeping their clients in sync with the server.
-+            net.minecraft.server.level.ChunkMap.TrackedEntity ete = ((net.minecraft.server.level.ServerLevel) this.level()).getChunkSource().chunkMap.entityMap.get(this.getId());
-+            if (ete != null) {
-+                net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket velocityPacket = new net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket(this);
-+                net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket positionPacket = net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket.teleport(this.getId(), net.minecraft.world.entity.PositionMoveRotation.of(this), java.util.Set.of(), this.onGround);
-+
-+                ete.seenBy.stream()
-+                    .filter(viewer -> (viewer.getPlayer().getX() - this.getX()) * (viewer.getPlayer().getY() - this.getY()) * (viewer.getPlayer().getZ() - this.getZ()) < 16 * 16)
-+                    .forEach(viewer -> {
-+                        viewer.send(velocityPacket);
-+                        viewer.send(positionPacket);
-+                    });
-+            }
++            this.hurtMarked = true;
++            this.hasImpulse = true;
 +        }
 +        // Paper end - Option to prevent TNT from moving in water
      }


### PR DESCRIPTION
This option should probably be removed as its a descendant of an option that allows "old tnt cannon" behavior before ~1.9 But this improves the fix so properly update the velocity/position rather than the questionable way it was doing it before.

Behavior wise this is mostly the same.