### PR TITLE
Remove no longer needed MC-210802 fix

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/EatBlockGoal.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/EatBlockGoal.java.patch
@@ -1,17 +1,5 @@
 --- a/net/minecraft/world/entity/ai/goal/EatBlockGoal.java
 +++ b/net/minecraft/world/entity/ai/goal/EatBlockGoal.java
-@@ -26,6 +_,11 @@
- 
-     @Override
-     public boolean canUse() {
-+        // Paper start - Fix MC-210802
-+        if (!((net.minecraft.server.level.ServerLevel) this.level).chunkSource.chunkMap.anyPlayerCloseEnoughForSpawning(this.mob.chunkPosition())) {
-+            return false;
-+        }
-+        // Paper end
-         if (this.mob.getRandom().nextInt(this.mob.isBaby() ? 50 : 1000) != 0) {
-             return false;
-         } else {
 @@ -60,8 +_,9 @@
          this.eatAnimationTick = Math.max(0, this.eatAnimationTick - 1);
          if (this.eatAnimationTick == this.adjustedTickDelay(4)) {


### PR DESCRIPTION
Now that all block (entity...) ticking chunks are random ticked, this is no longer needed. The Mojira issue is still open but a comment indicates the same thing as my analysis (it should be closed)