### PR TITLE
[ci skip] Add remote build cache configuration through Gradle properties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,12 @@ on:
 
 jobs:
   build:
+    env:
+      ORG_GRADLE_PROJECT_paperBuildCacheEnabled: ${{ github.repository == github.event.pull_request.head.repo.full_name }}
+      ORG_GRADLE_PROJECT_paperBuildCacheUsername: ${{ secrets.PAPER_BUILD_CACHE_USERNAME }}
+      ORG_GRADLE_PROJECT_paperBuildCachePassword: ${{ secrets.PAPER_BUILD_CACHE_PASSWORD }}
+      ORG_GRADLE_PROJECT_paperBuildCachePush: true
+
     # The goal of the build workflow is split into multiple requirements.
     # 1. Run on pushes to same repo.
     # 2. Run on PR open/reopen/syncs from repos that are not the same (PRs from the same repo are covered by 1)
@@ -95,11 +101,6 @@ jobs:
           git config --global user.email "no-reply@github.com"
           git config --global user.name "GitHub Actions"
           ./gradlew applyPatches --stacktrace
-        env:
-          ORG_GRADLE_PROJECT_paperBuildCacheEnabled: ${{ github.repository == github.event.pull_request.head.repo.full_name }}
-          ORG_GRADLE_PROJECT_paperBuildCacheUsername: ${{ secrets.PAPER_BUILD_CACHE_USERNAME }}
-          ORG_GRADLE_PROJECT_paperBuildCachePassword: ${{ secrets.PAPER_BUILD_CACHE_PASSWORD }}
-          ORG_GRADLE_PROJECT_paperBuildCachePush: true
 
       - name: Build
         run: ./gradlew build --stacktrace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     env:
-      ORG_GRADLE_PROJECT_paperBuildCacheEnabled: ${{ github.repository == github.event.pull_request.head.repo.full_name }}
+      ORG_GRADLE_PROJECT_paperBuildCacheEnabled: true
       ORG_GRADLE_PROJECT_paperBuildCacheUsername: ${{ secrets.PAPER_BUILD_CACHE_USERNAME }}
       ORG_GRADLE_PROJECT_paperBuildCachePassword: ${{ secrets.PAPER_BUILD_CACHE_PASSWORD }}
       ORG_GRADLE_PROJECT_paperBuildCachePush: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,11 @@ jobs:
           git config --global user.email "no-reply@github.com"
           git config --global user.name "GitHub Actions"
           ./gradlew applyPatches --stacktrace
+        env:
+          ORG_GRADLE_PROJECT_paperBuildCacheEnabled: ${{ github.repository == github.event.pull_request.head.repo.full_name }}
+          ORG_GRADLE_PROJECT_paperBuildCacheUsername: ${{ secrets.PAPER_BUILD_CACHE_USERNAME }}
+          ORG_GRADLE_PROJECT_paperBuildCachePassword: ${{ secrets.PAPER_BUILD_CACHE_PASSWORD }}
+          ORG_GRADLE_PROJECT_paperBuildCachePush: true
 
       - name: Build
         run: ./gradlew build --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
