### PR TITLE
feat: add stuckEntityPoiRetryDelay config

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -4,7 +4,7 @@
                              return false;
                          } else {
                              mutableLong.setValue(time + 20L + level.getRandom().nextInt(20));
-+                            if (mob.getNavigation().isStuck()) mutableLong.add(200); // Paper - Perf: Wait an additional 10s to check again if they're stuck // TODO Modifies Vanilla behavior, add config option
++                            if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay && mob.getNavigation().isStuck()) mutableLong.add(200); // Paper - Perf: Wait an additional 10s to check again if they're stuck.
                              PoiManager poiManager = level.getPoiManager();
                              map.long2ObjectEntrySet().removeIf(entry -> !entry.getValue().isStillValid(time));
                              Predicate<BlockPos> predicate1 = pos -> {

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -186,6 +186,8 @@ public class GlobalConfiguration extends ConfigurationPart {
         public CompressionFormat compressionFormat = CompressionFormat.ZLIB;
         @Comment("This setting controls if equipment should be updated when handling certain player actions.")
         public boolean updateEquipmentOnPlayerActions = true;
+        @Comment("Add 10-second delay before retrying POI acquisition when entity navigation is stuck to reduce pathfinding performance impact.")
+        public boolean stuckEntityPoiRetryDelay = true;
 
         public enum CompressionFormat {
             GZIP,


### PR DESCRIPTION
TL; DR: I added a config for a change that was already marked 'TODO:add config'

When I was using a kind of Raid farm, I found that the farm would stop working sometimes.
After investigation, I found that this modification in AcquirePoi was the key, and I found that Paper here indicates that this change will be added in the future, so I submitted this PR to add the configuration

Q: Should this configuration be placed in `unsupported-settings`? Is the name and description of the configuration reasonable?