### PR TITLE
Allow not change levels and avoid max level override for AnvilView#bypassEnchantmentLevelRestriction false

### DIFF
--- a/paper-api/src/main/java/org/bukkit/inventory/view/AnvilView.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/view/AnvilView.java
@@ -88,7 +88,22 @@ public interface AnvilView extends InventoryView {
      */
     void bypassEnchantmentLevelRestriction(boolean bypassEnchantmentLevelRestriction);
 
-    boolean keepLevels();
+    /**
+     * Returns whether this view will override the vanilla enchantment level to {@link org.bukkit.enchantments.Enchantment#getMaxLevel()}
+     * when combining enchantments to an item or not.
+     * <br>
+     * <b>Only is considered when {@link #bypassesEnchantmentLevelRestriction()} is {@code true}</b>
+     * <br>
+     * By default, vanilla will limit enchantments applied to items to the respective
+     * {@link org.bukkit.enchantments.Enchantment#getMaxLevel()}, even if the applied enchantment itself is above said
+     * limit.
+     * Disabling this limit via {@link AnvilView#shouldOverrideLevelsInRestriction(boolean)} allows for, e.g., enchanted
+     * books with enchantments up to the limit to be applied fully, even if their enchantments are beyond the limit.
+     *
+     * @return {@code true} if this view should override levels if are upper the max.
+     * @see #bypassesEnchantmentLevelRestriction()
+     */
+    boolean shouldOverrideLevelsInRestriction();
 
-    public void setKeepLevelsWithRestriction(boolean keepLevels);
+    public void shouldOverrideLevelsInRestriction(boolean keepLevels);
 }

--- a/paper-api/src/main/java/org/bukkit/inventory/view/AnvilView.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/view/AnvilView.java
@@ -2,16 +2,16 @@ package org.bukkit.inventory.view;
 
 import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.InventoryView;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An instance of {@link InventoryView} which provides extra methods related to
  * anvil view data.
  */
