### PR TITLE
Fix Failing to Open Nautilus Inventory

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -319,6 +319,7 @@ public net.minecraft.world.entity.animal.horse.AbstractHorse owner
 public net.minecraft.world.entity.animal.horse.Horse setVariantAndMarkings(Lnet/minecraft/world/entity/animal/horse/Variant;Lnet/minecraft/world/entity/animal/horse/Markings;)V
 public net.minecraft.world.entity.animal.horse.Llama setVariant(Lnet/minecraft/world/entity/animal/horse/Llama$Variant;)V
 public net.minecraft.world.entity.animal.horse.SkeletonHorse trapTime
+public net.minecraft.world.entity.animal.nautilus.AbstractNautilus inventory
 public net.minecraft.world.entity.animal.sniffer.Sniffer calculateDigPosition()Ljava/util/Optional;
 public net.minecraft.world.entity.animal.sniffer.Sniffer canDig()Z
 public net.minecraft.world.entity.animal.sniffer.Sniffer getExploredPositions()Ljava/util/stream/Stream;

--- a/paper-api/src/main/java/org/bukkit/entity/AbstractNautilus.java
+++ b/paper-api/src/main/java/org/bukkit/entity/AbstractNautilus.java
@@ -1,4 +1,6 @@
 package org.bukkit.entity;
 
-public interface AbstractNautilus extends Animals, Tameable {
+import org.bukkit.inventory.InventoryHolder;
+
+public interface AbstractNautilus extends Animals, InventoryHolder, Tameable {
 }

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -1043,7 +1043,7 @@
                  return OptionalInt.of(this.containerCounter);
              }
          }
