### PR TITLE
Update spark-paper dependency version

### DIFF
--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -185,7 +185,7 @@ dependencies {
 
     // Spark
     implementation("me.lucko:spark-api:0.1-20240720.200737-2")
-    implementation("me.lucko:spark-paper:1.10.133-20250413.112336-1")
+    implementation("me.lucko:spark-paper:1.10.152")
 }
 
 tasks.jar {


### PR DESCRIPTION
Abridged changelog since the last version:

* Optimise WorldStatisticsProvider regionising
* Fix division by zero error in TPS calculation
* Fix java version parsing
* Update async-profiler to v4.1
* Update server config hidden paths (accounts for new management server API properties)

FYI, `spark-paper` dependency is now published directly (as a release) to Paper's artifactory, instead of to the Central snapshots repository.