### PR TITLE
Replace access token action for publish PR task [ci skip]

### DIFF
--- a/.github/workflows/publish_pr.yml
+++ b/.github/workflows/publish_pr.yml
@@ -19,11 +19,11 @@ jobs:
     steps:
       - name: Generate an Application repository access token
         id: gen_repo_token
-        uses: kattecon/gh-app-access-token-gen@v1
+        uses: actions/create-github-app-token@v3.2.0
         with:
-          app_id: 1408328
-          private_key: ${{ secrets.PR_PUBLISHING_GH_APP_KEY }}
-          repository: ${{ github.repository }}
+          client-id: 1408328
+          private-key: ${{ secrets.PR_PUBLISHING_GH_APP_KEY }}
+          repositories: ${{ github.repository }}
       - name: Publish PR
         uses: PaperMC/action-pr-publishing@paper
         env:


### PR DESCRIPTION
Most of the changes in actions are for the new runner versions already present.

The only pending thing is the replace of https://github.com/tibdex/github-app-token for deprecation...