### PR TITLE
Support for showNotification in PlayerRecipeDiscoverEvent

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerRecipeDiscoverEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerRecipeDiscoverEvent.java
@@ -5,22 +5,25 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Called when a player discovers a new recipe in the recipe book.
  */
+@NullMarked
 public class PlayerRecipeDiscoverEvent extends PlayerEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final NamespacedKey recipe;
     private boolean cancelled;
+    private boolean showNotification;
 
     @ApiStatus.Internal
-    public PlayerRecipeDiscoverEvent(@NotNull Player player, @NotNull NamespacedKey recipe) {
+    public PlayerRecipeDiscoverEvent(Player player, NamespacedKey recipe, boolean showNotification) {
         super(player);
         this.recipe = recipe;
+        this.showNotification = showNotification;
     }
 
     /**
@@ -28,9 +31,26 @@ public class PlayerRecipeDiscoverEvent extends PlayerEvent implements Cancellabl
      *
      * @return the discovered recipe
      */
-    @NotNull
     public NamespacedKey getRecipe() {
         return this.recipe;
+    }
+
+    /**
+     * Get if the player should be notified (toast) of the discovery.
+     *
+     * @return true if the player should be notified
+     */
+    public boolean shouldShowNotification() {
+        return this.showNotification;
+    }
+
+    /**
+     * Set if the player should be notified (toast) of the discovery.
+     *
+     * @param showNotification true if the player should be notified
+     */
+    public void shouldShowNotification(boolean showNotification) {
+        this.showNotification = showNotification;
     }
 
     @Override
@@ -43,13 +63,11 @@ public class PlayerRecipeDiscoverEvent extends PlayerEvent implements Cancellabl
         this.cancelled = cancel;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
 
-    @NotNull
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/paper-server/patches/sources/net/minecraft/stats/ServerRecipeBook.java.patch
+++ b/paper-server/patches/sources/net/minecraft/stats/ServerRecipeBook.java.patch
@@ -1,10 +1,13 @@
 --- a/net/minecraft/stats/ServerRecipeBook.java
 +++ b/net/minecraft/stats/ServerRecipeBook.java
-@@ -64,17 +_,18 @@
+@@ -64,17 +_,21 @@
          for (RecipeHolder<?> recipeHolder : recipes) {
              ResourceKey<Recipe<?>> resourceKey = recipeHolder.id();
              if (!this.known.contains(resourceKey) && !recipeHolder.value().isSpecial()) {
-+                org.bukkit.event.player.PlayerRecipeDiscoverEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerRecipeListUpdateEvent(player, resourceKey.location(), recipeHolder); // Paper - call event
++                // Paper start - PlayerRecipeDiscoverEvent event
++                org.bukkit.event.player.PlayerRecipeDiscoverEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerRecipeListUpdateEvent(player, resourceKey.location(), recipeHolder);
++                if (event.isCancelled()) continue;
++                // Paper end
                  this.add(resourceKey);
                  this.addHighlight(resourceKey);
                  this.displayResolver

--- a/paper-server/patches/sources/net/minecraft/stats/ServerRecipeBook.java.patch
+++ b/paper-server/patches/sources/net/minecraft/stats/ServerRecipeBook.java.patch
@@ -1,15 +1,18 @@
 --- a/net/minecraft/stats/ServerRecipeBook.java
 +++ b/net/minecraft/stats/ServerRecipeBook.java
-@@ -63,7 +_,7 @@
- 
+@@ -64,17 +_,18 @@
          for (RecipeHolder<?> recipeHolder : recipes) {
              ResourceKey<Recipe<?>> resourceKey = recipeHolder.id();
--            if (!this.known.contains(resourceKey) && !recipeHolder.value().isSpecial()) {
-+            if (!this.known.contains(resourceKey) && !recipeHolder.value().isSpecial() && org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerRecipeListUpdateEvent(player, resourceKey.location())) { // CraftBukkit
+             if (!this.known.contains(resourceKey) && !recipeHolder.value().isSpecial()) {
++                org.bukkit.event.player.PlayerRecipeDiscoverEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerRecipeListUpdateEvent(player, resourceKey.location(), recipeHolder); // Paper - call event
                  this.add(resourceKey);
                  this.addHighlight(resourceKey);
                  this.displayResolver
-@@ -74,7 +_,7 @@
+                     .displaysForRecipe(
+-                        resourceKey, entry -> list.add(new ClientboundRecipeBookAddPacket.Entry(entry, recipeHolder.value().showNotification(), true))
++                        resourceKey, entry -> list.add(new ClientboundRecipeBookAddPacket.Entry(entry, event.shouldShowNotification(), true)) // Paper - set notification from the event
+                     );
+                 CriteriaTriggers.RECIPE_UNLOCKED.trigger(player, recipeHolder);
              }
          }
  

--- a/paper-server/patches/sources/net/minecraft/stats/ServerRecipeBook.java.patch
+++ b/paper-server/patches/sources/net/minecraft/stats/ServerRecipeBook.java.patch
@@ -5,7 +5,7 @@
              ResourceKey<Recipe<?>> resourceKey = recipeHolder.id();
              if (!this.known.contains(resourceKey) && !recipeHolder.value().isSpecial()) {
 +                // Paper start - PlayerRecipeDiscoverEvent event
-+                org.bukkit.event.player.PlayerRecipeDiscoverEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerRecipeListUpdateEvent(player, resourceKey.location(), recipeHolder);
++                org.bukkit.event.player.PlayerRecipeDiscoverEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerRecipeListUpdateEvent(player, recipeHolder);
 +                if (event.isCancelled()) continue;
 +                // Paper end
                  this.add(resourceKey);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -1816,10 +1816,10 @@ public class CraftEventFactory {
         return !event.isCancelled();
     }
 
-    public static boolean handlePlayerRecipeListUpdateEvent(net.minecraft.world.entity.player.Player player, ResourceLocation recipe) {
-        PlayerRecipeDiscoverEvent event = new PlayerRecipeDiscoverEvent((Player) player.getBukkitEntity(), CraftNamespacedKey.fromMinecraft(recipe));
-        Bukkit.getPluginManager().callEvent(event);
-        return !event.isCancelled();
+    public static PlayerRecipeDiscoverEvent callPlayerRecipeListUpdateEvent(net.minecraft.world.entity.player.Player player, ResourceLocation recipe, RecipeHolder<?> recipeHolder) {
+        PlayerRecipeDiscoverEvent event = new PlayerRecipeDiscoverEvent((Player) player.getBukkitEntity(), CraftNamespacedKey.fromMinecraft(recipe), recipeHolder.value().showNotification());
+        event.callEvent();
+        return event;
     }
 
     public static EntityPickupItemEvent callEntityPickupItemEvent(Entity entity, ItemEntity item, int remaining, boolean cancelled) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -1816,8 +1816,8 @@ public class CraftEventFactory {
         return !event.isCancelled();
     }
 
-    public static PlayerRecipeDiscoverEvent callPlayerRecipeListUpdateEvent(net.minecraft.world.entity.player.Player player, ResourceLocation recipe, RecipeHolder<?> recipeHolder) {
-        PlayerRecipeDiscoverEvent event = new PlayerRecipeDiscoverEvent((Player) player.getBukkitEntity(), CraftNamespacedKey.fromMinecraft(recipe), recipeHolder.value().showNotification());
+    public static PlayerRecipeDiscoverEvent callPlayerRecipeListUpdateEvent(net.minecraft.world.entity.player.Player player, RecipeHolder<?> recipeHolder) {
+        PlayerRecipeDiscoverEvent event = new PlayerRecipeDiscoverEvent((Player) player.getBukkitEntity(), CraftNamespacedKey.fromMinecraft(recipeHolder.id().location()), recipeHolder.value().showNotification());
         event.callEvent();
         return event;
     }


### PR DESCRIPTION
Close https://github.com/PaperMC/Paper/issues/12990 adding support for hide the notification (toast) of recipes using the event

PS: I wanna add support for recipe define that field... but the implementation its not the best for try that...