### PR TITLE
Restore previous PlayerToggleSneakEvent behaviour

### DIFF
--- a/paper-server/patches/features/0030-Optimise-collision-checking-in-player-move-packet-ha.patch
+++ b/paper-server/patches/features/0030-Optimise-collision-checking-in-player-move-packet-ha.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Optimise collision checking in player move packet handling
 Move collision logic to just the hasNewCollision call instead of getCubes + hasNewCollision
 
 diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ad03fbf426612484396b6990d744fabddead6205..c8b4631336406d42151576f9f445bd0b716d69e1 100644
+index 39a706ae5be3681c32c297c73d57b9bcf56638d4..c8dfd7fdaabc047eec05f1b78c97b551aa0fc586 100644
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -605,6 +605,7 @@ public class ServerGamePacketListenerImpl
+@@ -606,6 +606,7 @@ public class ServerGamePacketListenerImpl
                  }
  
                  rootVehicle.move(MoverType.PLAYER, new Vec3(d3, d4, d5));
@@ -17,7 +17,7 @@ index ad03fbf426612484396b6990d744fabddead6205..c8b4631336406d42151576f9f445bd0b
                  double verticalDelta = d4;
                  d3 = d - rootVehicle.getX();
                  d4 = d1 - rootVehicle.getY();
-@@ -616,12 +617,21 @@ public class ServerGamePacketListenerImpl
+@@ -617,12 +618,21 @@ public class ServerGamePacketListenerImpl
                  d7 = d3 * d3 + d4 * d4 + d5 * d5;
                  boolean flag1 = false;
                  if (d7 > org.spigotmc.SpigotConfig.movedWronglyThreshold) { // Spigot
@@ -42,7 +42,7 @@ index ad03fbf426612484396b6990d744fabddead6205..c8b4631336406d42151576f9f445bd0b
                      rootVehicle.absSnapTo(x, y, z, f, f1);
                      this.send(ClientboundMoveVehiclePacket.fromEntity(rootVehicle));
                      rootVehicle.removeLatestMovementRecording();
-@@ -700,9 +710,32 @@ public class ServerGamePacketListenerImpl
+@@ -701,9 +711,32 @@ public class ServerGamePacketListenerImpl
      }
  
      private boolean noBlocksAround(Entity entity) {
@@ -78,7 +78,7 @@ index ad03fbf426612484396b6990d744fabddead6205..c8b4631336406d42151576f9f445bd0b
      }
  
      @Override
-@@ -1478,7 +1511,7 @@ public class ServerGamePacketListenerImpl
+@@ -1479,7 +1512,7 @@ public class ServerGamePacketListenerImpl
                                      }
                                  }
  
@@ -87,7 +87,7 @@ index ad03fbf426612484396b6990d744fabddead6205..c8b4631336406d42151576f9f445bd0b
                                  d3 = d - this.lastGoodX; // Paper - diff on change, used for checking large move vectors above
                                  d4 = d1 - this.lastGoodY; // Paper - diff on change, used for checking large move vectors above
                                  d5 = d2 - this.lastGoodZ; // Paper - diff on change, used for checking large move vectors above
-@@ -1517,6 +1550,7 @@ public class ServerGamePacketListenerImpl
+@@ -1518,6 +1551,7 @@ public class ServerGamePacketListenerImpl
                                  boolean flag1 = this.player.verticalCollisionBelow;
                                  this.player.move(MoverType.PLAYER, new Vec3(d3, d4, d5));
                                  this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move
@@ -95,7 +95,7 @@ index ad03fbf426612484396b6990d744fabddead6205..c8b4631336406d42151576f9f445bd0b
                                  // Paper start - prevent position desync
                                  if (this.awaitingPositionFromClient != null) {
                                      return; // ... thanks Mojang for letting move calls teleport across dimensions.
-@@ -1549,7 +1583,17 @@ public class ServerGamePacketListenerImpl
+@@ -1550,7 +1584,17 @@ public class ServerGamePacketListenerImpl
                                  }
  
                                  // Paper start - Add fail move event
@@ -114,7 +114,7 @@ index ad03fbf426612484396b6990d744fabddead6205..c8b4631336406d42151576f9f445bd0b
                                  if (!allowMovement) {
                                      io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.CLIPPED_INTO_BLOCK,
                                              toX, toY, toZ, toYaw, toPitch, false);
