### PR TITLE
Add random tick batching config option

### DIFF
--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -374,7 +374,7 @@ index d51645b115780dac9ff6010806e8bd62dedc8e9f..3faf1b5556c55f3468182f75b2dbff4a
  import java.io.Writer;
  import java.nio.file.Path;
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 18551bebb7e40c936de94c6d1b009db4752d3bba..e6f958b6128213fb9577406c6495148dccac40ca 100644
+index f530211f5de780c969f0146e64db1197dcfb5920..b8069887d6885fbf6222069e870018ee33d2c8c2 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -548,6 +548,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -385,7 +385,7 @@ index 18551bebb7e40c936de94c6d1b009db4752d3bba..e6f958b6128213fb9577406c6495148d
              this.entityTickList
                  .forEach(
                      entity -> {
-@@ -990,12 +991,15 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -993,12 +994,15 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          entity.totalEntityAge++; // Paper - age-like counter for all entities
          profilerFiller.push(() -> BuiltInRegistries.ENTITY_TYPE.getKey(entity.getType()).toString());
          profilerFiller.incrementCounter("tickNonPassenger");
@@ -402,7 +402,7 @@ index 18551bebb7e40c936de94c6d1b009db4752d3bba..e6f958b6128213fb9577406c6495148d
          }
          // Paper start - log detailed entity tick information
          } finally {
-@@ -1006,7 +1010,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1009,7 +1013,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          // Paper end - log detailed entity tick information
      }
  
@@ -411,7 +411,7 @@ index 18551bebb7e40c936de94c6d1b009db4752d3bba..e6f958b6128213fb9577406c6495148d
          if (passengerEntity.isRemoved() || passengerEntity.getVehicle() != ridingEntity) {
              passengerEntity.stopRiding();
          } else if (passengerEntity instanceof Player || this.entityTickList.contains(passengerEntity)) {
-@@ -1016,12 +1020,21 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1019,12 +1023,21 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
              ProfilerFiller profilerFiller = Profiler.get();
              profilerFiller.push(() -> BuiltInRegistries.ENTITY_TYPE.getKey(passengerEntity.getType()).toString());
              profilerFiller.incrementCounter("tickPassenger");
@@ -484,7 +484,7 @@ index c70a58f5f633fa8e255f74c42f5e87c96b7b013a..ec20a5a6d7c8f65abda528fec36bec7b
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index b9f0745cdc42a093b69f46e353b99adf0c5aac56..a5d65e1b31e2e43cf039b8a19286a5324a739bbe 100644
+index a2fab6d5eb73c6c88f7b69fbe7f1aaa70cece100..dfdee94b8b1b4584c529bbdcfc95c86e019d861f 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -409,6 +409,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -562,7 +562,7 @@ index 8dd8a3d2a862998a920f226b2a6d9a877aac70a8..0c52e315557e1dae6a852694786e7224
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Mob.java b/net/minecraft/world/entity/Mob.java
-index c737fd87e804129fac95be7d19b4aafab38d8b94..21c6d4746c6a905ec312dc1e35535cbd13868322 100644
+index 63f0b0a39e51b1cd30c2d131414d9512886a664f..e0b3cb2b2694768803ed347a1026b881fd624951 100644
 --- a/net/minecraft/world/entity/Mob.java
 +++ b/net/minecraft/world/entity/Mob.java
 @@ -207,6 +207,19 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
@@ -838,7 +838,7 @@ index 52acc72841f0c6980f5f3f8ef21d0b29dd472ce3..41a6ec508a10a49a37539d2f10171d15
 +
  }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 06069d3ac598f5f12feab038de4f1199794298f6..980eaba27ce2616c1573a4760cf4acc2dd251190 100644
+index 27dc02fd57dfe8942dc835d610b922dd7e66f309..a3926741a46756d8f7fdeb934685ba36122add76 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -143,6 +143,12 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl

--- a/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
@@ -26931,7 +26931,7 @@ index 283f240511898e416b83ec4dcccd4901889b80bb..3d5a8163a7dd78a195b77c4aaebdee2d
          if (!passengers.equals(this.lastPassengers)) {
              List<UUID> list = this.mountedOrDismounted(passengers).map(Entity::getUUID).toList();
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03012d2866 100644
+index e6ac4e8db5733b17da2c5581d1f18b978d46516a..bcf08b65534bab762dab37af2b92e71a63d8ca45 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -168,7 +168,7 @@ import net.minecraft.world.ticks.LevelTicks;
@@ -27426,10 +27426,11 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
                  this.tickPrecipitation(this.getBlockRandomPos(minBlockX, 0, minBlockZ, 15));
              }
          }
