### PR TITLE
Add ability to override "IS_RUNNING_IN_IDE".

### DIFF
--- a/paper-server/patches/features/0032-Allow-overriding-IS_RUNNING_IN_IDE.patch
+++ b/paper-server/patches/features/0032-Allow-overriding-IS_RUNNING_IN_IDE.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mickey42302 <bgoodwin423@gmail.com>
+Date: Sun, 9 Nov 2025 14:50:22 -0500
+Subject: [PATCH] Allow overriding IS_RUNNING_IN_IDE
+
+
+diff --git a/net/minecraft/SharedConstants.java b/net/minecraft/SharedConstants.java
+index 5961f904ee58ea95b92a5d47f4b018f5c1f879c7..3236d9ed16abefb221294410fe69850cc3583fb5 100644
+--- a/net/minecraft/SharedConstants.java
++++ b/net/minecraft/SharedConstants.java
+@@ -149,6 +149,7 @@ public class SharedConstants {
+     public static final float AVERAGE_RANDOM_TICKS_PER_BLOCK_PER_MINUTE = 0.87890625F;
+     public static final float AVERAGE_RANDOM_TICKS_PER_BLOCK_PER_GAME_DAY = 17.578125F;
+     public static final int WORLD_ICON_SIZE = 64;
++    private static final boolean ENABLE_DEV_FEATURES = Boolean.getBoolean("paper.enableDevFeatures");
+     @Nullable
+     private static WorldVersion CURRENT_VERSION;
+ 
+@@ -225,5 +226,8 @@ public class SharedConstants {
+         ResourceLeakDetector.setLevel(NETTY_LEAK_DETECTION);
+         CommandSyntaxException.ENABLE_COMMAND_STACK_TRACES = COMMAND_STACK_TRACES;
+         CommandSyntaxException.BUILT_IN_EXCEPTIONS = new BrigadierExceptions();
++        if (ENABLE_DEV_FEATURES) {
++            IS_RUNNING_IN_IDE = true;
++        }
+     }
+ }


### PR DESCRIPTION
I would like to suggest adding the ability to override the "IS_RUNNING_IN_IDE" flag using a system property. Being able to override this would allow players to explore functionalities that are hidden within the game's code.

The patch file I created adds a "paper.enableDevFeatures" system property. When this is set to to true via a startup script, the "IS_RUNNING_IN_IDE" flag will be set to true. This causes a bunch of features to be enabled, including ones that don't have a debug property assigned to them (such as the export sub-commands for "/test").