### PR TITLE
Add GAMEMODE_SWITCHER gamemode change cause

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
@@ -129,7 +129,8 @@ public class PlayerGameModeChangeEvent extends PlayerEvent implements Cancellabl
          */
         HARDCORE_DEATH,
         /**
-         * A player changed their gamemode using the gamemode switcher (F3+F4, F3+N).
+         * A player changed their gamemode using the gamemode switcher (F3+F4)
+         * or spectator hotkey (F3+N).
          */
         GAMEMODE_SWITCHER,
         /**

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
@@ -129,6 +129,10 @@ public class PlayerGameModeChangeEvent extends PlayerEvent implements Cancellabl
          */
         HARDCORE_DEATH,
         /**
+         * A player changed their gamemode using the gamemode switcher (F3+F4, F3+N).
+         */
+        GAMEMODE_SWITCHER,
+        /**
          * This cause is only used if a plugin fired their own
          * {@link PlayerGameModeChangeEvent} and did not include a
          * cause. Can usually be ignored.

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
@@ -62,7 +62,7 @@ public class PlayerGameModeChangeEvent extends PlayerEvent implements Cancellabl
     }
 
     /**
-     * <b>Only valid if the gamemode change was caused by a command or the gamemode switcher.</b>
+     * <b>Only valid if the gamemode change was caused by the {@code /gamemode} command or the gamemode switcher.</b>
      * Gets the message shown to the command user if the event is cancelled
      * as a notification that a player's gamemode was not changed.
      *
@@ -75,8 +75,8 @@ public class PlayerGameModeChangeEvent extends PlayerEvent implements Cancellabl
 
     /**
      * Sets the message shown to the command user if the event was cancelled.
-     * <b>The message is only shown to cancelled events that are called by a command or the gamemode switcher
-     * not by a plugin or a player joining with the wrong gamemode.</b>
+     * <b>The message is only shown to cancelled events that are called by the {@code /gamemode} command
+     * or the gamemode switcher.</b>
      *
      * @param message the error message shown to the command user, {@code null} to show no message.
      */

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
@@ -62,7 +62,7 @@ public class PlayerGameModeChangeEvent extends PlayerEvent implements Cancellabl
     }
 
     /**
-     * <b>Only valid if the cause of the gamemode change was directly due to a command.</b>
+     * <b>Only valid if the gamemode change was caused by a command or the gamemode switcher.</b>
      * Gets the message shown to the command user if the event is cancelled
      * as a notification that a player's gamemode was not changed.
      *
@@ -75,7 +75,7 @@ public class PlayerGameModeChangeEvent extends PlayerEvent implements Cancellabl
 
     /**
      * Sets the message shown to the command user if the event was cancelled.
-     * <b>The message is only shown to cancelled events that are directly called by a command
+     * <b>The message is only shown to cancelled events that are called by a command or the gamemode switcher
      * not by a plugin or a player joining with the wrong gamemode.</b>
      *
      * @param message the error message shown to the command user, {@code null} to show no message.

--- a/paper-server/patches/sources/net/minecraft/server/commands/GameModeCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/GameModeCommand.java.patch
@@ -1,24 +1,21 @@
 --- a/net/minecraft/server/commands/GameModeCommand.java
 +++ b/net/minecraft/server/commands/GameModeCommand.java
-@@ -65,13 +_,24 @@
-     }
- 
-     public static void setGameMode(ServerPlayer player, GameType gameMode) {
-+        if (true) {setGameMode(player.createCommandSourceStack(), player, gameMode, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.GAMEMODE_SWITCHER); return;} // Paper - Expand PlayerGamemodeChangeEvent
-         setGameMode(player.createCommandSourceStack(), player, gameMode);
+@@ -69,9 +_,21 @@
      }
  
      private static boolean setGameMode(CommandSourceStack source, ServerPlayer player, GameType gameMode) {
 -        if (player.setGameMode(gameMode)) {
-+        // Paper start
++        // Paper start - Expand PlayerGameModeChangeEvent
 +        return setGameMode(source, player, gameMode, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.COMMAND);
 +    }
-+    private static boolean setGameMode(CommandSourceStack source, ServerPlayer player, GameType gameMode, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause cause) {
++
++    public static boolean setGameMode(CommandSourceStack source, ServerPlayer player, GameType gameMode, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause cause) {
 +        org.bukkit.event.player.PlayerGameModeChangeEvent event = player.setGameMode(gameMode, cause, null);
 +        if (event != null && !event.isCancelled()) {
-+            // Paper end
++            // Paper end - Expand PlayerGameModeChangeEvent
              logGamemodeChange(source, player, gameMode);
              return true;
++            // Paper start - Expand PlayerGameModeChangeEvent
 +        } else if (event != null && event.cancelMessage() != null) {
 +            source.sendSuccess(() -> io.papermc.paper.adventure.PaperAdventure.asVanilla(event.cancelMessage()), true);
 +            return false;

--- a/paper-server/patches/sources/net/minecraft/server/commands/GameModeCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/GameModeCommand.java.patch
@@ -1,12 +1,20 @@
 --- a/net/minecraft/server/commands/GameModeCommand.java
 +++ b/net/minecraft/server/commands/GameModeCommand.java
-@@ -69,9 +_,16 @@
+@@ -65,13 +_,24 @@
+     }
+ 
+     public static void setGameMode(ServerPlayer player, GameType gameMode) {
++        if (true) {setGameMode(player.createCommandSourceStack(), player, gameMode, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.GAMEMODE_SWITCHER); return;} // Paper - Expand PlayerGamemodeChangeEvent
+         setGameMode(player.createCommandSourceStack(), player, gameMode);
      }
  
      private static boolean setGameMode(CommandSourceStack source, ServerPlayer player, GameType gameMode) {
 -        if (player.setGameMode(gameMode)) {
 +        // Paper start
-+        org.bukkit.event.player.PlayerGameModeChangeEvent event = player.setGameMode(gameMode, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.COMMAND, null);
++        return setGameMode(source, player, gameMode, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.COMMAND);
++    }
++    private static boolean setGameMode(CommandSourceStack source, ServerPlayer player, GameType gameMode, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause cause) {
++        org.bukkit.event.player.PlayerGameModeChangeEvent event = player.setGameMode(gameMode, cause, null);
 +        if (event != null && !event.isCancelled()) {
 +            // Paper end
              logGamemodeChange(source, player, gameMode);

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -2501,6 +2501,15 @@
          }
      }
  
+@@ -1972,7 +_,7 @@
+                 packet.mode().getShortDisplayName().getString()
+             );
+         } else {
+-            GameModeCommand.setGameMode(this.player, packet.mode());
++            GameModeCommand.setGameMode(this.player.createCommandSourceStack(), this.player, packet.mode(), org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.GAMEMODE_SWITCHER); // Paper - add cause
+         }
+     }
+ 
 @@ -1992,7 +_,7 @@
          ProfilePublicKey.Data data2 = data.profilePublicKey();
          if (!Objects.equals(data1, data2)) {


### PR DESCRIPTION
Adds a new PlayerGameModeChangeEvent.Cause for when a player uses the gamemode switcher (F3+F4) or spectator hotkey (F3+N).

BREAKING CHANGE: Events that are now fired under this new cause were previously fired under the COMMAND cause.
Closes #13017

```java
    @EventHandler
    public void onGameMode(final PlayerGameModeChangeEvent event) {
        this.getSLF4JLogger().info("{}: {}->{} - {}",
            event.getPlayer().getName(), event.getPlayer().getGameMode(), event.getNewGameMode(), event.getCause());
    }
```
<img width="778" height="113" alt="Screenshot 2025-09-25 101857" src="https://github.com/user-attachments/assets/8d47b8e3-667c-44ea-abaa-3b519c8e42d7" />