### PR TITLE
Properly update hidden effects

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -137,6 +137,7 @@ public net.minecraft.world.damagesource.DamageSource <init>(Lnet/minecraft/core/
 public net.minecraft.world.effect.MobEffect attributeModifiers
 public net.minecraft.world.effect.MobEffect$AttributeTemplate
 public net.minecraft.world.effect.MobEffectInstance hiddenEffect
+public net.minecraft.world.effect.MobEffectInstance isShorterDurationThan(Lnet/minecraft/world/effect/MobEffectInstance;)Z
 public net.minecraft.world.entity.AreaEffectCloud durationOnUse
 public net.minecraft.world.entity.AreaEffectCloud owner
 public net.minecraft.world.entity.AreaEffectCloud potionContents

--- a/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
@@ -464,7 +464,7 @@ index 5461bd9a39bb20ad29d3bc110c38860cf35a770a..75f80787966cdda6f51f55a8f6cb2218
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 9ba74df17cad8b5039e4657d97daefae8c3524e9..e683302032e1fb4e38eb674472ef7fd22c7ae6e8 100644
+index 92ad0b17ff735801b9a4c840f14b4c12db729427..06837062905e08a3e9c29ee030ce199ce1d540b1 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -368,6 +368,15 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
@@ -523,10 +523,10 @@ index 9ba74df17cad8b5039e4657d97daefae8c3524e9..e683302032e1fb4e38eb674472ef7fd2
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index bf7d0552efd961ffe19e69e8ab194502f3a747c9..730bf0cfdc9698a74b269b76fed614e08e058153 100644
+index 38eac6d27ebf3497fc1c2dfb600a7cbf4f9da7f4..9dacf9cef03ecb87464bfecf2399f2864be6d6ba 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3318,6 +3318,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3330,6 +3330,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
      protected void playAttackSound() {
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -334,7 +334,7 @@
          }
      }
  
-@@ -987,21 +_,57 @@
+@@ -987,23 +_,71 @@
      }
  
      public final boolean addEffect(MobEffectInstance effectInstance) {
@@ -370,8 +370,12 @@
              boolean flag = false;
 +            // CraftBukkit start
 +            boolean override = false;
++            // Paper start - Properly update hidden effects
++            boolean addAsHiddenEffect = false;
 +            if (mobEffectInstance != null) {
 +                override = new MobEffectInstance(mobEffectInstance).update(effectInstance);
++                addAsHiddenEffect = mobEffectInstance.getAmplifier() > effectInstance.getAmplifier() && mobEffectInstance.isShorterDurationThan(effectInstance);
++            // Paper end - Properly update hidden effects
 +            }
 +
 +            if (fireEvent) { // Paper - Don't fire sync event during generation
@@ -393,7 +397,17 @@
 +                mobEffectInstance.update(effectInstance);
                  this.onEffectUpdated(mobEffectInstance, true, entity);
                  flag = true;
++                // Paper start - Properly update hidden effects
++            } else if (addAsHiddenEffect) {
++                if (mobEffectInstance.hiddenEffect == null) {
++                    mobEffectInstance.hiddenEffect = new MobEffectInstance(effectInstance);
++                } else {
++                    mobEffectInstance.hiddenEffect.update(effectInstance);
++                }
++                // Paper end - Properly update hidden effects
              }
+ 
+             effectInstance.onEffectStarted(this);
 @@ -1039,11 +_,35 @@
      }
  


### PR DESCRIPTION
Closes #13172

When an effect of the same type is added to an entity, we construct a new MobEffectInstance-instance and update that to see if any property of the existing effect can be overriden by the new effect. This works well, except for that the update method also has one extra side effect, namely updating the hidden effect, which doesn't count as overriding anything.

This PR adds some extra logic to check if the new effect should be added as a hidden effect if it isn't already being overriden, so that no effect gets lost.

Tested by drinking a long regeneration potion and a short regeneration 2 potion, regardless of which potion was drank first the longer effect always returned after the short one ended.