-@@ -1342,14 +_,25 @@
+@@ -1342,27 +_,49 @@
  
      @Override
      public void openHorseInventory(AbstractHorse horse, Container inventory) {
@@ -1069,6 +1069,32 @@
          this.connection.send(new ClientboundMountScreenOpenPacket(this.containerCounter, inventoryColumns, horse.getId()));
 -        this.containerMenu = new HorseInventoryMenu(this.containerCounter, this.getInventory(), inventory, horse, inventoryColumns);
 +        this.containerMenu = container; // CraftBukkit
+         this.initMenu(this.containerMenu);
+     }
+ 
+     @Override
+     public void openNautilusInventory(AbstractNautilus nautilus, Container inventory) {
++        // Paper start - Inventory open hook
++        this.nextContainerCounter(); // moved up from below
++        AbstractContainerMenu menu = new NautilusInventoryMenu(this.containerCounter, this.getInventory(), inventory, nautilus, nautilus.getInventoryColumns());
++        menu.setTitle(nautilus.getDisplayName());
++        menu = org.bukkit.craftbukkit.event.CraftEventFactory.callInventoryOpenEvent(this, containerMenu);
++
++        if (menu == null) {
++            inventory.stopOpen(this);
++            return;
++        }
++        // Paper end
+         if (this.containerMenu != this.inventoryMenu) {
+             this.closeContainer();
+         }
+ 
+-        this.nextContainerCounter();
++        // this.nextContainerCounter(); Paper - Move Up
+         int inventoryColumns = nautilus.getInventoryColumns();
+         this.connection.send(new ClientboundMountScreenOpenPacket(this.containerCounter, inventoryColumns, nautilus.getId()));
+-        this.containerMenu = new NautilusInventoryMenu(this.containerCounter, this.getInventory(), inventory, nautilus, inventoryColumns);
++        this.containerMenu = menu; // Paper - Moved up declaration
          this.initMenu(this.containerMenu);
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/nautilus/AbstractNautilus.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/nautilus/AbstractNautilus.java.patch
@@ -32,7 +32,7 @@
      protected void createInventory() {
          SimpleContainer simpleContainer = this.inventory;
 -        this.inventory = new SimpleContainer(this.getInventorySize());
-+        this.inventory = new SimpleContainer(this.getInventorySize(), (org.bukkit.craftbukkit.entity.CraftAbstractNautilus) getBukkitEntity()); // Paper add inv owner
++        this.inventory = new SimpleContainer(this.getInventorySize(), (org.bukkit.craftbukkit.entity.CraftAbstractNautilus) getBukkitEntity()); // Paper - add inv owner
          if (simpleContainer != null) {
              int min = Math.min(simpleContainer.getContainerSize(), this.inventory.getContainerSize());
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/nautilus/AbstractNautilus.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/nautilus/AbstractNautilus.java.patch
@@ -27,3 +27,12 @@
              this.tame(player);
              this.navigation.stop();
              this.level().broadcastEntityEvent(this, EntityEvent.TAMING_SUCCEEDED);
+@@ -481,7 +_,7 @@
+ 
+     protected void createInventory() {
+         SimpleContainer simpleContainer = this.inventory;
+-        this.inventory = new SimpleContainer(this.getInventorySize());
++        this.inventory = new SimpleContainer(this.getInventorySize(), (org.bukkit.craftbukkit.entity.CraftAbstractNautilus) getBukkitEntity());
+         if (simpleContainer != null) {
+             int min = Math.min(simpleContainer.getContainerSize(), this.inventory.getContainerSize());
+ 

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/nautilus/AbstractNautilus.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/nautilus/AbstractNautilus.java.patch
@@ -32,7 +32,7 @@
      protected void createInventory() {
          SimpleContainer simpleContainer = this.inventory;
 -        this.inventory = new SimpleContainer(this.getInventorySize());
-+        this.inventory = new SimpleContainer(this.getInventorySize(), (org.bukkit.craftbukkit.entity.CraftAbstractNautilus) getBukkitEntity());
++        this.inventory = new SimpleContainer(this.getInventorySize(), (org.bukkit.craftbukkit.entity.CraftAbstractNautilus) getBukkitEntity()); // Paper add inv owner
          if (simpleContainer != null) {
              int min = Math.min(simpleContainer.getContainerSize(), this.inventory.getContainerSize());
  

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractNautilus.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractNautilus.java
@@ -1,7 +1,11 @@
 package org.bukkit.craftbukkit.entity;
 
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.animal.nautilus.AbstractNautilus;
 import org.bukkit.craftbukkit.CraftServer;
+import org.bukkit.craftbukkit.inventory.CraftSaddledInventory;
+import org.bukkit.inventory.Inventory;
+import org.jetbrains.annotations.NotNull;
 
 public class CraftAbstractNautilus extends CraftTameableAnimal implements org.bukkit.entity.AbstractNautilus {
     public CraftAbstractNautilus(final CraftServer server, final AbstractNautilus entity) {
@@ -11,5 +15,14 @@ public class CraftAbstractNautilus extends CraftTameableAnimal implements org.bu
     @Override
     public AbstractNautilus getHandle() {
         return (AbstractNautilus) this.entity;
+    }
+
+    @Override
+    public @NotNull Inventory getInventory() {
+        return new CraftSaddledInventory(
+            getHandle().inventory,
+            this.getHandle().createEquipmentSlotContainer(EquipmentSlot.BODY),
+            this.getHandle().createEquipmentSlotContainer(EquipmentSlot.SADDLE)
+        );
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractNautilus.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractNautilus.java
@@ -5,7 +5,6 @@ import net.minecraft.world.entity.animal.nautilus.AbstractNautilus;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.inventory.CraftSaddledInventory;
 import org.bukkit.inventory.Inventory;
-import org.jetbrains.annotations.NotNull;
 
 public class CraftAbstractNautilus extends CraftTameableAnimal implements org.bukkit.entity.AbstractNautilus {
     public CraftAbstractNautilus(final CraftServer server, final AbstractNautilus entity) {
@@ -18,7 +17,7 @@ public class CraftAbstractNautilus extends CraftTameableAnimal implements org.bu
     }
 
     @Override
-    public @NotNull Inventory getInventory() {
+    public Inventory getInventory() {
         return new CraftSaddledInventory(
             getHandle().inventory,
             this.getHandle().createEquipmentSlotContainer(EquipmentSlot.BODY),


### PR DESCRIPTION
As specified on discord in [paper-contrib](https://discord.com/channels/289587909051416579/925530366192779286/1437892195674751166) the nautilus inventory wouldn't properly open.

This PR went a bit out of scope with that also adding inventory event triggering as well, but I'll go and roll back those changes if needed, because they weren't necessarily what was requested.