### PR TITLE
Expand usage of ItemType and BlockType

### DIFF
--- a/paper-api/src/main/java/org/bukkit/block/Block.java
+++ b/paper-api/src/main/java/org/bukkit/block/Block.java
@@ -100,6 +100,15 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
      */
     @NotNull
     Material getType();
+    // Paper start - BlockType API
+    /**
+     * Gets the type of this block
+     *
+     * @return block type
+     */
+    @NotNull
+    BlockType getBlockType();
+    // Paper end - BlockType API
 
     /**
      * Gets the light level between 0-15
@@ -308,6 +317,14 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
      * @param type Material to change this block to
      */
     void setType(@NotNull Material type);
+    // Paper start - BlockType API
+    /**
+     * Sets the type of this block
+     *
+     * @param type BlockType to change this block to
+     */
+    void setType(@NotNull BlockType type);
+    // Paper end - BlockType API
 
     /**
      * Sets the type of this block
@@ -329,6 +346,28 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
      * @param applyPhysics False to cancel physics on the changed block.
      */
     void setType(@NotNull Material type, boolean applyPhysics);
+    // Paper start - BlockType API
+    /**
+     * Sets the type of this block
+     *
+     * <br>
+     * Note that applyPhysics = false is not in general safe. It should only be
+     * used when you need to avoid triggering a physics update of neighboring
+     * blocks, for example when creating a {@link Bisected} block. If you are
+     * using a custom populator, then this parameter may also be required to
+     * prevent triggering infinite chunk loads on border blocks. This method
+     * should NOT be used to "hack" physics by placing blocks in impossible
+     * locations. Such blocks are liable to be removed on various events such as
+     * world upgrades. Furthermore setting large amounts of such blocks in close
+     * proximity may overload the server physics engine if an update is
+     * triggered at a later point. If this occurs, the resulting behavior is
+     * undefined.
+     *
+     * @param type BlockType to change this block to
+     * @param applyPhysics False to cancel physics on the changed block.
+     */
+    void setType(@NotNull BlockType type, boolean applyPhysics);
+    // Paper end - BlockType API
 
     /**
      * Gets the face relation of this block compared to the given block.

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -193,6 +193,17 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
     public Material getType() {
         return this.craftDelegate.getType(); // Paper - delegate
     }
+    // Paper start - ItemType API
+    /**
+     * Gets the type of this item
+     *
+     * @return Type of the items in this stack
+     */
+    @NotNull
+    public ItemType getItemType() {
+        return this.craftDelegate.getItemType();
+    }
+    // Paper end - ItemType API
 
     /**
      * Sets the type of this item
@@ -232,6 +243,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
         return this.craftDelegate.withType(type); // Paper - delegate
     }
     // Paper end
+    // Paper start - ItemType API
+    /**
+     * Creates a new ItemStack with the specified type, where the item count and item meta is preserved.
+     *
+     * @param type The type of the new ItemStack.
+     * @return A new ItemStack instance with the specified type.
+     */
+    @NotNull
+    @org.jetbrains.annotations.Contract(value = "_ -> new", pure = true)
+    public ItemStack withType(@NotNull ItemType type) {
+        return this.craftDelegate.withType(type); // Paper - delegate
+    }
+    // Paper end - ItemType API
 
     /**
      * Gets the amount of items in this stack

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
@@ -37,6 +37,7 @@ import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.BlockType;
 import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.CraftFluidCollisionMode;
@@ -60,6 +61,7 @@ import org.bukkit.util.BlockVector;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
 
 public class CraftBlock implements Block {
     private final net.minecraft.world.level.LevelAccessor world;
@@ -173,12 +175,25 @@ public class CraftBlock implements Block {
     public void setType(final Material type) {
         this.setType(type, true);
     }
+    // Paper start - BlockType API
+    @Override
+    public void setType(BlockType type) {
+        setType(type, true);
+    }
+    // Paper end - BlockType API
 
     @Override
     public void setType(Material type, boolean applyPhysics) {
         Preconditions.checkArgument(type != null, "Material cannot be null");
         this.setBlockData(type.createBlockData(), applyPhysics);
     }
+    // Paper start - BlockType API
+    @Override
+    public void setType(BlockType type, boolean applyPhysics) {
+        Preconditions.checkArgument(type != null, "BlockType cannot be null");
+        setBlockData(type.createBlockData(), applyPhysics);
+    }
+    // Paper end - BlockType API
 
     @Override
     public void setBlockData(BlockData data) {
@@ -229,6 +244,12 @@ public class CraftBlock implements Block {
     public Material getType() {
         return this.world.getBlockState(this.position).getBukkitMaterial(); // Paper - optimise getType calls
     }
+    // Paper start - BlockType API
+    @Override
+    public @NotNull BlockType getBlockType() {
+        return CraftBlockType.minecraftToBukkitNew(this.world.getBlockState(this.position).getBlock());
+    }
+    // Paper end - BlockType API
 
     @Override
     public byte getLightLevel() {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
@@ -193,6 +193,12 @@ public final class CraftItemStack extends ItemStack {
     public Material getType() {
         return this.handle != null ? CraftItemType.minecraftToBukkit(this.handle.getItem()) : Material.AIR;
     }
+    // Paper start - ItemType API
+    @Override
+    public @NotNull org.bukkit.inventory.ItemType getItemType() {
+        return this.handle != null ? CraftItemType.minecraftToBukkitNew(this.handle.getItem()) : org.bukkit.inventory.ItemType.AIR;
+    }
+    // Paper end - ItemType API
 
     @Override
     public void setType(Material type) {
@@ -481,6 +487,26 @@ public final class CraftItemStack extends ItemStack {
         return mirrored;
     }
     // Paper end
+    // Paper start - ItemType API
+    @Override
+    public ItemStack withType(org.bukkit.inventory.ItemType type) {
+        if (type == org.bukkit.inventory.ItemType.AIR) {
+            return CraftItemStack.asCraftMirror(null);
+        }
+
+        net.minecraft.world.item.ItemStack copy = new net.minecraft.world.item.ItemStack(
+            CraftItemType.bukkitToMinecraftNew(type), getAmount()
+        );
+
+        if (handle != null) {
+            copy.applyComponents(handle.getComponentsPatch());
+        }
+
+        CraftItemStack mirrored = CraftItemStack.asCraftMirror(copy);
+        mirrored.setItemMeta(mirrored.getItemMeta());
+        return mirrored;
+    }
+    // Paper end - ItemType API
 
     public static final String PDC_CUSTOM_DATA_KEY = "PublicBukkitValues";
     private net.minecraft.nbt.CompoundTag getPdcTag() {

--- a/paper-server/src/test/java/org/bukkit/craftbukkit/inventory/ItemTypeTest.java
+++ b/paper-server/src/test/java/org/bukkit/craftbukkit/inventory/ItemTypeTest.java
@@ -51,6 +51,7 @@ public class ItemTypeTest {
         final ItemStack itemStack = ItemType.DIAMOND.createItemStack();
         Assertions.assertEquals(itemStack.getType(), Material.DIAMOND);
         Assertions.assertEquals(itemStack.getType().asItemType(), ItemType.DIAMOND);
+        Assertions.assertEquals(itemStack.getItemType(), ItemType.DIAMOND);
     }
 
     @Test


### PR DESCRIPTION
This pull request expands the Paper API:
- `ItemStack#getItemType()`
- `ItemStack#withType(ItemType type)`
- `Block#getBlockType()`
- `Block#setType(BlockType type)`
- `Block#setType(BlockType type, boolean applyPhysics)`
