### PR TITLE
feat(plugin): make Plugin extend Namespaced

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
+++ b/paper-api/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
@@ -9,7 +9,6 @@ import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.PluginLoadOrder;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -187,7 +186,6 @@ public interface PluginMeta extends Namespaced {
     @KeyPattern.Namespace
     @SuppressWarnings("PatternValidation")
     @Override
-    @NotNull
     default String namespace() {
         return this.getName().toLowerCase(Locale.ROOT);
     }

--- a/paper-api/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
+++ b/paper-api/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
@@ -79,10 +79,9 @@ public interface PluginMeta extends Namespaced {
      * plugin.
      *
      * @return the specific overwrite of the logger prefix as defined by the plugin. If the plugin did not define a
-     * custom logger prefix, this method will return null
+     *     custom logger prefix, this method will return null
      */
-    @Nullable
-    String getLoggerPrefix();
+    @Nullable String getLoggerPrefix();
 
     /**
      * Provides a list of dependencies that are required for this plugin to load.
@@ -150,8 +149,7 @@ public interface PluginMeta extends Namespaced {
      *
      * @return description or null if the plugin did not define a human readable description.
      */
-    @Nullable
-    String getDescription();
+    @Nullable String getDescription();
 
     /**
      * Provides the website for the plugin or the plugin's author.
@@ -159,8 +157,7 @@ public interface PluginMeta extends Namespaced {
      *
      * @return a string representation of the website that serves as the main hub for this plugin/its author.
      */
-    @Nullable
-    String getWebsite();
+    @Nullable String getWebsite();
 
     /**
      * Provides the list of permissions that are defined via the plugin meta instance.
@@ -185,8 +182,7 @@ public interface PluginMeta extends Namespaced {
      * @return the version string made up of the major and minor version (e.g. 1.18 or 1.19). Minor versions like 1.18.2
      * are unified to their major release version (in this example 1.18)
      */
-    @Nullable
-    String getAPIVersion();
+    @Nullable String getAPIVersion();
 
     @KeyPattern.Namespace
     @SuppressWarnings("PatternValidation")

--- a/paper-api/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
+++ b/paper-api/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
@@ -1,11 +1,15 @@
 package io.papermc.paper.plugin.configuration;
 
 import java.util.List;
+import java.util.Locale;
+import net.kyori.adventure.key.KeyPattern;
+import net.kyori.adventure.key.Namespaced;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.PluginLoadOrder;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -14,7 +18,7 @@ import org.jspecify.annotations.Nullable;
  */
 @NullMarked
 @ApiStatus.NonExtendable
-public interface PluginMeta {
+public interface PluginMeta extends Namespaced {
 
     /**
      * Provides the name of the plugin. This name uniquely identifies the plugin amongst all loaded plugins on the
@@ -75,9 +79,10 @@ public interface PluginMeta {
      * plugin.
      *
      * @return the specific overwrite of the logger prefix as defined by the plugin. If the plugin did not define a
-     *     custom logger prefix, this method will return null
+     * custom logger prefix, this method will return null
      */
-    @Nullable String getLoggerPrefix();
+    @Nullable
+    String getLoggerPrefix();
 
     /**
      * Provides a list of dependencies that are required for this plugin to load.
@@ -145,7 +150,8 @@ public interface PluginMeta {
      *
      * @return description or null if the plugin did not define a human readable description.
      */
-    @Nullable String getDescription();
+    @Nullable
+    String getDescription();
 
     /**
      * Provides the website for the plugin or the plugin's author.
@@ -153,7 +159,8 @@ public interface PluginMeta {
      *
      * @return a string representation of the website that serves as the main hub for this plugin/its author.
      */
-    @Nullable String getWebsite();
+    @Nullable
+    String getWebsite();
 
     /**
      * Provides the list of permissions that are defined via the plugin meta instance.
@@ -178,6 +185,14 @@ public interface PluginMeta {
      * @return the version string made up of the major and minor version (e.g. 1.18 or 1.19). Minor versions like 1.18.2
      * are unified to their major release version (in this example 1.18)
      */
-    @Nullable String getAPIVersion();
+    @Nullable
+    String getAPIVersion();
 
+    @KeyPattern.Namespace
+    @SuppressWarnings("PatternValidation")
+    @Override
+    @NotNull
+    default String namespace() {
+        return this.getName().toLowerCase(Locale.ROOT);
+    }
 }

--- a/paper-api/src/main/java/org/bukkit/NamespacedKey.java
+++ b/paper-api/src/main/java/org/bukkit/NamespacedKey.java
@@ -72,7 +72,7 @@ public final class NamespacedKey implements Key, com.destroystokyo.paper.Namespa
     public NamespacedKey(@NotNull Plugin plugin, @NotNull String key) {
         Preconditions.checkArgument(plugin != null, "Plugin cannot be null");
         Preconditions.checkArgument(key != null, "Key cannot be null");
-        this.namespace = plugin.getName().toLowerCase(Locale.ROOT);
+        this.namespace = plugin.namespace();
         this.key = key.toLowerCase(Locale.ROOT);
 
         // Check validity after normalization

--- a/paper-api/src/main/java/org/bukkit/NamespacedKey.java
+++ b/paper-api/src/main/java/org/bukkit/NamespacedKey.java
@@ -72,7 +72,7 @@ public final class NamespacedKey implements Key, com.destroystokyo.paper.Namespa
     public NamespacedKey(@NotNull Plugin plugin, @NotNull String key) {
         Preconditions.checkArgument(plugin != null, "Plugin cannot be null");
         Preconditions.checkArgument(key != null, "Key cannot be null");
-        this.namespace = plugin.namespace();
+        this.namespace = plugin.getName().toLowerCase(Locale.ROOT);
         this.key = key.toLowerCase(Locale.ROOT);
 
         // Check validity after normalization

--- a/paper-api/src/main/java/org/bukkit/plugin/Plugin.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/Plugin.java
@@ -3,6 +3,7 @@ package org.bukkit.plugin;
 import java.io.File;
 import java.io.InputStream;
 import java.util.logging.Logger;
+import net.kyori.adventure.key.Namespaced;
 import org.bukkit.Server;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -16,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>
  * The use of {@link PluginBase} is recommended for actual Implementation
  */
-public interface Plugin extends TabExecutor, io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner { // Paper
+public interface Plugin extends TabExecutor, io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner, Namespaced { // Paper
     /**
      * Returns the folder that the plugin data files are located in. The
      * folder may not yet exist.

--- a/paper-api/src/main/java/org/bukkit/plugin/PluginBase.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/PluginBase.java
@@ -1,7 +1,7 @@
 package org.bukkit.plugin;
 
-import net.kyori.adventure.key.KeyPattern;
 import org.jetbrains.annotations.NotNull;
+import java.util.Locale;
 
 /**
  * Represents a base {@link Plugin}
@@ -35,10 +35,9 @@ public abstract class PluginBase implements Plugin {
         return getPluginMeta().getName(); // Paper
     }
 
-    @KeyPattern.Namespace
     @Override
     @NotNull
     public String namespace() {
-        return this.getPluginMeta().namespace();
+        return this.getPluginMeta().getName().toLowerCase(Locale.ROOT);
     }
 }

--- a/paper-api/src/main/java/org/bukkit/plugin/PluginBase.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/PluginBase.java
@@ -1,6 +1,7 @@
 package org.bukkit.plugin;
 
 import org.jetbrains.annotations.NotNull;
+import java.util.Locale;
 
 /**
  * Represents a base {@link Plugin}
@@ -32,5 +33,11 @@ public abstract class PluginBase implements Plugin {
     @NotNull
     public final String getName() {
         return getPluginMeta().getName(); // Paper
+    }
+
+    @Override
+    @NotNull
+    public String namespace() {
+        return this.getPluginMeta().getName().toLowerCase(Locale.ROOT);
     }
 }

--- a/paper-api/src/main/java/org/bukkit/plugin/PluginBase.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/PluginBase.java
@@ -1,7 +1,7 @@
 package org.bukkit.plugin;
 
+import net.kyori.adventure.key.KeyPattern;
 import org.jetbrains.annotations.NotNull;
-import java.util.Locale;
 
 /**
  * Represents a base {@link Plugin}
@@ -35,9 +35,10 @@ public abstract class PluginBase implements Plugin {
         return getPluginMeta().getName(); // Paper
     }
 
+    @KeyPattern.Namespace
     @Override
     @NotNull
     public String namespace() {
-        return this.getPluginMeta().getName().toLowerCase(Locale.ROOT);
+        return this.getPluginMeta().namespace();
     }
 }

--- a/paper-api/src/main/java/org/bukkit/plugin/PluginBase.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/PluginBase.java
@@ -38,6 +38,6 @@ public abstract class PluginBase implements Plugin {
     @Override
     @NotNull
     public String namespace() {
-        return this.getPluginMeta().getName().toLowerCase(Locale.ROOT);
+        return this.getPluginMeta().namespace();
     }
 }

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
@@ -91,7 +91,7 @@ public class PaperCommands implements Commands, PaperRegistrar<LifecycleEventOwn
 
     @Override
     public @Unmodifiable Set<String> registerWithFlags(final PluginMeta pluginMeta, final LiteralCommandNode<CommandSourceStack> node, final @Nullable String description, final Collection<String> aliases, final Set<CommandRegistrationFlag> flags) {
-        return registerWithFlagsInternal(pluginMeta, pluginMeta.getName().toLowerCase(Locale.ROOT), null, node, description, aliases, flags);
+        return registerWithFlagsInternal(pluginMeta, pluginMeta.namespace(), null, node, description, aliases, flags);
     }
 
     public @Unmodifiable Set<String> registerWithFlagsInternal(final @Nullable PluginMeta pluginMeta, final String namespace, final @Nullable String helpNamespaceOverride, final LiteralCommandNode<CommandSourceStack> node, final @Nullable String description, final Collection<String> aliases, final Set<CommandRegistrationFlag> flags) {

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
@@ -91,7 +91,7 @@ public class PaperCommands implements Commands, PaperRegistrar<LifecycleEventOwn
 
     @Override
     public @Unmodifiable Set<String> registerWithFlags(final PluginMeta pluginMeta, final LiteralCommandNode<CommandSourceStack> node, final @Nullable String description, final Collection<String> aliases, final Set<CommandRegistrationFlag> flags) {
-        return registerWithFlagsInternal(pluginMeta, pluginMeta.getName().toLowerCase(Locale.ROOT), null, node, description, aliases, flags);
+        return this.registerWithFlagsInternal(pluginMeta, pluginMeta.namespace(), null, node, description, aliases, flags);
     }
 
     public @Unmodifiable Set<String> registerWithFlagsInternal(final @Nullable PluginMeta pluginMeta, final String namespace, final @Nullable String helpNamespaceOverride, final LiteralCommandNode<CommandSourceStack> node, final @Nullable String description, final Collection<String> aliases, final Set<CommandRegistrationFlag> flags) {

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommands.java
@@ -91,7 +91,7 @@ public class PaperCommands implements Commands, PaperRegistrar<LifecycleEventOwn
 
     @Override
     public @Unmodifiable Set<String> registerWithFlags(final PluginMeta pluginMeta, final LiteralCommandNode<CommandSourceStack> node, final @Nullable String description, final Collection<String> aliases, final Set<CommandRegistrationFlag> flags) {
-        return registerWithFlagsInternal(pluginMeta, pluginMeta.namespace(), null, node, description, aliases, flags);
+        return registerWithFlagsInternal(pluginMeta, pluginMeta.getName().toLowerCase(Locale.ROOT), null, node, description, aliases, flags);
     }
 
     public @Unmodifiable Set<String> registerWithFlagsInternal(final @Nullable PluginMeta pluginMeta, final String namespace, final @Nullable String helpNamespaceOverride, final LiteralCommandNode<CommandSourceStack> node, final @Nullable String description, final Collection<String> aliases, final Set<CommandRegistrationFlag> flags) {


### PR DESCRIPTION
This PR makes Plugin extend adventures Namespaced and implements the `Namespaced#namespace()` method in PluginBase.

#### Motivation
This allows passing a plugin instance as namespace into `Key#key(Namespaced, String)` (or anything that accepts a Namespaced instance). I laid out my personal use case for this in [discord](https://discord.com/channels/289587909051416579/555462289851940864/1395882820664033280) (although very very simplified), but I believe this could be useful to have in general. 

Even if the benefit for my personal example is just a minor QOL thing, it seems as NamespacedKey is only actively being used in spigot code from before the hard fork and is supposed to be phased-out eventually (#10568 - although I'm unsure how up-to-date this is). So this change would also allow for an easier transition from NamespacedKey -> Key for developers.

#### Open questions
Should I also change the following methods in NamespacedKey to accept a Namespaced instead of a Plugin:
`new NamespacedKey(Plugin, String)` -> `new NamespacedKey(Namespaced, String)`
`NamespacedKey#fromString(String, Plugin)` -> `NamespacedKey#fromString(String, Namespaced)`
This change won't affect any existing use cases but could be beneficial for developers in cases where a NamespacedKey is still required (such as PDC).

Should I be doing code cleanup in the api-files I edited, such as:
- removing Paper comments
- changing fqns to imports
- removing public modifier from interface methods 


feel free to also ping me in discord for discussion of this `@emilxd.`