### PR TITLE
Only log name instead of full profile for configuration phase disconnects

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
@@ -28,18 +28,20 @@
  
      @Override
      protected GameProfile playerProfile() {
-@@ -61,6 +_,11 @@
+@@ -61,7 +_,12 @@
  
      @Override
      public void onDisconnect(DisconnectionDetails details) {
+-        LOGGER.info("{} lost connection: {}", this.gameProfile, details.reason().getString());
 +        // Paper start - Debugging
 +        if (this.server.isDebugging()) {
 +            ServerConfigurationPacketListenerImpl.LOGGER.info("{} lost connection: {}, while in configuration phase {}", this.gameProfile, details.reason().getString(), this.currentTask != null ? this.currentTask.type().id() : "null");
 +        } else
 +        // Paper end
-         LOGGER.info("{} lost connection: {}", this.gameProfile, details.reason().getString());
++        LOGGER.info("{} lost connection: {}", this.gameProfile.getName(), details.reason().getString()); // Paper - log name instead of whole profile (as with other similar messages)
          super.onDisconnect(details);
      }
+ 
 @@ -71,10 +_,15 @@
      }
  

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
@@ -35,7 +35,7 @@
 -        LOGGER.info("{} lost connection: {}", this.gameProfile, details.reason().getString());
 +        // Paper start - Debugging
 +        if (this.server.isDebugging()) {
-+            ServerConfigurationPacketListenerImpl.LOGGER.info("{} lost connection: {}, while in configuration phase {}", this.gameProfile, details.reason().getString(), this.currentTask != null ? this.currentTask.type().id() : "null");
++            ServerConfigurationPacketListenerImpl.LOGGER.info("{} lost connection: {}, while in configuration phase {}", this.gameProfile.getName(), details.reason().getString(), this.currentTask != null ? this.currentTask.type().id() : "null");
 +        } else
 +        // Paper end
 +        LOGGER.info("{} lost connection: {}", this.gameProfile.getName(), details.reason().getString()); // Paper - log name instead of whole profile (as with other similar messages)


### PR DESCRIPTION
fixes #13029

The login listener already logs the name -> id mapping.

The disconnect is still logged twice... but it's much less spammy now.