### PR TITLE
Add WorldBorder to EntityPortalEvent and PlayerPortalEvent

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.entity;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.PortalType;
 import org.bukkit.WorldBorder;
@@ -7,7 +8,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Called when a non-player entity is about to teleport because it is in
@@ -20,38 +20,33 @@ public class EntityPortalEvent extends EntityTeleportEvent {
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final PortalType type;
-    private int searchRadius = 128;
-    private boolean canCreatePortal = true;
-    private int creationRadius = 16;
-    private WorldBorder worldBorder;
+    private int searchRadius;
+    private boolean canCreatePortal;
+    private int creationRadius;
+    private WorldBorder worldBorder = null;
 
     @ApiStatus.Internal
-    public EntityPortalEvent(@NotNull final Entity entity, @NotNull final Location from, @Nullable final Location to) {
+    public EntityPortalEvent(@NotNull final Entity entity, @NotNull final Location from, @NotNull final Location to) {
         this(entity, from, to, 128);
-        this.worldBorder = from.getWorld().getWorldBorder();
     }
 
     @ApiStatus.Internal
-    public EntityPortalEvent(@NotNull Entity entity, @NotNull Location from, @Nullable Location to, int searchRadius) {
-        super(entity, from, to);
-        this.searchRadius = searchRadius;
-        this.type = PortalType.CUSTOM;
-        this.worldBorder = from.getWorld().getWorldBorder();
+    public EntityPortalEvent(@NotNull Entity entity, @NotNull Location from, @NotNull Location to, int searchRadius) {
+        this(entity, from, to, searchRadius, true, 16);
     }
 
     @ApiStatus.Internal
-    public EntityPortalEvent(@NotNull Entity entity, @NotNull Location from, @Nullable Location to, int searchRadius, boolean canCreatePortal, int creationRadius) {
+    public EntityPortalEvent(@NotNull Entity entity, @NotNull Location from, @NotNull Location to, int searchRadius, boolean canCreatePortal, int creationRadius) {
         this(entity, from, to, searchRadius, canCreatePortal, creationRadius, PortalType.CUSTOM);
     }
 
     @ApiStatus.Internal
-    public EntityPortalEvent(@NotNull Entity entity, @NotNull Location from, @Nullable Location to, int searchRadius, boolean canCreatePortal, int creationRadius, final @NotNull PortalType portalType) {
+    public EntityPortalEvent(@NotNull Entity entity, @NotNull Location from, @NotNull Location to, int searchRadius, boolean canCreatePortal, int creationRadius, final @NotNull PortalType portalType) {
         super(entity, from, to);
         this.type = portalType;
         this.searchRadius = searchRadius;
         this.canCreatePortal = canCreatePortal;
         this.creationRadius = creationRadius;
-        this.worldBorder = from.getWorld().getWorldBorder();
     }
 
     /**
@@ -65,7 +60,7 @@ public class EntityPortalEvent extends EntityTeleportEvent {
      * @return starting point for search or exact destination
      */
     @Override
-    public @Nullable Location getTo() {
+    public @NotNull Location getTo() {
         return super.getTo();
     }
 
@@ -75,7 +70,7 @@ public class EntityPortalEvent extends EntityTeleportEvent {
      *           or {@code null} to cancel
      */
     @Override
-    public void setTo(@Nullable final Location to) {
+    public void setTo(@NotNull final Location to) {
         super.setTo(to);
     }
 
@@ -162,26 +157,48 @@ public class EntityPortalEvent extends EntityTeleportEvent {
     }
 
     /**
-     * Sets the {@link WorldBorder} which the portal creation and search should be limited.
+     * Sets the {@link WorldBorder} that portal search and optionally creation will be limited to.
      * <p>
      * Does not apply to end portal target platforms which will always appear at
      * the target location.
      *
-     * @param worldBorder the {@link WorldBorder} to limit portal search and creation to.
+     * @param worldBorder the {@link WorldBorder} that portal search and optionally creation will be limited to.
      */
     public void setWorldBorder(@NotNull WorldBorder worldBorder) {
         this.worldBorder = worldBorder;
     }
 
     /**
-     * Gets the {@link WorldBorder} to which the portal creation and search is limited.
+     * Sets the {@link WorldBorder} that portal search and optionally creation will be limited to.
      * <p>
      * Does not apply to end portal target platforms which will always appear at
      * the target location.
      *
-     * @return the {@link WorldBorder} to which portal creation and search is limited.
+     * @param center the center of the world border.
+     * @param size the side length of the world border.
+     */
+    public void setWorldBorder(@NotNull Location center, double size) {
+        this.worldBorder = Bukkit.createWorldBorder();
+        this.worldBorder.setCenter(center);
+        this.worldBorder.setSize(size);
+    }
+
+    /**
+     * Gets the {@link WorldBorder} that portal search and optionally creation will be limited to.
+     * <p>
+     * Does not apply to end portal target platforms which will always appear at
+     * the target location.
+     *
+     * @return the {@link WorldBorder} that portal search and optionally creation will be limited to.
      */
     public @NotNull WorldBorder getWorldBorder() {
+        if  (this.worldBorder == null) {
+            var worldWorldBorder = this.getTo().getWorld().getWorldBorder();
+            this.worldBorder = Bukkit.createWorldBorder();
+            this.worldBorder.setCenter(worldWorldBorder.getCenter().clone());
+            this.worldBorder.setSize(worldWorldBorder.getSize());
+        }
+
         return this.worldBorder;
     }
 

--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
@@ -2,6 +2,7 @@ package org.bukkit.event.entity;
 
 import org.bukkit.Location;
 import org.bukkit.PortalType;
+import org.bukkit.WorldBorder;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
@@ -22,10 +23,12 @@ public class EntityPortalEvent extends EntityTeleportEvent {
     private int searchRadius = 128;
     private boolean canCreatePortal = true;
     private int creationRadius = 16;
+    private WorldBorder worldBorder;
 
     @ApiStatus.Internal
     public EntityPortalEvent(@NotNull final Entity entity, @NotNull final Location from, @Nullable final Location to) {
         this(entity, from, to, 128);
+        this.worldBorder = from.getWorld().getWorldBorder();
     }
 
     @ApiStatus.Internal
@@ -33,6 +36,7 @@ public class EntityPortalEvent extends EntityTeleportEvent {
         super(entity, from, to);
         this.searchRadius = searchRadius;
         this.type = PortalType.CUSTOM;
+        this.worldBorder = from.getWorld().getWorldBorder();
     }
 
     @ApiStatus.Internal
@@ -47,6 +51,7 @@ public class EntityPortalEvent extends EntityTeleportEvent {
         this.searchRadius = searchRadius;
         this.canCreatePortal = canCreatePortal;
         this.creationRadius = creationRadius;
+        this.worldBorder = from.getWorld().getWorldBorder();
     }
 
     /**
@@ -154,6 +159,30 @@ public class EntityPortalEvent extends EntityTeleportEvent {
      */
     public int getCreationRadius() {
         return this.creationRadius;
+    }
+
+    /**
+     * Sets the {@link WorldBorder} which the portal creation and search should be limited.
+     * <p>
+     * Does not apply to end portal target platforms which will always appear at
+     * the target location.
+     *
+     * @param worldBorder the {@link WorldBorder} to limit portal search and creation to.
+     */
+    public void setWorldBorder(@NotNull WorldBorder worldBorder) {
+        this.worldBorder = worldBorder;
+    }
+
+    /**
+     * Gets the {@link WorldBorder} to which the portal creation and search is limited.
+     * <p>
+     * Does not apply to end portal target platforms which will always appear at
+     * the target location.
+     *
+     * @return the {@link WorldBorder} to which portal creation and search is limited.
+     */
+    public @NotNull WorldBorder getWorldBorder() {
+        return this.worldBorder;
     }
 
     @NotNull

--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
@@ -6,7 +6,6 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Thrown when a non-player entity is teleported from one location to another.
@@ -24,7 +23,7 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
     private boolean cancelled;
 
     @ApiStatus.Internal
-    public EntityTeleportEvent(@NotNull Entity entity, @NotNull Location from, @Nullable Location to) {
+    public EntityTeleportEvent(@NotNull Entity entity, @NotNull Location from, @NotNull Location to) {
         super(entity);
         this.from = from;
         this.to = to;
@@ -54,7 +53,7 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
      *
      * @return Location the entity moved to
      */
-    @Nullable
+    @NotNull
     public Location getTo() {
         return this.to;
     }
@@ -64,8 +63,8 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
      *
      * @param to New Location this entity moved to
      */
-    public void setTo(@Nullable Location to) {
-        this.to = to != null ? to.clone() : null;
+    public void setTo(@NotNull Location to) {
+        this.to = to.clone();
     }
 
     @Override

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
@@ -2,6 +2,7 @@ package org.bukkit.event.player;
 
 import io.papermc.paper.entity.TeleportFlag;
 import org.bukkit.Location;
+import org.bukkit.WorldBorder;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
@@ -22,15 +23,18 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
     private int searchRadius = 128;
     private boolean canCreatePortal = true;
     private int creationRadius = 16;
+    private WorldBorder worldBorder;
 
     @ApiStatus.Internal
     public PlayerPortalEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to) {
         super(player, from, to);
+        this.worldBorder = from.getWorld().getWorldBorder();
     }
 
     @ApiStatus.Internal
     public PlayerPortalEvent(@NotNull Player player, @NotNull Location from, @Nullable Location to, @NotNull TeleportCause cause) {
         super(player, from, to, cause);
+        this.worldBorder = from.getWorld().getWorldBorder();
     }
 
     @ApiStatus.Internal
@@ -39,6 +43,7 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
         this.searchRadius = searchRadius;
         this.canCreatePortal = canCreatePortal;
         this.creationRadius = creationRadius;
+        this.worldBorder = from.getWorld().getWorldBorder();
     }
 
     /**
@@ -137,6 +142,30 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
      */
     public int getCreationRadius() {
         return this.creationRadius;
+    }
+
+    /**
+     * Sets the {@link WorldBorder} which the portal creation and search should be limited.
+     * <p>
+     * Does not apply to end portal target platforms which will always appear at
+     * the target location.
+     *
+     * @param worldBorder the {@link WorldBorder} to limit portal search and creation to.
+     */
+    public void setWorldBorder(@NotNull WorldBorder worldBorder) {
+        this.worldBorder = worldBorder;
+    }
+
+    /**
+     * Gets the {@link WorldBorder} to which the portal creation and search is limited.
+     * <p>
+     * Does not apply to end portal target platforms which will always appear at
+     * the target location.
+     *
+     * @return the {@link WorldBorder} to which portal creation and search is limited.
+     */
+    public @NotNull WorldBorder getWorldBorder() {
+        return this.worldBorder;
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
@@ -1,13 +1,13 @@
 package org.bukkit.event.player;
 
 import io.papermc.paper.entity.TeleportFlag;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.WorldBorder;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import java.util.Set;
 
 /**
@@ -23,27 +23,24 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
     private int searchRadius = 128;
     private boolean canCreatePortal = true;
     private int creationRadius = 16;
-    private WorldBorder worldBorder;
+    private WorldBorder worldBorder = null;
 
     @ApiStatus.Internal
-    public PlayerPortalEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to) {
+    public PlayerPortalEvent(@NotNull final Player player, @NotNull final Location from, @NotNull final Location to) {
         super(player, from, to);
-        this.worldBorder = from.getWorld().getWorldBorder();
     }
 
     @ApiStatus.Internal
-    public PlayerPortalEvent(@NotNull Player player, @NotNull Location from, @Nullable Location to, @NotNull TeleportCause cause) {
+    public PlayerPortalEvent(@NotNull Player player, @NotNull Location from, @NotNull Location to, @NotNull TeleportCause cause) {
         super(player, from, to, cause);
-        this.worldBorder = from.getWorld().getWorldBorder();
     }
 
     @ApiStatus.Internal
-    public PlayerPortalEvent(@NotNull Player player, @NotNull Location from, @Nullable Location to, @NotNull TeleportCause cause, int searchRadius, boolean canCreatePortal, int creationRadius) {
+    public PlayerPortalEvent(@NotNull Player player, @NotNull Location from, @NotNull Location to, @NotNull TeleportCause cause, int searchRadius, boolean canCreatePortal, int creationRadius) {
         super(player, from, to, cause);
         this.searchRadius = searchRadius;
         this.canCreatePortal = canCreatePortal;
         this.creationRadius = creationRadius;
-        this.worldBorder = from.getWorld().getWorldBorder();
     }
 
     /**
@@ -145,26 +142,62 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
     }
 
     /**
-     * Sets the {@link WorldBorder} which the portal creation and search should be limited.
+     * Sets the {@link WorldBorder} that portal search and optionally creation will be limited to.
      * <p>
      * Does not apply to end portal target platforms which will always appear at
      * the target location.
      *
-     * @param worldBorder the {@link WorldBorder} to limit portal search and creation to.
+     * @param worldBorder the {@link WorldBorder} that portal search and optionally creation will be limited to.
      */
     public void setWorldBorder(@NotNull WorldBorder worldBorder) {
         this.worldBorder = worldBorder;
     }
 
     /**
-     * Gets the {@link WorldBorder} to which the portal creation and search is limited.
+     * Sets the {@link WorldBorder} that portal search and optionally creation will be limited to.
      * <p>
      * Does not apply to end portal target platforms which will always appear at
      * the target location.
      *
-     * @return the {@link WorldBorder} to which portal creation and search is limited.
+     * @param center the center of the world border.
+     * @param size the side length of the world border.
+     */
+    public void setWorldBorder(@NotNull Location center, double size) {
+        this.worldBorder = Bukkit.createWorldBorder();
+        this.worldBorder.setCenter(center);
+        this.worldBorder.setSize(size);
+    }
+
+    /**
+     * Sets the {@link WorldBorder} that portal search and optionally creation will be limited to.
+     * <p>
+     * Does not apply to end portal target platforms which will always appear at
+     * the target location.
+     *
+     * @param x the x coordinate of the center of the world border.
+     * @param z the z coordinate of the center of the world border.
+     * @param size the side length of the world border.
+     */
+    public void setWorldBorder(double x, double z , double size) {
+        this.setWorldBorder(new Location(null, x, 0, z),  size);
+    }
+
+    /**
+     * Gets the {@link WorldBorder} that portal search and optionally creation will be limited to.
+     * <p>
+     * Does not apply to end portal target platforms which will always appear at
+     * the target location.
+     *
+     * @return the {@link WorldBorder} that portal search and optionally creation will be limited to.
      */
     public @NotNull WorldBorder getWorldBorder() {
+        if  (this.worldBorder == null) {
+            var worldWorldBorder = this.getTo().getWorld().getWorldBorder();
+            this.worldBorder = Bukkit.createWorldBorder();
+            this.worldBorder.setCenter(worldWorldBorder.getCenter().clone());
+            this.worldBorder.setSize(worldWorldBorder.getSize());
+        }
+
         return this.worldBorder;
     }
 

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -8,7 +8,6 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 import java.util.Collections;
 import java.util.Set;
@@ -24,19 +23,19 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
     private TeleportCause cause = TeleportCause.UNKNOWN;
 
     @ApiStatus.Internal
-    public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to) {
+    public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @NotNull final Location to) {
         super(player, from, to);
         this.teleportFlags = Collections.emptySet();
     }
 
     @ApiStatus.Internal
-    public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to, @NotNull final TeleportCause cause) {
+    public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @NotNull final Location to, @NotNull final TeleportCause cause) {
         this(player, from, to);
         this.cause = cause;
     }
 
     @ApiStatus.Internal
-    public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to, @NotNull final TeleportCause cause, @NotNull Set<TeleportFlag.Relative> teleportFlags) {
+    public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @NotNull final Location to, @NotNull final TeleportCause cause, @NotNull Set<TeleportFlag.Relative> teleportFlags) {
         super(player, from, to);
         this.cause = cause;
         this.teleportFlags = teleportFlags;

--- a/paper-server/patches/sources/net/minecraft/server/commands/TeleportCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/TeleportCommand.java.patch
@@ -13,7 +13,7 @@
 +                org.bukkit.Location to = new org.bukkit.Location(level.getWorld(), d, d1, d2, f2, f3);
 +                org.bukkit.event.entity.EntityTeleportEvent event = new org.bukkit.event.entity.EntityTeleportEvent(target.getBukkitEntity(), target.getBukkitEntity().getLocation(), to);
 +                level.getCraftServer().getPluginManager().callEvent(event);
-+                if (event.isCancelled() || event.getTo() == null) { // Paper
++                if (event.isCancelled()) { // Paper
 +                    return;
 +                }
 +                to = event.getTo(); // Paper - actually track new location

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -751,7 +751,7 @@
 +        org.bukkit.Location enter = this.getBukkitEntity().getLocation();
 +        org.bukkit.event.player.PlayerPortalEvent event = new org.bukkit.event.player.PlayerPortalEvent(this.getBukkitEntity(), enter, exit, cause, searchRadius, true, creationRadius);
 +        event.callEvent();
-+        if (event.isCancelled() || event.getTo() == null || event.getTo().getWorld() == null) {
++        if (event.isCancelled() || event.getTo().getWorld() == null) {
 +            return null;
 +        }
 +        return new org.bukkit.craftbukkit.event.CraftPortalEvent(event);

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1496,7 +1496,7 @@
 +                teleEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTeleportEvent(this, to);
 +            }
 +            // Paper end - gateway-specific teleport event
-+            if (teleEvent.isCancelled() || teleEvent.getTo() == null) {
++            if (teleEvent.isCancelled()) {
 +                return null;
 +            }
 +            if (!to.equals(teleEvent.getTo())) {
@@ -1518,7 +1518,7 @@
 +
 +                // Only change the target if actually needed, since we reset relative flags
 +                if (event.isCancelled() || !to.equals(event.getTo()) || !after.equals(event.getAfter())) {
-+                    if (event.isCancelled() || event.getTo() == null) {
++                    if (event.isCancelled()) {
 +                        org.bukkit.World toWorld = to.getWorld();
 +                        to = event.getFrom().clone();
 +                        to.setWorld(toWorld); // cancelling doesn't cancel the teleport just the position/velocity (old quirk)
@@ -1598,7 +1598,7 @@
 +        };
 +        org.bukkit.event.entity.EntityPortalEvent event = new org.bukkit.event.entity.EntityPortalEvent(bukkitEntity, enter, exit, searchRadius, true, creationRadius, portalType);
 +        event.callEvent();
-+        if (event.isCancelled() || event.getTo() == null || event.getTo().getWorld() == null || !entity.isAlive()) {
++        if (event.isCancelled() || event.getTo().getWorld() == null || !entity.isAlive()) {
 +            return null;
 +        }
 +        return new org.bukkit.craftbukkit.event.CraftPortalEvent(event);

--- a/paper-server/patches/sources/net/minecraft/world/entity/TamableAnimal.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/TamableAnimal.java.patch
@@ -44,7 +44,7 @@
 -            this.snapTo(x + 0.5, y, z + 0.5, this.getYRot(), this.getXRot());
 +            // CraftBukkit start
 +            org.bukkit.event.entity.EntityTeleportEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTeleportEvent(this, x + 0.5, y, z + 0.5);
-+            if (event.isCancelled() || event.getTo() == null) {
++            if (event.isCancelled()) {
 +                return false;
 +            }
 +            org.bukkit.Location to = event.getTo();

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/Shulker.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/Shulker.java.patch
@@ -21,7 +21,7 @@
                      Direction direction = this.findAttachableSurface(blockPos1);
 +                    // CraftBukkit start
 +                    org.bukkit.event.entity.EntityTeleportEvent teleportEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTeleportEvent(this, blockPos1.getX(), blockPos1.getY(), blockPos1.getZ());
-+                    if (teleportEvent.isCancelled() || teleportEvent.getTo() == null) { // Paper
++                    if (teleportEvent.isCancelled()) { // Paper
 +                        return false;
 +                    } else {
 +                        blockPos1 = org.bukkit.craftbukkit.util.CraftLocation.toBlockPosition(teleportEvent.getTo());

--- a/paper-server/patches/sources/net/minecraft/world/level/block/NetherPortalBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/NetherPortalBlock.java.patch
@@ -75,7 +75,7 @@
 +                return null;
 +            }
 +            level1 = ((org.bukkit.craftbukkit.CraftWorld) event.getTo().getWorld()).getHandle();
-+            worldBorder = level1.getWorldBorder();
++            worldBorder = ((org.bukkit.craftbukkit.CraftWorldBorder) event.getWorldBorder()).getHandle();
 +            blockPos = worldBorder.clampToBounds(event.getTo().getX(), event.getTo().getY(), event.getTo().getZ());
 +            return this.getExitPortal(level1, entity, pos, blockPos, flag, worldBorder, event.getSearchRadius(), event.getCanCreatePortal(), event.getCreationRadius());
 +            // CraftBukkit end

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -320,7 +320,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
             this, this.getLocation(), location);
         // cancelling the event is handled differently for players and entities,
         // entities just stop teleporting, players will still teleport to the "from" location of the event
-        if (!event.callEvent() || event.getTo() == null) {
+        if (!event.callEvent()) {
             return false;
         }
         location = event.getTo();

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftPortalEvent.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftPortalEvent.java
@@ -1,6 +1,7 @@
 package org.bukkit.craftbukkit.event;
 
 import org.bukkit.Location;
+import org.bukkit.WorldBorder;
 import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.player.PlayerPortalEvent;
 
@@ -15,12 +16,15 @@ public class CraftPortalEvent {
     private final boolean canCreatePortal;
     private final boolean cancelled;
 
+    private final WorldBorder worldBorder;
+
     public CraftPortalEvent(EntityPortalEvent portalEvent) {
         this.to = portalEvent.getTo();
         this.searchRadius = portalEvent.getSearchRadius();
         this.cancelled = portalEvent.isCancelled();
         this.creationRadius = portalEvent.getCreationRadius();
         this.canCreatePortal = portalEvent.getCanCreatePortal();
+        this.worldBorder = portalEvent.getWorldBorder();
     }
 
     public CraftPortalEvent(PlayerPortalEvent portalEvent) {
@@ -29,6 +33,7 @@ public class CraftPortalEvent {
         this.creationRadius = portalEvent.getCreationRadius();
         this.canCreatePortal = portalEvent.getCanCreatePortal();
         this.cancelled = portalEvent.isCancelled();
+        this.worldBorder = portalEvent.getWorldBorder();
     }
 
     public Location getTo() {
@@ -49,5 +54,9 @@ public class CraftPortalEvent {
 
     public boolean isCancelled() {
         return this.cancelled;
+    }
+
+    public WorldBorder getWorldBorder() {
+        return this.worldBorder;
     }
 }


### PR DESCRIPTION
Currently the EntityPortalEvent and PlayerPortalEvent events give nice handles to link portals differently. However there is no nice way to limit where this portal linking/creation can take place. This pull request exposes the WorldBorder used by NetherPortalBlock#getPortalDestination for this purpose.