### PR TITLE
chore: remove experimental status from Damageable#damage

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Damageable.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Damageable.java
@@ -2,7 +2,6 @@ package org.bukkit.entity;
 
 import org.bukkit.attribute.Attribute;
 import org.bukkit.damage.DamageSource;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -33,7 +32,6 @@ public interface Damageable extends Entity {
      * @param amount amount of damage to deal
      * @param damageSource source to which the damage should be attributed
      */
-    @ApiStatus.Experimental
     void damage(double amount, @NotNull DamageSource damageSource);
 
     /**


### PR DESCRIPTION
Someone pointed this out in discord, looks like it was forgotten in #12898.