### PR TITLE
Fix missing commands in plugins' HelpMap

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -604,7 +604,6 @@ public final class CraftServer implements Server {
             DefaultPermissions.registerCorePermissions();
             CraftDefaultPermissions.registerCorePermissions();
             if (!io.papermc.paper.configuration.GlobalConfiguration.get().misc.loadPermissionsYmlBeforePlugins) this.loadCustomPermissions(); // Paper
-            this.helpMap.initializeCommands();
             this.syncCommands();
         }
     }


### PR DESCRIPTION
`SimpleHelpMap#initializeCommands()` was called twice on server startup:
- Once at the end of `CraftServer#enablePlugins(PluginLoadOrder)` if the load order was POSTWORLD
- Once near the end of `MinecraftServer#initPostWorld()`

Bootstrap commands being registered on server boostrap meant they were already registered on the first `initializeCommands` call.
JavaPlugin commands on the other hand, specifically brigadier commands registered using the LifeCycle event manager, are only registered before the second `initializeCommands` call.

The issue is that the HelpMap was not cleared before the second call, and the second call could not register all plugins commands because the plugin was already there, and HelpMap topics works in a way that do not allow overrides.

This PR fixes the two issues mentionned above:
- Fixes `initializeCommands` being called twice on server startup
- Fixes `onEnable` brigadier commands not being shown in `/help <plugin>` commands

Fixes #13230