### PR TITLE
Make merchant accessible in `PlayerPurchaseEvent`

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPurchaseEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPurchaseEvent.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.MerchantRecipe;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
@@ -19,16 +20,27 @@ public class PlayerPurchaseEvent extends PlayerEvent implements Cancellable {
 
     private boolean rewardExp;
     private boolean increaseTradeUses;
+    private Merchant merchant;
     private MerchantRecipe trade;
 
     private boolean cancelled;
 
     @ApiStatus.Internal
-    public PlayerPurchaseEvent(final Player player, final MerchantRecipe trade, final boolean rewardExp, final boolean increaseTradeUses) {
+    public PlayerPurchaseEvent(final Player player, final Merchant merchant, final MerchantRecipe trade, final boolean rewardExp, final boolean increaseTradeUses) {
         super(player);
+        this.merchant = merchant;
         this.trade = trade;
         this.rewardExp = rewardExp;
         this.increaseTradeUses = increaseTradeUses;
+    }
+
+    /**
+     * Gets the merchant that the player is trading with
+     *
+     * @return the merchant
+     */
+    public Merchant getMerchant() {
+        return merchant;
     }
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerTradeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerTradeEvent.java
@@ -16,7 +16,7 @@ public class PlayerTradeEvent extends PlayerPurchaseEvent {
 
     @ApiStatus.Internal
     public PlayerTradeEvent(final Player player, final AbstractVillager villager, final MerchantRecipe trade, final boolean rewardExp, final boolean increaseTradeUses) {
-        super(player, trade, rewardExp, increaseTradeUses);
+        super(player, villager, trade, rewardExp, increaseTradeUses);
         this.villager = villager;
     }
 

--- a/paper-server/patches/sources/net/minecraft/world/inventory/MerchantResultSlot.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/inventory/MerchantResultSlot.java.patch
@@ -12,8 +12,8 @@
 +        if (activeOffer != null && player instanceof net.minecraft.server.level.ServerPlayer serverPlayer) {
 +            if (this.merchant instanceof net.minecraft.world.entity.npc.AbstractVillager abstractVillager) {
 +                event = new io.papermc.paper.event.player.PlayerTradeEvent(serverPlayer.getBukkitEntity(), (org.bukkit.entity.AbstractVillager) abstractVillager.getBukkitEntity(), activeOffer.asBukkit(), true, true);
-+            } else if (this.merchant instanceof org.bukkit.craftbukkit.inventory.CraftMerchantCustom.MinecraftMerchant) {
-+                event = new io.papermc.paper.event.player.PlayerPurchaseEvent(serverPlayer.getBukkitEntity(), activeOffer.asBukkit(), false, true);
++            } else if (this.merchant instanceof org.bukkit.craftbukkit.inventory.CraftMerchantCustom.MinecraftMerchant minecraftMerchant) {
++                event = new io.papermc.paper.event.player.PlayerPurchaseEvent(serverPlayer.getBukkitEntity(), minecraftMerchant.getCraftMerchant(), activeOffer.asBukkit(), false, true);
 +            }
 +            if (event != null) {
 +                if (!event.callEvent()) {


### PR DESCRIPTION
When using a custom merchant, it's common to want to know whether a recipe is just used by listening `PlayerPurchaseEvent`. However, if we couldn't know which merchant players are trading with, we can't reach that goal.

So I just simply add the approach.