### PR TITLE
[dev/snapshot] Fixes configurable invulnerable duration

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -32,7 +32,7 @@
 +    public org.bukkit.craftbukkit.entity.CraftLivingEntity getBukkitLivingEntity() { return (org.bukkit.craftbukkit.entity.CraftLivingEntity) super.getBukkitEntity(); } // Paper
 +    public boolean silentDeath = false; // Paper - mark entity as dying silently for cancellable death event
 +    public net.kyori.adventure.util.TriState frictionState = net.kyori.adventure.util.TriState.NOT_SET; // Paper - Friction API
-+    public int invulnerableDuration = 20; // Paper - add back this field - it was already unused by vanilla in 1.21.10... // TODO - snapshot - audit this code
++    public int invulnerableDuration = LivingEntity.INVULNERABLE_DURATION; // Paper - configurable invulnerable duration
 +    // CraftBukkit end
  
      protected LivingEntity(EntityType<? extends LivingEntity> type, Level level) {
@@ -1274,6 +1274,15 @@
      }
  
      public final int getStingerCount() {
+@@ -1968,7 +_,7 @@
+     @Override
+     public void handleDamageEvent(DamageSource damageSource) {
+         this.walkAnimation.setSpeed(1.5F);
+-        this.invulnerableTime = 20;
++        this.invulnerableTime = this.invulnerableDuration; // Paper - configurable invulnerable duration
+         this.hurtDuration = 10;
+         this.hurtTime = this.hurtDuration;
+         SoundEvent hurtSound = this.getHurtSound(damageSource);
 @@ -2080,7 +_,7 @@
  
      @Override


### PR DESCRIPTION
As discussed in [paper-contrib](<https://discord.com/channels/289587909051416579/925530366192779286/1428765289415311441>):
- Changes the `invulnerableDuration` field to use mojang's newly added constant
- Fixed a missed usage of invulnerableDuration