### PR TITLE
Fixes rapid fire of 'EntityCrossbowLoadEvent' until player stops holding right click.

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/item/CrossbowItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/CrossbowItem.java.patch
@@ -44,7 +44,7 @@
              }
  
 -            if (f >= 1.0F && !isCharged(stack) && tryLoadProjectiles(livingEntity, stack)) {
-+            if (f >= 1.0F && !isCharged(stack)) {
++            if (f == 1.0F && !isCharged(stack)) {
 +                // Paper start - Add EntityLoadCrossbowEvent
 +                final io.papermc.paper.event.entity.EntityLoadCrossbowEvent event = new io.papermc.paper.event.entity.EntityLoadCrossbowEvent(livingEntity.getBukkitLivingEntity(), stack.asBukkitMirror(), org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(livingEntity.getUsedItemHand()));
 +                if (!event.callEvent() || !tryLoadProjectiles(livingEntity, stack, event.shouldConsumeItem()) || !event.shouldConsumeItem()) {

--- a/paper-server/patches/sources/net/minecraft/world/item/CrossbowItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/CrossbowItem.java.patch
@@ -39,19 +39,100 @@
                  if (shooter instanceof ServerPlayer serverPlayer) {
                      CriteriaTriggers.SHOT_CROSSBOW.trigger(serverPlayer, weapon);
                      serverPlayer.awardStat(Stats.ITEM_USED.get(weapon.getItem()));
-@@ -211,7 +_,14 @@
-                     );
+@@ -190,45 +_,69 @@
+                 this.startSoundPlayed = false;
+                 this.midLoadSoundPlayed = false;
              }
- 
+-
+             if (f >= 0.2F && !this.startSoundPlayed) {
+                 this.startSoundPlayed = true;
+                 chargingSounds.start()
+-                    .ifPresent(
+-                        holder -> level.playSound(
+-                            null, livingEntity.getX(), livingEntity.getY(), livingEntity.getZ(), holder.value(), SoundSource.PLAYERS, 0.5F, 1.0F
+-                        )
+-                    );
++                    .ifPresent(holder -> level.playSound(
++                        null,
++                        livingEntity.getX(),
++                        livingEntity.getY(),
++                        livingEntity.getZ(),
++                        holder.value(),
++                        SoundSource.PLAYERS,
++                        0.5F,
++                        1.0F
++                    ));
+             }
+-
+             if (f >= 0.5F && !this.midLoadSoundPlayed) {
+                 this.midLoadSoundPlayed = true;
+                 chargingSounds.mid()
+-                    .ifPresent(
+-                        sound -> level.playSound(
+-                            null, livingEntity.getX(), livingEntity.getY(), livingEntity.getZ(), sound.value(), SoundSource.PLAYERS, 0.5F, 1.0F
+-                        )
+-                    );
++                    .ifPresent(sound -> level.playSound(
++                        null,
++                        livingEntity.getX(),
++                        livingEntity.getY(),
++                        livingEntity.getZ(),
++                        sound.value(),
++                        SoundSource.PLAYERS,
++                        0.5F,
++                        1.0F
++                    ));
+             }
+-
 -            if (f >= 1.0F && !isCharged(stack) && tryLoadProjectiles(livingEntity, stack)) {
 +            if (f == 1.0F && !isCharged(stack)) {
-+                // Paper start - Add EntityLoadCrossbowEvent
-+                final io.papermc.paper.event.entity.EntityLoadCrossbowEvent event = new io.papermc.paper.event.entity.EntityLoadCrossbowEvent(livingEntity.getBukkitLivingEntity(), stack.asBukkitMirror(), org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(livingEntity.getUsedItemHand()));
-+                if (!event.callEvent() || !tryLoadProjectiles(livingEntity, stack, event.shouldConsumeItem()) || !event.shouldConsumeItem()) {
-+                    if (livingEntity instanceof ServerPlayer player) player.containerMenu.sendAllDataToRemote();
++                // Paper start - Add EntityCrossbowLoadEvent
++                final io.papermc.paper.event.entity.EntityLoadCrossbowEvent event =
++                    new io.papermc.paper.event.entity.EntityLoadCrossbowEvent(
++                        livingEntity.getBukkitLivingEntity(),
++                        stack.asBukkitMirror(),
++                        org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(livingEntity.getUsedItemHand())
++                    );
++                if (!event.callEvent()
++                    || !tryLoadProjectiles(livingEntity, stack, event.shouldConsumeItem())
++                    || !event.shouldConsumeItem()
++                    // Paper end
++                ) {
++                    if (livingEntity instanceof net.minecraft.server.level.ServerPlayer serverPlayer) {
++                        // fix loading of crossbow when event is cancelled
++                        serverPlayer.containerMenu.sendAllDataToRemote();
++                        serverPlayer.stopUsingItem();
++                        serverPlayer.connection.send(new net.minecraft.network.protocol.game.ClientboundEntityEventPacket(serverPlayer, (byte)4));
++                    }
 +                    return;
 +                }
-+                // Paper end - Add EntityLoadCrossbowEvent
                  chargingSounds.end()
-                     .ifPresent(
-                         sound -> level.playSound(
+-                    .ifPresent(
+-                        sound -> level.playSound(
+-                            null,
+-                            livingEntity.getX(),
+-                            livingEntity.getY(),
+-                            livingEntity.getZ(),
+-                            sound.value(),
+-                            livingEntity.getSoundSource(),
+-                            1.0F,
+-                            1.0F / (level.getRandom().nextFloat() * 0.5F + 1.0F) + 0.2F
+-                        )
+-                    );
++                    .ifPresent(sound -> level.playSound(
++                        null,
++                        livingEntity.getX(),
++                        livingEntity.getY(),
++                        livingEntity.getZ(),
++                        sound.value(),
++                        livingEntity.getSoundSource(),
++                        1.0F,
++                        1.0F / (level.getRandom().nextFloat() * 0.5F + 1.0F) + 0.2F
++                    ));
+             }
+         }
+     }
+-
+     @Override
+     public int getUseDuration(ItemStack stack, LivingEntity entity) {
+         return 72000;


### PR DESCRIPTION
EntityCrossbowLoadEvent is practically broken at the moment for cancellation. This fixes it so that whilst the float continues to scale, the load event is only called at the proper time, and once, rather than every tick that the player continues to hold right click, and is able to be canceled.