### PR TITLE
Improvements in Player teleport causes

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -130,7 +130,7 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
          */
         DISMOUNT,
         /**
-         * Indicates the teleportation was caused by a player enters a vehicle
+         * Indicates the teleportation was caused by a player entering a vehicle
          */
         MOUNT,
         /**

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -88,7 +88,7 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
 
     public enum TeleportCause {
         /**
-         * Indicates the teleporation was caused by a player throwing an Ender
+         * Indicates the teleportation was caused by a player throwing an Ender
          * Pearl
          */
         ENDER_PEARL,
@@ -129,6 +129,10 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
          * Indicates the teleportation was caused by a player exiting a vehicle
          */
         DISMOUNT,
+        /**
+         * Indicates the teleportation was caused by a player enters a vehicle
+         */
+        MOUNT,
         /**
          * Indicates the teleportation was caused by a player exiting a bed
          */

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -354,7 +354,7 @@ index 0000000000000000000000000000000000000000..ae2bb9a73106febfe5f0d090abd4252b
 +    }
 +}
 diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
-index 7b5ed00c9b2f22af5cbc44171192d674936dc7d7..5fe3c9a159908785e08fa874982bc1a82283bb1d 100644
+index d51645b115780dac9ff6010806e8bd62dedc8e9f..3faf1b5556c55f3468182f75b2dbff4aaa3aae3a 100644
 --- a/net/minecraft/server/level/ChunkMap.java
 +++ b/net/minecraft/server/level/ChunkMap.java
 @@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
@@ -484,7 +484,7 @@ index c70a58f5f633fa8e255f74c42f5e87c96b7b013a..ec20a5a6d7c8f65abda528fec36bec7b
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index f961540a00bfb5e1c8eb0e739f8ae535e9eee8f3..7453ddb09f349b7836f966573e4933646a75cba6 100644
+index 73a8c7503a462057cfa3951589c623c16fcf559f..9e4d410a8b8e4b1662ebf5cd21a5be408636c27a 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -409,6 +409,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -661,10 +661,10 @@ index 3f780276be6766ef253c50212e06fd93a96b0caa..7e70c7bee633c54497d1cd2854dd60f4
                          }
                      }
 diff --git a/net/minecraft/world/entity/item/ItemEntity.java b/net/minecraft/world/entity/item/ItemEntity.java
-index 548d7c8dc517da6c4db86b11f579ae63e6db56cf..a29860af4c37b2b45df49f9ba18f7e38921dfb02 100644
+index fca31bbab8e7830933ceffcf992ff56ccc84414c..51804b611f469f2ab53e455e8c633b867b00cc88 100644
 --- a/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/net/minecraft/world/entity/item/ItemEntity.java
