### PR TITLE
Added `getWorldPath` to `World` API

### DIFF
--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2868,7 +2868,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * @return The folder of this world.
      */
     @NotNull
-    File getWorldFolder();
+    default File getWorldFolder() {
+        return getWorldPath().toFile();
+    }
     
     /**
      * Gets the path of this world on disk.

--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2,6 +2,7 @@ package org.bukkit;
 
 import io.papermc.paper.raytracing.PositionedRayTraceConfigurationBuilder;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -2867,7 +2868,15 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * @return The folder of this world.
      */
     @NotNull
-    public File getWorldFolder();
+    File getWorldFolder();
+    
+    /**
+     * Gets the path of this world on disk.
+     *
+     * @return The path of this world.
+     */
+    @NotNull
+    Path getWorldPath();
 
     /**
      * Gets the type of this world.

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1610,11 +1610,6 @@ public class CraftWorld extends CraftRegionAccessor implements World {
     }
 
     @Override
-    public File getWorldFolder() {
-        return this.world.levelStorageAccess.getLevelPath(LevelResource.ROOT).toFile().getParentFile();
-    }
-
-    @Override
     public Path getWorldPath() {
         return this.world.levelStorageAccess.getLevelPath(LevelResource.ROOT).getParent();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -13,6 +13,7 @@ import io.papermc.paper.raytracing.PositionedRayTraceConfigurationBuilder;
 import io.papermc.paper.raytracing.PositionedRayTraceConfigurationBuilderImpl;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1611,6 +1612,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
     @Override
     public File getWorldFolder() {
         return this.world.levelStorageAccess.getLevelPath(LevelResource.ROOT).toFile().getParentFile();
+    }
+
+    @Override
+    public Path getWorldPath() {
+        return this.world.levelStorageAccess.getLevelPath(LevelResource.ROOT).getParent();
     }
 
     @Override


### PR DESCRIPTION
Probably just a "me" thing but, I am annoyed by doing `world.getWorldFolder().toPath()` to get the `Path` object of the world folder, which is internally stored as a path anyway

Tested using:
<img width="700" height="596" alt="image" src="https://github.com/user-attachments/assets/5f7678e9-fc4d-4c8f-9b0d-c54b5e2f4c63" />
