### PR TITLE
feat: add stuckEntityPoiRetryDelay config

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -4,7 +4,7 @@
                              return false;
                          } else {
                              mutableLong.setValue(time + 20L + level.getRandom().nextInt(20));
-+                            if (level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay > 0 && mob.getNavigation().isStuck()) mutableLong.add(level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay * 20L); // Paper - Perf: Next stuck check delay config
++                            if (level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay > 0 && mob.getNavigation().isStuck()) mutableLong.add(level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay * 20L); // Paper - Next stuck check delay config
                              PoiManager poiManager = level.getPoiManager();
                              map.long2ObjectEntrySet().removeIf(entry -> !entry.getValue().isStillValid(time));
                              Predicate<BlockPos> predicate1 = pos -> {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -4,7 +4,7 @@
                              return false;
                          } else {
                              mutableLong.setValue(time + 20L + level.getRandom().nextInt(20));
-+                            if (io.papermc.paper.configuration.GlobalConfiguration.get().misc.stuckEntityPoiRetryDelay > 0 && mob.getNavigation().isStuck()) mutableLong.add(io.papermc.paper.configuration.GlobalConfiguration.get().misc.stuckEntityPoiRetryDelay * 20L); // Paper - Perf: Wait an additional seconds to check again if they're stuck.
++                            if (level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay > 0 && mob.getNavigation().isStuck()) mutableLong.add(level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay * 20L); // Paper - Perf: Wait an additional seconds to check again if they're stuck.
                              PoiManager poiManager = level.getPoiManager();
                              map.long2ObjectEntrySet().removeIf(entry -> !entry.getValue().isStillValid(time));
                              Predicate<BlockPos> predicate1 = pos -> {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -4,7 +4,7 @@
                              return false;
                          } else {
                              mutableLong.setValue(time + 20L + level.getRandom().nextInt(20));
-+                            if (level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay > 0 && mob.getNavigation().isStuck()) mutableLong.add(level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay * 20L); // Paper - Next stuck check delay config
++                            if (level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay.enabled() && mob.getNavigation().isStuck()) mutableLong.add(level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay.intValue() * 20L); // Paper - Next stuck check delay config
                              PoiManager poiManager = level.getPoiManager();
                              map.long2ObjectEntrySet().removeIf(entry -> !entry.getValue().isStillValid(time));
                              Predicate<BlockPos> predicate1 = pos -> {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -4,7 +4,7 @@
                              return false;
                          } else {
                              mutableLong.setValue(time + 20L + level.getRandom().nextInt(20));
-+                            if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay != 0 && mob.getNavigation().isStuck()) mutableLong.add(io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay * 20); // Paper - Perf: Wait an additional seconds to check again if they're stuck.
++                            if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay <= 0 && mob.getNavigation().isStuck()) mutableLong.add(io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay * 20); // Paper - Perf: Wait an additional seconds to check again if they're stuck.
                              PoiManager poiManager = level.getPoiManager();
                              map.long2ObjectEntrySet().removeIf(entry -> !entry.getValue().isStillValid(time));
                              Predicate<BlockPos> predicate1 = pos -> {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -4,7 +4,7 @@
                              return false;
                          } else {
                              mutableLong.setValue(time + 20L + level.getRandom().nextInt(20));
-+                            if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay && mob.getNavigation().isStuck()) mutableLong.add(200); // Paper - Perf: Wait an additional 10s to check again if they're stuck.
++                            if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay != 0 && mob.getNavigation().isStuck()) mutableLong.add(io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay * 20); // Paper - Perf: Wait an additional seconds to check again if they're stuck.
                              PoiManager poiManager = level.getPoiManager();
                              map.long2ObjectEntrySet().removeIf(entry -> !entry.getValue().isStillValid(time));
                              Predicate<BlockPos> predicate1 = pos -> {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -4,7 +4,7 @@
                              return false;
                          } else {
                              mutableLong.setValue(time + 20L + level.getRandom().nextInt(20));
-+                            if (level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay.enabled() && mob.getNavigation().isStuck()) mutableLong.add(level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay.intValue() * 20L); // Paper - Next stuck check delay config
++                            if (level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay.enabled() && mob.getNavigation().isStuck()) mutableLong.add(level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay.intValue()); // Paper - Next stuck check delay config
                              PoiManager poiManager = level.getPoiManager();
                              map.long2ObjectEntrySet().removeIf(entry -> !entry.getValue().isStillValid(time));
                              Predicate<BlockPos> predicate1 = pos -> {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -4,7 +4,7 @@
                              return false;
                          } else {
                              mutableLong.setValue(time + 20L + level.getRandom().nextInt(20));
-+                            if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay > 0 && mob.getNavigation().isStuck()) mutableLong.add(io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay * 20); // Paper - Perf: Wait an additional seconds to check again if they're stuck.
++                            if (io.papermc.paper.configuration.GlobalConfiguration.get().misc.stuckEntityPoiRetryDelay > 0 && mob.getNavigation().isStuck()) mutableLong.add(io.papermc.paper.configuration.GlobalConfiguration.get().misc.stuckEntityPoiRetryDelay * 20L); // Paper - Perf: Wait an additional seconds to check again if they're stuck.
                              PoiManager poiManager = level.getPoiManager();
                              map.long2ObjectEntrySet().removeIf(entry -> !entry.getValue().isStillValid(time));
                              Predicate<BlockPos> predicate1 = pos -> {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -4,7 +4,7 @@
                              return false;
                          } else {
                              mutableLong.setValue(time + 20L + level.getRandom().nextInt(20));
-+                            if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay <= 0 && mob.getNavigation().isStuck()) mutableLong.add(io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay * 20); // Paper - Perf: Wait an additional seconds to check again if they're stuck.
++                            if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay > 0 && mob.getNavigation().isStuck()) mutableLong.add(io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay * 20); // Paper - Perf: Wait an additional seconds to check again if they're stuck.
                              PoiManager poiManager = level.getPoiManager();
                              map.long2ObjectEntrySet().removeIf(entry -> !entry.getValue().isStillValid(time));
                              Predicate<BlockPos> predicate1 = pos -> {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -4,7 +4,7 @@
                              return false;
                          } else {
                              mutableLong.setValue(time + 20L + level.getRandom().nextInt(20));
-+                            if (level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay > 0 && mob.getNavigation().isStuck()) mutableLong.add(level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay * 20L); // Paper - Perf: Wait an additional seconds to check again if they're stuck.
++                            if (level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay > 0 && mob.getNavigation().isStuck()) mutableLong.add(level.paperConfig().entities.behavior.stuckEntityPoiRetryDelay * 20L); // Paper - Perf: Next stuck check delay config
                              PoiManager poiManager = level.getPoiManager();
                              map.long2ObjectEntrySet().removeIf(entry -> !entry.getValue().isStillValid(time));
                              Predicate<BlockPos> predicate1 = pos -> {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -4,7 +4,7 @@
                              return false;
                          } else {
                              mutableLong.setValue(time + 20L + level.getRandom().nextInt(20));
-+                            if (mob.getNavigation().isStuck()) mutableLong.add(200); // Paper - Perf: Wait an additional 10s to check again if they're stuck // TODO Modifies Vanilla behavior, add config option
++                            if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.stuckEntityPoiRetryDelay && mob.getNavigation().isStuck()) mutableLong.add(200); // Paper - Perf: Wait an additional 10s to check again if they're stuck.
                              PoiManager poiManager = level.getPoiManager();
                              map.long2ObjectEntrySet().removeIf(entry -> !entry.getValue().isStillValid(time));
                              Predicate<BlockPos> predicate1 = pos -> {

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -360,8 +360,6 @@ public class GlobalConfiguration extends ConfigurationPart {
         public IntOr.Default xpOrbGroupsPerArea = IntOr.Default.USE_DEFAULT;
         @Comment("See Fix MC-163962; prevent villager demand from going negative.")
         public boolean preventNegativeVillagerDemand = false;
-        @Comment("Add a delay before retrying POI acquisition when entity navigation is stuck to reduce pathfinding performance impact. (in seconds)")
-        public int stuckEntityPoiRetryDelay = 10;
     }
 
     public BlockUpdates blockUpdates;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -186,8 +186,6 @@ public class GlobalConfiguration extends ConfigurationPart {
         public CompressionFormat compressionFormat = CompressionFormat.ZLIB;
         @Comment("This setting controls if equipment should be updated when handling certain player actions.")
         public boolean updateEquipmentOnPlayerActions = true;
-        @Comment("Add a delay before retrying POI acquisition when entity navigation is stuck to reduce pathfinding performance impact. (in seconds)")
-        public int stuckEntityPoiRetryDelay = 10;
 
         public enum CompressionFormat {
             GZIP,
@@ -362,6 +360,8 @@ public class GlobalConfiguration extends ConfigurationPart {
         public IntOr.Default xpOrbGroupsPerArea = IntOr.Default.USE_DEFAULT;
         @Comment("See Fix MC-163962; prevent villager demand from going negative.")
         public boolean preventNegativeVillagerDemand = false;
+        @Comment("Add a delay before retrying POI acquisition when entity navigation is stuck to reduce pathfinding performance impact. (in seconds)")
+        public int stuckEntityPoiRetryDelay = 10;
     }
 
     public BlockUpdates blockUpdates;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -186,7 +186,7 @@ public class GlobalConfiguration extends ConfigurationPart {
         public CompressionFormat compressionFormat = CompressionFormat.ZLIB;
         @Comment("This setting controls if equipment should be updated when handling certain player actions.")
         public boolean updateEquipmentOnPlayerActions = true;
-        @Comment("Add seconds delay before retrying POI acquisition when entity navigation is stuck to reduce pathfinding performance impact.")
+        @Comment("Add a delay before retrying POI acquisition when entity navigation is stuck to reduce pathfinding performance impact. (in seconds)")
         public int stuckEntityPoiRetryDelay = 10;
 
         public enum CompressionFormat {

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -186,6 +186,8 @@ public class GlobalConfiguration extends ConfigurationPart {
         public CompressionFormat compressionFormat = CompressionFormat.ZLIB;
         @Comment("This setting controls if equipment should be updated when handling certain player actions.")
         public boolean updateEquipmentOnPlayerActions = true;
+        @Comment("Add 10-second delay before retrying POI acquisition when entity navigation is stuck to reduce pathfinding performance impact.")
+        public boolean stuckEntityPoiRetryDelay = true;
 
         public enum CompressionFormat {
             GZIP,

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -186,8 +186,8 @@ public class GlobalConfiguration extends ConfigurationPart {
         public CompressionFormat compressionFormat = CompressionFormat.ZLIB;
         @Comment("This setting controls if equipment should be updated when handling certain player actions.")
         public boolean updateEquipmentOnPlayerActions = true;
-        @Comment("Add 10-second delay before retrying POI acquisition when entity navigation is stuck to reduce pathfinding performance impact.")
-        public boolean stuckEntityPoiRetryDelay = true;
+        @Comment("Add seconds delay before retrying POI acquisition when entity navigation is stuck to reduce pathfinding performance impact.")
+        public int stuckEntityPoiRetryDelay = 10;
 
         public enum CompressionFormat {
             GZIP,

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -332,8 +332,8 @@ public class WorldConfiguration extends ConfigurationPart {
 
             @Comment("Adds a cooldown to bees being released after a failed release, which can occur if the hive is blocked or it being night.")
             public boolean cooldownFailedBeehiveReleases = true;
-            @Comment("The delay before retrying POI acquisition when entity navigation is stuck. This will reduce pathfinding performance impact. Measured in seconds.")
-            public IntOr.Disabled stuckEntityPoiRetryDelay = new IntOr.Disabled(OptionalInt.of(10));
+            @Comment("The delay before retrying POI acquisition when entity navigation is stuck. This will reduce pathfinding performance impact. Measured in ticks.")
+            public IntOr.Disabled stuckEntityPoiRetryDelay = new IntOr.Disabled(OptionalInt.of(200));
         }
 
         public TrackingRangeY trackingRangeY;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -331,6 +331,8 @@ public class WorldConfiguration extends ConfigurationPart {
 
             @Comment("Adds a cooldown to bees being released after a failed release, which can occur if the hive is blocked or it being night.")
             public boolean cooldownFailedBeehiveReleases = true;
+            @Comment("Add a delay before retrying POI acquisition when entity navigation is stuck to reduce pathfinding performance impact. (in seconds)")
+            public int stuckEntityPoiRetryDelay = 10;
         }
 
         public TrackingRangeY trackingRangeY;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -31,6 +31,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalDouble;
+import java.util.OptionalInt;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import net.minecraft.Util;
@@ -331,8 +332,8 @@ public class WorldConfiguration extends ConfigurationPart {
 
             @Comment("Adds a cooldown to bees being released after a failed release, which can occur if the hive is blocked or it being night.")
             public boolean cooldownFailedBeehiveReleases = true;
-            @Comment("Add a delay before retrying POI acquisition when entity navigation is stuck to reduce pathfinding performance impact. (in seconds)")
-            public int stuckEntityPoiRetryDelay = 10;
+            @Comment("The delay before retrying POI acquisition when entity navigation is stuck. This will reduce pathfinding performance impact. Measured in seconds.")
+            public IntOr.Disabled stuckEntityPoiRetryDelay = new IntOr.Disabled(OptionalInt.of(10));
         }
 
         public TrackingRangeY trackingRangeY;


### PR DESCRIPTION
TL;DR: I added a config for a change that was already marked '//TODO: add config option'

When I was using a kind of Raid farm, I found that the farm would stop working sometimes.
After investigation, I found that this modification in AcquirePoi was the key, and I found that Paper here indicates that this change will be added to config in the future, so I submitted this PR to add the configuration

Q: Should this configuration be placed in levelConfig.entities.behavior? Is the name and description of the configuration reasonable?
