### PR TITLE
Add Decorated Pot wobble API

### DIFF
--- a/paper-api/src/main/java/org/bukkit/block/DecoratedPot.java
+++ b/paper-api/src/main/java/org/bukkit/block/DecoratedPot.java
@@ -64,6 +64,15 @@ public interface DecoratedPot extends io.papermc.paper.block.TileStateInventoryH
     @NotNull
     public DecoratedPotInventory getSnapshotInventory();
 
+    // Paper start - expose wobble animation
+    /**
+     * Run the specified animation on the decorated pot.
+     *
+     * @param style the animation style
+     */
+    public void startWobble(@NotNull Wobble style);
+    // Paper end - expose wobble animation
+
     /**
      * A side on a decorated pot. Sides are relative to the facing state of a
      * {@link org.bukkit.block.data.type.DecoratedPot}.
@@ -74,4 +83,14 @@ public interface DecoratedPot extends io.papermc.paper.block.TileStateInventoryH
         RIGHT,
         FRONT
     }
+
+    // Paper start - expose wobble animation
+    /**
+     * An animation style of decorated pot.
+     */
+    public static enum Wobble {
+        POSITIVE,
+        NEGATIVE
+    }
+    // Paper end - expose wobble animation
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftDecoratedPot.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftDecoratedPot.java
@@ -18,6 +18,7 @@ import org.bukkit.block.DecoratedPot;
 import org.bukkit.craftbukkit.inventory.CraftInventoryDecoratedPot;
 import org.bukkit.craftbukkit.inventory.CraftItemType;
 import org.bukkit.inventory.DecoratedPotInventory;
+import org.jetbrains.annotations.NotNull;
 
 public class CraftDecoratedPot extends CraftBlockEntityState<DecoratedPotBlockEntity> implements DecoratedPot {
 
@@ -129,4 +130,18 @@ public class CraftDecoratedPot extends CraftBlockEntityState<DecoratedPotBlockEn
     public CraftDecoratedPot copy(Location location) {
         return new CraftDecoratedPot(this, location);
     }
+
+    // Paper start - expose wobble animation
+    @Override
+    public void startWobble(@NotNull final Wobble style) {
+        Preconditions.checkArgument(style != null, "style must not be null");
+
+        DecoratedPotBlockEntity.WobbleStyle originalStyle = switch (style) {
+            case POSITIVE -> DecoratedPotBlockEntity.WobbleStyle.POSITIVE;
+            case NEGATIVE -> DecoratedPotBlockEntity.WobbleStyle.NEGATIVE;
+            default -> throw new IllegalArgumentException("Unexpected value: " + style);
+        };
+        this.getBlockEntity().wobble(originalStyle);
+    }
+    // Paper end - expose wobble animation
 }


### PR DESCRIPTION
Adds an API to handle decorated pot wobble.
I used `getBlockEntity` instead of `getSnapshot` because the snapshot even with an `update()`, nothing happened.