### PR TITLE
Change onboarding message 

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -747,7 +747,7 @@
      protected void runServer() {
          try {
              if (!this.initServer()) {
-@@ -675,6 +_,35 @@
+@@ -675,6 +_,39 @@
              this.statusIcon = this.loadStatusIcon().orElse(null);
              this.status = this.buildServerStatus();
  
@@ -777,6 +777,10 @@
 +                LOGGER.info("It's recommended you read our 'Getting Started' documentation for guidance.");
 +                LOGGER.info("View this and more helpful information here: https://docs.papermc.io/paper/next-steps");
 +                LOGGER.info("*************************************************************************************");
++                LOGGER.info("");
++                LOGGER.info("This server is collecting anonymous statistics for PaperMC via bStats.");
++                LOGGER.info("This helps us improve our software. To disable, set 'enabled: false' in /plugins/bStats/config.yml");
++                LOGGER.info("For more details on what data is collected, see https://bstats.org/privacy-policy");
 +            }
 +            // Paper end - Add onboarding message for initial server start
 +


### PR DESCRIPTION
Paper collects metrics via bStats. As such, we should generally follow GDPR. 

The data collected falls under the legimate interest clause (pseudonymous, technical data, reasonable expectation, not overriding the fundamental rights and freedoms of the data subject), so consent is not required. 

However, it still is a requirement to inform the users of the data collection and of how they can opt-out (Transparency). 
If we do not inform them of the opt-out, we can not claim legitimate interest. 

The onboarding message is a good place for this, without spamming the regular startup log with information 99% of users do not care about. Showing the message once should be sufficient to inform the user. 

I've added the following message below the onboarding message:
```
This server is collecting anonymous statistics for PaperMC via bStats.
This helps us improve our software. To disable, set 'enabled: false' in /plugins/bStats/config.yml
For more details on what data is collected, see https://bstats.org/privacy-policy
```

Alternatively we could add a note with a link to bStats to the getting-started page itself, but that seems like a needless extra step and providing a direct link is the standard way of doing it. 