### PR TITLE
Fix config option 'fix-climbing-bypassing-cramming-rule'

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/EntitySelector.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/EntitySelector.java.patch
@@ -28,10 +28,10 @@
  
      public static Predicate<Entity> pushableBy(Entity entity) {
 +        // Paper start - Climbing should not bypass cramming gamerule
-+        return pushable(entity, false);
++        return pushable(entity);
 +    }
 +
-+    public static Predicate<Entity> pushable(Entity entity, boolean ignoreClimbing) {
++    public static Predicate<Entity> pushable(Entity entity) {
 +        // Paper end - Climbing should not bypass cramming gamerule
          Team team = entity.getTeam();
          Team.CollisionRule collisionRule = team == null ? Team.CollisionRule.ALWAYS : team.getCollisionRule();

--- a/paper-server/patches/sources/net/minecraft/world/entity/EntitySelector.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/EntitySelector.java.patch
@@ -41,7 +41,7 @@
 -                entity1 -> {
 -                    if (!entity1.isPushable()) {
 +                entity1 -> { final Entity pushedEntity = entity1; // Paper - OBFHELPER
-+                    if (!pushedEntity.isCollidable(ignoreClimbing) || !pushedEntity.canCollideWithBukkit(entity) || !entity.canCollideWithBukkit(pushedEntity)) { // CraftBukkit - collidable API // Paper - Climbing should not bypass cramming gamerule
++                    if (!pushedEntity.isPushable() || !pushedEntity.canCollideWithBukkit(entity) || !entity.canCollideWithBukkit(pushedEntity)) { // CraftBukkit - collidable API // Paper - Climbing should not bypass cramming gamerule
                          return false;
                      } else if (!entity.level().isClientSide || entity1 instanceof Player player && player.isLocalPlayer()) {
                          Team team1 = entity1.getTeam();


### PR DESCRIPTION
Would close #12748

The problem is caused by `EntitySelector.pushable` calling `LivingEntity#isCollideable` instead of `LivingEntity#isPushable`, which skips the config check entirely.

### Stack trace where the issue is clearly visible
```
[16:12:49 INFO]: fixClimbingBypassingCrammingRule: true
[16:12:49 INFO]: Ignore climbing: false
[16:12:49 WARN]: java.lang.Exception: Stack trace
[16:12:49 WARN]: 	at java.base/java.lang.Thread.dumpStack(Thread.java:2210 )
[16:12:49 WARN]: 	at net.minecraft.world.entity.LivingEntity.isCollidable(LivingEntity.java:3829)
[16:12:49 WARN]: 	at net.minecraft.world.entity.EntitySelector.lambda$pushable$9(EntitySelector.java:58)
[16:12:49 WARN]: 	at java.base/java.util.function.Predicate.lambda$and$0(Predicate.java:69)
[16:12:49 WARN]: 	at ca.spottedleaf.moonrise.patches.chunk_system.level.entity.ChunkEntitySlices$EntityCollectionBySection.getEntities(ChunkEntitySlices.java:549)
[16:12:49 WARN]: 	at ca.spottedleaf.moonrise.patches.chunk_system.level.entity.ChunkEntitySlices.getEntities(ChunkEntitySlices.java:327)
[16:12:49 WARN]: 	at ca.spottedleaf.moonrise.patches.chunk_system.level.entity.EntityLookup.getEntities(EntityLookup.java:599)
[16:12:49 WARN]: 	at net.minecraft.world.level.Level.getEntities(Level.java:1735)
[16:12:49 WARN]: 	at net.minecraft.world.level.Level.getPushableEntities(Level.java:1844)
[16:12:49 WARN]: 	at net.minecraft.world.entity.LivingEntity.pushEntities(LivingEntity.java:3664)
[16:12:49 WARN]: 	at net.minecraft.world.entity.LivingEntity.aiStep(LivingEntity.java:3571)
[16:12:49 WARN]: 	at net.minecraft.world.entity.Mob.aiStep(Mob.java:511)
[16:12:49 WARN]: 	at net.minecraft.world.entity.animal.allay.Allay.aiStep(Allay.java:241)
[16:12:49 WARN]: 	at net.minecraft.world.entity.LivingEntity.tick(LivingEntity.java:3267)
[16:12:49 WARN]: 	at net.minecraft.world.entity.Mob.tick(Mob.java:382)
[16:12:49 WARN]: 	at net.minecraft.world.entity.animal.allay.Allay.tick(Allay.java:256)
[16:12:49 WARN]: 	at net.minecraft.server.level.ServerLevel.tickNonPassenger(ServerLevel.java:1277)
[16:12:49 WARN]: 	at net.minecraft.world.level.Level.guardEntityTick(Level.java:1483)
[16:12:49 WARN]: 	at net.minecraft.server.level.ServerLevel.lambda$tick$4(ServerLevel.java:811)
[16:12:49 WARN]: 	at net.minecraft.world.level.entity.EntityTickList.forEach(EntityTickList.java:39)
[16:12:49 WARN]: 	at net.minecraft.server.level.ServerLevel.tick(ServerLevel.java:793)
[16:12:49 WARN]: 	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1724)
[16:12:49 WARN]: 	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1530)
[16:12:49 WARN]: 	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1252)
[16:12:49 WARN]: 	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310)
[16:12:49 WARN]: 	at java.base/java.lang.Thread.run(Thread.java:1583)
```