### PR TITLE
Remove @Experimental annotation from the org.bukkit.damage package

### DIFF
--- a/paper-api/src/main/java/org/bukkit/damage/package-info.java
+++ b/paper-api/src/main/java/org/bukkit/damage/package-info.java
@@ -1,7 +1,4 @@
 /**
  * Classes concerning damage types and sources applicable to living entities.
  */
-@ApiStatus.Experimental
 package org.bukkit.damage;
-
-import org.jetbrains.annotations.ApiStatus;


### PR DESCRIPTION
The `org.bukkit.damage` package have been pretty stable for quite some time now, so I suggest to removing the `@Experimental` annotation