### PR TITLE
Fix some issues with PlayerLeashEntityEvent

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/block/BlockShearEntityEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/BlockShearEntityEvent.java
@@ -12,7 +12,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Event fired when a dispenser shears a nearby sheep.
+ * Event fired when a dispenser shears a nearby entity.
  */
 public class BlockShearEntityEvent extends BlockEvent implements Cancellable {
 
@@ -43,9 +43,9 @@ public class BlockShearEntityEvent extends BlockEvent implements Cancellable {
     }
 
     /**
-     * Gets the item used to shear this sheep.
+     * Gets the item used to shear this entity.
      *
-     * @return the item used to shear this sheep.
+     * @return the item used to shear this entity.
      */
     @NotNull
     public ItemStack getTool() {

--- a/paper-server/patches/sources/net/minecraft/world/item/LeadItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/LeadItem.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/LeadItem.java
 +++ b/net/minecraft/world/item/LeadItem.java
-@@ -26,24 +_,46 @@
+@@ -26,25 +_,38 @@
          if (blockState.is(BlockTags.FENCES)) {
              Player player = context.getPlayer();
              if (!level.isClientSide() && player != null) {
@@ -18,9 +18,7 @@
          List<Leashable> list = Leashable.leashableInArea(level, Vec3.atCenterOf(pos), leashable1 -> leashable1.getLeashHolder() == player);
          boolean flag = false;
  
--        for (Leashable leashable : list) {
-+        for (java.util.Iterator<Leashable> iterator = list.iterator(); iterator.hasNext();) { // Paper - use iterator to remove
-+            Leashable leashable = iterator.next(); // Paper - use iterator to remove
+         for (Leashable leashable : list) {
              if (leashFenceKnotEntity == null) {
 -                leashFenceKnotEntity = LeashFenceKnotEntity.getOrCreateKnot(level, pos);
 +                // CraftBukkit start - fire HangingPlaceEvent
@@ -32,7 +30,7 @@
 +                    level.getCraftServer().getPluginManager().callEvent(event);
 +
 +                    if (event.isCancelled()) {
-+                        leashFenceKnotEntity.discard(null); // CraftBukkit - add Bukkit remove cause
++                        leashFenceKnotEntity.discard(null);
 +                        return InteractionResult.PASS;
 +                    }
 +                }
@@ -40,17 +38,11 @@
                  leashFenceKnotEntity.playPlacementSound();
              }
  
-+            // CraftBukkit start
-+            if (leashable instanceof net.minecraft.world.entity.Entity leashed) {
-+                if (org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerLeashEntityEvent(leashed, leashFenceKnotEntity, player, interactionHand).isCancelled()) {
-+                    iterator.remove();
-+                    continue;
-+                }
-+            }
-+            // CraftBukkit end
-             if (leashable.canHaveALeashAttachedTo(leashFenceKnotEntity)) {
+-            if (leashable.canHaveALeashAttachedTo(leashFenceKnotEntity)) {
++            if (leashable.canHaveALeashAttachedTo(leashFenceKnotEntity) && org.bukkit.craftbukkit.event.CraftEventFactory.handlePlayerLeashEntityEvent(leashable, leashFenceKnotEntity, player, interactionHand)) { // Paper - leash event
                  leashable.setLeashedTo(leashFenceKnotEntity, true);
                  flag = true;
+             }
 @@ -54,7 +_,18 @@
              level.gameEvent(GameEvent.BLOCK_ATTACH, pos, GameEvent.Context.of(player));
              return InteractionResult.SUCCESS_SERVER;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -6,6 +6,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.mojang.authlib.GameProfile;
 import com.mojang.datafixers.util.Either;
+import io.papermc.paper.adventure.PaperAdventure;
+import io.papermc.paper.connection.HorriblePlayerLoginEventHack;
+import io.papermc.paper.connection.PlayerConnection;
+import io.papermc.paper.event.connection.PlayerConnectionValidateLoginEvent;
+import io.papermc.paper.event.entity.ItemTransportingEntityValidateTargetEvent;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -14,17 +19,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import io.papermc.paper.adventure.PaperAdventure;
-import io.papermc.paper.connection.HorriblePlayerLoginEventHack;
-import io.papermc.paper.connection.PlayerConnection;
-import io.papermc.paper.event.connection.PlayerConnectionValidateLoginEvent;
-import io.papermc.paper.event.entity.ItemTransportingEntityValidateTargetEvent;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ServerboundContainerClosePacket;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -1540,8 +1539,8 @@ public class CraftEventFactory {
     }
 
     public static boolean handlePlayerLeashEntityEvent(Leashable leashed, Entity leashHolder, net.minecraft.world.entity.player.Player player, InteractionHand hand) {
-        if (!(leashed instanceof final Entity leashedEntity)) return false;
-        return callPlayerLeashEntityEvent(leashedEntity, leashHolder, player, hand).callEvent();
+        if (!(leashed instanceof final Entity leashedEntity)) return true;
+        return !callPlayerLeashEntityEvent(leashedEntity, leashHolder, player, hand).isCancelled();
     }
 
     public static @Nullable PlayerLeashEntityEvent callPlayerLeashEntityEvent(Leashable leashed, Entity leashHolder, net.minecraft.world.entity.player.Player player, InteractionHand hand) {


### PR DESCRIPTION
- a duplicate event when interact on an existing knot (reported in https://github.com/PaperMC/Paper/pull/12996)
- leashableInArea return an unmodifiable list, yet when the event is cancelled an element is removed, the new boolean should be enough to prevent the game event
- only call the event if the entity can actually be tied