### PR TITLE
Add debug logging for entities with invalid ids

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -754,6 +754,7 @@ public net.minecraft.world.level.storage.DimensionDataStorage cache
 public net.minecraft.world.level.storage.LevelStorageSource baseDir
 public net.minecraft.world.level.storage.LevelStorageSource$LevelStorageAccess levelDirectory
 public net.minecraft.world.level.storage.PrimaryLevelData settings
+public net.minecraft.world.level.storage.TagValueInput input
 public net.minecraft.world.scores.Objective displayName
 public net.minecraft.world.scores.criteria.ObjectiveCriteria CRITERIA_CACHE
 public-f net.minecraft.server.MinecraftServer potionBrewing

--- a/paper-server/patches/sources/net/minecraft/world/entity/EntityType.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/EntityType.java.patch
@@ -4,7 +4,7 @@
  import org.slf4j.Logger;
  
  public class EntityType<T extends Entity> implements FeatureElement, EntityTypeTest<Entity, T> {
-+    private static final boolean DEBUG_ENTITIES_MISSING_IDS = Boolean.getBoolean("paper.debugEntitiesMissingIds"); // Paper - Add logging for debugging entity tags without ids
++    private static final boolean DEBUG_ENTITIES_WITH_INVALID_IDS = Boolean.getBoolean("paper.debugEntitiesWithInvalidIds"); // Paper - Add logging for debugging entity tags with invalid ids
      private static final Logger LOGGER = LogUtils.getLogger();
      private final Holder.Reference<EntityType<?>> builtInRegistryHolder = BuiltInRegistries.ENTITY_TYPE.createIntrusiveHolder(this);
      public static final Codec<EntityType<?>> CODEC = BuiltInRegistries.ENTITY_TYPE.byNameCodec();
@@ -136,14 +136,14 @@
 +                entity.load(input);
 +            },
 +            // Paper end - Don't fire sync event during generation
-+            // Paper start - Add logging for debugging entity tags without ids
++            // Paper start - Add logging for debugging entity tags with invalid ids
 +            () -> {
 +                LOGGER.warn("Skipping Entity with id {}", input.getStringOr("id", "[invalid]"));
-+                if ((DEBUG_ENTITIES_MISSING_IDS || level.getCraftServer().getServer().isDebugging()) && input instanceof TagValueInput tagInput) {
++                if ((DEBUG_ENTITIES_WITH_INVALID_IDS || level.getCraftServer().getServer().isDebugging()) && input instanceof TagValueInput tagInput) {
 +                    LOGGER.warn("Skipped entity tag: {}", tagInput.input);
 +                }
 +            }
-+            // Paper end - Add logging for debugging entity tags without ids
++            // Paper end - Add logging for debugging entity tags with invalid ids
          );
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/EntityType.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/EntityType.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/world/entity/EntityType.java
 +++ b/net/minecraft/world/entity/EntityType.java
+@@ -185,6 +_,7 @@
+ import org.slf4j.Logger;
+ 
+ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeTest<Entity, T> {
++    private static final boolean DEBUG_ENTITIES_MISSING_IDS = Boolean.getBoolean("paper.debugEntitiesMissingIds"); // Paper - Add logging for debugging entity tags without ids
+     private static final Logger LOGGER = LogUtils.getLogger();
+     private final Holder.Reference<EntityType<?>> builtInRegistryHolder = BuiltInRegistries.ENTITY_TYPE.createIntrusiveHolder(this);
+     public static final Codec<EntityType<?>> CODEC = BuiltInRegistries.ENTITY_TYPE.byNameCodec();
 @@ -1265,6 +_,22 @@
          boolean shouldOffsetY,
          boolean shouldOffsetYMore
@@ -108,7 +116,7 @@
                      entityData.loadInto(entity);
                  }
              }
-@@ -1429,9 +_,20 @@
+@@ -1429,10 +_,28 @@
      }
  
      public static Optional<Entity> create(ValueInput input, Level level, EntitySpawnReason spawnReason) {
@@ -121,15 +129,24 @@
          return Util.ifElse(
              by(input).map(entityType -> entityType.create(level, spawnReason)),
 -            entity -> entity.load(input),
+-            () -> LOGGER.warn("Skipping Entity with id {}", input.getStringOr("id", "[invalid]"))
 +            // Paper start - Don't fire sync event during generation
 +            entity -> {
 +                if (generation) entity.generation = true; // Paper - Don't fire sync event during generation
 +                entity.load(input);
 +            },
 +            // Paper end - Don't fire sync event during generation
-             () -> LOGGER.warn("Skipping Entity with id {}", input.getStringOr("id", "[invalid]"))
++            // Paper start - Add logging for debugging entity tags without ids
++            () -> {
++                LOGGER.warn("Skipping Entity with id {}", input.getStringOr("id", "[invalid]"));
++                if ((DEBUG_ENTITIES_MISSING_IDS || level.getCraftServer().getServer().isDebugging()) && input instanceof TagValueInput tagInput) {
++                    LOGGER.warn("Skipped entity tag: {}", tagInput.input);
++                }
++            }
++            // Paper end - Add logging for debugging entity tags without ids
          );
      }
+ 
 @@ -1588,8 +_,23 @@
          return this.builtInRegistryHolder;
      }


### PR DESCRIPTION
While this warning doesn't normally happen, it can be hard to figure out what (usually a plugin) is causing it when it does. Logging the full tag gives more context as to what type of entity is being loaded and should make it easier to find the culprit.

Will open up a docs pr documenting the new system property if this is accepted as something wanted in paper.