### PR TITLE
Specify the class loader when loading services

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/command/brigadier/MessageComponentSerializer.java
+++ b/paper-api/src/main/java/io/papermc/paper/command/brigadier/MessageComponentSerializer.java
@@ -20,8 +20,7 @@ public interface MessageComponentSerializer extends ComponentSerializer<Componen
      */
     static MessageComponentSerializer message() {
         final class Holder {
-            static final Optional<MessageComponentSerializer> PROVIDER = ServiceLoader.load(MessageComponentSerializer.class)
-                .findFirst();
+            static final Optional<MessageComponentSerializer> PROVIDER = ServiceLoader.load(MessageComponentSerializer.class, MessageComponentSerializer.class.getClassLoader()).findFirst();
         }
         return Holder.PROVIDER.orElseThrow();
     }

--- a/paper-api/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProvider.java
+++ b/paper-api/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProvider.java
@@ -35,8 +35,7 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 interface VanillaArgumentProvider {
 
-    Optional<VanillaArgumentProvider> PROVIDER = ServiceLoader.load(VanillaArgumentProvider.class)
-        .findFirst();
+    Optional<VanillaArgumentProvider> PROVIDER = ServiceLoader.load(VanillaArgumentProvider.class, VanillaArgumentProvider.class.getClassLoader()).findFirst();
 
     static VanillaArgumentProvider provider() {
         return PROVIDER.orElseThrow();

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemComponentTypesBridge.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemComponentTypesBridge.java
@@ -24,7 +24,7 @@ import org.jspecify.annotations.Nullable;
 @ApiStatus.Internal
 interface ItemComponentTypesBridge {
 
-    Optional<ItemComponentTypesBridge> BRIDGE = ServiceLoader.load(ItemComponentTypesBridge.class).findFirst();
+    Optional<ItemComponentTypesBridge> BRIDGE = ServiceLoader.load(ItemComponentTypesBridge.class, ItemComponentTypesBridge.class.getClassLoader()).findFirst();
 
     static ItemComponentTypesBridge bridge() {
         return BRIDGE.orElseThrow();

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/attribute/AttributeModifierDisplayBridge.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/attribute/AttributeModifierDisplayBridge.java
@@ -10,7 +10,7 @@ import org.jspecify.annotations.NullMarked;
 @ApiStatus.Internal
 interface AttributeModifierDisplayBridge {
 
-    Optional<AttributeModifierDisplayBridge> BRIDGE = ServiceLoader.load(AttributeModifierDisplayBridge.class).findFirst();
+    Optional<AttributeModifierDisplayBridge> BRIDGE = ServiceLoader.load(AttributeModifierDisplayBridge.class, AttributeModifierDisplayBridge.class.getClassLoader()).findFirst();
 
     static AttributeModifierDisplayBridge bridge() {
         return BRIDGE.orElseThrow();

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/BlocksAttacksBridge.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/BlocksAttacksBridge.java
@@ -9,7 +9,7 @@ import org.jspecify.annotations.NullMarked;
 @ApiStatus.Internal
 interface BlocksAttacksBridge {
 
-    Optional<BlocksAttacksBridge> BRIDGE = ServiceLoader.load(BlocksAttacksBridge.class).findFirst();
+    Optional<BlocksAttacksBridge> BRIDGE = ServiceLoader.load(BlocksAttacksBridge.class, BlocksAttacksBridge.class.getClassLoader()).findFirst();
 
     static BlocksAttacksBridge bridge() {
         return BRIDGE.orElseThrow();

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumableTypesBridge.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumableTypesBridge.java
@@ -14,7 +14,7 @@ import org.jspecify.annotations.NullMarked;
 @ApiStatus.Internal
 interface ConsumableTypesBridge {
 
-    Optional<ConsumableTypesBridge> BRIDGE = ServiceLoader.load(ConsumableTypesBridge.class).findFirst();
+    Optional<ConsumableTypesBridge> BRIDGE = ServiceLoader.load(ConsumableTypesBridge.class, ConsumableTypesBridge.class.getClassLoader()).findFirst();
 
     static ConsumableTypesBridge bridge() {
         return BRIDGE.orElseThrow();

--- a/paper-api/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/LifecycleEventTypeProvider.java
+++ b/paper-api/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/LifecycleEventTypeProvider.java
@@ -9,8 +9,7 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 interface LifecycleEventTypeProvider {
 
-    Optional<LifecycleEventTypeProvider> INSTANCE = ServiceLoader.load(LifecycleEventTypeProvider.class)
-        .findFirst();
+    Optional<LifecycleEventTypeProvider> INSTANCE = ServiceLoader.load(LifecycleEventTypeProvider.class, LifecycleEventTypeProvider.class.getClassLoader()).findFirst();
 
     static LifecycleEventTypeProvider provider() {
         return INSTANCE.orElseThrow();

--- a/paper-api/src/main/java/io/papermc/paper/registry/RegistryAccessHolder.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/RegistryAccessHolder.java
@@ -5,7 +5,7 @@ import java.util.ServiceLoader;
 
 final class RegistryAccessHolder {
 
-    static final Optional<RegistryAccess> INSTANCE = ServiceLoader.load(RegistryAccess.class).findFirst();
+    static final Optional<RegistryAccess> INSTANCE = ServiceLoader.load(RegistryAccess.class, RegistryAccess.class.getClassLoader()).findFirst();
 
     private RegistryAccessHolder() {
     }

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/InlinedRegistryBuilderProvider.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/InlinedRegistryBuilderProvider.java
@@ -15,7 +15,7 @@ public interface InlinedRegistryBuilderProvider {
 
     static InlinedRegistryBuilderProvider instance() {
         final class Holder {
-            static final Optional<InlinedRegistryBuilderProvider> INSTANCE = ServiceLoader.load(InlinedRegistryBuilderProvider.class).findFirst();
+            static final Optional<InlinedRegistryBuilderProvider> INSTANCE = ServiceLoader.load(InlinedRegistryBuilderProvider.class, InlinedRegistryBuilderProvider.class.getClassLoader()).findFirst();
         }
         return Holder.INSTANCE.orElseThrow();
     }

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/DialogInstancesProvider.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/DialogInstancesProvider.java
@@ -36,7 +36,7 @@ public interface DialogInstancesProvider {
 
     static DialogInstancesProvider instance() {
         final class Holder {
-            static final Optional<DialogInstancesProvider> INSTANCE = ServiceLoader.load(DialogInstancesProvider.class).findFirst();
+            static final Optional<DialogInstancesProvider> INSTANCE = ServiceLoader.load(DialogInstancesProvider.class, DialogInstancesProvider.class.getClassLoader()).findFirst();
         }
         return Holder.INSTANCE.orElseThrow();
     }

--- a/paper-api/src/main/java/io/papermc/paper/registry/event/RegistryEventTypeProvider.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/event/RegistryEventTypeProvider.java
@@ -11,8 +11,7 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 interface RegistryEventTypeProvider {
 
-    Optional<RegistryEventTypeProvider> PROVIDER = ServiceLoader.load(RegistryEventTypeProvider.class)
-        .findFirst();
+    Optional<RegistryEventTypeProvider> PROVIDER = ServiceLoader.load(RegistryEventTypeProvider.class, RegistryEventTypeProvider.class.getClassLoader()).findFirst();
 
     static RegistryEventTypeProvider provider() {
         return PROVIDER.orElseThrow(() -> new IllegalStateException("Could not find a %s service implementation".formatted(RegistryEventTypeProvider.class.getSimpleName())));

--- a/paper-api/src/main/java/io/papermc/paper/world/flag/FeatureFlagProvider.java
+++ b/paper-api/src/main/java/io/papermc/paper/world/flag/FeatureFlagProvider.java
@@ -11,7 +11,7 @@ import org.jspecify.annotations.NullMarked;
 @ApiStatus.Internal
 interface FeatureFlagProvider {
 
-    Optional<FeatureFlagProvider> PROVIDER = ServiceLoader.load(FeatureFlagProvider.class).findFirst();
+    Optional<FeatureFlagProvider> PROVIDER = ServiceLoader.load(FeatureFlagProvider.class, FeatureFlagProvider.class.getClassLoader()).findFirst();
 
     static FeatureFlagProvider provider() {
         return PROVIDER.orElseThrow();


### PR DESCRIPTION
Plugins might be using threads provided by utilities like the common
fork join pool, which does not have the servers classloader around.
Previously this prevented the service loader from finding server
implementations for API types as the threads context class loader did
not point to the server or one of this child class loaders.

To prevent this, instead specify the class loader of the respective API
type, which itself is loaded by the servers class loader.
