### PR TITLE
Copy thrown pearls list

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -420,8 +420,9 @@
  
          player.unRide();
  
-         for (ThrownEnderpearl thrownEnderpearl : player.getEnderPearls()) {
+-        for (ThrownEnderpearl thrownEnderpearl : player.getEnderPearls()) {
 -            thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER);
++        for (ThrownEnderpearl thrownEnderpearl : new java.util.ArrayList<>(player.getEnderPearls())) { // Paper - copy, setOwner will remove from list;
 +            // Paper start - Allow using old ender pearl behavior
 +            if (!thrownEnderpearl.level().paperConfig().misc.legacyEnderPearlBehavior) {
 +                thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause


### PR DESCRIPTION
the legacy enderpearl configuration option removes the player from the pearl,
which updates the list of pearls tracked by player while it is being iterated.
Ideally we'd only clone as needed, but, this being per-dimension prevents us
from being able to do that
