### PR TITLE
Add isSingleBlock() to Bisected for distinguishing single-block bisected types

### DIFF
--- a/paper-api/src/main/java/org/bukkit/block/data/Bisected.java
+++ b/paper-api/src/main/java/org/bukkit/block/data/Bisected.java
@@ -25,6 +25,22 @@ public interface Bisected extends BlockData {
     void setHalf(@NotNull Half half);
 
     /**
+     * Determines whether this bisected block fits within a single block space.
+     * <p>
+     * Returns {@code true} for blocks like {@link org.bukkit.Tag#TRAPDOORS trapdoors} and {@link org.bukkit.Tag#STAIRS stairs},
+     * which are bisected but occupy only one block in height. Blocks that span two blocks vertically, such as doors or tall plants,
+     * return {@code false}.
+     * <p>
+     * The result influences in-game terminology: single-block bisected types use {@code top}/{@code bottom},
+     * while two-block structures use {@code upper}/{@code lower}.
+     *
+     * @return true if the block fits within a single block space; false otherwise
+     */
+    default boolean isSingleBlock() {
+        return false;
+    }
+
+    /**
      * The half of a vertically bisected block.
      */
     public enum Half {

--- a/paper-api/src/main/java/org/bukkit/block/data/type/Stairs.java
+++ b/paper-api/src/main/java/org/bukkit/block/data/type/Stairs.java
@@ -25,6 +25,11 @@ public interface Stairs extends Bisected, Directional, Waterlogged {
      */
     void setShape(@NotNull Shape shape);
 
+    @Override
+    default boolean isSingleBlock() {
+        return true;
+    }
+
     /**
      * The shape of a stair block - used for constructing corners.
      */

--- a/paper-api/src/main/java/org/bukkit/block/data/type/TrapDoor.java
+++ b/paper-api/src/main/java/org/bukkit/block/data/type/TrapDoor.java
@@ -7,4 +7,9 @@ import org.bukkit.block.data.Powerable;
 import org.bukkit.block.data.Waterlogged;
 
 public interface TrapDoor extends Bisected, Directional, Openable, Powerable, Waterlogged {
+
+    @Override
+    default boolean isSingleBlock() {
+        return true;
+    }
 }


### PR DESCRIPTION
This PR introduces a new method to the `org.bukkit.block.data.Bisected` interface:
```java
default boolean isSingleBlock() {
    return false;
}
```

# Purpose
The method allows plugins and internal logic to differentiate between bisected blocks that occupy a single block space (e.g., trapdoors, stairs) and those that span two vertical blocks (e.g., doors, tall plants).

# Behavior

- Returns true for trapdoor and stairs blocks
- Returns false for other blocks like doors and double-height plants