### PR TITLE
Fix clone return for Paper PlayerProfile

### DIFF
--- a/paper-api/src/main/java/com/destroystokyo/paper/event/server/PaperServerListPingEvent.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/event/server/PaperServerListPingEvent.java
@@ -477,7 +477,7 @@ public class PaperServerListPingEvent extends ServerListPingEvent implements Can
         }
 
         @Override
-        public org.bukkit.profile.@NotNull PlayerProfile clone() {
+        public @NotNull PlayerProfile clone() {
             throw new UnsupportedOperationException();
         }
 

--- a/paper-api/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
@@ -244,5 +244,11 @@ public interface PlayerProfile extends org.bukkit.profile.PlayerProfile {
         return this.hasProperty("textures");
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return the cloned player profile.
+     */
+    @Override
     PlayerProfile clone();
 }

--- a/paper-api/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
@@ -243,4 +243,6 @@ public interface PlayerProfile extends org.bukkit.profile.PlayerProfile {
     default boolean hasTextures() {
         return this.hasProperty("textures");
     }
+
+    PlayerProfile clone();
 }


### PR DESCRIPTION
Currently if you get the Paper PlayerProfile and try to clone this return the Bukkit PlayerProfile (deprecated) and require cast the clone for avoid that, this PR just add the missing clone with the valid return.