### PR TITLE
Call PlayerShearEntityEvent for equippable items which can be sheared

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -26470,7 +26470,7 @@ index 8e02980d29a15086805a93f1f1a416f0308c70b9..a7799e8c12713e00124f2caf69f74a61
      }
  
 diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
-index ca9e965a200ae4e9e5e8d53823918a24a56cb742..a5685e0b50610cc8213f34c5db62b475bd54789b 100644
+index e4d25ff84df6a5f6b6ce54e1463d77f3dd0bbbd6..31af863ec41180159c6f5dd0787a10361404c3ba 100644
 --- a/net/minecraft/server/level/ServerChunkCache.java
 +++ b/net/minecraft/server/level/ServerChunkCache.java
 @@ -54,7 +54,7 @@ import net.minecraft.world.level.storage.SavedDataStorage;
@@ -28876,7 +28876,7 @@ index 09b6da207530987b483444cebeadc2f1c9a15247..3666c3efd188508153b6482db425648e
 +    // Paper end - block counting
  }
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 666bd12677e62046d5f56544cadcbf1164211e0d..e5d56fdb5cfd4aa291dbdb879e478134a85c9beb 100644
+index b18c2f4331f66d532e60912e122802b2d741fc19..5e3864c988b06705657fc56688dbc43295ed74b3 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -167,7 +167,7 @@ public abstract class Entity
@@ -29344,7 +29344,7 @@ index 666bd12677e62046d5f56544cadcbf1164211e0d..e5d56fdb5cfd4aa291dbdb879e478134
      }
  
      public InteractionResult interact(final Player player, final InteractionHand hand, final Vec3 location) {
-@@ -4365,15 +4602,17 @@ public abstract class Entity
+@@ -4387,15 +4624,17 @@ public abstract class Entity
      }
  
      public Iterable<Entity> getIndirectPassengers() {
@@ -29370,7 +29370,7 @@ index 666bd12677e62046d5f56544cadcbf1164211e0d..e5d56fdb5cfd4aa291dbdb879e478134
      }
  
      public int countPlayerPassengers() {
-@@ -4684,6 +4923,15 @@ public abstract class Entity
+@@ -4706,6 +4945,15 @@ public abstract class Entity
      }
  
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
@@ -29386,7 +29386,7 @@ index 666bd12677e62046d5f56544cadcbf1164211e0d..e5d56fdb5cfd4aa291dbdb879e478134
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4833,6 +5081,12 @@ public abstract class Entity
+@@ -4855,6 +5103,12 @@ public abstract class Entity
  
      @Override
      public final void setRemoved(final Entity.RemovalReason reason, org.bukkit.event.entity.EntityRemoveEvent.@Nullable Cause cause) { // CraftBukkit - add Bukkit remove cause
@@ -29399,7 +29399,7 @@ index 666bd12677e62046d5f56544cadcbf1164211e0d..e5d56fdb5cfd4aa291dbdb879e478134
          org.bukkit.craftbukkit.event.CraftEventFactory.callEntityRemoveEvent(this, cause); // CraftBukkit
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
          if (this.removalReason == null) {
-@@ -4843,7 +5097,7 @@ public abstract class Entity
+@@ -4865,7 +5119,7 @@ public abstract class Entity
              this.stopRiding();
          }
  
@@ -29408,7 +29408,7 @@ index 666bd12677e62046d5f56544cadcbf1164211e0d..e5d56fdb5cfd4aa291dbdb879e478134
          this.levelCallback.onRemove(reason);
          this.onRemoval(reason);
          // Paper start - Folia schedulers
-@@ -4877,7 +5131,7 @@ public abstract class Entity
+@@ -4899,7 +5153,7 @@ public abstract class Entity
      public boolean shouldBeSaved() {
          return (this.removalReason == null || this.removalReason.shouldSave())
              && !this.isPassenger()
@@ -30025,7 +30025,7 @@ index 892b338a2b0a185511c352ca2bb76ee3890836fd..cc938f43c4a5e947ed87ca2001cbaca4
  
      // Paper start - Affects Spawning API
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index d7edeb01a9842e7cbe4d2ba40360c5604c69001c..85922fd54c703ce8a12452b2b3c5a00f716f79ad 100644
+index 8f88be76fdb84eaeb7f0c2787f00f73d0635dc6d..46ca14a186f23a05bd0e6437adcb67dc09d94d8b 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -87,6 +87,7 @@ import net.minecraft.world.level.storage.LevelData;

--- a/paper-server/patches/features/0025-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0025-Optimise-EntityScheduler-ticking.patch
@@ -66,10 +66,10 @@ index f9da26656b18327e3bcc1537a5f51e84b32cc43a..e69b540be1e0f0c699a57e07057cee74
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.ADVENTURE_CLICK_MANAGER.handleQueue(this.tickCount); // Paper
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.DIALOG_CLICK_MANAGER.handleQueue(this.tickCount); // Paper
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 5e030ff471248f501d8bca6cfa6cc4161a580d4d..5d4ae462c60723291b1c72dc5b933cd04d31133b 100644
+index 44327b202dc3f65fc1adea252899a39e959bf006..f882426d43e88d49b078641e38275d18782de242 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -5148,6 +5148,11 @@ public abstract class Entity
+@@ -5170,6 +5170,11 @@ public abstract class Entity
          this.getBukkitEntity().taskScheduler.retire();
      }
      // Paper end - Folia schedulers

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1813,7 +1813,7 @@
                              LOGGER.warn("Player {} tried to attack an invalid entity", this.player.getPlainTextName());
                          } else if (mainHandItem.isItemEnabled(level.enabledFeatures())) {
                              if (!this.player.cannotAttackWithItem(mainHandItem, 5)) {
-@@ -1821,25 +_,88 @@
+@@ -1821,25 +_,87 @@
                      }
                  }
              }
