### PR TITLE
Clarify the functionality of AbstractVillager#resetOffers

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/AbstractVillager.java
+++ b/paper-api/src/main/java/org/bukkit/entity/AbstractVillager.java
@@ -24,7 +24,12 @@ public interface AbstractVillager extends Breedable, NPC, InventoryHolder, Merch
 
     // Paper start
     /**
-     * Reset this villager's trade offers
+     * Reset this villager's trade offers.
+     * <br>
+     * For {@link org.bukkit.entity.Villager Villagers}, only two trades are
+     * created, rather than the number of trades expected for the villager's
+     * level. You should use {@link org.bukkit.entity.Villager#addTrades(int)}
+     * to add the remaining trades.
      */
     public void resetOffers();
     // Paper end


### PR DESCRIPTION
While working with villagers, I noticed that calling `AbstractVillager#resetOffers` with normal villagers only adds two trades after resetting, even if the villager is not the base level and previously had more than two. I thought I had to use NMS to fix this, until I found `Villager#addTrades` and realized I could add them through it. This PR clarifies how `resetOffers` works and explains how the remaining trades can be added to a villager with the API.