### PR TITLE
Make CommandExecutor and TabCompleter FunctionalInterfaces

### DIFF
--- a/paper-api/src/main/java/org/bukkit/command/CommandExecutor.java
+++ b/paper-api/src/main/java/org/bukkit/command/CommandExecutor.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Represents a class which contains a single method for executing commands
  */
+@FunctionalInterface
 public interface CommandExecutor {
 
     /**

--- a/paper-api/src/main/java/org/bukkit/command/TabCompleter.java
+++ b/paper-api/src/main/java/org/bukkit/command/TabCompleter.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Represents a class which can suggest tab completions for commands.
  */
+@FunctionalInterface
 public interface TabCompleter {
 
     /**


### PR DESCRIPTION
Makes `CommandExecutor` and `TabCompleter` functional interfaces. I don't think FunctionalInterface existed when these classes were written, but they both seem like good candidates for it. I think it would add a bit more convenience. 