### PR TITLE
Add Bee#set/getTimeSinceSting() methods (#12719)

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -778,3 +778,4 @@ public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData locked
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData scale
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData trackingPosition
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData unlimitedTracking
+public net.minecraft.world.entity.animal.Bee timeSinceSting

--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -273,6 +273,7 @@ public net.minecraft.world.entity.animal.Bee setHasStung(Z)V
 public net.minecraft.world.entity.animal.Bee setRolling(Z)V
 public net.minecraft.world.entity.animal.Bee stayOutOfHiveCountdown
 public net.minecraft.world.entity.animal.Bee ticksWithoutNectarSinceExitingHive
+public net.minecraft.world.entity.animal.Bee timeSinceSting
 public net.minecraft.world.entity.animal.Cat isRelaxStateOne()Z
 public net.minecraft.world.entity.animal.Cat setCollarColor(Lnet/minecraft/world/item/DyeColor;)V
 public net.minecraft.world.entity.animal.Cat setRelaxStateOne(Z)V
@@ -778,4 +779,3 @@ public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData locked
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData scale
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData trackingPosition
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData unlimitedTracking
-public net.minecraft.world.entity.animal.Bee timeSinceSting

--- a/paper-api/src/main/java/org/bukkit/entity/Bee.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Bee.java
@@ -144,5 +144,22 @@ public interface Bee extends Animals {
      * @return number of ticks
      */
     int getTicksSincePollination();
+
+    /**
+     * Sets how many ticks have passed since this bee last stung.
+     * This value is used to determine when the bee should die after stinging.
+     *
+     * @param time number of ticks since last sting
+     */
+    void setTimeSinceSting(int time);
+
+    /**
+     * Gets how many ticks have passed since this bee last stung.
+     * This value increases each tick after the bee stings and is used
+     * to determine when the bee should die.
+     *
+     * @return number of ticks since last sting
+     */
+    int getTimeSinceSting();
     // Paper end
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Bee.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Bee.java
@@ -1,6 +1,7 @@
 package org.bukkit.entity;
 
 import org.bukkit.Location;
+import org.checkerframework.checker.index.qual.NonNegative;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -151,7 +152,7 @@ public interface Bee extends Animals {
      *
      * @param time number of ticks since last sting
      */
-    void setTimeSinceSting(int time);
+    void setTimeSinceSting(@NonNegative int time);
 
     /**
      * Gets how many ticks have passed since this bee last stung.

--- a/paper-api/src/main/java/org/bukkit/entity/Bee.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Bee.java
@@ -149,6 +149,9 @@ public interface Bee extends Animals {
     /**
      * Sets how many ticks have passed since this bee last stung.
      * This value is used to determine when the bee should die after stinging.
+     * <p>
+     * Note that bees don’t die at a fixed time. Instead, every few ticks, they
+     * have a random chance of dying, and that chance increases with this value.
      *
      * @param time number of ticks since last sting
      */
@@ -158,6 +161,9 @@ public interface Bee extends Animals {
      * Gets how many ticks have passed since this bee last stung.
      * This value increases each tick after the bee stings and is used
      * to determine when the bee should die.
+     * <p>
+     * Note that bees don’t die at a fixed time. Instead, every few ticks, they
+     * have a random chance of dying, and that chance increases with this value.
      *
      * @return number of ticks since last sting
      */

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/Bee.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/Bee.java.patch
@@ -1,15 +1,6 @@
 --- a/net/minecraft/world/entity/animal/Bee.java
 +++ b/net/minecraft/world/entity/animal/Bee.java
-@@ -128,7 +128,7 @@
-     private UUID persistentAngerTarget;
-     private float rollAmount;
-     private float rollAmountO;
--    private int timeSinceSting;
-+    public int timeSinceSting;
-     public int ticksWithoutNectarSinceExitingHive = 0;
-     public int stayOutOfHiveCountdown = 0;
-     public int numCropsGrownSincePollination = 0;
-@@ -146,10 +146,26 @@
+@@ -146,10 +_,26 @@
      Bee.BeeGoToHiveGoal goToHiveGoal;
      private Bee.BeeGoToKnownFlowerGoal goToKnownFlowerGoal;
      private int underWaterTicks;

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/Bee.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/Bee.java.patch
@@ -77,6 +77,16 @@
          this.setFlag(2, isRolling);
      }
  
++    // Paper start - Add Bee#set/getTimeSinceSting() method
++    public void setTimeSinceSting(int time) {
++        this.timeSinceSting = time;
++    }
++
++    public int getTimeSinceSting() {
++        return this.timeSinceSting;
++    }
++    // Paper end - Add Bee#set/getTimeSinceSting() method
++
 @@ -580,7 +_,7 @@
              if (beeInteractionEffect != null) {
                  this.usePlayerItem(player, hand, itemInHand);

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/Bee.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/Bee.java.patch
@@ -1,6 +1,15 @@
 --- a/net/minecraft/world/entity/animal/Bee.java
 +++ b/net/minecraft/world/entity/animal/Bee.java
-@@ -146,10 +_,26 @@
+@@ -128,7 +128,7 @@
+     private UUID persistentAngerTarget;
+     private float rollAmount;
+     private float rollAmountO;
+-    private int timeSinceSting;
++    public int timeSinceSting;
+     public int ticksWithoutNectarSinceExitingHive = 0;
+     public int stayOutOfHiveCountdown = 0;
+     public int numCropsGrownSincePollination = 0;
+@@ -146,10 +146,26 @@
      Bee.BeeGoToHiveGoal goToHiveGoal;
      private Bee.BeeGoToKnownFlowerGoal goToKnownFlowerGoal;
      private int underWaterTicks;
@@ -77,16 +86,6 @@
          this.setFlag(2, isRolling);
      }
  
-+    // Paper start - Add Bee#set/getTimeSinceSting() method
-+    public void setTimeSinceSting(int time) {
-+        this.timeSinceSting = time;
-+    }
-+
-+    public int getTimeSinceSting() {
-+        return this.timeSinceSting;
-+    }
-+    // Paper end - Add Bee#set/getTimeSinceSting() method
-+
 @@ -580,7 +_,7 @@
              if (beeInteractionEffect != null) {
                  this.usePlayerItem(player, hand, itemInHand);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
@@ -121,10 +121,7 @@ public class CraftBee extends CraftAnimals implements Bee {
 
     @Override
     public void setTimeSinceSting(int time) {
-        if (time < 0) {
-            throw new IllegalArgumentException("Time since sting cannot be negative");
-        }
-
+        Preconditions.checkArgument(time >= 0, "Time since sting cannot be negative");
         this.getHandle().timeSinceSting = time;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
@@ -118,4 +118,14 @@ public class CraftBee extends CraftAnimals implements Bee {
     public int getTicksSincePollination() {
         return this.getHandle().ticksWithoutNectarSinceExitingHive;
     }
+
+    @Override
+    public void setTimeSinceSting(final int time) {
+        this.getHandle().setTimeSinceSting(time);
+    }
+
+    @Override
+    public int getTimeSinceSting() {
+        return this.getHandle().getTimeSinceSting();
+    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
@@ -120,12 +120,16 @@ public class CraftBee extends CraftAnimals implements Bee {
     }
 
     @Override
-    public void setTimeSinceSting(final int time) {
-        this.getHandle().setTimeSinceSting(time);
+    public void setTimeSinceSting(int time) {
+        if (time < 0) {
+            throw new IllegalArgumentException("Time since sting cannot be negative");
+        }
+
+        this.getHandle().timeSinceSting = time;
     }
 
     @Override
     public int getTimeSinceSting() {
-        return this.getHandle().getTimeSinceSting();
+        return this.getHandle().timeSinceSting;
     }
 }


### PR DESCRIPTION
## Description
Adds API methods to get and set the time since a bee last stung, allowing better control over bee behavior after stinging.

## Problem
Currently there's no way to access or modify the `timeSinceSting` field through the API. This prevents plugins from properly managing bee behavior when using `setHasStung(false)` to make bees attack repeatedly, as the `timeSinceSting` value keeps increasing and can eventually cause the bee to die.

## Solution
Added two new methods to the Bee API:
- `getTimeSinceSting()` - Returns the number of ticks since the bee last stung
- `setTimeSinceSting(int time)` - Sets the number of ticks since the bee last stung

Closes #12719