### PR TITLE
Add PlayerPostInteractEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPostInteractEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPostInteractEvent.java
@@ -1,0 +1,77 @@
+package io.papermc.paper.event.player;
+
+import io.papermc.paper.interact.InteractionResult;
+import io.papermc.paper.interact.InteractionType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Represents an event that is called after an interaction is performed. This event can be called multiple times for a
+ * single action, as the client may send multiple interaction packets for a single click. For example, with both the off
+ * and main hands. This event may be called after the following events, if an interaction is performed:
+ * <ul>
+ *     <li>{@link org.bukkit.event.player.PlayerInteractEvent}</li>
+ *     <li>{@link org.bukkit.event.player.PlayerInteractEntityEvent}</li>
+ *     <li>{@link org.bukkit.event.player.PlayerInteractAtEntityEvent}</li>
+ * </ul>
+ *
+ */
+@NullMarked
+public class PlayerPostInteractEvent extends PlayerEvent {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final InteractionResult interactionResult;
+    private final InteractionType interactionType;
+    private final EquipmentSlot hand;
+
+    @ApiStatus.Internal
+    public PlayerPostInteractEvent(Player player, EquipmentSlot hand, InteractionType interactionType, InteractionResult interactionResult) {
+        super(player);
+
+        this.hand = hand;
+        this.interactionType = interactionType;
+        this.interactionResult = interactionResult;
+    }
+
+    /**
+     * Returns the hand the interaction was performed with.
+     *
+     * @return the interaction hand
+     */
+    public EquipmentSlot getHand() {
+        return hand;
+    }
+
+    /**
+     * Returns the type of interaction performed, with additional context dependent on the type.
+     *
+     * @return the interaction type
+     */
+    public InteractionType getInteractionType() {
+        return interactionType;
+    }
+
+    /**
+     * Returns the result of the interaction.
+     *
+     * @return the interaction result
+     */
+    public InteractionResult getInteractionResult() {
+        return interactionResult;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+}

--- a/paper-api/src/main/java/io/papermc/paper/interact/InteractionResult.java
+++ b/paper-api/src/main/java/io/papermc/paper/interact/InteractionResult.java
@@ -1,0 +1,63 @@
+package io.papermc.paper.interact;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Represents the result of an interaction action.
+ */
+@NullMarked
+@ApiStatus.NonExtendable
+public sealed interface InteractionResult {
+
+    /**
+     * Whether this result is considered a terminal action. If <code>false</code>, further interactions may follow.
+     *
+     * @return if this result is a terminal action
+     */
+    boolean consumesAction();
+
+    @ApiStatus.NonExtendable
+    non-sealed interface Success extends InteractionResult {
+
+        /**
+         * Returns the source of the resulting arm swing, if any.
+         *
+         * @return the swing source
+         */
+        SwingSource swingSource();
+
+        /**
+         * Returns additional context for successful item-related interactions, if any.
+         *
+         * @return the item context
+         */
+        ItemContext itemContext();
+
+    }
+
+    /**
+     * Denotes a failed interaction.
+     */
+    @ApiStatus.NonExtendable
+    non-sealed interface Fail extends InteractionResult {
+
+    }
+
+    /**
+     * Denotes an interaction where no action had been performed.
+     */
+    @ApiStatus.NonExtendable
+    non-sealed interface Pass extends InteractionResult {
+
+    }
+
+    /**
+     * Denotes that another interaction will be performed for default block behavior, without an item.
+     */
+    @ApiStatus.NonExtendable
+    non-sealed interface TryEmptyHandInteraction extends InteractionResult {
+
+    }
+
+}

--- a/paper-api/src/main/java/io/papermc/paper/interact/InteractionType.java
+++ b/paper-api/src/main/java/io/papermc/paper/interact/InteractionType.java
@@ -1,0 +1,115 @@
+package io.papermc.paper.interact;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Entity;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Represents the type of interaction that has been performed.
+ */
+@NullMarked
+@ApiStatus.NonExtendable
+public sealed interface InteractionType {
+
+    /**
+     * Represents an interaction that involves an item. The item may be {@link ItemStack#isEmpty()}.
+     */
+    @ApiStatus.NonExtendable
+    sealed interface ItemUseInteraction extends InteractionType {
+
+        /**
+         * Returns a copy of the item in the hand that was used to perform the interaction, from before the interaction
+         * was performed. The item may be {@link ItemStack#isEmpty()}.
+         *
+         * @return the item
+         */
+        ItemStack itemInHand();
+
+    }
+
+    /**
+     * Represents an interaction that involves a block.
+     */
+    @ApiStatus.NonExtendable
+    sealed interface BlockUseInteraction extends InteractionType {
+
+        /**
+         * Returns a copy of the block data of the block involved in the interaction, from before the interaction was
+         * performed.
+         *
+         * @return the block data
+         */
+        BlockData interactedBlockData();
+
+        /**
+         * Returns the block that was interacted with.
+         *
+         * @return the block
+         */
+        Block interactedBlock();
+
+    }
+
+    /**
+     * Represents an interaction that involves an entity.
+     */
+    @ApiStatus.NonExtendable
+    sealed interface EntityUseInteraction extends InteractionType {
+
+        /**
+         * Returns the entity that was interacted with.
+         *
+         * @return the entity
+         */
+        Entity interactedEntity();
+
+    }
+
+    /**
+     * Denotes an interaction with an item, without a target block or entity.
+     */
+    @ApiStatus.NonExtendable
+    non-sealed interface UseItem extends ItemUseInteraction {
+
+    }
+
+    /**
+     * Denotes an interaction with an item and a target block.
+     */
+    @ApiStatus.NonExtendable
+    non-sealed interface UseItemOnBlock extends BlockUseInteraction, ItemUseInteraction {
+
+    }
+
+    /**
+     * Denotes an interaction with a block, without an item involved.
+     */
+    @ApiStatus.NonExtendable
+    non-sealed interface UseBlockWithoutItem extends BlockUseInteraction {
+
+    }
+
+    /**
+     * Denotes an interaction with an item and a target entity.
+     */
+    @ApiStatus.NonExtendable
+    non-sealed interface UseItemOnEntity extends EntityUseInteraction, ItemUseInteraction {
+
+    }
+
+    /**
+     * Denotes an interaction with an item and a target entity, that also contains the location where the entity was
+     * clicked.
+     */
+    @ApiStatus.NonExtendable
+    non-sealed interface UseItemOnEntityAt extends EntityUseInteraction, ItemUseInteraction {
+
+        Vector clickedPosition();
+
+    }
+
+}

--- a/paper-api/src/main/java/io/papermc/paper/interact/ItemContext.java
+++ b/paper-api/src/main/java/io/papermc/paper/interact/ItemContext.java
@@ -1,0 +1,29 @@
+package io.papermc.paper.interact;
+
+import org.bukkit.inventory.ItemStack;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Used to provide additional item-related context for {@link io.papermc.paper.interact.InteractionResult.Success} results.
+ */
+@NullMarked
+public interface ItemContext {
+
+    /**
+     * Returns if the related interaction involved an item.
+     *
+     * @return if the related interaction involved an item
+     */
+    boolean wasItemInteraction();
+
+    /**
+     * Returns what the item used in the interaction was transformed into after the interaction was performed. Will be
+     * <code>null</code> if the item was not transformed or if {@link #wasItemInteraction()} is <code>false</code>.
+     *
+     * @return the transformed item
+     */
+    @Nullable
+    ItemStack heldItemTransformedTo();
+
+}

--- a/paper-api/src/main/java/io/papermc/paper/interact/SwingSource.java
+++ b/paper-api/src/main/java/io/papermc/paper/interact/SwingSource.java
@@ -1,0 +1,12 @@
+package io.papermc.paper.interact;
+
+/**
+ * Used to determine whether the client or the server is responsible for initiating an arm swing, if any.
+ */
+public enum SwingSource {
+
+    NONE,
+    CLIENT,
+    SERVER
+
+}

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -317,7 +317,7 @@
                  }
  
                  return interactionResult;
