### PR TITLE
Dont eagerly write fall_distance on data upgrade

### DIFF
--- a/paper-server/patches/features/0031-DataConverter-Fixes.patch
+++ b/paper-server/patches/features/0031-DataConverter-Fixes.patch
@@ -4,6 +4,24 @@ Date: Sat, 7 Jun 2025 15:05:05 -0400
 Subject: [PATCH] DataConverter Fixes
 
 
+diff --git a/ca/spottedleaf/dataconverter/minecraft/versions/V4303.java b/ca/spottedleaf/dataconverter/minecraft/versions/V4303.java
+index dd5827a250807c810ac352547a868151dbae95df..e96cbc5e1c3adc7e6ca0ff1684a52c91c8c2a624 100644
+--- a/ca/spottedleaf/dataconverter/minecraft/versions/V4303.java
++++ b/ca/spottedleaf/dataconverter/minecraft/versions/V4303.java
+@@ -13,7 +13,12 @@ public final class V4303 {
+         final DataConverter<MapType, MapType> fallConverter = new DataConverter<>(VERSION) {
+             @Override
+             public MapType convert(final MapType data, final long sourceVersion, final long toVersion) {
+-                final float fallDistance = data.getFloat("FallDistance", 0.0f);
++                // Skip if this field is not present, dont eagerly write the field
++                if (!data.hasKey("FallDistance")) {
++                    return null;
++                }
++
++                final float fallDistance = data.getFloat("FallDistance");
+                 data.remove("FallDistance");
+ 
+                 data.setDouble("fall_distance", (double)fallDistance);
 diff --git a/ca/spottedleaf/dataconverter/minecraft/versions/V4307.java b/ca/spottedleaf/dataconverter/minecraft/versions/V4307.java
 index d2877c20f389d0131e1dd208b464f590671e5d82..27bdc70d861ca39487ad16cb3afb89d604b462c8 100644
 --- a/ca/spottedleaf/dataconverter/minecraft/versions/V4307.java


### PR DESCRIPTION
This is mostly an issue for spawners, which check the spawn data has a size of 1 in order to apply special finalization logic when spawning the entity (giving items, etc)

Fixes #12837