### PR TITLE
Fix handling of cancelled PlayerTeleportEvents with relative flags

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1000,7 +1000,7 @@
  
              return true;
          } else {
-@@ -1175,10 +_,77 @@
+@@ -1175,10 +_,81 @@
      }
  
      public void teleport(double x, double y, double z, float yaw, float pitch) {
@@ -1041,7 +1041,11 @@
 +        this.cserver.getPluginManager().callEvent(event);
 +
 +        if (event.isCancelled() || !to.equals(event.getTo())) {
-+            // set = Collections.emptySet(); // Can't relative teleport // Paper - Teleport API; Now you can!
++            // Paper start - Remove relative teleportation flags
++            relatives = EnumSet.copyOf(relatives);
++            relatives.retainAll(Relative.DELTA);
++            // set = Collections.emptySet(); // Can't relative teleport
++            // Paper end - Remove relative teleportation flags
 +            to = event.isCancelled() ? event.getFrom() : event.getTo();
 +            posMoveRotation = new PositionMoveRotation(CraftLocation.toVec3(to), Vec3.ZERO, to.getYaw(), to.getPitch());
 +        }


### PR DESCRIPTION
Fixes #12696, which happens when a player is teleported to a relative position, but the `PlayerTeleportEvent` is cancelled or the `to` field is changed. This issue is caused by the position being teleported to becoming an absolute value when getting it from the event.

To resolve this, all non-velocity relative flags are removed if the event is cancelled or modified.

This could also be fixed by converting the positions back to relative values, but that would add additional overhead and does not appear to give any benefit, as this is fairly late in teleportation processing.