### PR TITLE
Add CommandSourceStack to UnknownCommandEvent

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.command;
 
+import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.command.CommandSender;
@@ -18,40 +19,49 @@ public class UnknownCommandEvent extends Event {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
-    private final CommandSender sender;
+    private final CommandSourceStack commandSource;
     private final String commandLine;
     private @Nullable Component message;
 
     @ApiStatus.Internal
-    public UnknownCommandEvent(final CommandSender sender, final String commandLine, final @Nullable Component message) {
+    public UnknownCommandEvent(final CommandSourceStack commandSource, final String commandLine, final @Nullable Component message) {
         super(false);
-        this.sender = sender;
+        this.commandSource = commandSource;
         this.commandLine = commandLine;
         this.message = message;
     }
 
     /**
-     * Gets the CommandSender or ConsoleCommandSender
+     * Gets the CommandSender
      *
-     * @return Sender of the command
+     * @return sender of the command
      */
     public CommandSender getSender() {
-        return this.sender;
+        return this.commandSource.getSender();
+    }
+
+    /**
+     * Gets the command source associated with this event
+     *
+     * @return the {@link CommandSourceStack}
+     */
+    public CommandSourceStack getCommandSource() {
+        return this.commandSource;
     }
 
     /**
      * Gets the command that was sent
      *
-     * @return Command sent
+     * @return command sent
      */
     public String getCommandLine() {
         return this.commandLine;
     }
 
     /**
-     * Gets message that will be returned
+     * Gets the message that will be returned
      *
-     * @return Unknown command message
+     * @return unknown command message
      * @deprecated use {@link #message()}
      */
     @Deprecated
@@ -60,7 +70,7 @@ public class UnknownCommandEvent extends Event {
     }
 
     /**
-     * Sets message that will be returned
+     * Sets the message that will be returned
      * <p>
      * Set to {@code null} to avoid any message being sent
      *
@@ -73,9 +83,9 @@ public class UnknownCommandEvent extends Event {
     }
 
     /**
-     * Gets message that will be returned
+     * Gets the message that will be returned
      *
-     * @return Unknown command message
+     * @return unknown command message
      */
     @Contract(pure = true)
     public @Nullable Component message() {
@@ -83,7 +93,7 @@ public class UnknownCommandEvent extends Event {
     }
 
     /**
-     * Sets message that will be returned
+     * Sets the message that will be returned
      * <p>
      * Set to {@code null} to avoid any message being sent
      *

--- a/paper-server/patches/sources/net/minecraft/commands/Commands.java.patch
+++ b/paper-server/patches/sources/net/minecraft/commands/Commands.java.patch
@@ -124,7 +124,7 @@
 +                    .append(net.kyori.adventure.text.Component.newline())
 +                    .append(io.papermc.paper.adventure.PaperAdventure.asAdventure(mutableComponent));
 +            }
-+            org.bukkit.event.command.UnknownCommandEvent event = new org.bukkit.event.command.UnknownCommandEvent(source.getBukkitSender(), command, org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty() ? null : builder.build());
++            org.bukkit.event.command.UnknownCommandEvent event = new org.bukkit.event.command.UnknownCommandEvent(source, command, org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty() ? null : builder.build());
 +            org.bukkit.Bukkit.getServer().getPluginManager().callEvent(event);
 +            if (event.message() != null) {
 +                source.sendFailure(io.papermc.paper.adventure.PaperAdventure.asVanilla(event.message()), false);


### PR DESCRIPTION
This commit exposes the `CommandSourceStack` to the `UnknownCommandEvent`.

I felt modifying the constructor instead of deprecating was fine due to the `@ApiStatus.Internal` label on the constructor.

As an example use case, the `cloud` command library has a lovely help generator, and all of `cloud`'s Paper support is built around `CommandSourceStack`. Personally I'd want this event to expose the stack so I can listen in my plugin and display the help output to users, but also it could potentially be PR'd to the library itself to support automatically sending help to commands as a larger improvement.

I also cleaned up the javadocs in the event a little.