### PR TITLE
Add env var support for velocity forwarding secret

### DIFF
--- a/paper-server/src/main/java/com/destroystokyo/paper/proxy/VelocityProxy.java
+++ b/paper-server/src/main/java/com/destroystokyo/paper/proxy/VelocityProxy.java
@@ -44,7 +44,11 @@ public class VelocityProxy {
 
         try {
             final Mac mac = Mac.getInstance("HmacSHA256");
-            mac.init(new SecretKeySpec(GlobalConfiguration.get().proxies.velocity.secret.getBytes(java.nio.charset.StandardCharsets.UTF_8), "HmacSHA256"));
+            String forwardingSecret = System.getenv("VELOCITY_FORWARDING_SECRET");
+            if (forwardingSecret == null || forwardingSecret.isEmpty()) {
+                forwardingSecret = GlobalConfiguration.get().proxies.velocity.secret;
+            }
+            mac.init(new SecretKeySpec(forwardingSecret.getBytes(java.nio.charset.StandardCharsets.UTF_8), "HmacSHA256"));
             final byte[] mySignature = mac.doFinal(data);
             if (!MessageDigest.isEqual(signature, mySignature)) {
                 return false;


### PR DESCRIPTION
Defaults the Velocity forwarding secret to the VELOCITY_FORWARDING_SECRET environment variable if it's set, similar to [Velocity](https://github.com/PaperMC/Velocity/blob/dev/3.0.0/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java). I thought this would be useful for people using containers.