### PR TITLE
Fix clicked items disappearing when player dies

### DIFF
--- a/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
@@ -521,10 +521,10 @@ index e087d5596979044fe7fbcf7f2cccdae4e81a3d3a..fea6c3b48c4eb162fbdc099fa775bc31
              delta = this.maybeBackOffFromEdge(delta, moverType);
              Vec3 movement = this.collide(delta);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index c4da41f3b5ba6d8492d3776654b1ce62a5015895..6a0ebbdfcc0bc07915574c1cf87463e82213ca7e 100644
+index 8b0abe9c7a3907419f6e4d55ea22fb9bc749f28b..36c0081e3e8f8776293ae619156cd0828fe5b21d 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3385,6 +3385,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3372,6 +3372,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
      protected void playAttackSound() {
      }
  
@@ -817,7 +817,7 @@ index 3a590d4dc980a2912e9cc043d8c8db4cf9d60803..06ab7c48b18c03af494ab10fc2b584ce
 +
  }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index b8d56c7a14521cb77ba2cf619be826fb06be81da..2b3ec0a012918815ed0eda8b40647c2274a5b418 100644
+index c0f901c4ac61a0aa2b480f102feb3669b111f4c0..07c301ba02c7f2c032a29a0ae3bdf95fc522c03b 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -155,6 +155,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl

--- a/paper-server/patches/sources/net/minecraft/world/entity/vehicle/boat/AbstractBoat.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/vehicle/boat/AbstractBoat.java.patch
@@ -84,7 +84,7 @@
                  this.setDeltaMovement(this.getDeltaMovement().multiply(1.0, 0.0, 1.0));
                  this.lastYd = 0.0;
              }
-@@ -708,12 +_,20 @@
+@@ -704,12 +_,20 @@
      }
  
      @Override

--- a/paper-server/patches/sources/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -201,7 +201,7 @@
                      player.handleCreativeModeItemDrop(itemStack);
                  }
              }
-@@ -595,8 +_,9 @@
+@@ -595,14 +_,15 @@
          if (player instanceof ServerPlayer) {
              ItemStack carried = this.getCarried();
              if (!carried.isEmpty()) {
@@ -212,6 +212,13 @@
              }
          }
      }
+ 
+     private static void dropOrPlaceInInventory(final Player player, final ItemStack carried) {
+-        boolean playerRemovedNotChangingDimension = player.isRemoved() && player.getRemovalReason() != Entity.RemovalReason.CHANGED_DIMENSION;
++        boolean playerRemovedNotChangingDimension = !player.isAlive() && player.getRemovalReason() != Entity.RemovalReason.CHANGED_DIMENSION; // Paper - Make sure player is dead (https://github.com/PaperMC/Paper/pull/13002)
+         boolean serverPlayerHasDisconnected = player instanceof ServerPlayer serverPlayer && serverPlayer.hasDisconnected();
+         if (playerRemovedNotChangingDimension || serverPlayerHasDisconnected) {
+             player.drop(carried, false);
 @@ -642,6 +_,14 @@
      public abstract boolean stillValid(Player player);
  


### PR DESCRIPTION
Resolves #12928 

This issue was introduced on `1.21.2` when Mojang refactored `AbstractContainerMenu#removed()` and moved some of the logic to `AbstractContainerMenu.dropOrPlaceInInventory()`. When they did that, they inverted the logic of the flag that checked wether the player was dead or not and stopped using `!player.isAlive()` in favor of `player.isRemoved()`. 

On vanilla this works fine because by the time `AbstractContainerMenu.dropOrPlaceInInventory()` is executed the player is already removed, but this is not the case in paper — here's some examples:

```java
// SPIGOT-943 - only call if they have an inventory open
if (this.containerMenu != this.inventoryMenu) {
    this.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DEATH); // Paper - Inventory close reason
} // From ServerPlayer#die()
```

```java
// Paper end - Configurable container update tick rate
if (this.containerMenu != this.inventoryMenu && (this.isImmobile() || !this.containerMenu.stillValid(this))) { // Paper - Prevent opening inventories when frozen
    this.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.CANT_USE); // Paper - Inventory close reason
    this.containerMenu = this.inventoryMenu;
} // From ServerPlayer#tick()
```

