### PR TITLE
disconnectAsync: Fix missing reason

### DIFF
--- a/paper-server/patches/features/0032-Improve-keepalive-ping-system.patch
+++ b/paper-server/patches/features/0032-Improve-keepalive-ping-system.patch
@@ -100,7 +100,7 @@ index 962084054c0208470d0c3c99c5dca6327c9b8752..2abc21102bbd2da79dc0c50826cff7da
      }
  }
 diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index 5e074e6b5b8699b5c978a31518775479a43266ac..07c4a25c121676db867e8fb438ba41ad58528a4d 100644
+index 2a349b022503f5c0b71853c37f75eec4d488606b..f02800e4e941b05bde6f0d5fac76e2b6ec5b9832 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 @@ -38,12 +38,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
@@ -223,7 +223,7 @@ index 5e074e6b5b8699b5c978a31518775479a43266ac..07c4a25c121676db867e8fb438ba41ad
              }
          }
  
-@@ -425,6 +458,6 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -426,6 +459,6 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      }
  
      protected CommonListenerCookie createCookie(ClientInformation clientInformation) {

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
@@ -219,7 +219,7 @@
          if (packet.isTerminal()) {
              this.close();
          }
-@@ -173,19 +_,113 @@
+@@ -173,19 +_,114 @@
          }
      }
  
@@ -325,8 +325,9 @@
 +        this.disconnectAsync(new DisconnectionDetails(component, java.util.Optional.empty(), java.util.Optional.empty(), java.util.Optional.empty(), java.util.Optional.of(reason)));
 +    }
 +
++    @Deprecated @io.papermc.paper.annotation.DoNotUse
 +    public final void disconnectAsync(Component component) {
-+        this.disconnectAsync(new DisconnectionDetails(component));
++        this.disconnectAsync(component, io.papermc.paper.connection.DisconnectionReason.UNKNOWN);
 +    }
 +
 +    public abstract void disconnectAsync(DisconnectionDetails disconnectionInfo);


### PR DESCRIPTION
Currently, calling disconnectAsync(Component) will crash because the implementation of disconnect expects a reason to be present.

This PR adjusts disconnectAsync(Component) to match the behaviour of disconnect(Component).
It also adds the same Deprecated and io.papermc.paper.annotation.DoNotUse annotations that the non-async method has.