### PR TITLE
Migrate WorldBorder API to use ticks

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
@@ -106,6 +106,7 @@ public class WorldBorderBoundsChangeEvent extends WorldBorderEvent implements Ca
      * {@link Type#STARTED_MOVE}.
      *
      * @param duration the time in milliseconds for the change
+     * @deprecated deprecated in favor of {@link #setDurationTicks(long)}
      */
     @Deprecated(forRemoval = true, since = "1.21.11")
     public void setDuration(final long duration) {

--- a/paper-api/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
@@ -6,6 +6,7 @@ import org.bukkit.WorldBorder;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Range;
 import org.jspecify.annotations.NullMarked;
 import java.time.Duration;
 
@@ -94,9 +95,9 @@ public class WorldBorderBoundsChangeEvent extends WorldBorderEvent implements Ca
      *
      * @param duration the time in ticks for the change
      */
-    public void setDurationTicks(final long duration) {
+    public void setDurationTicks(@Range(from = 0, to = Integer.MAX_VALUE) final long duration) {
         this.duration = Math.clamp(duration, 0L, Integer.MAX_VALUE);
-        if (duration >= 0 && this.type == Type.INSTANT_MOVE) {
+        if (this.type == Type.INSTANT_MOVE) {
             this.type = Type.STARTED_MOVE;
         }
     }

--- a/paper-api/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
@@ -106,7 +106,7 @@ public class WorldBorderBoundsChangeEvent extends WorldBorderEvent implements Ca
      * {@link Type#STARTED_MOVE}.
      *
      * @param duration the time in milliseconds for the change
-     * @deprecated deprecated in favor of {@link #setDurationTicks(long)}
+     * @deprecated in favor of {@link #setDurationTicks(long)}
      */
     @Deprecated(forRemoval = true, since = "1.21.11")
     public void setDuration(final long duration) {

--- a/paper-api/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
@@ -95,7 +95,7 @@ public class WorldBorderBoundsChangeEvent extends WorldBorderEvent implements Ca
      * @param duration the time in ticks for the change
      */
     public void setDurationTicks(final long duration) {
-        this.duration = duration;
+        this.duration = Math.clamp(duration, 0L, Integer.MAX_VALUE);
         if (duration >= 0 && this.type == Type.INSTANT_MOVE) {
             this.type = Type.STARTED_MOVE;
         }
@@ -110,7 +110,7 @@ public class WorldBorderBoundsChangeEvent extends WorldBorderEvent implements Ca
      */
     @Deprecated(forRemoval = true, since = "1.21.11")
     public void setDuration(final long duration) {
-        this.setDurationTicks(Tick.tick().fromDuration(Duration.ofMillis(duration)));
+        this.setDurationTicks(Tick.tick().fromDuration(Duration.ofMillis(Math.clamp(duration, 0L, Integer.MAX_VALUE))));
     }
 
     @Override

--- a/paper-api/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
@@ -1,11 +1,13 @@
 package io.papermc.paper.event.world.border;
 
+import io.papermc.paper.util.Tick;
 import org.bukkit.World;
 import org.bukkit.WorldBorder;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
+import java.time.Duration;
 
 /**
  * Called when a world border changes its bounds, either over time, or instantly.
@@ -67,12 +69,36 @@ public class WorldBorderBoundsChangeEvent extends WorldBorderEvent implements Ca
     }
 
     /**
+     * Gets the time in ticks for the change. Will be 0 if instant.
+     *
+     * @return the time in ticks for the change
+     */
+    public long getDurationTicks() {
+        return this.duration;
+    }
+
+    /**
      * Gets the time in milliseconds for the change. Will be 0 if instant.
      *
      * @return the time in milliseconds for the change
+     * @deprecated deprecated in favor of {@link #getDurationTicks()}
      */
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public long getDuration() {
-        return this.duration;
+        return Tick.of(this.duration).toMillis();
+    }
+
+    /**
+     * Sets the time in ticks for the change. Will change {@link #getType()} to return
+     * {@link Type#STARTED_MOVE}.
+     *
+     * @param duration the time in ticks for the change
+     */
+    public void setDurationTicks(final long duration) {
+        this.duration = duration;
+        if (duration >= 0 && this.type == Type.INSTANT_MOVE) {
+            this.type = Type.STARTED_MOVE;
+        }
     }
 
     /**
@@ -81,12 +107,9 @@ public class WorldBorderBoundsChangeEvent extends WorldBorderEvent implements Ca
      *
      * @param duration the time in milliseconds for the change
      */
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public void setDuration(final long duration) {
-        // PAIL: TODO: Magic Values
-        this.duration = Math.min(9223372036854775L, Math.max(0L, duration));
-        if (duration >= 0 && this.type == Type.INSTANT_MOVE) {
-            this.type = Type.STARTED_MOVE;
-        }
+        this.setDurationTicks(Tick.tick().fromDuration(Duration.ofMillis(duration)));
     }
 
     @Override

--- a/paper-api/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeEvent.java
@@ -81,7 +81,7 @@ public class WorldBorderBoundsChangeEvent extends WorldBorderEvent implements Ca
      * Gets the time in milliseconds for the change. Will be 0 if instant.
      *
      * @return the time in milliseconds for the change
-     * @deprecated deprecated in favor of {@link #getDurationTicks()}
+     * @deprecated in favor of {@link #getDurationTicks()}
      */
     @Deprecated(forRemoval = true, since = "1.21.11")
     public long getDuration() {

--- a/paper-api/src/main/java/org/bukkit/WorldBorder.java
+++ b/paper-api/src/main/java/org/bukkit/WorldBorder.java
@@ -158,11 +158,11 @@ public interface WorldBorder {
      * Sets the warning time that causes the screen to be tinted red when a contracting border will reach the player within the specified time.
      *
      * @param seconds The amount of time in seconds.
-     * @deprecated Use {@link #setWarningTime(long)} instead
+     * @deprecated Use {@link #setWarningTimeTicks(long)} instead
      */
     @Deprecated(since = "1.21.11", forRemoval = true)
     default void setWarningTime(int seconds) {
-        this.getWarningTimeTicks(seconds);
+        this.setWarningTimeTicks(seconds);
     }
 
     /**
@@ -170,7 +170,7 @@ public interface WorldBorder {
      *
      * @param ticks The number of ticks.
      */
-    void getWarningTimeTicks(long ticks);
+    void setWarningTimeTicks(long ticks);
 
     /**
      * Gets the current border warning distance.

--- a/paper-api/src/main/java/org/bukkit/WorldBorder.java
+++ b/paper-api/src/main/java/org/bukkit/WorldBorder.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import com.google.common.base.Preconditions;
 import io.papermc.paper.util.Tick;
-import net.kyori.adventure.util.Ticks;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/paper-api/src/main/java/org/bukkit/WorldBorder.java
+++ b/paper-api/src/main/java/org/bukkit/WorldBorder.java
@@ -151,11 +151,11 @@ public interface WorldBorder {
      * Sets the warning time that causes the screen to be tinted red when a contracting border will reach the player within the specified time.
      *
      * @param seconds The amount of time in seconds.
-     * @deprecated Use {@link #setWarningTime(TimeUnit, long)} instead
+     * @deprecated Use {@link #setWarningTime(long)} instead
      */
     @Deprecated(since = "1.21.11", forRemoval = true)
     default void setWarningTime(int seconds) {
-        this.setWarningTime(TimeUnit.SECONDS, seconds);
+        this.setWarningTime(((long) seconds));
     }
 
     /**
@@ -164,16 +164,6 @@ public interface WorldBorder {
      * @param ticks The number of ticks.
      */
     void setWarningTime(long ticks);
-
-    /**
-     * Sets the warning time that causes the screen to be tinted red when a contracting border will reach the player within the specified time.
-     *
-     * @param unit The time unit.
-     * @param time The time that causes the screen to be tinted red when a contracting border will reach.
-     *
-     * @see Tick
-     */
-    void setWarningTime(@NotNull TimeUnit unit, long time);
 
     /**
      * Gets the current border warning distance.

--- a/paper-api/src/main/java/org/bukkit/WorldBorder.java
+++ b/paper-api/src/main/java/org/bukkit/WorldBorder.java
@@ -43,6 +43,7 @@ public interface WorldBorder {
      * @param seconds The time in seconds in which the border grows or shrinks from the previous size to that being set.
      *
      * @throws IllegalArgumentException if newSize is less than 1.0D or greater than {@link #getMaxSize()}
+     * @see #setSize(double, TimeUnit, long)
      */
     void setSize(double newSize, long seconds);
 
@@ -117,15 +118,40 @@ public interface WorldBorder {
      * Gets the current border warning time in seconds.
      *
      * @return The current border warning time in seconds.
+     * @deprecated Use {@link #getWarningTimeTicks()} instead
      */
-    int getWarningTime();
+    @Deprecated(since = "1.21.11", forRemoval = true)
+    default int getWarningTime() {
+        return (int) Tick.of(this.getWarningTimeTicks()).toSeconds();
+    }
+
+    /**
+     * Gets the current border warning time in ticks.
+     *
+     * @return The current border warning time in ticks.
+     */
+    long getWarningTimeTicks();
 
     /**
      * Sets the warning time that causes the screen to be tinted red when a contracting border will reach the player within the specified time.
      *
-     * @param seconds The amount of time in seconds. (The default is 15 seconds.)
+     * @param seconds The amount of time in seconds.
+     * @deprecated Use {@link #setWarningTime(TimeUnit, long)} instead
      */
-    void setWarningTime(int seconds);
+    @Deprecated(since = "1.21.11", forRemoval = true)
+    default void setWarningTime(int seconds) {
+        this.setWarningTime(TimeUnit.SECONDS, seconds);
+    }
+
+    /**
+     * Sets the warning time that causes the screen to be tinted red when a contracting border will reach the player within the specified time.
+     *
+     * @param unit The time unit.
+     * @param time The time that causes the screen to be tinted red when a contracting border will reach.
+     *
+     * @see Tick
+     */
+    void setWarningTime(@NotNull TimeUnit unit, long time);
 
     /**
      * Gets the current border warning distance.

--- a/paper-api/src/main/java/org/bukkit/WorldBorder.java
+++ b/paper-api/src/main/java/org/bukkit/WorldBorder.java
@@ -72,7 +72,9 @@ public interface WorldBorder {
      * @throws IllegalArgumentException if unit is <code>null</code> or newSize is less than 1.0D or greater than {@link #getMaxSize()}
      *
      * @see Tick
+     * @deprecated Use {@link #changeSize(double, long)} instead
      */
+    @Deprecated(since = "1.21.11", forRemoval = true)
     void setSize(double newSize, @NotNull TimeUnit unit, long time);
 
     /**

--- a/paper-api/src/main/java/org/bukkit/WorldBorder.java
+++ b/paper-api/src/main/java/org/bukkit/WorldBorder.java
@@ -1,6 +1,7 @@
 package org.bukkit;
 
 import java.util.concurrent.TimeUnit;
+import io.papermc.paper.util.Tick;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,20 +13,19 @@ public interface WorldBorder {
      * @return the associated world, or null if this world border is not associated
      * with any specific world, such as those created via {@link Server#createWorldBorder()}
      */
-    @Nullable
-    public World getWorld();
+    @Nullable World getWorld();
 
     /**
      * Resets the border to default values.
      */
-    public void reset();
+    void reset();
 
     /**
      * Gets the current side length of the border.
      *
      * @return The current side length of the border.
      */
-    public double getSize();
+    double getSize();
 
     /**
      * Sets the border to a square region with the specified side length in blocks.
@@ -34,7 +34,7 @@ public interface WorldBorder {
      *
      * @throws IllegalArgumentException if newSize is less than 1.0D or greater than {@link #getMaxSize()}
      */
-    public void setSize(double newSize);
+    void setSize(double newSize);
 
     /**
      * Sets the border to a square region with the specified side length in blocks.
@@ -44,7 +44,7 @@ public interface WorldBorder {
      *
      * @throws IllegalArgumentException if newSize is less than 1.0D or greater than {@link #getMaxSize()}
      */
-    public void setSize(double newSize, long seconds);
+    void setSize(double newSize, long seconds);
 
     /**
      * Sets the border to a square region with the specified side length in blocks.
@@ -54,16 +54,17 @@ public interface WorldBorder {
      * @param time The time in which the border grows or shrinks from the previous size to that being set.
      *
      * @throws IllegalArgumentException if unit is <code>null</code> or newSize is less than 1.0D or greater than {@link #getMaxSize()}
+     *
+     * @see Tick
      */
-    public void setSize(double newSize, @NotNull TimeUnit unit, long time);
+    void setSize(double newSize, @NotNull TimeUnit unit, long time);
 
     /**
      * Gets the current border center.
      *
      * @return The current border center.
      */
-    @NotNull
-    public Location getCenter();
+    @NotNull Location getCenter();
 
     /**
      * Sets the new border center.
@@ -73,7 +74,7 @@ public interface WorldBorder {
      *
      * @throws IllegalArgumentException if the absolute value of x or z is higher than {@link #getMaxCenterCoordinate()}
      */
-    public void setCenter(double x, double z);
+    void setCenter(double x, double z);
 
     /**
      * Sets the new border center.
@@ -82,63 +83,63 @@ public interface WorldBorder {
      *
      * @throws IllegalArgumentException if location is <code>null</code> or the absolute value of {@link Location#getX()} or {@link Location#getZ()} is higher than {@link #getMaxCenterCoordinate()}
      */
-    public void setCenter(@NotNull Location location);
+    void setCenter(@NotNull Location location);
 
     /**
      * Gets the current border damage buffer.
      *
      * @return The current border damage buffer.
      */
-    public double getDamageBuffer();
+    double getDamageBuffer();
 
     /**
      * Sets the amount of blocks a player may safely be outside the border before taking damage.
      *
      * @param blocks The amount of blocks. (The default is 5 blocks.)
      */
-    public void setDamageBuffer(double blocks);
+    void setDamageBuffer(double blocks);
 
     /**
      * Gets the current border damage amount.
      *
      * @return The current border damage amount.
      */
-    public double getDamageAmount();
+    double getDamageAmount();
 
     /**
      * Sets the amount of damage a player takes when outside the border plus the border buffer.
      *
      * @param damage The amount of damage. (The default is 0.2 damage per second per block.)
      */
-    public void setDamageAmount(double damage);
+    void setDamageAmount(double damage);
 
     /**
      * Gets the current border warning time in seconds.
      *
      * @return The current border warning time in seconds.
      */
-    public int getWarningTime();
+    int getWarningTime();
 
     /**
      * Sets the warning time that causes the screen to be tinted red when a contracting border will reach the player within the specified time.
      *
      * @param seconds The amount of time in seconds. (The default is 15 seconds.)
      */
-    public void setWarningTime(int seconds);
+    void setWarningTime(int seconds);
 
     /**
      * Gets the current border warning distance.
      *
      * @return The current border warning distance.
      */
-    public int getWarningDistance();
+    int getWarningDistance();
 
     /**
      * Sets the warning distance that causes the screen to be tinted red when the player is within the specified number of blocks from the border.
      *
      * @param distance The distance in blocks. (The default is 5 blocks.)
      */
-    public void setWarningDistance(int distance);
+    void setWarningDistance(int distance);
 
     /**
      * Check if the specified location is inside this border.
@@ -146,14 +147,14 @@ public interface WorldBorder {
      * @param location the location to check
      * @return if this location is inside the border or not
      */
-    public boolean isInside(@NotNull Location location);
+    boolean isInside(@NotNull Location location);
 
     /**
      * Gets the maximum possible size of a WorldBorder.
      *
      * @return The maximum size the WorldBorder
      */
-    public double getMaxSize();
+    double getMaxSize();
 
     /**
      * Gets the absolute value of the maximum x/z center coordinate of a
@@ -161,5 +162,5 @@ public interface WorldBorder {
      *
      * @return The absolute maximum center coordinate of the WorldBorder
      */
-    public double getMaxCenterCoordinate();
+    double getMaxCenterCoordinate();
 }

--- a/paper-api/src/main/java/org/bukkit/WorldBorder.java
+++ b/paper-api/src/main/java/org/bukkit/WorldBorder.java
@@ -44,8 +44,23 @@ public interface WorldBorder {
      *
      * @throws IllegalArgumentException if newSize is less than 1.0D or greater than {@link #getMaxSize()}
      * @see #setSize(double, TimeUnit, long)
+     * @deprecated Use {@link #changeSize(double, long)} instead
      */
-    void setSize(double newSize, long seconds);
+    @Deprecated(since = "1.21.11", forRemoval = true)
+    default void setSize(double newSize, long seconds) {
+        this.setSize(Math.min(this.getMaxSize(), Math.max(1.0D, newSize)), TimeUnit.SECONDS, Math.clamp(seconds, 0L, Integer.MAX_VALUE));
+    }
+
+    /**
+     * Sets the border to a square region with the specified side length in blocks.
+     *
+     * @param newSize The new side length of the border.
+     * @param ticks The time in ticks in which the border grows or shrinks from the previous size to that being set.
+     *
+     * @throws IllegalArgumentException if newSize is less than 1.0D or greater than {@link #getMaxSize()}
+     * @throws IllegalArgumentException if ticks are less than 0
+     */
+    void changeSize(double newSize, long ticks);
 
     /**
      * Sets the border to a square region with the specified side length in blocks.

--- a/paper-api/src/main/java/org/bukkit/WorldBorder.java
+++ b/paper-api/src/main/java/org/bukkit/WorldBorder.java
@@ -161,6 +161,13 @@ public interface WorldBorder {
     /**
      * Sets the warning time that causes the screen to be tinted red when a contracting border will reach the player within the specified time.
      *
+     * @param ticks The number of ticks.
+     */
+    void setWarningTime(long ticks);
+
+    /**
+     * Sets the warning time that causes the screen to be tinted red when a contracting border will reach the player within the specified time.
+     *
      * @param unit The time unit.
      * @param time The time that causes the screen to be tinted red when a contracting border will reach.
      *

--- a/paper-api/src/main/java/org/bukkit/WorldBorder.java
+++ b/paper-api/src/main/java/org/bukkit/WorldBorder.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import com.google.common.base.Preconditions;
 import io.papermc.paper.util.Tick;
+import net.kyori.adventure.util.Ticks;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -162,7 +163,7 @@ public interface WorldBorder {
      */
     @Deprecated(since = "1.21.11", forRemoval = true)
     default void setWarningTime(int seconds) {
-        this.setWarningTimeTicks(seconds);
+        this.setWarningTimeTicks(Tick.tick().fromDuration(Duration.ofSeconds(seconds)));
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/WorldBorder.java
+++ b/paper-api/src/main/java/org/bukkit/WorldBorder.java
@@ -152,13 +152,13 @@ public interface WorldBorder {
      *
      * @return The current border warning time in ticks.
      */
-    long getWarningTimeTicks();
+    int getWarningTimeTicks();
 
     /**
      * Sets the warning time that causes the screen to be tinted red when a contracting border will reach the player within the specified time.
      *
      * @param seconds The amount of time in seconds.
-     * @deprecated Use {@link #setWarningTimeTicks(long)} instead
+     * @deprecated Use {@link #setWarningTimeTicks(int)} instead
      */
     @Deprecated(since = "1.21.11", forRemoval = true)
     default void setWarningTime(int seconds) {
@@ -170,7 +170,7 @@ public interface WorldBorder {
      *
      * @param ticks The number of ticks.
      */
-    void setWarningTimeTicks(long ticks);
+    void setWarningTimeTicks(int ticks);
 
     /**
      * Gets the current border warning distance.

--- a/paper-api/src/main/java/org/bukkit/WorldBorder.java
+++ b/paper-api/src/main/java/org/bukkit/WorldBorder.java
@@ -1,6 +1,8 @@
 package org.bukkit;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import com.google.common.base.Preconditions;
 import io.papermc.paper.util.Tick;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -75,7 +77,10 @@ public interface WorldBorder {
      * @deprecated Use {@link #changeSize(double, long)} instead
      */
     @Deprecated(since = "1.21.11", forRemoval = true)
-    void setSize(double newSize, @NotNull TimeUnit unit, long time);
+    default void setSize(double newSize, @NotNull TimeUnit unit, long time) {
+        Preconditions.checkArgument(unit != null, "TimeUnit cannot be null.");
+        this.changeSize(newSize, Tick.tick().fromDuration(Duration.of(time, unit.toChronoUnit())));
+    }
 
     /**
      * Gets the current border center.

--- a/paper-api/src/main/java/org/bukkit/WorldBorder.java
+++ b/paper-api/src/main/java/org/bukkit/WorldBorder.java
@@ -162,7 +162,7 @@ public interface WorldBorder {
      */
     @Deprecated(since = "1.21.11", forRemoval = true)
     default void setWarningTime(int seconds) {
-        this.setWarningTime(((long) seconds));
+        this.getWarningTimeTicks(seconds);
     }
 
     /**
@@ -170,7 +170,7 @@ public interface WorldBorder {
      *
      * @param ticks The number of ticks.
      */
-    void setWarningTime(long ticks);
+    void getWarningTimeTicks(long ticks);
 
     /**
      * Gets the current border warning distance.

--- a/paper-server/patches/sources/net/minecraft/world/level/border/WorldBorder.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/border/WorldBorder.java.patch
@@ -4,7 +4,7 @@
      double centerZ;
      int absoluteMaxSize = 29999984;
      WorldBorder.BorderExtent extent = new WorldBorder.StaticBorderExtent(5.999997E7F);
-+    public net.minecraft.server.level.ServerLevel world; // CraftBukkit
++    public @javax.annotation.Nullable net.minecraft.server.level.ServerLevel world; // CraftBukkit
  
      public WorldBorder() {
          this(WorldBorder.Settings.DEFAULT);
@@ -77,7 +77,7 @@
 +            io.papermc.paper.event.world.border.WorldBorderBoundsChangeEvent event = new io.papermc.paper.event.world.border.WorldBorderBoundsChangeEvent(world.getWorld(), world.getWorld().getWorldBorder(), type, oldSize, newSize, time);
 +            if (!event.callEvent()) return;
 +            newSize = event.getNewSize();
-+            time = event.getDuration();
++            time = event.getDurationTicks();
 +        }
 +        // Paper end - Add worldborder events
          this.extent = (WorldBorder.BorderExtent)(oldSize == newSize

--- a/paper-server/patches/sources/net/minecraft/world/level/border/WorldBorder.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/border/WorldBorder.java.patch
@@ -52,8 +52,8 @@
 +        if (this.world != null) {
 +            io.papermc.paper.event.world.border.WorldBorderBoundsChangeEvent event = new io.papermc.paper.event.world.border.WorldBorderBoundsChangeEvent(world.getWorld(), world.getWorld().getWorldBorder(), io.papermc.paper.event.world.border.WorldBorderBoundsChangeEvent.Type.INSTANT_MOVE, getSize(), size, 0);
 +            if (!event.callEvent()) return;
-+            if (event.getType() == io.papermc.paper.event.world.border.WorldBorderBoundsChangeEvent.Type.STARTED_MOVE && event.getDuration() > 0) { // If changed to a timed transition
-+                lerpSizeBetween(event.getOldSize(), event.getNewSize(), event.getDuration(), this.world.getGameTime());
++            if (event.getType() == io.papermc.paper.event.world.border.WorldBorderBoundsChangeEvent.Type.STARTED_MOVE && event.getDurationTicks() > 0) { // If changed to a timed transition
++                lerpSizeBetween(event.getOldSize(), event.getNewSize(), event.getDurationTicks(), this.world.getGameTime());
 +                return;
 +            }
 +            size = event.getNewSize();

--- a/paper-server/patches/sources/net/minecraft/world/level/border/WorldBorder.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/border/WorldBorder.java.patch
@@ -4,7 +4,7 @@
      double centerZ;
      int absoluteMaxSize = 29999984;
      WorldBorder.BorderExtent extent = new WorldBorder.StaticBorderExtent(5.999997E7F);
-+    public @javax.annotation.Nullable net.minecraft.server.level.ServerLevel world; // CraftBukkit
++    public net.minecraft.server.level.@org.jspecify.annotations.Nullable ServerLevel world; // CraftBukkit
  
      public WorldBorder() {
          this(WorldBorder.Settings.DEFAULT);
@@ -91,7 +91,7 @@
          this.listeners.add(listener);
      }
  
-@@ -298,6 +_,21 @@
+@@ -298,6 +_,22 @@
          }
      }
  
@@ -103,7 +103,8 @@
 +        this.setWarningBlocks(settings.warningBlocks());
 +        this.setWarningTime(settings.warningTime());
 +        if (settings.lerpTime() > 0L) {
-+            this.lerpSizeBetween(settings.size(), settings.lerpTarget(), settings.lerpTime(), this.world.getGameTime());
++            final long startTime = (this.world != null) ? this.world.getGameTime() : 0; // Virtual Borders don't have a World
++            this.lerpSizeBetween(settings.size(), settings.lerpTarget(), settings.lerpTime(), startTime);
 +        } else {
 +            this.setSize(settings.size());
 +        }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
@@ -1,7 +1,9 @@
 package org.bukkit.craftbukkit;
 
 import com.google.common.base.Preconditions;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import io.papermc.paper.util.Tick;
 import net.minecraft.core.BlockPos;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -54,7 +56,8 @@ public class CraftWorldBorder implements WorldBorder {
         Preconditions.checkArgument(newSize >= 1.0D && newSize <= this.getMaxSize(), "newSize must be between 1.0D and %s", this.getMaxSize());
 
         if (time > 0L) {
-            this.handle.lerpSizeBetween(this.handle.getSize(), newSize, unit.toMillis(time), this.getWorld().getGameTime());
+            long gameTime = (this.getWorld() != null) ? this.getWorld().getGameTime() : 0; // Virtual Borders don't have a World
+            this.handle.lerpSizeBetween(this.handle.getSize(), newSize, Tick.tick().fromDuration(Duration.of(time, unit.toChronoUnit())), gameTime);
         } else {
             this.handle.setSize(newSize);
         }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
@@ -105,13 +105,16 @@ public class CraftWorldBorder implements WorldBorder {
     }
 
     @Override
-    public int getWarningTime() {
+    public long getWarningTimeTicks() {
         return this.handle.getWarningTime();
     }
 
     @Override
-    public void setWarningTime(int time) {
-        this.handle.setWarningTime(time);
+    public void setWarningTime(final TimeUnit unit, final long time) {
+        Preconditions.checkArgument(unit != null, "TimeUnit cannot be null.");
+        Preconditions.checkArgument(time >= 0, "time cannot be lower than 0");
+
+        this.handle.setWarningTime(Tick.tick().fromDuration(Duration.of(time, unit.toChronoUnit())));
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
@@ -56,8 +56,8 @@ public class CraftWorldBorder implements WorldBorder {
         Preconditions.checkArgument(newSize >= 1.0D && newSize <= this.getMaxSize(), "newSize must be between 1.0D and %s", this.getMaxSize());
 
         if (time > 0L) {
-            long gameTime = (this.getWorld() != null) ? this.getWorld().getGameTime() : 0; // Virtual Borders don't have a World
-            this.handle.lerpSizeBetween(this.handle.getSize(), newSize, Tick.tick().fromDuration(Duration.of(time, unit.toChronoUnit())), gameTime);
+            final long startTime = (this.getWorld() != null) ? this.getWorld().getGameTime() : 0; // Virtual Borders don't have a World
+            this.handle.lerpSizeBetween(this.handle.getSize(), newSize, Tick.tick().fromDuration(Duration.of(time, unit.toChronoUnit())), startTime);
         } else {
             this.handle.setSize(newSize);
         }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
@@ -1,9 +1,6 @@
 package org.bukkit.craftbukkit;
 
 import com.google.common.base.Preconditions;
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
-import io.papermc.paper.util.Tick;
 import net.minecraft.core.BlockPos;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -104,7 +101,7 @@ public class CraftWorldBorder implements WorldBorder {
     }
 
     @Override
-    public void getWarningTimeTicks(final long ticks) {
+    public void setWarningTimeTicks(final long ticks) {
         Preconditions.checkArgument(ticks >= 0, "ticks cannot be lower than 0");
 
         this.handle.setWarningTime(((int) ticks));

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
@@ -96,15 +96,15 @@ public class CraftWorldBorder implements WorldBorder {
     }
 
     @Override
-    public long getWarningTimeTicks() {
+    public int getWarningTimeTicks() {
         return this.handle.getWarningTime();
     }
 
     @Override
-    public void setWarningTimeTicks(final long ticks) {
+    public void setWarningTimeTicks(final int ticks) {
         Preconditions.checkArgument(ticks >= 0, "ticks cannot be lower than 0");
 
-        this.handle.setWarningTime(((int) ticks));
+        this.handle.setWarningTime(ticks);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
@@ -41,7 +41,7 @@ public class CraftWorldBorder implements WorldBorder {
 
     @Override
     public void setSize(double newSize) {
-        this.setSize(newSize, TimeUnit.MILLISECONDS, 0);
+        this.changeSize(newSize, 0);
     }
 
     @Override
@@ -115,6 +115,13 @@ public class CraftWorldBorder implements WorldBorder {
     @Override
     public long getWarningTimeTicks() {
         return this.handle.getWarningTime();
+    }
+
+    @Override
+    public void setWarningTime(final long ticks) {
+        Preconditions.checkArgument(ticks >= 0, "ticks cannot be lower than 0");
+
+        this.handle.setWarningTime(((int) ticks));
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
@@ -41,12 +41,20 @@ public class CraftWorldBorder implements WorldBorder {
 
     @Override
     public void setSize(double newSize) {
-        this.setSize(newSize, 0L);
+        this.setSize(newSize, TimeUnit.MILLISECONDS, 0);
     }
 
     @Override
-    public void setSize(double newSize, long time) {
-        this.setSize(Math.min(this.getMaxSize(), Math.max(1.0D, newSize)), TimeUnit.SECONDS, Math.clamp(time, 0L, Integer.MAX_VALUE));
+    public void changeSize(double newSize, long ticks) {
+        Preconditions.checkArgument(ticks >= 0, "ticks cannot be lower than 0");
+        Preconditions.checkArgument(newSize >= 1.0D && newSize <= this.getMaxSize(), "newSize must be between 1.0D and %s", this.getMaxSize());
+
+        if (ticks > 0L) {
+            final long startTime = (this.getWorld() != null) ? this.getWorld().getGameTime() : 0; // Virtual Borders don't have a World
+            this.handle.lerpSizeBetween(this.handle.getSize(), newSize, ticks, startTime);
+        } else {
+            this.handle.setSize(newSize);
+        }
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
@@ -58,20 +58,6 @@ public class CraftWorldBorder implements WorldBorder {
     }
 
     @Override
-    public void setSize(double newSize, TimeUnit unit, long time) {
-        Preconditions.checkArgument(unit != null, "TimeUnit cannot be null.");
-        Preconditions.checkArgument(time >= 0, "time cannot be lower than 0");
-        Preconditions.checkArgument(newSize >= 1.0D && newSize <= this.getMaxSize(), "newSize must be between 1.0D and %s", this.getMaxSize());
-
-        if (time > 0L) {
-            final long startTime = (this.getWorld() != null) ? this.getWorld().getGameTime() : 0; // Virtual Borders don't have a World
-            this.handle.lerpSizeBetween(this.handle.getSize(), newSize, Tick.tick().fromDuration(Duration.of(time, unit.toChronoUnit())), startTime);
-        } else {
-            this.handle.setSize(newSize);
-        }
-    }
-
-    @Override
     public Location getCenter() {
         double x = this.handle.getCenterX();
         double z = this.handle.getCenterZ();

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
@@ -104,7 +104,7 @@ public class CraftWorldBorder implements WorldBorder {
     }
 
     @Override
-    public void setWarningTime(final long ticks) {
+    public void getWarningTimeTicks(final long ticks) {
         Preconditions.checkArgument(ticks >= 0, "ticks cannot be lower than 0");
 
         this.handle.setWarningTime(((int) ticks));

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
@@ -125,14 +125,6 @@ public class CraftWorldBorder implements WorldBorder {
     }
 
     @Override
-    public void setWarningTime(final TimeUnit unit, final long time) {
-        Preconditions.checkArgument(unit != null, "TimeUnit cannot be null.");
-        Preconditions.checkArgument(time >= 0, "time cannot be lower than 0");
-
-        this.handle.setWarningTime(Tick.tick().fromDuration(Duration.of(time, unit.toChronoUnit())));
-    }
-
-    @Override
     public int getWarningDistance() {
         return this.handle.getWarningBlocks();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
@@ -46,7 +46,7 @@ public class CraftWorldBorder implements WorldBorder {
 
     @Override
     public void setSize(double newSize, long time) {
-        this.setSize(Math.min(this.getMaxSize(), Math.max(1.0D, newSize)), TimeUnit.SECONDS, Math.min(9223372036854775L, Math.max(0L, time)));
+        this.setSize(Math.min(this.getMaxSize(), Math.max(1.0D, newSize)), TimeUnit.SECONDS, Math.clamp(time, 0L, Integer.MAX_VALUE));
     }
 
     @Override


### PR DESCRIPTION
This PR try to manage the breaking change in the last snapshot where worldborder time for reduce now works with ticks and not seconds/milis
https://www.minecraft.net/en-us/article/minecraft-snapshot-25w43a

PD: Need test this with the virtual worldborder feature