### PR TITLE
Improve GameEvent events

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/ReceiveGameEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/ReceiveGameEvent.java
@@ -1,0 +1,50 @@
+package io.papermc.paper.event;
+
+import org.bukkit.GameEvent;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Common methods for {@link io.papermc.paper.event.entity.EntityReceiveGameEvent} and
+ * {@link org.bukkit.event.block.BlockReceiveGameEvent}.
+ */
+@NullMarked
+@ApiStatus.NonExtendable
+public interface ReceiveGameEvent extends Cancellable {
+
+    /**
+     * Get the underlying game event.
+     *
+     * @return the game event
+     */
+    GameEvent getEvent();
+
+    /**
+     * Get the entity which triggered this game event, if present.
+     *
+     * @return triggering entity or {@code null}
+     */
+    @Nullable Entity getTriggerEntity();
+
+    /**
+     * Get the block data change which triggered this game event, if present.
+     *
+     * @return triggering block data or {@code null}
+     */
+    @Nullable BlockData getTriggerBlockData();
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Cancels any action the receiver might take because of this game event
+     */
+    @Override
+    void setCancelled(boolean cancel);
+
+    @ApiStatus.Internal
+    boolean callEvent();
+}

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityReceiveGameEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityReceiveGameEvent.java
@@ -1,23 +1,23 @@
-package org.bukkit.event.block;
+package io.papermc.paper.event.entity;
 
 import io.papermc.paper.event.ReceiveGameEvent;
 import org.bukkit.GameEvent;
-import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityEvent;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Called when a block receives a game event and hence might take some action.
+ * Called when an entity receives a game event and hence might take some action.
  * <p>
- * Will be called cancelled if the block's default behavior is to ignore the
+ * Will be called cancelled if the entity's default behavior is to ignore the
  * event.
  */
 @NullMarked
