### PR TITLE
fix: properly handle redstone events to match vanilla

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/ComparatorBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/ComparatorBlock.java.patch
@@ -12,7 +12,7 @@
                  level.setBlock(pos, state.setValue(POWERED, false), Block.UPDATE_CLIENTS);
              } else if (!poweredValue && shouldTurnOn) {
 +                // CraftBukkit start
-+                if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 0, 15).getNewCurrent() != 15) {
++                if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 0, 15).getNewCurrent() == 0) {
 +                    return;
 +                }
 +                // CraftBukkit end

--- a/paper-server/patches/sources/net/minecraft/world/level/block/DiodeBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/DiodeBlock.java.patch
@@ -12,7 +12,7 @@
                  level.setBlock(pos, state.setValue(POWERED, false), Block.UPDATE_CLIENTS);
              } else if (!poweredValue) {
 +                // CraftBukkit start
-+                if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 0, 15).getNewCurrent() != 15) {
++                if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 0, 15).getNewCurrent() == 0) {
 +                    return;
 +                }
 +                // CraftBukkit end

--- a/paper-server/patches/sources/net/minecraft/world/level/block/ObserverBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/ObserverBlock.java.patch
@@ -12,7 +12,7 @@
              level.setBlock(pos, state.setValue(POWERED, false), Block.UPDATE_CLIENTS);
          } else {
 +            // CraftBukkit start
-+            if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 0, 15).getNewCurrent() != 15) {
++            if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 0, 15).getNewCurrent() == 0) {
 +                return;
 +            }
 +            // CraftBukkit end

--- a/paper-server/patches/sources/net/minecraft/world/level/block/PoweredRailBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/PoweredRailBlock.java.patch
@@ -1,15 +1,17 @@
 --- a/net/minecraft/world/level/block/PoweredRailBlock.java
 +++ b/net/minecraft/world/level/block/PoweredRailBlock.java
-@@ -127,6 +_,13 @@
+@@ -127,6 +_,15 @@
              || this.findPoweredRailSignal(level, pos, state, true, 0)
              || this.findPoweredRailSignal(level, pos, state, false, 0);
          if (flag != poweredValue) {
 +            // CraftBukkit start
-+            int power = flag ? 15 : 0;
-+            int newPower = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, power, 15 - power).getNewCurrent();
-+            if (newPower == power) {
++            int oldPower = poweredValue ? 15 : 0;
++            int newPower = flag ? 15 : 0;
++            int eventPower = org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, oldPower, newPower).getNewCurrent();
++            if (eventPower == oldPower) {
 +                return;
 +            }
++            flag = eventPower > 0;
 +            // CraftBukkit end
              level.setBlock(pos, state.setValue(POWERED, flag), Block.UPDATE_ALL);
              level.updateNeighborsAt(pos.below(), this);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/RedstoneLampBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/RedstoneLampBlock.java.patch
@@ -5,7 +5,7 @@
                      level.scheduleTick(pos, this, 4);
                  } else {
 +                    // CraftBukkit start
-+                    if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 0, 15).getNewCurrent() != 15) {
++                    if (org.bukkit.craftbukkit.event.CraftEventFactory.callRedstoneChange(level, pos, 0, 15).getNewCurrent() == 0) {
 +                        return;
 +                    }
 +                    // CraftBukkit end

--- a/paper-server/patches/sources/net/minecraft/world/level/block/RedstoneTorchBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/RedstoneTorchBlock.java.patch
@@ -54,10 +54,10 @@
              }
          } else if (!hasNeighborSignal && !isToggledTooFrequently(level, pos, false)) {
 +            // CraftBukkit start
-+            if (oldCurrent != 15) {
++            if (oldCurrent == 0) {
 +                event.setNewCurrent(15);
 +                manager.callEvent(event);
-+                if (event.getNewCurrent() != 15) {
++                if (event.getNewCurrent() == 0) {
 +                    return;
 +                }
 +            }


### PR DESCRIPTION
This pull request aims to make the redstone events match vanilla's behaviour when a plugin changes the power level.
Currently when you modify the `newCurrent` by listening to the `BlockRedstoneEvent` to a value that's above `0` but below `15` the current code will return, leaving the block in an unlit state, whereas in vanilla the block would get lit up as long as the power level is above 0.
One more issue was discovered too with the `PoweredRailBlock` event's logic being inverted and passing wrong values to listeners

#### Observed behaviour, with a plugin setting the event's current to `6`
<img width="500" height="800" alt="image" src="https://github.com/user-attachments/assets/4423e27f-fdc9-429a-a001-2113e83fc726" />

#### Expected behaviour with power level equal to `6` on vanilla/paper without plugins
<img width="500" height="800" alt="image" src="https://github.com/user-attachments/assets/b1d287b8-b58b-4eb5-b330-261724b54763" />

#### Minimal reproduction code
```java
    @EventHandler
    public void onRedstoneChange(BlockRedstoneEvent event) {
        event.setNewCurrent(6);
```

These changes might break API compatibility so it would be best fit to merge them in the next minecraft release
Would close #13291 