### PR TITLE
Update spigot plugin remapper to Minecraft 1.21.9

### DIFF
--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -27,9 +27,9 @@ paperweight {
     gitFilePatches = false
 
     spigot {
-        enabled = false
-        buildDataRef = "436eac9815c211be1a2a6ca0702615f995e81c44"
-        packageVersion = "v1_21_R5" // also needs to be updated in MappingEnvironment
+        enabled = true
+        buildDataRef = "42d18d4c4653ffc549778dbe223f6994a031d69e"
+        packageVersion = "v1_21_R6" // also needs to be updated in MappingEnvironment
     }
 
     reobfPackagesToFix.addAll(

--- a/paper-server/src/main/java/io/papermc/paper/util/MappingEnvironment.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/MappingEnvironment.java
@@ -11,7 +11,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
 @DefaultQualifier(NonNull.class)
 public final class MappingEnvironment {
     public static final boolean DISABLE_PLUGIN_REMAPPING = Boolean.getBoolean("paper.disablePluginRemapping");
-    public static final String LEGACY_CB_VERSION = "v1_21_R5";
+    public static final String LEGACY_CB_VERSION = "v1_21_R6";
     private static final @Nullable String MAPPINGS_HASH = readMappingsHash();
     private static final boolean REOBF = checkReobf();
 


### PR DESCRIPTION
Unfortunately I was unable to test this change yet because of a compilation error in `paper-server\src\main\java\io\papermc\paper\util\Holderable.java`