### PR TITLE
Allow you to set the number of items that a hopper moves

### DIFF
--- a/paper-api/src/main/java/org/bukkit/block/Hopper.java
+++ b/paper-api/src/main/java/org/bukkit/block/Hopper.java
@@ -1,7 +1,8 @@
 package org.bukkit.block;
 
 import com.destroystokyo.paper.loottable.LootableBlockInventory;
-import org.bukkit.loot.Lootable;
+import org.jetbrains.annotations.NotNull;
+import java.util.Optional;
 
 /**
  * Represents a captured state of a hopper.
@@ -21,5 +22,23 @@ public interface Hopper extends Container, LootableBlockInventory { // Paper
      */
     int getTransferCooldown();
     // Paper end - Expanded Hopper API
+
+    // Paper start - Allow you to set the number of items that a hopper moves
+
+    /**
+     * Define the number of items transferred by the hopper; the amount must be strictly greater than 0.
+     * Setting a value to null corresponds to resuming the server's default behavior.
+     * @param transferAmount Items amount
+     */
+    void setTransferAmount(@org.jetbrains.annotations.Range(from = 1, to = Integer.MAX_VALUE) @org.jspecify.annotations.Nullable Integer transferAmount);
+
+    /**
+     * Retrieve the number of items transferred by the hopper. If there is no value, it refers to the configuration of
+     * the server being used.
+     * @return Items amount
+     */
+    @NotNull
+    Optional<Integer> getTransferAmount();
+    // Paper end - Allow you to set the number of items that a hopper moves
 }
 

--- a/paper-api/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java
+++ b/paper-api/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java
@@ -3,7 +3,7 @@ package org.bukkit.entity.minecart;
 import com.destroystokyo.paper.loottable.LootableEntityInventory;
 import org.bukkit.entity.Minecart;
 import org.bukkit.inventory.InventoryHolder;
-import org.bukkit.loot.Lootable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a Minecart with a Hopper inside it
@@ -43,4 +43,22 @@ public interface HopperMinecart extends Minecart, InventoryHolder, LootableEntit
     @Deprecated(forRemoval = true, since = "1.19.4")
     void setPickupCooldown(int cooldown);
     // Paper end
+
+    // Paper start - Allow you to set the number of items that a hopper moves
+
+    /**
+     * Define the number of items transferred by the hopper; the amount must be strictly greater than 0.
+     * Setting a value to null corresponds to resuming the server's default behavior.
+     * @param transferAmount Items amount
+     */
+    void setTransferAmount(@org.jetbrains.annotations.Range(from = 1, to = Integer.MAX_VALUE) @org.jspecify.annotations.Nullable Integer transferAmount);
+
+    /**
+     * Retrieve the number of items transferred by the hopper. If there is no value, it refers to the configuration of
+     * the server being used.
+     * @return Items amount
+     */
+    @NotNull
+    java.util.Optional<Integer> getTransferAmount();
+    // Paper end - Allow you to set the number of items that a hopper moves
 }