-@@ -635,33 +929,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
- 
+@@ -636,34 +930,8 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          profilerFiller.popPush("tickBlocks");
          if (randomTickSpeed > 0) {
+             int batches = this.paperConfig().chunks.randomTickBatching.or(1);
+-            if (batches == 1 || this.random.nextInt(batches) == 0) {
 -            LevelChunkSection[] sections = chunk.getSections();
 -
 -            for (int i1 = 0; i1 < sections.length; i1++) {
@@ -27438,7 +27439,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
 -                    int sectionYFromSectionIndex = chunk.getSectionYFromSectionIndex(i1);
 -                    int blockPosCoord = SectionPos.sectionToBlockCoord(sectionYFromSectionIndex);
 -
--                    for (int i2 = 0; i2 < randomTickSpeed; i2++) {
+-                    for (int i2 = 0; i2 < randomTickSpeed * batches; i2++) {
 -                        BlockPos blockRandomPos = this.getBlockRandomPos(minBlockX, blockPosCoord, minBlockZ, 15);
 -                        profilerFiller.push("randomTick");
 -                        BlockState blockState = levelChunkSection.getBlockState(
@@ -27457,11 +27458,12 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
 -                    }
 -                }
 -            }
-+            this.optimiseRandomTick(chunk, randomTickSpeed); // Paper - optimise random ticking
++            if (batches == 1 || simpleRandom.nextInt(batches) == 0) {
++                this.optimiseRandomTick(chunk, randomTickSpeed * batches); // Paper - optimise random ticking
+             }
          }
  
-         profilerFiller.pop();
-@@ -956,6 +1224,12 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -959,6 +1227,12 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          if (fluidState.is(fluid)) {
              fluidState.tick(this, pos, blockState);
          }
@@ -27474,7 +27476,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
      }
  
      private void tickBlock(BlockPos pos, Block block) {
-@@ -963,6 +1237,12 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -966,6 +1240,12 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          if (blockState.is(block)) {
              blockState.tick(this, pos, this.random);
          }
@@ -27487,7 +27489,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
      }
  
      // Paper start - log detailed entity tick information
-@@ -1059,6 +1339,11 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1062,6 +1342,11 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      }
  
      public void save(@Nullable ProgressListener progress, boolean flush, boolean skipSave) {
@@ -27499,7 +27501,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
          ServerChunkCache chunkSource = this.getChunkSource();
          if (!skipSave) {
              org.bukkit.Bukkit.getPluginManager().callEvent(new org.bukkit.event.world.WorldSaveEvent(this.getWorld())); // CraftBukkit
-@@ -1071,13 +1356,18 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1074,13 +1359,18 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
                  progress.progressStage(Component.translatable("menu.savingChunks"));
              }
  
@@ -27523,7 +27525,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
  
          // CraftBukkit start - moved from MinecraftServer#saveAllChunks
          ServerLevel serverLevel1 = this;
-@@ -1208,7 +1498,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1211,7 +1501,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
              this.removePlayerImmediately((ServerPlayer)entity, Entity.RemovalReason.DISCARDED);
          }
  
@@ -27532,7 +27534,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
      }
  
      // CraftBukkit start
-@@ -1239,7 +1529,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1242,7 +1532,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
              }
              // CraftBukkit end
  
@@ -27541,7 +27543,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
          }
      }
  
-@@ -1250,7 +1540,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1253,7 +1543,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
  
      public boolean tryAddFreshEntityWithPassengers(Entity entity, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason) {
          // CraftBukkit end
@@ -27550,7 +27552,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
              return false;
          } else {
              this.addFreshEntityWithPassengers(entity, reason); // CraftBukkit
-@@ -1984,7 +2274,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1987,7 +2277,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
                  }
              }
  
@@ -27559,7 +27561,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
              bufferedWriter.write(String.format(Locale.ROOT, "block_entity_tickers: %d\n", this.blockEntityTickers.size()));
              bufferedWriter.write(String.format(Locale.ROOT, "block_ticks: %d\n", this.getBlockTicks().count()));
              bufferedWriter.write(String.format(Locale.ROOT, "fluid_ticks: %d\n", this.getFluidTicks().count()));
-@@ -2002,13 +2292,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2005,13 +2295,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          Path path1 = path.resolve("chunks.csv");
  
          try (Writer bufferedWriter2 = Files.newBufferedWriter(path1)) {
@@ -27575,7 +27577,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
          }
  
          Path path3 = path.resolve("entities.csv");
