### PR TITLE
Fix consistency issues for inventory result slots

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -588,6 +588,7 @@ public net.minecraft.world.level.block.ShulkerBoxBlock color
 public net.minecraft.world.level.block.SoundType breakSound
 public net.minecraft.world.level.block.SoundType hitSound
 public net.minecraft.world.level.block.TurtleEggBlock decreaseEggs(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V
+public net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity SLOT_RESULT
 public net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity cookingTimer
 public net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity cookingTotalTime
 public net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity getTotalCookTime(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity;)I
@@ -610,6 +611,7 @@ public net.minecraft.world.level.block.entity.BellBlockEntity resonating
 public net.minecraft.world.level.block.entity.BellBlockEntity resonationTicks
 public net.minecraft.world.level.block.entity.BlockEntity saveId(Lnet/minecraft/world/level/storage/ValueOutput;)V
 public net.minecraft.world.level.block.entity.BlockEntityType validBlocks
+public net.minecraft.world.level.block.entity.BrewingStandBlockEntity INGREDIENT_SLOT
 public net.minecraft.world.level.block.entity.BrewingStandBlockEntity brewTime
 public net.minecraft.world.level.block.entity.BrewingStandBlockEntity fuel
 public net.minecraft.world.level.block.entity.BrushableBlockEntity item

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryBrewer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryBrewer.java
@@ -1,6 +1,7 @@
 package org.bukkit.craftbukkit.inventory;
 
 import net.minecraft.world.Container;
+import net.minecraft.world.level.block.entity.BrewingStandBlockEntity;
 import org.bukkit.block.BrewingStand;
 import org.bukkit.inventory.BrewerInventory;
 import org.bukkit.inventory.ItemStack;
@@ -8,6 +9,11 @@ import org.bukkit.inventory.ItemStack;
 public class CraftInventoryBrewer extends CraftInventory implements BrewerInventory {
     public CraftInventoryBrewer(Container inventory) {
         super(inventory);
+    }
+
+    @Override
+    public ItemStack[] getStorageContents() {
+        return this.asCraftMirror(this.getInventory().getContents().subList(BrewingStandBlockEntity.INGREDIENT_SLOT, this.getInventory().getContainerSize()));
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryCrafting.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryCrafting.java
@@ -38,6 +38,16 @@ public class CraftInventoryCrafting extends CraftInventory implements CraftingIn
     }
 
     @Override
+    public ItemStack[] getStorageContents() {
+        return this.asCraftMirror(this.getMatrixInventory().getContents());
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.getInventory().isEmpty() && this.getResultInventory().isEmpty();
+    }
+
+    @Override
     public ItemStack[] getContents() {
         ItemStack[] items = new ItemStack[this.getSize()];
         List<net.minecraft.world.item.ItemStack> mcResultItems = this.getResultInventory().getContents();

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java
@@ -11,6 +11,11 @@ public class CraftInventoryFurnace extends CraftInventory implements FurnaceInve
     }
 
     @Override
+    public ItemStack[] getStorageContents() {
+        return this.asCraftMirror(this.getInventory().getContents().subList(0, AbstractFurnaceBlockEntity.SLOT_RESULT));
+    }
+
+    @Override
     public ItemStack getResult() {
         return this.getItem(2);
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryMerchant.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryMerchant.java
@@ -1,6 +1,7 @@
 package org.bukkit.craftbukkit.inventory;
 
 import net.minecraft.world.inventory.MerchantContainer;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.MerchantInventory;
 import org.bukkit.inventory.MerchantRecipe;
@@ -12,6 +13,11 @@ public class CraftInventoryMerchant extends CraftInventory implements MerchantIn
     public CraftInventoryMerchant(net.minecraft.world.item.trading.Merchant merchant, MerchantContainer inventory) {
         super(inventory);
         this.merchant = merchant;
+    }
+
+    @Override
+    public ItemStack[] getStorageContents() {
+        return this.asCraftMirror(this.getInventory().getContents().subList(0, 2));
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftResultInventory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftResultInventory.java
@@ -1,5 +1,7 @@
 package org.bukkit.craftbukkit.inventory;
 
+import java.util.ArrayList;
+import java.util.List;
 import net.minecraft.world.Container;
 import org.bukkit.inventory.ItemStack;
 
@@ -18,6 +20,24 @@ public class CraftResultInventory extends CraftInventory {
 
     public Container getIngredientsInventory() {
         return this.inventory;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.getIngredientsInventory().isEmpty() && this.getResultInventory().isEmpty();
+    }
+
+    @Override
+    public ItemStack[] getStorageContents() {
+        return this.asCraftMirror(this.getIngredientsInventory().getContents());
+    }
+
+    @Override
+    public ItemStack[] getContents() {
+        final List<net.minecraft.world.item.ItemStack> contents = new ArrayList<>();
+        contents.addAll(this.getIngredientsInventory().getContents());
+        contents.addAll(this.getResultInventory().getContents());
+        return this.asCraftMirror(contents);
     }
 
     @Override
@@ -42,6 +62,6 @@ public class CraftResultInventory extends CraftInventory {
 
     @Override
     public int getSize() {
-        return this.getResultInventory().getContainerSize() + this.getIngredientsInventory().getContainerSize();
+        return this.getIngredientsInventory().getContainerSize() + this.getResultInventory().getContainerSize();
     }
 }


### PR DESCRIPTION
Replaces https://github.com/PaperMC/Paper/pull/10721

----

So my thinking here, was any inventory that had result slots that wasn't already using CraftResultInventory should have their "storage" contents exclude the result slots. The ones I found were villager trading inventories, all the furnaces, brewing stands, and crafting inventories.

I also fixed an issue where Inventories that were CraftResultInventories didn't include all the contents in getContents.

Fixes https://github.com/PaperMC/Paper/issues/10720