### PR TITLE
fix: only fire dragon shoot level event on successful event

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/boss/enderdragon/phases/DragonStrafePlayerPhase.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/boss/enderdragon/phases/DragonStrafePlayerPhase.java.patch
@@ -1,14 +1,21 @@
 --- a/net/minecraft/world/entity/boss/enderdragon/phases/DragonStrafePlayerPhase.java
 +++ b/net/minecraft/world/entity/boss/enderdragon/phases/DragonStrafePlayerPhase.java
-@@ -77,8 +_,11 @@
+@@ -72,13 +_,17 @@
+                         double d6 = this.attackTarget.getY(0.5) - d3;
+                         double d7 = this.attackTarget.getZ() - d4;
+                         Vec3 vec32 = new Vec3(d5, d6, d7);
+-                        if (!this.dragon.isSilent()) {
++                        if (false && !this.dragon.isSilent()) { // Paper - EnderDragon Events; Fire after shoot fireball event
+                             level.levelEvent(null, 1017, this.dragon.blockPosition(), 0);
                          }
  
                          DragonFireball dragonFireball = new DragonFireball(level, this.dragon, vec32.normalize());
 +                        dragonFireball.preserveMotion = true; // Paper - Fix Entity Teleportation and cancel velocity if teleported
                          dragonFireball.snapTo(d2, d3, d4, 0.0F, 0.0F);
-+                        if (new com.destroystokyo.paper.event.entity.EnderDragonShootFireballEvent((org.bukkit.entity.EnderDragon) this.dragon.getBukkitEntity(), (org.bukkit.entity.DragonFireball) dragonFireball.getBukkitEntity()).callEvent()) // Paper - EnderDragon Events
++                        if (new com.destroystokyo.paper.event.entity.EnderDragonShootFireballEvent((org.bukkit.entity.EnderDragon) this.dragon.getBukkitEntity(), (org.bukkit.entity.DragonFireball) dragonFireball.getBukkitEntity()).callEvent()) { // Paper - EnderDragon Events
++                            if (!this.dragon.isSilent()) level.levelEvent(null, net.minecraft.world.level.block.LevelEvent.SOUND_DRAGON_FIREBALL, this.dragon.blockPosition(), 0); // Paper - EnderDragon Events; Fire after shoot fireball event
                          level.addFreshEntity(dragonFireball);
-+                        else dragonFireball.discard(null); // Paper - EnderDragon Events
++                        } else dragonFireball.discard(null); // Paper - EnderDragon Events
                          this.fireballCharge = 0;
                          if (this.currentPath != null) {
                              while (!this.currentPath.isDone()) {


### PR DESCRIPTION
only fires the "Ender dragon shoots" (1017) level event if the `EnderDragonShootFireballEvent` is not cancelled.

Fixes #12976