### PR TITLE
Fix async command building throwing CME in some cases

### DIFF
--- a/paper-server/patches/sources/com/mojang/brigadier/tree/CommandNode.java.patch
+++ b/paper-server/patches/sources/com/mojang/brigadier/tree/CommandNode.java.patch
@@ -1,7 +1,11 @@
 --- a/com/mojang/brigadier/tree/CommandNode.java
 +++ b/com/mojang/brigadier/tree/CommandNode.java
-@@ -27,11 +_,22 @@
-     private final Map<String, CommandNode<S>> children = new LinkedHashMap<>();
+@@ -24,14 +_,25 @@
+ import java.util.function.Predicate;
+ 
+ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
+-    private final Map<String, CommandNode<S>> children = new LinkedHashMap<>();
++    public final Map<String, CommandNode<S>> children = Collections.synchronizedMap(new LinkedHashMap<>()); // Paper - Prevent concurrent modification when sending commands; public
      private final Map<String, LiteralCommandNode<S>> literals = new LinkedHashMap<>();
      private final Map<String, ArgumentCommandNode<S, ?>> arguments = new LinkedHashMap<>();
 -    private final Predicate<S> requirement;

--- a/paper-server/patches/sources/net/minecraft/commands/Commands.java.patch
+++ b/paper-server/patches/sources/net/minecraft/commands/Commands.java.patch
@@ -132,7 +132,7 @@
              }
  
              return null;
-@@ -399,17 +_,110 @@
+@@ -399,17 +_,109 @@
      }
  
      public void sendCommands(ServerPlayer player) {
@@ -145,9 +145,7 @@
 +        // CraftBukkit start
 +        // Register Vanilla commands into builtRoot as before
 +        // Paper start - Perf: Async command map building
-+        // Copy root children to avoid concurrent modification during building
-+        final java.util.Collection<CommandNode<CommandSourceStack>> commandNodes = new java.util.ArrayList<>(this.dispatcher.getRoot().getChildren());
-+        COMMAND_SENDING_POOL.execute(() -> this.sendAsync(player, commandNodes));
++        COMMAND_SENDING_POOL.execute(() -> this.sendAsync(player));
 +    }
 +
 +    // Fixed pool, but with discard policy
@@ -161,13 +159,12 @@
 +        new java.util.concurrent.ThreadPoolExecutor.DiscardPolicy()
 +    );
 +
-+    private void sendAsync(ServerPlayer player, java.util.Collection<CommandNode<CommandSourceStack>> dispatcherRootChildren) {
++    private void sendAsync(ServerPlayer player) {
 +        // Paper end - Perf: Async command map building
          Map<CommandNode<CommandSourceStack>, CommandNode<CommandSourceStack>> map = new HashMap<>();
          RootCommandNode<CommandSourceStack> rootCommandNode = new RootCommandNode<>();
          map.put(this.dispatcher.getRoot(), rootCommandNode);
--        fillUsableCommands(this.dispatcher.getRoot(), rootCommandNode, player.createCommandSourceStack(), map);
-+        fillUsableCommands(dispatcherRootChildren, rootCommandNode, player.createCommandSourceStack(), map); // Paper - Perf: Async command map building; pass copy of children
+         fillUsableCommands(this.dispatcher.getRoot(), rootCommandNode, player.createCommandSourceStack(), map);
 +
 +        java.util.Collection<String> bukkit = new java.util.LinkedHashSet<>();
 +        for (CommandNode node : rootCommandNode.getChildren()) {
@@ -197,9 +194,9 @@
      }
  
 -    private static <S> void fillUsableCommands(CommandNode<S> root, CommandNode<S> current, S source, Map<CommandNode<S>, CommandNode<S>> output) {
--        for (CommandNode<S> commandNode : root.getChildren()) {
-+    private static <S> void fillUsableCommands(java.util.Collection<CommandNode<S>> children, CommandNode<S> current, S source, Map<CommandNode<S>, CommandNode<S>> output) { // Paper - Perf: Async command map building; pass copy of children
-+        for (CommandNode<S> commandNode : children) {  // Paper - Perf: Async command map building; pass copy of children
++    private static <S> void fillUsableCommands(CommandNode<S> root, CommandNode<S> current, S source, Map<CommandNode<S>, CommandNode<S>> output) { // Paper - Perf: Async command map building; pass copy of children
++        synchronized (root.children) { // Paper - Perf: Async command map building
+         for (CommandNode<S> commandNode : root.getChildren()) {
 +            // Paper start - Brigadier API
 +            if (commandNode.clientNode != null) {
 +                commandNode = commandNode.clientNode;
@@ -246,12 +243,11 @@
                  if (argumentBuilder.getRedirect() != null) {
                      argumentBuilder.redirect(output.get(argumentBuilder.getRedirect()));
                  }
-@@ -418,7 +_,7 @@
-                 output.put(commandNode, commandNode1);
-                 current.addChild(commandNode1);
-                 if (!commandNode.getChildren().isEmpty()) {
--                    fillUsableCommands(commandNode, commandNode1, source, output);
-+                    fillUsableCommands(commandNode.getChildren(), commandNode1, source, output); // Paper - Perf: Async command map building; pass copy of children
+@@ -422,6 +_,7 @@
                  }
              }
          }
++        } // Paper - Perf: Async command map building
+     }
+ 
+     public static LiteralArgumentBuilder<CommandSourceStack> literal(String name) {


### PR DESCRIPTION
The issue is from multiple places during that `sendAsync` process: Anything that loops through any CommandNode's children is subject to the CME.

The previous fix was only working for the root node, and wasn't even fully working given a few lines lower it's being added in an HashMap, which does .hashCode and loops through the root's children again.

This PR reverts the previous fix and fixes the concurrency issue once for all:
- Changed the CommandNode's children map to a synchronized map, still backed by a LinkedHashMap
- Lock everything in `Commands#fillUsableCommands` inside a synchronized block that uses the children map as lock object, the same lock object the synchronized map uses.

This has been tested with the test plugin published on [this branch of my fork](<https://github.com/roro1506HD/Paper/tree/other/async_command_cme_fix_test_plugin>)

Fixes #11101