### PR TITLE
Add PlayerShelfHotbarSwapEvent (cancellable) and fire before per-slot…

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerShelfHotbarSwapEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerShelfHotbarSwapEvent.java
@@ -1,0 +1,111 @@
+package io.papermc.paper.event.player;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Shelf;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Fired when a Shelf is about to pull/swap a specific hotbar slot from a player
+ * (including when the Shelf is part of a redstone-powered side-chain).
+ *
+ * <p>Cancelling this event prevents only this slot transfer; the rest of the
+ * Shelf interaction/chain continues unaffected.</p>
+ */
+@NullMarked
+public class PlayerShelfHotbarSwapEvent extends PlayerEvent implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final Block block;
+    private final int hotbarSlot;
+    private ItemStack item;
+    private boolean cancelled;
+
+    @ApiStatus.Internal
+    public PlayerShelfHotbarSwapEvent(final Player player, final Block block, final int hotbarSlot, final ItemStack item) {
+        super(player);
+        this.block = block;
+        this.hotbarSlot = hotbarSlot;
+        this.item = item.clone();
+    }
+
+    /**
+     * Gets the block of the shelf involved in this event.
+     *
+     * @return the shelf block
+     */
+    public Block getBlock() {
+        return this.block;
+    }
+
+    /**
+     * Returns the shelf block state involved in this event.
+     * This constructs a new snapshot {@link BlockState} and validates its type.
+     *
+     * @return a shelf state snapshot
+     * @throws IllegalStateException if the block is no longer a shelf
+     */
+    public Shelf getShelf() {
+        final BlockState state = this.block.getState();
+        Preconditions.checkState(state instanceof Shelf, "Block state is no longer a Shelf tile state!");
+        return (Shelf) state;
+    }
+
+    /**
+     * Gets the hotbar slot being pulled.
+     * Index is 0–8 inclusive.
+     *
+     * @return the hotbar slot index
+     */
+    public int getHotbarSlot() {
+        return this.hotbarSlot;
+    }
+
+    /**
+     * Gets a clone of the item the shelf is about to pull from the player's hotbar.
+     *
+     * @return the item being pulled
+     */
+    public ItemStack getItem() {
+        return this.item.clone();
+    }
+
+    /**
+     * Sets the item that will be inserted into the shelf for this transfer.
+     * The original item will be consumed from the player's slot.
+     *
+     * @param item the replacement item (non-null)
+     */
+    public void setItem(final ItemStack item) {
+        Preconditions.checkArgument(item != null, "item cannot be null");
+        this.item = item.clone();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(final boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}
+

--- a/paper-server/patches/sources/net/minecraft/world/level/block/ShelfBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/ShelfBlock.java.patch
@@ -12,3 +12,51 @@
                  BlockState blockState = state.setValue(POWERED, hasNeighborSignal);
                  if (!hasNeighborSignal) {
                      blockState = blockState.setValue(SIDE_CHAIN_PART, SideChainPart.UNCONNECTED);
+@@ -215,12 +_,41 @@
+                     for (int i1 = 0; i1 < shelfBlockEntity.getContainerSize(); i1++) {
+                         int i2 = 9 - (allBlocksConnectedTo.size() - i) * shelfBlockEntity.getContainerSize() + i1;
+                         if (i2 >= 0 && i2 <= inventory.getContainerSize()) {
+-                            ItemStack itemStack = inventory.removeItemNoUpdate(i2);
+-                            ItemStack itemStack1 = shelfBlockEntity.swapItemNoUpdate(i1, itemStack);
+-                            if (!itemStack.isEmpty() || !itemStack1.isEmpty()) {
+-                                inventory.setItem(i2, itemStack1);
+-                                flag = true;
+-                            }
++                            // Paper start - Add PlayerShelfHotbarSwapEvent (cancellable per-slot)
++                            ItemStack pre = inventory.getItem(i2);
++                            boolean swapped = false;
++                            if (pre != null && !pre.isEmpty() && inventory.player instanceof net.minecraft.server.level.ServerPlayer serverPlayer) {
++                                final io.papermc.paper.event.player.PlayerShelfHotbarSwapEvent event = new io.papermc.paper.event.player.PlayerShelfHotbarSwapEvent(
++                                    serverPlayer.getBukkitEntity(),
++                                    org.bukkit.craftbukkit.block.CraftBlock.at(level, pos),
++                                    i2,
++                                    org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(pre.copy())
++                                );
++                                if (event.callEvent()) {
++                                    final net.minecraft.world.item.ItemStack eventStack = org.bukkit.craftbukkit.inventory.CraftItemStack.unwrap(event.getItem());
++                                    // Remove original from player slot
++                                    inventory.removeItemNoUpdate(i2);
++                                    // Swap with shelf using (possibly) modified stack
++                                    ItemStack shelfPrev = shelfBlockEntity.swapItemNoUpdate(i1, eventStack);
++                                    if (!shelfPrev.isEmpty() || !eventStack.isEmpty()) {
++                                        inventory.setItem(i2, shelfPrev);
++                                        flag = true;
++                                    }
++                                    swapped = true;
++                                } else {
++                                    // cancelled: skip this slot transfer entirely
++                                    swapped = true;
++                                }
++                            }
++                            if (!swapped) {
++                                ItemStack itemStack = inventory.removeItemNoUpdate(i2);
++                                ItemStack itemStack1 = shelfBlockEntity.swapItemNoUpdate(i1, itemStack);
++                                if (!itemStack.isEmpty() || !itemStack1.isEmpty()) {
++                                    inventory.setItem(i2, itemStack1);
++                                    flag = true;
++                                }
++                            }
++                            // Paper end - Add PlayerShelfHotbarSwapEvent
+                         }
+                     }
+ 


### PR DESCRIPTION
### Summary
Introduces a new event, `PlayerShelfHotbarSwapEvent`, fired when a Shelf block attempts to pull an item from a player's hotbar (e.g., during redstone-powered item transfer).  
The event is cancellable per slot, allowing plugins to intercept or modify the item being transferred before it is moved.

### Technical details
- Added new event: `io.papermc.paper.event.player.PlayerShelfHotbarSwapEvent`
- Event extends `PlayerEvent` and implements `Cancellable`
- Provides:
  - `getBlock()` – Returns the Shelf block involved  
  - `getShelf()` – Returns the Shelf block state (validated as Shelf)  
  - `getHotbarSlot()` – Returns the index of the hotbar slot (0–8)  
  - `getItem()` / `setItem()` – Gets or modifies the `ItemStack` being pulled  

### Behaviour
When triggered, the event allows plugins to:
- Cancel the slot transfer entirely  
- Modify the item that will be pulled into the Shelf  
If the event is cancelled, the original slot remains unchanged.

### Implementation
The event is fired in `ShelfBlock.java` before each per-slot transfer within redstone-powered Shelf updates.  
Marked `@ApiStatus.Internal` since it’s not yet considered API-stable.

### Use cases
This addition allows developers to:
- Restrict or customize how Shelves pull items from players  
- Apply custom filters or permissions for item transfer logic  
- Log or modify items being transferred dynamically  

---

Closes no existing issues directly; proposed as an enhancement to extend Shelf block event handling.