-@@ -121,6 +121,29 @@ public class ItemEntity extends Entity implements TraceableEntity {
+@@ -129,6 +129,29 @@ public class ItemEntity extends Entity implements TraceableEntity {
          return 0.04;
      }
  
@@ -695,7 +695,7 @@ index 548d7c8dc517da6c4db86b11f579ae63e6db56cf..a29860af4c37b2b45df49f9ba18f7e38
      public void tick() {
          if (this.getItem().isEmpty()) {
 diff --git a/net/minecraft/world/entity/npc/Villager.java b/net/minecraft/world/entity/npc/Villager.java
-index b0607f4a9b35570b319423c7876bb904d5154e8e..98c8653647dc52059d8becfe38a74d4e62edf08f 100644
+index ef8347329b440833b45a54be2b6e4204ac0a425e..43f16df230f87a43e249a58fc10ef2da517f22ee 100644
 --- a/net/minecraft/world/entity/npc/Villager.java
 +++ b/net/minecraft/world/entity/npc/Villager.java
 @@ -269,11 +269,35 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
@@ -838,7 +838,7 @@ index 52acc72841f0c6980f5f3f8ef21d0b29dd472ce3..41a6ec508a10a49a37539d2f10171d15
 +
  }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index d26e4d85d8fd8bd4f0c7de30b50a2ce370b37bf5..bab28e7afb7b1249d40631aabff16fc18cf95ea0 100644
+index 06069d3ac598f5f12feab038de4f1199794298f6..980eaba27ce2616c1573a4760cf4acc2dd251190 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -143,6 +143,12 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl

--- a/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
@@ -27691,7 +27691,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
      }
  
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 69dbff3f62e3a9ba7090156380f842bb44deebf8..c0b74d408340101bc3aac4cb4b7232c5cc78b08a 100644
+index 46bc6ee229921ef610b231d0228002850f46173e..5ba884cc8c3d121e17084b25f206bac63f7ba0a5 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -193,7 +193,7 @@ import net.minecraft.world.scores.Team;
@@ -28728,7 +28728,7 @@ index 8cc5c0716392ba06501542ff5cbe71ee43979e5d..09fd99c9cbd23b5f3c899bfb00c9b896
 +    // Paper end - block counting
  }
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 27a01fd28ea565221768f31df02f0a2ddf242fce..45cdbea0bbf12697ffd1fb2193c2eafe34142ea9 100644
+index 197c9c0d7fc38e169fa9a84c8c3bb081ce0d132b..7be703a78a9e1f1404d7e7bfa6f09ec9151fe18d 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -147,7 +147,7 @@ import net.minecraft.world.waypoints.WaypointTransmitter;
@@ -29203,7 +29203,7 @@ index 27a01fd28ea565221768f31df02f0a2ddf242fce..45cdbea0bbf12697ffd1fb2193c2eafe
      }
  
      public InteractionResult interact(Player player, InteractionHand hand) {
-@@ -4291,15 +4528,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4297,15 +4534,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public Iterable<Entity> getIndirectPassengers() {
@@ -29229,7 +29229,7 @@ index 27a01fd28ea565221768f31df02f0a2ddf242fce..45cdbea0bbf12697ffd1fb2193c2eafe
      }
  
      public int countPlayerPassengers() {
-@@ -4442,77 +4681,136 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4448,77 +4687,136 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return Mth.lerp(partialTick, this.yRotO, this.yRot);
      }
  
@@ -29420,7 +29420,7 @@ index 27a01fd28ea565221768f31df02f0a2ddf242fce..45cdbea0bbf12697ffd1fb2193c2eafe
  
      public boolean touchingUnloadedChunk() {
          AABB aabb = this.getBoundingBox().inflate(1.0);
-@@ -4667,6 +4965,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4673,6 +4971,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
@@ -29436,7 +29436,7 @@ index 27a01fd28ea565221768f31df02f0a2ddf242fce..45cdbea0bbf12697ffd1fb2193c2eafe
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4828,6 +5135,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4824,6 +5131,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
      public final void setRemoved(Entity.RemovalReason removalReason, @Nullable org.bukkit.event.entity.EntityRemoveEvent.Cause cause) { // CraftBukkit - add Bukkit remove cause
@@ -29449,7 +29449,7 @@ index 27a01fd28ea565221768f31df02f0a2ddf242fce..45cdbea0bbf12697ffd1fb2193c2eafe
          org.bukkit.craftbukkit.event.CraftEventFactory.callEntityRemoveEvent(this, cause); // CraftBukkit
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
          if (this.removalReason == null) {
-@@ -4838,7 +5151,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4834,7 +5147,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              this.stopRiding();
          }
  
@@ -29458,7 +29458,7 @@ index 27a01fd28ea565221768f31df02f0a2ddf242fce..45cdbea0bbf12697ffd1fb2193c2eafe
          this.levelCallback.onRemove(removalReason);
          this.onRemoval(removalReason);
          // Paper start - Folia schedulers
-@@ -4872,7 +5185,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4868,7 +5181,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public boolean shouldBeSaved() {
          return (this.removalReason == null || this.removalReason.shouldSave())
              && !this.isPassenger()

--- a/paper-server/patches/features/0033-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0033-Optimise-EntityScheduler-ticking.patch
@@ -67,10 +67,10 @@ index 0a260fdf6b198a8ab52e60bf6db2fb5eab719c48..52fa5112cd90ba766c94512a02401dd3
          profilerFiller.push("commandFunctions");
          this.getFunctions().tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 45cdbea0bbf12697ffd1fb2193c2eafe34142ea9..81413ac0de7b3c7a72bc606fe5ae6fb4ae7055e3 100644
+index 7be703a78a9e1f1404d7e7bfa6f09ec9151fe18d..c2c2e34df01f888e2a655b3a10fb6c5da91881a7 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -5175,6 +5175,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -5171,6 +5171,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.getBukkitEntity().taskScheduler.retire();
      }
      // Paper end - Folia schedulers

--- a/paper-server/patches/sources/net/minecraft/server/commands/TeleportCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/TeleportCommand.java.patch
@@ -25,7 +25,7 @@
 +                f3 = to.getPitch();
 +                level = ((org.bukkit.craftbukkit.CraftWorld) to.getWorld()).getHandle();
 +
-+                result = target.teleportTo(level, d, d1, d2, relatives, f2, f3, true);
++                result = target.teleportTo(level, d, d1, d2, relatives, f2, f3, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.COMMAND); // Paper - track player passenger teleport
 +            }
 +
 +            if (result) {

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -1119,6 +1119,20 @@
          this.seenCredits = that.seenCredits;
          this.enteredNetherPosition = that.enteredNetherPosition;
          this.chunkTrackingView = that.chunkTrackingView;
+@@ -1557,6 +_,13 @@
+         CriteriaTriggers.EFFECTS_CHANGED.trigger(this, null);
+     }
+ 
++    // Paper start - use teleport cause
++    @Override
++    public void teleportTo(double x, double y, double z, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause) {
++        this.connection.teleport(new PositionMoveRotation(new Vec3(x, y, z), Vec3.ZERO, 0.0F, 0.0F), Relative.union(Relative.DELTA, Relative.ROTATION), cause);
++    }
++    // Paper end
++
+     @Override
+     public void teleportTo(double x, double y, double z) {
+         this.connection.teleport(new PositionMoveRotation(new Vec3(x, y, z), Vec3.ZERO, 0.0F, 0.0F), Relative.union(Relative.DELTA, Relative.ROTATION));
 @@ -1568,7 +_,7 @@
      }
  
@@ -1367,6 +1381,15 @@
          this.gameMode
              .setGameModeForPlayer(this.calculateGameModeForNewPlayer(readPlayerMode(input, "playerGameType")), readPlayerMode(input, "previousPlayerGameType"));
      }
+@@ -2015,7 +_,7 @@
+     public boolean startRiding(Entity vehicle, boolean force) {
+         if (super.startRiding(vehicle, force)) {
+             vehicle.positionRider(this);
+-            this.connection.teleport(new PositionMoveRotation(this.position(), Vec3.ZERO, 0.0F, 0.0F), Relative.ROTATION);
++            this.connection.teleport(new PositionMoveRotation(this.position(), Vec3.ZERO, 0.0F, 0.0F), Relative.ROTATION, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.MOUNT); // Paper - add teleport cause
+             if (vehicle instanceof LivingEntity livingEntity) {
+                 this.server.getPlayerList().sendActiveEffects(livingEntity, this.connection);
+             }
 @@ -2029,8 +_,14 @@
  
      @Override

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1556,6 +1556,15 @@
  
              for (Entity entity2 : list) {
                  entity2.startRiding(entityx, true);
+@@ -2949,7 +_,7 @@
+                 teleportTransition.relatives().contains(Relative.Y) ? 0.0 : vec3.y(),
+                 teleportTransition.relatives().contains(Relative.Z) ? 0.0 : vec3.z()
+             );
+-        return teleportTransition.withPosition(vec31).withRotation(f, f1).transitionAsPassenger();
++        return teleportTransition.withPosition(vec31).withRotation(f, f1).transitionAsPassenger().withCause(teleportTransition.cause()); // Paper - keep cause teleport
+     }
+ 
+     private void sendTeleportTransitionToRidingPlayers(TeleportTransition teleportTransition) {
 @@ -2999,9 +_,17 @@
      }
  
@@ -1615,7 +1624,7 @@
          if (fromLevel.dimension() == Level.END && toLevel.dimension() == Level.OVERWORLD) {
              for (Entity entity : this.getPassengers()) {
                  if (entity instanceof ServerPlayer serverPlayer && !serverPlayer.seenCredits) {
-@@ -3125,8 +_,14 @@
+@@ -3125,14 +_,26 @@
          return this.entityData.get(DATA_CUSTOM_NAME_VISIBLE);
      }
  
@@ -1632,6 +1641,18 @@
          return entity != null;
      }
  
+     public void dismountTo(double x, double y, double z) {
++        this.teleportTo(x, y, z, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.DISMOUNT); // Paper - set teleport cause
++    }
++
++    // Paper start - add teleportTo with teleport cause
++    public void teleportTo(double x, double y, double z, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause) {
+         this.teleportTo(x, y, z);
+     }
++    // Paper end
+ 
+     public void teleportTo(double x, double y, double z) {
+         if (this.level() instanceof ServerLevel) {
 @@ -3240,7 +_,26 @@
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/level/portal/TeleportTransition.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/portal/TeleportTransition.java.patch
@@ -69,3 +69,27 @@
      }
  
      private static void playPortalSound(Entity entity) {
+@@ -65,6 +_,23 @@
+     private static Vec3 findAdjustedSharedSpawnPos(ServerLevel level, Entity entity) {
+         return entity.adjustSpawnLocation(level, level.getSharedSpawnPos()).getBottomCenter();
+     }
++
++    // Paper start - add withCause
++    public TeleportTransition withCause(org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause) {
++        return new TeleportTransition(
++            this.newLevel(),
++            this.position(),
++            this.deltaMovement(),
++            this.yRot(),
++            this.xRot(),
++            this.missingRespawnBlock(),
++            this.asPassenger(),
++            this.relatives(),
++            this.postTeleportTransition(),
++            cause
++        );
++    }
++    // Paper end
+ 
+     public TeleportTransition withRotation(float yRot, float xRot) {
+         return new TeleportTransition(


### PR DESCRIPTION
This PR takes a few of things related to the cause of player teleport

- In teleport command if a vehicle has a player in passenger the cause is UNKNOWN
  - Caused because when move the player the cause is not passed and its reset when generate a new TeleportTransition
- Add MOUNT when a teleport happen by mounting an entity 
- Fix DISMOUNT not used in a few things