-@@ -1685,7 +1729,7 @@ public class ServerGamePacketListenerImpl
+@@ -1686,7 +1730,7 @@ public class ServerGamePacketListenerImpl
  
      private boolean updateAwaitingTeleport() {
          if (this.awaitingPositionFromClient != null) {
@@ -123,7 +123,7 @@ index ad03fbf426612484396b6990d744fabddead6205..c8b4631336406d42151576f9f445bd0b
                  this.awaitingTeleportTime = this.tickCount;
                  this.teleport(
                      this.awaitingPositionFromClient.x,
-@@ -1704,6 +1748,33 @@ public class ServerGamePacketListenerImpl
+@@ -1705,6 +1749,33 @@ public class ServerGamePacketListenerImpl
          }
      }
  

--- a/paper-server/patches/features/0030-Optimise-collision-checking-in-player-move-packet-ha.patch
+++ b/paper-server/patches/features/0030-Optimise-collision-checking-in-player-move-packet-ha.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Optimise collision checking in player move packet handling
 Move collision logic to just the hasNewCollision call instead of getCubes + hasNewCollision
 
 diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 08aba415735733f5968fd032ab7ca249cdcf6cde..ee4397711625344622c81424afd11fd6d967efba 100644
+index ad03fbf426612484396b6990d744fabddead6205..c8b4631336406d42151576f9f445bd0b716d69e1 100644
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -606,6 +606,7 @@ public class ServerGamePacketListenerImpl
+@@ -605,6 +605,7 @@ public class ServerGamePacketListenerImpl
                  }
  
                  rootVehicle.move(MoverType.PLAYER, new Vec3(d3, d4, d5));
@@ -17,7 +17,7 @@ index 08aba415735733f5968fd032ab7ca249cdcf6cde..ee4397711625344622c81424afd11fd6
                  double verticalDelta = d4;
                  d3 = d - rootVehicle.getX();
                  d4 = d1 - rootVehicle.getY();
-@@ -617,12 +618,21 @@ public class ServerGamePacketListenerImpl
+@@ -616,12 +617,21 @@ public class ServerGamePacketListenerImpl
                  d7 = d3 * d3 + d4 * d4 + d5 * d5;
                  boolean flag1 = false;
                  if (d7 > org.spigotmc.SpigotConfig.movedWronglyThreshold) { // Spigot
@@ -42,7 +42,7 @@ index 08aba415735733f5968fd032ab7ca249cdcf6cde..ee4397711625344622c81424afd11fd6
                      rootVehicle.absSnapTo(x, y, z, f, f1);
                      this.send(ClientboundMoveVehiclePacket.fromEntity(rootVehicle));
                      rootVehicle.removeLatestMovementRecording();
-@@ -701,9 +711,32 @@ public class ServerGamePacketListenerImpl
+@@ -700,9 +710,32 @@ public class ServerGamePacketListenerImpl
      }
  
      private boolean noBlocksAround(Entity entity) {
@@ -78,7 +78,7 @@ index 08aba415735733f5968fd032ab7ca249cdcf6cde..ee4397711625344622c81424afd11fd6
      }
  
      @Override
-@@ -1479,7 +1512,7 @@ public class ServerGamePacketListenerImpl
+@@ -1478,7 +1511,7 @@ public class ServerGamePacketListenerImpl
                                      }
                                  }
  
@@ -87,7 +87,7 @@ index 08aba415735733f5968fd032ab7ca249cdcf6cde..ee4397711625344622c81424afd11fd6
                                  d3 = d - this.lastGoodX; // Paper - diff on change, used for checking large move vectors above
                                  d4 = d1 - this.lastGoodY; // Paper - diff on change, used for checking large move vectors above
                                  d5 = d2 - this.lastGoodZ; // Paper - diff on change, used for checking large move vectors above
-@@ -1518,6 +1551,7 @@ public class ServerGamePacketListenerImpl
+@@ -1517,6 +1550,7 @@ public class ServerGamePacketListenerImpl
                                  boolean flag1 = this.player.verticalCollisionBelow;
                                  this.player.move(MoverType.PLAYER, new Vec3(d3, d4, d5));
                                  this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move
@@ -95,7 +95,7 @@ index 08aba415735733f5968fd032ab7ca249cdcf6cde..ee4397711625344622c81424afd11fd6
                                  // Paper start - prevent position desync
                                  if (this.awaitingPositionFromClient != null) {
                                      return; // ... thanks Mojang for letting move calls teleport across dimensions.
-@@ -1550,7 +1584,17 @@ public class ServerGamePacketListenerImpl
+@@ -1549,7 +1583,17 @@ public class ServerGamePacketListenerImpl
                                  }
  
                                  // Paper start - Add fail move event
