### PR TITLE
API: add PlayerShelfHotbarSwapEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerShelfHotbarSwapEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerShelfHotbarSwapEvent.java
@@ -1,0 +1,111 @@
+package io.papermc.paper.event.player;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Shelf;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fired when a Shelf is about to pull/swap a specific hotbar slot from a player
+ * (including when the Shelf is part of a redstone-powered side-chain).
+ *
+ * <p>Cancelling this event prevents only this slot transfer; the rest of the
+ * Shelf interaction/chain continues unaffected.</p>
+ */
+@NullMarked
+public class PlayerShelfHotbarSwapEvent extends PlayerEvent implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final Block block;
+    private final int hotbarSlot;
+    private ItemStack itemStack;
+    private boolean cancelled;
+
+    @ApiStatus.Internal
+    public PlayerShelfHotbarSwapEvent(final Player player, final Block block, final int hotbarSlot, final ItemStack itemStack) {
+        super(player);
+        this.block = block;
+        this.hotbarSlot = hotbarSlot;
+        this.itemStack = itemStack;
+    }
+
+    /**
+     * Gets the block of the shelf involved in this event.
+     *
+     * @return the shelf block
+     */
+    public Block getBlock() {
+        return this.block;
+    }
+
+    /**
+     * Returns the shelf block state involved in this event.
+     * This constructs a new snapshot {@link BlockState} and validates its type.
+     *
+     * @return a shelf state snapshot
+     * @throws IllegalStateException if the block is no longer a shelf
+     */
+    public Shelf getShelf() {
+        final BlockState state = this.block.getState();
+        Preconditions.checkState(state instanceof Shelf, "Block state is no longer a Shelf block state!");
+        return (Shelf) state;
+    }
+
+    /**
+     * Gets the hotbar slot being pulled.
+     * Index is 0–8 inclusive.
+     *
+     * @return the hotbar slot index
+     */
+    public int getHotbarSlot() {
+        return this.hotbarSlot;
+    }
+
+    /**
+     * Gets the {@link ItemStack} the shelf is about to pull from the player's hotbar.
+     *
+     * @return the item being pulled
+     */
+    public ItemStack getItemStack() {
+        return this.itemStack;
+    }
+
+    /**
+     * Sets the {@link ItemStack} that will be inserted into the shelf for this transfer.
+     * If {@code null} is provided, the ItemStack will become air and the transfer will insert nothing.
+     * The original item will be consumed from the player's slot.
+     *
+     * @param itemStack the replacement item
+     */
+    public void setItemStack(final @Nullable ItemStack itemStack) {
+        this.itemStack = itemStack == null ? ItemStack.empty() : itemStack;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(final boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/paper-server/patches/sources/net/minecraft/world/level/block/ShelfBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/ShelfBlock.java.patch
@@ -12,3 +12,28 @@
                  BlockState blockState = state.setValue(POWERED, hasNeighborSignal);
                  if (!hasNeighborSignal) {
                      blockState = blockState.setValue(SIDE_CHAIN_PART, SideChainPart.UNCONNECTED);
+@@ -214,9 +_,22 @@
+                 if (shelfBlockEntity != null) {
+                     for (int i1 = 0; i1 < shelfBlockEntity.getContainerSize(); i1++) {
+                         int i2 = 9 - (allBlocksConnectedTo.size() - i) * shelfBlockEntity.getContainerSize() + i1;
+-                        if (i2 >= 0 && i2 <= inventory.getContainerSize()) {
++                        if (i2 >= 0 && i2 < inventory.getContainerSize()) {
++                            // Paper start - Fire PlayerShelfHotbarSwapEvent before removing from hotbar
++                            final org.bukkit.entity.Player bukkitPlayer = (org.bukkit.entity.Player) inventory.player.getBukkitEntity();
++                            final org.bukkit.block.Block bukkitBlock = org.bukkit.craftbukkit.block.CraftBlock.at((net.minecraft.server.level.ServerLevel) level, allBlocksConnectedTo.get(i));
++                            final org.bukkit.inventory.ItemStack aboutToPull = org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(inventory.getItem(i2));
++                            final io.papermc.paper.event.player.PlayerShelfHotbarSwapEvent event = new io.papermc.paper.event.player.PlayerShelfHotbarSwapEvent(bukkitPlayer, bukkitBlock, i2, aboutToPull);
++                            ((net.minecraft.server.level.ServerLevel) level).getCraftServer().getPluginManager().callEvent(event);
++                            if (event.isCancelled()) {
++                                continue; // only skip this slot; rest of chain continues
++                            }
++                            // consume the original item from the player's hotbar slot
+                             ItemStack itemStack = inventory.removeItemNoUpdate(i2);
+-                            ItemStack itemStack1 = shelfBlockEntity.swapItemNoUpdate(i1, itemStack);
++                            // insert the (possibly replaced) item into the shelf slot
++                            final ItemStack replacement = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getItemStack());
++                            ItemStack itemStack1 = shelfBlockEntity.swapItemNoUpdate(i1, replacement);
++                            // Paper end - Fire PlayerShelfHotbarSwapEvent
+                             if (!itemStack.isEmpty() || !itemStack1.isEmpty()) {
+                                 inventory.setItem(i2, itemStack1);
+                                 flag = true;


### PR DESCRIPTION
### **Summary**

* Adds `PlayerShelfHotbarSwapEvent` to let plugins intercept a Shelf pulling a specific hotbar slot from a player.
* Wires the event in `ShelfBlock` before the item is removed from the player’s slot and inserted into the Shelf.
* Also fires `BlockRedstoneEvent` when Shelf power changes.

---

### **Why**

* Plugins need a clean, first-class way to cancel or replace the item that a Shelf pulls from a player’s hotbar (including redstone side-chains), without reflection or polling nearby shelves.
* Event aligns with existing Paper patterns (`ItemFrame` change, swap hand items), reduces plugin boilerplate, and avoids race conditions.

---

### **Behavior**

* Event is called **before** removing the item from the player’s hotbar.
* Cancelling the event skips **only that slot**; the rest of the Shelf interaction/chain proceeds normally.
* Plugins can replace the item to be inserted into the Shelf for that slot.
* Bukkit/NMS conversions are handled automatically (`asBukkitCopy` in, `asNMSCopy` out).

---

### **API Details**

* **New event:** `io.papermc.paper.event.player.PlayerShelfHotbarSwapEvent`

  * `getBlock()` → returns the Shelf block.
  * `getShelf()` → returns a snapshot Shelf state; throws `IllegalStateException` if no longer a Shelf.
  * `getHotbarSlot()` → index 0–8 inclusive.
  * `getItem()` / `setItem(ItemStack)` → `null` becomes `ItemStack.empty()`
  * Implements `Cancellable`.
  * Uses `HANDLER_LIST` naming convention

---

### **Server Changes**

* **ShelfBlock:**

  * Fires the event before consuming the player’s slot.
  * Honors cancellation per slot.
  * Inserts replacement item if provided.
* **Power event:** fires `BlockRedstoneEvent` when Shelf power changes.

---

### **Testing**

Steps to verify:

1. Place a Shelf, power it via redstone side-chain, and interact while a player has items in their hotbar.
2. Confirm that:

   * The event fires per slot before item removal.
   * Cancelling a slot keeps the original item while other slots continue.
   * Replacement items are correctly inserted, and the originals are consumed.
   * No `IndexOutOfBoundsException` occurs at hotbar boundaries.
3. Validate that existing Shelf behavior remains unchanged when no plugin listens.

---

### **Files Touched**

* **API:** `paper-api/src/main/java/io/papermc/paper/event/player/PlayerShelfHotbarSwapEvent.java`
* **Server:** `paper-server/patches/sources/net/minecraft/world/level/block/ShelfBlock.java.patch`

---

### **Notes**

* Updated Javadoc message: `getShelf()` now says *“Shelf block state”*.
* Fully additive API; no breaking changes introduced.
