### PR TITLE
Use target level for waypoint modify command

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/commands/WaypointCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/WaypointCommand.java.patch
@@ -5,7 +5,7 @@
  
      private static void mutateIcon(CommandSourceStack source, WaypointTransmitter waypoint, Consumer<Waypoint.Icon> mutator) {
 -        ServerLevel level = source.getLevel();
-+        ServerLevel level = (waypoint instanceof LivingEntity livingEntity) ? (net.minecraft.server.level.ServerLevel) livingEntity.level() : source.getLevel(); // Paper - use level of waypoint if it's a living entity for broadcast
++        ServerLevel level = (waypoint instanceof LivingEntity livingEntity) ? (net.minecraft.server.level.ServerLevel) livingEntity.level() : source.getLevel(); // Paper - MC-300685 use level of waypoint if it's a living entity for broadcast
          level.getWaypointManager().untrackWaypoint(waypoint);
          mutator.accept(waypoint.waypointIcon());
          level.getWaypointManager().trackWaypoint(waypoint);

--- a/paper-server/patches/sources/net/minecraft/server/commands/WaypointCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/WaypointCommand.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/server/commands/WaypointCommand.java
++++ b/net/minecraft/server/commands/WaypointCommand.java
+@@ -165,7 +_,7 @@
+     }
+ 
+     private static void mutateIcon(CommandSourceStack source, WaypointTransmitter waypoint, Consumer<Waypoint.Icon> mutator) {
+-        ServerLevel level = source.getLevel();
++        ServerLevel level = (waypoint instanceof LivingEntity livingEntity) ? (net.minecraft.server.level.ServerLevel) livingEntity.level() : source.getLevel(); // Paper - use level of waypoint if it's a living entity for broadcast
+         level.getWaypointManager().untrackWaypoint(waypoint);
+         mutator.accept(waypoint.waypointIcon());
+         level.getWaypointManager().trackWaypoint(waypoint);


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/12931
Currently the `waypoint modify` use the level of the command executer for save changes, if the target is in another dimension the command ignore that and send the modify to the executer world adding a waypoint and keeping... in vanilla singleplayer when join again to the world the waypoint its removed

PS: I dont find a MOJIRA issue for this...