### PR TITLE
Fix endermite spawn position

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/ThrownEnderpearl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/ThrownEnderpearl.java.patch
@@ -1,10 +1,13 @@
 --- a/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
 +++ b/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
-@@ -119,11 +_,18 @@
+@@ -119,11 +_,21 @@
                  Vec3 vec3 = this.oldPosition();
                  if (owner instanceof ServerPlayer serverPlayer) {
                      if (serverPlayer.connection.isAcceptingMessages()) {
 +                        // CraftBukkit start
++                        // Store pre teleportation position as the teleport has been moved up.
++                        final double preTeleportX = serverPlayer.getX(), preTeleportY = serverPlayer.getY(), preTeleportZ = serverPlayer.getZ();
++                        final float preTeleportYRot = serverPlayer.getYRot(), preTeleportXRot = serverPlayer.getXRot();
 +                        ServerPlayer serverPlayer1 = serverPlayer.teleport(new TeleportTransition(serverLevel, vec3, Vec3.ZERO, 0.0F, 0.0F, Relative.union(Relative.ROTATION, Relative.DELTA), TeleportTransition.DO_NOTHING, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.ENDER_PEARL));
 +                        if (serverPlayer1 == null) {
 +                            this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.HIT);
@@ -14,8 +17,9 @@
                          if (this.random.nextFloat() < 0.05F && serverLevel.getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING)) {
                              Endermite endermite = EntityType.ENDERMITE.create(serverLevel, EntitySpawnReason.TRIGGERED);
                              if (endermite != null) {
-                                 endermite.snapTo(owner.getX(), owner.getY(), owner.getZ(), owner.getYRot(), owner.getXRot());
+-                                endermite.snapTo(owner.getX(), owner.getY(), owner.getZ(), owner.getYRot(), owner.getXRot());
 -                                serverLevel.addFreshEntity(endermite);
++                                endermite.snapTo(preTeleportX, preTeleportY, preTeleportZ, preTeleportYRot, preTeleportXRot); // Paper - spawn endermite at pre teleport position as teleport has been moved up
 +                                serverLevel.addFreshEntity(endermite, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.ENDER_PEARL);
                              }
                          }


### PR DESCRIPTION
Origin issue: https://github.com/LeavesMC/Leaves/issues/631
Origin PR: https://github.com/LeavesMC/Leaves/pull/632
Origin license: [GPL3](https://github.com/LeavesMC/Leaves/blob/master/licenses/GPL.md)

record in [wiki](https://minecraft.wiki/w/Ender_Pearl): An ender pearl has a 5% chance to spawn an endermite when it lands. This is the only way through which endermites can spawn, without using cheats. The endermite spawns at the player's position when the pearl lands‌[Java Edition only], or at the pearl's landing site‌[Bedrock Edition only].

in the past the endermites will spawn at the position player teleported instead of old position becuse craftbukkit move teleport behind to create event, so it spawn in wrong place.