### PR TITLE
Fix dialog preconditions

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/dialog/Dialog.java
+++ b/paper-api/src/main/java/io/papermc/paper/dialog/Dialog.java
@@ -10,6 +10,7 @@ import net.kyori.adventure.dialog.DialogLike;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -43,5 +44,23 @@ public interface Dialog extends Keyed, DialogLike {
     private static Dialog getDialog(@KeyPattern.Value final String value) {
         final Registry<Dialog> registry = RegistryAccess.registryAccess().getRegistry(RegistryKey.DIALOG);
         return registry.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, value));
+    }
+
+    /**
+     * @deprecated use {@link Registry#getKey(Keyed)}, {@link io.papermc.paper.registry.RegistryAccess#getRegistry(io.papermc.paper.registry.RegistryKey)},
+     * and {@link io.papermc.paper.registry.RegistryKey#DIALOG}. Dialogs can exist without a key.
+     */
+    @Deprecated(since = "1.21.8", forRemoval = true)
+    @Override
+    NamespacedKey getKey();
+
+    /**
+     * @deprecated use {@link Registry#getKey(Keyed)}, {@link io.papermc.paper.registry.RegistryAccess#getRegistry(io.papermc.paper.registry.RegistryKey)},
+     * and {@link io.papermc.paper.registry.RegistryKey#DIALOG}. Dialogs can exist without a key.
+     */
+    @Deprecated(since = "1.21.8", forRemoval = true)
+    @Override
+    default Key key() {
+        return Keyed.super.key();
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/DialogRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/DialogRegistryEntry.java
@@ -63,9 +63,9 @@ public interface DialogRegistryEntry {
         Builder base(DialogBase dialogBase);
 
         /**
-         * Sets the specialty dialog for this entry.
+         * Sets the type of dialog for this entry.
          *
-         * @param dialogType the specialty dialog
+         * @param dialogType the type of dialog
          * @return this builder instance
          * @see DialogRegistryEntry#type()
          */

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/action/DialogAction.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/action/DialogAction.java
@@ -45,7 +45,7 @@ public sealed interface DialogAction permits DialogAction.CommandTemplateAction,
      *
      * @param id the identifier of the custom action
      * @param additions additional data to be sent with the action, or null if not needed
-     * @return a new custom all action instance
+     * @return a new custom click action instance
      */
     @Contract(pure = true, value = "_, _ -> new")
     static CustomClickAction customClick(final Key id, final @Nullable BinaryTagHolder additions) {
@@ -57,7 +57,7 @@ public sealed interface DialogAction permits DialogAction.CommandTemplateAction,
      *
      * @param callback the custom action to execute
      * @param options the options for the custom action
-     * @return a new custom all action instance
+     * @return a new custom click action instance
      */
     @Contract(pure = true, value = "_, _ -> new")
     static CustomClickAction customClick(final DialogActionCallback callback, final ClickCallback.Options options) {
@@ -93,7 +93,6 @@ public sealed interface DialogAction permits DialogAction.CommandTemplateAction,
         @Contract(pure = true)
         ClickEvent value();
     }
-
 
     /**
      * Represents an action that executes a custom action with additional data.

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/action/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/action/package-info.java
@@ -1,8 +1,8 @@
 /**
  * This package contains classes related to dialog actions in the Paper API.
  */
-@ApiStatus.Experimental
 @NullMarked
+@ApiStatus.Experimental
 package io.papermc.paper.registry.data.dialog.action;
 
 import org.jetbrains.annotations.ApiStatus;

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/body/DialogBody.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/body/DialogBody.java
@@ -58,7 +58,7 @@ public sealed interface DialogBody permits ItemDialogBody, PlainMessageDialogBod
      * @param contents the contents of the message
      * @return a new plain message body instance
      */
-    @Contract(pure = true, value = "_, -> new")
+    @Contract(pure = true, value = "_ -> new")
     static PlainMessageDialogBody plainMessage(final Component contents) {
         return DialogInstancesProvider.instance().plainMessageDialogBody(contents);
     }

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/body/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/body/package-info.java
@@ -1,8 +1,8 @@
 /**
  * This package contains classes related to dialog bodies in the Paper API.
  */
-@ApiStatus.Experimental
 @NullMarked
+@ApiStatus.Experimental
 package io.papermc.paper.registry.data.dialog.body;
 
 import org.jetbrains.annotations.ApiStatus;

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/DialogInput.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/DialogInput.java
@@ -80,7 +80,7 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
      * @param end   the end of the range
      * @return a new builder instance
      */
-    @Contract(value = "_, _, _, _ -> new", pure = true)
+    @Contract(pure = true, value = "_, _, _, _ -> new")
     static NumberRangeDialogInput.Builder numberRange(final String key, final Component label, final float start, final float end) {
         return DialogInstancesProvider.instance().numberRangeBuilder(key, label, start, end);
     }
@@ -114,7 +114,7 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
      * @param entries the list of options for the input
      * @return a new builder instance
      */
-    @Contract(value = "_, _, _ -> new", pure = true)
+    @Contract(pure = true, value = "_, _, _ -> new")
     static SingleOptionDialogInput.Builder singleOption(final String key, final Component label, final List<SingleOptionDialogInput.OptionEntry> entries) {
         return DialogInstancesProvider.instance().singleOptionBuilder(key, label, entries);
     }
@@ -128,7 +128,7 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
      * @param labelVisible whether the label should be visible
      * @param initial the initial value of the input
      * @param maxLength the maximum length of the input
-     * @param multilineOptions the multiline options
+     * @param multilineOptions the multiline options, or null if not set
      * @return a new text dialog input instance
      */
     @Contract(pure = true, value = "_, _, _, _, _, _, _ -> new")
@@ -138,7 +138,7 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
         final Component label,
         final boolean labelVisible,
         final String initial,
-        final @Range(from = 1, to = Integer.MAX_VALUE) int maxLength,
+        final @Positive int maxLength,
         final TextDialogInput.@Nullable MultilineOptions multilineOptions
     ) {
         return text(key, label).width(width).labelVisible(labelVisible).initial(initial).maxLength(maxLength).multiline(multilineOptions).build();
@@ -162,6 +162,6 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
      *
      * @return the key
      */
-    @Contract(pure = true, value = " -> new")
+    @Contract(pure = true)
     String key();
 }

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/NumberRangeDialogInput.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/NumberRangeDialogInput.java
@@ -4,8 +4,8 @@ import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.index.qual.Positive;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A number range dialog input.
@@ -103,7 +103,7 @@ public non-sealed interface NumberRangeDialogInput extends DialogInput {
          * @param initial the initial value, or null if not set
          * @return this builder
          */
-        @Contract(value = "_ -> this", pure = true)
+        @Contract(value = "_ -> this", mutates = "this")
         Builder initial(@Nullable Float initial);
 
         /**
@@ -112,7 +112,7 @@ public non-sealed interface NumberRangeDialogInput extends DialogInput {
          * @param step the step size, or null if not set
          * @return this builder
          */
-        @Contract(value = "_ -> this", pure = true)
+        @Contract(value = "_ -> this", mutates = "this")
         Builder step(@Positive @Nullable Float step);
 
         /**

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/SingleOptionDialogInput.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/SingleOptionDialogInput.java
@@ -5,9 +5,9 @@ import java.util.List;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
 import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A single option dialog input.

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/TextDialogInput.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/TextDialogInput.java
@@ -2,6 +2,7 @@ package io.papermc.paper.registry.data.dialog.input;
 
 import io.papermc.paper.registry.data.dialog.DialogInstancesProvider;
 import net.kyori.adventure.text.Component;
+import org.checkerframework.checker.index.qual.Positive;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Range;
@@ -52,7 +53,7 @@ public non-sealed interface TextDialogInput extends DialogInput {
      * @return the label format
      */
     @Contract(pure = true)
-    @Range(from = 1, to = Integer.MAX_VALUE) int maxLength();
+    @Positive int maxLength();
 
     /**
      * The multiline options for the input, or null if not set.
@@ -76,7 +77,7 @@ public non-sealed interface TextDialogInput extends DialogInput {
          * @return a new MultilineOptions instance
          */
         static MultilineOptions create(
-            final @Range(from = 1, to = Integer.MAX_VALUE) @Nullable Integer maxLines,
+            final @Positive @Nullable Integer maxLines,
             final @Range(from = 1, to = 512) @Nullable Integer height
         ) {
             return DialogInstancesProvider.instance().multilineOptions(maxLines, height);
@@ -88,7 +89,7 @@ public non-sealed interface TextDialogInput extends DialogInput {
          * @return the maximum number of lines, or null if not set
          */
         @Contract(pure = true)
-        @Nullable Integer maxLines();
+        @Positive @Nullable Integer maxLines();
 
         /**
          * Gets the height of the input.
@@ -96,7 +97,7 @@ public non-sealed interface TextDialogInput extends DialogInput {
          * @return the height of the input, or null if not set
          */
         @Contract(pure = true)
-        @Nullable Integer height();
+        @Range(from = 1, to = 512) @Nullable Integer height();
     }
 
     /**
@@ -140,12 +141,12 @@ public non-sealed interface TextDialogInput extends DialogInput {
          * @return this builder
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder maxLength(final @Range(from = 1, to = Integer.MAX_VALUE) int maxLength);
+        Builder maxLength(final @Positive int maxLength);
 
         /**
          * Sets the multiline options for the input.
          *
-         * @param multiline the multiline options
+         * @param multiline the multiline options, or null if not set
          * @return this builder
          */
         @Contract(value = "_ -> this", mutates = "this")

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/package-info.java
@@ -1,8 +1,8 @@
 /**
  * Dialog inputs for Paper API.
  */
-@ApiStatus.Experimental
 @NullMarked
+@ApiStatus.Experimental
 package io.papermc.paper.registry.data.dialog.input;
 
 import org.jetbrains.annotations.ApiStatus;

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/type/DialogListType.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/type/DialogListType.java
@@ -3,6 +3,7 @@ package io.papermc.paper.registry.data.dialog.type;
 import io.papermc.paper.dialog.Dialog;
 import io.papermc.paper.registry.data.dialog.ActionButton;
 import io.papermc.paper.registry.set.RegistrySet;
+import org.checkerframework.checker.index.qual.Positive;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Range;
@@ -37,7 +38,7 @@ public non-sealed interface DialogListType extends DialogType {
      * @return the number of columns
      */
     @Contract(pure = true)
-    @Range(from = 1, to = Integer.MAX_VALUE) int columns();
+    @Positive int columns();
 
     /**
      * Returns the width of each button in the dialog list.
@@ -69,7 +70,7 @@ public non-sealed interface DialogListType extends DialogType {
          * @return the builder
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder columns(final @Range(from = 1, to = Integer.MAX_VALUE) int columns);
+        Builder columns(final @Positive int columns);
 
         /**
          * Sets the width of each button in the dialog list.

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/type/DialogType.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/type/DialogType.java
@@ -5,6 +5,7 @@ import io.papermc.paper.registry.data.dialog.ActionButton;
 import io.papermc.paper.registry.data.dialog.DialogInstancesProvider;
 import io.papermc.paper.registry.set.RegistrySet;
 import java.util.List;
+import org.checkerframework.checker.index.qual.Positive;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Range;
 import org.jspecify.annotations.Nullable;
@@ -39,7 +40,7 @@ public sealed interface DialogType permits ConfirmationType, DialogListType, Mul
     static DialogListType dialogList(
         final RegistrySet<Dialog> dialogs,
         final @Nullable ActionButton exitAction,
-        final @Range(from = 1, to = Integer.MAX_VALUE) int columns,
+        final @Positive int columns,
         final @Range(from = 1, to = 1024) int buttonWidth
     ) {
         return dialogList(dialogs).exitAction(exitAction).columns(columns).buttonWidth(buttonWidth).build();
@@ -68,7 +69,7 @@ public sealed interface DialogType permits ConfirmationType, DialogListType, Mul
     static MultiActionType multiAction(
         final List<ActionButton> actions,
         final @Nullable ActionButton exitAction,
-        final @Range(from = 1, to = Integer.MAX_VALUE) int columns
+        final @Positive int columns
     ) {
         return multiAction(actions).exitAction(exitAction).columns(columns).build();
     }
@@ -116,7 +117,7 @@ public sealed interface DialogType permits ConfirmationType, DialogListType, Mul
     @Contract(value = "_, _, _ -> new", pure = true)
     static ServerLinksType serverLinks(
         final @Nullable ActionButton exitAction,
-        final @Range(from = 1, to = Integer.MAX_VALUE) int columns,
+        final @Positive int columns,
         final @Range(from = 1, to = 1024) int buttonWidth
     ) {
         return DialogInstancesProvider.instance().serverLinks(exitAction, columns, buttonWidth);

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/type/MultiActionType.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/type/MultiActionType.java
@@ -2,11 +2,11 @@ package io.papermc.paper.registry.data.dialog.type;
 
 import io.papermc.paper.registry.data.dialog.ActionButton;
 import java.util.List;
+import org.checkerframework.checker.index.qual.Positive;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.Range;
 import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a dialog that allows multiple actions to be performed.
@@ -38,7 +38,7 @@ public non-sealed interface MultiActionType extends DialogType {
      * @return the number of columns
      */
     @Contract(pure = true)
-    @Range(from = 1, to = Integer.MAX_VALUE) int columns();
+    @Positive int columns();
 
     /**
      * A builder for creating a multi-action dialog.
@@ -62,7 +62,7 @@ public non-sealed interface MultiActionType extends DialogType {
          * @return the builder
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder columns(final @Range(from = 1, to = Integer.MAX_VALUE) int columns);
+        Builder columns(final @Positive int columns);
 
         /**
          * Builds the multi-action dialog.

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/type/ServerLinksType.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/type/ServerLinksType.java
@@ -2,6 +2,7 @@ package io.papermc.paper.registry.data.dialog.type;
 
 
 import io.papermc.paper.registry.data.dialog.ActionButton;
+import org.checkerframework.checker.index.qual.Positive;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Range;
@@ -28,7 +29,7 @@ public non-sealed interface ServerLinksType extends DialogType {
      * @return the number of columns
      */
     @Contract(pure = true)
-    @Range(from = 1, to = Integer.MAX_VALUE) int columns();
+    @Positive int columns();
 
     /**
      * Returns the width of each button in the server links dialog.

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/type/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/type/package-info.java
@@ -2,6 +2,8 @@
  * Dialog types for the Paper API.
  */
 @NullMarked
+@ApiStatus.Experimental
 package io.papermc.paper.registry.data.dialog.type;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;

--- a/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/PaperDialogRegistryEntry.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/PaperDialogRegistryEntry.java
@@ -30,7 +30,7 @@ public class PaperDialogRegistryEntry implements DialogRegistryEntry {
         final CommonDialogData common = internal.common();
         this.dialogBase = conversions.convert(common, PaperDialogCodecs.DIALOG_BASE_CODEC, CommonDialogData.MAP_CODEC.codec());
 
-        this.dialogType = PaperDialogs.extractSpecialty(internal, conversions);
+        this.dialogType = PaperDialogs.extractType(internal, conversions);
     }
 
     @Override
@@ -40,7 +40,7 @@ public class PaperDialogRegistryEntry implements DialogRegistryEntry {
 
     @Override
     public DialogType type() {
-        return asConfigured(this.dialogType, "dialogSpecialty");
+        return asConfigured(this.dialogType, "dialogType");
     }
 
     public static final class PaperBuilder extends PaperDialogRegistryEntry implements Builder, PaperRegistryBuilder<Dialog, io.papermc.paper.dialog.Dialog> {
@@ -62,7 +62,7 @@ public class PaperDialogRegistryEntry implements DialogRegistryEntry {
 
         @Override
         public Builder type(final DialogType dialogType) {
-            this.dialogType = asArgument(dialogType, "dialogSpecialty");
+            this.dialogType = asArgument(dialogType, "dialogType");
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/PaperDialogs.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/PaperDialogs.java
@@ -26,7 +26,7 @@ public final class PaperDialogs {
     private PaperDialogs() {
     }
 
-    public static DialogType extractSpecialty(final Dialog nmsDialog, final Conversions conversions) {
+    public static DialogType extractType(final Dialog nmsDialog, final Conversions conversions) {
         final Function<net.minecraft.server.dialog.ActionButton, ActionButton> convertButton = button -> conversions.convert(button, PaperDialogCodecs.ACTION_BUTTON_CODEC, net.minecraft.server.dialog.ActionButton.CODEC);
         return switch (nmsDialog) {
             case final ConfirmationDialog conf ->

--- a/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/action/CustomClickActionImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/action/CustomClickActionImpl.java
@@ -16,8 +16,8 @@ public record CustomClickActionImpl(Key id, @Nullable BinaryTagHolder additions)
             try {
                 final Tag tag = additions.get(PaperAdventure.NBT_CODEC);
                 Preconditions.checkArgument(tag instanceof CompoundTag, "Additions must be a compound tag");
-            } catch (final CommandSyntaxException e) {
-                throw new RuntimeException(e);
+            } catch (final CommandSyntaxException ex) {
+                throw new RuntimeException(ex);
             }
         }
     }

--- a/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/action/StaticActionImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/action/StaticActionImpl.java
@@ -6,6 +6,6 @@ import net.kyori.adventure.text.event.ClickEvent;
 public record StaticActionImpl(ClickEvent value) implements DialogAction.StaticAction {
 
     public StaticActionImpl {
-        Preconditions.checkArgument(value.action().readable(), "action must be readable");
+        Preconditions.checkArgument(value.action().readable() || value.action() == ClickEvent.Action.SHOW_DIALOG, "action must be readable or show_dialog");
     }
 }

--- a/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/input/SingleOptionDialogInputImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/input/SingleOptionDialogInputImpl.java
@@ -5,7 +5,7 @@ import java.util.List;
 import net.kyori.adventure.text.Component;
 import net.minecraft.commands.functions.StringTemplate;
 import net.minecraft.server.dialog.body.PlainMessage;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record SingleOptionDialogInputImpl(
     String key,
@@ -32,9 +32,10 @@ public record SingleOptionDialogInputImpl(
 
         public BuilderImpl(final String key, final List<OptionEntry> entries, final Component label) {
             Preconditions.checkArgument(StringTemplate.isValidVariableName(key), "key must be a valid input name");
-            this.key = key;
             Preconditions.checkArgument(!entries.isEmpty(), "entries must not be empty");
             Preconditions.checkArgument(entries.stream().filter(OptionEntry::initial).count() <= 1, "only 1 option can be initially selected");
+
+            this.key = key;
             this.entries = entries;
             this.label = label;
         }

--- a/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/type/MultiActionTypeImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/type/MultiActionTypeImpl.java
@@ -26,7 +26,7 @@ public record MultiActionTypeImpl(
         }
 
         @Override
-        public Builder exitAction(final @org.jetbrains.annotations.Nullable ActionButton exitAction) {
+        public Builder exitAction(final @Nullable ActionButton exitAction) {
             this.exitAction = exitAction;
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/type/NoticeTypeImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/type/NoticeTypeImpl.java
@@ -1,13 +1,12 @@
 package io.papermc.paper.registry.data.dialog.type;
 
 import io.papermc.paper.registry.data.dialog.ActionButton;
-import net.minecraft.server.dialog.CommonButtonData;
 
 import static net.kyori.adventure.text.Component.translatable;
 
 public record NoticeTypeImpl(ActionButton action) implements NoticeType {
 
-    public static final ActionButton DEFAULT_ACTION = ActionButton.builder(translatable("gui.ok")).width(CommonButtonData.DEFAULT_WIDTH).build();
+    public static final ActionButton DEFAULT_ACTION = ActionButton.builder(translatable("gui.ok")).build();
 
     public NoticeTypeImpl() {
         this(DEFAULT_ACTION);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -214,138 +214,27 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         .resolving(Identity.DISPLAY_NAME, Player::displayName)
         .resolving(Identity.LOCALE, Player::locale)
         .build();
-    private static final WeakHashMap<Plugin, WeakReference<Plugin>> pluginWeakReferences = new WeakHashMap<>();
-    private static final net.kyori.adventure.text.Component DEFAULT_KICK_COMPONENT = net.kyori.adventure.text.Component.translatable("multiplayer.disconnect.kicked");
-    private final ConversationTracker conversationTracker = new ConversationTracker();
-    private final Map<UUID, Set<WeakReference<Plugin>>> invertedVisibilityEntities = new HashMap<>();
-    private final Set<UUID> unlistedEntities = new HashSet<>(); // Paper - Add Listing API for Player
+
     private long firstPlayed = 0;
     private long lastPlayed = 0;
     private boolean hasPlayedBefore = false;
+    private final ConversationTracker conversationTracker = new ConversationTracker();
+    private final Map<UUID, Set<WeakReference<Plugin>>> invertedVisibilityEntities = new HashMap<>();
+    private final Set<UUID> unlistedEntities = new HashSet<>(); // Paper - Add Listing API for Player
+    private static final WeakHashMap<Plugin, WeakReference<Plugin>> pluginWeakReferences = new WeakHashMap<>();
     private int hash = 0;
     private double health = 20;
-    // Paper end
-    // Spigot start
-    private final Player.Spigot spigot = new Player.Spigot() {
-
-        @Override
-        public InetSocketAddress getRawAddress() {
-            return (InetSocketAddress) CraftPlayer.this.getHandle().connection.getRawAddress();
-        }
-
-        @Override
-        public void respawn() {
-            if (CraftPlayer.this.getHealth() <= 0 && CraftPlayer.this.isOnline()) {
-                CraftPlayer.this.server.getServer().getPlayerList().respawn(CraftPlayer.this.getHandle(), false, Entity.RemovalReason.KILLED, org.bukkit.event.player.PlayerRespawnEvent.RespawnReason.PLUGIN);
-            }
-        }
-
-        @Override
-        public Set<Player> getHiddenPlayers() {
-            Set<Player> ret = new HashSet<>();
-            for (Player player : CraftPlayer.this.getServer().getOnlinePlayers()) {
-                if (!CraftPlayer.this.canSee(player)) {
-                    ret.add(player);
-                }
-            }
-
-            return java.util.Collections.unmodifiableSet(ret);
-        }
-
-        @Override
-        public void sendMessage(BaseComponent component) {
-            this.sendMessage(new BaseComponent[]{component});
-        }
-
-        @Override
-        public void sendMessage(BaseComponent... components) {
-            this.sendMessage(net.md_5.bungee.api.ChatMessageType.SYSTEM, components);
-        }
-
-        @Override
-        public void sendMessage(UUID sender, BaseComponent component) {
-            this.sendMessage(net.md_5.bungee.api.ChatMessageType.CHAT, sender, component);
-        }
-
-        @Override
-        public void sendMessage(UUID sender, BaseComponent... components) {
-            this.sendMessage(net.md_5.bungee.api.ChatMessageType.CHAT, sender, components);
-        }
-
-        @Override
-        public void sendMessage(net.md_5.bungee.api.ChatMessageType position, BaseComponent component) {
-            this.sendMessage(position, new BaseComponent[]{component});
-        }
-
-        @Override
-        public void sendMessage(net.md_5.bungee.api.ChatMessageType position, BaseComponent... components) {
-            this.sendMessage(position, null, components);
-        }
-
-        @Override
-        public void sendMessage(net.md_5.bungee.api.ChatMessageType position, UUID sender, BaseComponent component) {
-            this.sendMessage(position, sender, new BaseComponent[]{component});
-        }
-
-        @Override
-        public void sendMessage(net.md_5.bungee.api.ChatMessageType position, UUID sender, BaseComponent... components) {
-            if (CraftPlayer.this.getHandle().connection == null) return;
-
-            CraftPlayer.this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSystemChatPacket(components, position == net.md_5.bungee.api.ChatMessageType.ACTION_BAR));
-        }
-
-        // Paper start
-        @Override
-        public int getPing() {
-            return CraftPlayer.this.getPing();
-        }
-        // Paper end
-    };
     private boolean scaledHealth = false;
     private double healthScale = 20;
     private CraftWorldBorder clientWorldBorder = null;
     private BorderChangeListener clientWorldBorderListener = this.createWorldBorderListener();
     private long lastSaveTime; // Paper - getLastPlayed replacement API
-    private net.kyori.adventure.text.Component playerListHeader; // Paper - Adventure
-    private net.kyori.adventure.text.Component playerListFooter; // Paper - Adventure
-    private @Nullable Set<net.kyori.adventure.bossbar.BossBar> activeBossBars;
 
     public CraftPlayer(CraftServer server, ServerPlayer entity) {
         super(server, entity);
 
         this.firstPlayed = System.currentTimeMillis();
     }
-
-    public static net.minecraft.world.entity.Relative deltaRelativeToNMS(io.papermc.paper.entity.TeleportFlag.Relative apiFlag) {
-        return switch (apiFlag) {
-            case VELOCITY_X -> net.minecraft.world.entity.Relative.DELTA_X;
-            case VELOCITY_Y -> net.minecraft.world.entity.Relative.DELTA_Y;
-            case VELOCITY_Z -> net.minecraft.world.entity.Relative.DELTA_Z;
-            case VELOCITY_ROTATION -> net.minecraft.world.entity.Relative.ROTATE_DELTA;
-        };
-    }
-
-    public static @org.jetbrains.annotations.Nullable io.papermc.paper.entity.TeleportFlag.Relative deltaRelativeToAPI(net.minecraft.world.entity.Relative nmsFlag) {
-        return switch (nmsFlag) {
-            case DELTA_X -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_X;
-            case DELTA_Y -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_Y;
-            case DELTA_Z -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_Z;
-            case ROTATE_DELTA -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_ROTATION;
-            default -> null;
-        };
-    }
-
-    private static @Nullable WeakReference<Plugin> getPluginWeakReference(@Nullable Plugin plugin) {
-        return (plugin == null) ? null : CraftPlayer.pluginWeakReferences.computeIfAbsent(plugin, WeakReference::new);
-    }
-
-    private static int ticks(final java.time.Duration duration) {
-        if (duration == null) {
-            return -1;
-        }
-        return (int) (duration.toMillis() / 50L);
-    }
-    // Paper end
 
     @Override
     public ServerPlayer getHandle() {
@@ -404,13 +293,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public boolean isOnline() {
         return this.server.getPlayer(this.getUniqueId()) != null;
     }
-    // Paper end
 
     // Paper start
     @Override
     public boolean isConnected() {
         return !this.getHandle().hasDisconnected();
     }
+    // Paper end
 
     @Override
     public InetSocketAddress getAddress() {
@@ -431,7 +320,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
 
         return this.getHandle().connection.connection.haProxyAddress instanceof final InetSocketAddress inetSocketAddress ? inetSocketAddress : null;
     }
-
     // Paper end - Add API to get player's proxy address
     @Override
     public boolean isTransferred() {
@@ -465,6 +353,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         if (getHandle().connection == null) return null;
         return getHandle().connection.connection.virtualHost;
     }
+    // Paper end
 
     @Override
     public double getEyeHeight(boolean ignorePose) {
@@ -563,17 +452,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
 
     @Override
     public void setPlayerListHeaderFooter(@Nullable BaseComponent header, @Nullable BaseComponent footer) {
-        this.setPlayerListHeaderFooter(
-            header == null ? null : new BaseComponent[]{header},
-            footer == null ? null : new BaseComponent[]{footer}
-        );
+        this.setPlayerListHeaderFooter(header == null ? null : new BaseComponent[]{header},
+                footer == null ? null : new BaseComponent[]{footer});
     }
 
     @Override
     public void setTitleTimes(int fadeInTicks, int stayTicks, int fadeOutTicks) {
         getHandle().connection.send(new ClientboundSetTitlesAnimationPacket(fadeInTicks, stayTicks, fadeOutTicks));
     }
-    // Paper end
 
     @Override
     public void setSubtitle(BaseComponent[] subtitle) {
@@ -633,6 +519,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public void hideTitle() {
         getHandle().connection.send(new ClientboundClearTitlesPacket(false));
     }
+    // Paper end
 
     @Override
     public String getDisplayName() {
@@ -657,22 +544,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
             }
         }
     }
-
     @Override
     public net.kyori.adventure.text.Component playerListName() {
         return getHandle().listName == null ? net.kyori.adventure.text.Component.text(getName()) : io.papermc.paper.adventure.PaperAdventure.asAdventure(getHandle().listName);
     }
-
     @Override
     public net.kyori.adventure.text.Component playerListHeader() {
         return playerListHeader;
     }
-
     @Override
     public net.kyori.adventure.text.Component playerListFooter() {
         return playerListFooter;
     }
-
     // Paper end
     @Override
     public String getPlayerListName() {
@@ -713,20 +596,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         // Paper end - Send update packet
     }
 
+    private net.kyori.adventure.text.Component playerListHeader; // Paper - Adventure
+    private net.kyori.adventure.text.Component playerListFooter; // Paper - Adventure
+
     @Override
     public String getPlayerListHeader() {
         return (this.playerListHeader == null) ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.playerListHeader);
     }
 
     @Override
-    public void setPlayerListHeader(String header) {
-        this.playerListHeader = header == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(header); // Paper - Adventure
-        this.updatePlayerListHeaderFooter();
+    public String getPlayerListFooter() {
+        return (this.playerListFooter == null) ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.playerListFooter); // Paper - Adventure
     }
 
     @Override
-    public String getPlayerListFooter() {
-        return (this.playerListFooter == null) ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.playerListFooter); // Paper - Adventure
+    public void setPlayerListHeader(String header) {
+        this.playerListHeader = header == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(header); // Paper - Adventure
+        this.updatePlayerListHeaderFooter();
     }
 
     @Override
@@ -754,6 +640,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         org.spigotmc.AsyncCatcher.catchOp("player kick"); // Spigot
         this.getHandle().connection.disconnect(CraftChatMessage.fromStringOrEmpty(message, true), org.bukkit.event.player.PlayerKickEvent.Cause.PLUGIN); // Paper - kick event cause
     }
+
+    private static final net.kyori.adventure.text.Component DEFAULT_KICK_COMPONENT = net.kyori.adventure.text.Component.translatable("multiplayer.disconnect.kicked");
 
     @Override
     public void kick() {
@@ -817,11 +705,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
 
     @Override
-    public Location getCompassTarget() {
-        return this.getHandle().compassTarget;
-    }
-
-    @Override
     public void setCompassTarget(Location loc) {
         Preconditions.checkArgument(loc != null, "Location cannot be null");
 
@@ -829,6 +712,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
 
         // Do not directly assign here, from the packethandler we'll assign it.
         this.getHandle().connection.send(new ClientboundSetDefaultSpawnPositionPacket(CraftLocation.toBlockPosition(loc), loc.getYaw()));
+    }
+
+    @Override
+    public Location getCompassTarget() {
+        return this.getHandle().compassTarget;
     }
 
     @Override
@@ -916,14 +804,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         this.playSound0(loc, Holder.direct(SoundEvent.createVariableRangeEvent(ResourceLocation.parse(sound))), net.minecraft.sounds.SoundSource.valueOf(category.name()), volume, pitch, seed);
     }
 
-    private void playSound0(
-        Location loc,
-        Holder<SoundEvent> soundEffectHolder,
-        net.minecraft.sounds.SoundSource categoryNMS,
-        float volume,
-        float pitch,
-        long seed
-    ) {
+    private void playSound0(Location loc, Holder<SoundEvent> soundEffectHolder, net.minecraft.sounds.SoundSource categoryNMS, float volume, float pitch, long seed) {
         Preconditions.checkArgument(loc != null, "Location cannot be null");
 
         if (this.getHandle().connection == null) return;
@@ -966,14 +847,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         this.playSound0(entity, Holder.direct(SoundEvent.createVariableRangeEvent(ResourceLocation.parse(sound))), net.minecraft.sounds.SoundSource.valueOf(category.name()), volume, pitch, seed);
     }
 
-    private void playSound0(
-        org.bukkit.entity.Entity entity,
-        Holder<SoundEvent> soundEffectHolder,
-        net.minecraft.sounds.SoundSource categoryNMS,
-        float volume,
-        float pitch,
-        long seed
-    ) {
+    private void playSound0(org.bukkit.entity.Entity entity, Holder<SoundEvent> soundEffectHolder, net.minecraft.sounds.SoundSource categoryNMS, float volume, float pitch, long seed) {
         Preconditions.checkArgument(entity != null, "Entity cannot be null");
         Preconditions.checkArgument(soundEffectHolder != null, "Holder of SoundEffect cannot be null");
         Preconditions.checkArgument(categoryNMS != null, "SoundCategory cannot be null");
@@ -1127,6 +1001,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         }
     }
 
+    private record ChunkSectionChanges(ShortSet positions, List<net.minecraft.world.level.block.state.BlockState> blockData) {
+
+        public ChunkSectionChanges() {
+            this(new ShortArraySet(), new ArrayList<>());
+        }
+    }
+
     @Override
     public void sendBlockDamage(Location loc, float progress) {
         this.sendBlockDamage(loc, progress, this.getEntityId());
@@ -1171,8 +1052,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         Component[] components = CraftSign.sanitizeLines(lines);
         this.sendSignChange0(components, loc, dyeColor, hasGlowingText);
     }
-
     // Paper end
+
     @Override
     public void sendSignChange(Location loc, @Nullable String @Nullable [] lines) {
         this.sendSignChange(loc, lines, DyeColor.BLACK);
@@ -1340,12 +1221,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
             }
 
             @Override
-            public void onBorderSetDamagePerBlock(net.minecraft.world.level.border.WorldBorder border, double damagePerBlock) {
-            } // NO OP
+            public void onBorderSetDamagePerBlock(net.minecraft.world.level.border.WorldBorder border, double damagePerBlock) {} // NO OP
 
             @Override
-            public void onBorderSetDamageSafeZOne(net.minecraft.world.level.border.WorldBorder border, double safeZoneRadius) {
-            } // NO OP
+            public void onBorderSetDamageSafeZOne(net.minecraft.world.level.border.WorldBorder border, double safeZoneRadius) {} // NO OP
         };
     }
 
@@ -1374,7 +1253,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         // Paper start - Add target entity to sendHurtAnimation
         this.sendHurtAnimation(yaw, this);
     }
-
     public void sendHurtAnimation(float yaw, org.bukkit.entity.Entity target) {
         // Paper end - Add target entity to sendHurtAnimation
         if (this.getHandle().connection == null) {
@@ -1409,7 +1287,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public void removeCustomChatCompletions(Collection<String> completions) {
         this.sendCustomChatCompletionPacket(completions, ClientboundCustomChatCompletionsPacket.Action.REMOVE);
     }
-    // Paper end
 
     @Override
     public void setCustomChatCompletions(Collection<String> completions) {
@@ -1440,6 +1317,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public void setHasSeenWinScreen(boolean hasSeenWinScreen) {
         getHandle().seenCredits = hasSeenWinScreen;
     }
+    // Paper end
 
     @Override
     public void setRotation(float yaw, float pitch) {
@@ -1458,6 +1336,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     @Override
     public void lookAt(org.bukkit.entity.@NonNull Entity entity, @NonNull LookAnchor playerAnchor, @NonNull LookAnchor entityAnchor) {
         this.getHandle().lookAt(toNmsAnchor(playerAnchor), ((CraftEntity) entity).getHandle(), toNmsAnchor(entityAnchor));
+    }
+
+    public static net.minecraft.world.entity.Relative deltaRelativeToNMS(io.papermc.paper.entity.TeleportFlag.Relative apiFlag) {
+        return switch (apiFlag) {
+            case VELOCITY_X -> net.minecraft.world.entity.Relative.DELTA_X;
+            case VELOCITY_Y -> net.minecraft.world.entity.Relative.DELTA_Y;
+            case VELOCITY_Z -> net.minecraft.world.entity.Relative.DELTA_Z;
+            case VELOCITY_ROTATION -> net.minecraft.world.entity.Relative.ROTATE_DELTA;
+        };
+    }
+
+    public static @org.jetbrains.annotations.Nullable io.papermc.paper.entity.TeleportFlag.Relative deltaRelativeToAPI(net.minecraft.world.entity.Relative nmsFlag) {
+        return switch (nmsFlag) {
+            case DELTA_X -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_X;
+            case DELTA_Y -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_Y;
+            case DELTA_Z -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_Z;
+            case ROTATE_DELTA -> io.papermc.paper.entity.TeleportFlag.Relative.VELOCITY_ROTATION;
+            default -> null;
+        };
     }
 
     @Override
@@ -1550,11 +1447,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
             for (final io.papermc.paper.entity.TeleportFlag.Relative bukkit : relativeArguments) {
                 nms.add(deltaRelativeToNMS(bukkit));
             }
-            entity.connection.internalTeleport(
-                new net.minecraft.world.entity.PositionMoveRotation(
-                    io.papermc.paper.util.MCUtil.toVec3(to), net.minecraft.world.phys.Vec3.ZERO, to.getYaw(), to.getPitch()
-                ), nms
-            );
+            entity.connection.internalTeleport(new net.minecraft.world.entity.PositionMoveRotation(
+                io.papermc.paper.util.MCUtil.toVec3(to), net.minecraft.world.phys.Vec3.ZERO, to.getYaw(), to.getPitch()
+            ), nms);
             // Paper end - Teleport API
         } else {
             entity.portalProcess = null; // SPIGOT-7785: there is no need to carry this over as it contains the old world/location and we might run into trouble if there is a portal in the same spot in both worlds
@@ -1565,13 +1460,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
 
     @Override
-    public boolean isSneaking() {
-        return this.getHandle().isShiftKeyDown();
+    public void setSneaking(boolean sneak) {
+        this.getHandle().setShiftKeyDown(sneak);
     }
 
     @Override
-    public void setSneaking(boolean sneak) {
-        this.getHandle().setShiftKeyDown(sneak);
+    public boolean isSneaking() {
+        return this.getHandle().isShiftKeyDown();
     }
 
     @Override
@@ -1601,14 +1496,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
 
     @Override
-    public boolean isSleepingIgnored() {
-        return this.getHandle().fauxSleeping;
-    }
-
-    @Override
     public void setSleepingIgnored(boolean isSleeping) {
         this.getHandle().fauxSleeping = isSleeping;
         ((CraftWorld) this.getWorld()).getHandle().updateSleepingPlayerList();
+    }
+
+    @Override
+    public boolean isSleepingIgnored() {
+        return this.getHandle().fauxSleeping;
     }
 
     @Override
@@ -1809,13 +1704,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
 
     @Override
-    public WeatherType getPlayerWeather() {
-        return this.getHandle().weatherType;
+    public void setPlayerWeather(WeatherType type) {
+        this.getHandle().setPlayerWeather(type, true);
     }
 
     @Override
-    public void setPlayerWeather(WeatherType type) {
-        this.getHandle().setPlayerWeather(type, true);
+    public WeatherType getPlayerWeather() {
+        return this.getHandle().weatherType;
     }
 
     @Override
@@ -1854,12 +1749,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
 
     @Override
-    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> ban(
-        String reason,
-        Date expires,
-        String source,
-        boolean kickPlayer
-    ) { // Paper - fix ban list API
+    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> ban(String reason, Date expires, String source, boolean kickPlayer) { // Paper - fix ban list API
         BanEntry<com.destroystokyo.paper.profile.PlayerProfile> banEntry = ((ProfileBanList) this.server.getBanList(BanList.Type.PROFILE)).addBan(this.getPlayerProfile(), reason, expires, source); // Paper - fix ban list API
         if (kickPlayer) {
             this.kickPlayer(reason);
@@ -1868,22 +1758,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
 
     @Override
-    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> ban(
-        String reason,
-        Instant instant,
-        String source,
-        boolean kickPlayer
-    ) { // Paper - fix ban list API
+    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> ban(String reason, Instant instant, String source, boolean kickPlayer) { // Paper - fix ban list API
         return this.ban(reason, instant != null ? Date.from(instant) : null, source, kickPlayer);
     }
 
     @Override
-    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> ban(
-        String reason,
-        Duration duration,
-        String source,
-        boolean kickPlayer
-    ) { // Paper - fix ban list API
+    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> ban(String reason, Duration duration, String source, boolean kickPlayer) { // Paper - fix ban list API
         return this.ban(reason, duration != null ? Instant.now().plus(duration) : null, source, kickPlayer);
     }
 
@@ -1922,16 +1802,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
 
     @Override
-    public GameMode getGameMode() {
-        return GameMode.getByValue(this.getHandle().gameMode.getGameModeForPlayer().getId());
-    }
-
-    @Override
     public void setGameMode(GameMode mode) {
         Preconditions.checkArgument(mode != null, "GameMode cannot be null");
         if (this.getHandle().connection == null) return;
 
         this.getHandle().setGameMode(GameType.byId(mode.getValue()), org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.PLUGIN, null); // Paper - Expand PlayerGameModeChangeEvent
+    }
+
+    @Override
+    public GameMode getGameMode() {
+        return GameMode.getByValue(this.getHandle().gameMode.getGameModeForPlayer().getId());
     }
 
     @Override
@@ -1952,7 +1832,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         if (!itemstack.isEmpty() && itemstack.getItem().components().has(net.minecraft.core.component.DataComponents.MAX_DAMAGE)) {
             net.minecraft.world.entity.ExperienceOrb orb = net.minecraft.world.entity.EntityType.EXPERIENCE_ORB.create(handle.level(), net.minecraft.world.entity.EntitySpawnReason.COMMAND);
             orb.setValue(amount);
-            ;
             orb.spawnReason = org.bukkit.entity.ExperienceOrb.SpawnReason.CUSTOM;
             orb.setPosRaw(handle.getX(), handle.getY(), handle.getZ());
 
@@ -2019,7 +1898,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         Preconditions.checkArgument(exp >= 0, "Total experience points must not be negative (%s)", exp);
         this.getHandle().totalExperience = exp;
     }
-
     // Paper start
     @Override
     public int calculateTotalExperiencePoints() {
@@ -2036,7 +1914,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         this.getHandle().experienceProgress = (float) remainingPoints / this.getExperiencePointsNeededForNextLevel();
         this.getHandle().lastSentExp = -1;
     }
-    // Paper end
 
     @Override
     public int getExperiencePointsNeededForNextLevel() {
@@ -2063,6 +1940,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
             return (int) Math.floor((325.0 / 18.0) + Math.sqrt((2.0 / 9.0) * (points - (54215.0 / 72.0))));
         }
     }
+    // Paper end
 
     @Override
     public void sendExperienceChange(float progress) {
@@ -2080,6 +1958,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
 
         ClientboundSetExperiencePacket packet = new ClientboundSetExperiencePacket(progress, this.getTotalExperience(), level);
         this.getHandle().connection.send(packet);
+    }
+
+    private static @Nullable WeakReference<Plugin> getPluginWeakReference(@Nullable Plugin plugin) {
+        return (plugin == null) ? null : CraftPlayer.pluginWeakReferences.computeIfAbsent(plugin, WeakReference::new);
     }
 
     @Override
@@ -2141,7 +2023,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
 
         server.getPluginManager().callEvent(new PlayerHideEntityEvent(this, entity));
     }
-
     private void unregisterEntity(Entity other) {
         // Paper end
         ChunkMap tracker = ((ServerLevel) this.getHandle().level()).getChunkSource().chunkMap;
@@ -2224,8 +2105,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         // Paper start - uuid override
         this.trackAndShowEntity(entity, null);
     }
-    // Paper end
-
     private void trackAndShowEntity(org.bukkit.entity.Entity entity, final @Nullable UUID uuidOverride) {
         // Paper end
         ChunkMap tracker = ((ServerLevel) this.getHandle().level()).getChunkSource().chunkMap;
@@ -2251,24 +2130,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
 
         this.server.getPluginManager().callEvent(new PlayerShowEntityEvent(this, entity));
     }
-
-    void resetAndShowEntity(org.bukkit.entity.Entity entity) {
-        // SPIGOT-7312: Can't show/hide self
-        if (this.equals(entity)) {
-            return;
-        }
-
-        if (this.invertedVisibilityEntities.remove(entity.getUniqueId()) == null) {
-            this.trackAndShowEntity(entity);
-        }
-    }
-
-    // Paper start
-    public com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile() {
-        return new com.destroystokyo.paper.profile.CraftPlayerProfile(this).clone();
-    }
-    // Paper end
-
     // Paper start
     @Override
     public void setPlayerProfile(com.destroystokyo.paper.profile.PlayerProfile profile) {
@@ -2301,6 +2162,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         // Refresh misc player things AFTER sending game profile
         this.refreshPlayer();
     }
+    // Paper end
+
+    void resetAndShowEntity(org.bukkit.entity.Entity entity) {
+        // SPIGOT-7312: Can't show/hide self
+        if (this.equals(entity)) {
+            return;
+        }
+
+        if (this.invertedVisibilityEntities.remove(entity.getUniqueId()) == null) {
+            this.trackAndShowEntity(entity);
+        }
+    }
+    // Paper start
+    public com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile() {
+        return new com.destroystokyo.paper.profile.CraftPlayerProfile(this).clone();
+    }
 
     private void refreshPlayer() {
         ServerPlayer handle = this.getHandle();
@@ -2323,6 +2200,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
             connection.send(new net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket(handle.getId(), mobEffect, false));
         }
     }
+    // Paper end
 
     public void onEntityRemove(Entity entity) {
         this.invertedVisibilityEntities.remove(entity.getUUID());
@@ -2349,7 +2227,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public boolean isListed(Player other) {
         return !this.unlistedEntities.contains(other.getUniqueId());
     }
-    // Paper end - Add Listing API for Player
 
     @Override
     public boolean unlistPlayer(@NonNull Player other) {
@@ -2378,6 +2255,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
             return false;
         }
     }
+    // Paper end - Add Listing API for Player
 
     @Override
     public Map<String, Object> serialize() {
@@ -2398,10 +2276,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         return this.firstPlayed;
     }
 
-    public void setFirstPlayed(long firstPlayed) {
-        this.firstPlayed = firstPlayed;
-    }
-
     @Override
     public long getLastPlayed() {
         return this.lastPlayed;
@@ -2411,7 +2285,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public boolean hasPlayedBefore() {
         return this.hasPlayedBefore;
     }
-    // Paper end - getLastPlayed replacement API
+
+    public void setFirstPlayed(long firstPlayed) {
+        this.firstPlayed = firstPlayed;
+    }
 
     // Paper start - getLastPlayed replacement API
     @Override
@@ -2423,6 +2300,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public long getLastSeen() {
         return this.isOnline() ? System.currentTimeMillis() : this.lastSaveTime;
     }
+    // Paper end - getLastPlayed replacement API
 
     public void readExtraData(ValueInput input) {
         this.hasPlayedBefore = true;
@@ -2562,13 +2440,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
 
     // Paper start - adventure
     @Override
-    public void setResourcePack(
-        final UUID uuid,
-        final String url,
-        final byte @Nullable [] hashBytes,
-        final net.kyori.adventure.text.Component prompt,
-        final boolean force
-    ) {
+    public void setResourcePack(final UUID uuid, final String url, final byte @Nullable [] hashBytes, final net.kyori.adventure.text.Component prompt, final boolean force) {
         Preconditions.checkArgument(uuid != null, "Resource pack UUID cannot be null");
         Preconditions.checkArgument(url != null, "Resource pack URL cannot be null");
         final String hash;
@@ -2595,7 +2467,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
             this.clearResourcePacks();
         }
         final Component prompt = io.papermc.paper.adventure.PaperAdventure.asVanilla(request.prompt());
-        for (final java.util.Iterator<net.kyori.adventure.resource.ResourcePackInfo> iter = request.packs().iterator(); iter.hasNext(); ) {
+        for (final java.util.Iterator<net.kyori.adventure.resource.ResourcePackInfo> iter = request.packs().iterator(); iter.hasNext();) {
             final net.kyori.adventure.resource.ResourcePackInfo pack = iter.next();
             packs.add(new ClientboundResourcePackPushPacket(pack.id(), pack.uri().toASCIIString(), pack.hash(), request.required(), iter.hasNext() ? Optional.empty() : Optional.ofNullable(prompt)));
             if (request.callback() != net.kyori.adventure.resource.ResourcePackCallback.noOp()) {
@@ -2611,14 +2483,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         if (this.getHandle().connection == null) return;
         this.sendBundle(net.kyori.adventure.util.MonkeyBars.nonEmptyArrayToList(pack -> new ClientboundResourcePackPopPacket(Optional.of(pack)), id, others));
     }
-    // Paper end - adventure
 
     @Override
     public void clearResourcePacks() {
         if (this.getHandle().connection == null) return;
         this.getHandle().connection.send(new ClientboundResourcePackPopPacket(Optional.empty()));
     }
-    // Paper end - more resource pack API
+    // Paper end - adventure
 
     @Override
     public void showDialog(final DialogLike dialog) {
@@ -2629,8 +2500,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     // Paper start - more resource pack API
     @Override
     public org.bukkit.event.player.PlayerResourcePackStatusEvent.Status getResourcePackStatus() {
+        if (this.getHandle().connection == null) throw new UnsupportedOperationException("Too early to call this method at this stage");
         return this.getHandle().connection.connection.resourcePackStatus;
     }
+    // Paper end - more resource pack API
 
     @Override
     public void removeResourcePack(UUID id) {
@@ -2751,7 +2624,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         this.getHandle().getAbilities().mayfly = value;
         this.getHandle().onUpdateAbilities();
     }
-    // Paper end - flying fall damage
 
     // Paper start - flying fall damage
     @Override
@@ -2763,11 +2635,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public @NonNull TriState hasFlyingFallDamage() {
         return getHandle().flyingFallDamage;
     }
-
-    @Override
-    public float getFlySpeed() {
-        return (float) this.getHandle().getAbilities().flyingSpeed * 2f;
-    }
+    // Paper end - flying fall damage
 
     @Override
     public void setFlySpeed(float value) {
@@ -2779,17 +2647,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
 
     @Override
-    public float getWalkSpeed() {
-        return this.getHandle().getAbilities().walkingSpeed * 2f;
-    }
-
-    @Override
     public void setWalkSpeed(float value) {
         this.validateSpeed(value);
         ServerPlayer player = this.getHandle();
         player.getAbilities().walkingSpeed = value / 2f;
         player.onUpdateAbilities();
         this.getHandle().getAttribute(Attributes.MOVEMENT_SPEED).setBaseValue(player.getAbilities().walkingSpeed); // SPIGOT-5833: combination of the two in 1.16+
+    }
+
+    @Override
+    public float getFlySpeed() {
+        return (float) this.getHandle().getAbilities().flyingSpeed * 2f;
+    }
+
+    @Override
+    public float getWalkSpeed() {
+        return this.getHandle().getAbilities().walkingSpeed * 2f;
     }
 
     private void validateSpeed(float value) {
@@ -2826,11 +2699,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
 
     @Override
-    public double getHealthScale() {
-        return this.healthScale;
-    }
-
-    @Override
     public void setHealthScale(double value) {
         Preconditions.checkArgument(value > 0F, "Health value (%s) must be greater than 0", value);
         this.healthScale = value;
@@ -2839,8 +2707,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
 
     @Override
-    public boolean isHealthScaled() {
-        return this.scaledHealth;
+    public double getHealthScale() {
+        return this.healthScale;
     }
 
     @Override
@@ -2848,6 +2716,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         if (this.scaledHealth != (this.scaledHealth = scale)) {
             this.updateScaledHealth();
         }
+    }
+
+    @Override
+    public boolean isHealthScaled() {
+        return this.scaledHealth;
     }
 
     public float getScaledHealth() {
@@ -3020,50 +2893,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
 
     @Override
-    public <T> void spawnParticle(
-        Particle particle,
-        double x,
-        double y,
-        double z,
-        int count,
-        double offsetX,
-        double offsetY,
-        double offsetZ,
-        double extra,
-        T data
-    ) {
+    public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data) {
         this.spawnParticle(particle, x, y, z, count, offsetX, offsetY, offsetZ, extra, data, false);
     }
 
     @Override
-    public <T> void spawnParticle(
-        Particle particle,
-        Location location,
-        int count,
-        double offsetX,
-        double offsetY,
-        double offsetZ,
-        double extra,
-        T data,
-        boolean force
-    ) {
+    public <T> void spawnParticle(Particle particle, Location location, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {
         this.spawnParticle(particle, location.getX(), location.getY(), location.getZ(), count, offsetX, offsetY, offsetZ, extra, data, force);
     }
 
     @Override
-    public <T> void spawnParticle(
-        Particle particle,
-        double x,
-        double y,
-        double z,
-        int count,
-        double offsetX,
-        double offsetY,
-        double offsetZ,
-        double extra,
-        T data,
-        boolean force
-    ) {
+    public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {
         ClientboundLevelParticlesPacket packetplayoutworldparticles = new ClientboundLevelParticlesPacket(CraftParticle.createParticleParam(particle, data), force, false, x, y, z, (float) offsetX, (float) offsetY, (float) offsetZ, (float) extra, count); // Paper - fix x/y/z precision loss
         this.getHandle().connection.send(packetplayoutworldparticles);
     }
@@ -3089,10 +2929,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public java.util.Locale locale() {
         return getHandle().adventure$locale;
     }
-
     // Paper end
+
     @Override
     public int getPing() {
+        if (this.getHandle().connection == null) throw new UnsupportedOperationException("Too early to call this method at this stage");
         return this.getHandle().connection.latency();
     }
 
@@ -3103,17 +2944,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         return locale != null ? locale : "en_us";
         // Paper end
     }
-    // Paper end
-
-    @Override
-    public boolean getAffectsSpawning() {
-        return this.getHandle().affectsSpawning;
-    }
 
     // Paper start
     public void setAffectsSpawning(boolean affects) {
         this.getHandle().affectsSpawning = affects;
     }
+
+    @Override
+    public boolean getAffectsSpawning() {
+        return this.getHandle().affectsSpawning;
+    }
+    // Paper end
 
     @Override
     public void updateCommands() {
@@ -3214,24 +3055,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         } else {
             super.sendMessage(signedMessage, boundChatType);
         }
-        //        net.minecraft.network.chat.PlayerChatMessage playerChatMessage = new net.minecraft.network.chat.PlayerChatMessage(
-        //            null, // TODO:
-        //            new net.minecraft.network.chat.MessageSignature(signedMessage.signature().bytes()),
-        //            null, // TODO
-        //            io.papermc.paper.adventure.PaperAdventure.asVanilla(signedMessage.unsignedContent()),
-        //            net.minecraft.network.chat.FilterMask.PASS_THROUGH
-        //        );
-        //
-        //        this.getHandle().sendChatMessage(net.minecraft.network.chat.OutgoingChatMessage.create(playerChatMessage), this.getHandle().isTextFilteringEnabled(), this.toHandle(boundChatType));
+//        net.minecraft.network.chat.PlayerChatMessage playerChatMessage = new net.minecraft.network.chat.PlayerChatMessage(
+//            null, // TODO:
+//            new net.minecraft.network.chat.MessageSignature(signedMessage.signature().bytes()),
+//            null, // TODO
+//            io.papermc.paper.adventure.PaperAdventure.asVanilla(signedMessage.unsignedContent()),
+//            net.minecraft.network.chat.FilterMask.PASS_THROUGH
+//        );
+//
+//        this.getHandle().sendChatMessage(net.minecraft.network.chat.OutgoingChatMessage.create(playerChatMessage), this.getHandle().isTextFilteringEnabled(), this.toHandle(boundChatType));
     }
 
     @Deprecated(forRemoval = true)
     @Override
-    public void sendMessage(
-        final net.kyori.adventure.identity.Identity identity,
-        final net.kyori.adventure.text.Component message,
-        final net.kyori.adventure.audience.MessageType type
-    ) {
+    public void sendMessage(final net.kyori.adventure.identity.Identity identity, final net.kyori.adventure.text.Component message, final net.kyori.adventure.audience.MessageType type) {
         if (getHandle().connection == null) return;
         final net.minecraft.core.Registry<net.minecraft.network.chat.ChatType> chatTypeRegistry = this.getHandle().level().registryAccess().lookupOrThrow(net.minecraft.core.registries.Registries.CHAT_TYPE);
         this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSystemChatPacket(message, false));
@@ -3303,12 +3140,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         }
     }
 
-    // resetTitle implemented above
+    private static int ticks(final java.time.Duration duration) {
+        if (duration == null) {
+            return -1;
+        }
+        return (int) (duration.toMillis() / 50L);
+    }
 
     @Override
     public void clearTitle() {
         this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundClearTitlesPacket(false));
     }
+
+    // resetTitle implemented above
+
+    private @Nullable Set<net.kyori.adventure.bossbar.BossBar> activeBossBars;
 
     @Override
     public @NonNull Iterable<? extends net.kyori.adventure.bossbar.BossBar> activeBossBars() {
@@ -3403,20 +3249,96 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public void resetCooldown() {
         getHandle().resetAttackStrengthTicker();
     }
+    // Paper end
+    // Spigot start
+    private final Player.Spigot spigot = new Player.Spigot() {
+
+        @Override
+        public InetSocketAddress getRawAddress() {
+            return (InetSocketAddress) CraftPlayer.this.getHandle().connection.getRawAddress();
+        }
+
+        @Override
+        public void respawn() {
+            if (CraftPlayer.this.getHealth() <= 0 && CraftPlayer.this.isOnline()) {
+                CraftPlayer.this.server.getServer().getPlayerList().respawn(CraftPlayer.this.getHandle(), false, Entity.RemovalReason.KILLED, org.bukkit.event.player.PlayerRespawnEvent.RespawnReason.PLUGIN);
+            }
+        }
+
+        @Override
+        public Set<Player> getHiddenPlayers() {
+            Set<Player> ret = new HashSet<>();
+            for (Player player : CraftPlayer.this.getServer().getOnlinePlayers()) {
+                if (!CraftPlayer.this.canSee(player)) {
+                    ret.add(player);
+                }
+            }
+
+            return java.util.Collections.unmodifiableSet(ret);
+        }
+
+        @Override
+        public void sendMessage(BaseComponent component) {
+            this.sendMessage(new BaseComponent[]{component});
+        }
+
+        @Override
+        public void sendMessage(BaseComponent... components) {
+            this.sendMessage(net.md_5.bungee.api.ChatMessageType.SYSTEM, components);
+        }
+
+        @Override
+        public void sendMessage(UUID sender, BaseComponent component) {
+            this.sendMessage(net.md_5.bungee.api.ChatMessageType.CHAT, sender, component);
+        }
+
+        @Override
+        public void sendMessage(UUID sender, BaseComponent... components) {
+            this.sendMessage(net.md_5.bungee.api.ChatMessageType.CHAT, sender, components);
+        }
+
+        @Override
+        public void sendMessage(net.md_5.bungee.api.ChatMessageType position, BaseComponent component) {
+            this.sendMessage(position, new BaseComponent[]{component});
+        }
+
+        @Override
+        public void sendMessage(net.md_5.bungee.api.ChatMessageType position, BaseComponent... components) {
+            this.sendMessage(position, null, components);
+        }
+
+        @Override
+        public void sendMessage(net.md_5.bungee.api.ChatMessageType position, UUID sender, BaseComponent component) {
+            this.sendMessage(position, sender, new BaseComponent[]{component});
+        }
+
+        @Override
+        public void sendMessage(net.md_5.bungee.api.ChatMessageType position, UUID sender, BaseComponent... components) {
+            if (CraftPlayer.this.getHandle().connection == null) return;
+
+            CraftPlayer.this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSystemChatPacket(components, position == net.md_5.bungee.api.ChatMessageType.ACTION_BAR));
+        }
+
+        // Paper start
+        @Override
+        public int getPing() {
+            return CraftPlayer.this.getPing();
+        }
+        // Paper end
+    };
 
     // Paper start - brand support
     @Override
     public String getClientBrandName() {
         return getHandle().connection.playerBrand;
     }
+    // Paper end
 
     // Paper start
     @Override
     public void showElderGuardian(boolean silent) {
-        if (getHandle().connection != null)
-            getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
+        if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
     }
-    // Paper end
 
     @Override
     public int getWardenWarningCooldown() {
@@ -3452,18 +3374,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public void increaseWardenWarningLevel() {
         this.getHandle().wardenSpawnTracker.increaseWarningLevel();
     }
+    // Paper end
 
     // Paper start
     @Override
     public Duration getIdleDuration() {
         return Duration.ofMillis(net.minecraft.Util.getMillis() - this.getHandle().getLastActionTime());
     }
-    // Paper end
 
     @Override
     public void resetIdleDuration() {
         this.getHandle().resetLastActionTime();
     }
+    // Paper end
 
     // Paper start - Add chunk view API
     @Override
@@ -3471,7 +3394,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         org.spigotmc.AsyncCatcher.catchOp("accessing sent chunks");
         return FeatureHooks.getSentChunkKeys(this.getHandle());
     }
-    // Paper end
 
     @Override
     public Set<org.bukkit.Chunk> getSentChunks() {
@@ -3484,17 +3406,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         org.spigotmc.AsyncCatcher.catchOp("accessing sent chunks");
         return FeatureHooks.isChunkSent(this.getHandle(), chunkKey);
     }
+    // Paper end
 
     public Player.Spigot spigot() {
         return this.spigot;
     }
-    // Paper end
+    // Spigot end
 
     @Override
     public int getViewDistance() {
         return ca.spottedleaf.moonrise.common.PlatformHooks.get().getViewDistance(this.getHandle());
     }
-    // Spigot end
 
     @Override
     public void setViewDistance(final int viewDistance) {
@@ -3530,6 +3452,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         Preconditions.checkArgument(effect.isApplicableTo(target), "Entity effect cannot apply to the target");
         this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundEntityEventPacket(((CraftEntity) target).getHandle(), effect.getData()));
     }
+    // Paper end - entity effect API
 
     @Override
     public @NonNull PlayerGiveResult give(final @NonNull Collection<@NonNull ItemStack> items, final boolean dropIfFull) {
@@ -3561,7 +3484,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         handle.containerMenu.broadcastChanges();
         return new PaperPlayerGiveResult(leftovers.build(), drops.build());
     }
-    // Paper end - entity effect API
 
     @Override
     public float getSidewaysMovement() {
@@ -3592,12 +3514,5 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     @Override
     public PlayerGameConnection getConnection() {
         return this.getHandle().connection.playerGameConnection;
-    }
-
-    private record ChunkSectionChanges(ShortSet positions, List<net.minecraft.world.level.block.state.BlockState> blockData) {
-
-        public ChunkSectionChanges() {
-            this(new ShortArraySet(), new ArrayList<>());
-        }
     }
 }


### PR DESCRIPTION
Allow to use the show_dialog click event in a static action button. Deprecate key and getKey for dialogs since they can be inlined and revert the not planned cleanup done to CraftPlayer in the original PR.