### PR TITLE
Update 1.21.9 reobf mappings data

### DIFF
--- a/build-data/reobf-mappings-patch.tiny
+++ b/build-data/reobf-mappings-patch.tiny
@@ -14,14 +14,14 @@ tiny	2	0	mojang	spigot
 
 # CraftBukkit changes type
 c	net/minecraft/server/level/ServerLevel	net/minecraft/server/level/WorldServer
-	f	Lnet/minecraft/world/level/storage/PrimaryLevelData;	serverLevelData	L
+	f	Lnet/minecraft/world/level/storage/PrimaryLevelData;	serverLevelData	J
 
 c	net/minecraft/world/level/chunk/LevelChunk	net/minecraft/world/level/chunk/Chunk
-	f	Lnet/minecraft/server/level/ServerLevel;	level	r
+	f	Lnet/minecraft/server/level/ServerLevel;	level	q
 
 # See mappings-patch.tiny
 c	net/minecraft/server/level/ChunkMap	net/minecraft/server/level/PlayerChunkMap
-	f	Lnet/minecraft/server/level/ChunkMap$ChunkDistanceManager;	distanceManager	H
+	f	Lnet/minecraft/server/level/ChunkMap$ChunkDistanceManager;	distanceManager	G
 
 # The method is made public by Spigot, which then causes accidental overrides
 c	net/minecraft/world/entity/Entity	net/minecraft/world/entity/Entity

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version=1.21.9-R0.1-SNAPSHOT
 mcVersion=1.21.9
 
 # Set to true while updating Minecraft version
-updatingMinecraft=true
+updatingMinecraft=false
 
 org.gradle.configuration-cache=true
 org.gradle.caching=true

--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -27,9 +27,9 @@ paperweight {
     gitFilePatches = false
 
     spigot {
-        enabled = false
-        buildDataRef = "436eac9815c211be1a2a6ca0702615f995e81c44"
-        packageVersion = "v1_21_R5" // also needs to be updated in MappingEnvironment
+        enabled = true
+        buildDataRef = "42d18d4c4653ffc549778dbe223f6994a031d69e"
+        packageVersion = "v1_21_R6" // also needs to be updated in MappingEnvironment
     }
 
     reobfPackagesToFix.addAll(

--- a/paper-server/src/main/java/io/papermc/paper/util/MappingEnvironment.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/MappingEnvironment.java
@@ -11,7 +11,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
 @DefaultQualifier(NonNull.class)
 public final class MappingEnvironment {
     public static final boolean DISABLE_PLUGIN_REMAPPING = Boolean.getBoolean("paper.disablePluginRemapping");
-    public static final String LEGACY_CB_VERSION = "v1_21_R5";
+    public static final String LEGACY_CB_VERSION = "v1_21_R6";
     private static final @Nullable String MAPPINGS_HASH = readMappingsHash();
     private static final boolean REOBF = checkReobf();
 


### PR DESCRIPTION
This PR updates the reobf mappings data for 1.21.9

**Please do not contact me on other platforms about plugins not being updated. If a plugin dev has sent you a link to this PR as a reason they can't update- that does not mean spamming or threatening me is the way to make things happen. This PR is awaiting review.**