### PR TITLE
Fix Items with a negative pickup delay being able to be picked up

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Item.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Item.java
@@ -27,6 +27,10 @@ public interface Item extends Entity, io.papermc.paper.entity.Frictional { // Pa
 
     /**
      * Gets the delay before this Item is available to be picked up by players
+     * <p>
+     * If the value is 0, the item can be picked up immediately.
+     * If the value is negative or {@link Short#MAX_VALUE} (32767), the item cannot be picked up at all.
+     * Otherwise, the value is the number of ticks before the item can be picked up.
      *
      * @return Remaining delay
      */
@@ -34,7 +38,11 @@ public interface Item extends Entity, io.papermc.paper.entity.Frictional { // Pa
 
     /**
      * Sets the delay before this Item is available to be picked up by players
-     *
+     * <p>
+     * If the value is 0, the item can be picked up immediately.
+     * If the value is negative or {@link Short#MAX_VALUE} (32767), the item cannot be picked up at all.
+     * Otherwise, the value is the number of ticks before the item can be picked up.
+     * 
      * @param delay New delay
      */
     public void setPickupDelay(int delay);

--- a/paper-server/patches/sources/net/minecraft/world/entity/item/ItemEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/item/ItemEntity.java.patch
@@ -180,7 +180,7 @@
          }
      }
  
-@@ -334,10 +_,73 @@
+@@ -334,10 +_,70 @@
              ItemStack item = this.getItem();
              Item item1 = item.getItem();
              int count = item.getCount();
@@ -190,7 +190,7 @@
 +            boolean flyAtPlayer = false; // Paper
 +
 +            // Paper start - PlayerAttemptPickupItemEvent
-+            if (this.pickupDelay <= 0) {
++            if (this.pickupDelay == 0) {
 +                org.bukkit.event.player.PlayerAttemptPickupItemEvent attemptEvent = new org.bukkit.event.player.PlayerAttemptPickupItemEvent((org.bukkit.entity.Player) entity.getBukkitEntity(), (org.bukkit.entity.Item) this.getBukkitEntity(), remaining);
 +                this.level().getCraftServer().getPluginManager().callEvent(attemptEvent);
 +
@@ -204,7 +204,7 @@
 +                }
 +            }
 +
-+            if (this.pickupDelay <= 0 && canHold > 0) {
++            if (this.pickupDelay == 0 && canHold > 0) {
 +                item.setCount(canHold);
 +                // Call legacy event
 +                org.bukkit.event.player.PlayerPickupItemEvent playerEvent = new org.bukkit.event.player.PlayerPickupItemEvent((org.bukkit.entity.Player) entity.getBukkitEntity(), (org.bukkit.entity.Item) this.getBukkitEntity(), remaining);
@@ -237,12 +237,9 @@
 +                } else {
 +                    item.setCount(canHold + remaining); // = i
 +                }
-+
-+                // Possibly < 0; fix here so we do not have to modify code below
-+                this.pickupDelay = 0;
 +            } else if (this.pickupDelay == 0) {
 +                // ensure that the code below isn't triggered if canHold says we can't pick the items up
-+                this.pickupDelay = -1;
++                return;
 +            }
 +            // CraftBukkit end
 +            // Paper end - PlayerAttemptPickupItemEvent

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
@@ -41,7 +41,7 @@ public class CraftItem extends CraftEntity implements Item {
 
     @Override
     public void setPickupDelay(int delay) {
-        this.getHandle().pickupDelay = Math.min(delay, Short.MAX_VALUE);
+        this.getHandle().pickupDelay = Math.clamp(Short.MIN_VALUE, delay, Short.MAX_VALUE);
     }
 
     @Override


### PR DESCRIPTION
Fixes a bug where Items with a negative pickup delay can be picked up, which doesn't match vanilla behaviour, where any value != 0 is unable to be picked up

this is most noticable with summon commands, where high values (exceeding max short) of pickupdelay can overflow into the negatives:
ie `/summon item ~ ~1 ~5 {Item:{id:"minecraft:mace",count:1},PickupDelay:60000}`
(test item with `/data get entity @e[type=minecraft:item, distance=..4, limit=1] PickupDelay`)
-> `-5536s`

vanilla: unable to be picked up
paper main: able to be picked up
paper after patch: unable to be picked up

as all the changes were within existing bukkit / paper code, no new comments were added.
its possibly worth discussing the last change
```diff
-                this.pickupDelay = -1;
+                return;
```
the behaviour is effectively the same, skipping the if statement after, but I'm wondering if modifying pickupdelay had any deeper meaning / avoiding that early return, in-case behaviour changes in the future.