### PR TITLE
Fix ghost blocks created by offhand placement

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -366,11 +366,23 @@
                  return InteractionResult.CONSUME;
              } else {
                  return InteractionResult.PASS;
-@@ -340,7 +_,7 @@
+@@ -340,7 +_,19 @@
                  }
              }
  
 -            if (!stack.isEmpty() && !player.getCooldowns().isOnCooldown(stack)) {
++            // Paper start - fix ghost blocks created by offhand placement
++            if (hand == InteractionHand.MAIN_HAND) {
++                net.minecraft.world.item.Item mainItem = player.getMainHandItem().getItem();
++                net.minecraft.world.item.Item offItem  = player.getOffhandItem().getItem();
++
++                if (!(mainItem instanceof net.minecraft.world.item.BlockItem)
++                    && (offItem instanceof net.minecraft.world.item.BlockItem)) {
++                    return net.minecraft.world.InteractionResult.PASS;
++                }
++            }
++            // Paper end
++
 +            if (!stack.isEmpty() && !this.interactResult) { // add !interactResult SPIGOT-764
                  UseOnContext useOnContext = new UseOnContext(player, hand, hitResult);
                  InteractionResult interactionResult1;


### PR DESCRIPTION
I don't know if this bug exists on Mojira, but basically the client will very often send the server the wrong hand (main hand in this case) when it's placing blocks from the offhand leading to ghost blocks being created. As far as I know this bug has been only talked about [here](https://www.youtube.com/watch?v=qeE8c6V3nmE) and the only server to have fixed it is MMC.