### PR TITLE
Fix allowEnteringNetherUsingPortals gamerule not being respected

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -1143,6 +1143,19 @@
          this.effectiveRespawnData = serverLevel.getWorldBorderAdjustedRespawnData(respawnData);
      }
  
+@@ -1187,7 +_,11 @@
+     }
+ 
+-    public boolean isAllowedToEnterPortal(Level level) {
+-        return level.dimension() != Level.NETHER || this.getGameRules().getBoolean(GameRules.RULE_ALLOW_NETHER);
++    // Paper start - Fix allowEnteringNetherUsingPortals gamerule - check from source level
++    public boolean isAllowedToEnterPortal(Level sourceLevel, Level destinationLevel) {
++        return destinationLevel.dimension() != Level.NETHER || 
++            (sourceLevel instanceof ServerLevel serverLevel && serverLevel.getGameRules().getBoolean(GameRules.RULE_ALLOW_NETHER));
+     }
++    // Paper end - Fix allowEnteringNetherUsingPortals gamerule
+ 
+     public void addTickable(Runnable tickable) {
 @@ -1224,6 +_,22 @@
          return this.levels.get(dimension);
      }

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1276,11 +1276,8 @@
                          ServerLevel level = portalDestination.newLevel();
 -                        if (serverLevel.getServer().isAllowedToEnterPortal(level)
 -                            && (level.dimension() == serverLevel.dimension() || this.canTeleport(serverLevel, level))) {
-+                        // Paper start - Fix allowEnteringNetherUsingPortals gamerule to check level instead of server
-+                        if ((this instanceof ServerPlayer // CraftBukkit - always call event for players
-+                            || (level != null && (level.dimension() == serverLevel.dimension() || this.canTeleport(serverLevel, level)))) // CraftBukkit
-+                            && (level == null || level.dimension() != net.minecraft.world.level.Level.NETHER || serverLevel.getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_ALLOW_NETHER))) { // Paper - check gamerule from level instead of server
-+                        // Paper end - Fix allowEnteringNetherUsingPortals gamerule to check level instead of server
++                        if (level.getServer().isAllowedToEnterPortal(level) // Paper - use level instead of serverLevel
++                            && (level.dimension() == serverLevel.dimension() || this.canTeleport(serverLevel, level))) {
                              this.teleport(portalDestination);
                          }
                      }

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1276,8 +1276,11 @@
                          ServerLevel level = portalDestination.newLevel();
 -                        if (serverLevel.getServer().isAllowedToEnterPortal(level)
 -                            && (level.dimension() == serverLevel.dimension() || this.canTeleport(serverLevel, level))) {
-+                        if (this instanceof ServerPlayer // CraftBukkit - always call event for players
-+                            || (level != null && (level.dimension() == serverLevel.dimension() || this.canTeleport(serverLevel, level)))) { // CraftBukkit
++                        // Paper start - Fix allowEnteringNetherUsingPortals gamerule to check level instead of server
++                        if ((this instanceof ServerPlayer // CraftBukkit - always call event for players
++                            || (level != null && (level.dimension() == serverLevel.dimension() || this.canTeleport(serverLevel, level)))) // CraftBukkit
++                            && (level == null || level.dimension() != net.minecraft.world.level.Level.NETHER || serverLevel.getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_ALLOW_NETHER))) { // Paper - check gamerule from level instead of server
++                        // Paper end - Fix allowEnteringNetherUsingPortals gamerule to check level instead of server
                              this.teleport(portalDestination);
                          }
                      }

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1276,7 +1276,7 @@
                          ServerLevel level = portalDestination.newLevel();
 -                        if (serverLevel.getServer().isAllowedToEnterPortal(level)
 -                            && (level.dimension() == serverLevel.dimension() || this.canTeleport(serverLevel, level))) {
-+                        if (level.getServer().isAllowedToEnterPortal(level) // Paper - use level instead of serverLevel
++                        if (serverLevel.getServer().isAllowedToEnterPortal(serverLevel, level) // Paper - Pass source and destination levels
 +                            && (level.dimension() == serverLevel.dimension() || this.canTeleport(serverLevel, level))) {
                              this.teleport(portalDestination);
                          }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/NetherPortalBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/NetherPortalBlock.java.patch
@@ -42,11 +42,6 @@
      @Nullable
      @Override
      public TeleportTransition getPortalDestination(ServerLevel level, Entity entity, BlockPos pos) {
-+        // Paper start - Respect allowEnteringNetherUsingPortals gamerule
-+        if (!level.getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_ALLOW_NETHER)) {
-+            return null;
-+        }
-+        // Paper end - Respect allowEnteringNetherUsingPortals gamerule
 -        ResourceKey<Level> resourceKey = level.dimension() == Level.NETHER ? Level.OVERWORLD : Level.NETHER;
 +        // CraftBukkit start
 +        ResourceKey<Level> resourceKey = level.getTypeKey() == net.minecraft.world.level.dimension.LevelStem.NETHER ? Level.OVERWORLD : Level.NETHER;

--- a/paper-server/patches/sources/net/minecraft/world/level/block/NetherPortalBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/NetherPortalBlock.java.patch
@@ -42,6 +42,11 @@
      @Nullable
      @Override
      public TeleportTransition getPortalDestination(ServerLevel level, Entity entity, BlockPos pos) {
++        // Paper start - Respect allowEnteringNetherUsingPortals gamerule
++        if (!level.getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_ALLOW_NETHER)) {
++            return null;
++        }
++        // Paper end - Respect allowEnteringNetherUsingPortals gamerule
 -        ResourceKey<Level> resourceKey = level.dimension() == Level.NETHER ? Level.OVERWORLD : Level.NETHER;
 +        // CraftBukkit start
 +        ResourceKey<Level> resourceKey = level.getTypeKey() == net.minecraft.world.level.dimension.LevelStem.NETHER ? Level.OVERWORLD : Level.NETHER;


### PR DESCRIPTION
## Description
The `allowEnteringNetherUsingPortals` gamerule was being ignored when players attempted to use nether portals. This PR adds a check in `NetherPortalBlock#getPortalDestination` to return `null` (preventing teleportation) when the gamerule is set to `false`.

## Testing
- Set `/gamerule allowEnteringNetherUsingPortals false`
- Attempted to enter a nether portal
- Confirmed that the player is NOT teleported to the Nether
- Set the gamerule back to `true` and confirmed normal portal behavior works

Fixes #13261