@@ -1884,12 +1884,11 @@
 +                        if (resendData) {
 +                            // Refresh the current entity metadata
 +                            target.refreshEntityData(ServerGamePacketListenerImpl.this.player);
-+                            // SPIGOT-7136 - Allays
-+                            if (target instanceof net.minecraft.world.entity.animal.allay.Allay || target instanceof net.minecraft.world.entity.animal.equine.AbstractHorse) { // Paper - Fix horse armor desync
++                            if (target instanceof net.minecraft.world.entity.Mob mob) {
 +                                ServerGamePacketListenerImpl.this.send(new net.minecraft.network.protocol.game.ClientboundSetEquipmentPacket(
-+                                    target.getId(), java.util.Arrays.stream(net.minecraft.world.entity.EquipmentSlot.values())
-+                                    .map((slot) -> com.mojang.datafixers.util.Pair.of(slot, ((LivingEntity) target).getItemBySlot(slot).copy()))
-+                                    .collect(Collectors.toList()), true)); // Paper - sanitize
++                                    mob.getId(), java.util.Arrays.stream(EquipmentSlot.values())
++                                    .map(slot -> com.mojang.datafixers.util.Pair.of(slot, mob.getItemBySlot(slot).copy()))
++                                    .toList(), true));
 +                                player.containerMenu.sendAllDataToRemote();
 +                            } else {
 +                                ServerGamePacketListenerImpl.this.player.containerMenu.forceHeldSlot(hand); // Paper - fix slot desync (is this needed?)

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1127,16 +1127,60 @@
          }
  
          if (dropped) {
-@@ -2292,7 +_,9 @@
+@@ -2280,19 +_,43 @@
+     }
+ 
+     private boolean attemptToShearEquipment(final Player player, final InteractionHand hand, final ItemStack heldItem, final Mob target) {
++        // Paper start
++        List<com.mojang.datafixers.util.Pair<EquipmentSlot, ItemStack>> dirtyItems = new java.util.ArrayList<>();
++        boolean result = this.attemptToShearEquipment0(player, hand, heldItem, target, dirtyItems);
++        if (!dirtyItems.isEmpty()) {
++            ((ServerPlayer) player).connection.send(
++                new net.minecraft.network.protocol.game.ClientboundSetEquipmentPacket(target.getId(), dirtyItems, true)
++            );
++        }
++        return result;
++    }
++
++    private boolean attemptToShearEquipment0(final Player player, final InteractionHand hand, final ItemStack heldItem, final Mob target, final List<com.mojang.datafixers.util.Pair<EquipmentSlot, ItemStack>> dirtyItems) {
++        // Paper end
+         for (EquipmentSlot slot : EquipmentSlot.VALUES) {
+             ItemStack itemStack = target.getItemBySlot(slot);
+             Equippable equippable = itemStack.get(DataComponents.EQUIPPABLE);
+             if (equippable != null
+                 && equippable.canBeSheared()
+                 && (!EnchantmentHelper.has(itemStack, EnchantmentEffectComponents.PREVENT_ARMOR_CHANGE) || player.isCreative())) {
++                // Paper start - call PlayerShearEntityEvent
++                List<ItemStack> drops = List.of(itemStack);
++                org.bukkit.event.player.PlayerShearEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerShearEntityEvent(player, target, heldItem, hand, drops);
++                if (event.isCancelled()) {
++                    dirtyItems.add(com.mojang.datafixers.util.Pair.of(slot, itemStack));
++                    continue;
++                }
++                drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
++                // Paper end - call PlayerShearEntityEvent
+                 heldItem.hurtAndBreak(1, player, hand.asEquipmentSlot());
+                 Vec3 equipmentSpawnOffset = this.dimensions.attachments().getAverage(EntityAttachment.PASSENGER);
+                 target.setItemSlotAndDropWhenKilled(slot, ItemStack.EMPTY);
                  this.gameEvent(GameEvent.SHEAR, player);
                  this.playSound(equippable.shearingSound().value());
                  if (this.level() instanceof ServerLevel serverLevel) {
+-                    this.spawnAtLocation(serverLevel, itemStack, equipmentSpawnOffset);
 +                    this.forceDrops = true; // Paper
-                     this.spawnAtLocation(serverLevel, itemStack, equipmentSpawnOffset);
++                    drops.forEach(drop -> this.spawnAtLocation(serverLevel, drop, equipmentSpawnOffset)); // Paper call PlayerShearEntityEvent
 +                    this.forceDrops = false; // Paper
                      CriteriaTriggers.PLAYER_SHEARED_EQUIPMENT.trigger((ServerPlayer)player, itemStack, target);
                  }
  
+@@ -2300,7 +_,7 @@
+             }
+         }
+ 
+-        return false;
++        return !dirtyItems.isEmpty(); // Paper - call PlayerShearEntityEvent
+     }
+ 
+     public boolean canCollideWith(final Entity entity) {
 @@ -2360,7 +_,7 @@
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/cow/MushroomCow.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/cow/MushroomCow.java.patch
@@ -1,20 +1,16 @@
 --- a/net/minecraft/world/entity/animal/cow/MushroomCow.java
 +++ b/net/minecraft/world/entity/animal/cow/MushroomCow.java
-@@ -116,7 +_,17 @@
+@@ -116,7 +_,13 @@
              return InteractionResult.SUCCESS;
          } else if (itemStack.is(Items.SHEARS) && this.readyForShearing()) {
              if (this.level() instanceof ServerLevel level) {
 -                this.shear(level, SoundSource.PLAYERS, itemStack);
-+                // CraftBukkit start
 +                // Paper start - custom shear drops
 +                java.util.List<ItemStack> drops = this.generateDefaultDrops(level, itemStack);
 +                org.bukkit.event.player.PlayerShearEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerShearEntityEvent(player, this, itemStack, hand, drops);
-+                if (event != null) {
-+                    if (event.isCancelled()) return InteractionResult.PASS;
-+                    drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
-+                    // Paper end - custom shear drops
-+                }
-+                // CraftBukkit end
++                if (event.isCancelled()) return InteractionResult.PASS;
++                drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
++                // Paper end - custom shear drops
 +                this.shear(level, SoundSource.PLAYERS, itemStack, drops); // Paper - custom shear drops
                  this.gameEvent(GameEvent.SHEAR, player);
                  itemStack.hurtAndBreak(1, player, hand.asEquipmentSlot());

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/cow/MushroomCow.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/cow/MushroomCow.java.patch
@@ -5,13 +5,13 @@
          } else if (itemStack.is(Items.SHEARS) && this.readyForShearing()) {
              if (this.level() instanceof ServerLevel level) {
 -                this.shear(level, SoundSource.PLAYERS, itemStack);
-+                // Paper start - custom shear drops
++                // Paper start - call PlayerShearEntityEvent
 +                java.util.List<ItemStack> drops = this.generateDefaultDrops(level, itemStack);
 +                org.bukkit.event.player.PlayerShearEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerShearEntityEvent(player, this, itemStack, hand, drops);
 +                if (event.isCancelled()) return InteractionResult.PASS;
 +                drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
-+                // Paper end - custom shear drops
-+                this.shear(level, SoundSource.PLAYERS, itemStack, drops); // Paper - custom shear drops
++                this.shear(level, SoundSource.PLAYERS, itemStack, drops);
++                // Paper end - call PlayerShearEntityEvent
                  this.gameEvent(GameEvent.SHEAR, player);
                  itemStack.hurtAndBreak(1, player, hand.asEquipmentSlot());
              }

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/equine/AbstractChestedHorse.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/equine/AbstractChestedHorse.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/animal/equine/AbstractChestedHorse.java
 +++ b/net/minecraft/world/entity/animal/equine/AbstractChestedHorse.java
-@@ -75,6 +_,16 @@
+@@ -74,6 +_,14 @@
          super.dropEquipment(level);
          if (this.hasChest()) {
              this.spawnAtLocation(level, Blocks.CHEST);

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/golem/CopperGolem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/golem/CopperGolem.java.patch
@@ -20,7 +20,7 @@
      private int idleAnimationStartTick = 0;
      private final AnimationState idleAnimationState = new AnimationState();
      private final AnimationState interactionGetItemAnimationState = new AnimationState();
-@@ -218,7 +_,15 @@
+@@ -218,7 +_,13 @@
          Level level = this.level();
          if (itemStack.is(Items.SHEARS) && this.readyForShearing()) {
              if (level instanceof ServerLevel serverLevel) {
@@ -28,10 +28,8 @@
 +                // Paper start
 +                java.util.List<ItemStack> drops = this.generateDefaultDrops(serverLevel, itemStack);
 +                org.bukkit.event.player.PlayerShearEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerShearEntityEvent(player, this, itemStack, hand, drops);
-+                if (event != null) {
-+                    if (event.isCancelled()) return InteractionResult.PASS;
-+                    drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
-+                }
++                if (event.isCancelled()) return InteractionResult.PASS;
++                drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
 +                this.shear(serverLevel, SoundSource.PLAYERS, itemStack, drops);
 +                // Paper end
                  this.gameEvent(GameEvent.SHEAR, player);

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/golem/CopperGolem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/golem/CopperGolem.java.patch
@@ -25,13 +25,13 @@
          if (itemStack.is(Items.SHEARS) && this.readyForShearing()) {
              if (level instanceof ServerLevel serverLevel) {
 -                this.shear(serverLevel, SoundSource.PLAYERS, itemStack);
-+                // Paper start
++                // Paper start - call PlayerShearEntityEvent
 +                java.util.List<ItemStack> drops = this.generateDefaultDrops(serverLevel, itemStack);
 +                org.bukkit.event.player.PlayerShearEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerShearEntityEvent(player, this, itemStack, hand, drops);
 +                if (event.isCancelled()) return InteractionResult.PASS;
 +                drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
 +                this.shear(serverLevel, SoundSource.PLAYERS, itemStack, drops);
-+                // Paper end
++                // Paper end - call PlayerShearEntityEvent
                  this.gameEvent(GameEvent.SHEAR, player);
                  itemStack.hurtAndBreak(1, player, hand);
              }

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/golem/SnowGolem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/golem/SnowGolem.java.patch
@@ -23,15 +23,15 @@
          if (itemStack.is(Items.SHEARS) && this.readyForShearing()) {
              if (this.level() instanceof ServerLevel level) {
 -                this.shear(level, SoundSource.PLAYERS, itemStack);
-+                // Paper start - custom shear drops
++                // Paper start - call PlayerShearEntityEvent
 +                java.util.List<ItemStack> drops = this.generateDefaultDrops(level, itemStack);
 +                org.bukkit.event.player.PlayerShearEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerShearEntityEvent(player, this, itemStack, hand, drops);
 +                if (event.isCancelled()) {
 +                    return InteractionResult.PASS;
 +                }
 +                drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
-+                // Paper end - custom shear drops
-+                this.shear(level, SoundSource.PLAYERS, itemStack, drops); // Paper - custom shear drops
++                this.shear(level, SoundSource.PLAYERS, itemStack, drops);
++                // Paper end - call PlayerShearEntityEvent
                  this.gameEvent(GameEvent.SHEAR, player);
                  itemStack.hurtAndBreak(1, player, hand.asEquipmentSlot());
              }

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/golem/SnowGolem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/golem/SnowGolem.java.patch
@@ -18,23 +18,19 @@
                      this.level().gameEvent(GameEvent.BLOCK_PLACE, snowPos, GameEvent.Context.of(this, snow));
                  }
              }
-@@ -138,7 +_,19 @@
+@@ -138,7 +_,15 @@
          ItemStack itemStack = player.getItemInHand(hand);
          if (itemStack.is(Items.SHEARS) && this.readyForShearing()) {
              if (this.level() instanceof ServerLevel level) {
 -                this.shear(level, SoundSource.PLAYERS, itemStack);
-+                // CraftBukkit start
 +                // Paper start - custom shear drops
 +                java.util.List<ItemStack> drops = this.generateDefaultDrops(level, itemStack);
 +                org.bukkit.event.player.PlayerShearEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerShearEntityEvent(player, this, itemStack, hand, drops);
-+                if (event != null) {
-+                    if (event.isCancelled()) {
-+                        return InteractionResult.PASS;
-+                    }
-+                    drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
-+                    // Paper end - custom shear drops
++                if (event.isCancelled()) {
++                    return InteractionResult.PASS;
 +                }
-+                // CraftBukkit end
++                drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
++                // Paper end - custom shear drops
 +                this.shear(level, SoundSource.PLAYERS, itemStack, drops); // Paper - custom shear drops
                  this.gameEvent(GameEvent.SHEAR, player);
                  itemStack.hurtAndBreak(1, player, hand.asEquipmentSlot());

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/sheep/Sheep.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/sheep/Sheep.java.patch
@@ -5,15 +5,15 @@
          if (itemStack.is(Items.SHEARS)) {
              if (this.level() instanceof ServerLevel level && this.readyForShearing()) {
 -                this.shear(level, SoundSource.PLAYERS, itemStack);
-+                // Paper start - custom shear drops
++                // Paper start - call PlayerShearEntityEvent
 +                java.util.List<ItemStack> drops = this.generateDefaultDrops(level, itemStack);
 +                org.bukkit.event.player.PlayerShearEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerShearEntityEvent(player, this, itemStack, hand, drops);
 +                if (event.isCancelled()) {
 +                    return InteractionResult.PASS;
 +                }
 +                drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
-+                // Paper end - custom shear drops
-+                this.shear(level, SoundSource.PLAYERS, itemStack, drops); // Paper - custom shear drops
++                this.shear(level, SoundSource.PLAYERS, itemStack, drops);
++                // Paper end - call PlayerShearEntityEvent
                  this.gameEvent(GameEvent.SHEAR, player);
                  itemStack.hurtAndBreak(1, player, hand.asEquipmentSlot());
                  return InteractionResult.SUCCESS_SERVER;

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/sheep/Sheep.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/sheep/Sheep.java.patch
@@ -1,22 +1,18 @@
 --- a/net/minecraft/world/entity/animal/sheep/Sheep.java
 +++ b/net/minecraft/world/entity/animal/sheep/Sheep.java
-@@ -140,7 +_,19 @@
+@@ -140,7 +_,15 @@
          ItemStack itemStack = player.getItemInHand(hand);
          if (itemStack.is(Items.SHEARS)) {
              if (this.level() instanceof ServerLevel level && this.readyForShearing()) {
 -                this.shear(level, SoundSource.PLAYERS, itemStack);
-+                // CraftBukkit start
 +                // Paper start - custom shear drops
 +                java.util.List<ItemStack> drops = this.generateDefaultDrops(level, itemStack);
 +                org.bukkit.event.player.PlayerShearEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerShearEntityEvent(player, this, itemStack, hand, drops);
-+                if (event != null) {
-+                    if (event.isCancelled()) {
-+                        return InteractionResult.PASS;
-+                    }
-+                    drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
-+                    // Paper end - custom shear drops
++                if (event.isCancelled()) {
++                    return InteractionResult.PASS;
 +                }
-+                // CraftBukkit end
++                drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
++                // Paper end - custom shear drops
 +                this.shear(level, SoundSource.PLAYERS, itemStack, drops); // Paper - custom shear drops
                  this.gameEvent(GameEvent.SHEAR, player);
                  itemStack.hurtAndBreak(1, player, hand.asEquipmentSlot());

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/skeleton/Bogged.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/skeleton/Bogged.java.patch
@@ -1,22 +1,18 @@
 --- a/net/minecraft/world/entity/monster/skeleton/Bogged.java
 +++ b/net/minecraft/world/entity/monster/skeleton/Bogged.java
-@@ -72,7 +_,19 @@
+@@ -72,7 +_,15 @@
          ItemStack itemStack = player.getItemInHand(hand);
          if (itemStack.is(Items.SHEARS) && this.readyForShearing()) {
              if (this.level() instanceof ServerLevel level) {
 -                this.shear(level, SoundSource.PLAYERS, itemStack);
-+                // CraftBukkit start
 +                // Paper start - custom shear drops
 +                java.util.List<ItemStack> drops = this.generateDefaultDrops(level, itemStack);
 +                org.bukkit.event.player.PlayerShearEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerShearEntityEvent(player, this, itemStack, hand, drops);
-+                if (event != null) {
-+                    if (event.isCancelled()) {
-+                        return InteractionResult.PASS;
-+                    }
-+                    drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
-+                    // Paper end - custom shear drops
++                if (event.isCancelled()) {
++                    return InteractionResult.PASS;
 +                }
-+                // CraftBukkit end
++                drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
++                // Paper end - custom shear drops
 +                this.shear(level, SoundSource.PLAYERS, itemStack, drops); // Paper - custom shear drops
                  this.gameEvent(GameEvent.SHEAR, player);
                  itemStack.hurtAndBreak(1, player, hand.asEquipmentSlot());

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/skeleton/Bogged.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/skeleton/Bogged.java.patch
@@ -5,15 +5,15 @@
          if (itemStack.is(Items.SHEARS) && this.readyForShearing()) {
              if (this.level() instanceof ServerLevel level) {
 -                this.shear(level, SoundSource.PLAYERS, itemStack);
-+                // Paper start - custom shear drops
++                // Paper start - call PlayerShearEntityEvent
 +                java.util.List<ItemStack> drops = this.generateDefaultDrops(level, itemStack);
 +                org.bukkit.event.player.PlayerShearEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerShearEntityEvent(player, this, itemStack, hand, drops);
 +                if (event.isCancelled()) {
 +                    return InteractionResult.PASS;
 +                }
 +                drops = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getDrops());
-+                // Paper end - custom shear drops
-+                this.shear(level, SoundSource.PLAYERS, itemStack, drops); // Paper - custom shear drops
++                this.shear(level, SoundSource.PLAYERS, itemStack, drops);
++                // Paper end - call PlayerShearEntityEvent
                  this.gameEvent(GameEvent.SHEAR, player);
                  itemStack.hurtAndBreak(1, player, hand.asEquipmentSlot());
              }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -1707,13 +1707,9 @@ public class CraftEventFactory {
     }
 
     public static PlayerShearEntityEvent handlePlayerShearEntityEvent(net.minecraft.world.entity.player.Player player, Entity sheared, ItemStack shears, InteractionHand hand, List<ItemStack> drops) { // Paper - custom shear drops
-        if (!(player instanceof ServerPlayer)) {
-            return null; // Paper - custom shear drops
-        }
-
-        PlayerShearEntityEvent event = new PlayerShearEntityEvent((Player) player.getBukkitEntity(), sheared.getBukkitEntity(), CraftItemStack.asCraftMirror(shears), (hand == InteractionHand.OFF_HAND ? EquipmentSlot.OFF_HAND : EquipmentSlot.HAND), Lists.transform(drops, CraftItemStack::asCraftMirror)); // Paper - custom shear drops
+        PlayerShearEntityEvent event = new PlayerShearEntityEvent(((ServerPlayer) player).getBukkitEntity(), sheared.getBukkitEntity(), CraftItemStack.asCraftMirror(shears), CraftEquipmentSlot.getHand(hand), Lists.transform(drops, CraftItemStack::asCraftMirror)); // Paper - custom shear drops
         Bukkit.getPluginManager().callEvent(event);
-        return event; // Paper - custom shear drops
+        return event;
     }
 
     public static Cancellable handleStatisticsIncrease(net.minecraft.world.entity.player.Player entityHuman, net.minecraft.stats.Stat<?> statistic, int current, int newValue) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -1700,14 +1700,14 @@ public class CraftEventFactory {
         return event.callEvent();
     }
 
-    public static BlockShearEntityEvent callBlockShearEntityEvent(Entity animal, org.bukkit.block.Block dispenser, CraftItemStack is, List<ItemStack> drops) { // Paper - custom shear drops
-        BlockShearEntityEvent bse = new BlockShearEntityEvent(dispenser, animal.getBukkitEntity(), is, Lists.transform(drops, CraftItemStack::asCraftMirror)); // Paper - custom shear drops
+    public static BlockShearEntityEvent callBlockShearEntityEvent(Entity animal, org.bukkit.block.Block dispenser, CraftItemStack is, List<ItemStack> drops) {
+        BlockShearEntityEvent bse = new BlockShearEntityEvent(dispenser, animal.getBukkitEntity(), is, Lists.transform(drops, CraftItemStack::asCraftMirror));
         Bukkit.getPluginManager().callEvent(bse);
         return bse;
     }
 
-    public static PlayerShearEntityEvent handlePlayerShearEntityEvent(net.minecraft.world.entity.player.Player player, Entity sheared, ItemStack shears, InteractionHand hand, List<ItemStack> drops) { // Paper - custom shear drops
-        PlayerShearEntityEvent event = new PlayerShearEntityEvent(((ServerPlayer) player).getBukkitEntity(), sheared.getBukkitEntity(), CraftItemStack.asCraftMirror(shears), CraftEquipmentSlot.getHand(hand), Lists.transform(drops, CraftItemStack::asCraftMirror)); // Paper - custom shear drops
+    public static PlayerShearEntityEvent handlePlayerShearEntityEvent(net.minecraft.world.entity.player.Player player, Entity sheared, ItemStack shears, InteractionHand hand, List<ItemStack> drops) {
+        PlayerShearEntityEvent event = new PlayerShearEntityEvent(((ServerPlayer) player).getBukkitEntity(), sheared.getBukkitEntity(), CraftItemStack.asCraftMirror(shears), CraftEquipmentSlot.getHand(hand), Lists.transform(drops, CraftItemStack::asCraftMirror));
         Bukkit.getPluginManager().callEvent(event);
         return event;
     }


### PR DESCRIPTION
With Minecraft 1.21.6+ equippable items can be sheared off from mobs, e.g. a saddle from a horse.

Currently PlayerShearEntityEvents are not called for those interactions so plugins can't prevent that.

Closes https://github.com/EngineHub/WorldGuard/issues/2227