### PR TITLE
feat: Add PlayerGameModeChangeEvent.Cause.HOTKEY_GAMEMODE

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
@@ -135,7 +135,7 @@ public class PlayerGameModeChangeEvent extends PlayerEvent implements Cancellabl
         /**
          * When the player changes their gamemode using the F3+F4 game mode switcher.
          */
-        SWITCH_GAMEMODE,
+        HOTKEY_GAMEMODE,
         /**
          * This cause is only used if a plugin fired their own
          * {@link PlayerGameModeChangeEvent} and did not include a

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
@@ -133,6 +133,10 @@ public class PlayerGameModeChangeEvent extends PlayerEvent implements Cancellabl
          */
         HARDCORE_DEATH,
         /**
+         * When the player changes their gamemode using the F3+F4 game mode switcher.
+         */
+        SWITCH_GAMEMODE,
+        /**
          * This cause is only used if a plugin fired their own
          * {@link PlayerGameModeChangeEvent} and did not include a
          * cause. Can usually be ignored.

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -34,6 +34,7 @@
 +import org.bukkit.event.player.PlayerTeleportEvent;
 +import org.bukkit.event.player.PlayerToggleFlightEvent;
 +import org.bukkit.event.player.PlayerToggleSprintEvent;
++import net.minecraft.network.protocol.game.ServerboundChangeGameModePacket;
 +// CraftBukkit end
 +
  public class ServerGamePacketListenerImpl
@@ -2648,4 +2649,12 @@
 +        return this.playerGameConnection;
 +    }
 +    // Paper end
++
++    @Override
++    public void handleChangeGameMode(ServerboundChangeGameModePacket packet) {
++        PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
++        // Paper start - Use SWITCH_GAMEMODE cause for F3+F4 game mode switcher
++        this.player.setGameMode(packet.gameMode(), org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.SWITCH_GAMEMODE, null);
++        // Paper end - Use SWITCH_GAMEMODE cause for F3+F4 game mode switcher
++    }
  }

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -2653,8 +2653,8 @@
 +    @Override
 +    public void handleChangeGameMode(ServerboundChangeGameModePacket packet) {
 +        PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
-+        // Paper start - Use SWITCH_GAMEMODE cause for F3+F4 game mode switcher
-+        this.player.setGameMode(packet.gameMode(), org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.SWITCH_GAMEMODE, null);
-+        // Paper end - Use SWITCH_GAMEMODE cause for F3+F4 game mode switcher
++        // Paper start - Use HOTKEY_GAMEMODE cause for F3+F4 game mode switcher
++        this.player.setGameMode(packet.gameMode(), org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.HOTKEY_GAMEMODE, null);
++        // Paper end - Use HOTKEY_GAMEMODE cause for F3+F4 game mode switcher
 +    }
  }


### PR DESCRIPTION
## Description

Adds `PlayerGameModeChangeEvent.Cause.SWITCH_GAMEMODE` to handle game mode changes from the F3+F4 game mode switcher introduced in Minecraft 1.21.6.

Previously, these changes would fire with `Cause.UNKNOWN`, making it impossible for plugins to distinguish them from other game mode changes.

## Changes

- Added `SWITCH_GAMEMODE` cause to `PlayerGameModeChangeEvent.Cause` enum
- Added packet handler for `ServerboundChangeGameModePacket` in `ServerGamePacketListenerImpl`
- Uses `Cause.SWITCH_GAMEMODE` when handling F3+F4 game mode changes

## Usage

```java
@EventHandler
public void onGameModeChange(PlayerGameModeChangeEvent event) {
    if (event.getCause() == PlayerGameModeChangeEvent.Cause.SWITCH_GAMEMODE) {
        // Handle F3+F4 game mode change
    }
}
```

Closes #13017