### PR TITLE
BuildableDataComponent Extensions

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/AttackRange.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/AttackRange.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
@@ -9,7 +10,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface AttackRange {
+public interface AttackRange extends BuildableDataComponent<AttackRange, AttackRange.Builder> {
 
     /**
      * Returns a new builder for creating an Attack Range.

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BannerPatternLayers.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BannerPatternLayers.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.block.banner.Pattern;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface BannerPatternLayers {
+public interface BannerPatternLayers extends BuildableDataComponent<BannerPatternLayers, BannerPatternLayers.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static BannerPatternLayers bannerPatternLayers(final List<Pattern> patterns) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BannerPatternLayers.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BannerPatternLayers.java
@@ -62,6 +62,5 @@ public interface BannerPatternLayers extends BuildableDataComponent<BannerPatter
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addAll(List<Pattern> patterns);
-
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BannerPatternLayers.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BannerPatternLayers.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.block.banner.Pattern;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface BannerPatternLayers {
+public interface BannerPatternLayers extends BuildableDataComponent<BannerPatternLayers, BannerPatternLayers.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static BannerPatternLayers bannerPatternLayers(final List<Pattern> patterns) {
@@ -61,5 +62,6 @@ public interface BannerPatternLayers {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addAll(List<Pattern> patterns);
+
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BlocksAttacks.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BlocksAttacks.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.datacomponent.item.blocksattacks.DamageReduction;
 import io.papermc.paper.datacomponent.item.blocksattacks.ItemDamageFunction;
@@ -21,7 +22,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface BlocksAttacks {
+public interface BlocksAttacks extends BuildableDataComponent<BlocksAttacks, BlocksAttacks.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static Builder blocksAttacks() {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BlocksAttacks.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BlocksAttacks.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.datacomponent.item.blocksattacks.DamageReduction;
 import io.papermc.paper.datacomponent.item.blocksattacks.ItemDamageFunction;
@@ -20,7 +21,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface BlocksAttacks {
+public interface BlocksAttacks extends BuildableDataComponent<BlocksAttacks, BlocksAttacks.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static Builder blocksAttacks() {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BundleContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BundleContents.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.inventory.ItemStack;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface BundleContents {
+public interface BundleContents extends BuildableDataComponent<BundleContents, BundleContents.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static BundleContents bundleContents(final List<ItemStack> contents) {
@@ -61,5 +62,15 @@ public interface BundleContents {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addAll(List<ItemStack> stacks);
+
+        /**
+         * Sets items to this builder.
+         *
+         * @param stacks items
+         * @return the builder for chaining
+         * @see #contents()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder stacks(List<ItemStack> stacks);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BundleContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BundleContents.java
@@ -71,6 +71,6 @@ public interface BundleContents extends BuildableDataComponent<BundleContents, B
          * @see #contents()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder set(List<ItemStack> stacks);
+        Builder stacks(List<ItemStack> stacks);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BundleContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BundleContents.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.inventory.ItemStack;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface BundleContents {
+public interface BundleContents extends BuildableDataComponent<BundleContents, BundleContents.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static BundleContents bundleContents(final List<ItemStack> contents) {
@@ -61,5 +62,15 @@ public interface BundleContents {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addAll(List<ItemStack> stacks);
+
+        /**
+         * Sets items to this builder.
+         *
+         * @param stacks items
+         * @return the builder for chaining
+         * @see #contents()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder set(List<ItemStack> stacks);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BundleContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BundleContents.java
@@ -66,11 +66,11 @@ public interface BundleContents extends BuildableDataComponent<BundleContents, B
         /**
          * Sets items to this builder.
          *
-         * @param stacks items
+         * @param contents items
          * @return the builder for chaining
          * @see #contents()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder stacks(List<ItemStack> stacks);
+        Builder contents(List<ItemStack> contents);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ChargedProjectiles.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ChargedProjectiles.java
@@ -71,6 +71,6 @@ public interface ChargedProjectiles extends BuildableDataComponent<ChargedProjec
          * @see #projectiles()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder set(List<ItemStack> stacks);
+        Builder stacks(List<ItemStack> stacks);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ChargedProjectiles.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ChargedProjectiles.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.inventory.ItemStack;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ChargedProjectiles {
+public interface ChargedProjectiles extends BuildableDataComponent<ChargedProjectiles, ChargedProjectiles.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static ChargedProjectiles chargedProjectiles(final List<ItemStack> projectiles) {
@@ -61,5 +62,15 @@ public interface ChargedProjectiles {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addAll(List<ItemStack> stacks);
+
+        /**
+         * Sets the projectiles to be loaded in this builder.
+         *
+         * @param stacks projectiles
+         * @return the builder for chaining
+         * @see #projectiles()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder set(List<ItemStack> stacks);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ChargedProjectiles.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ChargedProjectiles.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.inventory.ItemStack;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ChargedProjectiles {
+public interface ChargedProjectiles extends BuildableDataComponent<ChargedProjectiles, ChargedProjectiles.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static ChargedProjectiles chargedProjectiles(final List<ItemStack> projectiles) {
@@ -61,5 +62,15 @@ public interface ChargedProjectiles {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addAll(List<ItemStack> items);
+
+        /**
+         * Sets the projectiles to be loaded in this builder.
+         *
+         * @param items projectiles
+         * @return the builder for chaining
+         * @see #projectiles()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder items(List<ItemStack> items);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/CustomModelData.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/CustomModelData.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.Color;
@@ -16,7 +17,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface CustomModelData {
+public interface CustomModelData extends BuildableDataComponent<CustomModelData, CustomModelData.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static CustomModelData.Builder customModelData() {
@@ -83,6 +84,16 @@ public interface CustomModelData {
         CustomModelData.Builder addFloats(List<Float> floats);
 
         /**
+         * Sets multiple floats to this custom model data.
+         *
+         * @param floats the floats
+         * @return the builder for chaining
+         * @see #floats()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        CustomModelData.Builder floats(List<Float> floats);
+
+        /**
          * Adds a flag to this custom model data.
          *
          * @param flag the flag
@@ -101,6 +112,16 @@ public interface CustomModelData {
          */
         @Contract(value = "_ -> this", mutates = "this")
         CustomModelData.Builder addFlags(List<Boolean> flags);
+
+        /**
+         * Sets multiple flags to this custom model data.
+         *
+         * @param flags the flags
+         * @return the builder for chaining
+         * @see #flags()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        CustomModelData.Builder flags(List<Boolean> flags);
 
         /**
          * Adds a string to this custom model data.
@@ -123,6 +144,16 @@ public interface CustomModelData {
         CustomModelData.Builder addStrings(List<String> strings);
 
         /**
+         * Sets multiple strings to this custom model data.
+         *
+         * @param strings the strings
+         * @return the builder for chaining
+         * @see #strings()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        CustomModelData.Builder strings(List<String> strings);
+
+        /**
          * Adds a color to this custom model data.
          *
          * @param color the color
@@ -141,5 +172,15 @@ public interface CustomModelData {
          */
         @Contract(value = "_ -> this", mutates = "this")
         CustomModelData.Builder addColors(List<Color> colors);
+
+        /**
+         * Sets multiple colors to this custom model data.
+         *
+         * @param colors the colors
+         * @return the builder for chaining
+         * @see #colors()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        CustomModelData.Builder colors(List<Color> colors);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/CustomModelData.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/CustomModelData.java
@@ -91,7 +91,7 @@ public interface CustomModelData extends BuildableDataComponent<CustomModelData,
          * @see #floats()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        CustomModelData.Builder setFloats(List<Float> floats);
+        CustomModelData.Builder floats(List<Float> floats);
 
         /**
          * Adds a flag to this custom model data.
@@ -121,7 +121,7 @@ public interface CustomModelData extends BuildableDataComponent<CustomModelData,
          * @see #flags()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        CustomModelData.Builder setFlags(List<Boolean> flags);
+        CustomModelData.Builder flags(List<Boolean> flags);
 
         /**
          * Adds a string to this custom model data.
@@ -151,7 +151,7 @@ public interface CustomModelData extends BuildableDataComponent<CustomModelData,
          * @see #strings()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        CustomModelData.Builder setStrings(List<String> strings);
+        CustomModelData.Builder strings(List<String> strings);
 
         /**
          * Adds a color to this custom model data.
@@ -181,6 +181,6 @@ public interface CustomModelData extends BuildableDataComponent<CustomModelData,
          * @see #colors()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        CustomModelData.Builder setColors(List<Color> colors);
+        CustomModelData.Builder colors(List<Color> colors);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/CustomModelData.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/CustomModelData.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.Color;
@@ -16,7 +17,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface CustomModelData {
+public interface CustomModelData extends BuildableDataComponent<CustomModelData, CustomModelData.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static CustomModelData.Builder customModelData() {
@@ -83,6 +84,16 @@ public interface CustomModelData {
         CustomModelData.Builder addFloats(List<Float> floats);
 
         /**
+         * Sets multiple floats to this custom model data.
+         *
+         * @param floats the floats
+         * @return the builder for chaining
+         * @see #floats()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        CustomModelData.Builder setFloats(List<Float> floats);
+
+        /**
          * Adds a flag to this custom model data.
          *
          * @param flag the flag
@@ -101,6 +112,16 @@ public interface CustomModelData {
          */
         @Contract(value = "_ -> this", mutates = "this")
         CustomModelData.Builder addFlags(List<Boolean> flags);
+
+        /**
+         * Sets multiple flags to this custom model data.
+         *
+         * @param flags the flags
+         * @return the builder for chaining
+         * @see #flags()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        CustomModelData.Builder setFlags(List<Boolean> flags);
 
         /**
          * Adds a string to this custom model data.
@@ -123,6 +144,16 @@ public interface CustomModelData {
         CustomModelData.Builder addStrings(List<String> strings);
 
         /**
+         * Sets multiple strings to this custom model data.
+         *
+         * @param strings the strings
+         * @return the builder for chaining
+         * @see #strings()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        CustomModelData.Builder setStrings(List<String> strings);
+
+        /**
          * Adds a color to this custom model data.
          *
          * @param color the color
@@ -141,5 +172,15 @@ public interface CustomModelData {
          */
         @Contract(value = "_ -> this", mutates = "this")
         CustomModelData.Builder addColors(List<Color> colors);
+
+        /**
+         * Sets multiple colors to this custom model data.
+         *
+         * @param colors the colors
+         * @return the builder for chaining
+         * @see #colors()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        CustomModelData.Builder setColors(List<Color> colors);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DeathProtection.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DeathProtection.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.datacomponent.item.consumable.ConsumeEffect;
 import java.util.List;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface DeathProtection {
+public interface DeathProtection extends BuildableDataComponent<DeathProtection, DeathProtection.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static DeathProtection deathProtection(final List<ConsumeEffect> deathEffects) {
@@ -42,5 +43,8 @@ public interface DeathProtection {
 
         @Contract(value = "_ -> this", mutates = "this")
         Builder addEffects(List<ConsumeEffect> effects);
+
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder effects(List<ConsumeEffect> effects);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DeathProtection.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DeathProtection.java
@@ -45,6 +45,6 @@ public interface DeathProtection extends BuildableDataComponent<DeathProtection,
         Builder addEffects(List<ConsumeEffect> effects);
 
         @Contract(value = "_ -> this", mutates = "this")
-        Builder setEffects(List<ConsumeEffect> effects);
+        Builder effects(List<ConsumeEffect> effects);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DeathProtection.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DeathProtection.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.datacomponent.item.consumable.ConsumeEffect;
 import java.util.List;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface DeathProtection {
+public interface DeathProtection extends BuildableDataComponent<DeathProtection, DeathProtection.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static DeathProtection deathProtection(final List<ConsumeEffect> deathEffects) {
@@ -42,5 +43,8 @@ public interface DeathProtection {
 
         @Contract(value = "_ -> this", mutates = "this")
         Builder addEffects(List<ConsumeEffect> effects);
+
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder setEffects(List<ConsumeEffect> effects);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DyedItemColor.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DyedItemColor.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.bukkit.Color;
 import org.jetbrains.annotations.ApiStatus;
@@ -13,7 +14,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface DyedItemColor {
+public interface DyedItemColor extends BuildableDataComponent<DyedItemColor, DyedItemColor.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static DyedItemColor dyedItemColor(final Color color) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DyedItemColor.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DyedItemColor.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.bukkit.Color;
 import org.jetbrains.annotations.ApiStatus;
@@ -13,7 +14,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface DyedItemColor {
+public interface DyedItemColor extends BuildableDataComponent<DyedItemColor, DyedItemColor.Builder> {
 
     @Contract(value = "_, _ -> new", pure = true)
     static DyedItemColor dyedItemColor(final Color color) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Enchantable.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Enchantable.java
@@ -24,7 +24,7 @@ public interface Enchantable {
      * a higher value allows enchantments with a higher cost to be picked.
      *
      * @return the value
-     * @see <a href="https://minecraft.wiki/w/Enchanting_mechanics#Java_Edition_2">Minecraft Wiki</a>
+     * @see <a href="https://minecraft.wiki/w/Enchanting_table_mechanics#Java_Edition">Minecraft Wiki</a>
      */
     @Contract(pure = true)
     @Positive int value();

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Fireworks.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Fireworks.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.FireworkEffect;
@@ -16,7 +17,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface Fireworks {
+public interface Fireworks extends BuildableDataComponent<Fireworks, Fireworks.Builder> {
 
     @Contract(value = "_, _ -> new", pure = true)
     static Fireworks fireworks(final List<FireworkEffect> effects, final int flightDuration) {
@@ -80,5 +81,15 @@ public interface Fireworks {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addEffects(List<FireworkEffect> effects);
+
+        /**
+         * Sets explosions to this builder.
+         *
+         * @param effects effects
+         * @return the builder for chaining
+         * @see #effects()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder effects(List<FireworkEffect> effects);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Fireworks.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Fireworks.java
@@ -90,6 +90,6 @@ public interface Fireworks extends BuildableDataComponent<Fireworks, Fireworks.B
          * @see #effects()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder setEffects(List<FireworkEffect> effects);
+        Builder effects(List<FireworkEffect> effects);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Fireworks.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Fireworks.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.FireworkEffect;
@@ -16,7 +17,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface Fireworks {
+public interface Fireworks extends BuildableDataComponent<Fireworks, Fireworks.Builder> {
 
     @Contract(value = "_, _ -> new", pure = true)
     static Fireworks fireworks(final List<FireworkEffect> effects, final int flightDuration) {
@@ -80,5 +81,15 @@ public interface Fireworks {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addEffects(List<FireworkEffect> effects);
+
+        /**
+         * Sets explosions to this builder.
+         *
+         * @param effects effects
+         * @return the builder for chaining
+         * @see #effects()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder setEffects(List<FireworkEffect> effects);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Fireworks.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Fireworks.java
@@ -53,16 +53,6 @@ public interface Fireworks extends BuildableDataComponent<Fireworks, Fireworks.B
     interface Builder extends DataComponentBuilder<Fireworks> {
 
         /**
-         * Sets the number of gunpowder used in this builder.
-         *
-         * @param duration duration
-         * @return the builder for chaining
-         * @see #flightDuration()
-         */
-        @Contract(value = "_ -> this", mutates = "this")
-        Builder flightDuration(@IntRange(from = 0, to = 255) int duration);
-
-        /**
          * Adds an explosion to this builder.
          *
          * @param effect effect
@@ -91,5 +81,15 @@ public interface Fireworks extends BuildableDataComponent<Fireworks, Fireworks.B
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder effects(List<FireworkEffect> effects);
+
+        /**
+         * Sets the number of gunpowder used in this builder.
+         *
+         * @param duration duration
+         * @return the builder for chaining
+         * @see #flightDuration()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder flightDuration(@IntRange(from = 0, to = 255) int duration);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemAdventurePredicate.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemAdventurePredicate.java
@@ -1,6 +1,7 @@
 package io.papermc.paper.datacomponent.item;
 
 import io.papermc.paper.block.BlockPredicate;
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
@@ -16,7 +17,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ItemAdventurePredicate {
+public interface ItemAdventurePredicate extends BuildableDataComponent<ItemAdventurePredicate, ItemAdventurePredicate.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static ItemAdventurePredicate itemAdventurePredicate(final List<BlockPredicate> predicates) {
@@ -61,5 +62,15 @@ public interface ItemAdventurePredicate {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addPredicates(List<BlockPredicate> predicates);
+
+        /**
+         * Sets block predicates to this builder.
+         *
+         * @param predicates predicates
+         * @return the builder for chaining
+         * @see #predicates()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder predicates(List<BlockPredicate> predicates);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemAdventurePredicate.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemAdventurePredicate.java
@@ -1,6 +1,7 @@
 package io.papermc.paper.datacomponent.item;
 
 import io.papermc.paper.block.BlockPredicate;
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
@@ -16,7 +17,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ItemAdventurePredicate {
+public interface ItemAdventurePredicate extends BuildableDataComponent<ItemAdventurePredicate, ItemAdventurePredicate.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static ItemAdventurePredicate itemAdventurePredicate(final List<BlockPredicate> predicates) {
@@ -61,5 +62,15 @@ public interface ItemAdventurePredicate {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addPredicates(List<BlockPredicate> predicates);
+
+        /**
+         * Sets block predicates to this builder.
+         *
+         * @param predicates predicates
+         * @return the builder for chaining
+         * @see #predicates()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder setPredicates(List<BlockPredicate> predicates);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemAdventurePredicate.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemAdventurePredicate.java
@@ -71,6 +71,6 @@ public interface ItemAdventurePredicate extends BuildableDataComponent<ItemAdven
          * @see #predicates()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder setPredicates(List<BlockPredicate> predicates);
+        Builder predicates(List<BlockPredicate> predicates);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemArmorTrim.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemArmorTrim.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.bukkit.inventory.meta.trim.ArmorTrim;
 import org.jetbrains.annotations.ApiStatus;
@@ -13,7 +14,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ItemArmorTrim  {
+public interface ItemArmorTrim extends BuildableDataComponent<ItemArmorTrim, ItemArmorTrim.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static ItemArmorTrim.Builder itemArmorTrim(final ArmorTrim armorTrim) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemArmorTrim.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemArmorTrim.java
@@ -1,6 +1,5 @@
 package io.papermc.paper.datacomponent.item;
 
-import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.bukkit.inventory.meta.trim.ArmorTrim;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,7 +13,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ItemArmorTrim extends BuildableDataComponent<ItemArmorTrim, ItemArmorTrim.Builder> {
+public interface ItemArmorTrim {
 
     @Contract(value = "_ -> new", pure = true)
     static ItemArmorTrim.Builder itemArmorTrim(final ArmorTrim armorTrim) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemAttributeModifiers.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemAttributeModifiers.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.datacomponent.item.attribute.AttributeModifierDisplay;
 import java.util.List;
@@ -18,7 +19,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ItemAttributeModifiers {
+public interface ItemAttributeModifiers extends BuildableDataComponent<ItemAttributeModifiers, ItemAttributeModifiers.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static ItemAttributeModifiers.Builder itemAttributes() {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemComponentTypesBridge.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemComponentTypesBridge.java
@@ -2,12 +2,12 @@ package io.papermc.paper.datacomponent.item;
 
 import com.destroystokyo.paper.profile.PlayerProfile;
 import io.papermc.paper.registry.set.RegistryKeySet;
-import io.papermc.paper.registry.tag.TagKey;
 import io.papermc.paper.text.Filtered;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.util.TriState;
+import org.bukkit.Color;
 import org.bukkit.JukeboxSong;
 import org.bukkit.block.BlockType;
 import org.bukkit.damage.DamageType;
@@ -51,6 +51,8 @@ interface ItemComponentTypesBridge {
     SuspiciousStewEffects.Builder suspiciousStewEffects();
 
     MapItemColor.Builder mapItemColor();
+
+    MapItemColor mapItemColor(Color color);
 
     MapDecorations.Builder mapDecorations();
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemContainerContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemContainerContents.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.inventory.ItemStack;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ItemContainerContents {
+public interface ItemContainerContents extends BuildableDataComponent<ItemContainerContents, ItemContainerContents.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static ItemContainerContents containerContents(final List<ItemStack> contents) {
@@ -58,5 +59,15 @@ public interface ItemContainerContents {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addAll(List<ItemStack> stacks);
+
+        /**
+         * Sets item stacks to the container.
+         *
+         * @param stacks the item stacks
+         * @return the builder for chaining
+         * @see #contents()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder stacks(List<ItemStack> stacks);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemContainerContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemContainerContents.java
@@ -68,6 +68,6 @@ public interface ItemContainerContents extends BuildableDataComponent<ItemContai
          * @see #contents()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder set(List<ItemStack> stacks);
+        Builder stacks(List<ItemStack> stacks);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemContainerContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemContainerContents.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.inventory.ItemStack;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ItemContainerContents {
+public interface ItemContainerContents extends BuildableDataComponent<ItemContainerContents, ItemContainerContents.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static ItemContainerContents containerContents(final List<ItemStack> contents) {
@@ -58,5 +59,15 @@ public interface ItemContainerContents {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addAll(List<ItemStack> stacks);
+
+        /**
+         * Sets item stacks to the container.
+         *
+         * @param stacks the item stacks
+         * @return the builder for chaining
+         * @see #contents()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder set(List<ItemStack> stacks);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemContainerContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemContainerContents.java
@@ -63,11 +63,11 @@ public interface ItemContainerContents extends BuildableDataComponent<ItemContai
         /**
          * Sets item stacks to the container.
          *
-         * @param stacks the item stacks
+         * @param contents the item stacks
          * @return the builder for chaining
          * @see #contents()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder stacks(List<ItemStack> stacks);
+        Builder contents(List<ItemStack> contents);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemEnchantments.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemEnchantments.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.Map;
 import org.bukkit.enchantments.Enchantment;
@@ -17,7 +18,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ItemEnchantments {
+public interface ItemEnchantments extends BuildableDataComponent<ItemEnchantments, ItemEnchantments.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static ItemEnchantments itemEnchantments(final Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments) {
@@ -64,5 +65,15 @@ public interface ItemEnchantments {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addAll(Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments);
+
+        /**
+         * Sets enchantments with the given level to this component.
+         *
+         * @param enchantments enchantments
+         * @return the builder for chaining
+         * @see #enchantments()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder enchantments(Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemEnchantments.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemEnchantments.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.Map;
 import org.bukkit.enchantments.Enchantment;
@@ -17,7 +18,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ItemEnchantments {
+public interface ItemEnchantments extends BuildableDataComponent<ItemEnchantments, ItemEnchantments.Builder> {
 
     @Contract(value = "_, _ -> new", pure = true)
     static ItemEnchantments itemEnchantments(final Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments) {
@@ -64,5 +65,15 @@ public interface ItemEnchantments {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addAll(Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments);
+
+        /**
+         * Sets enchantments with the given level to this component.
+         *
+         * @param enchantments enchantments
+         * @return the builder for chaining
+         * @see #enchantments()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder set(Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemEnchantments.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemEnchantments.java
@@ -74,6 +74,6 @@ public interface ItemEnchantments extends BuildableDataComponent<ItemEnchantment
          * @see #enchantments()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder set(Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments);
+        Builder enchantments(Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemLore.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemLore.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import net.kyori.adventure.text.Component;
@@ -16,7 +17,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ItemLore {
+public interface ItemLore extends BuildableDataComponent<ItemLore, ItemLore.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static ItemLore lore(final List<? extends ComponentLike> lines) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/JukeboxPlayable.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/JukeboxPlayable.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.bukkit.JukeboxSong;
 import org.jetbrains.annotations.ApiStatus;
@@ -13,7 +14,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface JukeboxPlayable  {
+public interface JukeboxPlayable extends BuildableDataComponent<JukeboxPlayable, JukeboxPlayable.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static JukeboxPlayable.Builder jukeboxPlayable(final JukeboxSong song) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/JukeboxPlayable.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/JukeboxPlayable.java
@@ -1,6 +1,5 @@
 package io.papermc.paper.datacomponent.item;
 
-import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.bukkit.JukeboxSong;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,7 +13,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface JukeboxPlayable extends BuildableDataComponent<JukeboxPlayable, JukeboxPlayable.Builder> {
+public interface JukeboxPlayable {
 
     @Contract(value = "_ -> new", pure = true)
     static JukeboxPlayable.Builder jukeboxPlayable(final JukeboxSong song) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/KineticWeapon.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/KineticWeapon.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.index.qual.NonNegative;
@@ -12,7 +13,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface KineticWeapon {
+public interface KineticWeapon extends BuildableDataComponent<KineticWeapon, KineticWeapon.Builder> {
 
     /**
      * Returns a new builder for creating a Kinetic Weapon.

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/KineticWeapon.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/KineticWeapon.java
@@ -6,7 +6,6 @@ import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.Range;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/LodestoneTracker.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/LodestoneTracker.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.bukkit.Location;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,7 +15,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface LodestoneTracker {
+public interface LodestoneTracker extends BuildableDataComponent<LodestoneTracker, LodestoneTracker.Builder> {
 
     @Contract(value = "_, _ -> new", pure = true)
     static LodestoneTracker lodestoneTracker(final @Nullable Location location, final boolean tracked) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/MapDecorations.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/MapDecorations.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.Map;
 import org.bukkit.map.MapCursor;
@@ -16,7 +17,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface MapDecorations {
+public interface MapDecorations extends BuildableDataComponent<MapDecorations, MapDecorations.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static MapDecorations mapDecorations(final Map<String, DecorationEntry> entries) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/MapItemColor.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/MapItemColor.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.bukkit.Color;
 import org.jetbrains.annotations.ApiStatus;
@@ -13,7 +14,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface MapItemColor {
+public interface MapItemColor extends BuildableDataComponent<MapItemColor, MapItemColor.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static MapItemColor.Builder mapItemColor() {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/MapItemColor.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/MapItemColor.java
@@ -1,6 +1,5 @@
 package io.papermc.paper.datacomponent.item;
 
-import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.bukkit.Color;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,11 +13,16 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface MapItemColor extends BuildableDataComponent<MapItemColor, MapItemColor.Builder> {
+public interface MapItemColor {
 
     @Contract(value = "-> new", pure = true)
     static MapItemColor.Builder mapItemColor() {
         return ItemComponentTypesBridge.bridge().mapItemColor();
+    }
+
+    @Contract(value = "_ -> new", pure = true)
+    static MapItemColor mapItemColor(Color color) {
+        return ItemComponentTypesBridge.bridge().mapItemColor(color);
     }
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PiercingWeapon.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PiercingWeapon.java
@@ -1,17 +1,17 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import net.kyori.adventure.key.Key;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.Range;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface PiercingWeapon {
+public interface PiercingWeapon extends BuildableDataComponent<PiercingWeapon, PiercingWeapon.Builder> {
 
     /**
      * Returns a new builder for creating a Piercing Weapon.

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotDecorations.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotDecorations.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.bukkit.inventory.ItemType;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,7 +15,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface PotDecorations {
+public interface PotDecorations extends BuildableDataComponent<PotDecorations, PotDecorations.Builder> {
 
     @Contract(value = "_, _, _, _ -> new", pure = true)
     static PotDecorations potDecorations(final @Nullable ItemType back, final @Nullable ItemType left, final @Nullable ItemType right, final @Nullable ItemType front) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotionContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotionContents.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.Color;
@@ -18,7 +19,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface PotionContents {
+public interface PotionContents extends BuildableDataComponent<PotionContents, PotionContents.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static PotionContents.Builder potionContents() {
@@ -135,5 +136,15 @@ public interface PotionContents {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addCustomEffects(List<PotionEffect> effects);
+
+        /**
+         * Sets custom effect instances to this builder.
+         *
+         * @param effects effects
+         * @return the builder for chaining
+         * @see #customEffects()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder customEffects(List<PotionEffect> effects);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotionContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotionContents.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.List;
 import org.bukkit.Color;
@@ -18,7 +19,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface PotionContents {
+public interface PotionContents extends BuildableDataComponent<PotionContents, PotionContents.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static PotionContents.Builder potionContents() {
@@ -135,5 +136,15 @@ public interface PotionContents {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addCustomEffects(List<PotionEffect> effects);
+
+        /**
+         * Sets custom effect instances to this builder.
+         *
+         * @param effects effects
+         * @return the builder for chaining
+         * @see #customEffects()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder setCustomEffects(List<PotionEffect> effects);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotionContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotionContents.java
@@ -145,6 +145,6 @@ public interface PotionContents extends BuildableDataComponent<PotionContents, P
          * @see #customEffects()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder setCustomEffects(List<PotionEffect> effects);
+        Builder customEffects(List<PotionEffect> effects);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotionContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotionContents.java
@@ -108,16 +108,6 @@ public interface PotionContents extends BuildableDataComponent<PotionContents, P
         Builder customColor(@Nullable Color color);
 
         /**
-         * Sets the suffix to the translation key of the potion item.
-         *
-         * @param name name
-         * @return the builder for chaining
-         * @see #customName()
-         */
-        @Contract(value = "_ -> this", mutates = "this")
-        Builder customName(@Nullable String name);
-
-        /**
          * Adds a custom effect instance to this builder.
          *
          * @param effect effect
@@ -146,5 +136,15 @@ public interface PotionContents extends BuildableDataComponent<PotionContents, P
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder customEffects(List<PotionEffect> effects);
+
+        /**
+         * Sets the suffix to the translation key of the potion item.
+         *
+         * @param name name
+         * @return the builder for chaining
+         * @see #customName()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder customName(@Nullable String name);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ResolvableProfile.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ResolvableProfile.java
@@ -2,6 +2,7 @@ package io.papermc.paper.datacomponent.item;
 
 import com.destroystokyo.paper.profile.PlayerProfile;
 import com.destroystokyo.paper.profile.ProfileProperty;
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import java.util.Collection;
 import java.util.UUID;
@@ -25,7 +26,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ResolvableProfile extends PlayerHeadObjectContents.SkinSource { // todo toBuilder
+public interface ResolvableProfile extends BuildableDataComponent<ResolvableProfile, ResolvableProfile.Builder>, PlayerHeadObjectContents.SkinSource {
 
     @Contract(value = "_ -> new", pure = true)
     static ResolvableProfile resolvableProfile(final PlayerProfile profile) {
@@ -38,12 +39,10 @@ public interface ResolvableProfile extends PlayerHeadObjectContents.SkinSource {
     }
 
     @Contract(pure = true)
-    @Nullable
-    UUID uuid();
+    @Nullable UUID uuid();
 
     @Contract(pure = true)
-    @Nullable
-    String name();
+    @Nullable String name();
 
     @Contract(pure = true)
     @Unmodifiable

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ResolvableProfile.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ResolvableProfile.java
@@ -25,7 +25,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ResolvableProfile extends PlayerHeadObjectContents.SkinSource {
+public interface ResolvableProfile extends PlayerHeadObjectContents.SkinSource { // todo toBuilder
 
     @Contract(value = "_ -> new", pure = true)
     static ResolvableProfile resolvableProfile(final PlayerProfile profile) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SeededContainerLoot.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SeededContainerLoot.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import net.kyori.adventure.key.Key;
 import org.jetbrains.annotations.ApiStatus;
@@ -13,7 +14,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface SeededContainerLoot {
+public interface SeededContainerLoot extends BuildableDataComponent<SeededContainerLoot, SeededContainerLoot.Builder> {
 
     @Contract(value = "_, _ -> new", pure = true)
     static SeededContainerLoot seededContainerLoot(final Key lootTableKey, final long seed) {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SuspiciousStewEffects.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SuspiciousStewEffects.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.potion.SuspiciousEffectEntry;
 import java.util.Collection;
@@ -16,7 +17,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface SuspiciousStewEffects {
+public interface SuspiciousStewEffects extends BuildableDataComponent<SuspiciousStewEffects, SuspiciousStewEffects.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static SuspiciousStewEffects suspiciousStewEffects(final Collection<SuspiciousEffectEntry> effects) {
@@ -62,5 +63,15 @@ public interface SuspiciousStewEffects {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addAll(Collection<SuspiciousEffectEntry> entries);
+
+        /**
+         * Sets effects applied to this builder.
+         *
+         * @param entries effect
+         * @return the builder for chaining
+         * @see #effects()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder effects(Collection<SuspiciousEffectEntry> entries);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SuspiciousStewEffects.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SuspiciousStewEffects.java
@@ -72,6 +72,6 @@ public interface SuspiciousStewEffects extends BuildableDataComponent<Suspicious
          * @see #effects()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder set(Collection<SuspiciousEffectEntry> entries);
+        Builder effects(Collection<SuspiciousEffectEntry> entries);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SuspiciousStewEffects.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SuspiciousStewEffects.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.potion.SuspiciousEffectEntry;
 import java.util.Collection;
@@ -16,7 +17,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface SuspiciousStewEffects {
+public interface SuspiciousStewEffects extends BuildableDataComponent<SuspiciousStewEffects, SuspiciousStewEffects.Builder> {
 
     @Contract(value = "_ -> new", pure = true)
     static SuspiciousStewEffects suspiciousStewEffects(final Collection<SuspiciousEffectEntry> effects) {
@@ -62,5 +63,15 @@ public interface SuspiciousStewEffects {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addAll(Collection<SuspiciousEffectEntry> entries);
+
+        /**
+         * Sets effects applied to this builder.
+         *
+         * @param entries effect
+         * @return the builder for chaining
+         * @see #effects()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder set(Collection<SuspiciousEffectEntry> entries);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SwingAnimation.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SwingAnimation.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.checkerframework.checker.index.qual.Positive;
 import org.jetbrains.annotations.ApiStatus;
@@ -9,7 +10,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface SwingAnimation {
+public interface SwingAnimation extends BuildableDataComponent<SwingAnimation, SwingAnimation.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static Builder swingAnimation() {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Tool.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Tool.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.registry.set.RegistryKeySet;
@@ -21,7 +22,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface Tool {
+public interface Tool extends BuildableDataComponent<Tool, Tool.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static Tool.Builder tool() {
@@ -164,5 +165,14 @@ public interface Tool {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addRules(Collection<Rule> rules);
+
+        /**
+         * Sets rules to the tool that control the breaking speed / damage per block if matched.
+         *
+         * @param rules rules
+         * @return the builder for chaining
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder rules(Collection<Rule> rules);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Tool.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Tool.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.registry.set.RegistryKeySet;
@@ -21,7 +22,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface Tool {
+public interface Tool extends BuildableDataComponent<Tool, Tool.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static Tool.Builder tool() {
@@ -164,5 +165,14 @@ public interface Tool {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addRules(Collection<Rule> rules);
+
+        /**
+         * Sets rules to the tool that control the breaking speed / damage per block if matched.
+         *
+         * @param rules rules
+         * @return the builder for chaining
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder setRules(Collection<Rule> rules);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Tool.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Tool.java
@@ -173,6 +173,6 @@ public interface Tool extends BuildableDataComponent<Tool, Tool.Builder> {
          * @return the builder for chaining
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder setRules(Collection<Rule> rules);
+        Builder rules(Collection<Rule> rules);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Tool.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Tool.java
@@ -117,26 +117,6 @@ public interface Tool extends BuildableDataComponent<Tool, Tool.Builder> {
     interface Builder extends DataComponentBuilder<Tool> {
 
         /**
-         * Controls the amount of durability to remove each time a block is mined with this tool.
-         *
-         * @param damage durability to remove
-         * @return the builder for chaining
-         * @see #damagePerBlock()
-         */
-        @Contract(value = "_ -> this", mutates = "this")
-        Builder damagePerBlock(@NonNegative int damage);
-
-        /**
-         * Controls mining speed to use if no rules match and don't override mining speed.
-         *
-         * @param miningSpeed mining speed
-         * @return the builder for chaining
-         * @see #defaultMiningSpeed()
-         */
-        @Contract(value = "_ -> this", mutates = "this")
-        Builder defaultMiningSpeed(float miningSpeed);
-
-        /**
          * Adds a rule to the tool that controls the breaking speed / damage per block if matched.
          *
          * @param rule rule
@@ -145,16 +125,6 @@ public interface Tool extends BuildableDataComponent<Tool, Tool.Builder> {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addRule(Rule rule);
-
-        /**
-         * Controls whether this tool can destroy blocks in creative mode.
-         *
-         * @param canDestroyBlocksInCreative whether this tool can destroy blocks in creative mode
-         * @return the builder for chaining
-         * @see #canDestroyBlocksInCreative()
-         */
-        @Contract(value = "_ -> this", mutates = "this")
-        Builder canDestroyBlocksInCreative(boolean canDestroyBlocksInCreative);
 
         /**
          * Adds rules to the tool that control the breaking speed / damage per block if matched.
@@ -174,5 +144,35 @@ public interface Tool extends BuildableDataComponent<Tool, Tool.Builder> {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder rules(Collection<Rule> rules);
+
+        /**
+         * Controls mining speed to use if no rules match and don't override mining speed.
+         *
+         * @param miningSpeed mining speed
+         * @return the builder for chaining
+         * @see #defaultMiningSpeed()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder defaultMiningSpeed(float miningSpeed);
+
+        /**
+         * Controls the amount of durability to remove each time a block is mined with this tool.
+         *
+         * @param damage durability to remove
+         * @return the builder for chaining
+         * @see #damagePerBlock()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder damagePerBlock(@NonNegative int damage);
+
+        /**
+         * Controls whether this tool can destroy blocks in creative mode.
+         *
+         * @param canDestroyBlocksInCreative whether this tool can destroy blocks in creative mode
+         * @return the builder for chaining
+         * @see #canDestroyBlocksInCreative()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder canDestroyBlocksInCreative(boolean canDestroyBlocksInCreative);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/TooltipDisplay.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/TooltipDisplay.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.datacomponent.DataComponentType;
 import java.util.Set;
@@ -10,7 +11,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface TooltipDisplay {
+public interface TooltipDisplay extends BuildableDataComponent<TooltipDisplay, TooltipDisplay.Builder> {
 
     /**
      * Returns a new builder for creating a TooltipDisplay.
@@ -38,6 +39,9 @@ public interface TooltipDisplay {
 
         @Contract(value = "_ -> this", mutates = "this")
         Builder addHiddenComponents(DataComponentType... components);
+
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder addHiddenComponents(Set<DataComponentType> components);
 
         @Contract(value = "_ -> this", mutates = "this")
         Builder hiddenComponents(Set<DataComponentType> components);

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/TooltipDisplay.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/TooltipDisplay.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.datacomponent.DataComponentType;
 import org.jetbrains.annotations.ApiStatus;
@@ -11,7 +12,7 @@ import java.util.Set;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface TooltipDisplay {
+public interface TooltipDisplay extends BuildableDataComponent<TooltipDisplay, TooltipDisplay.Builder> {
 
     /**
      * Returns a new builder for creating a TooltipDisplay.
@@ -42,5 +43,8 @@ public interface TooltipDisplay {
 
         @Contract(value = "_ -> this", mutates = "this")
         Builder hiddenComponents(Set<DataComponentType> components);
+
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder setHiddenComponents(Set<DataComponentType> components);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/TooltipDisplay.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/TooltipDisplay.java
@@ -42,9 +42,9 @@ public interface TooltipDisplay extends BuildableDataComponent<TooltipDisplay, T
         Builder addHiddenComponents(DataComponentType... components);
 
         @Contract(value = "_ -> this", mutates = "this")
-        Builder hiddenComponents(Set<DataComponentType> components);
+        Builder addHiddenComponents(Set<DataComponentType> components);
 
         @Contract(value = "_ -> this", mutates = "this")
-        Builder setHiddenComponents(Set<DataComponentType> components);
+        Builder hiddenComponents(Set<DataComponentType> components);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/UseCooldown.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/UseCooldown.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import net.kyori.adventure.key.Key;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,7 +15,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface UseCooldown {
+public interface UseCooldown extends BuildableDataComponent<UseCooldown, UseCooldown.Builder> {
 
     /**
      * Creates a new builder for use cooldown.

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/UseCooldown.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/UseCooldown.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.index.qual.Positive;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface UseCooldown {
+public interface UseCooldown extends BuildableDataComponent<UseCooldown, UseCooldown.Builder> {
 
     /**
      * Creates a new builder for use cooldown.

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/UseEffects.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/UseEffects.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
@@ -8,7 +9,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface UseEffects {
+public interface UseEffects extends BuildableDataComponent<UseEffects, UseEffects.Builder> {
 
     /**
      * Returns a new builder for creating a UseEffects component.

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Weapon.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Weapon.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
@@ -7,7 +8,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface Weapon {
+public interface Weapon extends BuildableDataComponent<Weapon, Weapon.Builder> {
 
     /**
      * Returns a new builder for creating a Weapon.

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Weapon.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Weapon.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.jetbrains.annotations.ApiStatus;
@@ -8,7 +9,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface Weapon {
+public interface Weapon extends BuildableDataComponent<Weapon, Weapon.Builder> {
 
     /**
      * Returns a new builder for creating a Weapon.

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WritableBookContent.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WritableBookContent.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.text.Filtered;
 import java.util.List;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface WritableBookContent {
+public interface WritableBookContent extends BuildableDataComponent<WritableBookContent, WritableBookContent.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static WritableBookContent.Builder writeableBookContent() {
@@ -58,6 +59,16 @@ public interface WritableBookContent {
         Builder addPages(List<String> pages);
 
         /**
+         * Sets pages that can be written to for this builder.
+         *
+         * @param pages pages
+         * @return the builder for chaining
+         * @see #pages()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder setPages(List<String> pages);
+
+        /**
          * Adds a filterable page that can be written to for this builder.
          *
          * @param page page
@@ -76,5 +87,15 @@ public interface WritableBookContent {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addFilteredPages(List<Filtered<String>> pages);
+
+        /**
+         * Sets filterable pages that can be written to for this builder.
+         *
+         * @param pages pages
+         * @return the builder for chaining
+         * @see #pages()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder setFilteredPages(List<Filtered<String>> pages);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WritableBookContent.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WritableBookContent.java
@@ -66,7 +66,7 @@ public interface WritableBookContent extends BuildableDataComponent<WritableBook
          * @see #pages()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder setPages(List<String> pages);
+        Builder pages(List<String> pages);
 
         /**
          * Adds a filterable page that can be written to for this builder.
@@ -96,6 +96,6 @@ public interface WritableBookContent extends BuildableDataComponent<WritableBook
          * @see #pages()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder setFilteredPages(List<Filtered<String>> pages);
+        Builder filteredPages(List<Filtered<String>> pages);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WritableBookContent.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WritableBookContent.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.text.Filtered;
 import java.util.List;
@@ -16,7 +17,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface WritableBookContent extends BookLike {
+public interface WritableBookContent extends BookLike, BuildableDataComponent<WritableBookContent, WritableBookContent.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static WritableBookContent.Builder writeableBookContent() {
@@ -59,6 +60,16 @@ public interface WritableBookContent extends BookLike {
         Builder addPages(List<String> pages);
 
         /**
+         * Sets pages that can be written to for this builder.
+         *
+         * @param pages pages
+         * @return the builder for chaining
+         * @see #pages()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder pages(List<String> pages);
+
+        /**
          * Adds a filterable page that can be written to for this builder.
          *
          * @param page page
@@ -77,5 +88,15 @@ public interface WritableBookContent extends BookLike {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addFilteredPages(List<Filtered<String>> pages);
+
+        /**
+         * Sets filterable pages that can be written to for this builder.
+         *
+         * @param pages pages
+         * @return the builder for chaining
+         * @see #pages()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder filteredPages(List<Filtered<String>> pages);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WrittenBookContent.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WrittenBookContent.java
@@ -158,7 +158,7 @@ public interface WrittenBookContent extends BuildableDataComponent<WrittenBookCo
          * @see #pages()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder setPages(List<? extends ComponentLike> pages);
+        Builder pages(List<? extends ComponentLike> pages);
 
         /**
          * Adds a filterable page to this book.
@@ -188,6 +188,6 @@ public interface WrittenBookContent extends BuildableDataComponent<WrittenBookCo
          * @see #pages()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder setFilteredPages(List<Filtered<? extends ComponentLike>> pages);
+        Builder filteredPages(List<Filtered<? extends ComponentLike>> pages);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WrittenBookContent.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WrittenBookContent.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.text.Filtered;
 import java.util.List;
@@ -18,7 +19,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface WrittenBookContent {
+public interface WrittenBookContent extends BuildableDataComponent<WrittenBookContent, WrittenBookContent.Builder> {
 
     @Contract(value = "_, _ -> new", pure = true)
     static WrittenBookContent.Builder writtenBookContent(final String title, final String author) {
@@ -142,12 +143,22 @@ public interface WrittenBookContent {
         /**
          * Adds pages to this book.
          *
-         * @param page the pages
+         * @param pages the pages
          * @return the builder for chaining
          * @see #pages()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder addPages(List<? extends ComponentLike> page);
+        Builder addPages(List<? extends ComponentLike> pages);
+
+        /**
+         * Sets pages to this book.
+         *
+         * @param pages the pages
+         * @return the builder for chaining
+         * @see #pages()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder setPages(List<? extends ComponentLike> pages);
 
         /**
          * Adds a filterable page to this book.
@@ -168,5 +179,15 @@ public interface WrittenBookContent {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addFilteredPages(List<Filtered<? extends ComponentLike>> pages);
+
+        /**
+         * Sets filterable pages to this book.
+         *
+         * @param pages the pages
+         * @return the builder for chaining
+         * @see #pages()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder setFilteredPages(List<Filtered<? extends ComponentLike>> pages);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WrittenBookContent.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WrittenBookContent.java
@@ -121,17 +121,6 @@ public interface WrittenBookContent extends BookLike, BuildableDataComponent<Wri
         Builder generation(@IntRange(from = 0, to = 3) int generation);
 
         /**
-         * Sets if the chat components in this book have already been resolved (entity selectors, scores substituted).
-         * If {@code false}, will be resolved when opened by a player.
-         *
-         * @param resolved resolved
-         * @return the builder for chaining
-         * @see #resolved()
-         */
-        @Contract(value = "_ -> this", mutates = "this")
-        Builder resolved(boolean resolved);
-
-        /**
          * Adds a page to this book.
          *
          * @param page the page
@@ -190,5 +179,16 @@ public interface WrittenBookContent extends BookLike, BuildableDataComponent<Wri
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder filteredPages(List<Filtered<? extends ComponentLike>> pages);
+
+        /**
+         * Sets if the chat components in this book have already been resolved (entity selectors, scores substituted).
+         * If {@code false}, will be resolved when opened by a player.
+         *
+         * @param resolved resolved
+         * @return the builder for chaining
+         * @see #resolved()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder resolved(boolean resolved);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WrittenBookContent.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WrittenBookContent.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.text.Filtered;
 import java.util.List;
@@ -19,7 +20,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface WrittenBookContent extends BookLike {
+public interface WrittenBookContent extends BookLike, BuildableDataComponent<WrittenBookContent, WrittenBookContent.Builder> {
 
     @Contract(value = "_, _ -> new", pure = true)
     static WrittenBookContent.Builder writtenBookContent(final String title, final String author) {
@@ -143,12 +144,22 @@ public interface WrittenBookContent extends BookLike {
         /**
          * Adds pages to this book.
          *
-         * @param page the pages
+         * @param pages the pages
          * @return the builder for chaining
          * @see #pages()
          */
         @Contract(value = "_ -> this", mutates = "this")
-        Builder addPages(List<? extends ComponentLike> page);
+        Builder addPages(List<? extends ComponentLike> pages);
+
+        /**
+         * Sets pages to this book.
+         *
+         * @param pages the pages
+         * @return the builder for chaining
+         * @see #pages()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder pages(List<? extends ComponentLike> pages);
 
         /**
          * Adds a filterable page to this book.
@@ -169,5 +180,15 @@ public interface WrittenBookContent extends BookLike {
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder addFilteredPages(List<Filtered<? extends ComponentLike>> pages);
+
+        /**
+         * Sets filterable pages to this book.
+         *
+         * @param pages the pages
+         * @return the builder for chaining
+         * @see #pages()
+         */
+        @Contract(value = "_ -> this", mutates = "this")
+        Builder filteredPages(List<Filtered<? extends ComponentLike>> pages);
     }
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/DamageReduction.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/DamageReduction.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item.blocksattacks;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import io.papermc.paper.registry.set.RegistryKeySet;
 import org.bukkit.damage.DamageType;
@@ -18,7 +19,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface DamageReduction {
+public interface DamageReduction extends BuildableDataComponent<DamageReduction, DamageReduction.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static DamageReduction.Builder damageReduction() {

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/ItemDamageFunction.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/ItemDamageFunction.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent.item.blocksattacks;
 
+import io.papermc.paper.datacomponent.BuildableDataComponent;
 import io.papermc.paper.datacomponent.DataComponentBuilder;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.jetbrains.annotations.ApiStatus;
@@ -15,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @ApiStatus.Experimental
 @ApiStatus.NonExtendable
-public interface ItemDamageFunction {
+public interface ItemDamageFunction extends BuildableDataComponent<ItemDamageFunction, ItemDamageFunction.Builder> {
 
     @Contract(value = "-> new", pure = true)
     static ItemDamageFunction.Builder itemDamageFunction() {

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/ItemComponentTypesBridgesImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/ItemComponentTypesBridgesImpl.java
@@ -10,6 +10,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.util.TriState;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.item.component.OminousBottleAmplifier;
+import org.bukkit.Color;
 import org.bukkit.JukeboxSong;
 import org.bukkit.block.BlockType;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
@@ -80,6 +81,11 @@ public final class ItemComponentTypesBridgesImpl implements ItemComponentTypesBr
     @Override
     public MapItemColor.Builder mapItemColor() {
         return new PaperMapItemColor.BuilderImpl();
+    }
+
+    @Override
+    public MapItemColor mapItemColor(Color color) {
+        return new PaperMapItemColor(new net.minecraft.world.item.component.MapItemColor(color.asRGB()));
     }
 
     @Override

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperAttackRange.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperAttackRange.java
@@ -43,6 +43,17 @@ public record PaperAttackRange(
         return this.impl.mobFactor();
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .minReach(this.minReach())
+            .maxReach(this.maxReach())
+            .minCreativeReach(this.minCreativeReach())
+            .maxCreativeReach(this.maxCreativeReach())
+            .hitboxMargin(this.hitboxMargin())
+            .mobFactor(this.mobFactor());
+    }
+
     static final class BuilderImpl implements AttackRange.Builder {
 
         private float minReach = net.minecraft.world.item.component.AttackRange.CODEC_DEFAULT.minReach();

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBannerPatternLayers.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBannerPatternLayers.java
@@ -2,6 +2,7 @@ package io.papermc.paper.datacomponent.item;
 
 import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.util.MCUtil;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -32,6 +33,11 @@ public record PaperBannerPatternLayers(
     @Override
     public @Unmodifiable List<Pattern> patterns() {
         return convert(impl);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().addAll(this.patterns());
     }
 
     static final class BuilderImpl implements BannerPatternLayers.Builder {

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBannerPatternLayers.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBannerPatternLayers.java
@@ -2,7 +2,6 @@ package io.papermc.paper.datacomponent.item;
 
 import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.util.MCUtil;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBlocksAttacks.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBlocksAttacks.java
@@ -61,6 +61,18 @@ public record PaperBlocksAttacks(
         return this.impl.disableSound().map(holder -> PaperAdventure.asAdventure(holder.value().location())).orElse(null);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .blockDelaySeconds(this.blockDelaySeconds())
+            .disableCooldownScale(this.disableCooldownScale())
+            .damageReductions(this.damageReductions())
+            .itemDamage(this.itemDamage())
+            .bypassedBy(this.bypassedBy())
+            .blockSound(this.blockSound())
+            .disableSound(this.disableSound());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private float blockDelaySeconds;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBlocksAttacks.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBlocksAttacks.java
@@ -65,6 +65,18 @@ public record PaperBlocksAttacks(
         return this.impl.disableSound().map(holder -> PaperAdventure.asAdventure(holder.value().location())).orElse(null);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .blockDelaySeconds(this.blockDelaySeconds())
+            .disableCooldownScale(this.disableCooldownScale())
+            .damageReductions(this.damageReductions())
+            .itemDamage(this.itemDamage())
+            .bypassedBy(this.bypassedBy())
+            .blockSound(this.blockSound())
+            .disableSound(this.disableSound());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private float blockDelaySeconds;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBundleContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBundleContents.java
@@ -46,7 +46,7 @@ public record PaperBundleContents(
         }
 
         @Override
-        public Builder set(final List<ItemStack> stacks) {
+        public Builder stacks(final List<ItemStack> stacks) {
             items.clear();
             stacks.forEach(this::add);
             return this;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBundleContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBundleContents.java
@@ -22,6 +22,11 @@ public record PaperBundleContents(
         return MCUtil.transformUnmodifiable((List<net.minecraft.world.item.ItemStack>) this.impl.items(), CraftItemStack::asBukkitCopy);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().addAll(this.contents());
+    }
+
     static final class BuilderImpl implements BundleContents.Builder {
 
         private final List<net.minecraft.world.item.ItemStack> items = new ObjectArrayList<>();
@@ -36,6 +41,13 @@ public record PaperBundleContents(
 
         @Override
         public BundleContents.Builder addAll(final List<ItemStack> stacks) {
+            stacks.forEach(this::add);
+            return this;
+        }
+
+        @Override
+        public Builder set(final List<ItemStack> stacks) {
+            items.clear();
             stacks.forEach(this::add);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBundleContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBundleContents.java
@@ -21,6 +21,11 @@ public record PaperBundleContents(
         return this.impl.itemCopyStream().map(CraftItemStack::asBukkitCopy).toList();
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().addAll(this.contents());
+    }
+
     static final class BuilderImpl implements BundleContents.Builder {
 
         private final List<net.minecraft.world.item.ItemStackTemplate> items = new ObjectArrayList<>();
@@ -36,6 +41,13 @@ public record PaperBundleContents(
         @Override
         public BundleContents.Builder addAll(final List<ItemStack> items) {
             items.forEach(this::add);
+            return this;
+        }
+
+        @Override
+        public Builder stacks(final List<ItemStack> stacks) {
+            items.clear();
+            stacks.forEach(this::add);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBundleContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperBundleContents.java
@@ -45,9 +45,10 @@ public record PaperBundleContents(
         }
 
         @Override
-        public Builder stacks(final List<ItemStack> stacks) {
-            items.clear();
-            stacks.forEach(this::add);
+        public Builder contents(final List<ItemStack> contents) {
+            Preconditions.checkArgument(contents != null, "contents cannot be null");
+            this.items.clear();
+            this.addAll(contents);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperChargedProjectiles.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperChargedProjectiles.java
@@ -46,7 +46,7 @@ public record PaperChargedProjectiles(
         }
 
         @Override
-        public Builder set(final List<ItemStack> stacks) {
+        public Builder stacks(final List<ItemStack> stacks) {
             items.clear();
             stacks.forEach(this::add);
             return this;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperChargedProjectiles.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperChargedProjectiles.java
@@ -22,6 +22,11 @@ public record PaperChargedProjectiles(
         return MCUtil.transformUnmodifiable(this.impl.getItems() /*makes copies internally*/, CraftItemStack::asCraftMirror);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().addAll(this.projectiles());
+    }
+
     static final class BuilderImpl implements ChargedProjectiles.Builder {
 
         private final List<net.minecraft.world.item.ItemStack> items = new ArrayList<>();
@@ -36,6 +41,13 @@ public record PaperChargedProjectiles(
 
         @Override
         public ChargedProjectiles.Builder addAll(final List<ItemStack> stacks) {
+            stacks.forEach(this::add);
+            return this;
+        }
+
+        @Override
+        public Builder set(final List<ItemStack> stacks) {
+            items.clear();
             stacks.forEach(this::add);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperChargedProjectiles.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperChargedProjectiles.java
@@ -22,6 +22,11 @@ public record PaperChargedProjectiles(
         return MCUtil.transformUnmodifiable(this.impl.itemCopies(), CraftItemStack::asCraftMirror);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().addAll(this.projectiles());
+    }
+
     static final class BuilderImpl implements ChargedProjectiles.Builder {
 
         private final List<net.minecraft.world.item.ItemStack> items = new ArrayList<>();
@@ -37,6 +42,13 @@ public record PaperChargedProjectiles(
         @Override
         public ChargedProjectiles.Builder addAll(final List<ItemStack> items) {
             items.forEach(this::add);
+            return this;
+        }
+
+        @Override
+        public Builder items(final List<ItemStack> stacks) {
+            this.items.clear();
+            stacks.forEach(this::add);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperConsumable.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperConsumable.java
@@ -59,7 +59,8 @@ public record PaperConsumable(
             .consumeSeconds(this.consumeSeconds())
             .animation(this.animation())
             .sound(this.sound())
-            .addEffects(this.consumeEffects());
+            .hasConsumeParticles(this.hasConsumeParticles())
+            .effects(this.consumeEffects());
     }
 
     static final class BuilderImpl implements Builder {

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperCustomModelData.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperCustomModelData.java
@@ -43,6 +43,15 @@ public record PaperCustomModelData(
         return MCUtil.transformUnmodifiable(this.impl.colors(), color -> Color.fromRGB(color & 0x00FFFFFF)); // skip alpha channel
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .floats(this.floats())
+            .flags(this.flags())
+            .strings(this.strings())
+            .colors(this.colors());
+    }
+
     static final class BuilderImpl implements CustomModelData.Builder {
 
         private final FloatList floats = new FloatArrayList();
@@ -66,6 +75,16 @@ public record PaperCustomModelData(
         }
 
         @Override
+        public Builder floats(final List<Float> floats) {
+            this.floats.clear();
+            for (Float f : floats) {
+                Preconditions.checkArgument(f != null, "Float cannot be null");
+            }
+            this.floats.addAll(floats);
+            return this;
+        }
+
+        @Override
         public Builder addFlag(final boolean flag) {
             this.flags.add(flag);
             return this;
@@ -73,6 +92,16 @@ public record PaperCustomModelData(
 
         @Override
         public Builder addFlags(final List<Boolean> flags) {
+            for (Boolean flag : flags) {
+                Preconditions.checkArgument(flag != null, "Flag cannot be null");
+            }
+            this.flags.addAll(flags);
+            return this;
+        }
+
+        @Override
+        public Builder flags(final List<Boolean> flags) {
+            this.flags.clear();
             for (Boolean flag : flags) {
                 Preconditions.checkArgument(flag != null, "Flag cannot be null");
             }
@@ -94,6 +123,13 @@ public record PaperCustomModelData(
         }
 
         @Override
+        public Builder strings(final List<String> strings) {
+            this.strings.clear();
+            strings.forEach(this::addString);
+            return this;
+        }
+
+        @Override
         public Builder addColor(final Color color) {
             Preconditions.checkArgument(color != null, "Color cannot be null");
             this.colors.add(color.asRGB());
@@ -102,6 +138,13 @@ public record PaperCustomModelData(
 
         @Override
         public Builder addColors(final List<Color> colors) {
+            colors.forEach(this::addColor);
+            return this;
+        }
+
+        @Override
+        public Builder colors(final List<Color> colors) {
+            this.colors.clear();
             colors.forEach(this::addColor);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperCustomModelData.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperCustomModelData.java
@@ -43,6 +43,15 @@ public record PaperCustomModelData(
         return MCUtil.transformUnmodifiable(this.impl.colors(), color -> Color.fromRGB(color & 0x00FFFFFF)); // skip alpha channel
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .setFloats(this.floats())
+            .setFlags(this.flags())
+            .setStrings(this.strings())
+            .setColors(this.colors());
+    }
+
     static final class BuilderImpl implements CustomModelData.Builder {
 
         private final FloatList floats = new FloatArrayList();
@@ -66,6 +75,16 @@ public record PaperCustomModelData(
         }
 
         @Override
+        public Builder setFloats(final List<Float> floats) {
+            for (Float f : floats) {
+                Preconditions.checkArgument(f != null, "Float cannot be null");
+            }
+            this.floats.clear();
+            this.floats.addAll(floats);
+            return this;
+        }
+
+        @Override
         public Builder addFlag(final boolean flag) {
             this.flags.add(flag);
             return this;
@@ -76,6 +95,16 @@ public record PaperCustomModelData(
             for (Boolean flag : flags) {
                 Preconditions.checkArgument(flag != null, "Flag cannot be null");
             }
+            this.flags.addAll(flags);
+            return this;
+        }
+
+        @Override
+        public Builder setFlags(final List<Boolean> flags) {
+            for (Boolean flag : flags) {
+                Preconditions.checkArgument(flag != null, "Flag cannot be null");
+            }
+            this.flags.clear();
             this.flags.addAll(flags);
             return this;
         }
@@ -94,6 +123,13 @@ public record PaperCustomModelData(
         }
 
         @Override
+        public Builder setStrings(final List<String> strings) {
+            this.strings.clear();
+            strings.forEach(this::addString);
+            return this;
+        }
+
+        @Override
         public Builder addColor(final Color color) {
             Preconditions.checkArgument(color != null, "Color cannot be null");
             this.colors.add(color.asRGB());
@@ -102,6 +138,13 @@ public record PaperCustomModelData(
 
         @Override
         public Builder addColors(final List<Color> colors) {
+            colors.forEach(this::addColor);
+            return this;
+        }
+
+        @Override
+        public Builder setColors(final List<Color> colors) {
+            this.colors.clear();
             colors.forEach(this::addColor);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperCustomModelData.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperCustomModelData.java
@@ -46,10 +46,10 @@ public record PaperCustomModelData(
     @Override
     public Builder toBuilder() {
         return new BuilderImpl()
-            .setFloats(this.floats())
-            .setFlags(this.flags())
-            .setStrings(this.strings())
-            .setColors(this.colors());
+            .floats(this.floats())
+            .flags(this.flags())
+            .strings(this.strings())
+            .colors(this.colors());
     }
 
     static final class BuilderImpl implements CustomModelData.Builder {
@@ -75,11 +75,11 @@ public record PaperCustomModelData(
         }
 
         @Override
-        public Builder setFloats(final List<Float> floats) {
+        public Builder floats(final List<Float> floats) {
+            this.floats.clear();
             for (Float f : floats) {
                 Preconditions.checkArgument(f != null, "Float cannot be null");
             }
-            this.floats.clear();
             this.floats.addAll(floats);
             return this;
         }
@@ -100,11 +100,11 @@ public record PaperCustomModelData(
         }
 
         @Override
-        public Builder setFlags(final List<Boolean> flags) {
+        public Builder flags(final List<Boolean> flags) {
+            this.flags.clear();
             for (Boolean flag : flags) {
                 Preconditions.checkArgument(flag != null, "Flag cannot be null");
             }
-            this.flags.clear();
             this.flags.addAll(flags);
             return this;
         }
@@ -123,7 +123,7 @@ public record PaperCustomModelData(
         }
 
         @Override
-        public Builder setStrings(final List<String> strings) {
+        public Builder strings(final List<String> strings) {
             this.strings.clear();
             strings.forEach(this::addString);
             return this;
@@ -143,7 +143,7 @@ public record PaperCustomModelData(
         }
 
         @Override
-        public Builder setColors(final List<Color> colors) {
+        public Builder colors(final List<Color> colors) {
             this.colors.clear();
             colors.forEach(this::addColor);
             return this;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperCustomModelData.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperCustomModelData.java
@@ -77,10 +77,7 @@ public record PaperCustomModelData(
         @Override
         public Builder floats(final List<Float> floats) {
             this.floats.clear();
-            for (Float f : floats) {
-                Preconditions.checkArgument(f != null, "Float cannot be null");
-            }
-            this.floats.addAll(floats);
+            this.addFloats(floats);
             return this;
         }
 
@@ -102,10 +99,7 @@ public record PaperCustomModelData(
         @Override
         public Builder flags(final List<Boolean> flags) {
             this.flags.clear();
-            for (Boolean flag : flags) {
-                Preconditions.checkArgument(flag != null, "Flag cannot be null");
-            }
-            this.flags.addAll(flags);
+            this.addFlags(flags);
             return this;
         }
 
@@ -125,7 +119,7 @@ public record PaperCustomModelData(
         @Override
         public Builder strings(final List<String> strings) {
             this.strings.clear();
-            strings.forEach(this::addString);
+            this.addStrings(strings);
             return this;
         }
 
@@ -145,7 +139,7 @@ public record PaperCustomModelData(
         @Override
         public Builder colors(final List<Color> colors) {
             this.colors.clear();
-            colors.forEach(this::addColor);
+            this.addColors(colors);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperDeathProtection.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperDeathProtection.java
@@ -24,7 +24,7 @@ public record PaperDeathProtection(
 
     @Override
     public Builder toBuilder() {
-        return new BuilderImpl().setEffects(this.deathEffects());
+        return new BuilderImpl().effects(this.deathEffects());
     }
 
     static final class BuilderImpl implements Builder {
@@ -46,7 +46,7 @@ public record PaperDeathProtection(
         }
 
         @Override
-        public Builder setEffects(final List<ConsumeEffect> effects) {
+        public Builder effects(final List<ConsumeEffect> effects) {
             effects.clear();
             for (final ConsumeEffect effect : effects) {
                 this.effects.add(PaperConsumableEffect.toNms(effect));

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperDeathProtection.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperDeathProtection.java
@@ -22,6 +22,11 @@ public record PaperDeathProtection(
         return MCUtil.transformUnmodifiable(this.impl.deathEffects(), PaperConsumableEffect::fromNms);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().setEffects(this.deathEffects());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private final List<net.minecraft.world.item.consume_effects.ConsumeEffect> effects = new ArrayList<>();
@@ -34,6 +39,15 @@ public record PaperDeathProtection(
 
         @Override
         public Builder addEffects(final List<ConsumeEffect> effects) {
+            for (final ConsumeEffect effect : effects) {
+                this.effects.add(PaperConsumableEffect.toNms(effect));
+            }
+            return this;
+        }
+
+        @Override
+        public Builder setEffects(final List<ConsumeEffect> effects) {
+            effects.clear();
             for (final ConsumeEffect effect : effects) {
                 this.effects.add(PaperConsumableEffect.toNms(effect));
             }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperDeathProtection.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperDeathProtection.java
@@ -22,6 +22,11 @@ public record PaperDeathProtection(
         return MCUtil.transformUnmodifiable(this.impl.deathEffects(), PaperConsumableEffect::fromVanilla);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().effects(this.deathEffects());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private final List<net.minecraft.world.item.consume_effects.ConsumeEffect> effects = new ArrayList<>();
@@ -34,6 +39,15 @@ public record PaperDeathProtection(
 
         @Override
         public Builder addEffects(final List<ConsumeEffect> effects) {
+            for (final ConsumeEffect effect : effects) {
+                this.effects.add(PaperConsumableEffect.toVanilla(effect));
+            }
+            return this;
+        }
+
+        @Override
+        public Builder effects(final List<ConsumeEffect> effects) {
+            effects.clear();
             for (final ConsumeEffect effect : effects) {
                 this.effects.add(PaperConsumableEffect.toVanilla(effect));
             }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperDeathProtection.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperDeathProtection.java
@@ -47,7 +47,7 @@ public record PaperDeathProtection(
 
         @Override
         public Builder effects(final List<ConsumeEffect> effects) {
-            effects.clear();
+            this.effects.clear();
             for (final ConsumeEffect effect : effects) {
                 this.effects.add(PaperConsumableEffect.toVanilla(effect));
             }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperDeathProtection.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperDeathProtection.java
@@ -48,9 +48,7 @@ public record PaperDeathProtection(
         @Override
         public Builder effects(final List<ConsumeEffect> effects) {
             this.effects.clear();
-            for (final ConsumeEffect effect : effects) {
-                this.effects.add(PaperConsumableEffect.toVanilla(effect));
-            }
+            this.addEffects(effects);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperDyedItemColor.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperDyedItemColor.java
@@ -17,6 +17,11 @@ public record PaperDyedItemColor(
         return Color.fromRGB(this.impl.rgb() & 0x00FFFFFF); // skip alpha channel
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().color(this.color());
+    }
+
     static final class BuilderImpl implements DyedItemColor.Builder {
 
         private Color color = Color.WHITE;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperEquippable.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperEquippable.java
@@ -104,8 +104,8 @@ public record PaperEquippable(
             .swappable(this.swappable())
             .damageOnHurt(this.damageOnHurt())
             .equipOnInteract(this.equipOnInteract())
-            .shearSound(this.shearSound())
-            .canBeSheared(this.canBeSheared());
+            .canBeSheared(this.canBeSheared())
+            .shearSound(this.shearSound());
     }
 
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperFireworks.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperFireworks.java
@@ -29,6 +29,13 @@ public record PaperFireworks(
         return this.impl.flightDuration();
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .flightDuration(this.flightDuration())
+            .effects(this.effects());
+    }
+
     static final class BuilderImpl implements Fireworks.Builder {
 
         private final List<FireworkExplosion> effects = new ObjectArrayList<>();
@@ -61,6 +68,19 @@ public record PaperFireworks(
                 net.minecraft.world.item.component.Fireworks.MAX_EXPLOSIONS,
                 this.effects.size() + effects.size()
             );
+            MCUtil.addAndConvert(this.effects, effects, CraftMetaFirework::getExplosion);
+            return this;
+        }
+
+        @Override
+        public Builder effects(final List<FireworkEffect> effects) {
+            Preconditions.checkArgument(
+                effects.size() <= net.minecraft.world.item.component.Fireworks.MAX_EXPLOSIONS,
+                "Cannot have more than %s effects, had %s",
+                net.minecraft.world.item.component.Fireworks.MAX_EXPLOSIONS,
+                effects.size()
+            );
+            this.effects.clear();
             MCUtil.addAndConvert(this.effects, effects, CraftMetaFirework::getExplosion);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperFireworks.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperFireworks.java
@@ -29,6 +29,13 @@ public record PaperFireworks(
         return this.impl.flightDuration();
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .flightDuration(this.flightDuration())
+            .setEffects(this.effects());
+    }
+
     static final class BuilderImpl implements Fireworks.Builder {
 
         private final List<FireworkExplosion> effects = new ObjectArrayList<>();
@@ -61,6 +68,19 @@ public record PaperFireworks(
                 net.minecraft.world.item.component.Fireworks.MAX_EXPLOSIONS,
                 this.effects.size() + effects.size()
             );
+            MCUtil.addAndConvert(this.effects, effects, CraftMetaFirework::getExplosion);
+            return this;
+        }
+
+        @Override
+        public Builder setEffects(final List<FireworkEffect> effects) {
+            Preconditions.checkArgument(
+                effects.size() <= net.minecraft.world.item.component.Fireworks.MAX_EXPLOSIONS,
+                "Cannot have more than %s effects, had %s",
+                net.minecraft.world.item.component.Fireworks.MAX_EXPLOSIONS,
+                effects.size()
+            );
+            this.effects.clear();
             MCUtil.addAndConvert(this.effects, effects, CraftMetaFirework::getExplosion);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperFireworks.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperFireworks.java
@@ -33,7 +33,7 @@ public record PaperFireworks(
     public Builder toBuilder() {
         return new BuilderImpl()
             .flightDuration(this.flightDuration())
-            .setEffects(this.effects());
+            .effects(this.effects());
     }
 
     static final class BuilderImpl implements Fireworks.Builder {
@@ -73,7 +73,7 @@ public record PaperFireworks(
         }
 
         @Override
-        public Builder setEffects(final List<FireworkEffect> effects) {
+        public Builder effects(final List<FireworkEffect> effects) {
             Preconditions.checkArgument(
                 effects.size() <= net.minecraft.world.item.component.Fireworks.MAX_EXPLOSIONS,
                 "Cannot have more than %s effects, had %s",

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperFireworks.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperFireworks.java
@@ -32,21 +32,14 @@ public record PaperFireworks(
     @Override
     public Builder toBuilder() {
         return new BuilderImpl()
-            .flightDuration(this.flightDuration())
-            .effects(this.effects());
+            .effects(this.effects())
+            .flightDuration(this.flightDuration());
     }
 
     static final class BuilderImpl implements Fireworks.Builder {
 
         private final List<FireworkExplosion> effects = new ObjectArrayList<>();
         private int duration = 0; // default set from nms Fireworks component
-
-        @Override
-        public Fireworks.Builder flightDuration(final int duration) {
-            Preconditions.checkArgument(duration >= 0 && duration <= 0xFF, "duration must be an unsigned byte ([%s, %s]), was %s", 0, 0xFF, duration);
-            this.duration = duration;
-            return this;
-        }
 
         @Override
         public Fireworks.Builder addEffect(final FireworkEffect effect) {
@@ -76,6 +69,13 @@ public record PaperFireworks(
         public Builder effects(final List<FireworkEffect> effects) {
             this.effects.clear();
             this.addEffects(effects);
+            return this;
+        }
+
+        @Override
+        public Fireworks.Builder flightDuration(final int duration) {
+            Preconditions.checkArgument(duration >= 0 && duration <= 0xFF, "duration must be an unsigned byte ([%s, %s]), was %s", 0, 0xFF, duration);
+            this.duration = duration;
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperFireworks.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperFireworks.java
@@ -74,14 +74,8 @@ public record PaperFireworks(
 
         @Override
         public Builder effects(final List<FireworkEffect> effects) {
-            Preconditions.checkArgument(
-                effects.size() <= net.minecraft.world.item.component.Fireworks.MAX_EXPLOSIONS,
-                "Cannot have more than %s effects, had %s",
-                net.minecraft.world.item.component.Fireworks.MAX_EXPLOSIONS,
-                effects.size()
-            );
             this.effects.clear();
-            MCUtil.addAndConvert(this.effects, effects, CraftMetaFirework::getExplosion);
+            this.addEffects(effects);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAdventurePredicate.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAdventurePredicate.java
@@ -31,6 +31,11 @@ public record PaperItemAdventurePredicate(
         return convert(this.impl);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().setPredicates(this.predicates());
+    }
+
     static final class BuilderImpl implements ItemAdventurePredicate.Builder {
 
         private final List<net.minecraft.advancements.critereon.BlockPredicate> predicates = new ObjectArrayList<>();
@@ -48,6 +53,13 @@ public record PaperItemAdventurePredicate(
             for (final BlockPredicate predicate : predicates) {
                 this.addPredicate(predicate);
             }
+            return this;
+        }
+
+        @Override
+        public Builder setPredicates(final List<BlockPredicate> predicates) {
+            this.predicates.clear();
+            predicates.forEach(this::addPredicate);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAdventurePredicate.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAdventurePredicate.java
@@ -33,7 +33,7 @@ public record PaperItemAdventurePredicate(
 
     @Override
     public Builder toBuilder() {
-        return new BuilderImpl().setPredicates(this.predicates());
+        return new BuilderImpl().predicates(this.predicates());
     }
 
     static final class BuilderImpl implements ItemAdventurePredicate.Builder {
@@ -57,7 +57,7 @@ public record PaperItemAdventurePredicate(
         }
 
         @Override
-        public Builder setPredicates(final List<BlockPredicate> predicates) {
+        public Builder predicates(final List<BlockPredicate> predicates) {
             this.predicates.clear();
             predicates.forEach(this::addPredicate);
             return this;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAdventurePredicate.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAdventurePredicate.java
@@ -59,7 +59,7 @@ public record PaperItemAdventurePredicate(
         @Override
         public Builder predicates(final List<BlockPredicate> predicates) {
             this.predicates.clear();
-            predicates.forEach(this::addPredicate);
+            this.addPredicates(predicates);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAdventurePredicate.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAdventurePredicate.java
@@ -31,6 +31,11 @@ public record PaperItemAdventurePredicate(
         return convert(this.impl);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().predicates(this.predicates());
+    }
+
     static final class BuilderImpl implements ItemAdventurePredicate.Builder {
 
         private final List<net.minecraft.advancements.predicates.BlockPredicate> predicates = new ObjectArrayList<>();
@@ -48,6 +53,13 @@ public record PaperItemAdventurePredicate(
             for (final BlockPredicate predicate : predicates) {
                 this.addPredicate(predicate);
             }
+            return this;
+        }
+
+        @Override
+        public Builder predicates(final List<BlockPredicate> predicates) {
+            this.predicates.clear();
+            predicates.forEach(this::addPredicate);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemArmorTrim.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemArmorTrim.java
@@ -19,6 +19,11 @@ public record PaperItemArmorTrim(
         return new ArmorTrim(CraftTrimMaterial.minecraftHolderToBukkit(this.impl.material()), CraftTrimPattern.minecraftHolderToBukkit(this.impl.pattern()));
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this.armorTrim());
+    }
+
     static final class BuilderImpl implements ItemArmorTrim.Builder {
 
         private ArmorTrim armorTrim;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemArmorTrim.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemArmorTrim.java
@@ -19,11 +19,6 @@ public record PaperItemArmorTrim(
         return new ArmorTrim(CraftTrimMaterial.minecraftHolderToBukkit(this.impl.material()), CraftTrimPattern.minecraftHolderToBukkit(this.impl.pattern()));
     }
 
-    @Override
-    public Builder toBuilder() {
-        return new BuilderImpl(this.armorTrim());
-    }
-
     static final class BuilderImpl implements ItemArmorTrim.Builder {
 
         private ArmorTrim armorTrim;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAttributeModifiers.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAttributeModifiers.java
@@ -38,6 +38,13 @@ public record PaperItemAttributeModifiers(
         return convert(this.impl);
     }
 
+    @Override
+    public Builder toBuilder() {
+        Builder builder = new BuilderImpl();
+        this.modifiers().forEach(entry -> builder.addModifier(entry.attribute(), entry.modifier(), entry.display()));
+        return builder;
+    }
+
     public record PaperEntry(Attribute attribute, AttributeModifier modifier, AttributeModifierDisplay display) implements ItemAttributeModifiers.Entry {
     }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAttributeModifiers.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemAttributeModifiers.java
@@ -41,7 +41,7 @@ public record PaperItemAttributeModifiers(
     @Override
     public Builder toBuilder() {
         Builder builder = new BuilderImpl();
-        this.modifiers().forEach(entry -> builder.addModifier(entry.attribute(), entry.modifier(), entry.display()));
+        this.modifiers().forEach(entry -> builder.addModifier(entry.attribute(), entry.modifier(), entry.display())); // todo check slot group
         return builder;
     }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemContainerContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemContainerContents.java
@@ -22,6 +22,11 @@ public record PaperItemContainerContents(
         return MCUtil.transformUnmodifiable(this.impl.items, CraftItemStack::asBukkitCopy);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().addAll(this.contents());
+    }
+
     static final class BuilderImpl implements ItemContainerContents.Builder {
 
         private final List<net.minecraft.world.item.ItemStack> items = new ObjectArrayList<>();
@@ -47,6 +52,22 @@ public record PaperItemContainerContents(
                 net.minecraft.world.item.component.ItemContainerContents.MAX_SIZE,
                 this.items.size() + stacks.size()
             );
+            MCUtil.addAndConvert(this.items, stacks, stack -> {
+                Preconditions.checkArgument(stack != null, "Cannot pass null item!");
+                return CraftItemStack.asNMSCopy(stack);
+            });
+            return this;
+        }
+
+        @Override
+        public Builder set(final List<ItemStack> stacks) {
+            Preconditions.checkArgument(
+                stacks.size() <= net.minecraft.world.item.component.ItemContainerContents.MAX_SIZE,
+                "Cannot have more than %s items, had %s",
+                net.minecraft.world.item.component.ItemContainerContents.MAX_SIZE,
+                stacks.size()
+            );
+            this.items.clear();
             MCUtil.addAndConvert(this.items, stacks, stack -> {
                 Preconditions.checkArgument(stack != null, "Cannot pass null item!");
                 return CraftItemStack.asNMSCopy(stack);

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemContainerContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemContainerContents.java
@@ -60,14 +60,14 @@ public record PaperItemContainerContents(
         }
 
         @Override
-        public Builder set(final List<ItemStack> stacks) {
+        public Builder stacks(final List<ItemStack> stacks) {
+            this.items.clear();
             Preconditions.checkArgument(
                 stacks.size() <= net.minecraft.world.item.component.ItemContainerContents.MAX_SIZE,
                 "Cannot have more than %s items, had %s",
                 net.minecraft.world.item.component.ItemContainerContents.MAX_SIZE,
                 stacks.size()
             );
-            this.items.clear();
             MCUtil.addAndConvert(this.items, stacks, stack -> {
                 Preconditions.checkArgument(stack != null, "Cannot pass null item!");
                 return CraftItemStack.asNMSCopy(stack);

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemContainerContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemContainerContents.java
@@ -60,18 +60,9 @@ public record PaperItemContainerContents(
         }
 
         @Override
-        public Builder stacks(final List<ItemStack> stacks) {
+        public Builder contents(final List<ItemStack> contents) {
             this.items.clear();
-            Preconditions.checkArgument(
-                stacks.size() <= net.minecraft.world.item.component.ItemContainerContents.MAX_SIZE,
-                "Cannot have more than %s items, had %s",
-                net.minecraft.world.item.component.ItemContainerContents.MAX_SIZE,
-                stacks.size()
-            );
-            MCUtil.addAndConvert(this.items, stacks, stack -> {
-                Preconditions.checkArgument(stack != null, "Cannot pass null item!");
-                return CraftItemStack.asNMSCopy(stack);
-            });
+            this.addAll(contents);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemContainerContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemContainerContents.java
@@ -22,6 +22,11 @@ public record PaperItemContainerContents(
         return MCUtil.transformUnmodifiable(this.impl.items, optional -> optional.map(CraftItemStack::asBukkitCopy).orElse(ItemStack.empty()));
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().addAll(this.contents());
+    }
+
     static final class BuilderImpl implements ItemContainerContents.Builder {
 
         private final List<net.minecraft.world.item.ItemStack> items = new ObjectArrayList<>();
@@ -50,6 +55,22 @@ public record PaperItemContainerContents(
             MCUtil.addAndConvert(this.items, items, item -> {
                 Preconditions.checkArgument(item != null, "Cannot pass null item!");
                 return CraftItemStack.asNMSCopy(item);
+            });
+            return this;
+        }
+
+        @Override
+        public Builder stacks(final List<ItemStack> stacks) {
+            this.items.clear();
+            Preconditions.checkArgument(
+                stacks.size() <= net.minecraft.world.item.component.ItemContainerContents.MAX_SIZE,
+                "Cannot have more than %s items, had %s",
+                net.minecraft.world.item.component.ItemContainerContents.MAX_SIZE,
+                stacks.size()
+            );
+            MCUtil.addAndConvert(this.items, stacks, stack -> {
+                Preconditions.checkArgument(stack != null, "Cannot pass null item!");
+                return CraftItemStack.asNMSCopy(stack);
             });
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemEnchantments.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemEnchantments.java
@@ -39,7 +39,7 @@ public record PaperItemEnchantments(
 
     @Override
     public Builder toBuilder() {
-        return new BuilderImpl().set(this.enchantments());
+        return new BuilderImpl().enchantments(this.enchantments());
     }
 
     static final class BuilderImpl implements ItemEnchantments.Builder {
@@ -65,7 +65,7 @@ public record PaperItemEnchantments(
         }
 
         @Override
-        public Builder set(final Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments) {
+        public Builder enchantments(final Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments) {
             this.enchantments.clear();
             enchantments.forEach(this::add);
             return this;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemEnchantments.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemEnchantments.java
@@ -10,6 +10,7 @@ import net.minecraft.core.Holder;
 import org.bukkit.craftbukkit.enchantments.CraftEnchantment;
 import org.bukkit.craftbukkit.util.Handleable;
 import org.bukkit.enchantments.Enchantment;
+import org.checkerframework.common.value.qual.IntRange;
 
 public record PaperItemEnchantments(
     net.minecraft.world.item.enchantment.ItemEnchantments impl,
@@ -36,6 +37,11 @@ public record PaperItemEnchantments(
         return this.impl;
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().set(this.enchantments());
+    }
+
     static final class BuilderImpl implements ItemEnchantments.Builder {
 
         private final Map<Enchantment, Integer> enchantments = new Object2ObjectOpenHashMap<>();
@@ -54,6 +60,13 @@ public record PaperItemEnchantments(
 
         @Override
         public ItemEnchantments.Builder addAll(final Map<Enchantment, Integer> enchantments) {
+            enchantments.forEach(this::add);
+            return this;
+        }
+
+        @Override
+        public Builder set(final Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments) {
+            this.enchantments.clear();
             enchantments.forEach(this::add);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemEnchantments.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemEnchantments.java
@@ -9,6 +9,7 @@ import net.minecraft.core.Holder;
 import org.bukkit.craftbukkit.enchantments.CraftEnchantment;
 import org.bukkit.craftbukkit.util.Handleable;
 import org.bukkit.enchantments.Enchantment;
+import org.checkerframework.common.value.qual.IntRange;
 
 import static io.papermc.paper.util.BoundChecker.requireRange;
 
@@ -37,6 +38,11 @@ public record PaperItemEnchantments(
         return this.impl;
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().enchantments(this.enchantments());
+    }
+
     static final class BuilderImpl implements ItemEnchantments.Builder {
 
         private final Map<Enchantment, Integer> enchantments = new Object2ObjectOpenHashMap<>();
@@ -49,6 +55,13 @@ public record PaperItemEnchantments(
 
         @Override
         public ItemEnchantments.Builder addAll(final Map<Enchantment, Integer> enchantments) {
+            enchantments.forEach(this::add);
+            return this;
+        }
+
+        @Override
+        public Builder enchantments(final Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments) {
+            this.enchantments.clear();
             enchantments.forEach(this::add);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemEnchantments.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemEnchantments.java
@@ -62,7 +62,7 @@ public record PaperItemEnchantments(
         @Override
         public Builder enchantments(final Map<Enchantment, @IntRange(from = 1, to = 255) Integer> enchantments) {
             this.enchantments.clear();
-            enchantments.forEach(this::add);
+            this.addAll(enchantments);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemLore.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemLore.java
@@ -30,6 +30,11 @@ public record PaperItemLore(
         return MCUtil.transformUnmodifiable(this.impl.styledLines(), PaperAdventure::asAdventure);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().lines(this.lines());
+    }
+
     static final class BuilderImpl implements ItemLore.Builder {
 
         private List<Component> lines = new ObjectArrayList<>();

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemTool.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemTool.java
@@ -67,7 +67,7 @@ public record PaperItemTool(
         return new BuilderImpl()
             .damagePerBlock(this.damagePerBlock())
             .defaultMiningSpeed(this.defaultMiningSpeed())
-            .setRules(this.rules())
+            .rules(this.rules())
             .canDestroyBlocksInCreative(this.canDestroyBlocksInCreative());
     }
 
@@ -114,7 +114,7 @@ public record PaperItemTool(
         }
 
         @Override
-        public Builder setRules(final Collection<Rule> rules) {
+        public Builder rules(final Collection<Rule> rules) {
             this.rules.clear();
             rules.forEach(this::addRule);
             return this;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemTool.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemTool.java
@@ -62,6 +62,15 @@ public record PaperItemTool(
         }
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .damagePerBlock(this.damagePerBlock())
+            .defaultMiningSpeed(this.defaultMiningSpeed())
+            .setRules(this.rules())
+            .canDestroyBlocksInCreative(this.canDestroyBlocksInCreative());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private final List<net.minecraft.world.item.component.Tool.Rule> rules = new ObjectArrayList<>();
@@ -100,6 +109,13 @@ public record PaperItemTool(
 
         @Override
         public Builder addRules(final Collection<Rule> rules) {
+            rules.forEach(this::addRule);
+            return this;
+        }
+
+        @Override
+        public Builder setRules(final Collection<Rule> rules) {
+            this.rules.clear();
             rules.forEach(this::addRule);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemTool.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemTool.java
@@ -64,6 +64,15 @@ public record PaperItemTool(
         }
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .damagePerBlock(this.damagePerBlock())
+            .defaultMiningSpeed(this.defaultMiningSpeed())
+            .rules(this.rules())
+            .canDestroyBlocksInCreative(this.canDestroyBlocksInCreative());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private final List<net.minecraft.world.item.component.Tool.Rule> rules = new ObjectArrayList<>();
@@ -101,6 +110,13 @@ public record PaperItemTool(
 
         @Override
         public Builder addRules(final Collection<Rule> rules) {
+            rules.forEach(this::addRule);
+            return this;
+        }
+
+        @Override
+        public Builder rules(final Collection<Rule> rules) {
+            this.rules.clear();
             rules.forEach(this::addRule);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemTool.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemTool.java
@@ -117,7 +117,7 @@ public record PaperItemTool(
         @Override
         public Builder rules(final Collection<Rule> rules) {
             this.rules.clear();
-            rules.forEach(this::addRule);
+            this.addRules(rules);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemTool.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemTool.java
@@ -67,30 +67,18 @@ public record PaperItemTool(
     @Override
     public Builder toBuilder() {
         return new BuilderImpl()
-            .damagePerBlock(this.damagePerBlock())
-            .defaultMiningSpeed(this.defaultMiningSpeed())
             .rules(this.rules())
+            .defaultMiningSpeed(this.defaultMiningSpeed())
+            .damagePerBlock(this.damagePerBlock())
             .canDestroyBlocksInCreative(this.canDestroyBlocksInCreative());
     }
 
     static final class BuilderImpl implements Builder {
 
         private final List<net.minecraft.world.item.component.Tool.Rule> rules = new ObjectArrayList<>();
-        private int damage = 1;
         private float miningSpeed = 1.0F;
+        private int damage = 1;
         private boolean canDestroyBlocksInCreative = true;
-
-        @Override
-        public Builder damagePerBlock(final @NonNegative int damage) {
-            this.damage = requireNonNegative(damage, "damage");
-            return this;
-        }
-
-        @Override
-        public Builder defaultMiningSpeed(final float miningSpeed) {
-            this.miningSpeed = miningSpeed;
-            return this;
-        }
 
         @Override
         public Builder addRule(final Rule rule) {
@@ -99,12 +87,6 @@ public record PaperItemTool(
                 Optional.ofNullable(rule.speed()),
                 Optional.ofNullable(rule.correctForDrops().toBoolean())
             ));
-            return this;
-        }
-
-        @Override
-        public Builder canDestroyBlocksInCreative(final boolean canDestroyBlocksInCreative) {
-            this.canDestroyBlocksInCreative = canDestroyBlocksInCreative;
             return this;
         }
 
@@ -118,6 +100,24 @@ public record PaperItemTool(
         public Builder rules(final Collection<Rule> rules) {
             this.rules.clear();
             this.addRules(rules);
+            return this;
+        }
+
+        @Override
+        public Builder defaultMiningSpeed(final float miningSpeed) {
+            this.miningSpeed = miningSpeed;
+            return this;
+        }
+
+        @Override
+        public Builder damagePerBlock(final @NonNegative int damage) {
+            this.damage = requireNonNegative(damage, "damage");
+            return this;
+        }
+
+        @Override
+        public Builder canDestroyBlocksInCreative(final boolean canDestroyBlocksInCreative) {
+            this.canDestroyBlocksInCreative = canDestroyBlocksInCreative;
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperJukeboxPlayable.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperJukeboxPlayable.java
@@ -23,6 +23,11 @@ public record PaperJukeboxPlayable(
             .orElseThrow();
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this.jukeboxSong());
+    }
+
     static final class BuilderImpl implements JukeboxPlayable.Builder {
 
         private JukeboxSong song;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperJukeboxPlayable.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperJukeboxPlayable.java
@@ -18,6 +18,11 @@ public record PaperJukeboxPlayable(
         return CraftJukeboxSong.minecraftHolderToBukkit(this.impl.song());
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this.jukeboxSong());
+    }
+
     static final class BuilderImpl implements JukeboxPlayable.Builder {
 
         private JukeboxSong song;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperJukeboxPlayable.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperJukeboxPlayable.java
@@ -18,11 +18,6 @@ public record PaperJukeboxPlayable(
         return CraftJukeboxSong.minecraftHolderToBukkit(this.impl.song());
     }
 
-    @Override
-    public Builder toBuilder() {
-        return new BuilderImpl(this.jukeboxSong());
-    }
-
     static final class BuilderImpl implements JukeboxPlayable.Builder {
 
         private JukeboxSong song;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperKineticWeapon.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperKineticWeapon.java
@@ -93,8 +93,8 @@ public record PaperKineticWeapon(
             .delayTicks(this.delayTicks())
             .dismountConditions(this.dismountConditions())
             .knockbackConditions(this.knockbackConditions())
-            .forwardMovement(this.forwardMovement())
             .damageConditions(this.damageConditions())
+            .forwardMovement(this.forwardMovement())
             .damageMultiplier(this.damageMultiplier())
             .sound(this.sound())
             .hitSound(this.hitSound());

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperKineticWeapon.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperKineticWeapon.java
@@ -86,6 +86,20 @@ public record PaperKineticWeapon(
             .orElse(null);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .contactCooldownTicks(this.contactCooldownTicks())
+            .delayTicks(this.delayTicks())
+            .dismountConditions(this.dismountConditions())
+            .knockbackConditions(this.knockbackConditions())
+            .damageConditions(this.damageConditions())
+            .forwardMovement(this.forwardMovement())
+            .damageMultiplier(this.damageMultiplier())
+            .sound(this.sound())
+            .hitSound(this.hitSound());
+    }
+
     public record PaperKineticWeaponCondition(
             net.minecraft.world.item.component.KineticWeapon.Condition impl
     ) implements KineticWeapon.Condition, Handleable<net.minecraft.world.item.component.KineticWeapon.Condition> {

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperKineticWeapon.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperKineticWeapon.java
@@ -93,8 +93,8 @@ public record PaperKineticWeapon(
             .delayTicks(this.delayTicks())
             .dismountConditions(this.dismountConditions())
             .knockbackConditions(this.knockbackConditions())
-            .damageConditions(this.damageConditions())
             .forwardMovement(this.forwardMovement())
+            .damageConditions(this.damageConditions())
             .damageMultiplier(this.damageMultiplier())
             .sound(this.sound())
             .hitSound(this.hitSound());

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperLodestoneTracker.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperLodestoneTracker.java
@@ -25,6 +25,13 @@ public record PaperLodestoneTracker(
         return this.impl.tracked();
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .location(this.location())
+            .tracked(this.tracked());
+    }
+
     static final class BuilderImpl implements LodestoneTracker.Builder {
 
         private @Nullable Location location;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperMapDecorations.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperMapDecorations.java
@@ -43,6 +43,11 @@ public record PaperMapDecorations(
         return Collections.unmodifiableMap(decorations);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().putAll(this.decorations());
+    }
+
     public record PaperDecorationEntry(net.minecraft.world.item.component.MapDecorations.Entry entry) implements DecorationEntry {
 
         public static DecorationEntry toApi(final MapCursor.Type type, final double x, final double z, final float rotation) {

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperMapId.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperMapId.java
@@ -15,5 +15,4 @@ public record PaperMapId(
     public int id() {
         return this.impl.id();
     }
-
 }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperMapItemColor.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperMapItemColor.java
@@ -17,6 +17,11 @@ public record PaperMapItemColor(
         return Color.fromRGB(this.impl.rgb() & 0x00FFFFFF); // skip alpha channel
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().color(this.color());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private Color color = Color.fromRGB(net.minecraft.world.item.component.MapItemColor.DEFAULT.rgb());

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperMapItemColor.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperMapItemColor.java
@@ -17,11 +17,6 @@ public record PaperMapItemColor(
         return Color.fromRGB(this.impl.rgb() & 0x00FFFFFF); // skip alpha channel
     }
 
-    @Override
-    public Builder toBuilder() {
-        return new BuilderImpl().color(this.color());
-    }
-
     static final class BuilderImpl implements Builder {
 
         private Color color = Color.fromRGB(net.minecraft.world.item.component.MapItemColor.DEFAULT.rgb());

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPiercingWeapon.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPiercingWeapon.java
@@ -45,6 +45,15 @@ public record PaperPiercingWeapon(
             .orElse(null);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .dealsKnockback(this.dealsKnockback())
+            .dismounts(this.dismounts())
+            .sound(this.sound())
+            .hitSound(this.hitSound());
+    }
+
     static final class BuilderImpl implements PiercingWeapon.Builder {
 
         private boolean dealsKnockback = true;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotDecorations.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotDecorations.java
@@ -31,6 +31,15 @@ public record PaperPotDecorations(
     }
 
     @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .front(this.front())
+            .right(this.right())
+            .back(this.back())
+            .left(this.left());
+    }
+
+    @Override
     public net.minecraft.world.level.block.entity.PotDecorations getHandle() {
         return this.impl;
     }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotDecorations.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotDecorations.java
@@ -33,10 +33,10 @@ public record PaperPotDecorations(
     @Override
     public Builder toBuilder() {
         return new BuilderImpl()
-            .front(this.front())
-            .right(this.right())
             .back(this.back())
-            .left(this.left());
+            .left(this.left())
+            .right(this.right())
+            .front(this.front());
     }
 
     @Override

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotionContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotionContents.java
@@ -63,6 +63,15 @@ public record PaperPotionContents(
         return Color.fromARGB(this.impl.getColor());
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .potion(this.potion())
+            .customColor(this.customColor())
+            .customName(this.customName())
+            .customEffects(this.customEffects());
+    }
+
     static final class BuilderImpl implements PotionContents.Builder {
 
         private final List<MobEffectInstance> customEffects = new ObjectArrayList<>();
@@ -97,6 +106,13 @@ public record PaperPotionContents(
 
         @Override
         public PotionContents.Builder addCustomEffects(final List<PotionEffect> effects) {
+            effects.forEach(this::addCustomEffect);
+            return this;
+        }
+
+        @Override
+        public Builder customEffects(final List<PotionEffect> effects) {
+            this.customEffects.clear();
             effects.forEach(this::addCustomEffect);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotionContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotionContents.java
@@ -63,6 +63,15 @@ public record PaperPotionContents(
         return Color.fromARGB(this.impl.getColor());
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .potion(this.potion())
+            .customColor(this.customColor())
+            .customName(this.customName())
+            .setCustomEffects(this.customEffects());
+    }
+
     static final class BuilderImpl implements PotionContents.Builder {
 
         private final List<MobEffectInstance> customEffects = new ObjectArrayList<>();
@@ -97,6 +106,13 @@ public record PaperPotionContents(
 
         @Override
         public PotionContents.Builder addCustomEffects(final List<PotionEffect> effects) {
+            effects.forEach(this::addCustomEffect);
+            return this;
+        }
+
+        @Override
+        public Builder setCustomEffects(final List<PotionEffect> effects) {
+            this.customEffects.clear();
             effects.forEach(this::addCustomEffect);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotionContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotionContents.java
@@ -69,7 +69,7 @@ public record PaperPotionContents(
             .potion(this.potion())
             .customColor(this.customColor())
             .customName(this.customName())
-            .setCustomEffects(this.customEffects());
+            .customEffects(this.customEffects());
     }
 
     static final class BuilderImpl implements PotionContents.Builder {
@@ -111,7 +111,7 @@ public record PaperPotionContents(
         }
 
         @Override
-        public Builder setCustomEffects(final List<PotionEffect> effects) {
+        public Builder customEffects(final List<PotionEffect> effects) {
             this.customEffects.clear();
             effects.forEach(this::addCustomEffect);
             return this;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotionContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotionContents.java
@@ -113,7 +113,7 @@ public record PaperPotionContents(
         @Override
         public Builder customEffects(final List<PotionEffect> effects) {
             this.customEffects.clear();
-            effects.forEach(this::addCustomEffect);
+            this.addCustomEffects(effects);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotionContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperPotionContents.java
@@ -27,11 +27,6 @@ public record PaperPotionContents(
     }
 
     @Override
-    public @Unmodifiable List<PotionEffect> customEffects() {
-        return MCUtil.transformUnmodifiable(this.impl.customEffects(), CraftPotionUtil::toBukkit);
-    }
-
-    @Override
     public @Nullable PotionType potion() {
         return this.impl.potion()
             .map(CraftPotionType::minecraftHolderToBukkit)
@@ -43,6 +38,11 @@ public record PaperPotionContents(
         return this.impl.customColor()
             .map(Color::fromARGB) // alpha channel is supported for tipped arrows, so let's just leave it in
             .orElse(null);
+    }
+
+    @Override
+    public @Unmodifiable List<PotionEffect> customEffects() {
+        return MCUtil.transformUnmodifiable(this.impl.customEffects(), CraftPotionUtil::toBukkit);
     }
 
     @Override
@@ -68,8 +68,8 @@ public record PaperPotionContents(
         return new BuilderImpl()
             .potion(this.potion())
             .customColor(this.customColor())
-            .customName(this.customName())
-            .customEffects(this.customEffects());
+            .customEffects(this.customEffects())
+            .customName(this.customName());
     }
 
     static final class BuilderImpl implements PotionContents.Builder {
@@ -92,13 +92,6 @@ public record PaperPotionContents(
         }
 
         @Override
-        public Builder customName(final @Nullable String name) {
-            Preconditions.checkArgument(name == null || name.length() <= Short.MAX_VALUE, "Custom name is longer than %s characters", Short.MAX_VALUE);
-            this.customName = name;
-            return this;
-        }
-
-        @Override
         public PotionContents.Builder addCustomEffect(final PotionEffect effect) {
             this.customEffects.add(CraftPotionUtil.fromBukkit(effect));
             return this;
@@ -114,6 +107,13 @@ public record PaperPotionContents(
         public Builder customEffects(final List<PotionEffect> effects) {
             this.customEffects.clear();
             this.addCustomEffects(effects);
+            return this;
+        }
+
+        @Override
+        public Builder customName(final @Nullable String name) {
+            Preconditions.checkArgument(name == null || name.length() <= Short.MAX_VALUE, "Custom name is longer than %s characters", Short.MAX_VALUE);
+            this.customName = name;
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperResolvableProfile.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperResolvableProfile.java
@@ -101,6 +101,11 @@ public record PaperResolvableProfile(
             .texture(this.impl.skinPatch().body().map(ClientAsset.ResourceTexture::id).map(PaperAdventure::asAdventure).orElse(null));
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().name(this.name()).uuid(this.uuid()).skinPatch(this.skinPatch()).addProperties(this.properties());
+    }
+
     record PaperSkinPatch(
         @Nullable Key body,
         @Nullable Key cape,

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperSeededContainerLoot.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperSeededContainerLoot.java
@@ -27,6 +27,11 @@ public record PaperSeededContainerLoot(
         return this.impl.seed();
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this.lootTable()).seed(this.seed());
+    }
+
     static final class BuilderImpl implements SeededContainerLoot.Builder {
 
         private long seed = LootTable.RANDOMIZE_SEED;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperSuspiciousStewEffects.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperSuspiciousStewEffects.java
@@ -25,6 +25,11 @@ public record PaperSuspiciousStewEffects(
         return MCUtil.transformUnmodifiable(this.impl.effects(), entry -> create(CraftPotionEffectType.minecraftHolderToBukkit(entry.effect()), entry.duration()));
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().effects(this.effects());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private final List<net.minecraft.world.item.component.SuspiciousStewEffects.Entry> effects = new ObjectArrayList<>();
@@ -40,6 +45,13 @@ public record PaperSuspiciousStewEffects(
 
         @Override
         public Builder addAll(final Collection<SuspiciousEffectEntry> entries) {
+            entries.forEach(this::add);
+            return this;
+        }
+
+        @Override
+        public Builder effects(final Collection<SuspiciousEffectEntry> entries) {
+            this.effects.clear();
             entries.forEach(this::add);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperSuspiciousStewEffects.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperSuspiciousStewEffects.java
@@ -27,7 +27,7 @@ public record PaperSuspiciousStewEffects(
 
     @Override
     public Builder toBuilder() {
-        return new BuilderImpl().set(this.effects());
+        return new BuilderImpl().effects(this.effects());
     }
 
     static final class BuilderImpl implements Builder {
@@ -50,7 +50,7 @@ public record PaperSuspiciousStewEffects(
         }
 
         @Override
-        public Builder set(final Collection<SuspiciousEffectEntry> entries) {
+        public Builder effects(final Collection<SuspiciousEffectEntry> entries) {
             this.effects.clear();
             entries.forEach(this::add);
             return this;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperSuspiciousStewEffects.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperSuspiciousStewEffects.java
@@ -25,6 +25,11 @@ public record PaperSuspiciousStewEffects(
         return MCUtil.transformUnmodifiable(this.impl.effects(), entry -> create(CraftPotionEffectType.minecraftHolderToBukkit(entry.effect()), entry.duration()));
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().set(this.effects());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private final List<net.minecraft.world.item.component.SuspiciousStewEffects.Entry> effects = new ObjectArrayList<>();
@@ -40,6 +45,13 @@ public record PaperSuspiciousStewEffects(
 
         @Override
         public Builder addAll(final Collection<SuspiciousEffectEntry> entries) {
+            entries.forEach(this::add);
+            return this;
+        }
+
+        @Override
+        public Builder set(final Collection<SuspiciousEffectEntry> entries) {
+            this.effects.clear();
             entries.forEach(this::add);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperSuspiciousStewEffects.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperSuspiciousStewEffects.java
@@ -52,7 +52,7 @@ public record PaperSuspiciousStewEffects(
         @Override
         public Builder effects(final Collection<SuspiciousEffectEntry> entries) {
             this.effects.clear();
-            entries.forEach(this::add);
+            this.addAll(entries);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperSwingAnimation.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperSwingAnimation.java
@@ -25,6 +25,13 @@ public record PaperSwingAnimation(
         return this.impl.duration();
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .type(this.type())
+            .duration(this.duration());
+    }
+
     static final class BuilderImpl implements SwingAnimation.Builder {
 
         private SwingAnimationType type = net.minecraft.world.item.component.SwingAnimation.DEFAULT.type();

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperTooltipDisplay.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperTooltipDisplay.java
@@ -29,6 +29,13 @@ public record PaperTooltipDisplay(
             .collect(Collectors.toCollection(ReferenceLinkedOpenHashSet::new));
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .hideTooltip(this.hideTooltip())
+            .hiddenComponents(this.hiddenComponents());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private final Set<DataComponentType> hiddenComponents = new ReferenceLinkedOpenHashSet<>();
@@ -47,7 +54,14 @@ public record PaperTooltipDisplay(
         }
 
         @Override
+        public Builder addHiddenComponents(final Set<DataComponentType> components) {
+            this.hiddenComponents.addAll(components);
+            return this;
+        }
+
+        @Override
         public Builder hiddenComponents(final Set<DataComponentType> components) {
+            this.hiddenComponents.clear();
             this.hiddenComponents.addAll(components);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperTooltipDisplay.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperTooltipDisplay.java
@@ -33,7 +33,7 @@ public record PaperTooltipDisplay(
     public Builder toBuilder() {
         return new BuilderImpl()
             .hideTooltip(this.hideTooltip())
-            .setHiddenComponents(this.hiddenComponents());
+            .hiddenComponents(this.hiddenComponents());
     }
 
     static final class BuilderImpl implements Builder {
@@ -54,13 +54,13 @@ public record PaperTooltipDisplay(
         }
 
         @Override
-        public Builder hiddenComponents(final Set<DataComponentType> components) {
+        public Builder addHiddenComponents(final Set<DataComponentType> components) {
             this.hiddenComponents.addAll(components);
             return this;
         }
 
         @Override
-        public Builder setHiddenComponents(final Set<DataComponentType> components) {
+        public Builder hiddenComponents(final Set<DataComponentType> components) {
             this.hiddenComponents.clear();
             this.hiddenComponents.addAll(components);
             return this;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperTooltipDisplay.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperTooltipDisplay.java
@@ -29,6 +29,13 @@ public record PaperTooltipDisplay(
             .collect(Collectors.toCollection(ReferenceLinkedOpenHashSet::new));
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .hideTooltip(this.hideTooltip())
+            .setHiddenComponents(this.hiddenComponents());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private final Set<DataComponentType> hiddenComponents = new ReferenceLinkedOpenHashSet<>();
@@ -48,6 +55,13 @@ public record PaperTooltipDisplay(
 
         @Override
         public Builder hiddenComponents(final Set<DataComponentType> components) {
+            this.hiddenComponents.addAll(components);
+            return this;
+        }
+
+        @Override
+        public Builder setHiddenComponents(final Set<DataComponentType> components) {
+            this.hiddenComponents.clear();
             this.hiddenComponents.addAll(components);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperUseCooldown.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperUseCooldown.java
@@ -28,6 +28,11 @@ public record PaperUseCooldown(
             .orElse(null);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this.seconds()).cooldownGroup(this.cooldownGroup());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private final float seconds;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperUseEffects.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperUseEffects.java
@@ -28,6 +28,14 @@ public record PaperUseEffects(
         return this.impl.speedMultiplier();
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .canSprint(this.canSprint())
+            .interactVibrations(this.interactVibrations())
+            .speedMultiplier(this.speedMultiplier());
+    }
+
     static final class BuilderImpl implements UseEffects.Builder {
 
         private boolean canSprint = net.minecraft.world.item.component.UseEffects.DEFAULT.canSprint();

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWeapon.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWeapon.java
@@ -22,6 +22,13 @@ public record PaperWeapon(
         return this.impl.disableBlockingForSeconds();
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .itemDamagePerAttack(this.itemDamagePerAttack())
+            .disableBlockingForSeconds(this.disableBlockingForSeconds());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private int itemDamagePerAttack = 1;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWeapon.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWeapon.java
@@ -24,6 +24,13 @@ public record PaperWeapon(
         return this.impl.disableBlockingForSeconds();
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .itemDamagePerAttack(this.itemDamagePerAttack())
+            .disableBlockingForSeconds(this.disableBlockingForSeconds());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private int itemDamagePerAttack = 1;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWritableBookContent.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWritableBookContent.java
@@ -26,7 +26,7 @@ public record PaperWritableBookContent(
 
     @Override
     public Builder toBuilder() {
-        return new BuilderImpl().setFilteredPages(this.pages());
+        return new BuilderImpl().filteredPages(this.pages());
     }
 
     static final class BuilderImpl implements WritableBookContent.Builder {
@@ -71,7 +71,7 @@ public record PaperWritableBookContent(
         }
 
         @Override
-        public Builder setPages(final List<String> pages) {
+        public Builder pages(final List<String> pages) {
             this.pages.clear();
             validatePageCount(0, pages.size());
             for (final String page : pages) {
@@ -106,7 +106,7 @@ public record PaperWritableBookContent(
         }
 
         @Override
-        public Builder setFilteredPages(final List<Filtered<String>> pages) {
+        public Builder filteredPages(final List<Filtered<String>> pages) {
             this.pages.clear();
             validatePageCount(0, pages.size());
             for (final Filtered<String> page : pages) {

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWritableBookContent.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWritableBookContent.java
@@ -24,6 +24,11 @@ public record PaperWritableBookContent(
         return MCUtil.transformUnmodifiable(this.impl.pages(), input -> Filtered.of(input.raw(), input.filtered().orElse(null)));
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().setFilteredPages(this.pages());
+    }
+
     static final class BuilderImpl implements WritableBookContent.Builder {
 
         private final List<Filterable<String>> pages = new ObjectArrayList<>();
@@ -66,6 +71,17 @@ public record PaperWritableBookContent(
         }
 
         @Override
+        public Builder setPages(final List<String> pages) {
+            this.pages.clear();
+            validatePageCount(0, pages.size());
+            for (final String page : pages) {
+                validatePageLength(page);
+                this.pages.add(Filterable.passThrough(page));
+            }
+            return this;
+        }
+
+        @Override
         public WritableBookContent.Builder addFilteredPage(final Filtered<String> page) {
             validatePageLength(page.raw());
             if (page.filtered() != null) {
@@ -79,6 +95,20 @@ public record PaperWritableBookContent(
         @Override
         public WritableBookContent.Builder addFilteredPages(final List<Filtered<String>> pages) {
             validatePageCount(this.pages.size(), pages.size());
+            for (final Filtered<String> page : pages) {
+                validatePageLength(page.raw());
+                if (page.filtered() != null) {
+                    validatePageLength(page.filtered());
+                }
+                this.pages.add(new Filterable<>(page.raw(), Optional.ofNullable(page.filtered())));
+            }
+            return this;
+        }
+
+        @Override
+        public Builder setFilteredPages(final List<Filtered<String>> pages) {
+            this.pages.clear();
+            validatePageCount(0, pages.size());
             for (final Filtered<String> page : pages) {
                 validatePageLength(page.raw());
                 if (page.filtered() != null) {

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWritableBookContent.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWritableBookContent.java
@@ -90,11 +90,7 @@ public record PaperWritableBookContent(
         @Override
         public Builder pages(final List<String> pages) {
             this.pages.clear();
-            validatePageCount(0, pages.size());
-            for (final String page : pages) {
-                validatePageLength(page);
-                this.pages.add(Filterable.passThrough(page));
-            }
+            this.addPages(pages);
             return this;
         }
 
@@ -125,14 +121,7 @@ public record PaperWritableBookContent(
         @Override
         public Builder filteredPages(final List<Filtered<String>> pages) {
             this.pages.clear();
-            validatePageCount(0, pages.size());
-            for (final Filtered<String> page : pages) {
-                validatePageLength(page.raw());
-                if (page.filtered() != null) {
-                    validatePageLength(page.filtered());
-                }
-                this.pages.add(new Filterable<>(page.raw(), Optional.ofNullable(page.filtered())));
-            }
+            this.addFilteredPages(pages);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWritableBookContent.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWritableBookContent.java
@@ -41,6 +41,11 @@ public record PaperWritableBookContent(
         );
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl().filteredPages(this.pages());
+    }
+
     static final class BuilderImpl implements WritableBookContent.Builder {
 
         private final List<Filterable<String>> pages = new ObjectArrayList<>();
@@ -83,6 +88,17 @@ public record PaperWritableBookContent(
         }
 
         @Override
+        public Builder pages(final List<String> pages) {
+            this.pages.clear();
+            validatePageCount(0, pages.size());
+            for (final String page : pages) {
+                validatePageLength(page);
+                this.pages.add(Filterable.passThrough(page));
+            }
+            return this;
+        }
+
+        @Override
         public WritableBookContent.Builder addFilteredPage(final Filtered<String> page) {
             validatePageLength(page.raw());
             if (page.filtered() != null) {
@@ -96,6 +112,20 @@ public record PaperWritableBookContent(
         @Override
         public WritableBookContent.Builder addFilteredPages(final List<Filtered<String>> pages) {
             validatePageCount(this.pages.size(), pages.size());
+            for (final Filtered<String> page : pages) {
+                validatePageLength(page.raw());
+                if (page.filtered() != null) {
+                    validatePageLength(page.filtered());
+                }
+                this.pages.add(new Filterable<>(page.raw(), Optional.ofNullable(page.filtered())));
+            }
+            return this;
+        }
+
+        @Override
+        public Builder filteredPages(final List<Filtered<String>> pages) {
+            this.pages.clear();
+            validatePageCount(0, pages.size());
             for (final Filtered<String> page : pages) {
                 validatePageLength(page.raw());
                 if (page.filtered() != null) {

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWrittenBookContent.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWrittenBookContent.java
@@ -6,6 +6,7 @@ import io.papermc.paper.text.Filtered;
 import io.papermc.paper.util.MCUtil;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
@@ -53,6 +54,17 @@ public record PaperWrittenBookContent(
     @Override
     public boolean resolved() {
         return this.impl.resolved();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this.title(), this.author())
+            .generation(this.generation())
+            .resolved(this.resolved())
+            .setPages(this.pages().stream()
+                .map(Filtered::filtered)
+                .filter(Objects::nonNull)
+                .toList());
     }
 
     static final class BuilderImpl implements WrittenBookContent.Builder {
@@ -151,6 +163,17 @@ public record PaperWrittenBookContent(
         }
 
         @Override
+        public Builder setPages(final List<? extends ComponentLike> pages) {
+            this.pages.clear();
+            for (final ComponentLike page : pages) {
+                final Component component = page.asComponent();
+                validatePageLength(component);
+                this.pages.add(Filterable.passThrough(asVanilla(component)));
+            }
+            return this;
+        }
+
+        @Override
         public WrittenBookContent.Builder addFilteredPage(final Filtered<? extends ComponentLike> page) {
             final Component raw = page.raw().asComponent();
             validatePageLength(raw);
@@ -165,6 +188,13 @@ public record PaperWrittenBookContent(
 
         @Override
         public WrittenBookContent.Builder addFilteredPages(final List<Filtered<? extends ComponentLike>> pages) {
+            pages.forEach(this::addFilteredPage);
+            return this;
+        }
+
+        @Override
+        public Builder setFilteredPages(final List<Filtered<? extends ComponentLike>> pages) {
+            this.pages.clear();
             pages.forEach(this::addFilteredPage);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWrittenBookContent.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWrittenBookContent.java
@@ -61,7 +61,7 @@ public record PaperWrittenBookContent(
         return new BuilderImpl(this.title(), this.author())
             .generation(this.generation())
             .resolved(this.resolved())
-            .setPages(this.pages().stream()
+            .pages(this.pages().stream()
                 .map(Filtered::filtered)
                 .filter(Objects::nonNull)
                 .toList());
@@ -163,7 +163,7 @@ public record PaperWrittenBookContent(
         }
 
         @Override
-        public Builder setPages(final List<? extends ComponentLike> pages) {
+        public Builder pages(final List<? extends ComponentLike> pages) {
             this.pages.clear();
             for (final ComponentLike page : pages) {
                 final Component component = page.asComponent();
@@ -193,7 +193,7 @@ public record PaperWrittenBookContent(
         }
 
         @Override
-        public Builder setFilteredPages(final List<Filtered<? extends ComponentLike>> pages) {
+        public Builder filteredPages(final List<Filtered<? extends ComponentLike>> pages) {
             this.pages.clear();
             pages.forEach(this::addFilteredPage);
             return this;

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWrittenBookContent.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWrittenBookContent.java
@@ -175,11 +175,7 @@ public record PaperWrittenBookContent(
         @Override
         public Builder pages(final List<? extends ComponentLike> pages) {
             this.pages.clear();
-            for (final ComponentLike page : pages) {
-                final Component component = page.asComponent();
-                validatePageLength(component);
-                this.pages.add(Filterable.passThrough(asVanilla(component)));
-            }
+            this.addPages(pages);
             return this;
         }
 
@@ -205,7 +201,7 @@ public record PaperWrittenBookContent(
         @Override
         public Builder filteredPages(final List<Filtered<? extends ComponentLike>> pages) {
             this.pages.clear();
-            pages.forEach(this::addFilteredPage);
+            this.addFilteredPages(pages);
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWrittenBookContent.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWrittenBookContent.java
@@ -64,7 +64,7 @@ public record PaperWrittenBookContent(
         return new BuilderImpl(this.title(), this.author())
             .generation(this.generation())
             .resolved(this.resolved())
-            .pages(this.pages().stream()
+            .pages(this.pages().stream() // todo check seems wrong
                 .map(Filtered::filtered)
                 .filter(Objects::nonNull)
                 .toList());
@@ -149,12 +149,6 @@ public record PaperWrittenBookContent(
         }
 
         @Override
-        public WrittenBookContent.Builder resolved(final boolean resolved) {
-            this.resolved = resolved;
-            return this;
-        }
-
-        @Override
         public WrittenBookContent.Builder addPage(final ComponentLike page) {
             final Component component = page.asComponent();
             validatePageLength(component);
@@ -202,6 +196,12 @@ public record PaperWrittenBookContent(
         public Builder filteredPages(final List<Filtered<? extends ComponentLike>> pages) {
             this.pages.clear();
             this.addFilteredPages(pages);
+            return this;
+        }
+
+        @Override
+        public WrittenBookContent.Builder resolved(final boolean resolved) {
+            this.resolved = resolved;
             return this;
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWrittenBookContent.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperWrittenBookContent.java
@@ -60,6 +60,17 @@ public record PaperWrittenBookContent(
     }
 
     @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this.title(), this.author())
+            .generation(this.generation())
+            .resolved(this.resolved())
+            .pages(this.pages().stream()
+                .map(Filtered::filtered)
+                .filter(Objects::nonNull)
+                .toList());
+    }
+
+    @Override
     public Book asBook() {
         final Filtered<String> title = this.title();
         return Book.book(
@@ -162,6 +173,17 @@ public record PaperWrittenBookContent(
         }
 
         @Override
+        public Builder pages(final List<? extends ComponentLike> pages) {
+            this.pages.clear();
+            for (final ComponentLike page : pages) {
+                final Component component = page.asComponent();
+                validatePageLength(component);
+                this.pages.add(Filterable.passThrough(asVanilla(component)));
+            }
+            return this;
+        }
+
+        @Override
         public WrittenBookContent.Builder addFilteredPage(final Filtered<? extends ComponentLike> page) {
             final Component raw = page.raw().asComponent();
             validatePageLength(raw);
@@ -176,6 +198,13 @@ public record PaperWrittenBookContent(
 
         @Override
         public WrittenBookContent.Builder addFilteredPages(final List<Filtered<? extends ComponentLike>> pages) {
+            pages.forEach(this::addFilteredPage);
+            return this;
+        }
+
+        @Override
+        public Builder filteredPages(final List<Filtered<? extends ComponentLike>> pages) {
+            this.pages.clear();
             pages.forEach(this::addFilteredPage);
             return this;
         }

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/PaperDamageReduction.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/PaperDamageReduction.java
@@ -37,6 +37,15 @@ public record PaperDamageReduction(
         return this.internal.factor();
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .type(this.type())
+            .horizontalBlockingAngle(this.horizontalBlockingAngle())
+            .base(this.base())
+            .factor(this.factor());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private Optional<HolderSet<net.minecraft.world.damagesource.DamageType>> type = Optional.empty();

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/PaperItemDamageFunction.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/PaperItemDamageFunction.java
@@ -29,6 +29,14 @@ public record PaperItemDamageFunction(
         return this.internal.apply(damage);
     }
 
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl()
+            .threshold(this.threshold())
+            .base(this.base())
+            .factor(this.factor());
+    }
+
     static final class BuilderImpl implements Builder {
 
         private float threshold = BlocksAttacks.ItemDamageFunction.DEFAULT.threshold();


### PR DESCRIPTION
This PR aims to update `Component` classes, that have a `Builder` sub-class, by extending `BuildableDataComponent`, allowing users to retrieve a builder object with the same data from the component object.
Additionally, adds setters for some builders, allowing to completely set data rather than just adding. In tandom with `#toBuilder` allowing all other data to be kept without the need to recreate and setting each data 1 by 1.
#13041 