### PR TITLE
fix: inventory desync when interaction is cancelled

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -317,7 +317,7 @@
                  }
  
                  return interactionResult;
-@@ -329,15 +_,47 @@
+@@ -329,15 +_,53 @@
          }
      }
  
@@ -358,7 +358,13 @@
 +            } else if (blockState.is(net.minecraft.world.level.block.Blocks.JIGSAW) || blockState.is(net.minecraft.world.level.block.Blocks.STRUCTURE_BLOCK) || blockState.getBlock() instanceof net.minecraft.world.level.block.CommandBlock) {
 +                player.connection.send(new net.minecraft.network.protocol.game.ClientboundContainerClosePacket(this.player.containerMenu.containerId));
 +            }
-+            player.containerMenu.forceHeldSlot(hand); // SPIGOT-2867
++            // Paper start - Fix inventory desync; SPIGOT-2867
++            if (io.papermc.paper.util.MCUtil.clientPredictsInteraction(this.player, blockState, stack)) {
++                this.player.containerMenu.sendAllDataToRemote();
++            } else {
++                this.player.containerMenu.forceHeldSlot(hand);
++            }
++            // Paper end - Fix inventory desync
 +            this.player.resyncUsingItem(this.player); // Paper - Properly cancel usable items
 +            return (event.useItemInHand() != org.bukkit.event.Event.Result.ALLOW) ? InteractionResult.SUCCESS : InteractionResult.PASS;
 +        } else if (this.gameModeForPlayer == GameType.SPECTATOR) {

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -316,13 +316,19 @@
              InteractionResult interactionResult = stack.use(level, player, hand);
              ItemStack itemStack;
              if (interactionResult instanceof InteractionResult.Success success) {
-@@ -321,7 +_,9 @@
+@@ -321,7 +_,14 @@
                  }
  
                  if (!player.isUsingItem()) {
-+                    if (io.papermc.paper.util.MCUtil.clientPredictsInteraction(player, net.minecraft.world.level.block.Blocks.AIR.defaultBlockState(), stackBeforeUse)) // Paper - Optimize sendAllDataToRemote calls
-                     player.inventoryMenu.sendAllDataToRemote();
-+                    else player.inventoryMenu.forceHeldSlot(hand); // Paper - Optimize sendAllDataToRemote calls
+-                    player.inventoryMenu.sendAllDataToRemote();
++                    // Paper start - Optimize sendAllDataToRemote calls
++                    // This is a weird one where the Vanilla behavior is from an ancient version, but also isn't calling startUsingItem on certain instant-use items
++                    // TODO Check up on this proper, possibly remove all and move into more specific places
++                    if (io.papermc.paper.util.MCUtil.clientPredictsInteraction(player, net.minecraft.world.level.block.Blocks.AIR.defaultBlockState(), stackBeforeUse)) {
++                        player.inventoryMenu.forceHeldSlot(hand);
++                    }
++                    player.inventoryMenu.broadcastChanges();
++                    // Paper end - Optimize sendAllDataToRemote calls
                  }
  
                  return interactionResult;

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -308,12 +308,21 @@
              }
          }
      }
