### PR TITLE
Migrate external JD links from javadoc.io to javadocs.dev

### DIFF
--- a/paper-api/build.gradle.kts
+++ b/paper-api/build.gradle.kts
@@ -170,10 +170,10 @@ tasks.withType<Javadoc>().configureEach {
     options.isDocFilesSubDirs = true
     options.links(
         "https://guava.dev/releases/33.3.1-jre/api/docs/",
-        //"https://javadoc.io/doc/org.yaml/snakeyaml/2.2/",
-        //"https://javadoc.io/doc/org.jetbrains/annotations/$annotationsVersion/",
-        //"https://javadoc.io/doc/org.joml/joml/1.10.8/",
-        //"https://www.javadoc.io/doc/com.google.code.gson/gson/2.11.0",
+        "https://www.javadocs.dev/org.yaml/snakeyaml/2.2/",
+        "https://www.javadocs.dev/org.jetbrains/annotations/$annotationsVersion/",
+        "https://www.javadocs.dev/org.joml/joml/1.10.8/",
+        "https://www.javadocs.dev/com.google.code.gson/gson/2.11.0",
         "https://jspecify.dev/docs/api/",
         "https://jd.advntr.dev/api/$adventureVersion/",
         "https://jd.advntr.dev/key/$adventureVersion/",
@@ -182,9 +182,9 @@ tasks.withType<Javadoc>().configureEach {
         "https://jd.advntr.dev/text-serializer-legacy/$adventureVersion/",
         "https://jd.advntr.dev/text-serializer-plain/$adventureVersion/",
         "https://jd.advntr.dev/text-logger-slf4j/$adventureVersion/",
-        //"https://javadoc.io/doc/org.slf4j/slf4j-api/$slf4jVersion/",
+        "https://www.javadocs.dev/org.slf4j/slf4j-api/$slf4jVersion/",
         "https://logging.apache.org/log4j/2.x/javadoc/log4j-api/",
-        //"https://javadoc.io/doc/org.apache.maven.resolver/maven-resolver-api/1.7.3",
+        "https://www.javadocs.dev/org.apache.maven.resolver/maven-resolver-api/1.7.3",
     )
     options.tags("apiNote:a:API Note:")
 


### PR DESCRIPTION
This PR enable again the javadocs url from javadoc.io (commented for random 5xx error) and migrate to javadocs.dev
ref: [discord](https://canary.discord.com/channels/289587909051416579/925530366192779286/1429144106591846564)