### PR TITLE
Make warning of PlayerLoginEvent don't repeat plugin names

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/connection/HorriblePlayerLoginEventHack.java
+++ b/paper-server/src/main/java/io/papermc/paper/connection/HorriblePlayerLoginEventHack.java
@@ -3,9 +3,9 @@ package io.papermc.paper.connection;
 import com.mojang.authlib.GameProfile;
 import com.mojang.logging.LogUtils;
 import io.papermc.paper.adventure.PaperAdventure;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import io.papermc.paper.util.StackWalkerUtil;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
@@ -48,7 +48,7 @@ public class HorriblePlayerLoginEventHack {
         }
 
         if (!nagged) {
-            List<String> plugins = new ArrayList<>();
+            Set<String> plugins = new HashSet<>();
             for (final RegisteredListener listener : PlayerLoginEvent.getHandlerList().getRegisteredListeners()) {
                 plugins.add(listener.getPlugin().getName());
             }
@@ -60,10 +60,10 @@ public class HorriblePlayerLoginEventHack {
                 
                 This event forces an alternative player loading path that is
                 deprecated and will be removed in a future release.
-                For more information, see: https://forums.papermc.io/threads/1-21-7.1635
+                For more information, see: https://go.papermc.io/announcement/1.21.7
                 
                 Please notify the following plugin developers: {}
-                ============================================================""", plugins.toString());
+                ============================================================""", plugins);
             nagged = true;
         }
         // We need to account for the fact that during the config stage we now call this event to mimic the old behavior.


### PR DESCRIPTION
This fixs a issue where if a plugin use the PlayerLoginEvent in many places then the warning for the use repeat the plugin name the name of times the event was used.

Currently:
![image](https://github.com/user-attachments/assets/e1c754b9-36df-4b7f-a646-8b85e5c7c3dd)

Also include a minor change for use the recent URL for the 1.21.7 announcement