-@@ -329,15 +_,47 @@
+@@ -329,18 +_,56 @@
          }
      }
  
@@ -333,11 +333,17 @@
 +        boolean cancelledBlock = false;
 +        boolean cancelledItem = false; // Paper - correctly handle items on cooldown
          if (!blockState.getBlock().isEnabled(level.enabledFeatures())) {
-             return InteractionResult.FAIL;
-         } else if (this.gameModeForPlayer == GameType.SPECTATOR) {
-             MenuProvider menuProvider = blockState.getMenuProvider(level, blockPos);
+-            return InteractionResult.FAIL;
+-        } else if (this.gameModeForPlayer == GameType.SPECTATOR) {
+-            MenuProvider menuProvider = blockState.getMenuProvider(level, blockPos);
 -            if (menuProvider != null) {
 -                player.openMenu(menuProvider);
+-                return InteractionResult.CONSUME;
+-            } else {
+-                return InteractionResult.PASS;
++            return org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerPostInteractEvent(player, InteractionResult.FAIL, hand, new io.papermc.paper.interact.PaperInteractionType.UseItemOnBlock(level, blockPos, blockState, stack)); // Paper - PlayerPostInteractEvent
++        } else if (this.gameModeForPlayer == GameType.SPECTATOR) {
++            MenuProvider menuProvider = blockState.getMenuProvider(level, blockPos);
 +            cancelledBlock = !(menuProvider instanceof MenuProvider);
 +        }
 +
@@ -360,14 +366,37 @@
 +            }
 +            player.containerMenu.forceHeldSlot(hand); // SPIGOT-2867
 +            this.player.resyncUsingItem(this.player); // Paper - Properly cancel usable items
