### PR TITLE
Adds missing deprecation for Player#boostElytra

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -1,10 +1,12 @@
 package org.bukkit.entity;
 
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import io.papermc.paper.datacomponent.item.Fireworks;
+import io.papermc.paper.datacomponent.item.UseCooldown;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.Consumer;
-import io.papermc.paper.datacomponent.item.UseCooldown;
 import net.kyori.adventure.key.Key;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -20,7 +22,6 @@ import org.bukkit.inventory.MainHand;
 import org.bukkit.inventory.MenuType;
 import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.inventory.meta.FireworkMeta;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -1009,16 +1010,35 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder 
      * Perform a firework boost.
      * <p>
      * This method will only work such that {@link #isGliding()} is true and
-     * the entity is actively gliding with an elytra. Additionally, the supplied
-     * {@code fireworkItemStack} must be a firework rocket. The power of the boost
-     * will directly correlate to {@link FireworkMeta#getPower()}.
+     * the entity is actively gliding with an item with {@link DataComponentTypes#GLIDER} component.
+     * <p>
+     * The power of the boost will directly correlate to {@link Fireworks#flightDuration()} from {@link DataComponentTypes#FIREWORKS} component.
+     * <p>
+     * This method does not fire {@link com.destroystokyo.paper.event.player.PlayerElytraBoostEvent}.
      *
-     * @param fireworkItemStack the firework item stack to use to glide
+     * @param boosterItem the item to use to boost
      * @return the attached {@link Firework}, or null if the entity could not
      * be boosted
-     * @throws IllegalArgumentException if the fireworkItemStack is not a firework
      */
     @Nullable
-    public Firework fireworkBoost(ItemStack fireworkItemStack);
+    Firework fireworkBoost(ItemStack boosterItem);
+
+    /**
+     * Perform a firework boost.
+     * <p>
+     * This method will only work such that {@link #isGliding()} is true and
+     * the entity is actively gliding with an item with {@link DataComponentTypes#GLIDER} component.
+     * <p>
+     * The power of the boost will directly correlate to {@link Fireworks#flightDuration()} from {@link DataComponentTypes#FIREWORKS} component.
+     * <p>
+     * This method does not fire {@link com.destroystokyo.paper.event.player.PlayerElytraBoostEvent}.
+     *
+     * @return the attached {@link Firework}, or null if the entity could not
+     * be boosted
+     */
+    @Nullable
+    default Firework fireworkBoost() {
+        return this.fireworkBoost(ItemStack.empty());
+    }
 
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -1,6 +1,7 @@
 package org.bukkit.entity;
 
 import com.destroystokyo.paper.ClientOption;
+import com.google.common.base.Preconditions;
 import io.papermc.paper.connection.PlayerGameConnection;
 import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.entity.PlayerGiveResult;
@@ -3617,24 +3618,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
     <T> T getClientOption(ClientOption<T> option);
     // Paper end - client option API
 
-    // Paper start - elytra boost API
     /**
      * Boost a Player that's {@link #isGliding()} using a {@link Firework}.
      * If the creation of the entity is cancelled, no boosting is done.
      * This method does not fire {@link com.destroystokyo.paper.event.player.PlayerElytraBoostEvent}.
      *
-     * @param firework The {@link Material#FIREWORK_ROCKET} to boost the player with
+     * @param boosterItem The itemstack to boost the player with
      * @return The {@link Firework} boosting the Player or null if the spawning of the entity was cancelled
-     * @throws IllegalArgumentException if {@link #isGliding()} is false
-     * or if the {@code firework} isn't a {@link Material#FIREWORK_ROCKET}
+     * @throws IllegalStateException if {@link #isGliding()} is false
      * @deprecated use {@link HumanEntity#fireworkBoost(ItemStack)} instead. Note that this method <b>does not</b>
      * check if the player is gliding or not.
      */
-    default @Nullable Firework boostElytra(final ItemStack firework) {
-        com.google.common.base.Preconditions.checkState(this.isGliding(), "Player must be gliding");
-        return this.fireworkBoost(firework);
+    @Deprecated(since = "1.20.5")
+    default @Nullable Firework boostElytra(final ItemStack boosterItem) {
+        Preconditions.checkState(this.isGliding(), "Player must be gliding");
+        return this.fireworkBoost(boosterItem);
     }
-    // Paper end - elytra boost API
 
     // Paper start - sendOpLevel API
     /**

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -2,12 +2,12 @@ package org.bukkit.craftbukkit.entity;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import io.papermc.paper.adventure.PaperAdventure;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import io.papermc.paper.adventure.PaperAdventure;
 import net.kyori.adventure.key.Key;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
@@ -896,11 +896,10 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
     }
 
     @Override
-    public Firework fireworkBoost(ItemStack fireworkItemStack) {
-        Preconditions.checkArgument(fireworkItemStack != null, "fireworkItemStack must not be null");
-        Preconditions.checkArgument(fireworkItemStack.getType() == Material.FIREWORK_ROCKET, "fireworkItemStack must be of type %s", Material.FIREWORK_ROCKET);
+    public Firework fireworkBoost(ItemStack boosterItem) {
+        Preconditions.checkArgument(boosterItem != null, "boosterItem cannot be null");
 
-        FireworkRocketEntity fireworks = new FireworkRocketEntity(this.getHandle().level(), CraftItemStack.asNMSCopy(fireworkItemStack), this.getHandle());
+        FireworkRocketEntity fireworks = new FireworkRocketEntity(this.getHandle().level(), CraftItemStack.asNMSCopy(boosterItem), this.getHandle());
         boolean success = this.getHandle().level().addFreshEntity(fireworks, SpawnReason.CUSTOM);
         return success ? (Firework) fireworks.getBukkitEntity() : null;
     }


### PR DESCRIPTION
Based in https://github.com/PaperMC/Paper/pull/9899 and a notice in a few tasks the method `Player#boostElytra` has a missing Deprecated annotation and also the throw in docs mention the wrong exception for the glide check.