### PR TITLE
Initial pass at GameRule refactor

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -718,6 +718,7 @@ public net.minecraft.world.level.dimension.end.EndDragonFight spawnExitPortal(Z)
 public net.minecraft.world.level.dimension.end.EndDragonFight spawnNewGateway(Lnet/minecraft/core/BlockPos;)V
 public net.minecraft.world.level.entity.PersistentEntitySectionManager ensureChunkQueuedForLoad(J)V
 public net.minecraft.world.level.entity.PersistentEntitySectionManager permanentStorage
+public net.minecraft.world.level.gamerules.GameRules rules
 public net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator settings
 public net.minecraft.world.level.levelgen.SurfaceRules$Condition
 public net.minecraft.world.level.levelgen.SurfaceRules$Context

--- a/paper-api/src/generated/java/io/papermc/paper/registry/keys/GameRuleKeys.java
+++ b/paper-api/src/generated/java/io/papermc/paper/registry/keys/GameRuleKeys.java
@@ -1,0 +1,447 @@
+package io.papermc.paper.registry.keys;
+
+import static net.kyori.adventure.key.Key.key;
+
+import io.papermc.paper.annotation.GeneratedClass;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.TypedKey;
+import net.kyori.adventure.key.Key;
+import org.bukkit.GameRule;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Vanilla keys for {@link RegistryKey#GAME_RULE}.
+ *
+ * @apiNote The fields provided here are a direct representation of
+ * what is available from the vanilla game source. They may be
+ * changed (including removals) on any Minecraft version
+ * bump, so cross-version compatibility is not provided on the
+ * same level as it is on most of the other API.
+ */
+@SuppressWarnings({
+        "unused",
+        "SpellCheckingInspection"
+})
+@NullMarked
+@GeneratedClass
+public final class GameRuleKeys {
+    /**
+     * {@code minecraft:advance_time}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> ADVANCE_TIME = create(key("advance_time"));
+
+    /**
+     * {@code minecraft:advance_weather}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> ADVANCE_WEATHER = create(key("advance_weather"));
+
+    /**
+     * {@code minecraft:allow_entering_nether_using_portals}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> ALLOW_ENTERING_NETHER_USING_PORTALS = create(key("allow_entering_nether_using_portals"));
+
+    /**
+     * {@code minecraft:block_drops}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> BLOCK_DROPS = create(key("block_drops"));
+
+    /**
+     * {@code minecraft:block_explosion_drop_decay}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> BLOCK_EXPLOSION_DROP_DECAY = create(key("block_explosion_drop_decay"));
+
+    /**
+     * {@code minecraft:command_block_output}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> COMMAND_BLOCK_OUTPUT = create(key("command_block_output"));
+
+    /**
+     * {@code minecraft:command_blocks_work}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> COMMAND_BLOCKS_WORK = create(key("command_blocks_work"));
+
+    /**
+     * {@code minecraft:drowning_damage}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> DROWNING_DAMAGE = create(key("drowning_damage"));
+
+    /**
+     * {@code minecraft:elytra_movement_check}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> ELYTRA_MOVEMENT_CHECK = create(key("elytra_movement_check"));
+
+    /**
+     * {@code minecraft:ender_pearls_vanish_on_death}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> ENDER_PEARLS_VANISH_ON_DEATH = create(key("ender_pearls_vanish_on_death"));
+
+    /**
+     * {@code minecraft:entity_drops}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> ENTITY_DROPS = create(key("entity_drops"));
+
+    /**
+     * {@code minecraft:fall_damage}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> FALL_DAMAGE = create(key("fall_damage"));
+
+    /**
+     * {@code minecraft:fire_damage}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> FIRE_DAMAGE = create(key("fire_damage"));
+
+    /**
+     * {@code minecraft:fire_spread_radius_around_player}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> FIRE_SPREAD_RADIUS_AROUND_PLAYER = create(key("fire_spread_radius_around_player"));
+
+    /**
+     * {@code minecraft:forgive_dead_players}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> FORGIVE_DEAD_PLAYERS = create(key("forgive_dead_players"));
+
+    /**
+     * {@code minecraft:freeze_damage}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> FREEZE_DAMAGE = create(key("freeze_damage"));
+
+    /**
+     * {@code minecraft:global_sound_events}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> GLOBAL_SOUND_EVENTS = create(key("global_sound_events"));
+
+    /**
+     * {@code minecraft:immediate_respawn}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> IMMEDIATE_RESPAWN = create(key("immediate_respawn"));
+
+    /**
+     * {@code minecraft:keep_inventory}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> KEEP_INVENTORY = create(key("keep_inventory"));
+
+    /**
+     * {@code minecraft:lava_source_conversion}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> LAVA_SOURCE_CONVERSION = create(key("lava_source_conversion"));
+
+    /**
+     * {@code minecraft:limited_crafting}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> LIMITED_CRAFTING = create(key("limited_crafting"));
+
+    /**
+     * {@code minecraft:locator_bar}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> LOCATOR_BAR = create(key("locator_bar"));
+
+    /**
+     * {@code minecraft:log_admin_commands}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> LOG_ADMIN_COMMANDS = create(key("log_admin_commands"));
+
+    /**
+     * {@code minecraft:max_block_modifications}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> MAX_BLOCK_MODIFICATIONS = create(key("max_block_modifications"));
+
+    /**
+     * {@code minecraft:max_command_forks}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> MAX_COMMAND_FORKS = create(key("max_command_forks"));
+
+    /**
+     * {@code minecraft:max_command_sequence_length}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> MAX_COMMAND_SEQUENCE_LENGTH = create(key("max_command_sequence_length"));
+
+    /**
+     * {@code minecraft:max_entity_cramming}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> MAX_ENTITY_CRAMMING = create(key("max_entity_cramming"));
+
+    /**
+     * {@code minecraft:max_minecart_speed}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> MAX_MINECART_SPEED = create(key("max_minecart_speed"));
+
+    /**
+     * {@code minecraft:max_snow_accumulation_height}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> MAX_SNOW_ACCUMULATION_HEIGHT = create(key("max_snow_accumulation_height"));
+
+    /**
+     * {@code minecraft:mob_drops}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> MOB_DROPS = create(key("mob_drops"));
+
+    /**
+     * {@code minecraft:mob_explosion_drop_decay}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> MOB_EXPLOSION_DROP_DECAY = create(key("mob_explosion_drop_decay"));
+
+    /**
+     * {@code minecraft:mob_griefing}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> MOB_GRIEFING = create(key("mob_griefing"));
+
+    /**
+     * {@code minecraft:natural_health_regeneration}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> NATURAL_HEALTH_REGENERATION = create(key("natural_health_regeneration"));
+
+    /**
+     * {@code minecraft:player_movement_check}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> PLAYER_MOVEMENT_CHECK = create(key("player_movement_check"));
+
+    /**
+     * {@code minecraft:players_nether_portal_creative_delay}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> PLAYERS_NETHER_PORTAL_CREATIVE_DELAY = create(key("players_nether_portal_creative_delay"));
+
+    /**
+     * {@code minecraft:players_nether_portal_default_delay}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> PLAYERS_NETHER_PORTAL_DEFAULT_DELAY = create(key("players_nether_portal_default_delay"));
+
+    /**
+     * {@code minecraft:players_sleeping_percentage}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> PLAYERS_SLEEPING_PERCENTAGE = create(key("players_sleeping_percentage"));
+
+    /**
+     * {@code minecraft:projectiles_can_break_blocks}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> PROJECTILES_CAN_BREAK_BLOCKS = create(key("projectiles_can_break_blocks"));
+
+    /**
+     * {@code minecraft:pvp}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> PVP = create(key("pvp"));
+
+    /**
+     * {@code minecraft:raids}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> RAIDS = create(key("raids"));
+
+    /**
+     * {@code minecraft:random_tick_speed}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> RANDOM_TICK_SPEED = create(key("random_tick_speed"));
+
+    /**
+     * {@code minecraft:reduced_debug_info}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> REDUCED_DEBUG_INFO = create(key("reduced_debug_info"));
+
+    /**
+     * {@code minecraft:respawn_radius}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> RESPAWN_RADIUS = create(key("respawn_radius"));
+
+    /**
+     * {@code minecraft:send_command_feedback}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> SEND_COMMAND_FEEDBACK = create(key("send_command_feedback"));
+
+    /**
+     * {@code minecraft:show_advancement_messages}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> SHOW_ADVANCEMENT_MESSAGES = create(key("show_advancement_messages"));
+
+    /**
+     * {@code minecraft:show_death_messages}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> SHOW_DEATH_MESSAGES = create(key("show_death_messages"));
+
+    /**
+     * {@code minecraft:spawn_mobs}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> SPAWN_MOBS = create(key("spawn_mobs"));
+
+    /**
+     * {@code minecraft:spawn_monsters}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> SPAWN_MONSTERS = create(key("spawn_monsters"));
+
+    /**
+     * {@code minecraft:spawn_patrols}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> SPAWN_PATROLS = create(key("spawn_patrols"));
+
+    /**
+     * {@code minecraft:spawn_phantoms}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> SPAWN_PHANTOMS = create(key("spawn_phantoms"));
+
+    /**
+     * {@code minecraft:spawn_wandering_traders}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> SPAWN_WANDERING_TRADERS = create(key("spawn_wandering_traders"));
+
+    /**
+     * {@code minecraft:spawn_wardens}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> SPAWN_WARDENS = create(key("spawn_wardens"));
+
+    /**
+     * {@code minecraft:spawner_blocks_work}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> SPAWNER_BLOCKS_WORK = create(key("spawner_blocks_work"));
+
+    /**
+     * {@code minecraft:spectators_generate_chunks}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> SPECTATORS_GENERATE_CHUNKS = create(key("spectators_generate_chunks"));
+
+    /**
+     * {@code minecraft:spread_vines}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> SPREAD_VINES = create(key("spread_vines"));
+
+    /**
+     * {@code minecraft:tnt_explodes}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> TNT_EXPLODES = create(key("tnt_explodes"));
+
+    /**
+     * {@code minecraft:tnt_explosion_drop_decay}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> TNT_EXPLOSION_DROP_DECAY = create(key("tnt_explosion_drop_decay"));
+
+    /**
+     * {@code minecraft:universal_anger}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> UNIVERSAL_ANGER = create(key("universal_anger"));
+
+    /**
+     * {@code minecraft:water_source_conversion}
+     *
+     * @apiNote This field is version-dependant and may be removed in future Minecraft versions
+     */
+    public static final TypedKey<GameRule> WATER_SOURCE_CONVERSION = create(key("water_source_conversion"));
+
+    private GameRuleKeys() {
+    }
+
+    private static TypedKey<GameRule> create(final Key key) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/InternalAPIBridge.java
+++ b/paper-api/src/main/java/io/papermc/paper/InternalAPIBridge.java
@@ -7,6 +7,7 @@ import io.papermc.paper.world.damagesource.CombatEntry;
 import io.papermc.paper.world.damagesource.FallLocationType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.Services;
+import org.bukkit.GameRule;
 import org.bukkit.block.Biome;
 import org.bukkit.damage.DamageEffect;
 import org.bukkit.damage.DamageSource;
@@ -16,6 +17,7 @@ import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
@@ -97,5 +99,7 @@ public interface InternalAPIBridge {
     SkinParts.Mutable allSkinParts();
 
     Component defaultMannequinDescription();
+
+    <MODERN, LEGACY> GameRule<LEGACY> legacyGameRuleBridge(GameRule<MODERN> rule, @Nullable Function<LEGACY, MODERN> fromLegacyToModern, @Nullable Function<MODERN, LEGACY> toLegacyFromModern, Class<LEGACY> legacyClass);
 }
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/RegistryKey.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/RegistryKey.java
@@ -9,6 +9,7 @@ import net.kyori.adventure.key.Keyed;
 import org.bukkit.Art;
 import org.bukkit.Fluid;
 import org.bukkit.GameEvent;
+import org.bukkit.GameRule;
 import org.bukkit.JukeboxSong;
 import org.bukkit.MusicInstrument;
 import org.bukkit.Particle;
@@ -127,6 +128,7 @@ public sealed interface RegistryKey<T> extends Keyed permits RegistryKeyImpl {
     RegistryKey<DataComponentType> DATA_COMPONENT_TYPE = create("data_component_type");
 
 
+    RegistryKey<GameRule<?>> GAME_RULE = create("game_rule");
 
     /* ********************** *
      * Data-driven Registries *

--- a/paper-api/src/main/java/org/bukkit/GameRule.java
+++ b/paper-api/src/main/java/org/bukkit/GameRule.java
@@ -150,121 +150,121 @@ public abstract class GameRule<T> implements net.kyori.adventure.translation.Tra
     /**
      * Toggles the announcing of advancements.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> ANNOUNCE_ADVANCEMENTS = InternalAPIBridge.get().legacyGameRuleBridge(SHOW_ADVANCEMENT_MESSAGES, null, null, Boolean.class);
 
     /**
      * Whether the server should skip checking player speed.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DISABLE_PLAYER_MOVEMENT_CHECK = InternalAPIBridge.get().legacyGameRuleBridge(PLAYER_MOVEMENT_CHECK, inverseBool(),  inverseBool(), Boolean.class);
 
     /**
      * Whether the server should skip checking player speed when the player is
      * wearing elytra.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DISABLE_ELYTRA_MOVEMENT_CHECK = InternalAPIBridge.get().legacyGameRuleBridge(ELYTRA_MOVEMENT_CHECK, inverseBool(),  inverseBool(), Boolean.class);
 
     /**
      * Whether time progresses from the current moment.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_DAYLIGHT_CYCLE = InternalAPIBridge.get().legacyGameRuleBridge(ADVANCE_TIME, null, null, Boolean.class);
 
     /**
      * Whether entities that are not mobs should have drops.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_ENTITY_DROPS = InternalAPIBridge.get().legacyGameRuleBridge(ENTITY_DROPS, null, null, Boolean.class);
 
     /**
      * Whether fire should spread and naturally extinguish.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_FIRE_TICK = InternalAPIBridge.get().legacyGameRuleBridge(FIRE_SPREAD_RADIUS_AROUND_PLAYER, (value) -> value ? 128 : 0, (value) -> value != 0, Boolean.class);
 
     /**
      * Whether players should only be able to craft recipes they've unlocked
      * first.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_LIMITED_CRAFTING = InternalAPIBridge.get().legacyGameRuleBridge(LIMITED_CRAFTING, null, null, Boolean.class);
 
     /**
      * Whether mobs should drop items.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_MOB_LOOT = InternalAPIBridge.get().legacyGameRuleBridge(MOB_DROPS, null, null, Boolean.class);
 
     /**
      * Whether mobs should naturally spawn.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_MOB_SPAWNING = InternalAPIBridge.get().legacyGameRuleBridge(SPAWN_MOBS, null, null, Boolean.class);
 
     /**
      * Whether blocks should have drops.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_TILE_DROPS = InternalAPIBridge.get().legacyGameRuleBridge(BLOCK_DROPS, null, null, Boolean.class);
 
     /**
      * Whether the weather will change from the current moment.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_WEATHER_CYCLE = InternalAPIBridge.get().legacyGameRuleBridge(ADVANCE_WEATHER, null, null, Boolean.class);
 
     /**
      * Whether players can regenerate health naturally through their hunger bar.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> NATURAL_REGENERATION = InternalAPIBridge.get().legacyGameRuleBridge(NATURAL_HEALTH_REGENERATION, null, null, Boolean.class);
 
     /**
      * Whether pillager raids are enabled or not.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DISABLE_RAIDS = InternalAPIBridge.get().legacyGameRuleBridge(RAIDS, inverseBool(), inverseBool(), Boolean.class);
 
     /**
      * Whether phantoms will appear without sleeping or not.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_INSOMNIA = InternalAPIBridge.get().legacyGameRuleBridge(SPAWN_PHANTOMS, null, null, Boolean.class);
 
     /**
      * Whether clients will respawn immediately after death or not.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_IMMEDIATE_RESPAWN = InternalAPIBridge.get().legacyGameRuleBridge(IMMEDIATE_RESPAWN, null, null, Boolean.class);
 
     /**
      * Whether patrols should naturally spawn.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_PATROL_SPAWNING = InternalAPIBridge.get().legacyGameRuleBridge(SPAWN_PATROLS, null, null, Boolean.class);
 
     /**
      * Whether traders should naturally spawn.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_TRADER_SPAWNING = InternalAPIBridge.get().legacyGameRuleBridge(SPAWN_WANDERING_TRADERS, null, null, Boolean.class);
 
     /**
      * Whether wardens should naturally spawn.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_WARDEN_SPAWNING = InternalAPIBridge.get().legacyGameRuleBridge(SPAWN_WARDENS, null, null, Boolean.class);
     /**
      * Whether vines will spread.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> DO_VINES_SPREAD = InternalAPIBridge.get().legacyGameRuleBridge(SPREAD_VINES, null, null, Boolean.class);
     /**
      * Whether fire will still propagate far away from players (8 chunks).
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> ALLOW_FIRE_TICKS_AWAY_FROM_PLAYER = InternalAPIBridge.get().legacyGameRuleBridge(FIRE_SPREAD_RADIUS_AROUND_PLAYER, (value) -> value ? 128 : 0, (value) -> value != 0, Boolean.class);
 
     /**
@@ -272,7 +272,7 @@ public abstract class GameRule<T> implements net.kyori.adventure.translation.Tra
      * player will spawn in when first joining a server or when dying without a
      * spawnpoint.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Integer> SPAWN_RADIUS = InternalAPIBridge.get().legacyGameRuleBridge(RESPAWN_RADIUS, null, null, Integer.class);
 
     /**
@@ -282,23 +282,23 @@ public abstract class GameRule<T> implements net.kyori.adventure.translation.Tra
      * This is the maximum amount of command blocks that can be activated in a
      * single tick from a single chain.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Integer> MAX_COMMAND_CHAIN_LENGTH = InternalAPIBridge.get().legacyGameRuleBridge(MAX_COMMAND_SEQUENCE_LENGTH, null, null, Integer.class);
 
     /**
      * Determines the number of different commands/functions which execute
      * commands can fork into.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Integer> MAX_COMMAND_FORK_COUNT = InternalAPIBridge.get().legacyGameRuleBridge(MAX_COMMAND_FORKS, null, null, Integer.class);
 
     /**
      * Determines the maximum number of blocks which a command can modify.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Integer> COMMAND_MODIFICATION_BLOCK_LIMIT = InternalAPIBridge.get().legacyGameRuleBridge(MAX_BLOCK_MODIFICATIONS, null, null, Integer.class);
 
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Integer> SNOW_ACCUMULATION_HEIGHT = InternalAPIBridge.get().legacyGameRuleBridge(MAX_SNOW_ACCUMULATION_HEIGHT, null, null, Integer.class);
 
     /**
@@ -307,19 +307,19 @@ public abstract class GameRule<T> implements net.kyori.adventure.translation.Tra
      */
     @MinecraftExperimental(MinecraftExperimental.Requires.MINECART_IMPROVEMENTS) // Paper - add missing annotation
     @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Integer> MINECART_MAX_SPEED = InternalAPIBridge.get().legacyGameRuleBridge(MAX_MINECART_SPEED, null, null, Integer.class);
 
     /**
      * Whether command blocks are enabled.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> COMMAND_BLOCKS_ENABLED = InternalAPIBridge.get().legacyGameRuleBridge(COMMAND_BLOCKS_WORK, null, null, Boolean.class);
 
     /**
      * Whether spawner blocks are enabled.
      */
-    @Deprecated(forRemoval = true, since = "??")
+    @Deprecated(forRemoval = true, since = "1.21.11")
     public static final GameRule<Boolean> SPAWNER_BLOCKS_ENABLED = InternalAPIBridge.get().legacyGameRuleBridge(SPAWNER_BLOCKS_WORK, null, null, Boolean.class);
 
     private static UnaryOperator<Boolean> inverseBool() {

--- a/paper-api/src/main/java/org/bukkit/GameRule.java
+++ b/paper-api/src/main/java/org/bukkit/GameRule.java
@@ -1,9 +1,16 @@
 package org.bukkit;
 
 import com.google.common.base.Preconditions;
+import io.papermc.paper.InternalAPIBridge;
+import io.papermc.paper.registry.RegistryAccess;
+import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.world.flag.FeatureDependant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.UnaryOperator;
+
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -16,242 +23,257 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <T> type of rule (Boolean or Integer)
  */
-public final class GameRule<T> implements net.kyori.adventure.translation.Translatable, FeatureDependant {
+@ApiStatus.NonExtendable
+public abstract class GameRule<T> implements net.kyori.adventure.translation.Translatable, FeatureDependant, Keyed {
 
-    private static Map<String, GameRule<?>> gameRules = new HashMap<>();
+    // Start generate - GameRule
+    public static final GameRule<Boolean> ADVANCE_TIME = getByName("advance_time");
+
+    public static final GameRule<Boolean> ADVANCE_WEATHER = getByName("advance_weather");
+
+    public static final GameRule<Boolean> ALLOW_ENTERING_NETHER_USING_PORTALS = getByName("allow_entering_nether_using_portals");
+
+    public static final GameRule<Boolean> BLOCK_DROPS = getByName("block_drops");
+
+    public static final GameRule<Boolean> BLOCK_EXPLOSION_DROP_DECAY = getByName("block_explosion_drop_decay");
+
+    public static final GameRule<Boolean> COMMAND_BLOCK_OUTPUT = getByName("command_block_output");
+
+    public static final GameRule<Boolean> COMMAND_BLOCKS_WORK = getByName("command_blocks_work");
+
+    public static final GameRule<Boolean> DROWNING_DAMAGE = getByName("drowning_damage");
+
+    public static final GameRule<Boolean> ELYTRA_MOVEMENT_CHECK = getByName("elytra_movement_check");
+
+    public static final GameRule<Boolean> ENDER_PEARLS_VANISH_ON_DEATH = getByName("ender_pearls_vanish_on_death");
+
+    public static final GameRule<Boolean> ENTITY_DROPS = getByName("entity_drops");
+
+    public static final GameRule<Boolean> FALL_DAMAGE = getByName("fall_damage");
+
+    public static final GameRule<Boolean> FIRE_DAMAGE = getByName("fire_damage");
+
+    public static final GameRule<Integer> FIRE_SPREAD_RADIUS_AROUND_PLAYER = getByName("fire_spread_radius_around_player");
+
+    public static final GameRule<Boolean> FORGIVE_DEAD_PLAYERS = getByName("forgive_dead_players");
+
+    public static final GameRule<Boolean> FREEZE_DAMAGE = getByName("freeze_damage");
+
+    public static final GameRule<Boolean> GLOBAL_SOUND_EVENTS = getByName("global_sound_events");
+
+    public static final GameRule<Boolean> IMMEDIATE_RESPAWN = getByName("immediate_respawn");
+
+    public static final GameRule<Boolean> KEEP_INVENTORY = getByName("keep_inventory");
+
+    public static final GameRule<Boolean> LAVA_SOURCE_CONVERSION = getByName("lava_source_conversion");
+
+    public static final GameRule<Boolean> LIMITED_CRAFTING = getByName("limited_crafting");
+
+    public static final GameRule<Boolean> LOCATOR_BAR = getByName("locator_bar");
+
+    public static final GameRule<Boolean> LOG_ADMIN_COMMANDS = getByName("log_admin_commands");
+
+    public static final GameRule<Integer> MAX_BLOCK_MODIFICATIONS = getByName("max_block_modifications");
+
+    public static final GameRule<Integer> MAX_COMMAND_FORKS = getByName("max_command_forks");
+
+    public static final GameRule<Integer> MAX_COMMAND_SEQUENCE_LENGTH = getByName("max_command_sequence_length");
+
+    public static final GameRule<Integer> MAX_ENTITY_CRAMMING = getByName("max_entity_cramming");
+
+    public static final GameRule<Integer> MAX_MINECART_SPEED = getByName("max_minecart_speed");
+
+    public static final GameRule<Integer> MAX_SNOW_ACCUMULATION_HEIGHT = getByName("max_snow_accumulation_height");
+
+    public static final GameRule<Boolean> MOB_DROPS = getByName("mob_drops");
+
+    public static final GameRule<Boolean> MOB_EXPLOSION_DROP_DECAY = getByName("mob_explosion_drop_decay");
+
+    public static final GameRule<Boolean> MOB_GRIEFING = getByName("mob_griefing");
+
+    public static final GameRule<Boolean> NATURAL_HEALTH_REGENERATION = getByName("natural_health_regeneration");
+
+    public static final GameRule<Boolean> PLAYER_MOVEMENT_CHECK = getByName("player_movement_check");
+
+    public static final GameRule<Integer> PLAYERS_NETHER_PORTAL_CREATIVE_DELAY = getByName("players_nether_portal_creative_delay");
+
+    public static final GameRule<Integer> PLAYERS_NETHER_PORTAL_DEFAULT_DELAY = getByName("players_nether_portal_default_delay");
+
+    public static final GameRule<Integer> PLAYERS_SLEEPING_PERCENTAGE = getByName("players_sleeping_percentage");
+
+    public static final GameRule<Boolean> PROJECTILES_CAN_BREAK_BLOCKS = getByName("projectiles_can_break_blocks");
+
+    public static final GameRule<Boolean> PVP = getByName("pvp");
+
+    public static final GameRule<Boolean> RAIDS = getByName("raids");
+
+    public static final GameRule<Integer> RANDOM_TICK_SPEED = getByName("random_tick_speed");
+
+    public static final GameRule<Boolean> REDUCED_DEBUG_INFO = getByName("reduced_debug_info");
+
+    public static final GameRule<Integer> RESPAWN_RADIUS = getByName("respawn_radius");
+
+    public static final GameRule<Boolean> SEND_COMMAND_FEEDBACK = getByName("send_command_feedback");
+
+    public static final GameRule<Boolean> SHOW_ADVANCEMENT_MESSAGES = getByName("show_advancement_messages");
+
+    public static final GameRule<Boolean> SHOW_DEATH_MESSAGES = getByName("show_death_messages");
+
+    public static final GameRule<Boolean> SPAWN_MOBS = getByName("spawn_mobs");
+
+    public static final GameRule<Boolean> SPAWN_MONSTERS = getByName("spawn_monsters");
+
+    public static final GameRule<Boolean> SPAWN_PATROLS = getByName("spawn_patrols");
+
+    public static final GameRule<Boolean> SPAWN_PHANTOMS = getByName("spawn_phantoms");
+
+    public static final GameRule<Boolean> SPAWN_WANDERING_TRADERS = getByName("spawn_wandering_traders");
+
+    public static final GameRule<Boolean> SPAWN_WARDENS = getByName("spawn_wardens");
+
+    public static final GameRule<Boolean> SPAWNER_BLOCKS_WORK = getByName("spawner_blocks_work");
+
+    public static final GameRule<Boolean> SPECTATORS_GENERATE_CHUNKS = getByName("spectators_generate_chunks");
+
+    public static final GameRule<Boolean> SPREAD_VINES = getByName("spread_vines");
+
+    public static final GameRule<Boolean> TNT_EXPLODES = getByName("tnt_explodes");
+
+    public static final GameRule<Boolean> TNT_EXPLOSION_DROP_DECAY = getByName("tnt_explosion_drop_decay");
+
+    public static final GameRule<Boolean> UNIVERSAL_ANGER = getByName("universal_anger");
+
+    public static final GameRule<Boolean> WATER_SOURCE_CONVERSION = getByName("water_source_conversion");
+    // End generate - GameRule
+
     // Boolean rules
     /**
      * Toggles the announcing of advancements.
      */
-    public static final GameRule<Boolean> ANNOUNCE_ADVANCEMENTS = new GameRule<>("announceAdvancements", Boolean.class);
-
-    /**
-     * Whether command blocks should notify admins when they perform commands.
-     */
-    public static final GameRule<Boolean> COMMAND_BLOCK_OUTPUT = new GameRule<>("commandBlockOutput", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> ANNOUNCE_ADVANCEMENTS = InternalAPIBridge.get().legacyGameRuleBridge(SHOW_ADVANCEMENT_MESSAGES, null, null, Boolean.class);
 
     /**
      * Whether the server should skip checking player speed.
      */
-    public static final GameRule<Boolean> DISABLE_PLAYER_MOVEMENT_CHECK = new GameRule<>("disablePlayerMovementCheck", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DISABLE_PLAYER_MOVEMENT_CHECK = InternalAPIBridge.get().legacyGameRuleBridge(PLAYER_MOVEMENT_CHECK, inverseBool(),  inverseBool(), Boolean.class);
 
     /**
      * Whether the server should skip checking player speed when the player is
      * wearing elytra.
      */
-    public static final GameRule<Boolean> DISABLE_ELYTRA_MOVEMENT_CHECK = new GameRule<>("disableElytraMovementCheck", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DISABLE_ELYTRA_MOVEMENT_CHECK = InternalAPIBridge.get().legacyGameRuleBridge(ELYTRA_MOVEMENT_CHECK, inverseBool(),  inverseBool(), Boolean.class);
 
     /**
      * Whether time progresses from the current moment.
      */
-    public static final GameRule<Boolean> DO_DAYLIGHT_CYCLE = new GameRule<>("doDaylightCycle", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_DAYLIGHT_CYCLE = InternalAPIBridge.get().legacyGameRuleBridge(ADVANCE_TIME, null, null, Boolean.class);
 
     /**
      * Whether entities that are not mobs should have drops.
      */
-    public static final GameRule<Boolean> DO_ENTITY_DROPS = new GameRule<>("doEntityDrops", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_ENTITY_DROPS = InternalAPIBridge.get().legacyGameRuleBridge(ENTITY_DROPS, null, null, Boolean.class);
 
     /**
      * Whether fire should spread and naturally extinguish.
      */
-    public static final GameRule<Boolean> DO_FIRE_TICK = new GameRule<>("doFireTick", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_FIRE_TICK = InternalAPIBridge.get().legacyGameRuleBridge(FIRE_SPREAD_RADIUS_AROUND_PLAYER, (value) -> value ? 128 : 0, (value) -> value != 0, Boolean.class);
 
     /**
      * Whether players should only be able to craft recipes they've unlocked
      * first.
      */
-    public static final GameRule<Boolean> DO_LIMITED_CRAFTING = new GameRule<>("doLimitedCrafting", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_LIMITED_CRAFTING = InternalAPIBridge.get().legacyGameRuleBridge(LIMITED_CRAFTING, null, null, Boolean.class);
 
     /**
      * Whether mobs should drop items.
      */
-    public static final GameRule<Boolean> DO_MOB_LOOT = new GameRule<>("doMobLoot", Boolean.class);
-
-    /**
-     * Whether projectiles can break blocks.
-     */
-    public static final GameRule<Boolean> PROJECTILES_CAN_BREAK_BLOCKS = new GameRule<>("projectilesCanBreakBlocks", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_MOB_LOOT = InternalAPIBridge.get().legacyGameRuleBridge(MOB_DROPS, null, null, Boolean.class);
 
     /**
      * Whether mobs should naturally spawn.
      */
-    public static final GameRule<Boolean> DO_MOB_SPAWNING = new GameRule<>("doMobSpawning", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_MOB_SPAWNING = InternalAPIBridge.get().legacyGameRuleBridge(SPAWN_MOBS, null, null, Boolean.class);
 
     /**
      * Whether blocks should have drops.
      */
-    public static final GameRule<Boolean> DO_TILE_DROPS = new GameRule<>("doTileDrops", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_TILE_DROPS = InternalAPIBridge.get().legacyGameRuleBridge(BLOCK_DROPS, null, null, Boolean.class);
 
     /**
      * Whether the weather will change from the current moment.
      */
-    public static final GameRule<Boolean> DO_WEATHER_CYCLE = new GameRule<>("doWeatherCycle", Boolean.class);
-
-    /**
-     * Whether the player should keep items in their inventory after death.
-     */
-    public static final GameRule<Boolean> KEEP_INVENTORY = new GameRule<>("keepInventory", Boolean.class);
-
-    /**
-     * Whether to log admin commands to server log.
-     */
-    public static final GameRule<Boolean> LOG_ADMIN_COMMANDS = new GameRule<>("logAdminCommands", Boolean.class);
-
-    /**
-     * Whether mobs can pick up items or change blocks.
-     */
-    public static final GameRule<Boolean> MOB_GRIEFING = new GameRule<>("mobGriefing", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_WEATHER_CYCLE = InternalAPIBridge.get().legacyGameRuleBridge(ADVANCE_WEATHER, null, null, Boolean.class);
 
     /**
      * Whether players can regenerate health naturally through their hunger bar.
      */
-    public static final GameRule<Boolean> NATURAL_REGENERATION = new GameRule<>("naturalRegeneration", Boolean.class);
-
-    /**
-     * Whether the debug screen shows all or reduced information.
-     */
-    public static final GameRule<Boolean> REDUCED_DEBUG_INFO = new GameRule<>("reducedDebugInfo", Boolean.class);
-
-    /**
-     * Whether the feedback from commands executed by a player should show up in
-     * chat. Also affects the default behavior of whether command blocks store
-     * their output text.
-     */
-    public static final GameRule<Boolean> SEND_COMMAND_FEEDBACK = new GameRule<>("sendCommandFeedback", Boolean.class);
-
-    /**
-     * Whether a message appears in chat when a player dies.
-     */
-    public static final GameRule<Boolean> SHOW_DEATH_MESSAGES = new GameRule<>("showDeathMessages", Boolean.class);
-
-    /**
-     * Whether players in spectator mode can generate chunks.
-     */
-    public static final GameRule<Boolean> SPECTATORS_GENERATE_CHUNKS = new GameRule<>("spectatorsGenerateChunks", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> NATURAL_REGENERATION = InternalAPIBridge.get().legacyGameRuleBridge(NATURAL_HEALTH_REGENERATION, null, null, Boolean.class);
 
     /**
      * Whether pillager raids are enabled or not.
      */
-    public static final GameRule<Boolean> DISABLE_RAIDS = new GameRule<>("disableRaids", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DISABLE_RAIDS = InternalAPIBridge.get().legacyGameRuleBridge(RAIDS, inverseBool(), inverseBool(), Boolean.class);
 
     /**
      * Whether phantoms will appear without sleeping or not.
      */
-    public static final GameRule<Boolean> DO_INSOMNIA = new GameRule<>("doInsomnia", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_INSOMNIA = InternalAPIBridge.get().legacyGameRuleBridge(SPAWN_PHANTOMS, null, null, Boolean.class);
 
     /**
      * Whether clients will respawn immediately after death or not.
      */
-    public static final GameRule<Boolean> DO_IMMEDIATE_RESPAWN = new GameRule<>("doImmediateRespawn", Boolean.class);
-
-    /**
-     * Whether drowning damage is enabled or not.
-     */
-    public static final GameRule<Boolean> DROWNING_DAMAGE = new GameRule<>("drowningDamage", Boolean.class);
-
-    /**
-     * Whether fall damage is enabled or not.
-     */
-    public static final GameRule<Boolean> FALL_DAMAGE = new GameRule<>("fallDamage", Boolean.class);
-
-    /**
-     * Whether fire damage is enabled or not.
-     */
-    public static final GameRule<Boolean> FIRE_DAMAGE = new GameRule<>("fireDamage", Boolean.class);
-
-    /**
-     * Whether freeze damage is enabled or not.
-     */
-    public static final GameRule<Boolean> FREEZE_DAMAGE = new GameRule<>("freezeDamage", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_IMMEDIATE_RESPAWN = InternalAPIBridge.get().legacyGameRuleBridge(IMMEDIATE_RESPAWN, null, null, Boolean.class);
 
     /**
      * Whether patrols should naturally spawn.
      */
-    public static final GameRule<Boolean> DO_PATROL_SPAWNING = new GameRule<>("doPatrolSpawning", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_PATROL_SPAWNING = InternalAPIBridge.get().legacyGameRuleBridge(SPAWN_PATROLS, null, null, Boolean.class);
 
     /**
      * Whether traders should naturally spawn.
      */
-    public static final GameRule<Boolean> DO_TRADER_SPAWNING = new GameRule<>("doTraderSpawning", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_TRADER_SPAWNING = InternalAPIBridge.get().legacyGameRuleBridge(SPAWN_WANDERING_TRADERS, null, null, Boolean.class);
 
     /**
      * Whether wardens should naturally spawn.
      */
-    public static final GameRule<Boolean> DO_WARDEN_SPAWNING = new GameRule<>("doWardenSpawning", Boolean.class);
-
-    /**
-     * Whether mobs should cease being angry at a player once they die.
-     */
-    public static final GameRule<Boolean> FORGIVE_DEAD_PLAYERS = new GameRule<>("forgiveDeadPlayers", Boolean.class);
-
-    /**
-     * Whether mobs will target all player entities once angered.
-     */
-    public static final GameRule<Boolean> UNIVERSAL_ANGER = new GameRule<>("universalAnger", Boolean.class);
-    /**
-     * Whether block explosions will destroy dropped items.
-     */
-    public static final GameRule<Boolean> BLOCK_EXPLOSION_DROP_DECAY = new GameRule<>("blockExplosionDropDecay", Boolean.class);
-    /**
-     * * Whether mob explosions will destroy dropped items.
-     */
-    public static final GameRule<Boolean> MOB_EXPLOSION_DROP_DECAY = new GameRule<>("mobExplosionDropDecay", Boolean.class);
-    /**
-     * Whether tnt explosions will destroy dropped items.
-     */
-    public static final GameRule<Boolean> TNT_EXPLOSION_DROP_DECAY = new GameRule<>("tntExplosionDropDecay", Boolean.class);
-    /**
-     * Whether water blocks can convert into water source blocks.
-     */
-    public static final GameRule<Boolean> WATER_SOURCE_CONVERSION = new GameRule<>("waterSourceConversion", Boolean.class);
-    /**
-     * Whether lava blocks can convert into lava source blocks.
-     */
-    public static final GameRule<Boolean> LAVA_SOURCE_CONVERSION = new GameRule<>("lavaSourceConversion", Boolean.class);
-    /**
-     * Whether global level events such as ender dragon, wither, and completed
-     * end portal effects will propagate across the entire server.
-     */
-    public static final GameRule<Boolean> GLOBAL_SOUND_EVENTS = new GameRule<>("globalSoundEvents", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_WARDEN_SPAWNING = InternalAPIBridge.get().legacyGameRuleBridge(SPAWN_WARDENS, null, null, Boolean.class);
     /**
      * Whether vines will spread.
      */
-    public static final GameRule<Boolean> DO_VINES_SPREAD = new GameRule<>("doVinesSpread", Boolean.class);
-    /**
-     * Whether ender pearls will vanish on player death.
-     */
-    public static final GameRule<Boolean> ENDER_PEARLS_VANISH_ON_DEATH = new GameRule<>("enderPearlsVanishOnDeath", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> DO_VINES_SPREAD = InternalAPIBridge.get().legacyGameRuleBridge(SPREAD_VINES, null, null, Boolean.class);
     /**
      * Whether fire will still propagate far away from players (8 chunks).
      */
-    public static final GameRule<Boolean> ALLOW_FIRE_TICKS_AWAY_FROM_PLAYER = new GameRule<>("allowFireTicksAwayFromPlayer", Boolean.class);
-    /**
-     * Whether primed tnt explodes.
-     */
-    public static final GameRule<Boolean> TNT_EXPLODES = new GameRule<>("tntExplodes", Boolean.class);
-
-    // Numerical rules
-    /**
-     * How often a random block tick occurs (such as plant growth, leaf decay,
-     * etc.) per chunk section per game tick. 0 will disable random ticks,
-     * higher numbers will increase random ticks.
-     */
-    public static final GameRule<Integer> RANDOM_TICK_SPEED = new GameRule<>("randomTickSpeed", Integer.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> ALLOW_FIRE_TICKS_AWAY_FROM_PLAYER = InternalAPIBridge.get().legacyGameRuleBridge(FIRE_SPREAD_RADIUS_AROUND_PLAYER, (value) -> value ? 128 : 0, (value) -> value != 0, Boolean.class);
 
     /**
      * The number of blocks outward from the world spawn coordinates that a
      * player will spawn in when first joining a server or when dying without a
      * spawnpoint.
      */
-    public static final GameRule<Integer> SPAWN_RADIUS = new GameRule<>("spawnRadius", Integer.class);
-
-    /**
-     * The maximum number of other pushable entities a mob or player can push,
-     * before taking suffocation damage.
-     * <br>
-     * Setting to 0 disables this rule.
-     */
-    public static final GameRule<Integer> MAX_ENTITY_CRAMMING = new GameRule<>("maxEntityCramming", Integer.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Integer> SPAWN_RADIUS = InternalAPIBridge.get().legacyGameRuleBridge(RESPAWN_RADIUS, null, null, Integer.class);
 
     /**
      * Determines the number at which the chain of command blocks act as a
@@ -260,37 +282,24 @@ public final class GameRule<T> implements net.kyori.adventure.translation.Transl
      * This is the maximum amount of command blocks that can be activated in a
      * single tick from a single chain.
      */
-    public static final GameRule<Integer> MAX_COMMAND_CHAIN_LENGTH = new GameRule<>("maxCommandChainLength", Integer.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Integer> MAX_COMMAND_CHAIN_LENGTH = InternalAPIBridge.get().legacyGameRuleBridge(MAX_COMMAND_SEQUENCE_LENGTH, null, null, Integer.class);
 
     /**
      * Determines the number of different commands/functions which execute
      * commands can fork into.
      */
-    public static final GameRule<Integer> MAX_COMMAND_FORK_COUNT = new GameRule<>("maxCommandForkCount", Integer.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Integer> MAX_COMMAND_FORK_COUNT = InternalAPIBridge.get().legacyGameRuleBridge(MAX_COMMAND_FORKS, null, null, Integer.class);
 
     /**
      * Determines the maximum number of blocks which a command can modify.
      */
-    public static final GameRule<Integer> COMMAND_MODIFICATION_BLOCK_LIMIT = new GameRule<>("commandModificationBlockLimit", Integer.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Integer> COMMAND_MODIFICATION_BLOCK_LIMIT = InternalAPIBridge.get().legacyGameRuleBridge(MAX_BLOCK_MODIFICATIONS, null, null, Integer.class);
 
-    /**
-     * The percentage of online players which must be sleeping for the night to
-     * advance.
-     */
-    public static final GameRule<Integer> PLAYERS_SLEEPING_PERCENTAGE = new GameRule<>("playersSleepingPercentage", Integer.class);
-    public static final GameRule<Integer> SNOW_ACCUMULATION_HEIGHT = new GameRule<>("snowAccumulationHeight", Integer.class);
-
-    /**
-     * The amount of time a player must stand in a nether portal before the
-     * portal activates.
-     */
-    public static final GameRule<Integer> PLAYERS_NETHER_PORTAL_DEFAULT_DELAY = new GameRule<>("playersNetherPortalDefaultDelay", Integer.class);
-
-    /**
-     * The amount of time a player in creative mode must stand in a nether
-     * portal before the portal activates.
-     */
-    public static final GameRule<Integer> PLAYERS_NETHER_PORTAL_CREATIVE_DELAY = new GameRule<>("playersNetherPortalCreativeDelay", Integer.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Integer> SNOW_ACCUMULATION_HEIGHT = InternalAPIBridge.get().legacyGameRuleBridge(MAX_SNOW_ACCUMULATION_HEIGHT, null, null, Integer.class);
 
     /**
      * The maximum speed of minecarts (when the new movement algorithm is
@@ -298,49 +307,23 @@ public final class GameRule<T> implements net.kyori.adventure.translation.Transl
      */
     @MinecraftExperimental(MinecraftExperimental.Requires.MINECART_IMPROVEMENTS) // Paper - add missing annotation
     @org.jetbrains.annotations.ApiStatus.Experimental // Paper - add missing annotation
-    public static final GameRule<Integer> MINECART_MAX_SPEED = new GameRule<>("minecartMaxSpeed", Integer.class);
-
-    /**
-     * Configures if the world uses the locator bar.
-     */
-    public static final GameRule<Boolean> LOCATOR_BAR = new GameRule<>("locatorBar", Boolean.class);
-
-    /**
-     * Whether player versus player combat is allowed.
-     */
-    public static final GameRule<Boolean> PVP = new GameRule<>("pvp", Boolean.class);
-
-    /**
-     * Whether monsters should naturally spawn.
-     */
-    public static final GameRule<Boolean> SPAWN_MONSTERS = new GameRule<>("spawnMonsters", Boolean.class);
-
-    /**
-     * Whether players can enter the Nether using portals.
-     */
-    public static final GameRule<Boolean> ALLOW_ENTERING_NETHER_USING_PORTALS = new GameRule<>("allowEnteringNetherUsingPortals", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Integer> MINECART_MAX_SPEED = InternalAPIBridge.get().legacyGameRuleBridge(MAX_MINECART_SPEED, null, null, Integer.class);
 
     /**
      * Whether command blocks are enabled.
      */
-    public static final GameRule<Boolean> COMMAND_BLOCKS_ENABLED = new GameRule<>("commandBlocksEnabled", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> COMMAND_BLOCKS_ENABLED = InternalAPIBridge.get().legacyGameRuleBridge(COMMAND_BLOCKS_WORK, null, null, Boolean.class);
 
     /**
      * Whether spawner blocks are enabled.
      */
-    public static final GameRule<Boolean> SPAWNER_BLOCKS_ENABLED = new GameRule<>("spawnerBlocksEnabled", Boolean.class);
+    @Deprecated(forRemoval = true, since = "??")
+    public static final GameRule<Boolean> SPAWNER_BLOCKS_ENABLED = InternalAPIBridge.get().legacyGameRuleBridge(SPAWNER_BLOCKS_WORK, null, null, Boolean.class);
 
-    // All GameRules instantiated above this for organizational purposes
-    private final String name;
-    private final Class<T> type;
-
-    private GameRule(@NotNull String name, @NotNull Class<T> clazz) {
-        Preconditions.checkNotNull(name, "GameRule name cannot be null");
-        Preconditions.checkNotNull(clazz, "GameRule type cannot be null");
-        Preconditions.checkArgument(clazz == Boolean.class || clazz == Integer.class, "Must be of type Boolean or Integer. Found %s ", clazz.getName());
-        this.name = name;
-        this.type = clazz;
-        gameRules.put(name, this);
+    private static UnaryOperator<Boolean> inverseBool() {
+        return operand -> !operand;
     }
 
     /**
@@ -349,9 +332,7 @@ public final class GameRule<T> implements net.kyori.adventure.translation.Transl
      * @return the name of this GameRule
      */
     @NotNull
-    public String getName() {
-        return name;
-    }
+    public abstract String getName();
 
     /**
      * Get the type of this rule.
@@ -359,26 +340,7 @@ public final class GameRule<T> implements net.kyori.adventure.translation.Transl
      * @return the rule type; Integer or Boolean
      */
     @NotNull
-    public Class<T> getType() {
-        return type;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof GameRule)) {
-            return false;
-        }
-        GameRule<?> other = (GameRule<?>) obj;
-        return this.getName().equals(other.getName()) && this.getType() == other.getType();
-    }
-
-    @Override
-    public String toString() {
-        return "GameRule{" + "key=" + name + ", type=" + type + '}';
-    }
+    public abstract Class<T> getType();
 
     /**
      * Get a {@link GameRule} by its name.
@@ -388,9 +350,13 @@ public final class GameRule<T> implements net.kyori.adventure.translation.Transl
      * name
      */
     @Nullable
-    public static GameRule<?> getByName(@NotNull String rule) {
+    public static <T> GameRule<T> getByName(@NotNull String rule) {
         Preconditions.checkNotNull(rule, "Rule cannot be null");
-        return gameRules.get(rule);
+        try {
+            return (GameRule<T>) RegistryAccess.registryAccess().getRegistry(RegistryKey.GAME_RULE).getOrThrow(NamespacedKey.minecraft(rule));
+        } catch (IllegalArgumentException | NoSuchElementException e) {
+            return null;
+        }
     }
 
     /**
@@ -400,12 +366,12 @@ public final class GameRule<T> implements net.kyori.adventure.translation.Transl
      */
     @NotNull
     public static GameRule<?>[] values() {
-        return gameRules.values().toArray(new GameRule<?>[gameRules.size()]);
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.GAME_RULE)
+                .stream()
+                .toArray(GameRule[]::new);
     }
 
     @Override
-    public @NotNull String translationKey() {
-        return "gamerule." + this.name;
-    }
+    public abstract @NotNull String translationKey();
 
 }

--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -3788,7 +3788,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * @return String value of rule
      * @deprecated use {@link #getGameRuleValue(GameRule)} instead
      */
-    @Deprecated(since = "1.13")
+    @Deprecated(since = "???", forRemoval = true)
     @Contract("null -> null; !null -> !null")
     @Nullable
     public String getGameRuleValue(@Nullable String rule);
@@ -3806,7 +3806,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * @return True if rule was set
      * @deprecated use {@link #setGameRule(GameRule, Object)} instead.
      */
-    @Deprecated(since = "1.13")
+    @Deprecated(since = "1.13", forRemoval = true)
     public boolean setGameRuleValue(@NotNull String rule, @NotNull String value);
 
     /**

--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -3788,7 +3788,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * @return String value of rule
      * @deprecated use {@link #getGameRuleValue(GameRule)} instead
      */
-    @Deprecated(since = "???", forRemoval = true)
+    @Deprecated(since = "1.21.11", forRemoval = true)
     @Contract("null -> null; !null -> !null")
     @Nullable
     public String getGameRuleValue(@Nullable String rule);

--- a/paper-generator/src/main/java/io/papermc/generator/Rewriters.java
+++ b/paper-generator/src/main/java/io/papermc/generator/Rewriters.java
@@ -16,6 +16,7 @@ import io.papermc.generator.rewriter.types.simple.CraftBlockDataMapping;
 import io.papermc.generator.rewriter.types.simple.CraftBlockEntityStateMapping;
 import io.papermc.generator.rewriter.types.simple.CraftPotionUtilRewriter;
 import io.papermc.generator.rewriter.types.simple.EntityTypeRewriter;
+import io.papermc.generator.rewriter.types.simple.GameRuleTypeRewriter;
 import io.papermc.generator.rewriter.types.simple.MapPaletteRewriter;
 import io.papermc.generator.rewriter.types.simple.MaterialRewriter;
 import io.papermc.generator.rewriter.types.simple.MemoryKeyRewriter;
@@ -48,6 +49,7 @@ import org.bukkit.Art;
 import org.bukkit.FeatureFlag;
 import org.bukkit.Fluid;
 import org.bukkit.GameEvent;
+import org.bukkit.GameRule;
 import org.bukkit.JukeboxSong;
 import org.bukkit.Material;
 import org.bukkit.MusicInstrument;
@@ -212,6 +214,7 @@ public final class Rewriters {
             .register("PigVariant", Pig.Variant.class, new RegistryFieldRewriter<>(Registries.PIG_VARIANT, "getVariant"))
             .register("Dialog", Dialog.class, new RegistryFieldRewriter<>(Registries.DIALOG, "getDialog"))
             .register("MemoryKey", MemoryKey.class, new MemoryKeyRewriter())
+            .register("GameRule", GameRule.class, new GameRuleTypeRewriter())
             // .register("ItemType", org.bukkit.inventory.ItemType.class, new io.papermc.generator.rewriter.types.simple.ItemTypeRewriter()) - disable for now, lynx want the generic type
             .register("BlockType", BlockType.class, new BlockTypeRewriter())
             .register("FeatureFlag", FeatureFlag.class, new FeatureFlagRewriter())

--- a/paper-generator/src/main/java/io/papermc/generator/registry/RegistryEntries.java
+++ b/paper-generator/src/main/java/io/papermc/generator/registry/RegistryEntries.java
@@ -62,12 +62,14 @@ import net.minecraft.world.item.equipment.trim.TrimPatterns;
 import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BannerPatterns;
+import net.minecraft.world.level.gamerules.GameRules;
 import net.minecraft.world.level.levelgen.structure.BuiltinStructures;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.saveddata.maps.MapDecorationTypes;
 import org.bukkit.Art;
 import org.bukkit.Fluid;
 import org.bukkit.GameEvent;
+import org.bukkit.GameRule;
 import org.bukkit.JukeboxSong;
 import org.bukkit.Keyed;
 import org.bukkit.MusicInstrument;
@@ -164,7 +166,8 @@ public final class RegistryEntries {
         entry(Registries.ATTRIBUTE, Attributes.class, Attribute.class).serializationUpdater("ATTRIBUTE_RENAME"),
         entry(Registries.FLUID, Fluids.class, Fluid.class),
         entry(Registries.SOUND_EVENT, SoundEvents.class, Sound.class).allowDirect().apiRegistryField("SOUNDS").apiRegistryBuilder(SoundEventRegistryEntry.Builder.class, "PaperSoundEventRegistryEntry.PaperBuilder", RegistryEntry.RegistryModificationApiSupport.NONE),
-        entry(Registries.DATA_COMPONENT_TYPE, DataComponents.class, DataComponentType.class, "Paper").preload(DataComponentTypes.class).apiAccessName("of")
+        entry(Registries.DATA_COMPONENT_TYPE, DataComponents.class, DataComponentType.class, "Paper").preload(DataComponentTypes.class).apiAccessName("of"),
+        entry(Registries.GAME_RULE, GameRules.class, GameRule.class).preload(GameRule.class)
     );
 
     public static final List<RegistryEntry<?>> DATA_DRIVEN = List.of(

--- a/paper-generator/src/main/java/io/papermc/generator/registry/RegistryEntries.java
+++ b/paper-generator/src/main/java/io/papermc/generator/registry/RegistryEntries.java
@@ -167,7 +167,7 @@ public final class RegistryEntries {
         entry(Registries.FLUID, Fluids.class, Fluid.class),
         entry(Registries.SOUND_EVENT, SoundEvents.class, Sound.class).allowDirect().apiRegistryField("SOUNDS").apiRegistryBuilder(SoundEventRegistryEntry.Builder.class, "PaperSoundEventRegistryEntry.PaperBuilder", RegistryEntry.RegistryModificationApiSupport.NONE),
         entry(Registries.DATA_COMPONENT_TYPE, DataComponents.class, DataComponentType.class, "Paper").preload(DataComponentTypes.class).apiAccessName("of"),
-        entry(Registries.GAME_RULE, GameRules.class, GameRule.class).preload(GameRule.class)
+        entry(Registries.GAME_RULE, GameRules.class, GameRule.class)
     );
 
     public static final List<RegistryEntry<?>> DATA_DRIVEN = List.of(

--- a/paper-generator/src/main/java/io/papermc/generator/rewriter/types/simple/GameRuleTypeRewriter.java
+++ b/paper-generator/src/main/java/io/papermc/generator/rewriter/types/simple/GameRuleTypeRewriter.java
@@ -1,0 +1,18 @@
+package io.papermc.generator.rewriter.types.simple;
+
+import io.papermc.generator.rewriter.types.registry.RegistryFieldRewriter;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.level.gamerules.GameRule;
+
+public class GameRuleTypeRewriter extends RegistryFieldRewriter<GameRule<?>> {
+
+    public GameRuleTypeRewriter() {
+        super(Registries.GAME_RULE, "getByName");
+    }
+
+    @Override
+    protected String rewriteFieldType(Holder.Reference<GameRule<?>> reference) {
+        return "%s<%s>".formatted(this.registryEntry.apiClass().getSimpleName(), this.importCollector.getShortName(reference.value().valueClass()));
+    }
+}

--- a/paper-server/patches/sources/net/minecraft/server/commands/GameRuleCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/GameRuleCommand.java.patch
@@ -6,7 +6,7 @@
          CommandSourceStack commandSourceStack = context.getSource();
 -        T argument = context.getArgument("value", rule.valueClass());
 -        commandSourceStack.getLevel().getGameRules().set(rule, argument, context.getSource().getServer());
-+        T argument = org.bukkit.craftbukkit.event.CraftEventFactory.handleGameRuleSet(rule, context.getArgument("value", rule.valueClass()), commandSourceStack.getLevel(), context.getSource().getBukkitSender(), null); // Paper - per-world game rules and event
++        T argument = org.bukkit.craftbukkit.event.CraftEventFactory.handleGameRuleSet(rule, context.getArgument("value", rule.valueClass()), commandSourceStack.getLevel(), context.getSource().getBukkitSender()).value(); // Paper - per-world game rules and event
          commandSourceStack.sendSuccess(() -> Component.translatable("commands.gamerule.set", rule.id(), rule.serialize(argument)), true);
          return rule.getCommandResult(argument);
      }

--- a/paper-server/patches/sources/net/minecraft/server/commands/GameRuleCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/GameRuleCommand.java.patch
@@ -1,22 +1,12 @@
 --- a/net/minecraft/server/commands/GameRuleCommand.java
 +++ b/net/minecraft/server/commands/GameRuleCommand.java
-@@ -34,7 +_,18 @@
+@@ -33,8 +_,7 @@
+ 
      static <T> int setRule(CommandContext<CommandSourceStack> context, GameRule<T> rule) {
          CommandSourceStack commandSourceStack = context.getSource();
-         T argument = context.getArgument("value", rule.valueClass());
+-        T argument = context.getArgument("value", rule.valueClass());
 -        commandSourceStack.getLevel().getGameRules().set(rule, argument, context.getSource().getServer());
-+        // Paper start - Add WorldGameRuleChangeEvent
-+        final var event = new io.papermc.paper.event.world.WorldGameRuleChangeEvent(
-+            context.getSource().getBukkitWorld(),
-+            context.getSource().getBukkitSender(),
-+            org.bukkit.GameRule.getByName(gameRuleKey.toString()),
-+            String.valueOf(argument)
-+        );
-+        if (!event.callEvent()) {
-+            return 0;
-+        }
-+        // Paper end - Add WorldGameRuleChangeEvent
-+        commandSourceStack.getLevel().getGameRules().set(rule, argument, context.getSource().getLevel()); // Paper - per-world game rules
++        T argument = org.bukkit.craftbukkit.event.CraftEventFactory.handleGameRuleSet(rule, context.getArgument("value", rule.valueClass()), commandSourceStack.getLevel(), context.getSource().getBukkitSender(), null); // Paper - per-world game rules and event
          commandSourceStack.sendSuccess(() -> Component.translatable("commands.gamerule.set", rule.id(), rule.serialize(argument)), true);
          return rule.getCommandResult(argument);
      }

--- a/paper-server/src/main/java/io/papermc/paper/PaperServerInternalAPIBridge.java
+++ b/paper-server/src/main/java/io/papermc/paper/PaperServerInternalAPIBridge.java
@@ -15,7 +15,9 @@ import net.minecraft.Optionull;
 import net.minecraft.commands.Commands;
 import net.minecraft.world.damagesource.FallLocation;
 import net.minecraft.world.entity.decoration.Mannequin;
+import org.bukkit.GameRule;
 import org.bukkit.block.Biome;
+import org.bukkit.craftbukkit.CraftGameRule;
 import org.bukkit.craftbukkit.block.CraftBiome;
 import org.bukkit.craftbukkit.damage.CraftDamageEffect;
 import org.bukkit.craftbukkit.damage.CraftDamageSource;
@@ -25,6 +27,8 @@ import org.bukkit.damage.DamageSource;
 import org.bukkit.entity.LivingEntity;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 @NullMarked
@@ -107,5 +111,10 @@ public class PaperServerInternalAPIBridge implements InternalAPIBridge {
     @Override
     public Component defaultMannequinDescription() {
         return PaperAdventure.asAdventure(Mannequin.DEFAULT_DESCRIPTION);
+    }
+
+    @Override
+    public <MODERN, LEGACY> GameRule<LEGACY> legacyGameRuleBridge(GameRule<MODERN> rule, @Nullable Function<LEGACY, MODERN> fromLegacyToModern, @Nullable Function<MODERN, LEGACY> toLegacyFromModern, Class<LEGACY> legacyClass) {
+        return CraftGameRule.wrap(rule, fromLegacyToModern, toLegacyFromModern, legacyClass);
     }
 }

--- a/paper-server/src/main/java/io/papermc/paper/registry/PaperRegistries.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/PaperRegistries.java
@@ -35,6 +35,7 @@ import net.minecraft.resources.ResourceKey;
 import org.bukkit.Art;
 import org.bukkit.Fluid;
 import org.bukkit.GameEvent;
+import org.bukkit.GameRule;
 import org.bukkit.JukeboxSong;
 import org.bukkit.Keyed;
 import org.bukkit.MusicInstrument;
@@ -46,6 +47,7 @@ import org.bukkit.block.banner.PatternType;
 import org.bukkit.craftbukkit.CraftArt;
 import org.bukkit.craftbukkit.CraftFluid;
 import org.bukkit.craftbukkit.CraftGameEvent;
+import org.bukkit.craftbukkit.CraftGameRule;
 import org.bukkit.craftbukkit.CraftJukeboxSong;
 import org.bukkit.craftbukkit.CraftMusicInstrument;
 import org.bukkit.craftbukkit.CraftSound;
@@ -115,6 +117,7 @@ public final class PaperRegistries {
             start(Registries.FLUID, RegistryKey.FLUID).craft(Fluid.class, CraftFluid::new).build(),
             start(Registries.SOUND_EVENT, RegistryKey.SOUND_EVENT).craft(Sound.class, CraftSound::new, true).create(PaperSoundEventRegistryEntry.PaperBuilder::new, RegistryEntryMeta.RegistryModificationApiSupport.NONE),
             start(Registries.DATA_COMPONENT_TYPE, RegistryKey.DATA_COMPONENT_TYPE).craft(DataComponentTypes.class, PaperDataComponentType::of).build(),
+            start(Registries.GAME_RULE, RegistryKey.GAME_RULE).craft(GameRule.class, CraftGameRule::new).build(),
 
             // data-driven
             start(Registries.BIOME, RegistryKey.BIOME).craft(Biome.class, CraftBiome::new).build().delayed(),

--- a/paper-server/src/main/java/io/papermc/paper/registry/entry/RegistryTypeMapper.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/entry/RegistryTypeMapper.java
@@ -6,6 +6,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import net.minecraft.core.Holder;
 import org.bukkit.NamespacedKey;
+import org.bukkit.craftbukkit.util.CraftNamespacedKey;
 
 public final class RegistryTypeMapper<M, A> {
 
@@ -14,7 +15,7 @@ public final class RegistryTypeMapper<M, A> {
             if (!(holder instanceof final Holder.Reference<M> reference)) {
                 throw new IllegalArgumentException("This type does not support direct holders: " + holder);
             }
-            return byValueCreator.apply(MCUtil.fromResourceKey(reference.key()), reference.value());
+            return byValueCreator.apply(CraftNamespacedKey.fromResourceKey(reference.key()), reference.value());
         };
     }
 

--- a/paper-server/src/main/java/io/papermc/paper/util/Holderable.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/Holderable.java
@@ -12,6 +12,7 @@ import net.minecraft.resources.RegistryOps;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.craftbukkit.CraftRegistry;
+import org.bukkit.craftbukkit.util.CraftNamespacedKey;
 import org.bukkit.craftbukkit.util.Handleable;
 import org.intellij.lang.annotations.Subst;
 import org.jspecify.annotations.NullMarked;
@@ -80,10 +81,10 @@ public interface Holderable<M> extends Handleable<M> {
     }
 
     default @Nullable NamespacedKey getKeyOrNull() {
-        return this.getHolder().unwrapKey().map(MCUtil::fromResourceKey).orElse(null);
+        return this.getHolder().unwrapKey().map(CraftNamespacedKey::fromResourceKey).orElse(null);
     }
 
     default NamespacedKey getKey() {
-        return MCUtil.fromResourceKey(this.getHolder().unwrapKey().orElseThrow(() -> new IllegalStateException("Cannot get key for this registry item, because it is not registered.")));
+        return CraftNamespacedKey.fromResourceKey(this.getHolder().unwrapKey().orElseThrow(() -> new IllegalStateException("Cannot get key for this registry item, because it is not registered.")));
     }
 }

--- a/paper-server/src/main/java/io/papermc/paper/util/MCUtil.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/MCUtil.java
@@ -199,17 +199,6 @@ public final class MCUtil {
         ASYNC_EXECUTOR.execute(run);
     }
 
-    public static <T> ResourceKey<T> toResourceKey(
-        final ResourceKey<? extends net.minecraft.core.Registry<T>> registry,
-        final NamespacedKey namespacedKey
-    ) {
-        return ResourceKey.create(registry, CraftNamespacedKey.toMinecraft(namespacedKey));
-    }
-
-    public static NamespacedKey fromResourceKey(final ResourceKey<?> key) {
-        return CraftNamespacedKey.fromMinecraft(key.location());
-    }
-
     public static <A, M> List<A> transformUnmodifiable(final List<? extends M> nms, final Function<? super M, ? extends A> converter) {
         return Collections.unmodifiableList(Lists.transform(nms, converter::apply));
     }

--- a/paper-server/src/main/java/io/papermc/paper/world/flag/PaperFeatureFlagProviderImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/flag/PaperFeatureFlagProviderImpl.java
@@ -12,6 +12,7 @@ import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.level.gamerules.GameRules;
 import org.bukkit.FeatureFlag;
 import org.bukkit.GameRule;
+import org.bukkit.craftbukkit.CraftGameRule;
 import org.bukkit.craftbukkit.entity.CraftEntityType;
 import org.bukkit.craftbukkit.potion.CraftPotionType;
 import org.bukkit.entity.EntityType;
@@ -51,18 +52,10 @@ public class PaperFeatureFlagProviderImpl implements FeatureFlagProvider {
         } else if (dependant instanceof final PotionType potionType) {
             return CraftPotionType.bukkitToMinecraft(potionType);
         } else if (dependant instanceof final GameRule<?> gameRule) {
-            return getGameRuleType(gameRule.getName()).asFeatureElement();
+            return () -> CraftGameRule.bukkitToMinecraft(gameRule).requiredFeatures();
         } else {
             throw new IllegalArgumentException(dependant + " is not a valid feature dependant");
         }
     }
 
-    private static GameRules.Type<?> getGameRuleType(final String name) {
-        for (final Map.Entry<GameRules.Key<?>, GameRules.Type<?>> gameRules : GameRules.GAME_RULE_TYPES.entrySet()) {
-            if (gameRules.getKey().getId().equals(name)) {
-                return gameRules.getValue();
-            }
-        }
-        return null;
-    }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftGameRule.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftGameRule.java
@@ -3,15 +3,14 @@ package org.bukkit.craftbukkit;
 import io.papermc.paper.util.Holderable;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.world.item.Instrument;
 import org.bukkit.GameRule;
-import org.bukkit.MusicInstrument;
 import org.bukkit.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.function.Function;
+
 @NullMarked
 public class CraftGameRule<T> extends GameRule<T> implements Holderable<net.minecraft.world.level.gamerules.GameRule<T>> {
 
@@ -82,7 +81,7 @@ public class CraftGameRule<T> extends GameRule<T> implements Holderable<net.mine
         return this.holder.value().id();
     }
 
-    public static class LegacyGameRuleWrapper<LEGACY, MODERN> extends CraftGameRule<LEGACY>  {
+    public static class LegacyGameRuleWrapper<LEGACY, MODERN> extends CraftGameRule<LEGACY> {
 
         private final Class<LEGACY> typeOverride;
         private final @Nullable Function<LEGACY, MODERN> fromLegacyToModern;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftGameRule.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftGameRule.java
@@ -1,0 +1,112 @@
+package org.bukkit.craftbukkit;
+
+import io.papermc.paper.util.Holderable;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.item.Instrument;
+import org.bukkit.GameRule;
+import org.bukkit.MusicInstrument;
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Function;
+@NullMarked
+public class CraftGameRule<T> extends GameRule<T> implements Holderable<net.minecraft.world.level.gamerules.GameRule<T>> {
+
+    public static GameRule<?> minecraftToBukkit(net.minecraft.world.level.gamerules.GameRule minecraft) {
+        return CraftRegistry.minecraftToBukkit(minecraft, Registries.GAME_RULE);
+    }
+
+    public static <T> net.minecraft.world.level.gamerules.GameRule<T> bukkitToMinecraft(GameRule<T> bukkit) {
+        return CraftRegistry.bukkitToMinecraft(bukkit);
+    }
+
+    public static Holder<net.minecraft.world.level.gamerules.GameRule<?>> bukkitToMinecraftHolder(GameRule<?> bukkit) {
+        return CraftRegistry.bukkitToMinecraftHolder(bukkit);
+    }
+
+    private final Holder<net.minecraft.world.level.gamerules.GameRule<T>> holder;
+
+    @SuppressWarnings("unchecked")
+    public CraftGameRule(Holder<net.minecraft.world.level.gamerules.GameRule<?>> holder) {
+        this.holder = (Holder) holder;
+    }
+
+    public static <LEGACY, MODERN> GameRule<LEGACY> wrap(GameRule<MODERN> rule, @Nullable Function<LEGACY, MODERN> fromLegacyToModern, @Nullable Function<MODERN, LEGACY> toLegacyFromModern, Class<LEGACY> legacyClass) {
+        return new LegacyGameRuleWrapper<>(bukkitToMinecraftHolder(rule), fromLegacyToModern, toLegacyFromModern, legacyClass);
+    }
+
+    @Override
+    public Holder<net.minecraft.world.level.gamerules.GameRule<T>> getHolder() {
+        return this.holder;
+    }
+
+    @Override
+    public NamespacedKey getKey() {
+        return Holderable.super.getKey();
+    }
+
+    @Override
+    public int hashCode() {
+        return Holderable.super.implHashCode();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return Holderable.super.implEquals(obj);
+    }
+
+    @Override
+    public String toString() {
+        return Holderable.super.implToString();
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return this.holder.getRegisteredName();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public @NotNull Class<T> getType() {
+        return (Class<T>) switch (this.holder.value().gameRuleType()) {
+            case INT -> Integer.class;
+            case BOOL -> Boolean.class;
+        };
+    }
+
+    @Override
+    public @NotNull String translationKey() {
+        return this.holder.value().id();
+    }
+
+    public static class LegacyGameRuleWrapper<LEGACY, MODERN> extends CraftGameRule<LEGACY>  {
+
+        private final Class<LEGACY> typeOverride;
+        private final @Nullable Function<LEGACY, MODERN> fromLegacyToModern;
+        private final @Nullable Function<MODERN, LEGACY> toLegacyFromModern;
+
+        public LegacyGameRuleWrapper(Holder<net.minecraft.world.level.gamerules.GameRule<?>> holder, @Nullable Function<LEGACY, MODERN> fromLegacyToModern, @Nullable Function<MODERN, LEGACY> toLegacyFromModern, Class<LEGACY> typeOverride) {
+            super(holder);
+            this.fromLegacyToModern = fromLegacyToModern;
+            this.toLegacyFromModern = toLegacyFromModern;
+            this.typeOverride = typeOverride;
+        }
+
+
+        public @Nullable Function<LEGACY, MODERN> getFromLegacyToModern() {
+            return fromLegacyToModern;
+        }
+
+        public @Nullable Function<MODERN, LEGACY> getToLegacyFromModern() {
+            return toLegacyFromModern;
+        }
+
+        @Override
+        public @NotNull Class<LEGACY> getType() {
+            return this.typeOverride;
+        }
+    }
+}

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
@@ -84,7 +84,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
                 }
                 yield ((CraftRegistry<B, M>) bukkitRegistry).createBukkit(direct);
             }
-            case final Holder.Reference<M> reference -> bukkitRegistry.get(MCUtil.fromResourceKey(reference.key()));
+            case final Holder.Reference<M> reference -> bukkitRegistry.get(CraftNamespacedKey.fromResourceKey(reference.key()));
             default -> throw new IllegalArgumentException("Unknown holder: " + minecraft);
         };
         Preconditions.checkArgument(bukkit != null);
@@ -196,7 +196,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
         }
 
         // Important to use the ResourceKey<?> "get" method below because it will work before registry is frozen
-        final Optional<Holder.Reference<M>> holderOptional = this.minecraftRegistry.get(MCUtil.toResourceKey(this.minecraftRegistry.key(), namespacedKey));
+        final Optional<Holder.Reference<M>> holderOptional = this.minecraftRegistry.get(CraftNamespacedKey.toResourceKey(this.minecraftRegistry.key(), namespacedKey));
         final Holder.Reference<M> holder;
         if (holderOptional.isPresent()) {
             holder = holderOptional.get();
@@ -204,7 +204,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
             // we lock the reference holders after the preload class has been initialized
             // this is to support the vanilla mechanic of preventing vanilla registry entries being loaded. We need
             // to create something to fill the API constant fields, so we create a dummy reference holder.
-            holder = Holder.Reference.createStandAlone(this.invalidHolderOwner, MCUtil.toResourceKey(this.minecraftRegistry.key(), namespacedKey));
+            holder = Holder.Reference.createStandAlone(this.invalidHolderOwner, CraftNamespacedKey.toResourceKey(this.minecraftRegistry.key(), namespacedKey));
         } else {
             return null;
         }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -26,6 +26,7 @@ import java.util.PrimitiveIterator;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -67,6 +68,7 @@ import net.minecraft.world.entity.raid.Raids;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Explosion;
+import net.minecraft.world.level.gamerules.GameRule;
 import net.minecraft.world.level.gamerules.GameRules;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Climate;
@@ -88,7 +90,6 @@ import org.bukkit.ChunkSnapshot;
 import org.bukkit.Difficulty;
 import org.bukkit.Effect;
 import org.bukkit.FluidCollisionMode;
-import org.bukkit.GameRule;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
@@ -110,6 +111,7 @@ import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.boss.CraftDragonBattle;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.craftbukkit.generator.structure.CraftGeneratedStructure;
 import org.bukkit.craftbukkit.generator.structure.CraftStructure;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
@@ -1647,54 +1649,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
     }
     // Paper end - Adventure
 
-    private Map<String, GameRules.Key<?>> gamerules;
-    public synchronized Map<String, GameRules.Key<?>> getGameRulesNMS() {
-        if (this.gamerules != null) {
-            return this.gamerules;
-        }
-
-        return this.gamerules = CraftWorld.getGameRulesNMS(this.getHandle().getGameRules());
-    }
-
-    public static Map<String, GameRules.Key<?>> getGameRulesNMS(GameRules gameRules) {
-        Map<String, GameRules.Key<?>> gamerules = new HashMap<>();
-        gameRules.visitGameRuleTypes(new GameRules.GameRuleTypeVisitor() {
-            @Override
-            public <T extends GameRules.Value<T>> void visit(GameRules.Key<T> key, GameRules.Type<T> type) {
-                gamerules.put(key.getId(), key);
-            }
-        });
-        return gamerules;
-    }
-
-    private Map<String, GameRules.Type<?>> gameruleDefinitions;
-    public synchronized Map<String, GameRules.Type<?>> getGameRuleDefinitions() {
-        if (this.gameruleDefinitions != null) {
-            return this.gameruleDefinitions;
-        }
-
-        Map<String, GameRules.Type<?>> gameruleDefinitions = new HashMap<>();
-        this.getHandle().getGameRules().visitGameRuleTypes(new GameRules.GameRuleTypeVisitor() {
-            @Override
-            public <T extends GameRules.Value<T>> void visit(GameRules.Key<T> key, GameRules.Type<T> type) {
-                gameruleDefinitions.put(key.getId(), type);
-            }
-        });
-
-        return this.gameruleDefinitions = gameruleDefinitions;
-    }
-
     @Override
     public String getGameRuleValue(String rule) {
         // In method contract for some reason
         if (rule == null) {
             return null;
         }
+        GameRule<?> nms = CraftGameRule.bukkitToMinecraft(org.bukkit.GameRule.getByName(rule));
+        GameRules gameRules = this.getHandle().getGameRules();
+        if (!gameRules.rules.has(nms)) {
+            return "";
+        }
 
-        GameRules.Value<?> value = this.getHandle().getGameRules().getRule(this.getGameRulesNMS().get(rule));
-        return value != null ? value.toString() : "";
+        return gameRules.getAsString(nms);
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public boolean setGameRuleValue(String rule, String value) {
         // No null values allowed
@@ -1702,76 +1672,75 @@ public class CraftWorld extends CraftRegionAccessor implements World {
 
         if (!this.isGameRule(rule)) return false;
         // Paper start - Add WorldGameRuleChangeEvent
-        GameRule<?> gameRule = GameRule.getByName(rule);
-        io.papermc.paper.event.world.WorldGameRuleChangeEvent event = new io.papermc.paper.event.world.WorldGameRuleChangeEvent(this, null, gameRule, value);
-        if (!event.callEvent()) return false;
-        // Paper end - Add WorldGameRuleChangeEvent
+        org.bukkit.GameRule<?> bukkit = org.bukkit.GameRule.getByName(rule);
 
-        GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(this.getGameRulesNMS().get(rule));
-        handle.deserialize(event.getValue()); // Paper - Add WorldGameRuleChangeEvent
-        handle.onChanged(this.getHandle());
-        return true;
+        GameRule nms = CraftGameRule.bukkitToMinecraft(bukkit);
+
+        AtomicBoolean cancelled = new AtomicBoolean();
+        CraftEventFactory.handleGameRuleSet(nms, value, this.getHandle(), null, cancelled);
+
+        return !cancelled.get();
     }
 
     @Override
     public String[] getGameRules() {
-        return this.getGameRulesNMS().keySet().toArray(new String[this.getGameRulesNMS().size()]);
+        return this.getHandle().getGameRules().availableRules()
+                .map(GameRule::id)
+                .toArray(String[]::new);
     }
 
     @Override
     public boolean isGameRule(String rule) {
         Preconditions.checkArgument(rule != null, "String rule cannot be null");
         Preconditions.checkArgument(!rule.isEmpty(), "String rule cannot be empty");
-        return this.getGameRulesNMS().containsKey(rule);
+
+        GameRule<?> nms = CraftGameRule.bukkitToMinecraft(org.bukkit.GameRule.getByName(rule));
+        GameRules gameRules = this.getHandle().getGameRules();
+        return gameRules.rules.has(nms);
+    }
+
+    public static <T> T shimLegacyValue(T value, org.bukkit.GameRule<?> gameRule){
+        //noinspection all
+        if (gameRule instanceof CraftGameRule.LegacyGameRuleWrapper legacyGameRuleWrapper) {
+            //noinspection all
+            return (T) legacyGameRuleWrapper.getToLegacyFromModern().apply(value);
+        }
+
+        return value;
     }
 
     @Override
-    public <T> T getGameRuleValue(GameRule<T> rule) {
+    public <T> @Nullable T getGameRuleValue(org.bukkit.@NotNull GameRule<T> rule) {
         Preconditions.checkArgument(rule != null, "GameRule cannot be null");
-        GameRules.Key<? extends GameRules.Value<?>> key = this.getGameRulesNMS().get(rule.getName());
-        Preconditions.checkArgument(key != null, "GameRule '%s' is not available", rule.getName());
 
-        return this.getGameRuleResult(rule, this.getHandle().getGameRules().getRule(key));
+        T value = this.getHandle().getGameRules().get(CraftGameRule.bukkitToMinecraft(rule));
+        return shimLegacyValue(value, rule);
     }
 
     @Override
-    public <T> T getGameRuleDefault(GameRule<T> rule) {
+    public <T> @Nullable T getGameRuleDefault(org.bukkit.@NotNull GameRule<T> rule) {
         Preconditions.checkArgument(rule != null, "GameRule cannot be null");
-        GameRules.Type<?> type = this.getGameRuleDefinitions().get(rule.getName());
-        Preconditions.checkArgument(type != null, "GameRule '%s' is not available", rule.getName());
+        T value = CraftGameRule.bukkitToMinecraft(rule).defaultValue();
 
-        return this.getGameRuleResult(rule, type.createRule());
+        return shimLegacyValue(value, rule);
     }
 
     @Override
-    public <T> boolean setGameRule(GameRule<T> rule, T newValue) {
+    public <T> boolean setGameRule(org.bukkit.@NotNull GameRule<T> rule, @NotNull T newValue) {
         Preconditions.checkArgument(rule != null, "GameRule cannot be null");
         Preconditions.checkArgument(newValue != null, "GameRule value cannot be null");
-
-        if (!this.isGameRule(rule.getName())) return false;
-        // Paper start - Add WorldGameRuleChangeEvent
-        io.papermc.paper.event.world.WorldGameRuleChangeEvent event = new io.papermc.paper.event.world.WorldGameRuleChangeEvent(this, null, rule, String.valueOf(newValue));
-        if (!event.callEvent()) return false;
-        // Paper end - Add WorldGameRuleChangeEvent
-
-        GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(this.getGameRulesNMS().get(rule.getName()));
-        handle.deserialize(event.getValue()); // Paper - Add WorldGameRuleChangeEvent
-        handle.onChanged(this.getHandle());
-        return true;
-    }
-
-    private <T> T getGameRuleResult(GameRule<T> rule, GameRules.Value<?> value) {
-        if (value == null) {
-            return null;
+        GameRule<@NotNull T> nms = CraftGameRule.bukkitToMinecraft(rule);
+        if (!this.getHandle().getGameRules().rules.has(nms)) {
+            return false;
+        }
+        if (rule instanceof CraftGameRule.LegacyGameRuleWrapper legacyGameRuleWrapper) {
+            newValue = (T) legacyGameRuleWrapper.getFromLegacyToModern().apply(newValue);
         }
 
-        if (value instanceof GameRules.BooleanValue) {
-            return rule.getType().cast(((GameRules.BooleanValue) value).get());
-        } else if (value instanceof GameRules.IntegerValue) {
-            return rule.getType().cast(value.getCommandResult());
-        } else {
-            throw new IllegalArgumentException("Invalid GameRule type (" + value + ") for GameRule " + rule.getName());
-        }
+        AtomicBoolean cancelled = new AtomicBoolean();
+        CraftEventFactory.handleGameRuleSet(nms, newValue, this.getHandle(), null, cancelled);
+
+        return !cancelled.get();
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1676,10 +1676,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
 
         GameRule nms = CraftGameRule.bukkitToMinecraft(bukkit);
 
-        AtomicBoolean cancelled = new AtomicBoolean();
-        CraftEventFactory.handleGameRuleSet(nms, value, this.getHandle(), null, cancelled);
-
-        return !cancelled.get();
+        return !CraftEventFactory.handleGameRuleSet(nms, nms.deserialize(value).getOrThrow(), this.getHandle(), null).cancelled();
     }
 
     @Override
@@ -1737,10 +1734,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
             newValue = (T) legacyGameRuleWrapper.getFromLegacyToModern().apply(newValue);
         }
 
-        AtomicBoolean cancelled = new AtomicBoolean();
-        CraftEventFactory.handleGameRuleSet(nms, newValue, this.getHandle(), null, cancelled);
-
-        return !cancelled.get();
+        return !CraftEventFactory.handleGameRuleSet(nms, newValue, this.getHandle(), null).cancelled();
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
@@ -106,17 +106,17 @@ public abstract class CraftFurnace<T extends AbstractFurnaceBlockEntity> extends
 
     @Override
     public int getRecipeUsedCount(org.bukkit.NamespacedKey furnaceRecipe) {
-        return this.getSnapshot().recipesUsed.getInt(io.papermc.paper.util.MCUtil.toResourceKey(net.minecraft.core.registries.Registries.RECIPE, furnaceRecipe));
+        return this.getSnapshot().recipesUsed.getInt(CraftNamespacedKey.toResourceKey(net.minecraft.core.registries.Registries.RECIPE, furnaceRecipe));
     }
 
     @Override
     public boolean hasRecipeUsedCount(org.bukkit.NamespacedKey furnaceRecipe) {
-        return this.getSnapshot().recipesUsed.containsKey(io.papermc.paper.util.MCUtil.toResourceKey(net.minecraft.core.registries.Registries.RECIPE, furnaceRecipe));
+        return this.getSnapshot().recipesUsed.containsKey(CraftNamespacedKey.toResourceKey(net.minecraft.core.registries.Registries.RECIPE, furnaceRecipe));
     }
 
     @Override
     public void setRecipeUsedCount(org.bukkit.inventory.CookingRecipe<?> furnaceRecipe, int count) {
-        final var location = io.papermc.paper.util.MCUtil.toResourceKey(net.minecraft.core.registries.Registries.RECIPE, furnaceRecipe.getKey());
+        final var location = CraftNamespacedKey.toResourceKey(net.minecraft.core.registries.Registries.RECIPE, furnaceRecipe.getKey());
         java.util.Optional<net.minecraft.world.item.crafting.RecipeHolder<?>> nmsRecipe = (this.isPlaced() ? this.world.getHandle().recipeAccess() : net.minecraft.server.MinecraftServer.getServer().getRecipeManager()).byKey(location);
         com.google.common.base.Preconditions.checkArgument(nmsRecipe.isPresent() && nmsRecipe.get().value() instanceof net.minecraft.world.item.crafting.AbstractCookingRecipe, furnaceRecipe.getKey() + " is not recognized as a valid and registered furnace recipe");
         if (count > 0) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -12,7 +12,6 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import io.papermc.paper.adventure.PaperAdventure;
@@ -26,7 +25,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ServerboundContainerClosePacket;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -35,7 +33,6 @@ import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.util.Unit;
 import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.attribute.EnvironmentAttribute;
 import net.minecraft.world.attribute.EnvironmentAttributes;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageTypes;
@@ -2228,7 +2225,7 @@ public class CraftEventFactory {
         return event.isAllowed();
     }
 
-    public static <T> T handleGameRuleSet(GameRule<@NotNull T> rule, T value, ServerLevel level, @Nullable CommandSender sender, @Nullable AtomicBoolean canceledTracker) {
+    public static <T> GameRuleSetResult<T> handleGameRuleSet(GameRule<@NotNull T> rule, T value, ServerLevel level, @Nullable CommandSender sender) {
         final var event = new io.papermc.paper.event.world.WorldGameRuleChangeEvent(
                 level.getWorld(),
                 sender,
@@ -2237,13 +2234,13 @@ public class CraftEventFactory {
         );
         if (event.callEvent()) {
             level.getGameRules().set(rule, value, level);
-            return value;
+            return new GameRuleSetResult<>(value, false);
         } else {
-            if (canceledTracker != null) {
-                canceledTracker.set(true);
-            }
-
-            return level.getGameRules().get(rule);
+            return new GameRuleSetResult<>(level.getGameRules().get(rule), true);
         }
+    }
+
+    public record GameRuleSetResult<T>(T value, boolean cancelled) {
+
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftNamespacedKey.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftNamespacedKey.java
@@ -1,5 +1,6 @@
 package org.bukkit.craftbukkit.util;
 
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
@@ -21,4 +22,16 @@ public final class CraftNamespacedKey {
     public static ResourceLocation toMinecraft(NamespacedKey key) {
         return ResourceLocation.fromNamespaceAndPath(key.getNamespace(), key.getKey());
     }
+
+    public static NamespacedKey fromResourceKey(final ResourceKey<?> key) {
+        return CraftNamespacedKey.fromMinecraft(key.location());
+    }
+
+    public static <T> ResourceKey<T> toResourceKey(
+            final ResourceKey<? extends net.minecraft.core.Registry<T>> registry,
+            final NamespacedKey namespacedKey
+    ) {
+        return ResourceKey.create(registry, CraftNamespacedKey.toMinecraft(namespacedKey));
+    }
+
 }

--- a/todo-snapshot.txt
+++ b/todo-snapshot.txt
@@ -5,3 +5,5 @@
 - 25w44a:
   - ShulkerBoxBlock: retainUnlootedShulkerBoxLootTableOnNonPlayerBreak patch no longer applies (getDrops override removed)
   - Add back array storage for game rules in GameRuleMap?
+  - Generate GAME_RULE in RegistryKey
+  - Make sure the experiemental annotations generate on game rules


### PR DESCRIPTION
Introduces a wrapper system for the legacy game rule values that support setting/getting.

In general, this api has had fields removed in the past and has broke before. This should hopefully have good enough legacy compat, for now?

Moved some utils out of MCUtil due to classloading issues

TODO:
- Generate GAME_RULE in RegistryKey
- Make sure the experiemental annotations generate on game rules