-@@ -2105,8 +2395,8 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2108,8 +2398,8 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
              Locale.ROOT,
              "players: %s, entities: %s [%s], block_entities: %d [%s], block_ticks: %d, fluid_ticks: %d, chunk_source: %s",
              this.players.size(),
@@ -27586,7 +27588,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
              this.blockEntityTickers.size(),
              getTypeCount(this.blockEntityTickers, TickingBlockEntity::getType),
              this.getBlockTicks().count(),
-@@ -2138,15 +2428,25 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2141,15 +2431,25 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      @Override
      public LevelEntityGetter<Entity> getEntities() {
          org.spigotmc.AsyncCatcher.catchOp("Chunk getEntities call"); // Spigot
@@ -27615,7 +27617,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
      }
  
      public void startTickingChunk(LevelChunk chunk) {
-@@ -2166,7 +2466,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2169,7 +2469,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          this.chunkSource.addTicketWithRadius(TicketType.UNKNOWN, chunkPos, i);
          list.forEach(chunkPos1 -> this.getChunk(chunkPos1.x, chunkPos1.z));
          this.server.managedBlock(() -> {
@@ -27624,7 +27626,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
  
              for (ChunkPos chunkPos1 : list) {
                  if (!this.areEntitiesLoaded(chunkPos1.toLong())) {
-@@ -2181,28 +2481,38 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2184,28 +2484,38 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      @Override
      public void close() throws IOException {
          super.close();
@@ -27669,7 +27671,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
      }
  
      public boolean anyPlayerCloseEnoughForSpawning(BlockPos pos) {
-@@ -2214,7 +2524,10 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2217,7 +2527,10 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      }
  
      public boolean canSpawnEntitiesInChunk(ChunkPos chunkPos) {
@@ -27681,7 +27683,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
      }
  
      @Override
-@@ -2269,7 +2582,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2272,7 +2585,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      @Override
      public CrashReportCategory fillReportDetails(CrashReport report) {
          CrashReportCategory crashReportCategory = super.fillReportDetails(report);
@@ -27691,7 +27693,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
      }
  
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 537821a41e4ef4be17b8859a23107cf726569112..514ff8543dbbe1c6ae47c7fd6c1545b87d3b2927 100644
+index f1706da6a1290a49cfcfb567e68acd5872c527ad..dcf371aeb3696fbee72a8a7e7cbd7677a788819b 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -193,7 +193,7 @@ import net.minecraft.world.scores.Team;

--- a/paper-server/patches/features/0019-Add-Alternate-Current-redstone-implementation.patch
+++ b/paper-server/patches/features/0019-Add-Alternate-Current-redstone-implementation.patch
@@ -2326,7 +2326,7 @@ index 0000000000000000000000000000000000000000..298076a0db4e6ee6e4775ac43bf749d9
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index f9c96bbdc54e68b9216b7f8662bfae03012d2866..34b7769663e235b93c6388ab0c92c00f0297e42f 100644
+index 19bde5b60f30c5d2a228d0632374812a778114f1..ae9af54148e7b06a68d9e05e6ddf8ea901e13ca0 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -213,6 +213,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -2337,7 +2337,7 @@ index f9c96bbdc54e68b9216b7f8662bfae03012d2866..34b7769663e235b93c6388ab0c92c00f
  
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
-@@ -2591,6 +2592,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2594,6 +2595,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          return this.chunkSource.getGenerator().getSeaLevel();
      }
  
@@ -2352,7 +2352,7 @@ index f9c96bbdc54e68b9216b7f8662bfae03012d2866..34b7769663e235b93c6388ab0c92c00f
          @Override
          public void onCreated(Entity entity) {
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index f286dd9996590e5d448ca809c34b6f640203e274..c41df4b1fff1f65532256e835dc30fadbb4f8c8b 100644
+index 2707fc5e0d0a63df51c9176ab52e341ca4529489..be16627136f7b3979e62308f58b96a2b16ee9f62 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -2093,6 +2093,17 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl

--- a/paper-server/patches/features/0024-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0024-Incremental-chunk-and-player-saving.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Incremental chunk and player saving
 
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index dc47259e40089a4793d950d4c3dc5bcc51ff680f..34b10db71d22cb7211dcfc5565e6833c8d4d2413 100644
+index 3b2b9d959e704abf87fd074418b47ff741a2a65e..6c8f06bc55cc6bffe6879433c5eda74eb5a13cb0 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -955,7 +955,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -50,10 +50,10 @@ index dc47259e40089a4793d950d4c3dc5bcc51ff680f..34b10db71d22cb7211dcfc5565e6833c
          ProfilerFiller profilerFiller = Profiler.get();
          this.runAllTasks(); // Paper - move runAllTasks() into full server tick (previously for timings)
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 34b7769663e235b93c6388ab0c92c00f0297e42f..dda8d38ef61672cc714d9e5a475f9b0412ed5ff9 100644
+index ae9af54148e7b06a68d9e05e6ddf8ea901e13ca0..d95aea81dff938cd2ddd9efdc2afb510b34c447c 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1339,6 +1339,28 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -1342,6 +1342,28 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          return !(entity instanceof Player player && (this.server.isUnderSpawnProtection(this, pos, player) || !this.getWorldBorder().isWithinBounds(pos)));
      }
  
@@ -83,7 +83,7 @@ index 34b7769663e235b93c6388ab0c92c00f0297e42f..dda8d38ef61672cc714d9e5a475f9b04
          // Paper start - add close param
          this.save(progress, flush, skipSave, false);
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 514ff8543dbbe1c6ae47c7fd6c1545b87d3b2927..4726c980ad52c1300de16b7607006ea4a13325eb 100644
+index dcf371aeb3696fbee72a8a7e7cbd7677a788819b..283074b1097768887e057e08843d5a2c70bbccac 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -195,6 +195,7 @@ import org.slf4j.Logger;
@@ -95,7 +95,7 @@ index 514ff8543dbbe1c6ae47c7fd6c1545b87d3b2927..4726c980ad52c1300de16b7607006ea4
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      private static final int FLY_STAT_RECORDING_SPEED = 25;
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index d099b76082e59baf42de8e265eb2bc593c6e6f86..802357d8b582539e08a8d48024ebe9c38493a2b3 100644
+index 9547000b6e41fab39b00ca55ebd41825d222592e..e1fd699b33832c0f01b14023db7cc2b9d6797227 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -489,6 +489,7 @@ public abstract class PlayerList {

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -294,7 +294,7 @@
          if (flag) {
              this.resetEmptyTime();
          }
-@@ -459,11 +_,13 @@
+@@ -459,14 +_,18 @@
          ProfilerFiller profilerFiller = Profiler.get();
          profilerFiller.push("iceandsnow");
  
@@ -308,6 +308,28 @@
  
          profilerFiller.popPush("tickBlocks");
          if (randomTickSpeed > 0) {
++            int batches = this.paperConfig().chunks.randomTickBatching.or(1);
++            if (batches == 1 || this.random.nextInt(batches) == 0) {
+             LevelChunkSection[] sections = chunk.getSections();
+ 
+             for (int i1 = 0; i1 < sections.length; i1++) {
+@@ -475,7 +_,7 @@
+                     int sectionYFromSectionIndex = chunk.getSectionYFromSectionIndex(i1);
+                     int blockPosCoord = SectionPos.sectionToBlockCoord(sectionYFromSectionIndex);
+ 
+-                    for (int i2 = 0; i2 < randomTickSpeed; i2++) {
++                    for (int i2 = 0; i2 < randomTickSpeed * batches; i2++) {
+                         BlockPos blockRandomPos = this.getBlockRandomPos(minBlockX, blockPosCoord, minBlockZ, 15);
+                         profilerFiller.push("randomTick");
+                         BlockState blockState = levelChunkSection.getBlockState(
+@@ -494,6 +_,7 @@
+                     }
+                 }
+             }
++            }
+         }
+ 
+         profilerFiller.pop();
 @@ -506,12 +_,12 @@
          int minBlockZ = pos.getMinBlockZ();
          ProfilerFiller profilerFiller = Profiler.get();

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -512,6 +512,7 @@ public class WorldConfiguration extends ConfigurationPart {
             map.put(EntityType.SMALL_FIREBALL, -1);
         });
         public boolean flushRegionsOnSave = false;
+        public IntOr.Disabled randomTickBatching = IntOr.Disabled.DISABLED;
 
         @PostProcess
         private void postProcess() {


### PR DESCRIPTION
This is a config option where, instead of running random ticking once every tick, you can run it once every *n* ticks, but when randomly ticked, chunks will be ticked *n* times more. While this does affect vanilla behaviour, the nature of random ticking is that this effect is barely noticeable, but it can have a significant impact on TPS.

With 50 bots randomly spread on a server, and a benchmark running for two minutes, setting randomTickScale to 10 reduced the footprint of optimiseRandomDespawn from 6 ms/t to 3.9 ms/t. On a real server with about 90 players, I have observed a reduction in the footprint from 4.04 ms/t to 0.76 ms/t (both with approximately 28,000 chunks loaded, plus or minus 10%), which is a significant performance boost for such a simple option.