### PR TITLE
Fix Instant Heal with high amplify cause negative values MC-266229

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/effect/HealOrHarmMobEffect.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/effect/HealOrHarmMobEffect.java.patch
@@ -9,15 +9,19 @@
          } else {
              entity.hurtServer(level, entity.damageSources().magic(), 6 << amplifier);
          }
-@@ -28,9 +_,10 @@
+@@ -28,11 +_,12 @@
      public void applyInstantenousEffect(
          ServerLevel level, @Nullable Entity source, @Nullable Entity indirectSource, LivingEntity entity, int amplifier, double health
      ) {
 +        if (!new io.papermc.paper.event.entity.EntityEffectTickEvent(entity.getBukkitLivingEntity(), org.bukkit.craftbukkit.potion.CraftPotionEffectType.minecraftToBukkit(this), amplifier).callEvent()) { return; } // Paper - Add EntityEffectTickEvent
          if (this.isHarm == entity.isInvertedHealAndHarm()) {
-             int i = (int)(health * (4 << amplifier) + 0.5);
+-            int i = (int)(health * (4 << amplifier) + 0.5);
 -            entity.heal(i);
++            int i = Math.max((int)(health * (4 << amplifier) + 0.5), 0); // Paper - avoid negative values for MC-266229
 +            entity.heal(i, org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason.MAGIC); // CraftBukkit
          } else {
-             int i = (int)(health * (6 << amplifier) + 0.5);
+-            int i = (int)(health * (6 << amplifier) + 0.5);
++            int i = Math.max((int)(health * (6 << amplifier) + 0.5), 0); // Paper - avoid negative values for MC-266229
              if (source == null) {
+                 entity.hurtServer(level, entity.damageSources().magic(), i);
+             } else {


### PR DESCRIPTION
Related to https://github.com/PaperMC/Paper/issues/13065 exists a issue where high amplify cause strange values where later the health can be 0 and the entity can be discarted ignoring invulnerability or gamemode.
i base in the applyEffectTick from the same class where apply a max for avoid negative values