### PR TITLE
Add plugin context to DamageSource

### DIFF
--- a/paper-api/src/main/java/org/bukkit/damage/DamageSource.java
+++ b/paper-api/src/main/java/org/bukkit/damage/DamageSource.java
@@ -1,10 +1,13 @@
 package org.bukkit.damage;
 
+import net.kyori.adventure.pointer.Pointers;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import java.util.function.Consumer;
 
 /**
  * Represents a source of damage.
@@ -98,6 +101,15 @@ public interface DamageSource {
     public boolean scalesWithDifficulty();
 
     /**
+     * Gets the {@link Pointers} used for plugin-provided damage context.
+     *
+     * @return the damage context
+     */
+    @ApiStatus.Experimental
+    @NotNull
+    public Pointers getDamageContext();
+
+    /**
      * Create a new {@link DamageSource.Builder}.
      *
      * @param damageType the {@link DamageType} to use
@@ -144,6 +156,17 @@ public interface DamageSource {
          */
         @NotNull
         public Builder withDamageLocation(@NotNull Location location);
+
+        /**
+         * Configures a builder for the {@link net.kyori.adventure.pointer.Pointers} used for plugin-provided damage context.
+         *
+         * @param consumer a consumer
+         * @return this instance. Allows for chained method calls
+         * @see DamageSource#getDamageContext()
+         */
+        @ApiStatus.Experimental
+        @NotNull
+        public Builder withDamageContext(@NotNull Consumer<Pointers.Builder> consumer);
 
         /**
          * Create a new {@link DamageSource} instance using the supplied

--- a/paper-api/src/main/java/org/bukkit/damage/DamageSource.java
+++ b/paper-api/src/main/java/org/bukkit/damage/DamageSource.java
@@ -1,10 +1,13 @@
 package org.bukkit.damage;
 
 import io.papermc.paper.InternalAPIBridge;
+import net.kyori.adventure.pointer.Pointers;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import java.util.function.Consumer;
 
 /**
  * Represents a source of damage.
@@ -98,6 +101,15 @@ public interface DamageSource {
     public boolean scalesWithDifficulty();
 
     /**
+     * Gets the {@link Pointers} used for plugin-provided damage context.
+     *
+     * @return the damage context
+     */
+    @ApiStatus.Experimental
+    @NotNull
+    public Pointers getDamageContext();
+
+    /**
      * Create a new {@link DamageSource.Builder}.
      *
      * @param damageType the {@link DamageType} to use
@@ -143,6 +155,17 @@ public interface DamageSource {
          */
         @NotNull
         public Builder withDamageLocation(@NotNull Location location);