-@@ -321,7 +_,7 @@
+@@ -299,6 +_,7 @@
+         } else {
+             int count = stack.getCount();
+             int damageValue = stack.getDamageValue();
++            final ItemStack stackBeforeUse = stack.copy(); // Paper - Store stack before use for interact prediction check
+             InteractionResult interactionResult = stack.use(level, player, hand);
+             ItemStack itemStack;
+             if (interactionResult instanceof InteractionResult.Success success) {
+@@ -321,7 +_,9 @@
                  }
  
                  if (!player.isUsingItem()) {
--                    player.inventoryMenu.sendAllDataToRemote();
-+                    player.inventoryMenu.broadcastChanges(); // Paper - change to broadcastChanges, super old code that might not even be needed at all
++                    if (io.papermc.paper.util.MCUtil.clientPredictsInteraction(player, net.minecraft.world.level.block.Blocks.AIR.defaultBlockState(), stackBeforeUse)) // Paper - Optimize sendAllDataToRemote calls
+                     player.inventoryMenu.sendAllDataToRemote();
++                    else player.inventoryMenu.forceHeldSlot(hand); // Paper - Optimize sendAllDataToRemote calls
                  }
  
                  return interactionResult;

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1226,17 +1226,18 @@
                  BlockPos blockPos = hitResult.getBlockPos();
                  if (this.player.isWithinBlockInteractionRange(blockPos, 1.0)) {
                      Vec3 vec3 = location.subtract(Vec3.atCenterOf(blockPos));
-@@ -1310,7 +_,8 @@
+@@ -1310,7 +_,9 @@
                          this.player.resetLastActionTime();
                          int maxY = this.player.level().getMaxY();
                          if (blockPos.getY() <= maxY) {
 -                            if (this.awaitingPositionFromClient == null && serverLevel.mayInteract(this.player, blockPos)) {
-+                            if (this.awaitingPositionFromClient == null && (serverLevel.mayInteract(this.player, blockPos) || (serverLevel.paperConfig().spawn.allowUsingSignsInsideSpawnProtection && serverLevel.getBlockState(blockPos).getBlock() instanceof net.minecraft.world.level.block.SignBlock))) { // Paper - Allow using signs inside spawn protection
++                            final boolean mayInteract = serverLevel.mayInteract(this.player, blockPos); // Paper - Reuse in inventory desync fix
++                            if (this.awaitingPositionFromClient == null && (mayInteract || (serverLevel.paperConfig().spawn.allowUsingSignsInsideSpawnProtection && serverLevel.getBlockState(blockPos).getBlock() instanceof net.minecraft.world.level.block.SignBlock))) { // Paper - Allow using signs inside spawn protection
 +                                this.player.stopUsingItem(); // CraftBukkit - SPIGOT-4706
                                  InteractionResult interactionResult = this.player.gameMode.useItemOn(this.player, serverLevel, itemInHand, hand, hitResult);
                                  if (interactionResult.consumesAction()) {
                                      CriteriaTriggers.ANY_BLOCK_USE.trigger(this.player, hitResult.getBlockPos(), itemInHand.copy());
-@@ -1323,10 +_,10 @@
+@@ -1323,10 +_,18 @@
                                      Component component = Component.translatable("build.tooHigh", maxY).withStyle(ChatFormatting.RED);
                                      this.player.sendSystemMessage(component, true);
                                  } else if (interactionResult instanceof InteractionResult.Success success
@@ -1244,8 +1245,15 @@
 +                                    && success.swingSource() == InteractionResult.SwingSource.SERVER && !this.player.gameMode.interactResult) { // Paper - Call interact event
                                      this.player.swing(hand, true);
                                  }
--                            }
-+                            } else { this.player.containerMenu.forceHeldSlot(hand); } // Paper - Fix inventory desync; MC-99075
++                            // Paper start - Fix inventory desync; MC-99075
++                            } else if (!mayInteract) {
++                                if (io.papermc.paper.util.MCUtil.clientPredictsInteraction(this.player, serverLevel.getBlockState(blockPos), itemInHand)) {
++                                    this.player.containerMenu.sendAllDataToRemote();
++                                } else {
++                                    this.player.containerMenu.forceHeldSlot(hand);
++                                }
+                             }
++                            // Paper end - Fix inventory desync
                          } else {
                              Component component1 = Component.translatable("build.tooHigh", maxY).withStyle(ChatFormatting.RED);
                              this.player.sendSystemMessage(component1, true);
@@ -1274,7 +1282,7 @@
          if (this.hasClientLoaded()) {
              this.ackBlockChangesUpTo(packet.getSequence());
              ServerLevel serverLevel = this.player.level();
-@@ -1363,6 +_,48 @@
+@@ -1363,6 +_,54 @@
                      this.player.absSnapRotationTo(f, f1);
                  }
  
@@ -1311,7 +1319,13 @@
 +
 +                if (cancelled) {
 +                    this.player.resyncUsingItem(this.player); // Paper - Properly cancel usable items
-+                    this.player.containerMenu.forceHeldSlotAndArmor(hand); // SPIGOT-2524
++                    // Paper start - Fix inventory desync; SPIGOT-2524
++                    if (io.papermc.paper.util.MCUtil.clientPredictsInteraction(this.player, net.minecraft.world.level.block.Blocks.AIR.defaultBlockState(), itemInHand)) {
++                        this.player.containerMenu.sendAllDataToRemote();
++                    } else {
++                        this.player.containerMenu.forceHeldSlotAndArmor(hand);
++                    }
++                    // Paper end - Fix inventory desync
 +                    return;
 +                }
 +                itemInHand = this.player.getItemInHand(hand); // Update in case it was changed in the event
@@ -1795,7 +1809,7 @@
              this.player.resetLastActionTime();
              this.player.setShiftKeyDown(packet.isUsingSecondaryAction());
              if (target != null) {
-@@ -1751,16 +_,54 @@
+@@ -1751,16 +_,63 @@
                  }
  
                  AABB boundingBox = target.getBoundingBox();
@@ -1821,8 +1835,17 @@
 +                                    // Entity in bucket - SPIGOT-4048 and SPIGOT-6859
 +                                    if (itemType == Items.WATER_BUCKET && target instanceof net.minecraft.world.entity.animal.Bucketable && target instanceof LivingEntity && resendData) {
 +                                        target.resendPossiblyDesyncedEntityData(ServerGamePacketListenerImpl.this.player); // Paper - The entire mob gets deleted, so resend it
-+                                        ServerGamePacketListenerImpl.this.player.containerMenu.sendAllDataToRemote();
 +                                    }
++
++                                    // Paper start - Fix inventory desync
++                                    if (resendData) {
++                                        if (io.papermc.paper.util.MCUtil.clientPredictsInteraction(ServerGamePacketListenerImpl.this.player, target, itemInHand)) {
++                                            ServerGamePacketListenerImpl.this.player.containerMenu.sendAllDataToRemote();
++                                        } else {
++                                            ServerGamePacketListenerImpl.this.player.containerMenu.forceHeldSlot(hand);
++                                        }
++                                    }
++                                    // Paper end - Fix inventory desync
 +
 +                                    if (triggerLeashUpdate && resendData) {
 +                                        // Refresh the current leash state

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1226,18 +1226,17 @@
                  BlockPos blockPos = hitResult.getBlockPos();
                  if (this.player.isWithinBlockInteractionRange(blockPos, 1.0)) {
                      Vec3 vec3 = location.subtract(Vec3.atCenterOf(blockPos));
-@@ -1310,7 +_,9 @@
+@@ -1310,7 +_,8 @@
                          this.player.resetLastActionTime();
                          int maxY = this.player.level().getMaxY();
                          if (blockPos.getY() <= maxY) {
 -                            if (this.awaitingPositionFromClient == null && serverLevel.mayInteract(this.player, blockPos)) {
-+                            final boolean mayInteract = serverLevel.mayInteract(this.player, blockPos); // Paper - Reuse in inventory desync fix
-+                            if (this.awaitingPositionFromClient == null && (mayInteract || (serverLevel.paperConfig().spawn.allowUsingSignsInsideSpawnProtection && serverLevel.getBlockState(blockPos).getBlock() instanceof net.minecraft.world.level.block.SignBlock))) { // Paper - Allow using signs inside spawn protection
++                            if (this.awaitingPositionFromClient == null && (serverLevel.mayInteract(this.player, blockPos) || (serverLevel.paperConfig().spawn.allowUsingSignsInsideSpawnProtection && serverLevel.getBlockState(blockPos).getBlock() instanceof net.minecraft.world.level.block.SignBlock))) { // Paper - Allow using signs inside spawn protection
 +                                this.player.stopUsingItem(); // CraftBukkit - SPIGOT-4706
                                  InteractionResult interactionResult = this.player.gameMode.useItemOn(this.player, serverLevel, itemInHand, hand, hitResult);
                                  if (interactionResult.consumesAction()) {
                                      CriteriaTriggers.ANY_BLOCK_USE.trigger(this.player, hitResult.getBlockPos(), itemInHand.copy());
-@@ -1323,10 +_,18 @@
+@@ -1323,10 +_,19 @@
                                      Component component = Component.translatable("build.tooHigh", maxY).withStyle(ChatFormatting.RED);
                                      this.player.sendSystemMessage(component, true);
                                  } else if (interactionResult instanceof InteractionResult.Success success
@@ -1246,7 +1245,8 @@
                                      this.player.swing(hand, true);
                                  }
 +                            // Paper start - Fix inventory desync; MC-99075
-+                            } else if (!mayInteract) {
++                            // From serverLevel.mayInteract(this.player, blockPos)
++                            } else if (this.server.isUnderSpawnProtection(serverLevel, blockPos, player)) {
 +                                if (io.papermc.paper.util.MCUtil.clientPredictsInteraction(this.player, serverLevel.getBlockState(blockPos), itemInHand)) {
 +                                    this.player.containerMenu.sendAllDataToRemote();
 +                                } else {

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -1744,7 +1744,7 @@
              }
          }
      }
-@@ -3423,7 +_,38 @@
+@@ -3423,9 +_,41 @@
                  this.releaseUsingItem();
              } else {
                  if (!this.useItem.isEmpty() && this.isUsingItem()) {
@@ -1764,7 +1764,7 @@
 +                            if (consumable != null) {
 +                                consumable.cancelUsingItem(serverPlayer, this.useItem);
 +                            }
-+                            serverPlayer.containerMenu.forceHeldSlot(this.getUsedItemHand());
++                            serverPlayer.containerMenu.forceHeldSlot(usedItemHand);
 +                            serverPlayer.getBukkitEntity().updateScaledHealth();
 +                            this.stopUsingItem(); // Paper - event is using an item, clear active item to reset its use
 +                            return;
@@ -1783,7 +1783,10 @@
 +                    // CraftBukkit end
                      if (itemStack != this.useItem) {
                          this.setItemInHand(usedItemHand, itemStack);
++                        if (event != null && event.getReplacement() != null && this instanceof final ServerPlayer player) player.containerMenu.forceHeldSlot(usedItemHand); // Paper - Fix inventory desync; Paper#13253
                      }
+ 
+                     this.stopUsingItem();
 @@ -3457,6 +_,7 @@
          ItemStack itemInHand = this.getItemInHand(this.getUsedItemHand());
          if (!this.useItem.isEmpty() && ItemStack.isSameItem(itemInHand, this.useItem)) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/Bucketable.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/Bucketable.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/animal/Bucketable.java
 +++ b/net/minecraft/world/entity/animal/Bucketable.java
-@@ -71,9 +_,19 @@
+@@ -71,9 +_,25 @@
      static <T extends LivingEntity & Bucketable> Optional<InteractionResult> bucketMobPickup(Player player, InteractionHand hand, T entity) {
          ItemStack itemInHand = player.getItemInHand(hand);
          if (itemInHand.getItem() == Items.WATER_BUCKET && entity.isAlive()) {
@@ -12,7 +12,13 @@
 +            org.bukkit.event.player.PlayerBucketEntityEvent playerBucketFishEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerFishBucketEvent(entity, player, itemInHand, bucketItemStack, hand);
 +            bucketItemStack = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(playerBucketFishEvent.getEntityBucket());
 +            if (playerBucketFishEvent.isCancelled()) {
-+                player.containerMenu.forceHeldSlot(hand); // We need to update inventory to resync client's bucket
++                // Paper start - Fix inventory desync
++                if (player.hasInfiniteMaterials() || itemInHand.getCount() > 1) {
++                    player.containerMenu.sendAllDataToRemote();
++                } else {
++                    player.containerMenu.forceHeldSlot(hand);
++                }
++                // Paper end - Fix inventory desync
 +                entity.resendPossiblyDesyncedEntityData((ServerPlayer) player); // Paper
 +                return Optional.of(InteractionResult.FAIL);
 +            }

--- a/paper-server/patches/sources/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -107,7 +107,7 @@
  
                      for (Slot slot1 : this.quickcraftSlots) {
                          ItemStack carried1 = this.getCarried();
-@@ -385,12 +_,46 @@
+@@ -385,12 +_,42 @@
                              int min = Math.min(itemStack.getMaxStackSize(), slot1.getMaxStackSize(itemStack));
                              int min1 = Math.min(getQuickCraftPlaceCount(this.quickcraftSlots, this.quickcraftType, itemStack) + i2, min);
                              count -= min1 - i2;
@@ -148,11 +148,7 @@
 +                        for (final it.unimi.dsi.fastutil.ints.Int2ObjectMap.Entry<net.minecraft.world.item.ItemStack> entry : draggedSlots.int2ObjectEntrySet()) {
 +                            view.setItem(entry.getIntKey(), org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(entry.getValue()));
 +                        }
-+                        // The only time the carried item will be set to empty is if the inventory is closed by the server.
-+                        // If the inventory is closed by the server, then the cursor items are dropped.  This is why we change the cursor early.
-+                        if (!this.getCarried().isEmpty()) {
-+                            this.setCarried(org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getCursor()));
-+                        }
++                        this.setCarried(org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getCursor()));
 +                    } else {
 +                        this.setCarried(oldCarried);
 +                    }

--- a/paper-server/patches/sources/net/minecraft/world/item/PotionItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/PotionItem.java.patch
@@ -1,12 +1,16 @@
 --- a/net/minecraft/world/item/PotionItem.java
 +++ b/net/minecraft/world/item/PotionItem.java
-@@ -40,6 +_,12 @@
+@@ -40,6 +_,16 @@
          PotionContents potionContents = itemInHand.getOrDefault(DataComponents.POTION_CONTENTS, PotionContents.EMPTY);
          BlockState blockState = level.getBlockState(clickedPos);
          if (context.getClickedFace() != Direction.DOWN && blockState.is(BlockTags.CONVERTABLE_TO_MUD) && potionContents.is(Potions.WATER)) {
 +            // Paper start
 +            if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, clickedPos, Blocks.MUD.defaultBlockState())) {
-+                player.containerMenu.forceHeldSlot(context.getHand());
++                if (itemInHand.getCount() > 1 || player.hasInfiniteMaterials()) {
++                    player.containerMenu.sendAllDataToRemote();
++                } else {
++                    player.containerMenu.forceHeldSlot(context.getHand());
++                }
 +                return InteractionResult.PASS;
 +            }
 +            // Paper end


### PR DESCRIPTION
Fixes to a9399451481e3f8b376484e63909ff6c274f03db that caused inventory desyncs when the client predicted an interaction would result in an item being added to its inventory

Fixes #12947 Fixes #12954 Fixes #13253