-public class BlockReceiveGameEvent extends BlockEvent implements ReceiveGameEvent {
+public class EntityReceiveGameEvent extends EntityEvent implements ReceiveGameEvent {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
@@ -28,27 +28,27 @@ public class BlockReceiveGameEvent extends BlockEvent implements ReceiveGameEven
     private boolean cancelled;
 
     @ApiStatus.Internal
-    public BlockReceiveGameEvent(final Block block, final GameEvent event, final @Nullable Entity triggerEntity, final @Nullable BlockData triggerBlockData) {
-        super(block);
+    public EntityReceiveGameEvent(final Entity target, final GameEvent event, final @Nullable Entity triggerEntity, final @Nullable BlockData triggerBlockData) {
+        super(target);
         this.event = event;
         this.triggerEntity = triggerEntity;
         this.triggerBlockData = triggerBlockData;
     }
 
+    /**
+     * Gets the entity which received the game event, not to be
+     * confused with the entity which may have caused the game event.
+     *
+     * @see #getTriggerEntity()
+     */
+    @Override
+    public Entity getEntity() {
+        return super.getEntity();
+    }
+
     @Override
     public GameEvent getEvent() {
         return this.event;
-    }
-
-    /**
-     * Get the entity which triggered this event, if present.
-     *
-     * @return triggering entity or {@code null}
-     * @deprecated name is ambiguous, use {@link #getTriggerEntity()}
-     */
-    @Deprecated(since = "26.1")
-    public @Nullable Entity getEntity() {
-        return this.getTriggerEntity();
     }
 
     @Override

--- a/paper-api/src/main/java/io/papermc/paper/event/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Paper events.
+ */
+package io.papermc.paper.event;

--- a/paper-api/src/main/java/org/bukkit/event/world/GenericGameEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/world/GenericGameEvent.java
@@ -37,9 +37,9 @@ public class GenericGameEvent extends WorldEvent implements Cancellable {
     }
 
     /**
-     * Get the underlying event.
+     * Get the underlying game event.
      *
-     * @return the event
+     * @return the game event
      */
     @NotNull
     public GameEvent getEvent() {
@@ -47,9 +47,9 @@ public class GenericGameEvent extends WorldEvent implements Cancellable {
     }
 
     /**
-     * Get the location where the event occurred.
+     * Get the location where the game event occurred.
      *
-     * @return event location
+     * @return game event location
      */
     @NotNull
     public Location getLocation() {
@@ -57,7 +57,7 @@ public class GenericGameEvent extends WorldEvent implements Cancellable {
     }
 
     /**
-     * Get the entity which triggered this event, if present.
+     * Get the entity which triggered this game event, if present.
      *
      * @return triggering entity or {@code null}
      */
@@ -67,7 +67,7 @@ public class GenericGameEvent extends WorldEvent implements Cancellable {
     }
 
     /**
-     * Get the block radius to which this event will be broadcast.
+     * Get the block radius to which this game event will be broadcast.
      *
      * @return broadcast radius
      */
@@ -76,7 +76,7 @@ public class GenericGameEvent extends WorldEvent implements Cancellable {
     }
 
     /**
-     * Set the radius to which the event should be broadcast.
+     * Set the radius to which the game event should be broadcast.
      *
      * @param radius radius, must be greater than or equal to 0
      */

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/allay/Allay.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/allay/Allay.java.patch
@@ -81,3 +81,38 @@
      }
  
      public void resetDuplicationCooldown() {
+@@ -532,9 +_,21 @@
+         @Override
+         public boolean handleGameEvent(final ServerLevel level, final Holder<GameEvent> event, final GameEvent.Context context, final Vec3 sourcePosition) {
+             if (event.is(GameEvent.JUKEBOX_PLAY)) {
++                // Paper start - improve GameEvent events
++                io.papermc.paper.event.ReceiveGameEvent entityEvent = Allay.this.vibrationUser.createReceiveGameEvent(level, event, context, sourcePosition);
++                if (!entityEvent.callEvent()) {
++                    return false;
++                }
++                // Paper end - improve GameEvent events
+                 Allay.this.setJukeboxPlaying(BlockPos.containing(sourcePosition), true);
+                 return true;
+             } else if (event.is(GameEvent.JUKEBOX_STOP_PLAY)) {
++                // Paper start - improve GameEvent events
++                io.papermc.paper.event.ReceiveGameEvent entityEvent = Allay.this.vibrationUser.createReceiveGameEvent(level, event, context, sourcePosition);
++                if (!entityEvent.callEvent()) {
++                    return false;
++                }
++                // Paper end - improve GameEvent events
+                 Allay.this.setJukeboxPlaying(BlockPos.containing(sourcePosition), false);
+                 return true;
+             } else {
+@@ -596,5 +_,12 @@
+         public TagKey<GameEvent> getListenableEvents() {
+             return GameEventTags.ALLAY_CAN_LISTEN;
+         }
++
++        // Paper start - improve GameEvent events
++        @Override
++        public io.papermc.paper.event.ReceiveGameEvent createReceiveGameEvent(final ServerLevel level, final Holder<GameEvent> event, final GameEvent.Context context, final Vec3 position) {
++            return org.bukkit.craftbukkit.event.CraftEventFactory.createReceiveGameEvent(Allay.this, event, context);
++        }
++        // Paper end - improve GameEvent events
+     }
+ }

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/allay/Allay.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/allay/Allay.java.patch
@@ -96,3 +96,38 @@
      }
  
      public void resetDuplicationCooldown() {
+@@ -535,9 +_,21 @@
+         @Override
+         public boolean handleGameEvent(final ServerLevel level, final Holder<GameEvent> event, final GameEvent.Context context, final Vec3 sourcePosition) {
+             if (event.is(GameEvent.JUKEBOX_PLAY)) {
++                // Paper start - improve GameEvent events
++                io.papermc.paper.event.ReceiveGameEvent entityEvent = Allay.this.vibrationUser.createReceiveGameEvent(level, event, context, sourcePosition);
++                if (!entityEvent.callEvent()) {
++                    return false;
++                }
++                // Paper end - improve GameEvent events
+                 Allay.this.setJukeboxPlaying(BlockPos.containing(sourcePosition), true);
+                 return true;
+             } else if (event.is(GameEvent.JUKEBOX_STOP_PLAY)) {
++                // Paper start - improve GameEvent events
++                io.papermc.paper.event.ReceiveGameEvent entityEvent = Allay.this.vibrationUser.createReceiveGameEvent(level, event, context, sourcePosition);
++                if (!entityEvent.callEvent()) {
++                    return false;
++                }
++                // Paper end - improve GameEvent events
+                 Allay.this.setJukeboxPlaying(BlockPos.containing(sourcePosition), false);
+                 return true;
+             } else {
+@@ -593,5 +_,12 @@
+         public TagKey<GameEvent> getListenableEvents() {
+             return GameEventTags.ALLAY_CAN_LISTEN;
+         }
++
++        // Paper start - improve GameEvent events
++        @Override
++        public io.papermc.paper.event.ReceiveGameEvent createReceiveGameEvent(final ServerLevel level, final Holder<GameEvent> event, final GameEvent.Context context, final Vec3 position) {
++            return org.bukkit.craftbukkit.event.CraftEventFactory.createReceiveGameEvent(Allay.this, event, context);
++        }
++        // Paper end - improve GameEvent events
+     }
+ }

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/warden/Warden.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/warden/Warden.java.patch
@@ -28,3 +28,16 @@
              WardenAi.setDigCooldown(this);
              boolean maybeSwitchTarget = !(this.getTarget() instanceof Player);
              int newAnger = this.angerManagement.increaseAnger(entity, amount);
+@@ -653,5 +_,12 @@
+                 }
+             }
+         }
++
++        // Paper start - improve GameEvent events
++        @Override
++        public io.papermc.paper.event.ReceiveGameEvent createReceiveGameEvent(final ServerLevel level, final Holder<GameEvent> event, final GameEvent.Context context, final Vec3 position) {
++            return org.bukkit.craftbukkit.event.CraftEventFactory.createReceiveGameEvent(Warden.this, event, context);
++        }
++        // Paper end - improve GameEvent events
+     }
+ }

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/warden/Warden.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/warden/Warden.java.patch
@@ -28,3 +28,16 @@
              WardenAi.setDigCooldown(this);
              boolean maybeSwitchTarget = !(this.getTarget() instanceof Player);
              int newAnger = this.angerManagement.increaseAnger(entity, amount);
