### PR TITLE
Add entity removal reason API

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/entity/RemovalReason.java
+++ b/paper-api/src/main/java/io/papermc/paper/entity/RemovalReason.java
@@ -1,0 +1,40 @@
+package io.papermc.paper.entity;
+
+import org.bukkit.entity.Entity;
+
+/**
+ * Represents the reason an entity was removed.
+ *
+ * @see Entity#getRemovalReason()
+ */
+public enum RemovalReason {
+    // Start generate - RemovalReason
+    KILLED(true, false),
+    DISCARDED(true, false),
+    UNLOADED_TO_CHUNK(false, true),
+    UNLOADED_WITH_PLAYER(false, false),
+    CHANGED_DIMENSION(false, false);
+    // End generate - RemovalReason
+
+    private final boolean destroy;
+    private final boolean save;
+
+    RemovalReason(final boolean destroy, final boolean save) {
+        this.destroy = destroy;
+        this.save = save;
+    }
+
+    /**
+     * {@return whether the entity should be destroyed after being removed}
+     */
+    public boolean shouldDestroy() {
+        return this.destroy;
+    }
+
+    /**
+     * {@return whether the entity should be saved after being removed}
+     */
+    public boolean shouldSave() {
+        return this.save;
+    }
+}

--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.UUID;
 import io.papermc.paper.datacomponent.DataComponentView;
 import io.papermc.paper.entity.LookAnchor;
+import io.papermc.paper.entity.RemovalReason;
 import net.kyori.adventure.util.TriState;
 import org.bukkit.Chunk; // Paper
 import org.bukkit.EntityEffect;