--- a/paper-server/patches/features/0034-Allow-you-to-set-the-number-of-items-that-a-hopper-m.patch
+++ b/paper-server/patches/features/0034-Allow-you-to-set-the-number-of-items-that-a-hopper-m.patch
@@ -1,0 +1,167 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: William AVENTIN <william.aventin@elesia.org>
+Date: Mon, 11 Aug 2025 09:56:45 +0200
+Subject: [PATCH] Allow you to set the number of items that a hopper moves
+
+
+diff --git a/net/minecraft/world/entity/vehicle/MinecartHopper.java b/net/minecraft/world/entity/vehicle/MinecartHopper.java
+index 41a6ec508a10a49a37539d2f10171d15c233b280..fd84b0e4d6990a23a8078c14917c2dee0a1e26b8 100644
+--- a/net/minecraft/world/entity/vehicle/MinecartHopper.java
++++ b/net/minecraft/world/entity/vehicle/MinecartHopper.java
+@@ -24,6 +24,10 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
+     private boolean enabled = true;
+     private boolean consumedItemThisFrame = false;
+ 
++    // Paper - Allow you to set the number of items that a hopper moves
++    @org.jspecify.annotations.Nullable
++    private Integer transferAmount = null;
++
+     public MinecartHopper(EntityType<? extends MinecartHopper> entityType, Level level) {
+         super(entityType, level);
+     }
+@@ -80,6 +84,18 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
+         return false;
+     }
+ 
++    // Paper start - Allow you to set the number of items that a hopper moves
++    @Override
++    public void setTransferAmount(@org.jspecify.annotations.Nullable final Integer transferAmount) {
++        this.transferAmount = transferAmount;
++    }
++
++    @Override
++    public java.util.Optional<Integer> getTransferAmount() {
++        return java.util.Optional.ofNullable(this.transferAmount);
++    }
++    // Paper end - Allow you to set the number of items that a hopper moves
++
+     @Override
+     public void tick() {
+         this.consumedItemThisFrame = false;
+@@ -132,12 +148,22 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
+     protected void addAdditionalSaveData(ValueOutput output) {
+         super.addAdditionalSaveData(output);
+         output.putBoolean("Enabled", this.enabled);
++
++        // Paper start - Allow you to set the number of items that a hopper moves
++        if(this.transferAmount != null) {
++            output.putInt("TransferAmount", this.transferAmount);
++        }
++        // Paper end - Allow you to set the number of items that a hopper moves
+     }
+ 
+     @Override
+     protected void readAdditionalSaveData(ValueInput input) {
+         super.readAdditionalSaveData(input);
+         this.enabled = input.getBooleanOr("Enabled", true);
++
++        // Paper - Allow you to set the number of items that a hopper moves
++        this.transferAmount = input.getInt("TransferAmount").orElse(null);
++
+     }
+ 
+     @Override
+diff --git a/net/minecraft/world/level/block/entity/Hopper.java b/net/minecraft/world/level/block/entity/Hopper.java
+index 484c2ba2752fbf3ad929e46c2f078e906f6f0637..229f5adef5f81d236cda6e55007b0693772316f5 100644
+--- a/net/minecraft/world/level/block/entity/Hopper.java
++++ b/net/minecraft/world/level/block/entity/Hopper.java
+@@ -18,4 +18,10 @@ public interface Hopper extends Container {
+     double getLevelZ();
+ 
+     boolean isGridAligned();
++
++    // Paper start - Allow you to set the number of items that a hopper moves
++    void setTransferAmount(@org.jspecify.annotations.Nullable Integer transferAmount);
++
++    java.util.Optional<Integer> getTransferAmount();
++    // Paper end - Allow you to set the number of items that a hopper moves
+ }
+diff --git a/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
+index 800b7e78ae989868ed0b9e060c80dcd002759412..59b8bf1629a61e0955620ad5b330decf961b58e1 100644
+--- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
++++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
+@@ -1,6 +1,7 @@
+ package net.minecraft.world.level.block.entity;
+ 
+ import java.util.List;
++import java.util.Optional;
+ import java.util.function.BooleanSupplier;
+ import javax.annotation.Nullable;
+ import net.minecraft.core.BlockPos;
+@@ -42,6 +43,10 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+     public List<org.bukkit.entity.HumanEntity> transaction = new java.util.ArrayList<>();
+     private int maxStack = MAX_STACK;
+ 
++    // Paper - Allow you to set the number of items that a hopper moves
++    @Nullable
++    private Integer transferAmount = null;
++
+     @Override
+     public List<ItemStack> getContents() {
+         return this.items;
+@@ -86,6 +91,9 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+         }
+ 
+         this.cooldownTime = input.getIntOr("TransferCooldown", -1);
++
++        //Paper - Allow you to set the number of items that a hopper moves
++        this.transferAmount = input.getInt("TransferAmount").orElse(null);
+     }
+ 
+     @Override
+@@ -96,6 +104,12 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+         }
+ 
+         output.putInt("TransferCooldown", this.cooldownTime);
++
++        //Paper start - Allow you to set the number of items that a hopper moves
++        if(this.transferAmount != null) {
++            output.putInt("TransferAmount", this.transferAmount);
++        }
++        //Paper end - Allow you to set the number of items that a hopper moves
+     }
+ 
+     @Override
+@@ -232,7 +246,14 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+                 ItemStack movedItem = origItemStack;
+ 
+                 final int originalItemCount = origItemStack.getCount();
+-                final int movedItemCount = Math.min(level.spigotConfig.hopperAmount, originalItemCount);
++
++                //Paper - Allow you to set the number of items that a hopper moves
++                int movedItemCount = Math.min(hopper.getTransferAmount().orElse(level.spigotConfig.hopperAmount), originalItemCount);
++
+                 origItemStack.setCount(movedItemCount);
+ 
+                 // We only need to fire the event once to give protection plugins a chance to cancel this event
+@@ -269,7 +290,14 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+     private static boolean hopperPull(final Level level, final Hopper hopper, final Container container, ItemStack origItemStack, final int i) {
+         ItemStack movedItem = origItemStack;
+         final int originalItemCount = origItemStack.getCount();
+-        final int movedItemCount = Math.min(level.spigotConfig.hopperAmount, originalItemCount);
++
++        //Paper - Allow you to set the number of items that a hopper moves
++        int movedItemCount = Math.min(hopper.getTransferAmount().orElse(level.spigotConfig.hopperAmount), originalItemCount);
++
+         container.setChanged(); // original logic always marks source inv as changed even if no move happens.
+         movedItem.setCount(movedItemCount);
+ 
+@@ -840,6 +868,18 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+         return true;
+     }
+ 
++    // Paper start - Allow you to set the number of items that a hopper moves
++    @Override
++    public void setTransferAmount(@Nullable final Integer transferAmount) {
++        this.transferAmount = transferAmount;
++    }
++
++    @Override
++    public Optional<Integer> getTransferAmount() {
++        return Optional.ofNullable(this.transferAmount);
++    }
++    // Paper end - Allow you to set the number of items that a hopper moves
++
+     public void setCooldown(int cooldownTime) {
+         this.cooldownTime = cooldownTime;
+     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftHopper.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftHopper.java
@@ -1,11 +1,14 @@
 package org.bukkit.craftbukkit.block;
 
+import com.google.common.base.Preconditions;
 import net.minecraft.world.level.block.entity.HopperBlockEntity;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Hopper;
 import org.bukkit.craftbukkit.inventory.CraftInventory;
 import org.bukkit.inventory.Inventory;
+import org.jetbrains.annotations.Nullable;
+import java.util.Optional;
 
 public class CraftHopper extends CraftLootable<HopperBlockEntity> implements Hopper {
 
@@ -53,4 +56,19 @@ public class CraftHopper extends CraftLootable<HopperBlockEntity> implements Hop
         return getSnapshot().cooldownTime;
     }
     // Paper end - Expanded Hopper API
+
+    // Paper start - Allow you to set the number of items that a hopper moves
+    @Override
+    public void setTransferAmount(@Nullable final Integer transferAmount) {
+        if(transferAmount != null){
+            com.google.common.base.Preconditions.checkArgument(transferAmount > 0, "Hopper transfer amount cannot be less than 1");
+        }
+        this.getSnapshot().setTransferAmount(transferAmount);
+    }
+
+    @Override
+    public Optional<Integer> getTransferAmount() {
+        return this.getSnapshot().getTransferAmount();
+    }
+    //Paper end - Allow you to set the number of items that a hopper moves
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartHopper.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartHopper.java
@@ -5,6 +5,8 @@ import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.inventory.CraftInventory;
 import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.inventory.Inventory;
+import org.jspecify.annotations.Nullable;
+import java.util.Optional;
 
 public class CraftMinecartHopper extends CraftMinecartContainer implements HopperMinecart, com.destroystokyo.paper.loottable.PaperLootableEntityInventory { // Paper
 
@@ -44,4 +46,20 @@ public class CraftMinecartHopper extends CraftMinecartContainer implements Hoppe
     public void setPickupCooldown(int cooldown) {
         throw new UnsupportedOperationException("Hopper minecarts don't have cooldowns");
     }
+
+    // Paper start - Allow you to set the number of items that a hopper moves
+    @Override
+    public void setTransferAmount(@Nullable final Integer transferAmount) {
+        if (transferAmount != null) {
+            com.google.common.base.Preconditions.checkArgument(transferAmount > 0, "Hopper transfer amount cannot be less than 1");
+        }
+        this.getHandle().setTransferAmount(transferAmount);
+    }
+
+    @Override
+    public Optional<Integer> getTransferAmount() {
+        return this.getHandle().getTransferAmount();
+    }
+    // Paper end - Allow you to set the number of items that a hopper moves
+
 }


### PR DESCRIPTION
Currently, the server configuration only allows setting a single item transfer amount for all hoppers. While this works globally, it’s not possible to create exceptions for specific hoppers — even though it’s already possible to customize their cooldown individually.

**Problem**
The lack of per-hopper configuration limits flexibility. For example, you cannot have a hopper with a different transfer rate without changing the server-wide setting for all hoppers.

**Proposed changes**
- Added a getter and setter to define the number of items transferred by a specific hopper.

The value is nullable:
- null → the hopper uses the default value from the server configuration.
- set value → the hopper uses this specific configuration.
