### PR TITLE
Attribute wind burst explosions to the player that caused it

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -782,6 +782,7 @@ public-f net.minecraft.world.item.trading.MerchantOffer rewardExp
 public-f net.minecraft.world.item.trading.MerchantOffer xp
 public-f net.minecraft.world.level.LevelSettings hardcore
 public-f net.minecraft.world.level.LevelSettings levelName
+public-f net.minecraft.world.level.ServerExplosion damageSource
 public-f net.minecraft.world.level.block.ChestBlock MENU_PROVIDER_COMBINER
 public-f net.minecraft.world.level.block.entity.BannerBlockEntity baseColor
 public-f net.minecraft.world.level.saveddata.maps.MapItemSavedData centerX

--- a/paper-server/patches/resources/data/minecraft/enchantment/wind_burst.json.patch
+++ b/paper-server/patches/resources/data/minecraft/enchantment/wind_burst.json.patch
@@ -1,0 +1,10 @@
+--- a/data/minecraft/enchantment/wind_burst.json
++++ b/data/minecraft/enchantment/wind_burst.json
+@@ -9,6 +_,7 @@
+         "affected": "attacker",
+         "effect": {
+           "type": "minecraft:explode",
++          "paper_attribute_indirectly_to_user": true,
+           "block_interaction": "trigger",
+           "immune_blocks": "#minecraft:blocks_wind_charge_explosions",
+           "knockback_multiplier": {

--- a/paper-server/patches/sources/net/minecraft/world/item/enchantment/effects/ExplodeEffect.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/enchantment/effects/ExplodeEffect.java.patch
@@ -1,0 +1,61 @@
+--- a/net/minecraft/world/item/enchantment/effects/ExplodeEffect.java
++++ b/net/minecraft/world/item/enchantment/effects/ExplodeEffect.java
+@@ -27,6 +_,7 @@
+ 
+ public record ExplodeEffect(
+     boolean attributeToUser,
++    boolean attributeIndirectlyToUser, // Paper - Add field to attribute explosions indirectly to user
+     Optional<Holder<DamageType>> damageType,
+     Optional<LevelBasedValue> knockbackMultiplier,
+     Optional<HolderSet<Block>> immuneBlocks,
+@@ -39,9 +_,27 @@
+     WeightedList<ExplosionParticleInfo> blockParticles,
+     Holder<SoundEvent> sound
+ ) implements EnchantmentEntityEffect {
++    // Paper start - Add field to attribute explosions indirectly to user - Add default constructor
++    public ExplodeEffect(boolean attributeToUser,
++                         Optional<Holder<DamageType>> damageType,
++                         Optional<LevelBasedValue> knockbackMultiplier,
++                         Optional<HolderSet<Block>> immuneBlocks,
++                         Vec3 offset,
++                         LevelBasedValue radius,
++                         boolean createFire,
++                         Level.ExplosionInteraction blockInteraction,
++                         ParticleOptions smallParticle,
++                         ParticleOptions largeParticle,
++                         WeightedList<ExplosionParticleInfo> blockParticles,
++                         Holder<SoundEvent> sound) {
++        this(attributeToUser, false, damageType, knockbackMultiplier, immuneBlocks, offset, radius, createFire, blockInteraction, smallParticle, largeParticle, blockParticles, sound);
++    }
++    // Paper end - Add field to attribute explosions indirectly to user - Add default constructor
++
+     public static final MapCodec<ExplodeEffect> CODEC = RecordCodecBuilder.mapCodec(
+         instance -> instance.group(
+                 Codec.BOOL.optionalFieldOf("attribute_to_user", false).forGetter(ExplodeEffect::attributeToUser),
++                Codec.BOOL.optionalFieldOf("paper_attribute_indirectly_to_user", false).forGetter(ExplodeEffect::attributeIndirectlyToUser), // Paper - Add field to attribute explosions indirectly to user
+                 DamageType.CODEC.optionalFieldOf("damage_type").forGetter(ExplodeEffect::damageType),
+                 LevelBasedValue.CODEC.optionalFieldOf("knockback_multiplier").forGetter(ExplodeEffect::knockbackMultiplier),
+                 RegistryCodecs.homogeneousList(Registries.BLOCK).optionalFieldOf("immune_blocks").forGetter(ExplodeEffect::immuneBlocks),
+@@ -60,7 +_,7 @@
+     @Override
+     public void apply(ServerLevel level, int enchantmentLevel, EnchantedItemInUse item, Entity entity, Vec3 origin) {
+         Vec3 vec3 = origin.add(this.offset);
+-        level.explode(
++        level.explode0( // Paper - Add field to attribute explosions indirectly to user
+             this.attributeToUser ? entity : null,
+             this.getDamageSource(entity, vec3),
+             new SimpleExplosionDamageCalculator(
+@@ -79,6 +_,13 @@
+             this.largeParticle,
+             this.blockParticles,
+             this.sound
++            // Paper start - Add field to attribute explosions indirectly to user
++            , explosion -> {
++                if (this.attributeIndirectlyToUser) {
++                    explosion.damageSource = level.damageSources().explosion(explosion.getDirectSourceEntity(), entity);
++                }
++            }
++            // Paper end - Add field to attribute explosions indirectly to user
+         );
+     }
+ 

--- a/paper-server/patches/sources/net/minecraft/world/level/ServerExplosion.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/ServerExplosion.java.patch
@@ -16,7 +16,7 @@
      private static final ExplosionDamageCalculator EXPLOSION_DAMAGE_CALCULATOR = new ExplosionDamageCalculator();
      private static final int MAX_DROPS_PER_COMBINED_STACK = 16;
 @@ -49,6 +_,11 @@
-     private final DamageSource damageSource;
+     public DamageSource damageSource;
      private final ExplosionDamageCalculator damageCalculator;
      private final Map<Player, Vec3> hitPlayers = new HashMap<>();
 +    // CraftBukkit - add field


### PR DESCRIPTION
Closes #13079
Supersedes #13132

Adds a new field to the explode effect definition to allow attributing the player as the causing entity for the wind burst effect specifically, which aims to match how the player is the causing entity for wind charge explosions.

The problem with directly setting attribute_to_user to true (which I initially saw as a way to fix this) is that it creates too large of a difference in behavior, most notably by preventing the player from shooting up into the air from the explosion.