### PR TITLE
Use Adventure properties default override provider to set a global flattener nesting limit

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
@@ -76,7 +76,6 @@ import static java.util.Objects.requireNonNull;
 public final class PaperAdventure {
     private static final Pattern LOCALIZATION_PATTERN = Pattern.compile("%(?:(\\d+)\\$)?s");
     public static final ComponentFlattener FLATTENER = ComponentFlattener.basic().toBuilder()
-        .nestingLimit(30) // todo: should this be configurable? a system property or config value?
         .complexMapper(TranslatableComponent.class, (translatable, consumer) -> {
             final Language language = Language.getInstance();
             final @Nullable String fallback = translatable.fallback();

--- a/paper-server/src/main/java/io/papermc/paper/adventure/providers/AdventurePropertiesDefaultOverrideProviderImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/providers/AdventurePropertiesDefaultOverrideProviderImpl.java
@@ -1,0 +1,20 @@
+package io.papermc.paper.adventure.providers;
+
+import net.kyori.adventure.internal.properties.AdventureProperties;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@SuppressWarnings("UnstableApiUsage") // Permitted provider.
+public class AdventurePropertiesDefaultOverrideProviderImpl implements AdventureProperties.DefaultOverrideProvider {
+    @SuppressWarnings("unchecked") // We do check.
+    @Override
+    public <T> @Nullable T overrideDefault(final AdventureProperties.@NotNull Property<T> property, @Nullable final T existingDefault) {
+        if (property == AdventureProperties.DEFAULT_FLATTENER_NESTING_LIMIT) {
+            // Large nesting limits can cause stack overflows with overly complicated components.
+            // Limiting to 30 is a reasonable default.
+            return (T) Integer.valueOf(30);
+        } else {
+            return null;
+        }
+    }
+}

--- a/paper-server/src/main/resources/META-INF/services/net.kyori.adventure.internal.properties.AdventureProperties$DefaultOverrideProvider
+++ b/paper-server/src/main/resources/META-INF/services/net.kyori.adventure.internal.properties.AdventureProperties$DefaultOverrideProvider
@@ -1,0 +1,1 @@
+io.papermc.paper.adventure.providers.AdventurePropertiesDefaultOverrideProviderImpl


### PR DESCRIPTION
Using this system also means the limit is configurable using system properties.