### PR TITLE
Add SpawnReason for REANIMATE a Copper Golem Statue

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
@@ -229,7 +229,7 @@ public class CreatureSpawnEvent extends EntitySpawnEvent {
         /**
          * When a Copper Golem Statue turns back into a Copper Golem
          *
-         * @apiNote Cancel an {@link CreatureSpawnEvent} with this reason not avoid the statue block to being change, you need to use {@link EntityChangeBlockEvent} for that
+         * @apiNote Canceling a {@link CreatureSpawnEvent} with this reason does not prevent the statue block from being removed, use {@link EntityChangeBlockEvent} to account for all side effects
          */
         REANIMATE,
         /**

--- a/paper-api/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
@@ -227,7 +227,7 @@ public class CreatureSpawnEvent extends EntitySpawnEvent {
          */
         POTION_EFFECT,
         /**
-         * When a copper golem statue is turned back into a copper golem
+         * When a Copper Golem Statue turns back into a Copper Golem
          *
          * @apiNote Cancel an {@link CreatureSpawnEvent} with this reason not avoid the statue block to being change, you need to use {@link EntityChangeBlockEvent} for that
          */

--- a/paper-api/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
@@ -227,6 +227,10 @@ public class CreatureSpawnEvent extends EntitySpawnEvent {
          */
         POTION_EFFECT,
         /**
+         * When a copper golem statue is turned back into a copper golem
+         */
+        REANIMATE,
+        /**
          * When a creature is spawned by being rehydrated
          */
         REHYDRATION,

--- a/paper-api/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
@@ -229,7 +229,7 @@ public class CreatureSpawnEvent extends EntitySpawnEvent {
         /**
          * When a copper golem statue is turned back into a copper golem
          *
-         * @apiNote Cancel a event with this reason not avoid the statue to being change, you need to check {@link EntityChangeBlockEvent} for that
+         * @apiNote Cancel an {@link CreatureSpawnEvent} with this reason not avoid the statue block to being change, you need to use {@link EntityChangeBlockEvent} for that
          */
         REANIMATE,
         /**

--- a/paper-api/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
@@ -228,6 +228,8 @@ public class CreatureSpawnEvent extends EntitySpawnEvent {
         POTION_EFFECT,
         /**
          * When a copper golem statue is turned back into a copper golem
+         *
+         * @apiNote Cancel a event with this reason not avoid the statue to being change, you need to check {@link EntityChangeBlockEvent} for that
          */
         REANIMATE,
         /**

--- a/paper-server/patches/sources/net/minecraft/world/level/block/WeatheringCopperGolemStatueBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/WeatheringCopperGolemStatueBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/WeatheringCopperGolemStatueBlock.java
 +++ b/net/minecraft/world/level/block/WeatheringCopperGolemStatueBlock.java
-@@ -58,16 +_,20 @@
+@@ -58,16 +_,21 @@
                      return InteractionResult.PASS;
                  }
  
@@ -17,10 +17,11 @@
 -                    level.removeBlock(pos, false);
 +                    // Paper start - call EntityChangeBlockEvent and spawnReason
 +                    BlockState newState = level.getFluidState(pos).createLegacyBlock();
-+                    if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, pos, newState) || !level.addFreshEntity(copperGolem, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.REANIMATE)) {
++                    if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, pos, newState)) {
 +                        return InteractionResult.PASS;
 +                    }
 +                    stack.hurtAndBreak(1, player, hand.asEquipmentSlot()); // Paper - moved after event
++                    level.addFreshEntity(copperGolem, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.REANIMATE); // Paper - add SpawnReason
 +                    level.setBlock(pos, newState, 3);
 +                    // Paper end - call EntityChangeBlockEvent and spawnReason
                      return InteractionResult.SUCCESS;

--- a/paper-server/patches/sources/net/minecraft/world/level/block/WeatheringCopperGolemStatueBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/WeatheringCopperGolemStatueBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/WeatheringCopperGolemStatueBlock.java
 +++ b/net/minecraft/world/level/block/WeatheringCopperGolemStatueBlock.java
-@@ -58,16 +_,21 @@
+@@ -58,16 +_,20 @@
                      return InteractionResult.PASS;
                  }
  
@@ -13,16 +13,16 @@
                  CopperGolem copperGolem = copperGolemStatueBlockEntity.removeStatue(state);
 -                stack.hurtAndBreak(1, player, hand.asEquipmentSlot());
                  if (copperGolem != null) {
-+                    // Paper start - call EntityChangeBlockEvent
+-                    level.addFreshEntity(copperGolem);
+-                    level.removeBlock(pos, false);
++                    // Paper start - call EntityChangeBlockEvent and spawnReason
 +                    BlockState newState = level.getFluidState(pos).createLegacyBlock();
-+                    if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, pos, newState)) {
++                    if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, pos, newState) || !level.addFreshEntity(copperGolem, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.REANIMATE)) {
 +                        return InteractionResult.PASS;
 +                    }
 +                    stack.hurtAndBreak(1, player, hand.asEquipmentSlot()); // Paper - moved after event
-                     level.addFreshEntity(copperGolem);
--                    level.removeBlock(pos, false);
 +                    level.setBlock(pos, newState, 3);
-+                    // Paper end - call EntityChangeBlockEvent
++                    // Paper end - call EntityChangeBlockEvent and spawnReason
                      return InteractionResult.SUCCESS;
                  }
              }


### PR DESCRIPTION
Adds the reason for spawn de Copper Golem from a Statue, the name of the reason its based in
[https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/2ffa847835b0d2d7f85bccbb6951e819374e13a6](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/2ffa847835b0d2d7f85bccbb6951e819374e13a6#src%2Fmain%2Fjava%2Forg%2Fbukkit%2Fevent%2Fentity%2FCreatureSpawnEvent.java?t=224)