### PR TITLE
Optimise mob despawning

### DIFF
--- a/paper-server/patches/features/0034-Optimise-mob-despawning.patch
+++ b/paper-server/patches/features/0034-Optimise-mob-despawning.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: okx-code <okx@okx.sh>
+Date: Mon, 21 Jul 2025 19:52:53 +0100
+Subject: [PATCH] Optimise mob despawning
+
+
+diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
+index dda8d38ef61672cc714d9e5a475f9b0412ed5ff9..2c21fc430de7cec90ee83a508b45e56e6fdb4545 100644
+--- a/net/minecraft/server/level/ServerLevel.java
++++ b/net/minecraft/server/level/ServerLevel.java
+@@ -789,6 +789,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+             }
+ 
+             io.papermc.paper.entity.activation.ActivationRange.activateEntities(this); // Paper - EAR
++            generateEligiblePlayersForDespawning();
+             this.entityTickList
+                 .forEach(
+                     entity -> {
+@@ -2797,4 +2798,26 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+         this.lagCompensationTick = (System.nanoTime() - MinecraftServer.SERVER_INIT) / (java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(50L));
+     }
+     // Paper end - lag compensation
++
++    // Paper start - optimise despawns
++    @Nullable
++    private io.papermc.paper.util.kdtree.Kd3Tree despawnEligiblePlayers;
++
++    private void generateEligiblePlayersForDespawning() {
++        Vec3[] nodes = new Vec3[players.size()];
++        int i = 0;
++        for (ServerPlayer player : players) {
++            if (net.minecraft.world.entity.EntitySelector.PLAYER_AFFECTS_SPAWNING.test(player)) {
++                nodes[i] = player.position();
++                i++;
++            }
++        }
++        this.despawnEligiblePlayers = new io.papermc.paper.util.kdtree.Kd3Tree(java.util.Arrays.copyOf(nodes, i));
++    }
++
++    @Nullable
++    public io.papermc.paper.util.kdtree.Kd3Tree getDespawnEligiblePlayers() {
++        return despawnEligiblePlayers;
++    }
++    // Paper end - optimise despawns
+ }
+diff --git a/net/minecraft/world/entity/Mob.java b/net/minecraft/world/entity/Mob.java
+index 0470c4bbf8be7e48ce8dfa4910c3b9f5ebb23360..415025f25d35f795bf0157fff7f5a20e25cbfd5d 100644
+--- a/net/minecraft/world/entity/Mob.java
++++ b/net/minecraft/world/entity/Mob.java
+@@ -700,15 +700,16 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+         if (this.level().getDifficulty() == Difficulty.PEACEFUL && this.shouldDespawnInPeaceful()) {
+             this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
+         } else if (!this.isPersistenceRequired() && !this.requiresCustomPersistence()) {
+-            Entity nearestPlayer = this.level().findNearbyPlayer(this, -1.0, EntitySelector.PLAYER_AFFECTS_SPAWNING); // Paper - Affects Spawning API
+-            if (nearestPlayer != null) {
++            final io.papermc.paper.util.kdtree.Kd3Tree despawnEligiblePlayers = ((ServerLevel) this.level()).getDespawnEligiblePlayers();
++            if (despawnEligiblePlayers != null && !despawnEligiblePlayers.isEmpty()) {
++                final Vec3 nearest = despawnEligiblePlayers.nearest(this.position());
+                 // Paper start - Configurable despawn distances
+                 final io.papermc.paper.configuration.WorldConfiguration.Entities.Spawning.DespawnRangePair despawnRangePair = this.level().paperConfig().entities.spawning.despawnRanges.get(this.getType().getCategory());
+                 final io.papermc.paper.configuration.type.DespawnRange.Shape shape = this.level().paperConfig().entities.spawning.despawnRangeShape;
+-                final double dy = Math.abs(nearestPlayer.getY() - this.getY());
++                final double dy = Math.abs(nearest.y() - this.getY());
+                 final double dySqr = Mth.square(dy);
+-                final double dxSqr = Mth.square(nearestPlayer.getX() - this.getX());
+-                final double dzSqr = Mth.square(nearestPlayer.getZ() - this.getZ());
++                final double dxSqr = Mth.square(nearest.x() - this.getX());
++                final double dzSqr = Mth.square(nearest.z() - this.getZ());
+                 final double distanceSquared = dxSqr + dzSqr + dySqr;
+                 // Despawn if hard/soft limit is exceeded
+                 if (despawnRangePair.hard().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy) && this.removeWhenFarAway(distanceSquared)) {

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -27,6 +27,7 @@ import it.unimi.dsi.fastutil.objects.Reference2LongOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -197,6 +198,11 @@ public class WorldConfiguration extends ConfigurationPart {
                 map.put(EntityType.SNOWBALL, IntOr.Disabled.DISABLED);
                 map.put(EntityType.LLAMA_SPIT, IntOr.Disabled.DISABLED);
             });
+
+            @PostProcess
+            public void makeDespawnRangesEnumMap() {
+                this.despawnRanges = new EnumMap<>(this.despawnRanges);
+            }
 
             @PostProcess
             public void precomputeDespawnDistances() throws SerializationException {

--- a/paper-server/src/main/java/io/papermc/paper/util/kdtree/Kd3Node.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/kdtree/Kd3Node.java
@@ -1,0 +1,184 @@
+package io.papermc.paper.util.kdtree;
+
+import net.minecraft.world.phys.Vec3;
+
+public final class Kd3Node {
+    private final int dimension;
+    private final Vec3 point;
+    private final double pointAtDimension;
+    private final Kd3Node below;
+    private final Kd3Node above;
+
+    public Kd3Node(int dimension, Vec3 point, Kd3Node below, Kd3Node above) {
+        this.dimension = dimension;
+        this.point = point;
+        this.pointAtDimension = getDimension(point, dimension);
+        this.below = below;
+        this.above = above;
+    }
+
+    public static Kd3Node create(int dimension, Vec3[] points, int left, int right) {
+        if (right < left) {
+            return null;
+        } else if (right == left) {
+            return new Kd3Node(dimension, points[left], null, null);
+        }
+
+        int m = 1 + (right - left) / 2;
+        select(points, dimension, m, left, right);
+        final int nextDimension = (dimension + 1) % 3;
+        return new Kd3Node(
+            dimension,
+            points[left + m - 1],
+            Kd3Node.create(nextDimension, points, left, left + m - 2),
+            Kd3Node.create(nextDimension, points, left + m, right));
+    }
+
+    private double shorter(Vec3 target, double min) {
+        double minsq = min * min;
+        double maxV = minsq;
+
+        for (int i = 0; i < 3; i++) {
+            double d = getDimension(target, i) - getDimension(point, i);
+            if ((maxV -= d * d) < 0) {
+                return -1;
+            }
+        }
+        return Math.sqrt(minsq - maxV);
+    }
+
+    public Vec3 nearest(Vec3 target, double[] min) {
+        Vec3 result = null;
+
+        double d = shorter(target, min[0]);
+        if (d >= 0 && d < min[0]) {
+            min[0] = d;
+            result = point;
+        }
+
+        double dp = Math.abs(this.pointAtDimension - getDimension(target, dimension));
+        Vec3 newResult = null;
+
+        if (dp < min[0]) {
+            if (above != null) {
+                newResult = above.nearest(target, min);
+                if (newResult != null) {
+                    result = newResult;
+                }
+            }
+
+            if (below != null) {
+                newResult = below.nearest(target, min);
+                if (newResult != null) {
+                    result = newResult;
+                }
+            }
+        } else {
+            if (getDimension(target, dimension) < this.pointAtDimension) {
+                if (below != null) {
+                    newResult = below.nearest(target, min);
+                }
+            } else {
+                if (above != null) {
+                    newResult = above.nearest(target, min);
+                }
+            }
+
+            if (newResult != null) {
+                return newResult;
+            }
+        }
+        return result;
+    }
+
+    public boolean isBelow(Vec3 point) {
+        return getDimension(point, dimension) < this.pointAtDimension;
+    }
+
+    public Kd3Node getBelow() {
+        return below;
+    }
+
+    public Kd3Node getAbove() {
+        return above;
+    }
+
+    public Vec3 getPoint() {
+        return point;
+    }
+
+    private static double getDimension(Vec3 point, int dimension) {
+        if (dimension == 0) {
+            return point.x();
+        } else if (dimension == 1) {
+            return point.z();
+        } else if (dimension == 2) {
+            return point.y();
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private static void swap(Vec3[] points, int pos1, int pos2) {
+        if (pos1 == pos2) {
+            return;
+        }
+
+        Vec3 tmp = points[pos1];
+        points[pos1] = points[pos2];
+        points[pos2] = tmp;
+    }
+
+    private static int partition(Vec3[] points, int dimension, int left, int right, int pivotIndex) {
+        final Vec3 pivot = points[pivotIndex];
+        swap(points, right, pivotIndex);
+
+        int store = left;
+        for (int i = left; i < right; i++) {
+            if (getDimension(points[i], dimension) <= getDimension(pivot, dimension)) {
+                swap(points, i, store);
+                store++;
+            }
+        }
+
+        swap(points, right, store);
+        return store;
+    }
+
+    private static int selectPivotIndex(Vec3[] points, int dimension, int left, int right) {
+        int midIndex = (left + right) / 2;
+
+        int lowIndex = left;
+
+        if (getDimension(points[lowIndex], dimension) >= getDimension(points[midIndex], dimension)) {
+            lowIndex = midIndex;
+            midIndex = left;
+        }
+
+        if (getDimension(points[right], dimension) <= getDimension(points[lowIndex], dimension)) {
+            return lowIndex;
+        } else if (getDimension(points[right], dimension) <= getDimension(points[midIndex], dimension)) {
+            return midIndex;
+        }
+
+        return right;
+    }
+
+    private static void select(Vec3[] points, int dimension, int k, int left, int right) {
+        while (true) {
+            int idx = selectPivotIndex(points, dimension, left, right);
+
+            int pivotIndex = partition(points, dimension, left, right, idx);
+            if (left + k - 1 == pivotIndex) {
+                return;
+            }
+
+            if (left + k - 1 < pivotIndex) {
+                right = pivotIndex - 1;
+            } else {
+                k -= (pivotIndex - left + 1);
+                left = pivotIndex + 1;
+            }
+        }
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/util/kdtree/Kd3Tree.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/kdtree/Kd3Tree.java
@@ -1,0 +1,55 @@
+package io.papermc.paper.util.kdtree;
+
+import net.minecraft.world.phys.Vec3;
+
+public class Kd3Tree {
+    private final Kd3Node root;
+
+    public Kd3Tree(Vec3[] points) {
+        if (points.length > 0) {
+            this.root = Kd3Node.create(0, points, 0, points.length - 1);
+        } else {
+            this.root = null;
+        }
+    }
+
+    public boolean isEmpty() {
+        return root == null;
+    }
+
+    public Vec3 nearest(Vec3 target) {
+        if (root == null) {
+            return null;
+        }
+        Kd3Node parent = parent(target);
+        Vec3 result = parent.getPoint();
+        double smallest = target.distanceTo(result);
+
+        double[] best = new double[]{smallest};
+
+        Vec3 nearest = root.nearest(target, best);
+        if (nearest != null) {
+            return nearest;
+        }
+        return result;
+    }
+
+    private Kd3Node parent(Vec3 value) {
+        Kd3Node node = root;
+        Kd3Node next;
+        while (true) {
+            if (node.isBelow(value)) {
+                next = node.getBelow();
+            } else {
+                next = node.getAbove();
+            }
+            if (next == null) {
+                break;
+            } else {
+                node = next;
+            }
+        }
+
+        return node;
+    }
+}


### PR DESCRIPTION
This PR introduces a spatial data structure used to find the nearest player for the purposes of despawning mobs.

Currently, every mob loops over every player per tick to determine if they are:
1. Eligible for despawning mobs (not in spectator mode; is alive)
2. The closest player to that mob

This is effectively an `O(n ^ 2)` operation with per-player mob spawning, and loads a lot of player data unnecessarily (those player checks add up when they are done hundreds of thousands of times a tick!)

In this PR, we construct a K-d tree (k=3) with every despawn-eligible player every tick and use that to find the closest player to determine whether the mob should despawn. This is a very efficient data structure for nearest-neighbour searches (the implemented data structure is an adapted version from the book "Algorithms In A Nutshell").

I have also changed the despawnRanges config option to be represented as an EnumMap rather than a HashMap to make it more efficient.

I considered using the NearbyPlayers class, however it raises a couple complications that made me decide against using it in the end. It stores players by chunk, and the area you get is a square grid, rather than a disc which is what is desired here, so you potentially still have to filter through a lot of players. In addition, pillagers will only despawn if they are not in the middle of a raid but with a hard coded despawn range of 128. You'd have to redo the Mojang logic with `respawnWhenFarAway` to make this work well. Another factor is that the user can set the despawn ranges to whatever they want, and it's a lot of logic to make sure that this is properly captured in NearbyPlayers.

Ensuring all the behaviour was correct ended up being rather awkward; the code was too tightly coupled, and didn't even perform better, so I went with this approach instead. Let me know if you think it would ultimately be better to use NearbyPlayers though, I might be missing something.

#### Benchmarks:

I use /spreadplayers to spread 50 bots over a 1000 block radius. Then I allowed the server to run for a few minutes and took a spark report. [The latest 1.21.8 paper](https://spark.lucko.me/9aHOYxfEwe) took 1.8 ms/t in Mob.checkDespawn, and [this patch](https://spark.lucko.me/ww2X8iVXvW) takes 1.07 ms/t in Mob.checkDespawn (plus 0.01 ms/t for calculating the player K-d trees). The difference is likely to be larger with even more players online. In total, that's a 0.72 ms/t decrease in tick time, which is similar to my other performance optimisation, [TemptGoal](https://github.com/PaperMC/Paper/pull/11942).