### PR TITLE
Expose isReplaceable on BlockData

### DIFF
--- a/paper-api/src/main/java/org/bukkit/block/Block.java
+++ b/paper-api/src/main/java/org/bukkit/block/Block.java
@@ -483,9 +483,7 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
      */
     boolean isBurnable();
     /**
-     * Check if this block is replaceable
-     * <p>
-     * Determined by Minecraft, representing a block that you can place a new block at, such as air or tall grass.
+     * Checks if this block can be immediately replaced by another block, such as placing a new block in air or tall grass.
      * @return true if block is replaceable
      */
     boolean isReplaceable();

--- a/paper-api/src/main/java/org/bukkit/block/Block.java
+++ b/paper-api/src/main/java/org/bukkit/block/Block.java
@@ -485,7 +485,7 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
     /**
      * Check if this block is replaceable
      * <p>
-     * Determined by Minecraft, representing a block that is not AIR that you can still place a new block at, such as flowers.
+     * Determined by Minecraft, representing a block that you can place a new block at, such as air or tall grass.
      * @return true if block is replaceable
      */
     boolean isReplaceable();

--- a/paper-api/src/main/java/org/bukkit/block/data/BlockData.java
+++ b/paper-api/src/main/java/org/bukkit/block/data/BlockData.java
@@ -319,9 +319,7 @@ public interface BlockData extends Cloneable {
     // Paper end - Tick API
 
     /**
-     * Check if this block is replaceable
-     * <p>
-     * Determined by Minecraft, representing a block that you can place a new block at, such as air or tall grass.
+     * Checks if this block can be immediately replaced by another block, such as placing a new block in air or tall grass.
      * @return true if block is replaceable
      */
     boolean isReplaceable();

--- a/paper-api/src/main/java/org/bukkit/block/data/BlockData.java
+++ b/paper-api/src/main/java/org/bukkit/block/data/BlockData.java
@@ -317,4 +317,12 @@ public interface BlockData extends Cloneable {
      */
     boolean isRandomlyTicked();
     // Paper end - Tick API
+
+    /**
+     * Check if this block is replaceable
+     * <p>
+     * Determined by Minecraft, representing a block that you can place a new block at, such as air or tall grass.
+     * @return true if block is replaceable
+     */
+    boolean isReplaceable();
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
@@ -792,4 +792,9 @@ public class CraftBlockData implements BlockData {
         return this.state.isRandomlyTicking();
     }
     // Paper end - Block tick API
+
+    @Override
+    public boolean isReplaceable() {
+        return this.state.canBeReplaced();
+    }
 }


### PR DESCRIPTION
Since it's implemented using NMS BlockState, there's no reason this should solely be limited to Bukkit's Block interface, which is limited to only blocks that exist in the world.

Also corrects the javadoc, since air is included, and there aren't any replaceable flowers in the game.