### PR TITLE
Resend block data after cancelled block damage/player interact event

### DIFF
--- a/paper-server/patches/features/0004-Anti-Xray.patch
+++ b/paper-server/patches/features/0004-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/io/papermc/paper/FeatureHooks.java b/io/papermc/paper/FeatureHooks.java
-index 811a8e5141f2061a185b53b63d951646141c0c7d..33d3eb510c5844e72bbc382bd24641aae080962d 100644
+index 77738ab478bcafb4cec4172c797014162cce9285..b1a7af2dd3a3e166b1e58125f13ce08b9ec6d9ff 100644
 --- a/io/papermc/paper/FeatureHooks.java
 +++ b/io/papermc/paper/FeatureHooks.java
 @@ -45,20 +45,25 @@ public final class FeatureHooks {
@@ -156,10 +156,10 @@ index e6f958b6128213fb9577406c6495148dccac40ca..49008b4cbaead8a66a93d2b0d4b50b33
          this.levelStorageAccess = levelStorageAccess;
          this.uuid = org.bukkit.craftbukkit.util.WorldUUID.getOrCreate(levelStorageAccess.levelDirectory.path().toFile());
 diff --git a/net/minecraft/server/level/ServerPlayerGameMode.java b/net/minecraft/server/level/ServerPlayerGameMode.java
-index b29ecfcc07304c1ee3d77cd431db0889ebc7d6b1..6734756d7a51e635a50a47577f9e6b6f8111db51 100644
+index 3e8b4fd9c721daf85172966c2421752b5d2a5aa5..7498cf68e2d281b2e8888afc2558a3faa51cb059 100644
 --- a/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -296,6 +296,7 @@ public class ServerPlayerGameMode {
+@@ -298,6 +298,7 @@ public class ServerPlayerGameMode {
                  org.bukkit.craftbukkit.event.CraftEventFactory.callBlockDamageAbortEvent(this.player, pos, this.player.getInventory().getSelectedItem()); // CraftBukkit
              }
          }
@@ -186,7 +186,7 @@ index 8cd7363704d4532c926dbf4778eb4dfec5fdf8bc..0376a10ee0544b13e8fd629a7b13f788
          if (io.papermc.paper.event.packet.PlayerChunkLoadEvent.getHandlerList().getRegisteredListeners().length > 0) {
              new io.papermc.paper.event.packet.PlayerChunkLoadEvent(new org.bukkit.craftbukkit.CraftChunk(chunk), packetListener.getPlayer().getBukkitEntity()).callEvent();
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index b595fc3bd844eaf2a56f70f166523ee6254386b6..891d3e13057c6034c59a78e594935c433921de04 100644
+index cd1296641283a7dda799d4370cf82089df47e35d..21b7b2f88708eb9e29d4c327b9bca79119b7124d 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -408,7 +408,7 @@ public abstract class PlayerList {

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -164,7 +164,14 @@
                  if (!blockState.isAir() && f >= 1.0F) {
                      this.destroyAndAck(pos, sequence, "insta mine");
                  } else {
-@@ -212,14 +_,22 @@
+@@ -207,19 +_,29 @@
+                             this.delayedTickStart = this.destroyProgressStart;
+                         }
+                     }
++                } else {
++                    this.capturedBlockEntity = true; // Paper - Send block entities after destroy prediction
+                 }
+ 
                  this.debugLogging(pos, true, sequence, "stopped destroying");
              } else if (action == ServerboundPlayerActionPacket.Action.ABORT_DESTROY_BLOCK) {
                  this.isDestroyingBlock = false;


### PR DESCRIPTION
fixes #10759 

https://github.com/user-attachments/assets/d84715d7-6d55-488e-a4b3-e8fd46ff3fe4