### PR TITLE
Allow replace effects in Consumable Component Builder

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Consumable.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Consumable.java
@@ -67,7 +67,7 @@ public interface Consumable extends BuildableDataComponent<Consumable, Consumabl
         Builder animation(ItemUseAnimation animation);
 
         /**
-         * Sets the sound associated with a consumable item.
+         * Sets the sound played when consuming the item.
          *
          * @param sound the {@link Key} representing the sound to be used
          * @return the builder for chaining
@@ -86,6 +86,8 @@ public interface Consumable extends BuildableDataComponent<Consumable, Consumabl
 
         /**
          * Sets the effects that occur when an item is consumed.
+         * <br>
+         * <b>Note:</b> this clears any previous effects set.
          *
          * @param effects a list of {@link ConsumeEffect} instances representing the effects to apply upon consumption
          * @return the builder for chaining

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Consumable.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Consumable.java
@@ -48,24 +48,66 @@ public interface Consumable extends BuildableDataComponent<Consumable, Consumabl
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<Consumable> {
 
+        /**
+         * Sets the amount of time (in seconds) it takes to consume the item.
+         *
+         * @param consumeSeconds the consumption duration in seconds
+         * @return the builder for chaining
+         */
         @Contract(value = "_ -> this", mutates = "this")
         Builder consumeSeconds(@NonNegative float consumeSeconds);
 
+        /**
+         * Sets the hand animation used when a player consumes the item.
+         *
+         * @param animation the {@link ItemUseAnimation} representing the hand animation to be used
+         * @return the builder for chaining
+         */
         @Contract(value = "_ -> this", mutates = "this")
         Builder animation(ItemUseAnimation animation);
 
+        /**
+         * Sets the sound associated with a consumable item.
+         *
+         * @param sound the {@link Key} representing the sound to be used
+         * @return the builder for chaining
+         */
         @Contract(value = "_ -> this", mutates = "this")
         Builder sound(Key sound);
 
+        /**
+         * Sets whether consuming the item results in particle effects.
+         *
+         * @param hasConsumeParticles true to enable particle effects upon consumption, false to disable
+         * @return the builder for chaining
+         */
         @Contract(value = "_ -> this", mutates = "this")
         Builder hasConsumeParticles(boolean hasConsumeParticles);
 
+        /**
+         * Sets the effects that occur when an item is consumed.
+         *
+         * @param effects a list of {@link ConsumeEffect} instances representing the effects to apply upon consumption
+         * @return the builder for chaining
+         */
         @Contract(value = "_ -> this", mutates = "this")
         Builder effects(List<ConsumeEffect> effects);
 
+        /**
+         * Adds a single {@link ConsumeEffect} to the consumable item being built.
+         *
+         * @param effect the {@link ConsumeEffect} instance to add
+         * @return the builder for chaining
+         */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addEffect(ConsumeEffect effect);
 
+        /**
+         * Adds multiple {@link ConsumeEffect} instances to the consumable item being built.
+         *
+         * @param effects a list of {@link ConsumeEffect} instances to add
+         * @return the builder for chaining
+         */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addEffects(List<ConsumeEffect> effects);
     }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Consumable.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Consumable.java
@@ -61,6 +61,9 @@ public interface Consumable extends BuildableDataComponent<Consumable, Consumabl
         Builder hasConsumeParticles(boolean hasConsumeParticles);
 
         @Contract(value = "_ -> this", mutates = "this")
+        Builder effects(List<ConsumeEffect> effects);
+
+        @Contract(value = "_ -> this", mutates = "this")
         Builder addEffect(ConsumeEffect effect);
 
         @Contract(value = "_ -> this", mutates = "this")

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperConsumable.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperConsumable.java
@@ -97,6 +97,13 @@ public record PaperConsumable(
         }
 
         @Override
+        public Builder effects(final List<ConsumeEffect> effects) {
+            this.effects.clear();
+            this.addEffects(effects);
+            return this;
+        }
+
+        @Override
         public Builder addEffect(final ConsumeEffect effect) {
             this.effects.add(PaperConsumableEffect.toNms(effect));
             return this;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperConsumable.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperConsumable.java
@@ -99,8 +99,7 @@ public record PaperConsumable(
         @Override
         public Builder effects(final List<ConsumeEffect> effects) {
             this.effects.clear();
-            this.addEffects(effects);
-            return this;
+            return this.addEffects(effects);
         }
 
         @Override


### PR DESCRIPTION
This PR add a new method in the Consumable Component Builder for allow replace the effects being added, the reason for this is because currently if wanna for example take the Consumable component from Rotten Flesh and modify just the effects you cannot use the toBuilder from the original component because cannot delete/modify the effects then need make a custom toBuilder for pass every value and then use the addEffects with this PR you can make a thing like.
```java
ItemStack itemStack = ItemType.ROTTEN_FLESH.createItemStack();

List<PotionEffect> potionEffects = List.of(new PotionEffect(PotionEffectType.HUNGER, 600 * 5, 0, false, true));

final Consumable consumableOriginal = itemStack.getData(DataComponentTypes.CONSUMABLE);
final Consumable consumable = consumableOriginal.toBuilder().effects(List.of(ConsumeEffect.applyStatusEffects(potionEffects, 0.9F))).build();
itemStack.setData(DataComponentTypes.CONSUMABLE, consumable);
```