### PR TITLE
Expose HexColor argument type

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/command/brigadier/argument/ArgumentTypes.java
+++ b/paper-api/src/main/java/io/papermc/paper/command/brigadier/argument/ArgumentTypes.java
@@ -18,6 +18,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.GameMode;
 import org.bukkit.HeightMap;
 import org.bukkit.NamespacedKey;
@@ -165,6 +166,15 @@ public final class ArgumentTypes {
      */
     public static ArgumentType<NamedTextColor> namedColor() {
         return provider().namedColor();
+    }
+
+    /**
+     * A hex color argument.
+     *
+     * @return argument
+     */
+    public static ArgumentType<TextColor> hexColor() {
+        return provider().hexColor();
     }
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProvider.java
+++ b/paper-api/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProvider.java
@@ -20,6 +20,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.GameMode;
 import org.bukkit.HeightMap;
 import org.bukkit.NamespacedKey;
@@ -64,6 +65,8 @@ interface VanillaArgumentProvider {
     ArgumentType<ItemStackPredicate> itemStackPredicate();
 
     ArgumentType<NamedTextColor> namedColor();
+
+    ArgumentType<TextColor> hexColor();
 
     ArgumentType<Component> component();
 

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
@@ -39,6 +39,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
 import net.minecraft.advancements.critereon.MinMaxBounds;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.ColorArgument;
@@ -49,6 +50,7 @@ import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.commands.arguments.GameModeArgument;
 import net.minecraft.commands.arguments.GameProfileArgument;
 import net.minecraft.commands.arguments.HeightmapTypeArgument;
+import net.minecraft.commands.arguments.HexColorArgument;
 import net.minecraft.commands.arguments.MessageArgument;
 import net.minecraft.commands.arguments.ObjectiveCriteriaArgument;
 import net.minecraft.commands.arguments.RangeArgument;
@@ -203,6 +205,11 @@ public class VanillaArgumentProviderImpl implements VanillaArgumentProvider {
                 () -> result.getColor() + " didn't map to an adventure named color"
             )
         );
+    }
+
+    @Override
+    public ArgumentType<TextColor> hexColor() {
+        return this.wrap(HexColorArgument.hexColor(), TextColor::color);
     }
 
     @Override


### PR DESCRIPTION
This PR exposes the hex color argument type.
It's a small change, but I believe it can be useful in many cases.