### PR TITLE
Use BUILD_STARTED_AT instead of Instant.now() for build timestamp

### DIFF
--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     `maven-publish`
     idea
     id("io.papermc.paperweight.core")
-    id("io.papermc.fill.gradle") version "1.0.7"
+    id("io.papermc.fill.gradle") version "1.0.8"
 }
 
 val paperMavenPublicUrl = "https://repo.papermc.io/repository/maven-public/"

--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -193,7 +193,7 @@ tasks.jar {
         val git = Git(rootProject.layout.projectDirectory.path)
         val mcVersion = rootProject.providers.gradleProperty("mcVersion").get()
         val build = System.getenv("BUILD_NUMBER") ?: null
-        val buildTime = if (build != null) Instant.now() else Instant.EPOCH
+        val buildTime = providers.environmentVariable("BUILD_STARTED_AT").map(Instant::parse).orElse(Instant.EPOCH).get()
         val gitHash = git.exec(providers, "rev-parse", "--short=7", "HEAD").get().trim()
         val implementationVersion = "$mcVersion-${build ?: "DEV"}-$gitHash"
         val date = git.exec(providers, "show", "-s", "--format=%ci", gitHash).get().trim()


### PR DESCRIPTION
This allows for consistent values across a TeamCity run and between Maven/Fill publications.

Should also speed up TeamCity runs.