### PR TITLE
Fix bees and parrots ignoring flying_speed attribute

### DIFF
--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -543,10 +543,10 @@ index a2fab6d5eb73c6c88f7b69fbe7f1aaa70cece100..dfdee94b8b1b4584c529bbdcfc95c86e
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 4d1486296348b245e1b226ac2a2d759325017c03..9fd4a23c705f915d4bf9676cddc2f06f15ae7c1b 100644
+index 25c9b2635d3eecaf8cb3dd71c021fc3f9a14256d..bc441cf3d9a8b17811f751a22b7b96eaf26a0ddb 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3222,6 +3222,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3221,6 +3221,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
          return false;
      }
  

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -543,10 +543,10 @@ index a2fab6d5eb73c6c88f7b69fbe7f1aaa70cece100..dfdee94b8b1b4584c529bbdcfc95c86e
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 25089f9ebde144d59d347ce2640a836132b1b4a6..3f6656550fc89267c042edf36391db9982102305 100644
+index 4d1486296348b245e1b226ac2a2d759325017c03..9fd4a23c705f915d4bf9676cddc2f06f15ae7c1b 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3220,6 +3220,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3222,6 +3222,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
          return false;
      }
  

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -484,7 +484,7 @@ index c70a58f5f633fa8e255f74c42f5e87c96b7b013a..ec20a5a6d7c8f65abda528fec36bec7b
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index b9f0745cdc42a093b69f46e353b99adf0c5aac56..a5d65e1b31e2e43cf039b8a19286a5324a739bbe 100644
+index a2fab6d5eb73c6c88f7b69fbe7f1aaa70cece100..dfdee94b8b1b4584c529bbdcfc95c86e019d861f 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -409,6 +409,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -543,10 +543,10 @@ index b9f0745cdc42a093b69f46e353b99adf0c5aac56..a5d65e1b31e2e43cf039b8a19286a532
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 8dd8a3d2a862998a920f226b2a6d9a877aac70a8..0c52e315557e1dae6a852694786e72241fff1e29 100644
+index 25089f9ebde144d59d347ce2640a836132b1b4a6..3f6656550fc89267c042edf36391db9982102305 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3215,6 +3215,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3220,6 +3220,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
          return false;
      }
  
@@ -562,7 +562,7 @@ index 8dd8a3d2a862998a920f226b2a6d9a877aac70a8..0c52e315557e1dae6a852694786e7224
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Mob.java b/net/minecraft/world/entity/Mob.java
-index c737fd87e804129fac95be7d19b4aafab38d8b94..21c6d4746c6a905ec312dc1e35535cbd13868322 100644
+index 63f0b0a39e51b1cd30c2d131414d9512886a664f..e0b3cb2b2694768803ed347a1026b881fd624951 100644
 --- a/net/minecraft/world/entity/Mob.java
 +++ b/net/minecraft/world/entity/Mob.java
 @@ -207,6 +207,19 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
@@ -838,7 +838,7 @@ index 52acc72841f0c6980f5f3f8ef21d0b29dd472ce3..41a6ec508a10a49a37539d2f10171d15
 +
  }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 06069d3ac598f5f12feab038de4f1199794298f6..980eaba27ce2616c1573a4760cf4acc2dd251190 100644
+index 27dc02fd57dfe8942dc835d610b922dd7e66f309..a3926741a46756d8f7fdeb934685ba36122add76 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -143,6 +143,12 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -1333,11 +1333,16 @@
      }
  
      private Vec3 updateFallFlyingMovement(Vec3 deltaMovement) {
-@@ -2507,7 +_,7 @@
+@@ -2507,7 +_,12 @@
      }
  
      protected float getFlyingSpeed() {
 -        return this.getControllingPassenger() instanceof Player ? this.getSpeed() * 0.1F : 0.02F;
++        // Paper start - Fix MC-172801
++        if (this.getAttributes().hasAttribute(Attributes.FLYING_SPEED)) {
++            return (float) (this.getAttributeValue(Attributes.FLYING_SPEED) / 20.0F);
++        }
++        // Paper end - Fix MC-172801
 +        return this.getControllingPassenger() instanceof net.minecraft.world.entity.player.Player ? this.getSpeed() * 0.1F : 0.02F;
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -1333,19 +1333,18 @@
      }
  
      private Vec3 updateFallFlyingMovement(Vec3 deltaMovement) {
-@@ -2507,7 +_,14 @@
+@@ -2507,7 +_,13 @@
      }
  
      protected float getFlyingSpeed() {
 -        return this.getControllingPassenger() instanceof Player ? this.getSpeed() * 0.1F : 0.02F;
 +        // Paper start - Fix MC-172801
-+        float defaultFlyingSpeed = 0.02F;
 +        if (this.getAttributes().hasAttribute(Attributes.FLYING_SPEED)) {
-+            double flyingSpeedFactor = this.getAttributes().getBaseValue(Attributes.FLYING_SPEED) / defaultFlyingSpeed;
++            double flyingSpeedFactor = this.getAttributes().getBaseValue(Attributes.FLYING_SPEED) / 0.02F;
 +            return (float) (this.getAttributeValue(Attributes.FLYING_SPEED) / flyingSpeedFactor);
 +        }
 +        // Paper end - Fix MC-172801
-+        return this.getControllingPassenger() instanceof net.minecraft.world.entity.player.Player ? this.getSpeed() * 0.1F : defaultFlyingSpeed;
++        return this.getControllingPassenger() instanceof net.minecraft.world.entity.player.Player ? this.getSpeed() * 0.1F : 0.02F;
      }
  
      public float getSpeed() {

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -1333,17 +1333,19 @@
      }
  
      private Vec3 updateFallFlyingMovement(Vec3 deltaMovement) {
-@@ -2507,7 +_,12 @@
+@@ -2507,7 +_,14 @@
      }
  
      protected float getFlyingSpeed() {
 -        return this.getControllingPassenger() instanceof Player ? this.getSpeed() * 0.1F : 0.02F;
 +        // Paper start - Fix MC-172801
++        float defaultFlyingSpeed = 0.02F;
 +        if (this.getAttributes().hasAttribute(Attributes.FLYING_SPEED)) {
-+            return (float) (this.getAttributeValue(Attributes.FLYING_SPEED) / 20.0F);
++            double flyingSpeedFactor = this.getAttributes().getBaseValue(Attributes.FLYING_SPEED) / defaultFlyingSpeed;
++            return (float) (this.getAttributeValue(Attributes.FLYING_SPEED) / flyingSpeedFactor);
 +        }
 +        // Paper end - Fix MC-172801
-+        return this.getControllingPassenger() instanceof net.minecraft.world.entity.player.Player ? this.getSpeed() * 0.1F : 0.02F;
++        return this.getControllingPassenger() instanceof net.minecraft.world.entity.player.Player ? this.getSpeed() * 0.1F : defaultFlyingSpeed;
      }
  
      public float getSpeed() {


### PR DESCRIPTION
Fixes #9827, also known as [MC-172801](https://bugs.mojang.com/browse/MC/issues/MC-172801)

~~Dividing by 20.0 is necessary to preserve the default speeds of these mobs.~~