### PR TITLE
Fix quitmessage nullability issues

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1348,7 +1348,7 @@
          LOGGER.info("{} lost connection: {}", this.player.getName().getString(), details.reason().getString());
 -        this.removePlayerFromWorld();
 +        // Paper start - Fix kick event leave message not being sent
-+        final net.kyori.adventure.text.Component quitMessage = io.papermc.paper.adventure.PaperAdventure.asAdventure(details.quitMessage().orElse(null));
++        final net.kyori.adventure.text.Component quitMessage = details.quitMessage().map(io.papermc.paper.adventure.PaperAdventure::asAdventure).orElse(null);
 +        this.removePlayerFromWorld(quitMessage);
 +        // Paper end - Fix kick event leave message not being sent
          super.onDisconnect(details);


### PR DESCRIPTION
This would return an empty component causing it to be ignored, but we want this to be null as then it will delegate to the default quit message.