### PR TITLE
Fix typo in give command

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
@@ -22,7 +22,7 @@
                          serverPlayer.containerMenu.broadcastChanges();
                      } else {
 -                        ItemEntity itemEntity = serverPlayer.drop(itemStack1, false);
-+                        ItemEntity itemEntity = serverPlayer.drop(itemStack, false, false, false, null); // Paper - do not fire PlayerDropItemEvent for /give command
++                        ItemEntity itemEntity = serverPlayer.drop(itemStack1, false, false, false, null); // Paper - do not fire PlayerDropItemEvent for /give command
                          if (itemEntity != null) {
                              itemEntity.setNoPickUpDelay();
                              itemEntity.setTarget(serverPlayer.getUUID());


### PR DESCRIPTION
Fixes a typo in the `/give` command that caused incorrect behavior when dropping excess items.