### PR TITLE
Add EntityPushByExplodeEvent

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -30177,7 +30177,7 @@ index 60be05520f1093e3edc7dbfcf5bd01601d5e6e7b..fd5a38a9f24c26f8eca738f78180446d
  
      @Nullable ChunkAccess getChunkIfLoadedImmediately(int x, int z); // Paper - ifLoaded api (we need this since current impl blocks if the chunk is loading)
 diff --git a/net/minecraft/world/level/ServerExplosion.java b/net/minecraft/world/level/ServerExplosion.java
-index ebbf5ceab837675ffa6a5380c0c54bc1dd788348..6279596058f76f113d238be3201cb0c6e6b49566 100644
+index 995d47eca49b31675683083d668edbbfbdf704f3..3665f1ce8bb78d0b1afff29f1de63533b4d248a9 100644
 --- a/net/minecraft/world/level/ServerExplosion.java
 +++ b/net/minecraft/world/level/ServerExplosion.java
 @@ -62,6 +62,249 @@ public class ServerExplosion implements Explosion {
@@ -30580,7 +30580,7 @@ index ebbf5ceab837675ffa6a5380c0c54bc1dd788348..6279596058f76f113d238be3201cb0c6
      }
  
      private void hurtEntities() {
-@@ -350,6 +632,14 @@ public class ServerExplosion implements Explosion {
+@@ -346,6 +628,14 @@ public class ServerExplosion implements Explosion {
      }
  
      public int explode() {
@@ -30595,7 +30595,7 @@ index ebbf5ceab837675ffa6a5380c0c54bc1dd788348..6279596058f76f113d238be3201cb0c6
          this.level.gameEvent(this.source, GameEvent.EXPLODE, this.center);
          List<BlockPos> list = this.calculateExplodedPositions();
          this.hurtEntities();
-@@ -364,6 +654,13 @@ public class ServerExplosion implements Explosion {
+@@ -360,6 +650,13 @@ public class ServerExplosion implements Explosion {
              this.createFire(list);
          }
  
@@ -30609,7 +30609,7 @@ index ebbf5ceab837675ffa6a5380c0c54bc1dd788348..6279596058f76f113d238be3201cb0c6
          return list.size();
      }
  
-@@ -447,12 +744,12 @@ public class ServerExplosion implements Explosion {
+@@ -443,12 +740,12 @@ public class ServerExplosion implements Explosion {
      // Paper start - Optimize explosions
      private float getBlockDensity(Vec3 vec3d, Entity entity) {
          if (!this.level.paperConfig().environment.optimizeExplosions) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -981,7 +981,7 @@
                  deltaMovement.z / 2.0 - vec3.z
              );
 +            Vec3 diff = finalVelocity.subtract(deltaMovement);
-+            io.papermc.paper.event.entity.EntityKnockbackEvent event = CraftEventFactory.callEntityKnockbackEvent((org.bukkit.craftbukkit.entity.CraftLivingEntity) this.getBukkitEntity(), attacker, attacker, eventCause, strength, diff);
++            io.papermc.paper.event.entity.EntityKnockbackEvent event = CraftEventFactory.callEntityKnockbackEvent(this.getBukkitEntity(), attacker, attacker, eventCause, strength, diff);
 +            // Paper end - knockback events
 +            if (event.isCancelled()) {
 +                return;

--- a/paper-server/patches/sources/net/minecraft/world/level/ServerExplosion.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/ServerExplosion.java.patch
@@ -75,7 +75,7 @@
                  if (!entity.ignoreExplosion(this)) {
                      double d = Math.sqrt(entity.distanceToSqr(this.center)) / f;
                      if (!(d > 1.0)) {
-@@ -186,20 +_,56 @@
+@@ -186,20 +_,52 @@
                          Vec3 vec31 = vec3.subtract(this.center).normalize();
                          boolean shouldDamageEntity = this.damageCalculator.shouldDamageEntity(this, entity);
                          float knockbackMultiplier = this.damageCalculator.getKnockbackMultiplier(entity);
@@ -120,14 +120,10 @@
 -                        double d2 = (1.0 - d) * f1 * knockbackMultiplier * (1.0 - d1);
 +                        double d2 = entity instanceof Player && this.level.paperConfig().environment.disableExplosionKnockback ? 0 : (1.0 - d) * f1 * knockbackMultiplier * (1.0 - d1); // Paper
                          Vec3 vec32 = vec31.scale(d2);
-+                        // CraftBukkit start - Call EntityKnockbackEvent
-+                        if (entity instanceof LivingEntity) {
-+                            // Paper start - knockback events
-+                            io.papermc.paper.event.entity.EntityKnockbackEvent event = CraftEventFactory.callEntityKnockbackEvent((org.bukkit.craftbukkit.entity.CraftLivingEntity) entity.getBukkitEntity(), this.source, this.damageSource.getEntity() != null ? this.damageSource.getEntity() : this.source, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.EXPLOSION, d2, vec32);
-+                            vec32 = event.isCancelled() ? Vec3.ZERO : org.bukkit.craftbukkit.util.CraftVector.toVec3(event.getKnockback());
-+                            // Paper end - knockback events
-+                        }
-+                        // CraftBukkit end
++                        // Paper start - knockback events
++                        io.papermc.paper.event.entity.EntityKnockbackEvent event = CraftEventFactory.callEntityKnockbackEvent(entity.getBukkitEntity(), this.source, this.damageSource.getEntity() != null ? this.damageSource.getEntity() : this.source, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.EXPLOSION, d2, vec32);
++                        vec32 = event.isCancelled() ? Vec3.ZERO : org.bukkit.craftbukkit.util.CraftVector.toVec3(event.getKnockback());
++                        // Paper end - knockback events
                          entity.push(vec32);
                          if (entity.getType().is(EntityTypeTags.REDIRECTABLE_PROJECTILE) && entity instanceof Projectile projectile) {
                              projectile.setOwner(this.damageSource.getEntity());

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -2166,28 +2166,36 @@ public class CraftEventFactory {
         return event;
     }
 
-    public static io.papermc.paper.event.entity.EntityKnockbackEvent callEntityKnockbackEvent(CraftLivingEntity entity, Entity pusher, Entity attacker, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause cause, double force, Vec3 knockback) {
+    public static io.papermc.paper.event.entity.EntityKnockbackEvent callEntityKnockbackEvent(CraftEntity entity, Entity pusher, Entity attacker, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause cause, double force, Vec3 knockback) {
         Vector apiKnockback = CraftVector.toBukkit(knockback);
 
         final Vector currentVelocity = entity.getVelocity();
-        final Vector legacyFinalKnockback = currentVelocity.clone().add(apiKnockback);
-        final org.bukkit.event.entity.EntityKnockbackEvent.KnockbackCause legacyCause = org.bukkit.event.entity.EntityKnockbackEvent.KnockbackCause.valueOf(cause.name());
-        EntityKnockbackEvent legacyEvent;
-        if (pusher != null) {
-            legacyEvent = new EntityKnockbackByEntityEvent(entity, pusher.getBukkitEntity(), legacyCause, force, apiKnockback, legacyFinalKnockback);
-        } else {
-            legacyEvent = new EntityKnockbackEvent(entity, legacyCause, force, apiKnockback, legacyFinalKnockback);
+
+        EntityKnockbackEvent legacyEvent = null;
+        if (entity instanceof CraftLivingEntity) {
+            CraftLivingEntity livingEntity = (CraftLivingEntity) entity;
+            final Vector legacyFinalKnockback = currentVelocity.clone().add(apiKnockback);
+            final org.bukkit.event.entity.EntityKnockbackEvent.KnockbackCause legacyCause = org.bukkit.event.entity.EntityKnockbackEvent.KnockbackCause.valueOf(cause.name());
+            if (pusher != null) {
+                legacyEvent = new EntityKnockbackByEntityEvent(livingEntity, pusher.getBukkitEntity(), legacyCause, force, apiKnockback, legacyFinalKnockback);
+            } else {
+                legacyEvent = new EntityKnockbackEvent(livingEntity, legacyCause, force, apiKnockback, legacyFinalKnockback);
+            }
+            legacyEvent.callEvent();
         }
-        legacyEvent.callEvent();
 
         final io.papermc.paper.event.entity.EntityKnockbackEvent event;
-        apiKnockback = legacyEvent.getFinalKnockback().subtract(currentVelocity);
+        apiKnockback = legacyEvent != null ? legacyEvent.getFinalKnockback().subtract(currentVelocity) : apiKnockback;
         if (attacker != null) {
-            event = new com.destroystokyo.paper.event.entity.EntityKnockbackByEntityEvent(entity, attacker.getBukkitEntity(), cause, (float) force, apiKnockback);
+            if (entity instanceof CraftLivingEntity) {
+                event = new com.destroystokyo.paper.event.entity.EntityKnockbackByEntityEvent((CraftLivingEntity) entity, attacker.getBukkitEntity(), cause, (float) force, apiKnockback);
+            } else {
+                event = new io.papermc.paper.event.entity.EntityPushedByEntityAttackEvent(entity, cause, pusher.getBukkitEntity(), apiKnockback);
+            }
         } else {
             event = new io.papermc.paper.event.entity.EntityKnockbackEvent(entity, cause, apiKnockback);
         }
-        event.setCancelled(legacyEvent.isCancelled());
+        event.setCancelled(legacyEvent != null && legacyEvent.isCancelled());
         event.callEvent();
         return event;
     }


### PR DESCRIPTION
Add a way to check what Entity got pushed by an Explosion happening. This event is only called for non LivingEntities because there is the EntityKnockbackEvent for that already. I am using this on a server where I am a Developer already for cancelling specific Explosions knocking around other Entities.