### PR TITLE
Add Bee#set/getTimeSinceSting() methods (#12719)

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Bee.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Bee.java
@@ -144,5 +144,22 @@ public interface Bee extends Animals {
      * @return number of ticks
      */
     int getTicksSincePollination();
+
+    /**
+     * Sets how many ticks have passed since this bee last stung.
+     * This value is used to determine when the bee should die after stinging.
+     *
+     * @param time number of ticks since last sting
+     */
+    void setTimeSinceSting(int time);
+
+    /**
+     * Gets how many ticks have passed since this bee last stung.
+     * This value increases each tick after the bee stings and is used
+     * to determine when the bee should die.
+     *
+     * @return number of ticks since last sting
+     */
+    int getTimeSinceSting();
     // Paper end
 }

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/Bee.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/Bee.java.patch
@@ -77,6 +77,16 @@
          this.setFlag(2, isRolling);
      }
  
++    // Paper start - Add Bee#set/getTimeSinceSting() method
++    public void setTimeSinceSting(int time) {
++        this.timeSinceSting = time;
++    }
++
++    public int getTimeSinceSting() {
++        return this.timeSinceSting;
++    }
++    // Paper end - Add Bee#set/getTimeSinceSting() method
++
 @@ -580,7 +_,7 @@
              if (beeInteractionEffect != null) {
                  this.usePlayerItem(player, hand, itemInHand);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
@@ -118,4 +118,14 @@ public class CraftBee extends CraftAnimals implements Bee {
     public int getTicksSincePollination() {
         return this.getHandle().ticksWithoutNectarSinceExitingHive;
     }
+
+    @Override
+    public void setTimeSinceSting(final int time) {
+        this.getHandle().setTimeSinceSting(time);
+    }
+
+    @Override
+    public int getTimeSinceSting() {
+        return this.getHandle().getTimeSinceSting();
+    }
 }


### PR DESCRIPTION
## Description
Adds API methods to get and set the time since a bee last stung, allowing better control over bee behavior after stinging.

## Problem
Currently there's no way to access or modify the `timeSinceSting` field through the API. This prevents plugins from properly managing bee behavior when using `setHasStung(false)` to make bees attack repeatedly, as the `timeSinceSting` value keeps increasing and can eventually cause the bee to die.

## Solution
Added two new methods to the Bee API:
- `getTimeSinceSting()` - Returns the number of ticks since the bee last stung
- `setTimeSinceSting(int time)` - Sets the number of ticks since the bee last stung

Closes #12719