### PR TITLE
[ci skip] Extend PlayerBucketEmptyEvent java doc to mention that it's not called for powdered snow buckets

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerBucketEmptyEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerBucketEmptyEvent.java
@@ -5,6 +5,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
@@ -12,6 +13,10 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player empties a bucket
+ * <p>
+ *     Note that this event is not called when the player empties a powdered snow bucket.
+ *     Use {@link BlockPlaceEvent} for that.
+ * </p>
  */
 public class PlayerBucketEmptyEvent extends PlayerBucketEvent {
 


### PR DESCRIPTION
Since I don't think restructuring the events would be a good solution, mention this so people don't get confused like I did.

Closes https://github.com/PaperMC/Paper/issues/12239