### PR TITLE
[ci skip] javadoc: Fix grammatical error for getState

### DIFF
--- a/paper-api/src/main/java/org/bukkit/conversations/Conversation.java
+++ b/paper-api/src/main/java/org/bukkit/conversations/Conversation.java
@@ -193,9 +193,9 @@ public class Conversation {
     }
 
     /**
-     * Returns Returns the current state of the conversation.
+     * Returns the current state of the conversation.
      *
-     * @return The current state of the conversation.
+     * @return The ConversationState.
      */
     @NotNull
     public ConversationState getState() {

--- a/paper-api/src/main/java/org/bukkit/conversations/Conversation.java
+++ b/paper-api/src/main/java/org/bukkit/conversations/Conversation.java
@@ -195,7 +195,7 @@ public class Conversation {
     /**
      * Returns the current state of the conversation.
      *
-     * @return The ConversationState.
+     * @return The current state of the conversation.
      */
     @NotNull
     public ConversationState getState() {


### PR DESCRIPTION
Fixes a small grammatical javadoc mistake in Conversation#getState.