### PR TITLE
Restore vanilla non-player teleports

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/entity/TeleportFlag.java
+++ b/paper-api/src/main/java/io/papermc/paper/entity/TeleportFlag.java
@@ -13,13 +13,12 @@ import org.bukkit.event.player.PlayerTeleportEvent;
 public sealed interface TeleportFlag permits TeleportFlag.EntityState, TeleportFlag.Relative {
 
     /**
-     * Note: These flags only work on {@link org.bukkit.entity.Player} entities.
-     * <p>
-     * Relative flags enable a player to not lose their velocity in the flag-specific axis/context when teleporting.
+     * Relative flags enable an entity to not lose their velocity in the flag-specific axis/context when teleporting.
      *
      * @apiNote The relative flags exposed in the API do *not* mirror all flags known to vanilla, as relative flags concerning
      * the position are non-applicable given teleports always expect an absolute location.
      * @see org.bukkit.entity.Player#teleport(Location, PlayerTeleportEvent.TeleportCause, TeleportFlag...)
+     * @see org.bukkit.entity.Entity#teleport(Location, PlayerTeleportEvent.TeleportCause, TeleportFlag...)
      */
     enum Relative implements TeleportFlag {
         /**

--- a/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
@@ -27691,7 +27691,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
      }
  
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 6f7f92cc43c56a7453b289f205502d089474ef6d..b390ba657b8b880e431c84e9dd948ac9c84af2fd 100644
+index 5ee4719791723e2359a15c29b19b6c2cc6b90d77..3909d090a447535c7b99273cc45975ebe5d13680 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -193,7 +193,7 @@ import net.minecraft.world.scores.Team;
@@ -28728,7 +28728,7 @@ index 8cc5c0716392ba06501542ff5cbe71ee43979e5d..09fd99c9cbd23b5f3c899bfb00c9b896
 +    // Paper end - block counting
  }
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 06d07f93e42edcfdd7d69df0b52efe2a58e7dfc1..da880f52920b1101f23ef94f3fd0dbdea218c373 100644
+index 07ba10a24bf5cbee10855bf38f67768f9cfe410d..f38289aa50f842df12298fbb2904d0b729034669 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -147,7 +147,7 @@ import net.minecraft.world.waypoints.WaypointTransmitter;
@@ -29203,7 +29203,7 @@ index 06d07f93e42edcfdd7d69df0b52efe2a58e7dfc1..da880f52920b1101f23ef94f3fd0dbde
      }
  
      public InteractionResult interact(Player player, InteractionHand hand) {
-@@ -4291,15 +4528,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4293,15 +4530,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public Iterable<Entity> getIndirectPassengers() {
@@ -29229,7 +29229,7 @@ index 06d07f93e42edcfdd7d69df0b52efe2a58e7dfc1..da880f52920b1101f23ef94f3fd0dbde
      }
  
      public int countPlayerPassengers() {
-@@ -4442,77 +4681,136 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4444,77 +4683,136 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return Mth.lerp(partialTick, this.yRotO, this.yRot);
      }
  
@@ -29420,7 +29420,7 @@ index 06d07f93e42edcfdd7d69df0b52efe2a58e7dfc1..da880f52920b1101f23ef94f3fd0dbde
  
      public boolean touchingUnloadedChunk() {
          AABB aabb = this.getBoundingBox().inflate(1.0);
-@@ -4667,6 +4965,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4669,6 +4967,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
@@ -29436,7 +29436,7 @@ index 06d07f93e42edcfdd7d69df0b52efe2a58e7dfc1..da880f52920b1101f23ef94f3fd0dbde
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4818,6 +5125,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4820,6 +5127,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
      public final void setRemoved(Entity.RemovalReason removalReason, @Nullable org.bukkit.event.entity.EntityRemoveEvent.Cause cause) { // CraftBukkit - add Bukkit remove cause
@@ -29449,7 +29449,7 @@ index 06d07f93e42edcfdd7d69df0b52efe2a58e7dfc1..da880f52920b1101f23ef94f3fd0dbde
          org.bukkit.craftbukkit.event.CraftEventFactory.callEntityRemoveEvent(this, cause); // CraftBukkit
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
          if (this.removalReason == null) {
-@@ -4828,7 +5141,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4830,7 +5143,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              this.stopRiding();
          }
  
@@ -29458,7 +29458,7 @@ index 06d07f93e42edcfdd7d69df0b52efe2a58e7dfc1..da880f52920b1101f23ef94f3fd0dbde
          this.levelCallback.onRemove(removalReason);
          this.onRemoval(removalReason);
          // Paper start - Folia schedulers
-@@ -4862,7 +5175,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4864,7 +5177,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public boolean shouldBeSaved() {
          return (this.removalReason == null || this.removalReason.shouldSave())
              && !this.isPassenger()

--- a/paper-server/patches/features/0033-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0033-Optimise-EntityScheduler-ticking.patch
@@ -67,10 +67,10 @@ index 0a260fdf6b198a8ab52e60bf6db2fb5eab719c48..52fa5112cd90ba766c94512a02401dd3
          profilerFiller.push("commandFunctions");
          this.getFunctions().tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index da880f52920b1101f23ef94f3fd0dbdea218c373..3d2c0a4d3a1f9d3e5cc6cd0cdb988ae1205de821 100644
+index f38289aa50f842df12298fbb2904d0b729034669..d6b162ea152189c92a2e2bc3df46b0c38ed57123 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -5165,6 +5165,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -5167,6 +5167,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.getBukkitEntity().taskScheduler.retire();
      }
      // Paper end - Folia schedulers

--- a/paper-server/patches/sources/net/minecraft/server/commands/TeleportCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/TeleportCommand.java.patch
@@ -1,35 +1,11 @@
 --- a/net/minecraft/server/commands/TeleportCommand.java
 +++ b/net/minecraft/server/commands/TeleportCommand.java
-@@ -290,7 +_,31 @@
+@@ -290,7 +_,7 @@
              float f1 = relatives.contains(Relative.X_ROT) ? xRot - target.getXRot() : xRot;
              float f2 = Mth.wrapDegrees(f);
              float f3 = Mth.wrapDegrees(f1);
 -            if (target.teleportTo(level, d, d1, d2, relatives, f2, f3, true)) {
-+            // CraftBukkit start - Teleport event
-+            boolean result;
-+            if (target instanceof final net.minecraft.server.level.ServerPlayer player) {
-+                result = player.teleportTo(level, d, d1, d2, relatives, f2, f3, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.COMMAND);
-+            } else {
-+                org.bukkit.Location to = new org.bukkit.Location(level.getWorld(), d, d1, d2, f2, f3);
-+                org.bukkit.event.entity.EntityTeleportEvent event = new org.bukkit.event.entity.EntityTeleportEvent(target.getBukkitEntity(), target.getBukkitEntity().getLocation(), to);
-+                level.getCraftServer().getPluginManager().callEvent(event);
-+                if (event.isCancelled() || event.getTo() == null) { // Paper
-+                    return;
-+                }
-+                to = event.getTo(); // Paper - actually track new location
-+
-+                d = to.getX();
-+                d1 = to.getY();
-+                d2 = to.getZ();
-+                f2 = to.getYaw();
-+                f3 = to.getPitch();
-+                level = ((org.bukkit.craftbukkit.CraftWorld) to.getWorld()).getHandle();
-+
-+                result = target.teleportTo(level, d, d1, d2, relatives, f2, f3, true);
-+            }
-+
-+            if (result) {
-+                // CraftBukkit end
++            if (target.teleportTo(level, d, d1, d2, relatives, f2, f3, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.COMMAND)) { // Paper - teleport cause
                  if (lookAt != null) {
                      lookAt.perform(source, target);
                  }

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1473,7 +1473,7 @@
          try (ProblemReporter.ScopedCollector scopedCollector = new ProblemReporter.ScopedCollector(this.problemPath(), LOGGER)) {
              TagValueOutput tagValueOutput = TagValueOutput.createWithContext(scopedCollector, entity.registryAccess());
              entity.saveWithoutId(tagValueOutput);
-@@ -2864,7 +_,65 @@
+@@ -2864,13 +_,72 @@
  
      @Nullable
      public Entity teleport(TeleportTransition teleportTransition) {
@@ -1539,6 +1539,13 @@
              ServerLevel level = teleportTransition.newLevel();
              boolean flag = level.dimension() != serverLevel.dimension();
              if (!teleportTransition.asPassenger()) {
+                 this.stopRiding();
+             }
+ 
++            if (teleportTransition.postTeleportTransition() == TeleportTransition.DONT_KEEP_PASSENGERS) this.ejectPassengers(); // Paper - eject passengers if requested
+             return flag ? this.teleportCrossDimension(serverLevel, level, teleportTransition) : this.teleportSameDimension(serverLevel, teleportTransition);
+         } else {
+             return null;
 @@ -2913,10 +_,15 @@
              profilerFiller.pop();
              return null;
@@ -1615,19 +1622,20 @@
          if (fromLevel.dimension() == Level.END && toLevel.dimension() == Level.OVERWORLD) {
              for (Entity entity : this.getPassengers()) {
                  if (entity instanceof ServerPlayer serverPlayer && !serverPlayer.seenCredits) {
-@@ -3125,8 +_,14 @@
+@@ -3125,8 +_,15 @@
          return this.entityData.get(DATA_CUSTOM_NAME_VISIBLE);
      }
  
 -    public boolean teleportTo(ServerLevel level, double x, double y, double z, Set<Relative> relativeMovements, float yaw, float pitch, boolean setCamera) {
 -        Entity entity = this.teleport(new TeleportTransition(level, new Vec3(x, y, z), Vec3.ZERO, yaw, pitch, relativeMovements, TeleportTransition.DO_NOTHING));
-+    // CraftBukkit start
++    // Paper start - add teleport cause
++    @io.papermc.paper.annotation.DoNotUse
 +    public final boolean teleportTo(ServerLevel level, double x, double y, double z, Set<Relative> relativeMovements, float yaw, float pitch, boolean setCamera) {
 +        return this.teleportTo(level, x, y, z, relativeMovements, yaw, pitch, setCamera, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.UNKNOWN);
 +    }
 +
 +    public boolean teleportTo(ServerLevel level, double x, double y, double z, Set<Relative> relativeMovements, float yaw, float pitch, boolean setCamera, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause) {
-+        // CraftBukkit end
++        // Paper end - add teleport cause
 +        Entity entity = this.teleport(new TeleportTransition(level, new Vec3(x, y, z), Vec3.ZERO, yaw, pitch, relativeMovements, TeleportTransition.DO_NOTHING, cause)); // CraftBukkit
          return entity != null;
      }

--- a/paper-server/patches/sources/net/minecraft/world/level/portal/TeleportTransition.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/portal/TeleportTransition.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/portal/TeleportTransition.java
 +++ b/net/minecraft/world/level/portal/TeleportTransition.java
-@@ -19,15 +_,34 @@
+@@ -19,15 +_,31 @@
      boolean asPassenger,
      Set<Relative> relatives,
      TeleportTransition.PostTeleportTransition postTeleportTransition
@@ -9,17 +9,14 @@
      public static final TeleportTransition.PostTeleportTransition DO_NOTHING = entity -> {};
      public static final TeleportTransition.PostTeleportTransition PLAY_PORTAL_SOUND = TeleportTransition::playPortalSound;
      public static final TeleportTransition.PostTeleportTransition PLACE_PORTAL_TICKET = TeleportTransition::placePortalTicket;
- 
++    public static final TeleportTransition.PostTeleportTransition DONT_KEEP_PASSENGERS = entity -> {}; // Paper - marker
++
 +    // CraftBukkit start
 +    public TeleportTransition(ServerLevel newLevel, Vec3 position, Vec3 deltaMovement, float yRot, float xRot, boolean missingRespawnBlock, boolean asPassenger, Set<Relative> relatives, TeleportTransition.PostTeleportTransition postTeleportTransition) {
 +        this(newLevel, position, deltaMovement, yRot, xRot, missingRespawnBlock, asPassenger, relatives, postTeleportTransition, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.UNKNOWN);
 +    }
-+
-+    public TeleportTransition(org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause) {
-+        this(null, Vec3.ZERO, Vec3.ZERO, 0.0F, 0.0F, false, false, Set.of(), DO_NOTHING, cause);
-+    }
 +    // CraftBukkit end
-+
+ 
      public TeleportTransition(
          ServerLevel newLevel, Vec3 position, Vec3 deltaMovement, float yRot, float xRot, TeleportTransition.PostTeleportTransition postTeleportTransition
      ) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
@@ -425,7 +425,7 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
         Preconditions.checkArgument(!entity.isInWorld(), "Entity has already been added to a world");
         net.minecraft.world.entity.Entity nmsEntity = ((CraftEntity) entity).getHandle();
         if (nmsEntity.level() != this.getHandle().getLevel()) {
-            nmsEntity = nmsEntity.teleport(new TeleportTransition(this.getHandle().getLevel(), nmsEntity, TeleportTransition.DO_NOTHING));
+            throw new IllegalArgumentException(entity + " wasn't created with this world, you must create the entity with the world you want to add it to."); // Paper - throw instead of teleporting
         }
 
         this.addEntityWithPassengers(nmsEntity, CreatureSpawnEvent.SpawnReason.CUSTOM);


### PR DESCRIPTION
Replaces https://github.com/PaperMC/Paper/pull/10734/files

Restores more vanilla-like logic for non-player teleports. Player's will be handled later, as well as changing the default behavior of api teleport methods to include passengers by default.

Also makes relative velocity flags work for teleporting entities.