### PR TITLE
Support ignore hidden entities in Waypoints

### DIFF
--- a/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
@@ -23061,7 +23061,7 @@ index 0000000000000000000000000000000000000000..f1f72a051083b61273202cb4e67ecb11
 +    private SaveUtil() {}
 +}
 diff --git a/io/papermc/paper/FeatureHooks.java b/io/papermc/paper/FeatureHooks.java
-index 338dc0fb07cdba5f7350cca332fa3e942c622bfb..e1fe49e4bf014e2405708270efd81bab4e1512da 100644
+index 68e1e2da7a3291c6260898c90373bf21630f3351..b2b67a3b1b4620dc97a32df953d4ad47bbe5e481 100644
 --- a/io/papermc/paper/FeatureHooks.java
 +++ b/io/papermc/paper/FeatureHooks.java
 @@ -1,6 +1,9 @@
@@ -23286,6 +23286,7 @@ index 338dc0fb07cdba5f7350cca332fa3e942c622bfb..e1fe49e4bf014e2405708270efd81bab
      }
  
  }
+\ No newline at end of file
 diff --git a/io/papermc/paper/command/subcommands/ChunkDebugCommand.java b/io/papermc/paper/command/subcommands/ChunkDebugCommand.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..2dca7afbd93cfbb8686f336fcd3b45dd01fba0fc
@@ -24067,7 +24068,7 @@ index f7362a979126c5c0a581c05c0b623cf40b8f0ebd..338ef549efe82c250c74365c1c107198
      // CraftBukkit start
      public boolean isDebugging() {
 diff --git a/net/minecraft/server/dedicated/DedicatedServer.java b/net/minecraft/server/dedicated/DedicatedServer.java
-index 5db176be3bd31eb886a541eeaee922ee30ee9908..5fea5e2e9fc10d348fa3e65cd354ef6a4a717a4d 100644
+index 4488d0a2f05ef07afab0f9a1483f54b21757b29e..98927d4a5fba2a0dcdb147ac10b82c3286ccdc6b 100644
 --- a/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -391,7 +391,33 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -31626,7 +31627,7 @@ index 96e8dfb1ff24954656470925a1fc6280fe5e09d9..be6f37f91569c659c609e5e8d38671ca
  
      public void animateTick(BlockState state, Level level, BlockPos pos, RandomSource random) {
 diff --git a/net/minecraft/world/level/block/state/BlockBehaviour.java b/net/minecraft/world/level/block/state/BlockBehaviour.java
-index 1c81dc30aabb354d18290d42dfc419d9b1581fbd..834e27ef2f7b342b074ff9e1e390e02f3ca1c399 100644
+index c846d5d47c6488b11930b858da946e636e025294..d4c02b9bb9bfc10484a79ede35985ba35c99bada 100644
 --- a/net/minecraft/world/level/block/state/BlockBehaviour.java
 +++ b/net/minecraft/world/level/block/state/BlockBehaviour.java
 @@ -413,7 +413,7 @@ public abstract class BlockBehaviour implements FeatureElement {
@@ -36675,10 +36676,10 @@ index c634d795644be86ad85395ffa39fbac33bf7418b..66d0a6390febe929ef774b0a78133290
  
              for (SavedTick<T> savedTick : this.pendingTicks) {
 diff --git a/net/minecraft/world/waypoints/WaypointTransmitter.java b/net/minecraft/world/waypoints/WaypointTransmitter.java
-index b579839c03b371d408e3750ec09af7da1d7bc9a0..9b41c62afc861847571ad739d1dd848b8276230c 100644
+index 47382efcd50f29601a6623876be50c4d047336c5..5d1c933dfa862d0733777d305563a89ea7827f07 100644
 --- a/net/minecraft/world/waypoints/WaypointTransmitter.java
 +++ b/net/minecraft/world/waypoints/WaypointTransmitter.java
-@@ -31,7 +31,10 @@ public interface WaypointTransmitter extends Waypoint {
+@@ -32,7 +32,10 @@ public interface WaypointTransmitter extends Waypoint {
      }
  
      static boolean isChunkVisible(ChunkPos pos, ServerPlayer player) {

--- a/paper-server/patches/sources/net/minecraft/world/waypoints/WaypointTransmitter.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/waypoints/WaypointTransmitter.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/waypoints/WaypointTransmitter.java
++++ b/net/minecraft/world/waypoints/WaypointTransmitter.java
+@@ -20,6 +_,7 @@
+     Waypoint.Icon waypointIcon();
+ 
+     static boolean doesSourceIgnoreReceiver(LivingEntity entity, ServerPlayer player) {
++        if (!player.getBukkitEntity().canSee(entity.getBukkitEntity())) return true; // Paper - ignore if entity is hidden from player
+         if (player.isSpectator()) {
+             return false;
+         } else if (!entity.isSpectator() && !entity.hasIndirectPassenger(player)) {


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/12714 by adding support for mark the entity hidden like "ignored" if is hidden from receiver.

Example using.
```java
// first call this in command
player.getWorld().spawn(player.getLocation().toCenterLocation(), Wolf.class, wolf -> {
    wolf.setOwner(player);
    wolf.setAI(false);
    player.hideEntity(TestPlugin.this, wolf);
    AttributeInstance waypointTransmitRange = wolf.getAttribute(Attribute.WAYPOINT_TRANSMIT_RANGE);
    waypointTransmitRange.setBaseValue(100);
});

// then make the entity show again
player.getWorld().getEntitiesByClass(Wolf.class).forEach(wolf -> {
    player.showEntity(TestPlugin.this, wolf);
});                    
```

https://github.com/user-attachments/assets/d112b903-327c-4f4f-a067-b50a15b8e719

