### PR TITLE
Fix inverted disabled in CraftCrafter#setSlotDisabled

### DIFF
--- a/paper-api/src/main/java/org/bukkit/block/Crafter.java
+++ b/paper-api/src/main/java/org/bukkit/block/Crafter.java
@@ -28,7 +28,7 @@ public interface Crafter extends Container, com.destroystokyo.paper.loottable.Lo
      * have items placed in it.
      *
      * @param slot slot index
-     * @return disabled status
+     * @return true if the slot is disabled otherwise false
      */
     boolean isSlotDisabled(int slot);
 
@@ -37,7 +37,7 @@ public interface Crafter extends Container, com.destroystokyo.paper.loottable.Lo
      * have items placed in it.
      *
      * @param slot slot index
-     * @param disabled disabled status
+     * @param disabled true if the slot should be disabled otherwise false
      */
     void setSlotDisabled(int slot, boolean disabled);
 

--- a/paper-api/src/main/java/org/bukkit/block/Crafter.java
+++ b/paper-api/src/main/java/org/bukkit/block/Crafter.java
@@ -28,7 +28,7 @@ public interface Crafter extends Container, com.destroystokyo.paper.loottable.Lo
      * have items placed in it.
      *
      * @param slot slot index
-     * @return true if the slot is disabled otherwise false
+     * @return whether the slot is disabled
      */
     boolean isSlotDisabled(int slot);
 
@@ -37,7 +37,7 @@ public interface Crafter extends Container, com.destroystokyo.paper.loottable.Lo
      * have items placed in it.
      *
      * @param slot slot index
-     * @param disabled true if the slot should be disabled otherwise false
+     * @param disabled whether the slot should be disabled
      */
     void setSlotDisabled(int slot, boolean disabled);
 

--- a/paper-api/src/main/java/org/bukkit/inventory/view/CrafterView.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/view/CrafterView.java
@@ -18,7 +18,7 @@ public interface CrafterView extends InventoryView {
      * Checks if the given crafter slot is disabled.
      *
      * @param slot the slot to check
-     * @return true if the slot is disabled otherwise false
+     * @return whether the slot is disabled
      */
     boolean isSlotDisabled(int slot);
 
@@ -33,7 +33,7 @@ public interface CrafterView extends InventoryView {
      * Sets the status of the crafter slot.
      *
      * @param slot the slot to set the status of
-     * @param disabled true if the slot should be disabled otherwise false
+     * @param disabled whether the slot should be disabled
      */
     void setSlotDisabled(int slot, boolean disabled);
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftCrafter.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftCrafter.java
@@ -63,7 +63,7 @@ public class CraftCrafter extends CraftLootable<CrafterBlockEntity> implements C
     public void setSlotDisabled(int slot, boolean disabled) {
         Preconditions.checkArgument(slot >= 0 && slot < 9, "Invalid slot index %s for Crafter", slot);
 
-        this.getSnapshot().setSlotState(slot, disabled);
+        this.getSnapshot().setSlotState(slot, !disabled);
     }
 
     @Override


### PR DESCRIPTION
To sync Spigot's fix in `CraftCrafterView#setSlotDisabled`. And also clarify the Javadoc comments.

The `disabled` boolean passed to `CrafterBlockEntity#setSlotState` should be inverted, since the  `CrafterBlockEntity #setSlotState(slot, true)` is to enable the slot instead of to disable it.

For reference, see https://github.com/PaperMC/Paper/commit/1a0dce328a377fb7c1636e02070f839dbfd9a992 ([Original Spigot commit](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/d53d0d0b1987545d64ef1de1e53403893ff684fc))