-+            return (event.useItemInHand() != org.bukkit.event.Event.Result.ALLOW) ? InteractionResult.SUCCESS : InteractionResult.PASS;
++            // Paper start - PlayerPostInteractEvent
++            if (event.useItemInHand() != org.bukkit.event.Event.Result.ALLOW) {
++                return org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerPostInteractEvent(player, InteractionResult.SUCCESS, hand, new io.papermc.paper.interact.PaperInteractionType.UseItemOnBlock(level, blockPos, blockState, stack));
++            } else {
++                return org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerPostInteractEvent(player, InteractionResult.PASS, hand, new io.papermc.paper.interact.PaperInteractionType.UseItemOnBlock(level, blockPos, blockState, stack));
++            }
++            // Paper end - PlayerPostInteractEvent
 +        } else if (this.gameModeForPlayer == GameType.SPECTATOR) {
 +            MenuProvider menuProvider = blockState.getMenuProvider(level, blockPos);
 +            if (menuProvider != null && player.openMenu(menuProvider).isPresent()) { // Paper - Fix InventoryOpenEvent cancellation
-                 return InteractionResult.CONSUME;
-             } else {
-                 return InteractionResult.PASS;
-@@ -362,7 +_,7 @@
++                return org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerPostInteractEvent(player, InteractionResult.CONSUME, hand, new io.papermc.paper.interact.PaperInteractionType.UseItemOnBlock(level, blockPos, blockState, stack)); // Paper - PlayerPostInteractEvent
++            } else {
++                return org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerPostInteractEvent(player, InteractionResult.PASS, hand, new io.papermc.paper.interact.PaperInteractionType.UseItemOnBlock(level, blockPos, blockState, stack)); // Paper - PlayerPostInteractEvent
+             }
+         } else {
+             boolean flag = !player.getMainHandItem().isEmpty() || !player.getOffhandItem().isEmpty();
+@@ -350,19 +_,19 @@
+                 InteractionResult interactionResult = blockState.useItemOn(player.getItemInHand(hand), level, player, hand, hitResult);
+                 if (interactionResult.consumesAction()) {
+                     CriteriaTriggers.ITEM_USED_ON_BLOCK.trigger(player, blockPos, itemStack);
+-                    return interactionResult;
++                    return org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerPostInteractEvent(player, interactionResult, hand, new io.papermc.paper.interact.PaperInteractionType.UseItemOnBlock(level, blockPos, blockState, itemStack)); // Paper - PlayerPostInteractEvent
+                 }
+ 
+                 if (interactionResult instanceof InteractionResult.TryEmptyHandInteraction && hand == InteractionHand.MAIN_HAND) {
+                     InteractionResult interactionResult1 = blockState.useWithoutItem(level, player, hitResult);
+                     if (interactionResult1.consumesAction()) {
+                         CriteriaTriggers.DEFAULT_BLOCK_USE.trigger(player, blockPos);
+-                        return interactionResult1;
++                        return org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerPostInteractEvent(player, interactionResult1, hand, new io.papermc.paper.interact.PaperInteractionType.UseBlockWithoutItem(level, blockPos, blockState)); // Paper - PlayerPostInteractEvent
+                     }
                  }
              }
  