@@ -114,7 +114,7 @@ index 08aba415735733f5968fd032ab7ca249cdcf6cde..ee4397711625344622c81424afd11fd6
                                  if (!allowMovement) {
                                      io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.CLIPPED_INTO_BLOCK,
                                              toX, toY, toZ, toYaw, toPitch, false);
-@@ -1686,7 +1730,7 @@ public class ServerGamePacketListenerImpl
+@@ -1685,7 +1729,7 @@ public class ServerGamePacketListenerImpl
  
      private boolean updateAwaitingTeleport() {
          if (this.awaitingPositionFromClient != null) {
@@ -123,7 +123,7 @@ index 08aba415735733f5968fd032ab7ca249cdcf6cde..ee4397711625344622c81424afd11fd6
                  this.awaitingTeleportTime = this.tickCount;
                  this.teleport(
                      this.awaitingPositionFromClient.x,
-@@ -1705,6 +1749,33 @@ public class ServerGamePacketListenerImpl
+@@ -1704,6 +1748,33 @@ public class ServerGamePacketListenerImpl
          }
      }
  

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -154,7 +154,7 @@
      }
  
      private int getMaximumFlyingTicks(Entity entity) {
-@@ -388,11 +_,37 @@
+@@ -388,11 +_,36 @@
      @Override
      public void handlePlayerInput(ServerboundPlayerInputPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
@@ -166,15 +166,15 @@
 +        // CraftBukkit end
 +        // Paper start - PlayerToggleSneakEvent
 +        net.minecraft.world.entity.player.Input lastInput = this.player.getLastClientInput();
-+        boolean shiftKeyDown = packet.input().shift();
 +        if (lastInput.shift() != packet.input().shift()) {
 +            // Has sneak changed
 +            org.bukkit.event.player.PlayerToggleSneakEvent event = new org.bukkit.event.player.PlayerToggleSneakEvent(this.getCraftPlayer(), packet.input().shift());
 +            this.cserver.getPluginManager().callEvent(event);
 +
 +            // Technically the player input and the flag is desynced, but this is previous behavior.. so should be fine?
-+            if (event.isCancelled()) {
-+               shiftKeyDown = this.player.isShiftKeyDown();
++            if (!event.isCancelled() && this.player.hasClientLoaded()) {
++                // Only set the shift key status if the shift input has changed and the event has not been cancelled
++                this.player.setShiftKeyDown(packet.input().shift());
 +            }
 +        }
 +        // Paper end - PlayerToggleSneakEvent
@@ -183,7 +183,6 @@
              this.player.resetLastActionTime();
 -            this.player.setShiftKeyDown(packet.input().shift());
 -        }
-+            this.player.setShiftKeyDown(shiftKeyDown); // Paper
 +        }
 +        // Paper start - Add option to make parrots stay
 +        if (packet.input().shift() && this.player.level().paperConfig().entities.behavior.parrotsAreUnaffectedByPlayerMovement) {

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -154,7 +154,7 @@
      }
  
      private int getMaximumFlyingTicks(Entity entity) {
-@@ -388,11 +_,36 @@
+@@ -388,11 +_,37 @@
      @Override
      public void handlePlayerInput(ServerboundPlayerInputPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
@@ -183,6 +183,7 @@
              this.player.resetLastActionTime();
 -            this.player.setShiftKeyDown(packet.input().shift());
 -        }
++            // this.player.setShiftKeyDown(packet.input().shift()); // Paper - move up and only set if event is not cancelled.
 +        }
 +        // Paper start - Add option to make parrots stay
 +        if (packet.input().shift() && this.player.level().paperConfig().entities.behavior.parrotsAreUnaffectedByPlayerMovement) {


### PR DESCRIPTION
Cancelling PlayerToggleSneakEvent should prevent the player from sneaking server-side and for other clients. Since 1.21.6, cancelling `PlayerToggleSneakEvent` prevents server-side sneaking only until another movement key is pressed. The player then sneaks after pressing another movement key while still holding sneak. This is because `net.minecraft.server.network.ServerGamePacketListenerImpl#handlePlayerInput` only triggers the event if the shift input has changed *this packet*. Therefore, after another movement key is pressed, `PlayerToggleSneakEvent` is not fired, but the player's sneaking state is toggled anyways. 

This PR changes the behaviour to only set the player's sneaking state if the shift input has changed in this packet and `PlayerToggleSneakEvent` has been triggered and not cancelled, fixing this regression.