### PR TITLE
Update PlayerPostRespawnEvent to include full location data

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -557,7 +557,7 @@
 +        // Call post respawn event
 +        new com.destroystokyo.paper.event.player.PlayerPostRespawnEvent(
 +            serverPlayer.getBukkitEntity(),
-+            org.bukkit.craftbukkit.util.CraftLocation.toBukkit(serverPlayer.position(), serverPlayer.level(), serverPlayer.getYRot(), serverPlayer.getXRot()),
++            org.bukkit.craftbukkit.util.CraftLocation.toBukkit(teleportTransition.position(), level, teleportTransition.yRot(), teleportTransition.xRot()),
 +            result.isBedSpawn(),
 +            result.isAnchorSpawn(),
 +            teleportTransition.missingRespawnBlock(),

--- a/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -557,7 +557,7 @@
 +        // Call post respawn event
 +        new com.destroystokyo.paper.event.player.PlayerPostRespawnEvent(
 +            serverPlayer.getBukkitEntity(),
-+            org.bukkit.craftbukkit.util.CraftLocation.toBukkit(vec3),
++            org.bukkit.craftbukkit.util.CraftLocation.toBukkit(serverPlayer.position(), serverPlayer.level(), serverPlayer.getYRot(), serverPlayer.getXRot()),
 +            result.isBedSpawn(),
 +            result.isAnchorSpawn(),
 +            teleportTransition.missingRespawnBlock(),


### PR DESCRIPTION
The post respawn event used to provide the full location, but that was recently broken
_This is apparently Owen's fault :)_