@@ -376,15 +405,20 @@
                  UseOnContext useOnContext = new UseOnContext(player, hand, hitResult);
                  InteractionResult interactionResult1;
                  if (player.hasInfiniteMaterials()) {
-@@ -379,6 +_,11 @@
+@@ -377,9 +_,14 @@
+                     CriteriaTriggers.ITEM_USED_ON_BLOCK.trigger(player, blockPos, itemStack);
+                 }
  
-                 return interactionResult1;
+-                return interactionResult1;
++                return org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerPostInteractEvent(player, interactionResult1, hand, new io.papermc.paper.interact.PaperInteractionType.UseItemOnBlock(level, blockPos, blockState, itemStack)); // Paper - PlayerPostInteractEvent
              } else {
+-                return InteractionResult.PASS;
 +                // Paper start - Properly cancel usable items; Cancel only if cancelled + if the interact result is different from default response
 +                if (this.interactResult && this.interactResult != cancelledItem) {
 +                    this.player.resyncUsingItem(this.player);
 +                }
 +                // Paper end - Properly cancel usable items
-                 return InteractionResult.PASS;
++                return org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerPostInteractEvent(player, InteractionResult.PASS, hand, new io.papermc.paper.interact.PaperInteractionType.UseItemOnBlock(level, blockPos, blockState, itemStack)); // Paper - PlayerPostInteractEvent
              }
          }
+     }

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1274,10 +1274,11 @@
          if (this.hasClientLoaded()) {
              this.ackBlockChangesUpTo(packet.getSequence());
              ServerLevel serverLevel = this.player.level();
-@@ -1363,6 +_,48 @@
+@@ -1363,7 +_,49 @@
                      this.player.absSnapRotationTo(f, f1);
                  }
  
+-                if (this.player.gameMode.useItem(this.player, serverLevel, itemInHand, hand) instanceof InteractionResult.Success success
 +                // CraftBukkit start
 +                // Raytrace to look for 'rogue armswings'
 +                double x = this.player.getX();
@@ -1320,9 +1321,10 @@
 +                }
 +                // CraftBukkit end
 +
