### PR TITLE
Replace compileOnly with implementation for test visibility

### DIFF
--- a/paper-api/build.gradle.kts
+++ b/paper-api/build.gradle.kts
@@ -66,8 +66,8 @@ dependencies {
     apiAndDocs("net.kyori:adventure-text-logger-slf4j")
 
     api("org.apache.maven:maven-resolver-provider:3.9.6") // make API dependency for Paper Plugins
-    compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.9.18")
-    compileOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.9.18")
+    implementation("org.apache.maven.resolver:maven-resolver-connector-basic:1.9.18")
+    implementation("org.apache.maven.resolver:maven-resolver-transport-http:1.9.18")
 
     // Annotations - Slowly migrate to jspecify
     val annotations = "org.jetbrains:annotations:$annotationsVersion"

--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -166,10 +166,6 @@ dependencies {
         isTransitive = false // includes junit
     }
 
-    runtimeOnly("org.apache.maven:maven-resolver-provider:3.9.6")
-    runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.9.18")
-    runtimeOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.9.18")
-
     testImplementation("io.github.classgraph:classgraph:4.8.179") // For mob goal test
     testImplementation("org.junit.jupiter:junit-jupiter:5.12.2")
     testImplementation("org.junit.platform:junit-platform-suite-engine:1.12.2")


### PR DESCRIPTION
While writing tests for `MavenLibraryResolver`, it was discovered that the Paper API's transitive Maven resolver dependencies were not available at runtime. 
This was due to `maven-resolver-connector-basic` and `maven-resolver-transport-http` being declared with the `compileOnly`.
<img width="1099" height="494" alt="Screenshot 2025-07-13 at 22 36 47" src="https://github.com/user-attachments/assets/0e572d64-d036-4757-8761-93284567a5d1" />
