### PR TITLE
Fix MC-118740

### DIFF
--- a/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0016-Moonrise-optimisation-patches.patch
@@ -23867,7 +23867,7 @@ index 46de98a6bbbae48c4837e1e588ba198a363d2dde..fd3553bdc1c3cdbf6aa3dc00e0a4987f
                  thread1 -> {
                      DedicatedServer dedicatedServer1 = new DedicatedServer(
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index f1346c2dc8fcf24a1ed945dbc57775daaa683b72..3b2b9d959e704abf87fd074418b47ff741a2a65e 100644
+index 530a753043f6673dbca3b95ad59cf3b1b482741a..88583ca23ef16a515deb2b90b7e2d61a54ab4f20 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -173,7 +173,7 @@ import net.minecraft.world.phys.Vec2;
@@ -24037,7 +24037,7 @@ index f1346c2dc8fcf24a1ed945dbc57775daaa683b72..3b2b9d959e704abf87fd074418b47ff7
          // Paper start - Improved watchdog support - move final shutdown items here
          Util.shutdownExecutors();
          try {
-@@ -1170,6 +1250,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1171,6 +1251,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                      profilerFiller.push("tick");
                      this.tickFrame.start();
                      this.tickServer(flag ? () -> false : this::haveTime);
@@ -24051,7 +24051,7 @@ index f1346c2dc8fcf24a1ed945dbc57775daaa683b72..3b2b9d959e704abf87fd074418b47ff7
                      this.tickFrame.end();
                      profilerFiller.popPush("nextTickWait");
                      this.mayHaveDelayedTasks = true;
-@@ -1340,6 +1427,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1341,6 +1428,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      private boolean pollTaskInternal() {
          if (super.pollTask()) {
@@ -24059,7 +24059,7 @@ index f1346c2dc8fcf24a1ed945dbc57775daaa683b72..3b2b9d959e704abf87fd074418b47ff7
              return true;
          } else {
              boolean ret = false; // Paper - force execution of all worlds, do not just bias the first
-@@ -2482,6 +2570,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2483,6 +2571,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
  
@@ -27691,7 +27691,7 @@ index 49008b4cbaead8a66a93d2b0d4b50b335a6c3eed..f9c96bbdc54e68b9216b7f8662bfae03
      }
  
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 537821a41e4ef4be17b8859a23107cf726569112..514ff8543dbbe1c6ae47c7fd6c1545b87d3b2927 100644
+index f1706da6a1290a49cfcfb567e68acd5872c527ad..dcf371aeb3696fbee72a8a7e7cbd7677a788819b 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -193,7 +193,7 @@ import net.minecraft.world.scores.Team;
@@ -28728,7 +28728,7 @@ index 8cc5c0716392ba06501542ff5cbe71ee43979e5d..09fd99c9cbd23b5f3c899bfb00c9b896
 +    // Paper end - block counting
  }
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 7f4c5c40b1d16595f41fb97633036491861427a4..f148e7ecf00a406f4de36b11641fb6bfbe1f5eec 100644
+index 17d9e4699e8e2ce934c25d34d7269bdda5c87d00..295d40341df325b3fb6f14164283863a5a96b8bf 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -147,7 +147,7 @@ import net.minecraft.world.waypoints.WaypointTransmitter;

--- a/paper-server/patches/features/0024-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0024-Incremental-chunk-and-player-saving.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Incremental chunk and player saving
 
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index dc47259e40089a4793d950d4c3dc5bcc51ff680f..34b10db71d22cb7211dcfc5565e6833c8d4d2413 100644
+index 88583ca23ef16a515deb2b90b7e2d61a54ab4f20..88a1e2d2b9172b6db53a57b969c29ac2f837ed98 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -955,7 +955,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -17,7 +17,7 @@ index dc47259e40089a4793d950d4c3dc5bcc51ff680f..34b10db71d22cb7211dcfc5565e6833c
              var4 = this.saveAllChunks(suppressLog, flush, forced);
          } finally {
              this.isSaving = false;
-@@ -1534,9 +1534,29 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1535,9 +1535,29 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
  
          this.ticksUntilAutosave--;
@@ -83,7 +83,7 @@ index 34b7769663e235b93c6388ab0c92c00f0297e42f..dda8d38ef61672cc714d9e5a475f9b04
          // Paper start - add close param
          this.save(progress, flush, skipSave, false);
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 514ff8543dbbe1c6ae47c7fd6c1545b87d3b2927..4726c980ad52c1300de16b7607006ea4a13325eb 100644
+index dcf371aeb3696fbee72a8a7e7cbd7677a788819b..283074b1097768887e057e08843d5a2c70bbccac 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -195,6 +195,7 @@ import org.slf4j.Logger;
@@ -95,7 +95,7 @@ index 514ff8543dbbe1c6ae47c7fd6c1545b87d3b2927..4726c980ad52c1300de16b7607006ea4
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      private static final int FLY_STAT_RECORDING_SPEED = 25;
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index d099b76082e59baf42de8e265eb2bc593c6e6f86..802357d8b582539e08a8d48024ebe9c38493a2b3 100644
+index 9547000b6e41fab39b00ca55ebd41825d222592e..e1fd699b33832c0f01b14023db7cc2b9d6797227 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -489,6 +489,7 @@ public abstract class PlayerList {

--- a/paper-server/patches/features/0028-Optimize-Hoppers.patch
+++ b/paper-server/patches/features/0028-Optimize-Hoppers.patch
@@ -48,10 +48,10 @@ index 0000000000000000000000000000000000000000..24a2090e068ad3c0d08705050944abdf
 +    }
 +}
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 6c8f06bc55cc6bffe6879433c5eda74eb5a13cb0..914ab3ad3e9b5735fcc179e17aaad82ab1b63b18 100644
+index 88a1e2d2b9172b6db53a57b969c29ac2f837ed98..fd93b0c887420789276ebf92023d3e02b99cc1c9 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1719,6 +1719,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1720,6 +1720,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              serverLevel.hasPhysicsEvent = org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
              serverLevel.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - Add EntityMoveEvent
              serverLevel.updateLagCompensationTick(); // Paper - lag compensation

--- a/paper-server/patches/features/0033-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0033-Optimise-EntityScheduler-ticking.patch
@@ -20,10 +20,10 @@ index 5f2deeb5cc01d8bbeb7449bd4e59c466b3dfdf57..82824ae7ffbced513a8bcace684af949
  
      @Override
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 382d2b6b53bd144f4d56dccdc603ed0da8fe07a7..7aac2a6889af3edaebfaf94deecbf00d00758b68 100644
+index fd93b0c887420789276ebf92023d3e02b99cc1c9..9243bb11e3f968d0bf0eb2e3dc9295c0232bc15d 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1654,33 +1654,22 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1655,33 +1655,22 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
  
@@ -67,7 +67,7 @@ index 382d2b6b53bd144f4d56dccdc603ed0da8fe07a7..7aac2a6889af3edaebfaf94deecbf00d
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.DIALOG_CLICK_MANAGER.handleQueue(this.tickCount); // Paper
          profilerFiller.push("commandFunctions");
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 813064b4d135c34cf76437a0f26546a8863abf85..70b6ea8ab35e88989b5b1f5ffd64490a9d743b56 100644
+index 295d40341df325b3fb6f14164283863a5a96b8bf..9a102b2c58446bd0aac5bd7f00e647f0270e7983 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -5164,6 +5164,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess

--- a/paper-server/patches/features/0034-Fix-MC-118740-Right-click-resets-attack-cooldown.patch
+++ b/paper-server/patches/features/0034-Fix-MC-118740-Right-click-resets-attack-cooldown.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: bl4stySKID <gamwtimana69@gmail.com>
+Date: Sat, 30 Aug 2025 02:50:11 +0300
+Subject: [PATCH] Fix MC-118740 Right click resets attack cooldown
+
+
+diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
+index 8f94c963f2c59668d72d162f46f7505d6a6b06a5..18aa4666396fe6565e565cfa3fe44650f4371bde 100644
+--- a/net/minecraft/server/level/ServerPlayer.java
++++ b/net/minecraft/server/level/ServerPlayer.java
+@@ -2436,7 +2436,12 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+     @Override
+     public void swing(InteractionHand hand) {
+         super.swing(hand);
+-        this.resetAttackStrengthTicker();
++
++        // Paper start - Fix MC-118740
++        if (hand == InteractionHand.MAIN_HAND) {
++            this.resetAttackStrengthTicker();
++        }
++        // Paper end
+     }
+ 
+     public boolean isChangingDimension() {


### PR DESCRIPTION
https://bugs.mojang.com/browse/MC/issues/MC-118740

This patch stops offhand swings from resetting the attack cooldown.