### PR TITLE
Fix #11169

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/raid/Raider.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/raid/Raider.java.patch
@@ -48,7 +48,7 @@
          }
  
          private boolean cannotPickUpBanner() {
-+            if (!getServerLevel(this.mob).getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_MOBGRIEFING)) return false; // Paper - respect game and entity rules for picking up items
++            if (!getServerLevel(this.mob).getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_MOBGRIEFING)) return true; // Paper - respect game and entity rules for picking up items
              if (!this.mob.hasActiveRaid()) {
                  return true;
              } else if (this.mob.getCurrentRaid().isOver()) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/raid/Raider.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/raid/Raider.java.patch
@@ -48,7 +48,7 @@
          }
  
          private boolean cannotPickUpBanner() {
-+            if (!getServerLevel(this.mob).getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_MOBGRIEFING) || !this.mob.canPickUpLoot()) return false; // Paper - respect game and entity rules for picking up items
++            if (!getServerLevel(this.mob).getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_MOBGRIEFING)) return false; // Paper - respect game and entity rules for picking up items
              if (!this.mob.hasActiveRaid()) {
                  return true;
              } else if (this.mob.getCurrentRaid().isOver()) {


### PR DESCRIPTION
This is a rather aggressive behavior change and is mostly an issue with canPickUpLoot. Normally entities that are able to pickup items have this set to true but this is not the case for raiders. Further changing this behavior will cause even more vanilla deviation, so it's better to just undo this change until vanilla properly fixes it.