### PR TITLE
Allow to change despawnInPeaceful

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Mob.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Mob.java
@@ -1,15 +1,21 @@
 package org.bukkit.entity;
 
+import com.destroystokyo.paper.entity.Pathfinder;
+import io.papermc.paper.entity.Leashable;
 import net.kyori.adventure.util.TriState;
+import org.bukkit.Location;
 import org.bukkit.Sound;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.loot.LootTable;
 import org.bukkit.loot.Lootable;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a Mob. Mobs are living entities with simple AI.
  */
-public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Leashable { // Paper - Leashable API
+@NullMarked
+public interface Mob extends LivingEntity, Lootable, Leashable {
 
     /**
      * Check if a mob should be despawned when the world is set to peaceful difficulty.
@@ -22,39 +28,36 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
     /**
      * Sets if the entity should be despawned when the game is set to peaceful difficulty.
      * <ul>
-     *     <li>{@link TriState#NOT_SET} – Use the default behavior for the entity type</li>
+     *     <li>{@link TriState#NOT_SET} – Use the default behavior for the entity</li>
      *     <li>{@link TriState#TRUE} – The entity will be removed in Peaceful difficulty</li>
-     *     <li>{@link TriState#FALSE} – The entity will not be automatically removed in Peaceful difficulty</li>
+     *     <li>{@link TriState#FALSE} – The entity will not automatically be removed in Peaceful difficulty</li>
      * </ul>
      *
      * @param state a TriState representing the state of the override
      */
-    void setDespawnInPeacefulOverride(@NotNull TriState state);
+    void setDespawnInPeacefulOverride(TriState state);
 
     /**
      * Gets the current override value for whether this entity should despawn in peaceful difficulty.
-     * * <ul>
-     *     <li>{@link TriState#NOT_SET} – Use the default behavior for the entity type</li>
+     * <ul>
+     *     <li>{@link TriState#NOT_SET} – Use the default behavior for the entity</li>
      *     <li>{@link TriState#TRUE} – The entity will be removed in Peaceful difficulty</li>
-     *     <li>{@link TriState#FALSE} – The entity will not be automatically removed in Peaceful difficulty</li>
+     *     <li>{@link TriState#FALSE} – The entity will not automatically be removed in Peaceful difficulty</li>
      * </ul>
      *
      * @return a TriState representing the state of the override
      * @see Mob#setDespawnInPeacefulOverride(TriState)
      */
-    @NotNull
     TriState getDespawnInPeacefulOverride();
 
-    // Paper start
     @Override
-    org.bukkit.inventory.@org.jetbrains.annotations.NotNull EntityEquipment getEquipment();
+    EntityEquipment getEquipment();
 
     /**
      * Enables access to control the pathing of an Entity
      * @return Pathfinding Manager for this entity
      */
-    @NotNull
-    com.destroystokyo.paper.entity.Pathfinder getPathfinder();
+    Pathfinder getPathfinder();
 
     /**
      * Check if this mob is exposed to daylight
@@ -70,7 +73,7 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
      *
      * @param location location to look at
      */
-    void lookAt(@NotNull org.bukkit.Location location);
+    void lookAt(Location location);
 
     /**
      * Instruct this Mob to look at a specific Location
@@ -81,7 +84,7 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
      * @param headRotationSpeed head rotation speed
      * @param maxHeadPitch max head pitch rotation
      */
-    void lookAt(@NotNull org.bukkit.Location location, float headRotationSpeed, float maxHeadPitch);
+    void lookAt(Location location, float headRotationSpeed, float maxHeadPitch);
 
     /**
      * Instruct this Mob to look at a specific Entity
@@ -92,7 +95,7 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
      *
      * @param entity entity to look at
      */
-    void lookAt(@NotNull Entity entity);
+    void lookAt(Entity entity);
 
     /**
      * Instruct this Mob to look at a specific Entity
@@ -105,7 +108,7 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
      * @param headRotationSpeed head rotation speed
      * @param maxHeadPitch max head pitch rotation
      */
-    void lookAt(@NotNull Entity entity, float headRotationSpeed, float maxHeadPitch);
+    void lookAt(Entity entity, float headRotationSpeed, float maxHeadPitch);
 
     /**
      * Instruct this Mob to look at a specific position
@@ -144,7 +147,7 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
      * @return the max head pitch rotation
      */
     int getMaxHeadPitch();
-    // Paper end
+
     /**
      * Instructs this Mob to set the specified LivingEntity as its target.
      * <p>
@@ -153,26 +156,25 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
      *
      * @param target New LivingEntity to target, or null to clear the target
      */
-    public void setTarget(@Nullable LivingEntity target);
+    void setTarget(@Nullable LivingEntity target);
 
     /**
      * Gets the current target of this Mob
      *
      * @return Current target of this creature, or null if none exists
      */
-    @Nullable
-    public LivingEntity getTarget();
+    @Nullable LivingEntity getTarget();
 
     /**
      * Sets whether this mob is aware of its surroundings.
-     *
+     * <p>
      * Unaware mobs will still move if pushed, attacked, etc. but will not move
      * or perform any actions on their own. Unaware mobs may also have other
      * unspecified behaviours disabled, such as drowning.
      *
      * @param aware whether the mob is aware
      */
-    public void setAware(boolean aware);
+    void setAware(boolean aware);
 
     /**
      * Gets whether this mob is aware of its surroundings.
@@ -183,7 +185,7 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
      *
      * @return whether the mob is aware
      */
-    public boolean isAware();
+    boolean isAware();
 
     /**
      * Get the {@link Sound} this mob makes while ambiently existing. This sound
@@ -195,18 +197,14 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
      *
      * @return the ambient sound, or null if this entity is ambiently quiet
      */
-    @Nullable
-    public Sound getAmbientSound();
+    @Nullable Sound getAmbientSound();
 
-    // Paper start - LootTable API
     @Override
-    default void setLootTable(final @Nullable org.bukkit.loot.LootTable table, final long seed) {
+    default void setLootTable(final @Nullable LootTable table, final long seed) {
         this.setLootTable(table);
         this.setSeed(seed);
     }
-    // Paper end - LootTable API
 
-    // Paper start - Missing Entity API
     /**
      * Some mobs will raise their arm(s) when aggressive:
      * <ul>
@@ -238,30 +236,25 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
      * @see #isAggressive()
      */
     void setAggressive(boolean aggressive);
-    // Paper end - Missing Entity API
 
-    // Paper start - left-handed API
     /**
      * Check if Mob is left-handed
      *
      * @return True if left-handed
      */
-    public boolean isLeftHanded();
+    boolean isLeftHanded();
 
     /**
       * Set if Mob is left-handed
       *
       * @param leftHanded True if left-handed
       */
-    public void setLeftHanded(boolean leftHanded);
-    // Paper end - left-handed API
+    void setLeftHanded(boolean leftHanded);
 
-    // Paper start - mob xp reward API
     /**
      * Gets the amount of experience the mob will possibly drop. This value is randomized and it can give different results
      *
      * @return the amount of experience the mob will possibly drop
      */
-    public int getPossibleExperienceReward();
-    // Paper end - mob xp reward API
+    int getPossibleExperienceReward();
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Mob.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Mob.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Leashable { // Paper - Leashable API
 
     /**
-     * Check if a mob should be despawned on the peaceful difficulty.
+     * Check if a mob should be despawned when the world is set to peaceful difficulty.
      * This also takes the {@link Mob#getSpawnInPeacefulOverride()} into account.
      *
      * @return True if the entity should be removed in peaceful
@@ -20,11 +20,11 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
     boolean shouldDespawnInPeaceful();
 
     /**
-     * Sets if the entity should be removed on the peaceful difficulty.
+     * Sets if the entity should be despawned when the game is set to peaceful difficulty.
      * <ul>
-     *     <li>{@link TriState#NOT_SET} – will revert to the default value</li>
-     *     <li>{@link TriState#TRUE} – will set the entity to be removed on peaceful</li>
-     *     <li>{@link TriState#FALSE} – will set the entity to persist on peaceful difficulty</li>
+     *     <li>{@link TriState#NOT_SET} – Use the default behavior for the entity type</li>#
+     *     <li>{@link TriState#TRUE} – The entity will be removed in Peaceful difficulty</li>
+     *     <li>{@link TriState#FALSE} – The entity will not be automatically removed in Peaceful difficulty</li>
      * </ul>
      *
      * @param state a TriState representing the state of the override
@@ -32,14 +32,15 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
     void setDespawnInPeacefulOverride(TriState state);
 
     /**
-     * Gets the state of the spawn in peaceful override.
-     * <ul>
-     *     <li>{@link TriState#NOT_SET} – to the value of the entity type is used</li>
-     *     <li>{@link TriState#TRUE} – the entity will be removed on peaceful</li>
-     *     <li>{@link TriState#FALSE} – the entity will persist on peaceful</li>
+     * Gets the current override value for whether this entity should despawn in peaceful difficulty.
+     * * <ul>
+     *     <li>{@link TriState#NOT_SET} – Use the default behavior for the entity type</li>#
+     *     <li>{@link TriState#TRUE} – The entity will be removed in Peaceful difficulty</li>
+     *     <li>{@link TriState#FALSE} – The entity will not be automatically removed in Peaceful difficulty</li>
      * </ul>
      *
      * @return a TriState representing the state of the override
+     * @see Mob#setDespawnInPeacefulOverride(TriState)
      */
     TriState getSpawnInPeacefulOverride();
 

--- a/paper-api/src/main/java/org/bukkit/entity/Mob.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Mob.java
@@ -13,7 +13,7 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
 
     /**
      * Check if a mob should be despawned when the world is set to peaceful difficulty.
-     * This also takes the {@link Mob#getSpawnInPeacefulOverride()} into account.
+     * This also takes the {@link Mob#getDespawnInPeacefulOverride()} into account.
      *
      * @return True if the entity should be removed in peaceful
      */
@@ -43,7 +43,7 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
      * @see Mob#setDespawnInPeacefulOverride(TriState)
      */
     @NotNull
-    TriState getSpawnInPeacefulOverride();
+    TriState getDespawnInPeacefulOverride();
 
     // Paper start
     @Override

--- a/paper-api/src/main/java/org/bukkit/entity/Mob.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Mob.java
@@ -29,7 +29,7 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
      *
      * @param state a TriState representing the state of the override
      */
-    void setDespawnInPeacefulOverride(TriState state);
+    void setDespawnInPeacefulOverride(@NotNull TriState state);
 
     /**
      * Gets the current override value for whether this entity should despawn in peaceful difficulty.
@@ -42,6 +42,7 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
      * @return a TriState representing the state of the override
      * @see Mob#setDespawnInPeacefulOverride(TriState)
      */
+    @NotNull
     TriState getSpawnInPeacefulOverride();
 
     // Paper start

--- a/paper-api/src/main/java/org/bukkit/entity/Mob.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Mob.java
@@ -22,7 +22,7 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
     /**
      * Sets if the entity should be despawned when the game is set to peaceful difficulty.
      * <ul>
-     *     <li>{@link TriState#NOT_SET} – Use the default behavior for the entity type</li>#
+     *     <li>{@link TriState#NOT_SET} – Use the default behavior for the entity type</li>
      *     <li>{@link TriState#TRUE} – The entity will be removed in Peaceful difficulty</li>
      *     <li>{@link TriState#FALSE} – The entity will not be automatically removed in Peaceful difficulty</li>
      * </ul>
@@ -34,7 +34,7 @@ public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Lea
     /**
      * Gets the current override value for whether this entity should despawn in peaceful difficulty.
      * * <ul>
-     *     <li>{@link TriState#NOT_SET} – Use the default behavior for the entity type</li>#
+     *     <li>{@link TriState#NOT_SET} – Use the default behavior for the entity type</li>
      *     <li>{@link TriState#TRUE} – The entity will be removed in Peaceful difficulty</li>
      *     <li>{@link TriState#FALSE} – The entity will not be automatically removed in Peaceful difficulty</li>
      * </ul>

--- a/paper-api/src/main/java/org/bukkit/entity/Mob.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Mob.java
@@ -1,5 +1,6 @@
 package org.bukkit.entity;
 
+import net.kyori.adventure.util.TriState;
 import org.bukkit.Sound;
 import org.bukkit.loot.Lootable;
 import org.jetbrains.annotations.NotNull;
@@ -9,6 +10,38 @@ import org.jetbrains.annotations.Nullable;
  * Represents a Mob. Mobs are living entities with simple AI.
  */
 public interface Mob extends LivingEntity, Lootable, io.papermc.paper.entity.Leashable { // Paper - Leashable API
+
+    /**
+     * Check if a mob should be despawned on the peaceful difficulty.
+     * This also takes the {@link Mob#getSpawnInPeacefulOverride()} into account.
+     *
+     * @return True if the entity should be removed in peaceful
+     */
+    boolean shouldDespawnInPeaceful();
+
+    /**
+     * Sets if the entity should be removed on the peaceful difficulty.
+     * <ul>
+     *     <li>{@link TriState#NOT_SET} – will revert to the default value</li>
+     *     <li>{@link TriState#TRUE} – will set the entity to be removed on peaceful</li>
+     *     <li>{@link TriState#FALSE} – will set the entity to persist on peaceful difficulty</li>
+     * </ul>
+     *
+     * @param state a TriState representing the state of the override
+     */
+    void setDespawnInPeacefulOverride(TriState state);
+
+    /**
+     * Gets the state of the spawn in peaceful override.
+     * <ul>
+     *     <li>{@link TriState#NOT_SET} – to the value of the entity type is used</li>
+     *     <li>{@link TriState#TRUE} – the entity will be removed on peaceful</li>
+     *     <li>{@link TriState#FALSE} – the entity will persist on peaceful</li>
+     * </ul>
+     *
+     * @return a TriState representing the state of the override
+     */
+    TriState getSpawnInPeacefulOverride();
 
     // Paper start
     @Override

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -484,7 +484,7 @@ index c70a58f5f633fa8e255f74c42f5e87c96b7b013a..ec20a5a6d7c8f65abda528fec36bec7b
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 75f81a6bc156a6455a616b8de0d7701fd2255a2d..b3d951670b3a097d04cfe347d7df496b1d0a0e09 100644
+index b9f0745cdc42a093b69f46e353b99adf0c5aac56..a5d65e1b31e2e43cf039b8a19286a5324a739bbe 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -409,6 +409,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -543,7 +543,7 @@ index 75f81a6bc156a6455a616b8de0d7701fd2255a2d..b3d951670b3a097d04cfe347d7df496b
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 13cf40918ead3e2cb2699398ac659a3e1806294b..1ba342a1a60951f828034d3ed535b577b3990bf6 100644
+index 8dd8a3d2a862998a920f226b2a6d9a877aac70a8..0c52e315557e1dae6a852694786e72241fff1e29 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
 @@ -3215,6 +3215,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
@@ -562,10 +562,10 @@ index 13cf40918ead3e2cb2699398ac659a3e1806294b..1ba342a1a60951f828034d3ed535b577
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Mob.java b/net/minecraft/world/entity/Mob.java
-index 3047763580fabd069db5e90a9a854396c6243763..0470c4bbf8be7e48ce8dfa4910c3b9f5ebb23360 100644
+index c737fd87e804129fac95be7d19b4aafab38d8b94..21c6d4746c6a905ec312dc1e35535cbd13868322 100644
 --- a/net/minecraft/world/entity/Mob.java
 +++ b/net/minecraft/world/entity/Mob.java
-@@ -206,6 +206,19 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
+@@ -207,6 +207,19 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
          return this.lookControl;
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
@@ -28,7 +28,7 @@
      private BlockPos homePosition = BlockPos.ZERO;
      private int homeRadius = -1;
 +    public boolean aware = true; // CraftBukkit
-+    public net.kyori.adventure.util.TriState despawnInPeacefulOverride = net.kyori.adventure.util.TriState.NOT_SET; //Paper - allow changing despawnInPeaceful
++    public net.kyori.adventure.util.TriState despawnInPeacefulOverride = net.kyori.adventure.util.TriState.NOT_SET; // Paper - allow changing despawnInPeaceful
  
      protected Mob(EntityType<? extends Mob> entityType, Level level) {
          super(entityType, level);
@@ -85,12 +85,16 @@
      }
  
      @Override
-@@ -365,13 +_,23 @@
+@@ -365,13 +_,27 @@
          if (this.isNoAi()) {
              output.putBoolean("NoAI", this.isNoAi());
          }
 +        output.putBoolean("Bukkit.Aware", this.aware); // CraftBukkit
-+        output.putString("Paper.DespawnInPeacefulOverride", this.despawnInPeacefulOverride.name());  //Paper - allow changing despawnInPeaceful
++        // Paper start - allow changing despawnInPeaceful
++        if (this.despawnInPeacefulOverride != net.kyori.adventure.util.TriState.NOT_SET) {
++            output.putString("Paper.DespawnInPeacefulOverride", this.despawnInPeacefulOverride.name());
++        }
++        // Paper end - allow changing despawnInPeaceful
      }
  
      @Override
@@ -111,20 +115,12 @@
          this.dropChances = input.read("drop_chances", DropChances.CODEC).orElse(DropChances.DEFAULT);
          this.readLeashData(input);
          this.homeRadius = input.getIntOr("home_radius", -1);
-@@ -383,6 +_,16 @@
+@@ -383,6 +_,8 @@
          this.lootTable = input.read("DeathLootTable", LootTable.KEY_CODEC);
          this.lootTableSeed = input.getLongOr("DeathLootTableSeed", 0L);
          this.setNoAi(input.getBooleanOr("NoAI", false));
 +        this.aware = input.getBooleanOr("Bukkit.Aware", true); // CraftBukkit
-+        //Paper start - allow changing despawnInPeaceful
-+        input.getString("Paper.DespawnInPeacefulOverride").ifPresent(override -> {
-+            try {
-+                this.despawnInPeacefulOverride = net.kyori.adventure.util.TriState.valueOf(override);
-+            } catch (final Exception ignored) {
-+                com.mojang.logging.LogUtils.getLogger().error("Unknown peaceful despawn override {} for {}", override, this);
-+            }
-+        });
-+        //Paper end - allow changing despawnInPeaceful
++        this.despawnInPeacefulOverride = input.read("Paper.DespawnInPeacefulOverride", io.papermc.paper.util.PaperCodecs.TRI_STATE_CODEC).orElse(net.kyori.adventure.util.TriState.NOT_SET); // Paper - allow changing despawnInPeaceful
      }
  
      @Override
@@ -191,11 +187,11 @@
          return this.isPassenger();
      }
  
-+    //Paper start - allow changing despawnInPeaceful
-+    public boolean shouldActuallyDespawnInPeaceful() {
-+        return this.despawnInPeacefulOverride.toBooleanOrElse(shouldDespawnInPeaceful());
++    // Paper start - allow changing despawnInPeaceful
++    public final boolean shouldActuallyDespawnInPeaceful() {
++        return this.despawnInPeacefulOverride.toBooleanOrElse(this.shouldDespawnInPeaceful());
 +    }
-+    //Paper end - allow changing despawnInPeaceful
++    // Paper end - allow changing despawnInPeaceful
 +
      protected boolean shouldDespawnInPeaceful() {
          return false;

--- a/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
@@ -23,11 +23,12 @@
      public GoalSelector targetSelector;
      @Nullable
      private LivingEntity target;
-@@ -129,6 +_,7 @@
+@@ -129,6 +_,8 @@
      private Leashable.LeashData leashData;
      private BlockPos homePosition = BlockPos.ZERO;
      private int homeRadius = -1;
 +    public boolean aware = true; // CraftBukkit
++    public net.kyori.adventure.util.TriState despawnInPeacefulOverride = net.kyori.adventure.util.TriState.NOT_SET; //Paper - allow changing despawnInPeaceful
  
      protected Mob(EntityType<? extends Mob> entityType, Level level) {
          super(entityType, level);
@@ -84,11 +85,12 @@
      }
  
      @Override
-@@ -365,13 +_,22 @@
+@@ -365,13 +_,23 @@
          if (this.isNoAi()) {
              output.putBoolean("NoAI", this.isNoAi());
          }
 +        output.putBoolean("Bukkit.Aware", this.aware); // CraftBukkit
++        output.putString("Paper.DespawnInPeacefulOverride", this.despawnInPeacefulOverride.name());  //Paper - allow changing despawnInPeaceful
      }
  
      @Override
@@ -109,11 +111,20 @@
          this.dropChances = input.read("drop_chances", DropChances.CODEC).orElse(DropChances.DEFAULT);
          this.readLeashData(input);
          this.homeRadius = input.getIntOr("home_radius", -1);
-@@ -383,6 +_,7 @@
+@@ -383,6 +_,16 @@
          this.lootTable = input.read("DeathLootTable", LootTable.KEY_CODEC);
          this.lootTableSeed = input.getLongOr("DeathLootTableSeed", 0L);
          this.setNoAi(input.getBooleanOr("NoAI", false));
 +        this.aware = input.getBooleanOr("Bukkit.Aware", true); // CraftBukkit
++        //Paper start - allow changing despawnInPeaceful
++        input.getString("Paper.DespawnInPeacefulOverride").ifPresent(override -> {
++            try {
++                this.despawnInPeacefulOverride = net.kyori.adventure.util.TriState.valueOf(override);
++            } catch (final Exception ignored) {
++                com.mojang.logging.LogUtils.getLogger().error("Unknown peaceful despawn override {} for {}", override, this);
++            }
++        });
++        //Paper end - allow changing despawnInPeaceful
      }
  
      @Override
@@ -176,11 +187,25 @@
                  }
  
                  ItemStack itemStack = equipmentSlotForItem.limit(stack);
-@@ -608,22 +_,29 @@
+@@ -601,29 +_,42 @@
+         return this.isPassenger();
+     }
+ 
++    //Paper start - allow changing despawnInPeaceful
++    public boolean shouldActuallyDespawnInPeaceful() {
++        return this.despawnInPeacefulOverride.toBooleanOrElse(shouldDespawnInPeaceful());
++    }
++    //Paper end - allow changing despawnInPeaceful
++
+     protected boolean shouldDespawnInPeaceful() {
+         return false;
+     }
+ 
      @Override
      public void checkDespawn() {
-         if (this.level().getDifficulty() == Difficulty.PEACEFUL && this.shouldDespawnInPeaceful()) {
+-        if (this.level().getDifficulty() == Difficulty.PEACEFUL && this.shouldDespawnInPeaceful()) {
 -            this.discard();
++        if (this.level().getDifficulty() == Difficulty.PEACEFUL && this.shouldActuallyDespawnInPeaceful()) { //Paper - allow changing despawnInPeaceful
 +            this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
          } else if (!this.isPersistenceRequired() && !this.requiresCustomPersistence()) {
 -            Entity nearestPlayer = this.level().getNearestPlayer(this, -1.0);

--- a/paper-server/patches/sources/net/minecraft/world/entity/boss/wither/WitherBoss.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/boss/wither/WitherBoss.java.patch
@@ -95,8 +95,9 @@
  
      @Override
      public void checkDespawn() {
-         if (this.level().getDifficulty() == Difficulty.PEACEFUL && this.shouldDespawnInPeaceful()) {
+-        if (this.level().getDifficulty() == Difficulty.PEACEFUL && this.shouldDespawnInPeaceful()) {
 -            this.discard();
++        if (this.level().getDifficulty() == Difficulty.PEACEFUL && this.shouldActuallyDespawnInPeaceful()) { //Paper - allow changing despawnInPeaceful
 +            this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
          } else {
              this.noActionTime = 0;

--- a/paper-server/src/main/java/io/papermc/paper/util/PaperCodecs.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/PaperCodecs.java
@@ -15,6 +15,7 @@ import io.papermc.paper.registry.TypedKey;
 import java.util.Optional;
 import java.util.function.Function;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.util.TriState;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.RegistryOps;
 import org.bukkit.Keyed;
@@ -23,6 +24,14 @@ import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public final class PaperCodecs {
+
+    public static final Codec<TriState> TRI_STATE_CODEC = Codec.STRING.comapFlatMap(s -> {
+        try {
+            return DataResult.success(TriState.valueOf(s));
+        } catch (Exception e) {
+            return DataResult.error(() -> "Unknown TriState value: " + s);
+        }
+    }, TriState::name);
 
     /**
      * This codec is lenient on decoding and encoding compared to native OptionalFieldCodec

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
@@ -33,7 +33,7 @@ public abstract class CraftMob extends CraftLivingEntity implements Mob, io.pape
     }
 
     @Override
-    public TriState getSpawnInPeacefulOverride() {
+    public TriState getDespawnInPeacefulOverride() {
         return this.getHandle().despawnInPeacefulOverride;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
@@ -2,6 +2,7 @@ package org.bukkit.craftbukkit.entity;
 
 import com.google.common.base.Preconditions;
 import java.util.Optional;
+import net.kyori.adventure.util.TriState;
 import net.minecraft.sounds.SoundEvent;
 import org.bukkit.Sound;
 import org.bukkit.craftbukkit.CraftLootTable;
@@ -18,6 +19,22 @@ public abstract class CraftMob extends CraftLivingEntity implements Mob, io.pape
     public CraftMob(CraftServer server, net.minecraft.world.entity.Mob entity) {
         super(server, entity);
         this.paperPathfinder = new com.destroystokyo.paper.entity.PaperPathfinder(entity); // Paper - Mob Pathfinding API
+    }
+
+    @Override
+    public boolean shouldDespawnInPeaceful() {
+        return this.getHandle().shouldActuallyDespawnInPeaceful();
+    }
+
+    @Override
+    public void setDespawnInPeacefulOverride(final TriState state) {
+        Preconditions.checkArgument(state != null, "TriState cannot be null");
+        this.getHandle().despawnInPeacefulOverride = state;
+    }
+
+    @Override
+    public TriState getSpawnInPeacefulOverride() {
+        return this.getHandle().despawnInPeacefulOverride;
     }
 
     @Override


### PR DESCRIPTION
This PR adds a method to check if an entity should be removed on the peaceful difficulty and adds a method to change the behavior. I considered a cancellable event, however it seems like that this check is done every tick, so I decided for this approach. 

The value also gets persisted in the entity data. However, I'm not sure if the data should be persisted when set to Tristate#NOT_SET. E.g. VisualFire is persisted even when set to NOT_SET, but I'm not sure if saving that data for every mob is necessary. 

On the NMS side I decided to add a new method (shouldActuallyDespawnInPeaceful) as running this method in the only two places it is used is much cleaner than modifying shouldDespawnInPeaceful in every entity that implements it (like Ghast, Monster, etc.) 

My usecase for this is the following: We use Entities like Zombies to represent spawn locations etc. in our setup on our map building server. However, most maps are set to peaceful so we are limited in the amount of entities that work for us. This would solve the problem