### PR TITLE
Get all available keys in DialogResponseView

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/dialog/DialogResponseView.java
+++ b/paper-api/src/main/java/io/papermc/paper/dialog/DialogResponseView.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.Nullable;
+import java.util.Collection;
 
 /**
  * A view for a possible response to a dialog.
@@ -49,4 +50,12 @@ public interface DialogResponseView {
      */
     @Contract(pure = true)
     @Nullable Float getFloat(String key);
+
+    /**
+     * Gets all keys in the response.
+     *
+     * @return a collection of keys
+     */
+    @Contract(pure = true)
+    Collection<String> keys();
 }

--- a/paper-server/src/main/java/io/papermc/paper/dialog/PaperDialogResponseView.java
+++ b/paper-server/src/main/java/io/papermc/paper/dialog/PaperDialogResponseView.java
@@ -4,6 +4,7 @@ import io.papermc.paper.adventure.PaperAdventure;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.minecraft.nbt.CompoundTag;
 import org.jspecify.annotations.Nullable;
+import java.util.Collection;
 
 public class PaperDialogResponseView implements DialogResponseView {
 
@@ -44,5 +45,10 @@ public class PaperDialogResponseView implements DialogResponseView {
             return null;
         }
         return this.payload.getFloat(key).orElse(null);
+    }
+
+    @Override
+    public Collection<String> keys() {
+        return this.payload.keySet();
     }
 }


### PR DESCRIPTION
This PR adds a new method in DialogResponseView to get all available keys.

I don't know if there is any real-world usage with this, but in my case, I need a way to convert a response view to a simple String-Object map without reflection.