### PR TITLE
Ignore HopperInventorySearchEvent when it has no listeners

### DIFF
--- a/paper-server/patches/features/0028-Optimize-Hoppers.patch
+++ b/paper-server/patches/features/0028-Optimize-Hoppers.patch
@@ -48,7 +48,7 @@ index 0000000000000000000000000000000000000000..24a2090e068ad3c0d08705050944abdf
 +    }
 +}
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 34b10db71d22cb7211dcfc5565e6833c8d4d2413..382d2b6b53bd144f4d56dccdc603ed0da8fe07a7 100644
+index 6c8f06bc55cc6bffe6879433c5eda74eb5a13cb0..914ab3ad3e9b5735fcc179e17aaad82ab1b63b18 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -1719,6 +1719,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -103,7 +103,7 @@ index 275646a9f99f3c46bc81a23143c1960f2a6300b1..5986825d6a381eeb445dd424dd127864
          }
      }
 diff --git a/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index 94d68fbb3d152b2fd43f989b728c5efabbf3c22c..800b7e78ae989868ed0b9e060c80dcd002759412 100644
+index 0af3eef04782b7d54c5bb0b0cfe2c2b5e052661e..01ed25d1f895d94485b5fecd98476534cbb26930 100644
 --- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 @@ -143,18 +143,56 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
@@ -628,7 +628,7 @@ index 94d68fbb3d152b2fd43f989b728c5efabbf3c22c..800b7e78ae989868ed0b9e060c80dcd0
                  stack = leftover; // Paper - Make hoppers respect inventory max stack size
                  flag = true;
              } else if (canMergeItems(item, stack)) {
-@@ -523,13 +772,19 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -525,13 +774,19 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
  
      @Nullable
      public static Container getContainerAt(Level level, BlockPos pos) {
@@ -650,7 +650,7 @@ index 94d68fbb3d152b2fd43f989b728c5efabbf3c22c..800b7e78ae989868ed0b9e060c80dcd0
              blockContainer = getEntityContainer(level, x, y, z);
          }
  
-@@ -555,14 +810,14 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -557,14 +812,14 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
  
      @Nullable
      private static Container getEntityContainer(Level level, double x, double y, double z) {

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
@@ -263,7 +263,7 @@
      @Nullable
      private static Container getAttachedContainer(Level level, BlockPos pos, HopperBlockEntity blockEntity) {
 -        return getContainerAt(level, pos.relative(blockEntity.facing));
-+        // CraftBukkit start
++        // Paper start
 +        BlockPos searchPosition = pos.relative(blockEntity.facing);
 +        Container inventory = getContainerAt(level, searchPosition);
 +        if (org.bukkit.event.inventory.HopperInventorySearchEvent.getHandlerList().getRegisteredListeners().length == 0) return inventory; // Paper
@@ -276,13 +276,13 @@
 +            searchBlock,
 +            org.bukkit.event.inventory.HopperInventorySearchEvent.ContainerType.DESTINATION
 +        );
-+        // CraftBukkit end
++        // Paper end
      }
  
      @Nullable
      private static Container getSourceContainer(Level level, Hopper hopper, BlockPos pos, BlockState state) {
 -        return getContainerAt(level, pos, state, hopper.getLevelX(), hopper.getLevelY() + 1.0, hopper.getLevelZ());
-+        // CraftBukkit start
++        // Paper start
 +        final Container inventory = HopperBlockEntity.getContainerAt(level, pos, state, hopper.getLevelX(), hopper.getLevelY() + 1.0D, hopper.getLevelZ());
 +        if (org.bukkit.event.inventory.HopperInventorySearchEvent.getHandlerList().getRegisteredListeners().length == 0) return inventory; // Paper
 +
@@ -295,7 +295,7 @@
 +            containerBlock,
 +            org.bukkit.event.inventory.HopperInventorySearchEvent.ContainerType.SOURCE
 +        );
-+        // CraftBukkit end
++        // Paper end
      }
  
      public static List<ItemEntity> getItemsAtAndAbove(Level level, Hopper hopper) {

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
@@ -237,7 +237,7 @@
                  }
  
                  destination.setChanged();
-@@ -336,14 +_,57 @@
+@@ -336,14 +_,59 @@
          return stack;
      }
  
@@ -266,6 +266,7 @@
 +        // CraftBukkit start
 +        BlockPos searchPosition = pos.relative(blockEntity.facing);
 +        Container inventory = getContainerAt(level, searchPosition);
++        if (org.bukkit.event.inventory.HopperInventorySearchEvent.getHandlerList().getRegisteredListeners().length == 0) return inventory; // Paper
 +
 +        org.bukkit.craftbukkit.block.CraftBlock hopper = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
 +        org.bukkit.craftbukkit.block.CraftBlock searchBlock = org.bukkit.craftbukkit.block.CraftBlock.at(level, searchPosition);
@@ -283,6 +284,7 @@
 -        return getContainerAt(level, pos, state, hopper.getLevelX(), hopper.getLevelY() + 1.0, hopper.getLevelZ());
 +        // CraftBukkit start
 +        final Container inventory = HopperBlockEntity.getContainerAt(level, pos, state, hopper.getLevelX(), hopper.getLevelY() + 1.0D, hopper.getLevelZ());
++        if (org.bukkit.event.inventory.HopperInventorySearchEvent.getHandlerList().getRegisteredListeners().length == 0) return inventory; // Paper
 +
 +        final BlockPos hopperPos = BlockPos.containing(hopper.getLevelX(), hopper.getLevelY(), hopper.getLevelZ());
 +        org.bukkit.craftbukkit.block.CraftBlock hopperBlock = org.bukkit.craftbukkit.block.CraftBlock.at(level, hopperPos);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
@@ -266,7 +266,7 @@
 +        // Paper start
 +        BlockPos searchPosition = pos.relative(blockEntity.facing);
 +        Container inventory = getContainerAt(level, searchPosition);
-+        if (org.bukkit.event.inventory.HopperInventorySearchEvent.getHandlerList().getRegisteredListeners().length == 0) return inventory; // Paper
++        if (org.bukkit.event.inventory.HopperInventorySearchEvent.getHandlerList().getRegisteredListeners().length == 0) return inventory;
 +
 +        org.bukkit.craftbukkit.block.CraftBlock hopper = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
 +        org.bukkit.craftbukkit.block.CraftBlock searchBlock = org.bukkit.craftbukkit.block.CraftBlock.at(level, searchPosition);
@@ -284,7 +284,7 @@
 -        return getContainerAt(level, pos, state, hopper.getLevelX(), hopper.getLevelY() + 1.0, hopper.getLevelZ());
 +        // Paper start
 +        final Container inventory = HopperBlockEntity.getContainerAt(level, pos, state, hopper.getLevelX(), hopper.getLevelY() + 1.0D, hopper.getLevelZ());
-+        if (org.bukkit.event.inventory.HopperInventorySearchEvent.getHandlerList().getRegisteredListeners().length == 0) return inventory; // Paper
++        if (org.bukkit.event.inventory.HopperInventorySearchEvent.getHandlerList().getRegisteredListeners().length == 0) return inventory;
 +
 +        final BlockPos hopperPos = BlockPos.containing(hopper.getLevelX(), hopper.getLevelY(), hopper.getLevelZ());
 +        org.bukkit.craftbukkit.block.CraftBlock hopperBlock = org.bukkit.craftbukkit.block.CraftBlock.at(level, hopperPos);


### PR DESCRIPTION
Depending on the amount of hoppers on a server this code could be a bit hot, this prevents doing extra work for each hopper to construct an event when no plugin on the server makes use of it.