### PR TITLE
Add `UnsafeValues#deserializeItemHover`

### DIFF
--- a/paper-api/src/main/java/org/bukkit/UnsafeValues.java
+++ b/paper-api/src/main/java/org/bukkit/UnsafeValues.java
@@ -3,6 +3,7 @@ package org.bukkit;
 import com.google.common.collect.Multimap;
 import io.papermc.paper.entity.EntitySerializationFlag;
 import io.papermc.paper.registry.RegistryKey;
+import net.kyori.adventure.text.event.HoverEvent;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
@@ -384,4 +385,12 @@ public interface UnsafeValues {
     @NotNull Map<String, Object> serializeStack(ItemStack itemStack);
 
     @NotNull ItemStack deserializeStack(@NotNull Map<String, Object> args);
+
+    /**
+     * Deserializes a {@link HoverEvent.ShowItem} hover event value into an {@code ItemStack}.
+     *
+     * @param itemHover the hover to deserialize
+     * @return the deserialized {@code ItemStack}
+     */
+    @NotNull ItemStack deserializeItemHover(HoverEvent.@NotNull ShowItem itemHover);
 }

--- a/paper-server/src/main/java/io/papermc/paper/adventure/AdventureCodecs.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/AdventureCodecs.java
@@ -194,7 +194,7 @@ public final class AdventureCodecs {
         COMPONENT_CODEC.lenientOptionalFieldOf("name").forGetter(a -> Optional.ofNullable(a.value().name()))
     ).apply(instance, (key, uuid, component) -> HoverEvent.showEntity(key, uuid, component.orElse(null))));
 
-    static final MapCodec<HoverEvent<HoverEvent.ShowItem>> SHOW_ITEM_CODEC = net.minecraft.network.chat.HoverEvent.ShowItem.CODEC.xmap(internal -> {
+    public static final MapCodec<HoverEvent<HoverEvent.ShowItem>> SHOW_ITEM_CODEC = net.minecraft.network.chat.HoverEvent.ShowItem.CODEC.xmap(internal -> {
         @Subst("key") final String typeKey = internal.item().getItemHolder().unwrapKey().orElseThrow().identifier().toString();
         return HoverEvent.showItem(Key.key(typeKey), internal.item().getCount(), PaperAdventure.asAdventure(internal.item().getComponentsPatch()));
     }, adventure -> {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
@@ -12,6 +12,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.logging.LogUtils;
 import com.mojang.serialization.Dynamic;
 import com.mojang.serialization.JsonOps;
+import io.papermc.paper.adventure.PaperAdventure;
 import io.papermc.paper.registry.RegistryKey;
 import java.io.File;
 import java.io.IOException;
@@ -26,6 +27,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Stream;
 import io.papermc.paper.entity.EntitySerializationFlag;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.minecraft.SharedConstants;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.commands.Commands;
@@ -56,6 +58,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.UnsafeValues;
 import org.bukkit.World;
 import org.bukkit.advancement.Advancement;
@@ -859,5 +862,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
     @Override
     public org.bukkit.inventory.ItemStack createEmptyStack() {
         return CraftItemStack.asCraftMirror(null);
+    }
+
+    @Override
+    public ItemStack deserializeItemHover(final HoverEvent.ShowItem itemHover) {
+        if (itemHover.dataComponents().isEmpty()) {
+            return ItemStack.of(Registry.MATERIAL.getOrThrow(itemHover.item()), itemHover.count());
+        }
+        return new net.minecraft.world.item.ItemStack(BuiltInRegistries.ITEM.getOrThrow(PaperAdventure.asVanilla(Registries.ITEM, itemHover.item())), itemHover.count(), PaperAdventure.asVanilla(itemHover.dataComponents())).asBukkitMirror();
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
@@ -867,7 +867,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
     @Override
     public ItemStack deserializeItemHover(final HoverEvent.ShowItem itemHover) {
         if (itemHover.dataComponents().isEmpty()) {
-            return ItemStack.of(Registry.MATERIAL.getOrThrow(itemHover.item()), itemHover.count());
+            return Registry.ITEM.getOrThrow(itemHover.item()).createItemStack(itemHover.count());
         }
         return new net.minecraft.world.item.ItemStack(BuiltInRegistries.ITEM.getOrThrow(PaperAdventure.asVanilla(Registries.ITEM, itemHover.item())), itemHover.count(), PaperAdventure.asVanilla(itemHover.dataComponents())).asBukkitMirror();
     }


### PR DESCRIPTION
Adds `UnsafeValues#deserializeItemHover`, to de-serialize an adventure `ShowItem` into an `ItemStack`.

My use case for this is a custom component serializer implementation (similar idea to MiniMessage), that needs to get an `ItemStack` instance for its serialization logic (I'm aware there may be better methods to implement this, but the serializer already exists and is in use with Bungee chat, I'm just migrating it to adventure & need to maintain the exact same format and behavior).

See discussion starting at https://discord.com/channels/289587909051416579/555462289851940864/1415331111856508980 (and specifically with lynx at https://discord.com/channels/289587909051416579/555462289851940864/1415336667237060650).

> [!NOTE]
> This can throw some exceptions for invalid `ShowItem` data (e.g. uses `Registry#getOrThrow`), didn't really bother with that too much as it's an `UnsafeValues` use at your own risk, but let me know if you'd want more specific docs still/to catch them and return `null`.