### PR TITLE
Prevent world mutation on copper golem spawn cancel

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/CarvedPumpkinBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/CarvedPumpkinBlock.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/world/level/block/CarvedPumpkinBlock.java
 +++ b/net/minecraft/world/level/block/CarvedPumpkinBlock.java
+@@ -94,6 +_,7 @@
+             CopperGolem copperGolem = EntityType.COPPER_GOLEM.create(level, EntitySpawnReason.TRIGGERED);
+             if (copperGolem != null) {
+                 spawnGolemInWorld(level, blockPatternMatch2, copperGolem, blockPatternMatch2.getBlock(0, 0, 0).getPos());
++                if (!copperGolem.valid) return; // Paper - entityspawnevent - entity was not added to the world so prevent world mutation
+                 this.replaceCopperBlockWithChest(level, blockPatternMatch2);
+                 copperGolem.spawn(this.getWeatherStateFromPattern(blockPatternMatch2));
+             }
 @@ -112,9 +_,22 @@
      }
  


### PR DESCRIPTION
The event logic prevents mutation of the world by moving down block
placement post the addFreshEntity call, however did not respect the
possible event cancellation in the caller.

Simply early exit in case the entity was not marked as valid by the
spawning logic to prevent world modifications.

Resolves: #13151
