### PR TITLE
Fix riptide without calling PlayerRiptideEvent (#12779 and #11676)

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1109,7 +1109,8 @@
 +                            this.player.setItemInHand(InteractionHand.MAIN_HAND, CraftItemStack.asNMSCopy(swapItemsEvent.getMainHandItem()));
 +                        }
 +                        // CraftBukkit end
-                         this.player.stopUsingItem();
+-                        this.player.stopUsingItem();
++                        this.player.releaseUsingItem();
 +                        if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.updateEquipmentOnPlayerActions) this.player.detectEquipmentUpdatesPublic(); // Paper - Force update attributes.
                      }
  


### PR DESCRIPTION
## Description
Fixes PlayerRiptideEvent not being called when a player uses riptide and quickly switches the trident to their offhand

## Problem
When switching hands during riptide usage, `stopUsingItem()` was called which cleared the `useItem` before the `RELEASE_USE_ITEM` packet could properly call the `releaseUsing()` method. This caused the riptide effect to occur without firing the corresponding event

## Solution
Changed `stopUsingItem()` to `releaseUsingItem()` in the `SWAP_ITEM_WITH_OFFHAND` case to ensure proper completion of item usage and event firing

Fixes #12779
Fixes #11676
