### PR TITLE
Add world configuration setting: `chunks.mob-spawning-disable-radius-around-spawn-chunk`

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -188,6 +188,30 @@
          } else {
              filteredSpawningCategories = List.of();
          }
+@@ -430,6 +_,23 @@
+             this.level.tickThunder(chunk);
+         }
+ 
++        // Paper start - disable mob spawning within configured radius around spawn chunk
++        int mobSpawningDisableRadiusAroundSpawnChunk = level.paperConfig().chunks.mobSpawningDisableRadiusAroundSpawnChunk;
++
++        if (mobSpawningDisableRadiusAroundSpawnChunk >= 0)
++        {
++            ChunkPos spawnChunk = new net.minecraft.world.level.ChunkPos(level.getSharedSpawnPos());
++
++            if (pos.x <= spawnChunk.x + mobSpawningDisableRadiusAroundSpawnChunk &&
++                pos.x >= spawnChunk.x - mobSpawningDisableRadiusAroundSpawnChunk &&
++                pos.z <= spawnChunk.z + mobSpawningDisableRadiusAroundSpawnChunk &&
++                pos.z >= spawnChunk.z - mobSpawningDisableRadiusAroundSpawnChunk)
++            {
++                return;
++            }
++        }
++        // Paper end - disable mob spawning within configured radius around spawn chunk
++
+         if (!spawnCategories.isEmpty()) {
+             if (this.level.canSpawnEntitiesInChunk(pos)) {
+                 NaturalSpawner.spawnForChunk(this.level, chunk, spawnState, spawnCategories);
 @@ -547,8 +_,13 @@
  
      @Override

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -515,6 +515,7 @@ public class WorldConfiguration extends ConfigurationPart {
             map.put(EntityType.SMALL_FIREBALL, -1);
         });
         public boolean flushRegionsOnSave = false;
+        public int mobSpawningDisableRadiusAroundSpawnChunk = -1;
 
         @PostProcess
         private void postProcess() {


### PR DESCRIPTION
PSA: This is a duplicate of https://github.com/PaperMC/Paper/pull/13108 - I didn't know that making it my new main branch and deleting the old one would cause the original PR to be closed. Sorry - I hope it is acceptable to open this new one. It is exactly the same.

This is my first PR, so I apologise in advance if it is inherently flawed, but it seems to work fine in my testing.

This setting aims to solve the problem that servers with protected regions around their world's spawn point will probably have, where said regions may disable mob spawning via a WorldGuard flag for example, and as a result, the server will continuously try to spawn mobs there, never being able to meet the mob caps due to the cancelled spawns, potentially wasting a considerable amount of time per tick.

It allows you to set a square radius, in chunks, around the world's spawn chunk (by spawn chunk, I just mean the chunk that the world's spawn point happens to be inside). The chunks within this radius will not be considered for mob spawning.

- If set to `-1` (default) or lower, the feature will be disabled (vanilla behaviour).
- If set to `0`, only the spawn chunk will not be considered for mob spawning.
- If set to anything higher than `0`, a square radius of chunks around the spawn chunk will all not be considered for mob spawning.

Solves https://github.com/PaperMC/Paper/issues/13107