### PR TITLE
Fix command-block-overrides from commands.yml

### DIFF
--- a/paper-server/patches/sources/com/mojang/brigadier/tree/CommandNode.java.patch
+++ b/paper-server/patches/sources/com/mojang/brigadier/tree/CommandNode.java.patch
@@ -48,7 +48,7 @@
 +                if (!text.contains(":")) {
 +                    literal = this.literals.get("minecraft:" + text);
 +                }
-+            } else if (source instanceof net.minecraft.commands.CommandSourceStack css && css.source instanceof net.minecraft.world.level.BaseCommandBlock) {
++            } else if (source instanceof net.minecraft.commands.CommandSourceStack css && (css.source instanceof net.minecraft.world.level.BaseCommandBlock || css.source instanceof net.minecraft.world.level.BaseCommandBlock.CloseableCommandBlockSource)) {
 +                if (css.getServer().server.getCommandBlockOverride(text) && !text.contains(":")) {
 +                    literal = this.literals.get("minecraft:" + text);
 +                }


### PR DESCRIPTION
This was broken because the source type changed from simply BaseCommandBlock to the inner class CloseableCommandBlockSource, but I left BaseCommandBlock there as well just in case.