### PR TITLE
Parse pasted multi-line commands separately line by line

### DIFF
--- a/paper-server/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
+++ b/paper-server/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
@@ -4,8 +4,12 @@ import io.papermc.paper.configuration.GlobalConfiguration;
 import io.papermc.paper.console.BrigadierCompletionMatcher;
 import io.papermc.paper.console.BrigadierConsoleParser;
 import io.papermc.paper.util.PaperCacheDir;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.util.StringUtil;
 import net.minecrell.terminalconsole.SimpleTerminalConsole;
+import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.command.ConsoleCommandCompleter;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -46,12 +50,23 @@ public final class PaperConsole extends SimpleTerminalConsole {
         // terminals interpret pressing [enter] and pasting a multi-line string differently,
         // the latter makes the line reader read it as a single line - and we don't want that
         // https://github.com/PaperMC/Paper/issues/13006
-        for (String line : command.split("\n")) {
-            if (line.isEmpty()) {
-                continue;
-            }
-            this.server.handleConsoleInput(line, this.server.createCommandSourceStack());
-        }
+        command.lines()
+            .filter(line -> !line.isEmpty())
+            .forEach(line -> {
+                for (char character : line.toCharArray()) {
+                    if (!StringUtil.isAllowedChatCharacter(character)) {
+                        Bukkit.getConsoleSender().sendMessage(
+                            Component.text()
+                                .append(Component.text("Illegal console input character: 0x"))
+                                .append(Component.text(Integer.toHexString(character)))
+                                .color(NamedTextColor.RED)
+                        );
+                        return;
+                    }
+                }
+
+                this.server.handleConsoleInput(line, this.server.createCommandSourceStack());
+            });
     }
 
     @Override

--- a/paper-server/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
+++ b/paper-server/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
@@ -43,7 +43,15 @@ public final class PaperConsole extends SimpleTerminalConsole {
 
     @Override
     protected void runCommand(String command) {
-        this.server.handleConsoleInput(command, this.server.createCommandSourceStack());
+        // terminals interpret pressing [enter] and pasting a multi-line string differently,
+        // the latter makes the line reader read it as a single line - and we don't want that
+        // https://github.com/PaperMC/Paper/issues/13006
+        for (String line : command.split("\n")) {
+            if (line.isEmpty()) {
+                continue;
+            }
+            this.server.handleConsoleInput(line, this.server.createCommandSourceStack());
+        }
     }
 
     @Override


### PR DESCRIPTION
This effectively reverts to the older pasting behavior from somewhere around 1.19. This does not address the root cause, but rather re-enables a specific use case of pasting multiple commands at once until a proper solution is in place.

Line separators are converted from `\r\n` or `\r` to `\n` **before** the `#runCommand(String)` call, so platform line separators don't require any additional handling

Fixes #13006