### PR TITLE
Trapped chest signal api

### DIFF
--- a/paper-api/src/main/java/org/bukkit/block/TrappedChest.java
+++ b/paper-api/src/main/java/org/bukkit/block/TrappedChest.java
@@ -1,0 +1,35 @@
+package org.bukkit.block;
+
+import org.checkerframework.common.value.qual.IntRange;
+
+/**
+ * Represents a captured state of a Trapped Chest.
+ */
+public interface TrappedChest extends Chest {
+    /**
+     * Gets the current redstone power level emitted by this trapped chest.
+     *
+     * @return the redstone power level (0–15)
+     */
+    int getPower();
+
+    /**
+     * Checks if the power level is being forced rather than determined
+     * dynamically (for example by player interaction).
+     *
+     * @return {@code true} if the power is forced, {@code false} otherwise
+     */
+    boolean isForcedPower();
+
+    /**
+     * Sets a forced redstone power level for this trapped chest.
+     * <p>
+     * When a non-null value is provided, the trapped chest will emit
+     * the given power level regardless of its normal behavior.
+     * When {@code null} is passed, the chest will revert to its default
+     * dynamic behavior (power depending on open state and players nearby).
+     *
+     * @param power the forced power level (0–15), or {@code null} to disable forcing
+     */
+    void setForcedPower(@org.jspecify.annotations.Nullable @IntRange(from = 0, to = 15) Integer power);
+}

--- a/paper-api/src/main/java/org/bukkit/block/TrappedChest.java
+++ b/paper-api/src/main/java/org/bukkit/block/TrappedChest.java
@@ -1,6 +1,7 @@
 package org.bukkit.block;
 
 import org.checkerframework.common.value.qual.IntRange;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a captured state of a Trapped Chest.
@@ -31,5 +32,5 @@ public interface TrappedChest extends Chest {
      *
      * @param power the forced power level (0–15), or {@code null} to disable forcing
      */
-    void setForcedPower(@org.jspecify.annotations.Nullable @IntRange(from = 0, to = 15) Integer power);
+    void setForcedPower(@Nullable @IntRange(from = 0, to = 15) Integer power);
 }