-    id("io.papermc.paperweight.core") version "2.0.0-beta.17" apply false
+    id("io.papermc.paperweight.core") version "2.0.0-beta.18" apply false
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,19 +24,19 @@ subprojects {
 val paperMavenPublicUrl = "https://repo.papermc.io/repository/maven-public/"
 
 subprojects {
-    tasks.withType<JavaCompile> {
+    tasks.withType<JavaCompile>().configureEach {
         options.encoding = Charsets.UTF_8.name()
         options.release = 21
         options.isFork = true
         options.compilerArgs.addAll(listOf("-Xlint:-deprecation", "-Xlint:-removal"))
     }
-    tasks.withType<Javadoc> {
+    tasks.withType<Javadoc>().configureEach {
         options.encoding = Charsets.UTF_8.name()
     }
-    tasks.withType<ProcessResources> {
+    tasks.withType<ProcessResources>().configureEach {
         filteringCharset = Charsets.UTF_8.name()
     }
-    tasks.withType<Test> {
+    tasks.withType<Test>().configureEach {
         testLogging {
             showStackTraces = true
             exceptionFormat = TestExceptionFormat.FULL

--- a/paper-api/build.gradle.kts
+++ b/paper-api/build.gradle.kts
@@ -164,7 +164,7 @@ abstract class Services {
 }
 val services = objects.newInstance<Services>()
 
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
     val options = options as StandardJavadocDocletOptions
     options.overview = "src/main/javadoc/overview.html"
     options.use()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -55,21 +55,25 @@ fun optionalInclude(name: String, op: (ProjectDescriptor.() -> Unit)? = null) {
     }
 }
 
-val buildCacheUsername = providers.gradleProperty("paperBuildCacheUsername").orNull
-val buildCachePassword = providers.gradleProperty("paperBuildCachePassword").orNull
-if (buildCacheUsername != null && buildCachePassword != null) {
-    val buildCacheUrl = providers.gradleProperty("paperBuildCacheUrl")
-        .orElse("https://gradle-build-cache.papermc.io/")
-        .get()
-    val buildCachePush = providers.gradleProperty("paperBuildCachePush").orNull?.toBoolean()
-        ?: System.getProperty("CI").toBoolean()
-    buildCache {
-        remote<HttpBuildCache> {
-            url = uri(buildCacheUrl)
-            isPush = buildCachePush
-            credentials {
-                username = buildCacheUsername
-                password = buildCachePassword
+if (providers.gradleProperty("paperBuildCacheEnabled").orNull.toBoolean()) {
+    val buildCacheUsername = providers.gradleProperty("paperBuildCacheUsername").orNull
+    val buildCachePassword = providers.gradleProperty("paperBuildCachePassword").orNull
+    if (buildCacheUsername == null || buildCachePassword == null) {
+        println("The Paper remote build cache is enabled, but no credentials were provided. Remote build cache will not be used.")
+    } else {
+        val buildCacheUrl = providers.gradleProperty("paperBuildCacheUrl")
+            .orElse("https://gradle-build-cache.papermc.io/")
+            .get()
+        val buildCachePush = providers.gradleProperty("paperBuildCachePush").orNull?.toBoolean()
+            ?: System.getProperty("CI").toBoolean()
+        buildCache {
+            remote<HttpBuildCache> {
+                url = uri(buildCacheUrl)
+                isPush = buildCachePush
+                credentials {
+                    username = buildCacheUsername
+                    password = buildCachePassword
+                }
             }
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,9 +56,9 @@ fun optionalInclude(name: String, op: (ProjectDescriptor.() -> Unit)? = null) {
 }
 
 if (providers.gradleProperty("paperBuildCacheEnabled").orNull.toBoolean()) {
-    val buildCacheUsername = providers.gradleProperty("paperBuildCacheUsername").orNull
-    val buildCachePassword = providers.gradleProperty("paperBuildCachePassword").orNull
-    if (buildCacheUsername == null || buildCachePassword == null) {
+    val buildCacheUsername = providers.gradleProperty("paperBuildCacheUsername").orElse("").get()
+    val buildCachePassword = providers.gradleProperty("paperBuildCachePassword").orElse("").get()
+    if (buildCacheUsername.isBlank() || buildCachePassword.isBlank()) {
         println("The Paper remote build cache is enabled, but no credentials were provided. Remote build cache will not be used.")
     } else {
         val buildCacheUrl = providers.gradleProperty("paperBuildCacheUrl")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,3 @@
-import java.util.Locale
-
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -54,5 +52,25 @@ fun optionalInclude(name: String, op: (ProjectDescriptor.() -> Unit)? = null) {
 
             """.trimIndent()
         )
+    }
+}
+
+val buildCacheUsername = providers.gradleProperty("paperBuildCacheUsername").orNull
+val buildCachePassword = providers.gradleProperty("paperBuildCachePassword").orNull
+if (buildCacheUsername != null && buildCachePassword != null) {
+    val buildCacheUrl = providers.gradleProperty("paperBuildCacheUrl")
+        .orElse("https://gradle-build-cache.papermc.io/")
+        .get()
+    val buildCachePush = providers.gradleProperty("paperBuildCachePush").orNull?.toBoolean()
+        ?: System.getProperty("CI").toBoolean()
+    buildCache {
+        remote<HttpBuildCache> {
+            url = uri(buildCacheUrl)
+            isPush = buildCachePush
+            credentials {
+                username = buildCacheUsername
+                password = buildCachePassword
+            }
+        }
     }
 }


### PR DESCRIPTION
https://github.com/PaperMC/gradle-build-cache-worker

Remote build cache speeds up tasks on fresh checkouts/branch switches for team members.