@@ -423,6 +424,16 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      * @throws UnsupportedOperationException if you try to remove a {@link Player} use {@link Player#kick(net.kyori.adventure.text.Component)} in this case instead
      */
     public void remove();
+
+    /**
+     * {@return true if it was removed by a plugin}
+     */
+    boolean isPluginRemoved();
+
+    /**
+     * {@return the reason this entity was removed}
+     */
+    @Nullable RemovalReason getRemovalReason();
 
     /**
      * Returns true if this entity has been marked for removal.

--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.UUID;
 import io.papermc.paper.datacomponent.DataComponentView;
 import io.papermc.paper.entity.LookAnchor;
+import io.papermc.paper.entity.RemovalReason;
 import io.papermc.paper.math.Angle;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
@@ -23,6 +24,7 @@ import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityRemoveEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Directional;
@@ -500,6 +502,19 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      * @throws UnsupportedOperationException if you try to remove a {@link Player} use {@link Player#kick(net.kyori.adventure.text.Component)} in this case instead
      */
     public void remove();
+
+    /**
+     * Gets the cause used for this entity's remove event.
+     *
+     * @return the remove event cause, or null if this entity has not been removed or no event cause was supplied
+     */
+    @Nullable
+    EntityRemoveEvent.Cause getRemoveEventCause();
+
+    /**
+     * {@return the reason this entity was removed}
+     */
+    @Nullable RemovalReason getRemovalReason();
 
     /**
      * Returns true if this entity has been marked for removal.

--- a/paper-generator/src/main/java/io/papermc/generator/Rewriters.java
+++ b/paper-generator/src/main/java/io/papermc/generator/Rewriters.java
@@ -25,6 +25,7 @@ import io.papermc.generator.types.goal.MobGoalNames;
 import io.papermc.generator.utils.Formatting;
 import io.papermc.paper.datacomponent.item.consumable.ItemUseAnimation;
 import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.entity.RemovalReason;
 import io.papermc.paper.world.WeatheringCopperState;
 import io.papermc.typewriter.preset.EnumCloneRewriter;
 import io.papermc.typewriter.preset.model.EnumValue;
@@ -107,6 +108,12 @@ public final class Rewriters {
         sourceSet
             .register("PotionType", PotionType.class, new EnumRegistryRewriter<>(Registries.POTION))
             .register("EntityType", EntityType.class, new EntityTypeRewriter())
+            .register("RemovalReason", RemovalReason.class, new EnumCloneRewriter<>(net.minecraft.world.entity.Entity.RemovalReason.class) {
+                @Override
+                protected EnumValue.Builder rewriteEnumValue(net.minecraft.world.entity.Entity.RemovalReason reason) {
+                    return super.rewriteEnumValue(reason).arguments(Boolean.toString(reason.shouldDestroy()), Boolean.toString(reason.shouldSave()));
+                }
+            })
             .register("DisplaySlot", DisplaySlot.class, new EnumCloneRewriter<>(net.minecraft.world.scores.DisplaySlot.class) {
                 @Override
                 protected EnumValue.Builder rewriteEnumValue(net.minecraft.world.scores.DisplaySlot slot) {

--- a/paper-generator/src/main/java/io/papermc/generator/Rewriters.java
+++ b/paper-generator/src/main/java/io/papermc/generator/Rewriters.java
@@ -28,6 +28,7 @@ import io.papermc.paper.datacomponent.item.consumable.ItemUseAnimation;
 import io.papermc.paper.dialog.Dialog;
 import io.papermc.paper.entity.poi.PoiTypes;
 import io.papermc.paper.item.MapPostProcessing;
+import io.papermc.paper.entity.RemovalReason;
 import io.papermc.paper.world.WeatheringCopperState;
 import io.papermc.typewriter.preset.EnumCloneRewriter;
 import io.papermc.typewriter.preset.model.EnumValue;
@@ -116,6 +117,12 @@ public final class Rewriters {
         sourceSet
             .register("PotionType", PotionType.class, new EnumRegistryRewriter<>(Registries.POTION))
             .register("EntityType", EntityType.class, new EntityTypeRewriter())
+            .register("RemovalReason", RemovalReason.class, new EnumCloneRewriter<>(net.minecraft.world.entity.Entity.RemovalReason.class) {
+                @Override
+                protected EnumValue.Builder rewriteEnumValue(net.minecraft.world.entity.Entity.RemovalReason reason) {
+                    return super.rewriteEnumValue(reason).arguments(Boolean.toString(reason.shouldDestroy()), Boolean.toString(reason.shouldSave()));
+                }
+            })
             .register("DisplaySlot", DisplaySlot.class, new EnumCloneRewriter<>(net.minecraft.world.scores.DisplaySlot.class) {
                 @Override
                 protected EnumValue.Builder rewriteEnumValue(net.minecraft.world.scores.DisplaySlot slot) {

--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -28864,7 +28864,7 @@ index 09b6da207530987b483444cebeadc2f1c9a15247..3666c3efd188508153b6482db425648e
 +    // Paper end - block counting
  }
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index a9302dcc5614595bffd377eb4f77b7af3798e2ba..00d1ba3e42076f0de52455d66c4e056fdc48cd7a 100644
+index 118f393b82cc37d2b2b0a3faa843b79bbe512f0c..a5792bc27fdc85ecf388ab44c0b1b3055fc41d21 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -164,7 +164,7 @@ public abstract class Entity
@@ -28958,7 +28958,7 @@ index a9302dcc5614595bffd377eb4f77b7af3798e2ba..00d1ba3e42076f0de52455d66c4e056f
      }
      // Paper end - Share random for entities to make them more random
      public org.bukkit.event.entity.CreatureSpawnEvent.@Nullable SpawnReason spawnReason; // Paper - Entity#getEntitySpawnReason
-@@ -433,6 +389,156 @@ public abstract class Entity
+@@ -434,6 +390,156 @@ public abstract class Entity
          return this.dimensions.makeBoundingBox(x, y, z);
      }
      // Paper end
@@ -29115,7 +29115,7 @@ index a9302dcc5614595bffd377eb4f77b7af3798e2ba..00d1ba3e42076f0de52455d66c4e056f
  
      public Entity(final EntityType<?> type, final Level level) {
          this.type = type;
-@@ -1483,34 +1589,76 @@ public abstract class Entity
+@@ -1484,34 +1590,76 @@ public abstract class Entity
      }
  
      private Vec3 collide(final Vec3 movement) {
@@ -29215,7 +29215,7 @@ index a9302dcc5614595bffd377eb4f77b7af3798e2ba..00d1ba3e42076f0de52455d66c4e056f
      }
  
      private static float[] collectCandidateStepUpHeights(
-@@ -2826,17 +2974,106 @@ public abstract class Entity
+@@ -2827,17 +2975,106 @@ public abstract class Entity
              return false;
          }
  
@@ -29332,7 +29332,7 @@ index a9302dcc5614595bffd377eb4f77b7af3798e2ba..00d1ba3e42076f0de52455d66c4e056f
      }
  
      public InteractionResult interact(final Player player, final InteractionHand hand, final Vec3 location) {
-@@ -4443,15 +4680,17 @@ public abstract class Entity
+@@ -4444,15 +4681,17 @@ public abstract class Entity
      }
  
      public Iterable<Entity> getIndirectPassengers() {
@@ -29358,7 +29358,7 @@ index a9302dcc5614595bffd377eb4f77b7af3798e2ba..00d1ba3e42076f0de52455d66c4e056f
      }
  
      public int countPlayerPassengers() {
-@@ -4762,6 +5001,15 @@ public abstract class Entity
+@@ -4763,6 +5002,15 @@ public abstract class Entity
      }
  
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
@@ -29374,7 +29374,7 @@ index a9302dcc5614595bffd377eb4f77b7af3798e2ba..00d1ba3e42076f0de52455d66c4e056f
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4911,6 +5159,12 @@ public abstract class Entity
+@@ -4912,6 +5160,12 @@ public abstract class Entity
  
      @Override
      public final void setRemoved(final Entity.RemovalReason reason, org.bukkit.event.entity.EntityRemoveEvent.@Nullable Cause cause) { // CraftBukkit - add Bukkit remove cause
@@ -29387,7 +29387,7 @@ index a9302dcc5614595bffd377eb4f77b7af3798e2ba..00d1ba3e42076f0de52455d66c4e056f
          org.bukkit.craftbukkit.event.CraftEventFactory.callEntityRemoveEvent(this, cause); // CraftBukkit
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
          if (this.removalReason == null) {
-@@ -4921,7 +5175,7 @@ public abstract class Entity
+@@ -4923,7 +5177,7 @@ public abstract class Entity
              this.stopRiding();
          }
  
@@ -29396,7 +29396,7 @@ index a9302dcc5614595bffd377eb4f77b7af3798e2ba..00d1ba3e42076f0de52455d66c4e056f
          this.levelCallback.onRemove(reason);
          this.onRemoval(reason);
          // Paper start - Folia schedulers
-@@ -4955,7 +5209,7 @@ public abstract class Entity
+@@ -4961,7 +5215,7 @@ public abstract class Entity
      public boolean shouldBeSaved() {
          return (this.removalReason == null || this.removalReason.shouldSave())
              && !this.isPassenger()

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -355,7 +355,7 @@ index 0000000000000000000000000000000000000000..829f7685904fd741e00403647ae76d32
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 5bb8ddc9490ce6c7bc4544ef0ea05484e67ddbe3..10696186f7776f21a9fbcc49224d05ea2962a93a 100644
+index e5328f08d6a323aa1307ed791a88916b4588939c..1afbe7a877f8055702809bc33b110bdf2933f999 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -880,6 +880,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
@@ -463,10 +463,10 @@ index 271ed1128959287f6c1b6ca59ded377b88f5afff..f03fa06c0ba56f7f5e1e45bc1568a490
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index ba0cdbd064ad3e0cf645c50ab14adcddef48e932..68855c16d2cb3e5b7d7a86f05e7bb2e7922a5ba0 100644
+index a5792bc27fdc85ecf388ab44c0b1b3055fc41d21..4a18f74c7513f0ac6a3415163165d9239ee5b567 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -382,6 +382,15 @@ public abstract class Entity
+@@ -383,6 +383,15 @@ public abstract class Entity
      private final int despawnTime; // Paper - entity despawn time limit
      public int totalEntityAge; // Paper - age-like counter for all entities
      public final io.papermc.paper.entity.activation.ActivationType activationType = io.papermc.paper.entity.activation.ActivationType.activationTypeFor(this); // Paper - EAR 2/tracking ranges
@@ -482,7 +482,7 @@ index ba0cdbd064ad3e0cf645c50ab14adcddef48e932..68855c16d2cb3e5b7d7a86f05e7bb2e7
      // CraftBukkit end
  
      // Paper start
-@@ -548,6 +557,13 @@ public abstract class Entity
+@@ -549,6 +558,13 @@ public abstract class Entity
          this.position = Vec3.ZERO;
          this.blockPosition = BlockPos.ZERO;
          this.chunkPosition = ChunkPos.ZERO;
@@ -496,7 +496,7 @@ index ba0cdbd064ad3e0cf645c50ab14adcddef48e932..68855c16d2cb3e5b7d7a86f05e7bb2e7
          SynchedEntityData.Builder entityDataBuilder = new SynchedEntityData.Builder(this);
          entityDataBuilder.define(DATA_SHARED_FLAGS_ID, (byte)0);
          entityDataBuilder.define(DATA_AIR_SUPPLY_ID, this.getMaxAirSupply());
-@@ -1140,6 +1156,10 @@ public abstract class Entity
+@@ -1141,6 +1157,10 @@ public abstract class Entity
          } else {
              if (moverType == MoverType.PISTON) {
                  delta = this.limitPistonMovement(delta);
@@ -507,7 +507,7 @@ index ba0cdbd064ad3e0cf645c50ab14adcddef48e932..68855c16d2cb3e5b7d7a86f05e7bb2e7
                  if (delta.equals(Vec3.ZERO)) {
                      return;
                  }
-@@ -1155,6 +1175,13 @@ public abstract class Entity
+@@ -1156,6 +1176,13 @@ public abstract class Entity
                  this.stuckSpeedMultiplier = Vec3.ZERO;
                  this.setDeltaMovement(Vec3.ZERO);
              }
@@ -675,7 +675,7 @@ index fd25032b8a68bec2951fdc626fd95946fea5deb4..c800c894a921ae77ed1757794ddf8d73
      public void tick() {
          if (this.getItem().isEmpty()) {
 diff --git a/net/minecraft/world/entity/npc/villager/Villager.java b/net/minecraft/world/entity/npc/villager/Villager.java
-index e1cac3972e8ec33ee269061e2f4dee83c04dbeb7..4f8439afa4ea602b662e68e6b86e9d927fb6a481 100644
+index 48bf5f612b91c457dd8e99955429832daeaab9e2..0a02aef2ff159a1d94870bf3cede0ed29ae192af 100644
 --- a/net/minecraft/world/entity/npc/villager/Villager.java
 +++ b/net/minecraft/world/entity/npc/villager/Villager.java
 @@ -235,11 +235,35 @@ public class Villager extends AbstractVillager implements VillagerDataHolder, Re

--- a/paper-server/patches/features/0017-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0017-Optimise-EntityScheduler-ticking.patch
@@ -66,10 +66,10 @@ index 0ea7ca24a557ed1fe8d5b043430d7a89ef80bfa2..3f7ea010df940daba07e4739f3498b37
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.ADVENTURE_CLICK_MANAGER.handleQueue(this.tickCount); // Paper
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.DIALOG_CLICK_MANAGER.handleQueue(this.tickCount); // Paper
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 700b5740229b5a97b8755c7d4205e8a99f229f9e..56dc9019708d74f92d43d8a9ed37fba7d82b1877 100644
+index 4a18f74c7513f0ac6a3415163165d9239ee5b567..933969f4555f9dbfb935cf23dcb7c231f7e819e5 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -5226,6 +5226,11 @@ public abstract class Entity
+@@ -5232,6 +5232,11 @@ public abstract class Entity
          this.getBukkitEntity().taskScheduler.retire();
      }
      // Paper end - Folia schedulers

--- a/paper-server/patches/sources/net/minecraft/world/damagesource/CombatTracker.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/damagesource/CombatTracker.java.patch
@@ -7,7 +7,7 @@
 -    public final List<CombatEntry> entries = Lists.newArrayList();
 +    public final List<CombatEntry> entries = new net.minecraft.util.ArrayListDeque<>(); // Paper - Fix mem leak (MC-301114); Use ArrayListDeque
      public final LivingEntity mob;
-     private int lastDamageTime;
+     public int lastDamageTime;
      private int combatStartTime;
      private int combatEndTime;
      public boolean inCombat;

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -106,14 +106,6 @@
      private static final Logger LOGGER = LogUtils.getLogger();
      public static final String TAG_ID = "id";
      public static final String TAG_UUID = "UUID";
-@@ -233,6 +_,7 @@
-     public boolean hurtMarked;
-     protected Vec3 stuckSpeedMultiplier = Vec3.ZERO;
-     private Entity.@Nullable RemovalReason removalReason;
-+    private org.bukkit.event.entity.EntityRemoveEvent.Cause removeEventCause;
-     public static final float DEFAULT_BB_WIDTH = 0.6F;
-     public static final float DEFAULT_BB_HEIGHT = 1.8F;
-     public float moveDist;
 @@ -243,7 +_,7 @@
      public double yOld;
      public double zOld;
@@ -140,7 +132,7 @@
      private @Nullable BlockState inBlockState = null;
      public static final int MAX_MOVEMENTS_HANDELED_PER_TICK = 100;
      private final ArrayDeque<Entity.Movement> movementThisTick = new ArrayDeque<>(100);
-@@ -300,6 +_,39 @@
+@@ -300,6 +_,40 @@
      private final LongSet visitedBlocks = new LongOpenHashSet();
      private final InsideBlockEffectApplier.StepBasedCollector insideEffectCollector = new InsideBlockEffectApplier.StepBasedCollector();
      private CustomData customData = CustomData.EMPTY;
@@ -158,6 +150,7 @@
 +    // Marks an entity, that it was removed by a plugin via Entity#remove
 +    // Main use case currently is for SPIGOT-7487, preventing dropping of leash when leash is removed
 +    public boolean pluginRemoved = false;
++    public org.bukkit.event.entity.EntityRemoveEvent.@Nullable Cause removeEventCause;
 +    protected int numCollisions = 0; // Paper - Cap entity collisions
 +    public boolean fromNetherPortal; // Paper - Add option to nerf pigmen from nether portals
 +    public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
@@ -1830,14 +1823,9 @@
      public float getYRot() {
          return this.yRot;
      }
-@@ -3933,10 +_,18 @@
-         return this.removalReason;
+@@ -3934,9 +_,12 @@
      }
  
-+    public org.bukkit.event.entity.EntityRemoveEvent.@Nullable Cause getRemoveEventCause() {
-+        return this.removeEventCause;
-+    }
-+
      @Override
 -    public final void setRemoved(final Entity.RemovalReason reason) {
 +    public final void setRemoved(final Entity.RemovalReason reason, org.bukkit.event.entity.EntityRemoveEvent.@Nullable Cause cause) { // CraftBukkit - add Bukkit remove cause
@@ -1845,11 +1833,11 @@
 +        final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
          if (this.removalReason == null) {
              this.removalReason = reason;
-+            this.removeEventCause = cause;
++            this.removeEventCause = cause; // Paper
          }
  
          if (this.removalReason.shouldDestroy()) {
-@@ -3946,11 +_,28 @@
+@@ -3946,11 +_,31 @@
          this.getPassengers().forEach(Entity::stopRiding);
          this.levelCallback.onRemove(reason);
          this.onRemoval(reason);
@@ -1864,7 +1852,10 @@
      public void unsetRemoved() {
          this.removalReason = null;
 -    }
++        // Paper start
 +        this.removeEventCause = null;
++        this.pluginRemoved = false;
++        // Paper end
 +    }
 +
 +    // Paper start - Folia schedulers

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -106,6 +106,14 @@
      private static final Logger LOGGER = LogUtils.getLogger();
      public static final String TAG_ID = "id";
      public static final String TAG_UUID = "UUID";
+@@ -233,6 +_,7 @@
+     public boolean hurtMarked;
+     protected Vec3 stuckSpeedMultiplier = Vec3.ZERO;
+     private Entity.@Nullable RemovalReason removalReason;
++    private org.bukkit.event.entity.EntityRemoveEvent.Cause removeEventCause;
+     public static final float DEFAULT_BB_WIDTH = 0.6F;
+     public static final float DEFAULT_BB_HEIGHT = 1.8F;
+     public float moveDist;
 @@ -243,7 +_,7 @@
      public double yOld;
      public double zOld;
@@ -1822,9 +1830,14 @@
      public float getYRot() {
          return this.yRot;
      }
-@@ -3934,7 +_,9 @@
+@@ -3933,10 +_,18 @@
+         return this.removalReason;
      }
  
++    public org.bukkit.event.entity.EntityRemoveEvent.@Nullable Cause getRemoveEventCause() {
++        return this.removeEventCause;
++    }
++
      @Override
 -    public final void setRemoved(final Entity.RemovalReason reason) {
 +    public final void setRemoved(final Entity.RemovalReason reason, org.bukkit.event.entity.EntityRemoveEvent.@Nullable Cause cause) { // CraftBukkit - add Bukkit remove cause
@@ -1832,8 +1845,11 @@
 +        final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
          if (this.removalReason == null) {
              this.removalReason = reason;
++            this.removeEventCause = cause;
          }
-@@ -3946,12 +_,28 @@
+ 
+         if (this.removalReason.shouldDestroy()) {
+@@ -3946,11 +_,28 @@
          this.getPassengers().forEach(Entity::stopRiding);
          this.levelCallback.onRemove(reason);
          this.onRemoval(reason);
@@ -1847,8 +1863,10 @@
  
      public void unsetRemoved() {
          this.removalReason = null;
-     }
- 
+-    }
++        this.removeEventCause = null;
++    }
++
 +    // Paper start - Folia schedulers
 +    /**
 +     * Invoked only when the entity is truly removed from the server, never to be added to any world.
@@ -1858,10 +1876,9 @@
 +        this.getBukkitEntity().taskScheduler.retire();
 +    }
 +    // Paper end - Folia schedulers
-+
+ 
      @Override
      public void setLevelCallback(final EntityInLevelCallback levelCallback) {
-         this.levelCallback = levelCallback;
 @@ -4173,4 +_,10 @@
              return this.save;
          }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.mojang.logging.LogUtils;
 import io.papermc.paper.datacomponent.DataComponentType;
+import io.papermc.paper.entity.RemovalReason;
 import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.entity.TeleportFlag;
 import java.util.HashSet;
@@ -466,6 +467,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     public void remove() {
         this.entity.pluginRemoved = true;
         this.entity.discard(this.getHandle().generation ? null : EntityRemoveEvent.Cause.PLUGIN);
+    }
+
+    @Override
+    public boolean isPluginRemoved() {
+        return this.entity.pluginRemoved;
+    }
+
+    @Override
+    public @Nullable RemovalReason getRemovalReason() {
+        final Entity.RemovalReason removalReason = this.entity.getRemovalReason();
+        if (removalReason == null) return null;
+        return RemovalReason.valueOf(removalReason.name());
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -482,14 +482,13 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
 
     @Override
     public @Nullable EntityRemoveEvent.Cause getRemoveEventCause() {
-        return this.entity.getRemoveEventCause();
+        return this.entity.removeEventCause;
     }
 
     @Override
     public @Nullable RemovalReason getRemovalReason() {
         final Entity.RemovalReason removalReason = this.entity.getRemovalReason();
-        if (removalReason == null) return null;
-        return RemovalReason.valueOf(removalReason.name());
+        return removalReason == null ? null : RemovalReason.valueOf(removalReason.name());
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -9,6 +9,7 @@ import com.mojang.logging.LogUtils;
 import io.papermc.paper.datacomponent.DataComponentType;
 import io.papermc.paper.datacomponent.PaperDataComponentType;
 import io.papermc.paper.entity.LookAnchor;
+import io.papermc.paper.entity.RemovalReason;
 import io.papermc.paper.entity.TeleportFlag;
 import java.util.EnumSet;
 import java.util.List;
@@ -477,6 +478,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     public void remove() {
         this.entity.pluginRemoved = true;
         this.entity.discard(this.getHandle().generation ? null : EntityRemoveEvent.Cause.PLUGIN);
+    }
+
+    @Override
+    public @Nullable EntityRemoveEvent.Cause getRemoveEventCause() {
+        return this.entity.getRemoveEventCause();
+    }
+
+    @Override
+    public @Nullable RemovalReason getRemovalReason() {
+        final Entity.RemovalReason removalReason = this.entity.getRemovalReason();
+        if (removalReason == null) return null;
+        return RemovalReason.valueOf(removalReason.name());
     }
 
     @Override


### PR DESCRIPTION
Sometimes we want to know why an entity is removed in an easier way instead of listening `EntityRemoveEvent`. So here is the API.