--- a/paper-generator/src/main/java/io/papermc/generator/utils/BlockEntityMapping.java
+++ b/paper-generator/src/main/java/io/papermc/generator/utils/BlockEntityMapping.java
@@ -18,7 +18,7 @@ public final class BlockEntityMapping {
         .put("CraftFurnace", "CraftFurnaceFurnace")
         .put("CraftMobSpawner", "CraftCreatureSpawner")
         .put("CraftPiston", "CraftMovingPiston")
-        .put("CraftTrappedChest", "CraftChest") // not really a rename
+        .put("CraftChest", "CraftChestChest")
         .buildOrThrow();
 
     public static final Map<ResourceKey<BlockEntityType<?>>, String> MAPPING;

--- a/paper-server/patches/sources/net/minecraft/world/level/block/TrappedChestBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TrappedChestBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/block/TrappedChestBlock.java
++++ b/net/minecraft/world/level/block/TrappedChestBlock.java
+@@ -44,7 +_,7 @@
+ 
+     @Override
+     protected int getSignal(BlockState blockState, BlockGetter blockAccess, BlockPos pos, Direction side) {
+-        return Mth.clamp(ChestBlockEntity.getOpenCount(blockAccess, pos), 0, 15);
++        return Mth.clamp(TrappedChestBlockEntity.getSignal(blockAccess, pos), 0, 15); // Paper - TrappedChest Signal Api
+     }
+ 
+     @Override

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java.patch
@@ -8,7 +8,7 @@
  
      protected abstract void onOpen(Level level, BlockPos pos, BlockState state);
  
-@@ -20,10 +_,36 @@
+@@ -20,29 +_,84 @@
  
      protected abstract void openerCountChanged(Level level, BlockPos pos, BlockState state, int count, int openCount);
  
@@ -31,41 +31,70 @@
      public void incrementOpeners(Player player, Level level, BlockPos pos, BlockState state) {
 +        int oldPower = Math.max(0, Math.min(15, this.openCount)); // CraftBukkit - Get power before new viewer is added
          int i = this.openCount++;
++        int j = this.openCount; // Paper - TrappedChest Signal Api
 +
 +        // CraftBukkit start - Call redstone event
 +        if (level.getBlockState(pos).is(net.minecraft.world.level.block.Blocks.TRAPPED_CHEST)) {
-+            int newPower = Math.max(0, Math.min(15, this.openCount));
++            // Paper start - TrappedChest Signal Api
++            TrappedChestBlockEntity trappedChestBlock = (TrappedChestBlockEntity) java.util.Objects.requireNonNull(level.getBlockEntity(pos));
++            int newPower = Math.max(0, Math.min(15, j));
 +
 +            if (oldPower != newPower) {
-+                org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldPower, newPower);
++                org.bukkit.event.block.BlockRedstoneEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldPower, newPower);
++                if (event.getNewCurrent() != newPower) {
++                    trappedChestBlock.setForcedSignal(event.getNewCurrent());
++                    j = event.getNewCurrent();
++                }
 +            }
++            // Paper end - TrappedChest Signal Api
 +        }
 +        // CraftBukkit end
 +
          if (i == 0) {
              this.onOpen(level, pos, state);
              level.gameEvent(player, GameEvent.CONTAINER_OPEN, pos);
-@@ -35,7 +_,20 @@
+             scheduleRecheck(level, pos, state);
+         }
+ 
+-        this.openerCountChanged(level, pos, state, i, this.openCount);
++        this.openerCountChanged(level, pos, state, i, j); // Paper - TrappedChest Signal Api
+         this.maxInteractionRange = Math.max(player.blockInteractionRange(), this.maxInteractionRange);
      }
  
      public void decrementOpeners(Player player, Level level, BlockPos pos, BlockState state) {
 +        int oldPower = Math.max(0, Math.min(15, this.openCount)); // CraftBukkit - Get power before new viewer is added
 +        if (this.openCount == 0) return; // Paper - Prevent ContainerOpenersCounter openCount from going negative
          int i = this.openCount--;
++        int j = this.openCount; // Paper - TrappedChest Signal Api
 +
 +        // CraftBukkit start - Call redstone event
 +        if (level.getBlockState(pos).is(net.minecraft.world.level.block.Blocks.TRAPPED_CHEST)) {
++            // Paper start - TrappedChest Signal Api
++            TrappedChestBlockEntity trappedChestBlock = (TrappedChestBlockEntity) java.util.Objects.requireNonNull(level.getBlockEntity(pos));
 +            int newPower = Math.max(0, Math.min(15, this.openCount));
 +
 +            if (oldPower != newPower) {
-+                org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldPower, newPower);
++                org.bukkit.event.block.BlockRedstoneEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldPower, newPower);
++                if (event.getNewCurrent() != newPower) {
++                    trappedChestBlock.setForcedSignal(event.getNewCurrent());
++                    j = event.getNewCurrent();
++                }
 +            }
