### PR TITLE
configure velocity proxy using env variable

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -122,8 +122,18 @@ public class GlobalConfiguration extends ConfigurationPart {
 
             @PostProcess
             private void postProcess() {
+                final String environmentSourcedVelocityEnabled = System.getenv("PAPER_VELOCITY_ENABLED");
+                if (environmentSourcedVelocityEnabled != null && !environmentSourcedVelocityEnabled.isEmpty()) {
+                    this.enabled = Boolean.parseBoolean(environmentSourcedVelocityEnabled);
+                }
+                
                 if (!this.enabled) return;
 
+                final String environmentSourcedVelocityOnlineMode = System.getenv("PAPER_VELOCITY_ONLINE_MODE");
+                if (environmentSourcedVelocityOnlineMode != null && !environmentSourcedVelocityOnlineMode.isEmpty()) {
+                    this.onlineMode = Boolean.parseBoolean(environmentSourcedVelocityOnlineMode);
+                }
+                
                 final String environmentSourcedVelocitySecret = System.getenv("PAPER_VELOCITY_SECRET");
                 if (environmentSourcedVelocitySecret != null && !environmentSourcedVelocitySecret.isEmpty()) {
                     this.secret = environmentSourcedVelocitySecret;


### PR DESCRIPTION
The ability to configure the Velocity forwarding secret via the environment variable `PAPER_VELOCITY_SECRET` was introduced in #10127. However, since Velocity support is disabled by default, using this feature still requires manual modification of `paper-global.yml`.

To enable full automation of Velocity configuration via environment variables, this PR adds support for two additional env vars:

* `PAPER_VELOCITY_ENABLED` - enables the Velocity proxy support (`true` or `false`)
* `PAPER_VELOCITY_ONLINE_MODE` - sets the `online-mode` value (`true` or `false`)

This ensures that all necessary Velocity settings can be configured via environment variables without manual intervention.

**Note:** `paper-global.yml` is currently not generated when using the `--initSettings` CLI flag, which limits the ability to preconfigure the server without a full startup. Unless that behavior changes, environment variables remain the only viable option for automating this configuration in containerized environments.