### PR TITLE
Fix TrialSpawnerConfiguration to support live BlockStates

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrialSpawner.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftTrialSpawner.java
@@ -23,8 +23,8 @@ public class CraftTrialSpawner extends CraftBlockEntityState<TrialSpawnerBlockEn
 
     public CraftTrialSpawner(World world, TrialSpawnerBlockEntity blockEntity) {
         super(world, blockEntity);
-        this.normalConfig = new CraftTrialSpawnerConfiguration(blockEntity.getTrialSpawner().normalConfig(), this.getSnapshot());
-        this.ominousConfig = new CraftTrialSpawnerConfiguration(blockEntity.getTrialSpawner().ominousConfig(), this.getSnapshot());
+        this.normalConfig = new CraftTrialSpawnerConfiguration(blockEntity.getTrialSpawner().normalConfig(), this.getSnapshot(), this);
+        this.ominousConfig = new CraftTrialSpawnerConfiguration(blockEntity.getTrialSpawner().ominousConfig(), this.getSnapshot(), this);
     }
 
     protected CraftTrialSpawner(CraftTrialSpawner state, Location location) {
@@ -169,6 +169,14 @@ public class CraftTrialSpawner extends CraftBlockEntityState<TrialSpawnerBlockEn
 
     @Override
     public TrialSpawnerConfiguration getOminousConfiguration() {
+        return this.ominousConfig;
+    }
+
+    CraftTrialSpawnerConfiguration getNormalConfigInternal() {
+        return this.normalConfig;
+    }
+
+    CraftTrialSpawnerConfiguration getOminousConfigInternal() {
         return this.ominousConfig;
     }
 


### PR DESCRIPTION
## Description
This PR fixes issue #11026 where `TrialSpawnerConfiguration` did not work properly with live BlockStates.

Live BlockStates do not need to be applied to have their changes reflected in-game. However, the current `TrialSpawnerConfiguration` implementation was a full copy that only applied changes when updating.

## Changes
- Modified `CraftTrialSpawnerConfiguration` to track whether it belongs to a live BlockState
- Added `updateConfig()` method that immediately applies changes to the underlying block entity when working with a live BlockState
- All setter methods now call `updateConfig()` to ensure changes are reflected immediately for live BlockStates
- Added package-private methods `getNormalConfigInternal()` and `getOminousConfigInternal()` to `CraftTrialSpawner` for internal config access

## Testing
The following code (from issue #11026) should now work correctly:
```java
final BlockState state = block.getState(false);
if (state instanceof final TrialSpawner trialSpawner) {
    trialSpawner.getNormalConfiguration().setBaseSpawnsBeforeCooldown(100);
}
```

The change will be immediately reflected in the in-game block entity without needing to call `update()`.

## Affected Issues
Fixes #11026