+@@ -644,5 +_,12 @@
+                 }
+             }
+         }
++
++        // Paper start - improve GameEvent events
++        @Override
++        public io.papermc.paper.event.ReceiveGameEvent createReceiveGameEvent(final ServerLevel level, final Holder<GameEvent> event, final GameEvent.Context context, final Vec3 position) {
++            return org.bukkit.craftbukkit.event.CraftEventFactory.createReceiveGameEvent(Warden.this, event, context);
++        }
++        // Paper end - improve GameEvent events
+     }
+ }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/SculkCatalystBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/SculkCatalystBlockEntity.java.patch
@@ -19,3 +19,17 @@
      }
  
      @Override
+@@ -87,6 +_,13 @@
+         public boolean handleGameEvent(final ServerLevel level, final Holder<GameEvent> event, final GameEvent.Context context, final Vec3 sourcePosition) {
+             if (event.is(GameEvent.ENTITY_DIE) && context.sourceEntity() instanceof LivingEntity mob) {
+                 if (!mob.wasExperienceConsumed()) {
++                    // Paper start - improve GameEvent events
++                    // TODO(future) add a sub event to capture more info about this happening, xp amount, amount to spread, etc.
++                    io.papermc.paper.event.ReceiveGameEvent blockEvent = org.bukkit.craftbukkit.event.CraftEventFactory.createReceiveGameEvent(level, this.positionSource.getPosition(level).orElseThrow(), event, context);
++                    if (!blockEvent.callEvent()) {
++                        return false;
++                    }
++                    // Paper end - improve GameEvent events
+                     DamageSource lastDamageSource = mob.getLastDamageSource();
+                     int experienceWouldDrop = mob.getExperienceReward(level, Optionull.map(lastDamageSource, DamageSource::getEntity));
+                     if (mob.shouldDropExperience() && experienceWouldDrop > 0) {

--- a/paper-server/patches/sources/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java.patch
@@ -9,19 +9,30 @@
                      ExtraCodecs.NON_NEGATIVE_INT.fieldOf("event_delay").orElse(0).forGetter(VibrationSystem.Data::getTravelTimeInTicks)
                  )
                  .apply(
-@@ -219,7 +_,14 @@
+@@ -219,7 +_,13 @@
                      return false;
                  } else {
                      Vec3 destination = listenerSourcePos.get();
 -                    if (!user.canReceiveVibration(level, BlockPos.containing(sourcePosition), event, context)) {
-+                    // CraftBukkit start
-+                    boolean defaultCancel = !user.canReceiveVibration(level, BlockPos.containing(sourcePosition), event, context);
-+                    Entity entity = context.sourceEntity();
-+                    org.bukkit.event.block.BlockReceiveGameEvent event1 = new org.bukkit.event.block.BlockReceiveGameEvent(org.bukkit.craftbukkit.CraftGameEvent.minecraftHolderToBukkit(event), org.bukkit.craftbukkit.block.CraftBlock.at(level, BlockPos.containing(sourcePosition)), (entity == null) ? null : entity.getBukkitEntity());
-+                    event1.setCancelled(defaultCancel);
-+                    level.getCraftServer().getPluginManager().callEvent(event1);
-+                    if (event1.isCancelled()) {
-+                        // CraftBukkit end
++                    // Paper start - improve GameEvent events
++                    boolean deaf = !user.canReceiveVibration(level, BlockPos.containing(sourcePosition), event, context);
++                    // TODO add special sub vibration events to control LOS check (GameEvent != Vibration)
++                    io.papermc.paper.event.ReceiveGameEvent bukkitEvent = user.createReceiveGameEvent(level, event, context, destination);
++                    bukkitEvent.setCancelled(deaf);
++                    if (!bukkitEvent.callEvent()) {
++                        // Paper end - improve GameEvent events
                          return false;
                      } else if (isOccluded(level, sourcePosition, destination)) {
                          return false;
+@@ -434,5 +_,11 @@
+ 
+         default void onDataChanged() {
+         }
++
++        // Paper start - improve GameEvent events
++        default io.papermc.paper.event.ReceiveGameEvent createReceiveGameEvent(final ServerLevel level, final Holder<GameEvent> event, final GameEvent.Context context, final Vec3 position) {
++            return org.bukkit.craftbukkit.event.CraftEventFactory.createReceiveGameEvent(level, position, event, context);
++        }
++        // Paper end - improve GameEvent events
+     }
+ }

--- a/paper-server/patches/sources/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java.patch
@@ -9,19 +9,30 @@
                      ExtraCodecs.optionalAlwaysPresentFieldOf(ExtraCodecs.NON_NEGATIVE_INT, "event_delay", 0)
                          .forGetter(VibrationSystem.Data::getTravelTimeInTicks)
                  )
-@@ -225,7 +_,14 @@
+@@ -225,7 +_,13 @@
              }
  
              Vec3 destination = listenerSourcePos.get();
 -            if (!user.canReceiveVibration(level, BlockPos.containing(sourcePosition), event, context)) {
-+            // CraftBukkit start
-+            boolean defaultCancel = !user.canReceiveVibration(level, BlockPos.containing(sourcePosition), event, context);
-+            Entity entity = context.sourceEntity();
-+            org.bukkit.event.block.BlockReceiveGameEvent event1 = new org.bukkit.event.block.BlockReceiveGameEvent(org.bukkit.craftbukkit.CraftGameEvent.minecraftHolderToBukkit(event), org.bukkit.craftbukkit.block.CraftBlock.at(level, BlockPos.containing(destination)), (entity == null) ? null : entity.getBukkitEntity());
-+            event1.setCancelled(defaultCancel);
-+            level.getCraftServer().getPluginManager().callEvent(event1);
-+            if (event1.isCancelled()) {
-+                // CraftBukkit end
++            // Paper start - improve GameEvent events
++            boolean deaf = !user.canReceiveVibration(level, BlockPos.containing(sourcePosition), event, context);
++            // TODO add special sub vibration events to control LOS check (GameEvent != Vibration)
++            io.papermc.paper.event.ReceiveGameEvent bukkitEvent = user.createReceiveGameEvent(level, event, context, destination);
++            bukkitEvent.setCancelled(deaf);
++            if (!bukkitEvent.callEvent()) {
++                // Paper end - improve GameEvent events
                  return false;
              }
  
+@@ -440,5 +_,11 @@
+ 
+         default void onDataChanged() {
+         }
++
++        // Paper start - improve GameEvent events
++        default io.papermc.paper.event.ReceiveGameEvent createReceiveGameEvent(final ServerLevel level, final Holder<GameEvent> event, final GameEvent.Context context, final Vec3 position) {
++            return org.bukkit.craftbukkit.event.CraftEventFactory.createReceiveGameEvent(level, position, event, context);
++        }
++        // Paper end - improve GameEvent events
+     }
+ }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -12,6 +12,7 @@ import io.papermc.paper.connection.HorriblePlayerLoginEventHack;
 import io.papermc.paper.connection.PlayerConnection;
 import io.papermc.paper.event.block.BlockLockCheckEvent;
 import io.papermc.paper.event.connection.PlayerConnectionValidateLoginEvent;
+import io.papermc.paper.event.entity.EntityReceiveGameEvent;
 import io.papermc.paper.event.entity.ItemTransportingEntityValidateTargetEvent;
 import io.papermc.paper.event.player.PlayerBedFailEnterEvent;
 import io.papermc.paper.event.player.PlayerToggleEntityAgeLockEvent;
@@ -23,9 +24,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import net.minecraft.Optionull;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Holder;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ServerboundContainerClosePacket;
@@ -68,6 +71,7 @@ import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.SignBlockEntity;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
+import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.level.gamerules.GameRule;
 import net.minecraft.world.level.redstone.Redstone;
 import net.minecraft.world.level.storage.loot.LootContext;
@@ -91,6 +95,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.craftbukkit.CraftChunk;
 import org.bukkit.craftbukkit.CraftEquipmentSlot;
 import org.bukkit.craftbukkit.CraftExplosionResult;
+import org.bukkit.craftbukkit.CraftGameEvent;
 import org.bukkit.craftbukkit.CraftGameRule;
 import org.bukkit.craftbukkit.CraftLootTable;
 import org.bukkit.craftbukkit.CraftRaid;
@@ -156,6 +161,7 @@ import org.bukkit.event.block.BlockIgniteEvent.IgniteCause;
 import org.bukkit.event.block.BlockMultiPlaceEvent;
 import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.BlockReceiveGameEvent;
 import org.bukkit.event.block.BlockRedstoneEvent;
 import org.bukkit.event.block.BlockShearEntityEvent;
 import org.bukkit.event.block.BlockSpreadEvent;
@@ -364,7 +370,7 @@ public class CraftEventFactory {
         final var event = new PlayerBedFailEnterEvent(
             (org.bukkit.entity.Player) player.getBukkitEntity(),
             actionPair.getFirst(),
-            org.bukkit.craftbukkit.block.CraftBlock.at(player.level(), bed),
+            CraftBlock.at(player.level(), bed),
             bedSleepingProblem == net.minecraft.world.entity.player.Player.BedSleepingProblem.EXPLOSION,
             actionPair.getSecond().errorMessage(),
             actionPair.getSecond());
@@ -559,7 +565,7 @@ public class CraftEventFactory {
     public static EntityPlaceEvent callEntityPlaceEvent(Level level, BlockPos clickedPos, Direction clickedFace, net.minecraft.world.entity.player.Player player, Entity entity, InteractionHand hand) {
         Player cplayer = (player == null) ? null : (Player) player.getBukkitEntity();
         org.bukkit.block.Block clickedBlock = CraftBlock.at(level, clickedPos);
-        org.bukkit.block.BlockFace blockFace = org.bukkit.craftbukkit.block.CraftBlock.notchToBlockFace(clickedFace);
+        org.bukkit.block.BlockFace blockFace = CraftBlock.notchToBlockFace(clickedFace);
 
         EntityPlaceEvent event = new EntityPlaceEvent(entity.getBukkitEntity(), cplayer, clickedBlock, blockFace, CraftEquipmentSlot.getHand(hand));
         entity.level().getCraftServer().getPluginManager().callEvent(event);
@@ -626,7 +632,7 @@ public class CraftEventFactory {
         CraftServer craftServer = (CraftServer) cplayer.getServer();
         Block clickedBlock = null;
         if (pos != null) {
-            clickedBlock = org.bukkit.craftbukkit.block.CraftBlock.at(player.level(), pos);
+            clickedBlock = CraftBlock.at(player.level(), pos);
         } else {
             switch (action) {
                 case LEFT_CLICK_BLOCK:
@@ -2370,7 +2376,7 @@ public class CraftEventFactory {
             && blockEntity != null
             && blockEntity.getLevel() != null
             && blockEntity.getLevel().getBlockEntity(blockEntity.getBlockPos()) == blockEntity) {
-            final org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(blockEntity.getLevel(), blockEntity.getBlockPos());
+            final org.bukkit.block.Block block = CraftBlock.at(blockEntity.getLevel(), blockEntity.getBlockPos());
             net.kyori.adventure.text.Component lockedMessage = net.kyori.adventure.text.Component.translatable("container.isLocked", io.papermc.paper.adventure.PaperAdventure.asAdventure(displayName));
             net.kyori.adventure.sound.Sound lockedSound = net.kyori.adventure.sound.Sound.sound(org.bukkit.Sound.BLOCK_CHEST_LOCKED, net.kyori.adventure.sound.Sound.Source.BLOCK, 1.0F, 1.0F);
             final io.papermc.paper.event.block.BlockLockCheckEvent event = new io.papermc.paper.event.block.BlockLockCheckEvent(block, player.getBukkitEntity(), lockedMessage, lockedSound);
@@ -2426,5 +2432,23 @@ public class CraftEventFactory {
             return new ClockTimeSkipEvent(ClockTimeSkipEvent.SkipReason.COMMAND, skipAmount);
         }
         return new TimeSkipEvent(source.getLevel().getWorld(), ClockTimeSkipEvent.SkipReason.COMMAND, skipAmount);
+    }
+
+    public static BlockReceiveGameEvent createReceiveGameEvent(final ServerLevel level, final Vec3 position, final Holder<GameEvent> event, final GameEvent.Context context) {
+        return new BlockReceiveGameEvent(
+            CraftBlock.at(level, BlockPos.containing(position)),
+            CraftGameEvent.minecraftHolderToBukkit(event),
+            Optionull.map(context.sourceEntity(), Entity::getBukkitEntity),
+            Optionull.map(context.affectedState(), net.minecraft.world.level.block.state.BlockState::asBlockData)
+        );
+    }
+
+    public static EntityReceiveGameEvent createReceiveGameEvent(final Entity target, final Holder<GameEvent> event, final GameEvent.Context context) {
+        return new EntityReceiveGameEvent(
+            target.getBukkitEntity(),
+            CraftGameEvent.minecraftHolderToBukkit(event),
+            Optionull.map(context.sourceEntity(), Entity::getBukkitEntity),
+            Optionull.map(context.affectedState(), net.minecraft.world.level.block.state.BlockState::asBlockData)
+        );
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -12,6 +12,7 @@ import io.papermc.paper.connection.PlayerConnection;
 import io.papermc.paper.event.block.BlockLockCheckEvent;
 import io.papermc.paper.event.connection.PlayerConnectionValidateLoginEvent;
 import io.papermc.paper.event.entity.EntityIgniteEvent;
+import io.papermc.paper.event.entity.EntityReceiveGameEvent;
 import io.papermc.paper.event.entity.ItemTransportingEntityValidateTargetEvent;
 import io.papermc.paper.event.player.PlayerBedFailEnterEvent;
 import io.papermc.paper.event.player.PlayerToggleEntityAgeLockEvent;
@@ -28,6 +29,7 @@ import net.minecraft.Optionull;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Holder;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ServerboundContainerClosePacket;
@@ -72,6 +74,7 @@ import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.SignBlockEntity;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
+import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.level.gamerules.GameRule;
 import net.minecraft.world.level.redstone.Redstone;
 import net.minecraft.world.level.storage.loot.LootContext;
@@ -95,6 +98,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.craftbukkit.CraftChunk;
 import org.bukkit.craftbukkit.CraftEquipmentSlot;
 import org.bukkit.craftbukkit.CraftExplosionResult;
+import org.bukkit.craftbukkit.CraftGameEvent;
 import org.bukkit.craftbukkit.CraftGameRule;
 import org.bukkit.craftbukkit.CraftLootTable;
 import org.bukkit.craftbukkit.CraftRaid;
@@ -160,6 +164,7 @@ import org.bukkit.event.block.BlockIgniteEvent.IgniteCause;
 import org.bukkit.event.block.BlockMultiPlaceEvent;
 import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.BlockReceiveGameEvent;
 import org.bukkit.event.block.BlockRedstoneEvent;
 import org.bukkit.event.block.BlockShearEntityEvent;
 import org.bukkit.event.block.BlockSpreadEvent;
@@ -368,7 +373,7 @@ public class CraftEventFactory {
         final var event = new PlayerBedFailEnterEvent(
             (org.bukkit.entity.Player) player.getBukkitEntity(),
             actionPair.getFirst(),
-            org.bukkit.craftbukkit.block.CraftBlock.at(player.level(), bed),
+            CraftBlock.at(player.level(), bed),
             bedSleepingProblem == net.minecraft.world.entity.player.Player.BedSleepingProblem.EXPLOSION,
             actionPair.getSecond().errorMessage(),
             actionPair.getSecond());
@@ -563,7 +568,7 @@ public class CraftEventFactory {
     public static EntityPlaceEvent callEntityPlaceEvent(Level level, BlockPos clickedPos, Direction clickedFace, net.minecraft.world.entity.player.Player player, Entity entity, InteractionHand hand) {
         Player cplayer = (player == null) ? null : (Player) player.getBukkitEntity();
         org.bukkit.block.Block clickedBlock = CraftBlock.at(level, clickedPos);
-        org.bukkit.block.BlockFace blockFace = org.bukkit.craftbukkit.block.CraftBlock.notchToBlockFace(clickedFace);
+        org.bukkit.block.BlockFace blockFace = CraftBlock.notchToBlockFace(clickedFace);
 
         EntityPlaceEvent event = new EntityPlaceEvent(entity.getBukkitEntity(), cplayer, clickedBlock, blockFace, CraftEquipmentSlot.getHand(hand));
         entity.level().getCraftServer().getPluginManager().callEvent(event);
@@ -630,7 +635,7 @@ public class CraftEventFactory {
         CraftServer craftServer = (CraftServer) cplayer.getServer();
         Block clickedBlock = null;
         if (pos != null) {
-            clickedBlock = org.bukkit.craftbukkit.block.CraftBlock.at(player.level(), pos);
+            clickedBlock = CraftBlock.at(player.level(), pos);
         } else {
             switch (action) {
                 case LEFT_CLICK_BLOCK:
@@ -2356,7 +2361,7 @@ public class CraftEventFactory {
             && blockEntity != null
             && blockEntity.getLevel() != null
             && blockEntity.getLevel().getBlockEntity(blockEntity.getBlockPos()) == blockEntity) {
-            final org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(blockEntity.getLevel(), blockEntity.getBlockPos());
+            final org.bukkit.block.Block block = CraftBlock.at(blockEntity.getLevel(), blockEntity.getBlockPos());
             net.kyori.adventure.text.Component lockedMessage = net.kyori.adventure.text.Component.translatable("container.isLocked", io.papermc.paper.adventure.PaperAdventure.asAdventure(displayName));
             net.kyori.adventure.sound.Sound lockedSound = net.kyori.adventure.sound.Sound.sound(org.bukkit.Sound.BLOCK_CHEST_LOCKED, net.kyori.adventure.sound.Sound.Source.BLOCK, 1.0F, 1.0F);
             final io.papermc.paper.event.block.BlockLockCheckEvent event = new io.papermc.paper.event.block.BlockLockCheckEvent(block, player.getBukkitEntity(), lockedMessage, lockedSound);
@@ -2424,5 +2429,23 @@ public class CraftEventFactory {
             return PrimedTnt.NO_FUSE;
         }
         return event.getFuseTime();
+    }
+
+    public static BlockReceiveGameEvent createReceiveGameEvent(final ServerLevel level, final Vec3 position, final Holder<GameEvent> event, final GameEvent.Context context) {
+        return new BlockReceiveGameEvent(
+            CraftBlock.at(level, BlockPos.containing(position)),
+            CraftGameEvent.minecraftHolderToBukkit(event),
+            Optionull.map(context.sourceEntity(), Entity::getBukkitEntity),
+            Optionull.map(context.affectedState(), net.minecraft.world.level.block.state.BlockState::asBlockData)
+        );
+    }
+
+    public static EntityReceiveGameEvent createReceiveGameEvent(final Entity target, final Holder<GameEvent> event, final GameEvent.Context context) {
+        return new EntityReceiveGameEvent(
+            target.getBukkitEntity(),
+            CraftGameEvent.minecraftHolderToBukkit(event),
+            Optionull.map(context.sourceEntity(), Entity::getBukkitEntity),
+            Optionull.map(context.affectedState(), net.minecraft.world.level.block.state.BlockState::asBlockData)
+        );
     }
 }


### PR DESCRIPTION
Replaces https://github.com/PaperMC/Paper/pull/8636

----

Adds EntityReceiveGameEvent and expands BlockReceiveGameEvent

BlockReceiveGameEvent was not called for all block listeners, and was called for entity listeners. This separates them out into two events and adds missing event calls. It also adds more api for bypassing line of sight/occlusion checks (not sure what to call that).