### PR TITLE
Fix `EntityPushedByEntityAttackEvent` not being called for Wind Burst attacks

### DIFF
--- a/paper-server/patches/resources/data/minecraft/enchantment/wind_burst.json.patch
+++ b/paper-server/patches/resources/data/minecraft/enchantment/wind_burst.json.patch
@@ -1,0 +1,10 @@
+--- a/data/minecraft/enchantment/wind_burst.json
++++ b/data/minecraft/enchantment/wind_burst.json
+@@ -11,6 +_,7 @@
+           "type": "minecraft:explode",
+           "block_interaction": "trigger",
+           "immune_blocks": "#minecraft:blocks_wind_charge_explosions",
++          "attribute_to_user": true,
+           "knockback_multiplier": {
+             "type": "minecraft:lookup",
+             "fallback": {


### PR DESCRIPTION
This resolves #13079. As already noted in the issue comments, the fix is to set `attribute_to_user` to `true` in  the Wind Burst file.