++            // Paper end - TrappedChest Signal Api
 +        }
 +        // CraftBukkit end
 +
          if (this.openCount == 0) {
              this.onClose(level, pos, state);
              level.gameEvent(player, GameEvent.CONTAINER_CLOSE, pos);
+             this.maxInteractionRange = 0.0;
+         }
+ 
+-        this.openerCountChanged(level, pos, state, i, this.openCount);
++        this.openerCountChanged(level, pos, state, i, j); // Paper - TrappedChest Signal Api
+     }
+ 
+     private List<Player> getPlayersWithContainerOpen(Level level, BlockPos pos) {
 @@ -60,6 +_,7 @@
          }
  

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/TrappedChestBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/TrappedChestBlockEntity.java.patch
@@ -1,0 +1,75 @@
+--- a/net/minecraft/world/level/block/entity/TrappedChestBlockEntity.java
++++ b/net/minecraft/world/level/block/entity/TrappedChestBlockEntity.java
+@@ -14,14 +_,68 @@
+         super(BlockEntityType.TRAPPED_CHEST, pos, blockState);
+     }
+ 
+-    @Override
+-    protected void signalOpenCount(Level level, BlockPos pos, BlockState state, int eventId, int eventParam) {
+-        super.signalOpenCount(level, pos, state, eventId, eventParam);
+-        if (eventId != eventParam) {
++    // Paper start - TrappedChest Signal Api
++    private @org.jetbrains.annotations.Nullable Integer forcedSignal = null;
++
++    @Override
++    protected void saveAdditional(net.minecraft.world.level.storage.ValueOutput output) {
++        super.saveAdditional(output);
++        if (this.forcedSignal != null) {
++            output.putInt("Paper.ForcedSignal", this.forcedSignal);
++        }
++    }
++
++    @Override
++    protected void loadAdditional(net.minecraft.world.level.storage.ValueInput input) {
++        super.loadAdditional(input);
++        this.forcedSignal = input.getInt("Paper.ForcedSignal").orElse(null);
++    }
++
++    public @org.jetbrains.annotations.Nullable Integer getForcedSignal() {
++        return forcedSignal;
++    }
++
++    public void setForcedSignal(@org.jetbrains.annotations.Nullable Integer forcedSignal) {
++        if (forcedSignal == null) {
++            this.forcedSignal = null;
++            return;
++        }
++
++        this.forcedSignal = Math.max(0, Math.min(15, forcedSignal));
++    }
++
++    public int getSignal() {
++        if (this.forcedSignal != null)
++            return this.forcedSignal;
++        return this.openersCounter.getOpenerCount();
++    }
++
++    public static int getSignal(net.minecraft.world.level.BlockGetter level, BlockPos pos) {
++        BlockState blockState = level.getBlockState(pos);
++        if (blockState.hasBlockEntity()) {
++            BlockEntity blockEntity = level.getBlockEntity(pos);
++            if (blockEntity instanceof TrappedChestBlockEntity) {
++                return ((TrappedChestBlockEntity) blockEntity).getSignal();
++            }
++        }
++
++        return 0;
++    }
++
++    public void updateRedStone(Level level, BlockPos pos, BlockState state, int from, int to) {
++        if (from != to) {
+             Orientation orientation = ExperimentalRedstoneUtils.initialOrientation(level, state.getValue(TrappedChestBlock.FACING).getOpposite(), Direction.UP);
+             Block block = state.getBlock();
+             level.updateNeighborsAt(pos, block, orientation);
+             level.updateNeighborsAt(pos.below(), block, orientation);
+         }
+     }
++
++    @Override
++    protected void signalOpenCount(Level level, BlockPos pos, BlockState state, int eventId, int eventParam) {
++        super.signalOpenCount(level, pos, state, eventId, eventParam);
++        updateRedStone(level, pos, state, eventId, eventParam);
++    }
++
++    // Paper end - TrappedChest Signal Api
+ }

--- a/paper-server/patches/sources/net/minecraft/world/level/levelgen/structure/StructurePiece.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/levelgen/structure/StructurePiece.java.patch
@@ -1,5 +1,22 @@
 --- a/net/minecraft/world/level/levelgen/structure/StructurePiece.java
 +++ b/net/minecraft/world/level/levelgen/structure/StructurePiece.java
+@@ -24,8 +_,6 @@
+ import net.minecraft.world.level.block.Mirror;
+ import net.minecraft.world.level.block.Rotation;
+ import net.minecraft.world.level.block.entity.BlockEntity;
+-import net.minecraft.world.level.block.entity.ChestBlockEntity;
+-import net.minecraft.world.level.block.entity.DispenserBlockEntity;
+ import net.minecraft.world.level.block.state.BlockState;
+ import net.minecraft.world.level.chunk.ChunkGenerator;
+ import net.minecraft.world.level.levelgen.Heightmap;
+@@ -33,6 +_,7 @@
+ import net.minecraft.world.level.levelgen.structure.pieces.StructurePieceType;
+ import net.minecraft.world.level.material.FluidState;
+ import net.minecraft.world.level.storage.loot.LootTable;
++import org.bukkit.craftbukkit.block.CraftChestChest;
+ 
+ public abstract class StructurePiece {
+     protected static final BlockState CAVE_AIR = Blocks.CAVE_AIR.defaultBlockState();
 @@ -181,6 +_,11 @@
                  }
  
@@ -76,7 +93,7 @@
 +            // if (blockEntity instanceof ChestBlockEntity) {
 +            //     ((ChestBlockEntity)blockEntity).setLootTable(lootTable, random.nextLong());
 +            // }
-+            org.bukkit.craftbukkit.block.CraftChest chestState = (org.bukkit.craftbukkit.block.CraftChest) org.bukkit.craftbukkit.block.CraftBlockStates.getBlockState(level, pos, state, null);
++            CraftChestChest chestState = (CraftChestChest) org.bukkit.craftbukkit.block.CraftBlockStates.getBlockState(level, pos, state, null);
 +            chestState.setLootTable(org.bukkit.craftbukkit.CraftLootTable.minecraftToBukkit(lootTable));
 +            chestState.setSeed(random.nextLong());
 +            this.placeCraftBlockEntity(level, pos, chestState, 2);

--- a/paper-server/patches/sources/net/minecraft/world/level/levelgen/structure/structures/OceanRuinPieces.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/levelgen/structure/structures/OceanRuinPieces.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/level/levelgen/structure/structures/OceanRuinPieces.java
 +++ b/net/minecraft/world/level/levelgen/structure/structures/OceanRuinPieces.java
+@@ -25,8 +_,6 @@
+ import net.minecraft.world.level.block.ChestBlock;
+ import net.minecraft.world.level.block.Mirror;
+ import net.minecraft.world.level.block.Rotation;
+-import net.minecraft.world.level.block.entity.BlockEntity;
+-import net.minecraft.world.level.block.entity.ChestBlockEntity;
+ import net.minecraft.world.level.block.state.BlockState;
+ import net.minecraft.world.level.chunk.ChunkGenerator;
+ import net.minecraft.world.level.levelgen.Heightmap;
 @@ -314,12 +_,18 @@
          @Override
          protected void handleDataMarker(String name, BlockPos pos, ServerLevelAccessor level, RandomSource random, BoundingBox box) {
@@ -17,7 +26,7 @@
 +                //     ((ChestBlockEntity)blockEntity)
 +                //         .setLootTable(this.isLarge ? BuiltInLootTables.UNDERWATER_RUIN_BIG : BuiltInLootTables.UNDERWATER_RUIN_SMALL, random.nextLong());
 +                // }
-+                org.bukkit.craftbukkit.block.CraftChest craftChest = (org.bukkit.craftbukkit.block.CraftChest) org.bukkit.craftbukkit.block.CraftBlockStates.getBlockState(level, pos, Blocks.CHEST.defaultBlockState().setValue(ChestBlock.WATERLOGGED, level.getFluidState(pos).is(FluidTags.WATER)), null);
++                org.bukkit.craftbukkit.block.CraftChestChest craftChest = (org.bukkit.craftbukkit.block.CraftChestChest) org.bukkit.craftbukkit.block.CraftBlockStates.getBlockState(level, pos, Blocks.CHEST.defaultBlockState().setValue(ChestBlock.WATERLOGGED, level.getFluidState(pos).is(FluidTags.WATER)), null);
 +                craftChest.setSeed(random.nextLong());
 +                craftChest.setLootTable(org.bukkit.craftbukkit.CraftLootTable.minecraftToBukkit(this.isLarge ? BuiltInLootTables.UNDERWATER_RUIN_BIG : BuiltInLootTables.UNDERWATER_RUIN_SMALL));
 +                this.placeCraftBlockEntity(level, pos, craftChest, 2);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
@@ -97,7 +97,7 @@ public final class CraftBlockStates {
         register(BlockEntityType.BRUSHABLE_BLOCK, CraftBrushableBlock.class, CraftBrushableBlock::new);
         register(BlockEntityType.CALIBRATED_SCULK_SENSOR, CraftCalibratedSculkSensor.class, CraftCalibratedSculkSensor::new);
         register(BlockEntityType.CAMPFIRE, CraftCampfire.class, CraftCampfire::new);
-        register(BlockEntityType.CHEST, CraftChest.class, CraftChest::new);
+        register(BlockEntityType.CHEST, CraftChest.class, CraftChestChest::new);
         register(BlockEntityType.CHISELED_BOOKSHELF, CraftChiseledBookshelf.class, CraftChiseledBookshelf::new);
         register(BlockEntityType.COMMAND_BLOCK, CraftCommandBlock.class, CraftCommandBlock::new);
         register(BlockEntityType.COMPARATOR, CraftComparator.class, CraftComparator::new);
@@ -130,7 +130,7 @@ public final class CraftBlockStates {
         register(BlockEntityType.STRUCTURE_BLOCK, CraftStructureBlock.class, CraftStructureBlock::new);
         register(BlockEntityType.TEST_BLOCK, CraftTestBlock.class, CraftTestBlock::new);
         register(BlockEntityType.TEST_INSTANCE_BLOCK, CraftTestInstanceBlock.class, CraftTestInstanceBlock::new);
-        register(BlockEntityType.TRAPPED_CHEST, CraftChest.class, CraftChest::new);
+        register(BlockEntityType.TRAPPED_CHEST, CraftChest.class, CraftTrappedChest::new);
         register(BlockEntityType.TRIAL_SPAWNER, CraftTrialSpawner.class, CraftTrialSpawner::new);
         register(BlockEntityType.VAULT, CraftVault.class, CraftVault::new);
         // End generate - CraftBlockEntityStates

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
@@ -14,13 +14,13 @@ import org.bukkit.craftbukkit.inventory.CraftInventory;
 import org.bukkit.craftbukkit.inventory.CraftInventoryDoubleChest;
 import org.bukkit.inventory.Inventory;
 
-public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest {
+public abstract class CraftChest<T extends ChestBlockEntity> extends CraftLootable<T> implements Chest {
 
-    public CraftChest(World world, ChestBlockEntity blockEntity) {
+    public CraftChest(World world, T blockEntity) {
         super(world, blockEntity);
     }
 
-    protected CraftChest(CraftChest state, Location location) {
+    protected CraftChest(CraftChest<T> state, Location location) {
         super(state, location);
     }
 
@@ -84,14 +84,10 @@ public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest
     }
 
     @Override
-    public CraftChest copy() {
-        return new CraftChest(this, null);
-    }
+    public abstract CraftChest<T> copy();
 
     @Override
-    public CraftChest copy(Location location) {
-        return new CraftChest(this, location);
-    }
+    public abstract CraftChest<T> copy(Location location);
 
     // Paper start - More Lidded Block API
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftChestChest.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftChestChest.java
@@ -1,0 +1,26 @@
+package org.bukkit.craftbukkit.block;
+
+import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import org.bukkit.Location;
+import org.bukkit.World;
+
+public class CraftChestChest extends CraftChest<ChestBlockEntity> {
+
+    public CraftChestChest(World world, ChestBlockEntity blockEntity) {
+        super(world, blockEntity);
+    }
+
+    protected CraftChestChest(CraftChestChest state, Location location) {
+        super(state, location);
+    }
+
+    @Override
+    public CraftChestChest copy() {
+        return new CraftChestChest(this, null);
+    }
+
+    @Override
+    public CraftChestChest copy(Location location) {
+        return new CraftChestChest(this, location);
+    }
+}

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrappedChest.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrappedChest.java
@@ -5,7 +5,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.TrappedChest;
 import org.checkerframework.common.value.qual.IntRange;
-import org.jspecify.annotations.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class CraftTrappedChest extends CraftChest<TrappedChestBlockEntity> implements TrappedChest {
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrappedChest.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrappedChest.java
@@ -2,8 +2,10 @@ package org.bukkit.craftbukkit.block;
 
 import net.minecraft.world.level.block.entity.TrappedChestBlockEntity;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.TrappedChest;
+import org.bukkit.event.block.BlockRedstoneEvent;
 import org.checkerframework.common.value.qual.IntRange;
 import org.jetbrains.annotations.Nullable;
 
@@ -47,9 +49,17 @@ public class CraftTrappedChest extends CraftChest<TrappedChestBlockEntity> imple
         int from = this.getBlockEntity().getSignal();
         int to = this.getSnapshot().getSignal();
 
+        if (from != to) {
+            BlockRedstoneEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(getNMSWorld(), getPosition(), from, to);
+            if (event.getNewCurrent() != to) {
+                this.getSnapshot().setForcedSignal(event.getNewCurrent());
+                to = event.getNewCurrent();
+            }
+        }
+
         boolean result = super.update(force, applyPhysics);
 
-        if (result && from != to) {
+        if (result && this.isPlaced() && this.getType() == Material.TRAPPED_CHEST && from != to) {
             this.getBlockEntity().updateRedStone(getNMSWorld(), getPosition(), getHandle(), from, to);
         }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrappedChest.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrappedChest.java
@@ -1,0 +1,58 @@
+package org.bukkit.craftbukkit.block;
+
+import net.minecraft.world.level.block.entity.TrappedChestBlockEntity;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.TrappedChest;
+import org.checkerframework.common.value.qual.IntRange;
+import org.jspecify.annotations.Nullable;
+
+public class CraftTrappedChest extends CraftChest<TrappedChestBlockEntity> implements TrappedChest {
+
+    public CraftTrappedChest(World world, TrappedChestBlockEntity blockEntity) {
+        super(world, blockEntity);
+    }
+
+    protected CraftTrappedChest(CraftTrappedChest state, Location location) {
+        super(state, location);
+    }
+
+    @Override
+    public CraftTrappedChest copy() {
+        return new CraftTrappedChest(this, null);
+    }
+
+    @Override
+    public CraftTrappedChest copy(Location location) {
+        return new CraftTrappedChest(this, location);
+    }
+
+    @Override
+    public int getPower() {
+        return this.getSnapshot().getSignal();
+    }
+
+    @Override
+    public boolean isForcedPower() {
+        return this.getSnapshot().getForcedSignal() != null;
+    }
+
+    @Override
+    public void setForcedPower(@Nullable @IntRange(from = 0, to = 15) final Integer power) {
+        this.getSnapshot().setForcedSignal(power);
+    }
+
+    @Override
+    public boolean update(final boolean force, final boolean applyPhysics) {
+        int from = this.getBlockEntity().getSignal();
+        int to = this.getSnapshot().getSignal();
+
+        boolean result = super.update(force, applyPhysics);
+
+        if (result && from != to) {
+            this.getBlockEntity().updateRedStone(getNMSWorld(), getPosition(), getHandle(), from, to);
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
This PR introduces an API for handling the redstone signal emitted by trapped chests.

I would like feedback on the use of `BlockRedstoneEvent`:
- Currently, it is triggered with the standard redstone signal value.  
- However, I am considering whether it should use the *forced* value instead.  
  - If I use the forced value, then technically it should be applied both before and after the change.  
  - This would mean the event would not be triggered in the same way as it is now.  

Looking for opinions on which approach would be cleaner and more consistent.