+
+        /**
+         * Configures a builder for the {@link net.kyori.adventure.pointer.Pointers} used for plugin-provided damage context.
+         *
+         * @param consumer a consumer
+         * @return this instance. Allows for chained method calls
+         * @see DamageSource#getDamageContext()
+         */
+        @ApiStatus.Experimental
+        @NotNull
+        public Builder withDamageContext(@NotNull Consumer<Pointers.Builder> consumer);
 
         /**
          * Create a new {@link DamageSource} instance using the supplied

--- a/paper-server/patches/sources/net/minecraft/world/damagesource/CombatTracker.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/damagesource/CombatTracker.java.patch
@@ -7,7 +7,7 @@
 -    public final List<CombatEntry> entries = Lists.newArrayList();
 +    public final List<CombatEntry> entries = new net.minecraft.util.ArrayListDeque<>(); // Paper - Fix mem leak (MC-301114); Use ArrayListDeque
      public final LivingEntity mob;
-     private int lastDamageTime;
+     public int lastDamageTime;
      private int combatStartTime;
      private int combatEndTime;
      public boolean inCombat;

--- a/paper-server/patches/sources/net/minecraft/world/damagesource/DamageSource.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/damagesource/DamageSource.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/damagesource/DamageSource.java
 +++ b/net/minecraft/world/damagesource/DamageSource.java
-@@ -17,6 +_,86 @@
+@@ -17,6 +_,92 @@
      private final @Nullable Entity causingEntity;
      private final @Nullable Entity directEntity;
      private final @Nullable Vec3 damageSourcePosition;
@@ -11,6 +11,7 @@
 +    private org.bukkit.block.@Nullable Block eventBlockDamager; // Relevant block set. damageSourcePosition is only used for bad respawn point explosion or custom damage
 +    private org.bukkit.block.@Nullable BlockState fromBlockSnapshot; // Captured block snapshot when the eventBlockDamager is not relevant (e.g. for bad respawn point explosions the block is already removed)
 +    private boolean critical; // Supports arrows and sweeping damage
++    private net.kyori.adventure.pointer.Pointers damageContext;
 +
 +    public DamageSource knownCause(final org.bukkit.event.entity.EntityDamageEvent.DamageCause cause) {
 +        final DamageSource damageSource = this.copy();
@@ -73,6 +74,10 @@
 +        return damageSource;
 +    }
 +
++    public net.kyori.adventure.pointer.Pointers getDamageContext() {
++        return this.damageContext;
++    }
++
 +    // Cloning the instance lets us return unique instances of DamageSource without affecting constants defined in DamageSources
 +    private DamageSource copy() {
 +        final DamageSource damageSource = new DamageSource(this.type, this.directEntity, this.causingEntity, this.damageSourcePosition);
@@ -81,9 +86,32 @@
 +        damageSource.eventBlockDamager = this.eventBlockDamager;
 +        damageSource.fromBlockSnapshot = this.fromBlockSnapshot;
 +        damageSource.critical = this.critical;
++        damageSource.damageContext = this.damageContext;
 +        return damageSource;
 +    }
 +    // CraftBukkit end
  
      @Override
      public String toString() {
+@@ -31,12 +_,19 @@
+         return this.causingEntity == this.directEntity;
+     }
+ 
+-    public DamageSource(Holder<DamageType> type, @Nullable Entity directEntity, @Nullable Entity causingEntity, @Nullable Vec3 damageSourcePosition) {
++    public DamageSource(Holder<DamageType> type, @Nullable Entity directEntity, @Nullable Entity causingEntity, @Nullable Vec3 damageSourcePosition, net.kyori.adventure.pointer.Pointers damageContext) { // Paper - Add damage context
+         this.type = type;
+         this.causingEntity = causingEntity;
+         this.directEntity = directEntity;
+         this.damageSourcePosition = damageSourcePosition;
+-    }
++        // Paper start - Add damage context
++        this.damageContext = damageContext;
++    }
++
++    public DamageSource(Holder<DamageType> type, @Nullable Entity directEntity, @Nullable Entity causingEntity, @Nullable Vec3 damageSourcePosition) {
++        this(type, directEntity, causingEntity, damageSourcePosition, net.kyori.adventure.pointer.Pointers.empty());
++    }
++    // Paper end - Add damage context
+ 
+     public DamageSource(Holder<DamageType> type, @Nullable Entity directEntity, @Nullable Entity causingEntity) {
+         this(type, directEntity, causingEntity, null);

--- a/paper-server/patches/sources/net/minecraft/world/damagesource/DamageSource.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/damagesource/DamageSource.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/damagesource/DamageSource.java
 +++ b/net/minecraft/world/damagesource/DamageSource.java
-@@ -17,6 +_,90 @@
+@@ -17,6 +_,95 @@
      private final @Nullable Entity causingEntity;
      private final @Nullable Entity directEntity;
      private final @Nullable Vec3 damageSourcePosition;
@@ -11,6 +11,7 @@
 +    private org.bukkit.block.@Nullable Block eventBlockDamager; // Relevant block set. damageSourcePosition is only used for bad respawn point explosion or custom damage
 +    private org.bukkit.block.@Nullable BlockState fromBlockSnapshot; // Captured block snapshot when the eventBlockDamager is not relevant (e.g. for bad respawn point explosions the block is already removed)
 +    private boolean critical; // Supports arrows and sweeping damage
++    private final net.kyori.adventure.pointer.Pointers damageContext;
 +
 +    public DamageSource knownCause(final org.bukkit.event.entity.EntityDamageEvent.DamageCause cause) {
 +        final DamageSource damageSource = this.copy();
@@ -77,9 +78,13 @@
 +        return damageSource;
 +    }
 +
++    public net.kyori.adventure.pointer.Pointers getDamageContext() {
++        return this.damageContext;
++    }
++
 +    // Cloning the instance lets us return unique instances of DamageSource without affecting constants defined in DamageSources
 +    private DamageSource copy() {
-+        final DamageSource damageSource = new DamageSource(this.type, this.directEntity, this.causingEntity, this.damageSourcePosition);
++        final DamageSource damageSource = new DamageSource(this.type, this.directEntity, this.causingEntity, this.damageSourcePosition, this.damageContext);
 +        damageSource.knownCause = this.knownCause;
 +        damageSource.eventEntityDamager = this.eventEntityDamager;
 +        damageSource.eventBlockDamager = this.eventBlockDamager;
@@ -91,3 +96,28 @@
  
      @Override
      public String toString() {
+@@ -32,13 +_,22 @@
+     }
+ 
+     public DamageSource(
+-        final Holder<DamageType> type, final @Nullable Entity directEntity, final @Nullable Entity causingEntity, final @Nullable Vec3 damageSourcePosition
++        final Holder<DamageType> type, final @Nullable Entity directEntity, final @Nullable Entity causingEntity, final @Nullable Vec3 damageSourcePosition, final net.kyori.adventure.pointer.Pointers damageContext // Paper - Add damage context
+     ) {
+         this.type = type;
+         this.causingEntity = causingEntity;
+         this.directEntity = directEntity;
+         this.damageSourcePosition = damageSourcePosition;
+-    }
++        // Paper start - Add damage context
++        this.damageContext = damageContext;
++    }
++
++    public DamageSource(
++        final Holder<DamageType> type, final @Nullable Entity directEntity, final @Nullable Entity causingEntity, final @Nullable Vec3 damageSourcePosition
++    ) {
++        this(type, directEntity, causingEntity, damageSourcePosition, net.kyori.adventure.pointer.Pointers.empty());
++    }
++    // Paper end - Add damage context
+ 
+     public DamageSource(final Holder<DamageType> type, final @Nullable Entity directEntity, final @Nullable Entity causingEntity) {
+         this(type, directEntity, causingEntity, null);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/damage/CraftDamageSource.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/damage/CraftDamageSource.java
@@ -1,6 +1,7 @@
 package org.bukkit.craftbukkit.damage;
 
 import java.util.Objects;
+import net.kyori.adventure.pointer.Pointers;
 import net.minecraft.Optionull;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.Location;
@@ -70,6 +71,11 @@ public class CraftDamageSource implements DamageSource {
     }
 
     @Override
+    public Pointers getDamageContext() {
+        return this.getHandle().getDamageContext();
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) {
             return true;
@@ -98,7 +104,7 @@ public class CraftDamageSource implements DamageSource {
         return "DamageSource{damageType=" + this.getDamageType() + ", causingEntity=" + this.getCausingEntity() + ", directEntity=" + this.getDirectEntity() + ", damageLocation=" + this.getDamageLocation() + "}";
     }
 
-    public static DamageSource buildFromBukkit(DamageType damageType, Entity causingEntity, Entity directEntity, Location damageLocation) {
+    public static DamageSource buildFromBukkit(DamageType damageType, Entity causingEntity, Entity directEntity, Location damageLocation, Pointers damageContext) {
         net.minecraft.core.Holder<net.minecraft.world.damagesource.DamageType> holderDamageType = CraftDamageType.bukkitToMinecraftHolder(damageType);
 
         net.minecraft.world.entity.Entity nmsCausingEntity = null;
@@ -113,6 +119,6 @@ public class CraftDamageSource implements DamageSource {
 
         Vec3 sourcePos = (damageLocation == null) ? null : CraftLocation.toVec3(damageLocation);
 
-        return new CraftDamageSource(new net.minecraft.world.damagesource.DamageSource(holderDamageType, nmsDirectEntity, nmsCausingEntity, sourcePos));
+        return new CraftDamageSource(new net.minecraft.world.damagesource.DamageSource(holderDamageType, nmsDirectEntity, nmsCausingEntity, sourcePos, damageContext));
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/damage/CraftDamageSourceBuilder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/damage/CraftDamageSourceBuilder.java
@@ -1,10 +1,12 @@
 package org.bukkit.craftbukkit.damage;
 
 import com.google.common.base.Preconditions;
+import net.kyori.adventure.pointer.Pointers;
 import org.bukkit.Location;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.damage.DamageType;
 import org.bukkit.entity.Entity;
+import java.util.function.Consumer;
 
 public class CraftDamageSourceBuilder implements DamageSource.Builder {
 
@@ -12,10 +14,12 @@ public class CraftDamageSourceBuilder implements DamageSource.Builder {
     private Entity causingEntity;
     private Entity directEntity;
     private Location damageLocation;
+    private Pointers.Builder damageContext;
 
     public CraftDamageSourceBuilder(DamageType damageType) {
         Preconditions.checkArgument(damageType != null, "DamageType cannot be null");
         this.damageType = damageType;
+        this.damageContext = Pointers.builder();
     }
 
     @Override
@@ -40,11 +44,18 @@ public class CraftDamageSourceBuilder implements DamageSource.Builder {
     }
 
     @Override
+    public DamageSource.Builder withDamageContext(Consumer<Pointers.Builder> consumer) {
+        Preconditions.checkArgument(consumer != null, "Consumer cannot be null");
+        consumer.accept(damageContext);
+        return this;
+    }
+
+    @Override
     public DamageSource build() {
         if (this.causingEntity != null && this.directEntity == null) {
             throw new IllegalArgumentException("Direct entity must be set if causing entity is set");
         }
 
-        return CraftDamageSource.buildFromBukkit(this.damageType, this.causingEntity, this.directEntity, this.damageLocation);
+        return CraftDamageSource.buildFromBukkit(this.damageType, this.causingEntity, this.directEntity, this.damageLocation, this.damageContext.build());
     }
 }


### PR DESCRIPTION
Adds a `DamageContext` interface. Plugins can implement the interface in order to store additional context on a `DamageSource`, for use in events that provide a damage source and the combat tracker.

Originally attempted to also include use cases such as #9704, by instead introducing a mutable map that plugins could store their own values on. [This original attempt can be viewed here](https://github.com/TonytheMacaroni/Paper/tree/damage-context/pointered-map). However `DamageSource` is functionally immutable, and introducing a mutable field on it would require ensuring all damage source constants had to be cloned whenever used, which seemed untenable. Another approach could be to instead have the context/map on `EntityDamageEvent` itself and later store it in the combat entry when it's added to the combat tracker.