### PR TITLE
Pass PrimingBlock to TNTPrimeEvent when caused by REDSTONE

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/SignalGetter.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/SignalGetter.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/world/level/SignalGetter.java
++++ b/net/minecraft/world/level/SignalGetter.java
+@@ -99,4 +_,26 @@
+ 
+         return best;
+     }
++
++    // Paper start - Add getBestNeighborSignalPos for get the BlockPos of the best signal based on getBestNeighborSignal
++    default @org.jspecify.annotations.Nullable BlockPos getBestNeighborSignalPos(final BlockPos pos) {
++        BlockPos bestPos = null;
++        int best = Redstone.SIGNAL_MIN;
++
++        for (Direction direction : DIRECTIONS) {
++            BlockPos signalPos = pos.relative(direction);
++            int signal = this.getSignal(signalPos, direction);
++            if (signal >= Redstone.SIGNAL_MAX) {
++                return signalPos;
++            }
++
++            if (signal > best) {
++                bestPos = signalPos;
++                best = signal;
++            }
++        }
++
++        return bestPos;
++    }
++    // Paper end
+ }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/TntBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TntBlock.java.patch
@@ -5,7 +5,7 @@
      protected void onPlace(final BlockState state, final Level level, final BlockPos pos, final BlockState oldState, final boolean movedByPiston) {
          if (!oldState.is(state.getBlock())) {
 -            if (level.hasNeighborSignal(pos) && prime(level, pos)) {
-+            if (level.hasNeighborSignal(pos) && prime(level, pos, () -> org.bukkit.craftbukkit.event.CraftEventFactory.callTNTPrimeEvent(level, pos, org.bukkit.event.block.TNTPrimeEvent.PrimeCause.REDSTONE, null, null))) { // CraftBukkit - TNTPrimeEvent
++            if (level.hasNeighborSignal(pos) && prime(level, pos, () -> org.bukkit.craftbukkit.event.CraftEventFactory.callTNTPrimeEvent(level, pos, org.bukkit.event.block.TNTPrimeEvent.PrimeCause.REDSTONE, null, level.getBestNeighborSignalPos(pos)))) { // CraftBukkit - TNTPrimeEvent
                  level.removeBlock(pos, false);
              }
          }
@@ -14,7 +14,7 @@
          final BlockState state, final Level level, final BlockPos pos, final Block block, final @Nullable Orientation orientation, final boolean movedByPiston
      ) {
 -        if (level.hasNeighborSignal(pos) && prime(level, pos)) {
-+        if (level.hasNeighborSignal(pos) && prime(level, pos, () -> org.bukkit.craftbukkit.event.CraftEventFactory.callTNTPrimeEvent(level, pos, org.bukkit.event.block.TNTPrimeEvent.PrimeCause.REDSTONE, null, null))) { // CraftBukkit - TNTPrimeEvent
++        if (level.hasNeighborSignal(pos) && prime(level, pos, () -> org.bukkit.craftbukkit.event.CraftEventFactory.callTNTPrimeEvent(level, pos, org.bukkit.event.block.TNTPrimeEvent.PrimeCause.REDSTONE, null, level.getBestNeighborSignalPos(pos)))) { // CraftBukkit - TNTPrimeEvent
              level.removeBlock(pos, false);
          }
      }


### PR DESCRIPTION
Fix https://github.com/PaperMC/Paper/issues/13140 by adding a method for get the BlockPos for the best signal based in the best signal method checked for trigger the TNT.

Using:
```java
@EventHandler
public void onTNTPrime(TNTPrimeEvent event) {
        if (!event.getCause().equals(TNTPrimeEvent.PrimeCause.REDSTONE)) return;
        this.getLogger().info("TNTPrimeEvent caused by redstone");
        this.getLogger().info("Block: " + event.getBlock());
        this.getLogger().info("PrimingBlock: " + event.getPrimingBlock());
}
```
i get this for put redstone.
```
[10:21:51 INFO]: [Paper-Test-Plugin] TNTPrimeEvent caused by redstone
[10:21:51 INFO]: [Paper-Test-Plugin] Block: CraftBlock{pos=BlockPos{x=49, y=66, z=-217},type=TNT,data=Block{minecraft:tnt}[unstable=false],fluid=net.minecraft.world.level.material.EmptyFluid@2ab09943}
[10:21:51 INFO]: [Paper-Test-Plugin] PrimingBlock: CraftBlock{pos=BlockPos{x=49, y=66, z=-218},type=REDSTONE_BLOCK,data=Block{minecraft:redstone_block},fluid=net.minecraft.world.level.material.EmptyFluid@2ab09943}
```