### PR TITLE
PluginManager#getPlugin and PluginManager#isPluginEnabled are case-insensitive

### DIFF
--- a/paper-api/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -29,7 +29,7 @@ public interface PluginManager extends io.papermc.paper.plugin.PermissionManager
     /**
      * Checks if the given plugin is loaded and returns it when applicable
      * <p>
-     * Please note that the name of the plugin is case-sensitive
+     * Please note that the name of the plugin is case-insensitive
      *
      * @param name Name of the plugin to check
      * @return Plugin if it exists, otherwise null
@@ -48,7 +48,7 @@ public interface PluginManager extends io.papermc.paper.plugin.PermissionManager
     /**
      * Checks if the given plugin is enabled or not
      * <p>
-     * Please note that the name of the plugin is case-sensitive.
+     * Please note that the name of the plugin is case-insensitive.
      *
      * @param name Name of the plugin to check
      * @return true if the plugin is enabled, otherwise false

--- a/paper-api/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -464,7 +464,7 @@ public final class SimplePluginManager implements PluginManager {
     /**
      * Checks if the given plugin is loaded and returns it when applicable
      * <p>
-     * Please note that the name of the plugin is case-sensitive
+     * Please note that the name of the plugin is case-insensitive
      *
      * @param name Name of the plugin to check
      * @return Plugin if it exists, otherwise null
@@ -486,7 +486,7 @@ public final class SimplePluginManager implements PluginManager {
     /**
      * Checks if the given plugin is enabled or not
      * <p>
-     * Please note that the name of the plugin is case-sensitive.
+     * Please note that the name of the plugin is case-insensitive.
      *
      * @param name Name of the plugin to check
      * @return true if the plugin is enabled, otherwise false


### PR DESCRIPTION
Fixes the javadoc as both implementations of the PluginManager are treating the names case-sensitive. I assume the original javadoc is from Bukkit and was not updated, maybe the line can be removed fully?