### PR TITLE
The issue "Formatting was not a valid color: §m"

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/adventure/AdventureCodecs.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/AdventureCodecs.java
@@ -88,6 +88,18 @@ public final class AdventureCodecs {
         if (s.startsWith("#")) {
             @Nullable TextColor value = TextColor.fromHexString(s);
             return value != null ? DataResult.success(value) : DataResult.error(() -> "Cannot convert " + s + " to adventure TextColor");
+        } else if (s.startsWith("§")) {
+            // Check if this is a formatting code (not a color)
+            if (s.length() == 2) {
+                char code = s.charAt(1);
+                // These are formatting codes, not colors
+                if (code == 'k' || code == 'l' || code == 'm' || code == 'n' || code == 'o' || code == 'r') {
+                    return DataResult.error(() -> "Formatting was not a valid color: " + s);
+                }
+            }
+            // Fall through to normal named color handling
+            final @Nullable NamedTextColor value = NamedTextColor.NAMES.value(s);
+            return value != null ? DataResult.success(value) : DataResult.error(() -> "Cannot convert " + s + " to adventure NamedTextColor");
         } else {
             final @Nullable NamedTextColor value = NamedTextColor.NAMES.value(s);
             return value != null ? DataResult.success(value) : DataResult.error(() -> "Cannot convert " + s + " to adventure NamedTextColor");

--- a/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
@@ -475,7 +475,7 @@ public final class PaperAdventure {
     public static @NotNull TextColor asAdventure(final ChatFormatting formatting) {
         final Integer color = formatting.getColor();
         if (color == null) {
-            throw new IllegalArgumentException("Not a valid color");
+            throw new IllegalArgumentException("Formatting was not a valid color: " + formatting);
         }
         return TextColor.color(color);
     }


### PR DESCRIPTION
This pull request improves error handling and validation in the `AdventureCodecs` and `PaperAdventure` classes. The changes ensure better differentiation between formatting codes and valid colors, enhancing clarity and robustness in handling text color conversions.

### Error Handling Improvements:

* `AdventureCodecs` (`paper-server/src/main/java/io/papermc/paper/adventure/AdventureCodecs.java`): Added checks to identify and reject formatting codes (e.g., `§k`, `§l`, etc.) when they are mistakenly passed as colors. This ensures that only valid color codes or named colors are processed, with appropriate error messages for invalid inputs.

* `PaperAdventure` (`paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java`): Enhanced the error message in the `asAdventure` method to include the specific formatting code that caused the exception, providing more context for debugging.