### PR TITLE
Fix CraftContainer#getNotchInventoryType detection of player inventory

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
@@ -123,7 +123,7 @@ public class CraftContainer extends AbstractContainerMenu {
                     case 27:
                         return net.minecraft.world.inventory.MenuType.GENERIC_9x3;
                     case 36:
-                    case 41: // PLAYER
+                    case 43: // PLAYER
                         return net.minecraft.world.inventory.MenuType.GENERIC_9x4;
                     case 45:
                         return net.minecraft.world.inventory.MenuType.GENERIC_9x5;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
@@ -111,7 +111,6 @@ public class CraftContainer extends AbstractContainerMenu {
     public static net.minecraft.world.inventory.MenuType getNotchInventoryType(Inventory inventory) {
         final InventoryType type = inventory.getType();
         switch (type) {
-            case PLAYER:
             case CHEST:
             case ENDER_CHEST:
             case BARREL:
@@ -123,7 +122,6 @@ public class CraftContainer extends AbstractContainerMenu {
                     case 27:
                         return net.minecraft.world.inventory.MenuType.GENERIC_9x3;
                     case 36:
-                    case 43: // PLAYER
                         return net.minecraft.world.inventory.MenuType.GENERIC_9x4;
                     case 45:
                         return net.minecraft.world.inventory.MenuType.GENERIC_9x5;


### PR DESCRIPTION
This was used by some primitive invsee plugins, which were broken by vanilla adding 2 more items to player inventory
Can be tested with just `player.openInventory(player.getInventory());`
Currently throws https://pastes.dev/swutgCc86m