### PR TITLE
Remove invalid team colors nicely

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/scores/PlayerTeam.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/scores/PlayerTeam.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/scores/PlayerTeam.java
++++ b/net/minecraft/world/scores/PlayerTeam.java
+@@ -222,7 +_,7 @@
+             instance -> instance.group(
+                     Codec.STRING.fieldOf("Name").forGetter(PlayerTeam.Packed::name),
+                     ComponentSerialization.CODEC.optionalFieldOf("DisplayName").forGetter(PlayerTeam.Packed::displayName),
+-                    ChatFormatting.COLOR_CODEC.optionalFieldOf("TeamColor").forGetter(PlayerTeam.Packed::color),
++                    io.papermc.paper.util.PaperCodecs.lenientCodec("TeamColor", ChatFormatting.COLOR_CODEC).forGetter(PlayerTeam.Packed::color), // Paper - better fail on decode
+                     Codec.BOOL.optionalFieldOf("AllowFriendlyFire", true).forGetter(PlayerTeam.Packed::allowFriendlyFire),
+                     Codec.BOOL.optionalFieldOf("SeeFriendlyInvisibles", true).forGetter(PlayerTeam.Packed::seeFriendlyInvisibles),
+                     ComponentSerialization.CODEC.optionalFieldOf("MemberNamePrefix", CommonComponents.EMPTY).forGetter(PlayerTeam.Packed::memberNamePrefix),

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
@@ -149,6 +149,7 @@ final class CraftTeam extends CraftScoreboardComponent implements Team {
     @Override
     public void setColor(ChatColor color) {
         Preconditions.checkArgument(color != null, "Color cannot be null");
+        Preconditions.checkArgument(!color.isFormat(), "Color must be a color not a format");
         this.checkState();
 
         this.team.setColor(CraftChatMessage.getColor(color));


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/12860

Makes the codec lenient on both serialization as well as de serialization.