### PR TITLE
NULLSAFTEY - getPlayer() Method is now player()

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -714,6 +714,18 @@ public final class CraftServer implements Server {
 
         return null;
     }
+    //Paper - start
+    /**
+     * Gets an online player by their exact username.
+     *
+     * @param name The exact username of the player.
+     * @return An {@link Optional} containing the player if found, otherwise empty.
+     */
+
+    public Optional<Player> player(@NotNull String name) {
+        return Optional.ofNullable(getPlayer(name));
+    }
+    //Paper - end
 
     @Override
     @Deprecated


### PR DESCRIPTION
What i did: I added a new method in the server class: Optional<Player> player(String name);
As the method getPlayer(String name) was deprecated this works as a replacement.