-                 if (this.player.gameMode.useItem(this.player, serverLevel, itemInHand, hand) instanceof InteractionResult.Success success
++                if (CraftEventFactory.callPlayerPostInteractEvent(this.player, this.player.gameMode.useItem(this.player, serverLevel, itemInHand, hand), hand, new io.papermc.paper.interact.PaperInteractionType.UseItem(itemInHand)) instanceof InteractionResult.Success success // Paper - PlayerPostInteractEvent
                      && success.swingSource() == InteractionResult.SwingSource.SERVER) {
                      this.player.swing(hand, true);
+                 }
 @@ -1378,7 +_,7 @@
              for (ServerLevel serverLevel : this.server.getAllLevels()) {
                  Entity entity = packet.getEntity(serverLevel);
@@ -1848,7 +1850,7 @@
 +                                        return;
 +                                    }
 +                                    // CraftBukkit end
-+                                    InteractionResult result = entityInteraction.run(ServerGamePacketListenerImpl.this.player, target, hand);
++                                    InteractionResult result = CraftEventFactory.callPlayerPostInteractEvent(ServerGamePacketListenerImpl.this.player, entityInteraction.run(ServerGamePacketListenerImpl.this.player, target, hand), hand, new io.papermc.paper.interact.PaperInteractionType.UseItemOnEntity(target, itemStack)); // Paper - PlayerPostInteractEvent
 +
 +                                    if (result instanceof InteractionResult.Success success // CraftBukkit
 +                                    ) {

--- a/paper-server/src/main/java/io/papermc/paper/interact/PaperInteractionResult.java
+++ b/paper-server/src/main/java/io/papermc/paper/interact/PaperInteractionResult.java
@@ -1,0 +1,53 @@
+package io.papermc.paper.interact;
+
+import net.minecraft.world.InteractionResult;
+
+public final class PaperInteractionResult {
+
+    public record Success(InteractionResult.Success handle) implements io.papermc.paper.interact.InteractionResult.Success {
+
+        @Override
+        public boolean consumesAction() {
+            return handle.consumesAction();
+        }
+
+        @Override
+        public SwingSource swingSource() {
+            return SwingSource.values()[handle.swingSource().ordinal()];
+        }
+
+        @Override
+        public ItemContext itemContext() {
+            return new PaperItemContext(handle.itemContext());
+        }
+
+    }
+
+    public record Fail(InteractionResult.Fail handle) implements io.papermc.paper.interact.InteractionResult.Fail {
+
+        @Override
+        public boolean consumesAction() {
+            return handle.consumesAction();
+        }
+
+    }
+
+    public record Pass(InteractionResult.Pass handle) implements io.papermc.paper.interact.InteractionResult.Pass {
+
+        @Override
+        public boolean consumesAction() {
+            return handle.consumesAction();
+        }
+
+    }
+
+    public record TryEmptyHandInteraction(InteractionResult.TryEmptyHandInteraction handle) implements io.papermc.paper.interact.InteractionResult.TryEmptyHandInteraction {
+
+        @Override
+        public boolean consumesAction() {
+            return handle.consumesAction();
+        }
+
+    }
+
+}

--- a/paper-server/src/main/java/io/papermc/paper/interact/PaperInteractionType.java
+++ b/paper-server/src/main/java/io/papermc/paper/interact/PaperInteractionType.java
@@ -1,0 +1,48 @@
+package io.papermc.paper.interact;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.craftbukkit.block.CraftBlock;
+import org.bukkit.craftbukkit.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.entity.Entity;
+import org.bukkit.inventory.ItemStack;
+
+public final class PaperInteractionType {
+
+    public record UseItem(ItemStack itemInHand) implements InteractionType.UseItem {
+
+        public UseItem(net.minecraft.world.item.ItemStack itemInHand) {
+            this(itemInHand == null ? ItemStack.empty() : CraftItemStack.asBukkitCopy(itemInHand));
+        }
+
+    }
+
+    public record UseItemOnBlock(BlockData interactedBlockData, Block interactedBlock, ItemStack itemInHand) implements InteractionType.UseItemOnBlock {
+
+        public UseItemOnBlock(Level level, BlockPos blockPos, BlockState state, net.minecraft.world.item.ItemStack itemInHand) {
+            this(CraftBlockData.fromData(state), CraftBlock.at(level, blockPos), itemInHand == null ? ItemStack.empty() : CraftItemStack.asBukkitCopy(itemInHand));
+        }
+
+    }
+
+    public record UseBlockWithoutItem(BlockData interactedBlockData, Block interactedBlock) implements InteractionType.UseBlockWithoutItem {
+
+        public UseBlockWithoutItem(Level level, BlockPos blockPos, BlockState state) {
+            this(CraftBlockData.fromData(state), CraftBlock.at(level, blockPos));
+        }
+
+    }
+
+    public record UseItemOnEntity(Entity interactedEntity, ItemStack itemInHand) implements InteractionType.UseItemOnEntity {
+
+        public UseItemOnEntity(net.minecraft.world.entity.Entity interactedEntity, net.minecraft.world.item.ItemStack itemInHand) {
+            this(interactedEntity.getBukkitEntity(), itemInHand == null ? ItemStack.empty() : CraftItemStack.asBukkitCopy(itemInHand));
+        }
+
+    }
+
+}

--- a/paper-server/src/main/java/io/papermc/paper/interact/PaperItemContext.java
+++ b/paper-server/src/main/java/io/papermc/paper/interact/PaperItemContext.java
@@ -1,0 +1,20 @@
+package io.papermc.paper.interact;
+
+import net.minecraft.world.InteractionResult;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.inventory.ItemStack;
+
+public record PaperItemContext(InteractionResult.ItemContext handle) implements ItemContext {
+
+    @Override
+    public boolean wasItemInteraction() {
+        return handle().wasItemInteraction();
+    }
+
+    @Override
+    public ItemStack heldItemTransformedTo() {
+        net.minecraft.world.item.ItemStack item = handle.heldItemTransformedTo();
+        return item == null ? null : CraftItemStack.asBukkitCopy(item);
+    }
+
+}

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -23,6 +23,9 @@ import io.papermc.paper.event.block.BlockLockCheckEvent;
 import io.papermc.paper.event.connection.PlayerConnectionValidateLoginEvent;
 import io.papermc.paper.event.entity.ItemTransportingEntityValidateTargetEvent;
 import io.papermc.paper.event.player.PlayerBedFailEnterEvent;
+import io.papermc.paper.event.player.PlayerPostInteractEvent;
+import io.papermc.paper.interact.InteractionType;
+import io.papermc.paper.interact.PaperInteractionResult;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.Connection;
@@ -36,6 +39,7 @@ import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.util.Unit;
 import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.LockCode;
 import net.minecraft.world.attribute.EnvironmentAttributes;
 import net.minecraft.world.damagesource.DamageSource;
@@ -2378,5 +2382,22 @@ public class CraftEventFactory {
             return true;
         }
         return false;
+    }
+
+    public static InteractionResult callPlayerPostInteractEvent(ServerPlayer player, InteractionResult result, InteractionHand hand, InteractionType interactionType) {
+        if (PlayerPostInteractEvent.getHandlerList().getRegisteredListeners().length == 0) return result;
+
+        io.papermc.paper.interact.InteractionResult paperResult = switch (result) {
+            case InteractionResult.Fail r -> new PaperInteractionResult.Fail(r);
+            case InteractionResult.Pass p -> new PaperInteractionResult.Pass(p);
+            case InteractionResult.Success s -> new PaperInteractionResult.Success(s);
+            case InteractionResult.TryEmptyHandInteraction t -> new PaperInteractionResult.TryEmptyHandInteraction(t);
+        };
+
+        new PlayerPostInteractEvent(
+            player.getBukkitEntity(), CraftEquipmentSlot.getHand(hand), interactionType, paperResult
+        ).callEvent();
+
+        return result;
     }
 }


### PR DESCRIPTION
Adds `PlayerPostInteractEvent`. When using `PlayerInteractEvent`, it's common to want to only perform an action if the interaction performed does not lead to anything. However, because the event is fired prior to any logic being done, that context isn't available. This event instead fires after the interaction is already performed, and exposes the `InteractionResult` returned from the interaction attempt.

Some open questions regarding the current implementation:

- Is `InteractionType` a good way of representing the type of interaction that was performed?
	- Are the `ItemUseInteraction`, `BlockUseInteraction`, and `EntityUseInteraction` interfaces useful/necessary?
- What interaction type should be used in `ServerPlayerGameMode#useItemOn`, when `PlayerInteractEvent#useInteractedBlock` is `DENIED`?
https://github.com/PaperMC/Paper/blob/df17d2fc59e0fcf93edc0dda955bd45da952fd50/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch#L368-L374
- Is `InteractionType.UseItemOnBlock` the appropiate interaction type for spectators interacting with inventories?
https://github.com/PaperMC/Paper/blob/df17d2fc59e0fcf93edc0dda955bd45da952fd50/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch#L375-L382
- The general naming of things.