### PR TITLE
Add back MagicConstant annotations

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/TicketType.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/TicketType.java.patch
@@ -1,5 +1,24 @@
 --- a/net/minecraft/server/level/TicketType.java
 +++ b/net/minecraft/server/level/TicketType.java
+@@ -9,11 +_,13 @@
+ 
+ public record TicketType(long timeout, @TicketType.Flags int flags) {
+     public static final long NO_TIMEOUT = 0L;
+-    public static final int FLAG_PERSIST = 1;
+-    public static final int FLAG_LOADING = 2;
+-    public static final int FLAG_SIMULATION = 4;
+-    public static final int FLAG_KEEP_DIMENSION_ACTIVE = 8;
+-    public static final int FLAG_CAN_EXPIRE_IF_UNLOADED = 16;
++    // Paper start - diff on change - all listed in Flags annotation
++    public static final int FLAG_PERSIST = 1; // Paper - diff on change - all listed in Flags annotation
++    public static final int FLAG_LOADING = 2; // Paper - diff on change - all listed in Flags annotation
++    public static final int FLAG_SIMULATION = 4; // Paper - diff on change - all listed in Flags annotation
++    public static final int FLAG_KEEP_DIMENSION_ACTIVE = 8; // Paper - diff on change - all listed in Flags annotation
++    public static final int FLAG_CAN_EXPIRE_IF_UNLOADED = 16; // Paper - diff on change - all listed in Flags annotation
++    // Paper end - diff on change - all listed in Flags annotation
+     public static final TicketType PLAYER_SPAWN = register("player_spawn", 20L, 2);
+     public static final TicketType SPAWN_SEARCH = register("spawn_search", 1L, 2);
+     public static final TicketType DRAGON = register("dragon", 0L, 6);
 @@ -23,6 +_,11 @@
      public static final TicketType PORTAL = register("portal", 300L, 15);
      public static final TicketType ENDER_PEARL = register("ender_pearl", 40L, 14);
@@ -12,7 +31,7 @@
  
      private static TicketType register(String name, long timeout, @TicketType.Flags int flags) {
          return Registry.register(BuiltInRegistries.TICKET_TYPE, name, new TicketType(timeout, flags));
-@@ -48,8 +_,15 @@
+@@ -48,12 +_,20 @@
          return (this.flags & 16) != 0;
      }
  
@@ -29,3 +48,8 @@
      }
  
      @Retention(RetentionPolicy.CLASS)
+     @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.METHOD, ElementType.TYPE_USE})
++    @org.intellij.lang.annotations.MagicConstant(flags = {FLAG_PERSIST, FLAG_LOADING, FLAG_SIMULATION, FLAG_KEEP_DIMENSION_ACTIVE, FLAG_CAN_EXPIRE_IF_UNLOADED}) // Paper - add back source-retention annotation for IDE
+     public @interface Flags {
+     }
+ }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/Block.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/Block.java.patch
@@ -1,5 +1,34 @@
 --- a/net/minecraft/world/level/block/Block.java
 +++ b/net/minecraft/world/level/block/Block.java
+@@ -88,16 +_,18 @@
+                 return !Shapes.joinIsNotEmpty(Shapes.block(), shape, BooleanOp.NOT_SAME);
+             }
+         });
+-    public static final int UPDATE_NEIGHBORS = 1;
+-    public static final int UPDATE_CLIENTS = 2;
+-    public static final int UPDATE_INVISIBLE = 4;
+-    public static final int UPDATE_IMMEDIATE = 8;
+-    public static final int UPDATE_KNOWN_SHAPE = 16;
+-    public static final int UPDATE_SUPPRESS_DROPS = 32;
+-    public static final int UPDATE_MOVE_BY_PISTON = 64;
+-    public static final int UPDATE_SKIP_SHAPE_UPDATE_ON_WIRE = 128;
+-    public static final int UPDATE_SKIP_BLOCK_ENTITY_SIDEEFFECTS = 256;
+-    public static final int UPDATE_SKIP_ON_PLACE = 512;
++    // Paper start - diff on change - all listed in UpdateFlags annotation
++    public static final int UPDATE_NEIGHBORS = 1; // Paper - diff on change - all listed in UpdateFlags annotation
++    public static final int UPDATE_CLIENTS = 2; // Paper - diff on change - all listed in UpdateFlags annotation
++    public static final int UPDATE_INVISIBLE = 4; // Paper - diff on change - all listed in UpdateFlags annotation
++    public static final int UPDATE_IMMEDIATE = 8; // Paper - diff on change - all listed in UpdateFlags annotation
++    public static final int UPDATE_KNOWN_SHAPE = 16; // Paper - diff on change - all listed in UpdateFlags annotation
++    public static final int UPDATE_SUPPRESS_DROPS = 32; // Paper - diff on change - all listed in UpdateFlags annotation
++    public static final int UPDATE_MOVE_BY_PISTON = 64; // Paper - diff on change - all listed in UpdateFlags annotation
++    public static final int UPDATE_SKIP_SHAPE_UPDATE_ON_WIRE = 128; // Paper - diff on change - all listed in UpdateFlags annotation
++    public static final int UPDATE_SKIP_BLOCK_ENTITY_SIDEEFFECTS = 256; // Paper - diff on change - all listed in UpdateFlags annotation
++    public static final int UPDATE_SKIP_ON_PLACE = 512; // Paper - diff on change - all listed in UpdateFlags annotation
++    // Paper end - diff on change - all listed in UpdateFlags annotation
+     @Block.UpdateFlags
+     public static final int UPDATE_NONE = 260;
+     @Block.UpdateFlags
 @@ -111,6 +_,21 @@
      public static final int UPDATE_LIMIT = 512;
      protected final StateDefinition<Block, BlockState> stateDefinition;
@@ -140,3 +169,11 @@
  
      record ShapePairKey(VoxelShape first, VoxelShape second) {
          @Override
+@@ -603,6 +_,7 @@
+ 
+     @Retention(RetentionPolicy.CLASS)
+     @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.METHOD, ElementType.TYPE_USE})
++    @org.intellij.lang.annotations.MagicConstant(flags = {UPDATE_NEIGHBORS, UPDATE_CLIENTS, UPDATE_INVISIBLE, UPDATE_IMMEDIATE, UPDATE_KNOWN_SHAPE, UPDATE_SUPPRESS_DROPS, UPDATE_MOVE_BY_PISTON, UPDATE_SKIP_SHAPE_UPDATE_ON_WIRE, UPDATE_SKIP_BLOCK_ENTITY_SIDEEFFECTS, UPDATE_SKIP_ON_PLACE}) // Paper - add back source-retention annotation for IDE
+     public @interface UpdateFlags {
+     }
+ }


### PR DESCRIPTION
This allows the IDE to provide warnings when constants are not properly used etc.

Once we use unpick v4 the IDE warnings on vanilla code will be fixed

For example:
<img width="1428" height="473" alt="image" src="https://github.com/user-attachments/assets/7f76ab92-0ebd-4d59-8c0b-466d356f42c8" />
<img width="1442" height="543" alt="image" src="https://github.com/user-attachments/assets/56663d23-882b-4ab0-afec-ca2a36809ecb" />

This is especially useful for Paper-added code and userdev consumers