### PR TITLE
Add vanilla error message to precondition for DialogBaseImpl

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/DialogBaseImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/DialogBaseImpl.java
@@ -20,7 +20,7 @@ public record DialogBaseImpl(
 ) implements DialogBase {
 
     public DialogBaseImpl {
-        Preconditions.checkArgument(!pause || afterAction != DialogAfterAction.NONE);
+        Preconditions.checkArgument(!pause || afterAction != DialogAfterAction.NONE, "Dialogs that pause the game must use after_action values that unpause it after user action!");
         body = List.copyOf(body);
         inputs = List.copyOf(inputs);
     }


### PR DESCRIPTION
Add the vanilla error message to the precondition for DialogBaseImpl so the error is easier to understand and does not require opening up the server source to debug.