+@NullMarked
 public interface AnvilView extends InventoryView {
 
-    @NotNull
     @Override
     AnvilInventory getTopInventory();
 
@@ -66,7 +66,6 @@ public interface AnvilView extends InventoryView {
      */
     void setMaximumRepairCost(int levels);
 
-    // Paper start - bypass anvil level restrictions
     /**
      * Returns whether this view will bypass the vanilla enchantment level restriction
      * when applying enchantments to an item or not.
@@ -88,5 +87,8 @@ public interface AnvilView extends InventoryView {
      * @see AnvilView#bypassesEnchantmentLevelRestriction()
      */
     void bypassEnchantmentLevelRestriction(boolean bypassEnchantmentLevelRestriction);
-    // Paper end - bypass anvil level restrictions
+
+    boolean keepLevels();
+
+    public void setKeepLevelsWithRestriction(boolean keepLevels);
 }

--- a/paper-server/patches/sources/net/minecraft/world/inventory/AnvilMenu.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/AnvilMenu.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/net/minecraft/world/inventory/AnvilMenu.java
-@@ -44,6 +_,12 @@
+@@ -44,6 +_,13 @@
      private static final int ADDITIONAL_SLOT_X_PLACEMENT = 76;
      private static final int RESULT_SLOT_X_PLACEMENT = 134;
      private static final int SLOT_Y_PLACEMENT = 47;
@@ -10,6 +10,7 @@
 +    private org.bukkit.craftbukkit.inventory.view.CraftAnvilView bukkitEntity;
 +    // CraftBukkit end
 +    public boolean bypassEnchantmentLevelRestriction = false; // Paper - bypass anvil level restrictions
++    public boolean keepLevels = false; // Paper
  
      public AnvilMenu(int containerId, Inventory playerInventory) {
          this(containerId, playerInventory, ContainerLevelAccess.NULL);
@@ -70,15 +71,17 @@
                          return;
                      }
  
-@@ -197,7 +_,7 @@
+@@ -197,8 +_,8 @@
                              flag1 = true;
                          } else {
                              flag = true;
 -                            if (intValue > enchantment.getMaxLevel()) {
+-                                intValue = enchantment.getMaxLevel();
 +                            if (intValue > enchantment.getMaxLevel() && !this.bypassEnchantmentLevelRestriction) { // Paper - bypass anvil level restrictions
-                                 intValue = enchantment.getMaxLevel();
++                                intValue = this.keepLevels ? Math.max(entry.getIntValue(), level) : enchantment.getMaxLevel(); // Paper
                              }
  
+                             mutable.set(holder, intValue);
 @@ -215,8 +_,8 @@
                      }
  

--- a/paper-server/patches/sources/net/minecraft/world/inventory/AnvilMenu.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/AnvilMenu.java.patch
@@ -10,7 +10,7 @@
 +    private org.bukkit.craftbukkit.inventory.view.CraftAnvilView bukkitEntity;
 +    // CraftBukkit end
 +    public boolean bypassEnchantmentLevelRestriction = false; // Paper - bypass anvil level restrictions
-+    public boolean keepLevels = false; // Paper
++    public boolean shouldOverrideLevelsInRestriction = true; // Paper - override levels if cannot bypass anvil level restrictions
  
      public AnvilMenu(int containerId, Inventory playerInventory) {
          this(containerId, playerInventory, ContainerLevelAccess.NULL);
@@ -78,7 +78,7 @@
 -                            if (intValue > enchantment.getMaxLevel()) {
 -                                intValue = enchantment.getMaxLevel();
 +                            if (intValue > enchantment.getMaxLevel() && !this.bypassEnchantmentLevelRestriction) { // Paper - bypass anvil level restrictions
-+                                intValue = this.keepLevels ? Math.max(entry.getIntValue(), level) : enchantment.getMaxLevel(); // Paper
++                                intValue = this.shouldOverrideLevelsInRestriction ? enchantment.getMaxLevel() : Math.max(entry.getIntValue(), level); // Paper - override level
                              }
  
                              mutable.set(holder, intValue);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/view/CraftAnvilView.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/view/CraftAnvilView.java
@@ -61,13 +61,13 @@ public class CraftAnvilView extends CraftInventoryView<AnvilMenu, AnvilInventory
     }
 
     @Override
-    public boolean keepLevels() {
-        return this.container.keepLevels;
+    public boolean shouldOverrideLevelsInRestriction() {
+        return this.container.shouldOverrideLevelsInRestriction;
     }
 
     @Override
-    public void setKeepLevelsWithRestriction(final boolean keepLevels) {
-        this.container.keepLevels = keepLevels;
+    public void shouldOverrideLevelsInRestriction(final boolean shouldOverrideLevelsInRestriction) {
+        this.container.shouldOverrideLevelsInRestriction = shouldOverrideLevelsInRestriction;
     }
 
     public void updateFromLegacy(CraftInventoryAnvil legacy) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/view/CraftAnvilView.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/view/CraftAnvilView.java
@@ -60,6 +60,16 @@ public class CraftAnvilView extends CraftInventoryView<AnvilMenu, AnvilInventory
         this.container.bypassEnchantmentLevelRestriction = bypassEnchantmentLevelRestriction;
     }
 
+    @Override
+    public boolean keepLevels() {
+        return this.container.keepLevels;
+    }
+
+    @Override
+    public void setKeepLevelsWithRestriction(final boolean keepLevels) {
+        this.container.keepLevels = keepLevels;
+    }
+
     public void updateFromLegacy(CraftInventoryAnvil legacy) {
         if (legacy.isRepairCostSet()) {
             this.setRepairCost(legacy.getRepairCost());


### PR DESCRIPTION
First sorry.
Related to [a discord message](https://canary.discord.com/channels/289587909051416579/925530366192779286/1408898194607313082) this PR try to allow modify the behaviour when combining two enchants but one is over the max, currently the bypassEnchantmentLevelRestriction just allow set the "ilegal" value but cannot change if wanna replace the level with max or just keep the max levels used.