### PR TITLE
Pre-Adventure 5.0 changes

### DIFF
--- a/paper-api/build.gradle.kts
+++ b/paper-api/build.gradle.kts
@@ -12,7 +12,7 @@ java {
 }
 
 val annotationsVersion = "26.0.2"
-val adventureVersion = "4.25.0"
+val adventureVersion = "4.26.1"
 val bungeeCordChatVersion = "1.21-R0.2-deprecated+build.21"
 val slf4jVersion = "2.0.16"
 val log4jVersion = "2.24.1"

--- a/paper-api/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java
@@ -240,6 +240,8 @@ public class AsyncTabCompleteEvent extends Event implements Cancellable {
 
     /**
      * A rich tab completion, consisting of a string suggestion, and a nullable {@link Component} tooltip.
+     *
+     * <p><b>Warning:</b> In a future update, this class will no longer implement Examinable.</p>
      */
     public interface Completion extends Examinable {
 
@@ -258,6 +260,7 @@ public class AsyncTabCompleteEvent extends Event implements Cancellable {
         @Nullable Component tooltip();
 
         @Override
+        @Deprecated(forRemoval = true, since = "1.21.10")
         default Stream<? extends ExaminableProperty> examinableProperties() {
             return Stream.of(ExaminableProperty.of("suggestion", this.suggestion()), ExaminableProperty.of("tooltip", this.tooltip()));
         }

--- a/paper-api/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java
@@ -240,8 +240,8 @@ public class AsyncTabCompleteEvent extends Event implements Cancellable {
 
     /**
      * A rich tab completion, consisting of a string suggestion, and a nullable {@link Component} tooltip.
-     *
-     * <p><b>Warning:</b> In a future update, this class will no longer implement Examinable.</p>
+     * <p>
+     * <b>Warning:</b> In a future update, this class will no longer implement {@link Examinable}.
      */
     public interface Completion extends Examinable {
 
@@ -260,7 +260,7 @@ public class AsyncTabCompleteEvent extends Event implements Cancellable {
         @Nullable Component tooltip();
 
         @Override
-        @Deprecated(forRemoval = true, since = "1.21.10")
+        @Deprecated(forRemoval = true, since = "1.21.11")
         default Stream<? extends ExaminableProperty> examinableProperties() {
             return Stream.of(ExaminableProperty.of("suggestion", this.suggestion()), ExaminableProperty.of("tooltip", this.tooltip()));
         }

--- a/paper-api/src/main/java/org/bukkit/inventory/meta/BookMeta.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/meta/BookMeta.java
@@ -14,6 +14,9 @@ import org.jetbrains.annotations.Nullable;
  * {@link org.bukkit.inventory.ItemStack#getType()}. {@code instanceof} on
  * the meta instance is not sufficient due to unusual inheritance
  * with relation to {@link WritableBookMeta}.
+ * <p>
+ * <b>Warning: </b> in an upcoming version of Paper, this interface will no
+ * longer extend Adventure's {@link net.kyori.adventure.inventory.Book}.
  */
 public interface BookMeta extends WritableBookMeta, net.kyori.adventure.inventory.Book { // Paper - adventure
 
@@ -243,27 +246,58 @@ public interface BookMeta extends WritableBookMeta, net.kyori.adventure.inventor
      */
     void addPages(net.kyori.adventure.text.@NotNull Component @NotNull ... pages);
 
+    /**
+     * @deprecated BookMeta is mutable, there is no need for a builder.
+     */
+    @Deprecated(forRemoval = true, since = "1.21.11")
     interface BookMetaBuilder extends net.kyori.adventure.inventory.Book.Builder {
-
+        /**
+         * @deprecated BookMeta is mutable, there is no need for a builder.
+         */
+        @Deprecated(forRemoval = true, since = "1.21.11")
         @Override
         @NotNull BookMetaBuilder title(net.kyori.adventure.text.@Nullable Component title);
 
+        /**
+         * @deprecated BookMeta is mutable, there is no need for a builder.
+         */
+        @Deprecated(forRemoval = true, since = "1.21.11")
         @Override
         @NotNull BookMetaBuilder author(net.kyori.adventure.text.@Nullable Component author);
 
+        /**
+         * @deprecated BookMeta is mutable, there is no need for a builder.
+         */
+        @Deprecated(forRemoval = true, since = "1.21.11")
         @Override
         @NotNull BookMetaBuilder addPage(net.kyori.adventure.text.@NotNull Component page);
 
+        /**
+         * @deprecated BookMeta is mutable, there is no need for a builder.
+         */
+        @Deprecated(forRemoval = true, since = "1.21.11")
         @Override
         @NotNull BookMetaBuilder pages(net.kyori.adventure.text.@NotNull Component @NotNull ... pages);
 
+        /**
+         * @deprecated BookMeta is mutable, there is no need for a builder.
+         */
+        @Deprecated(forRemoval = true, since = "1.21.11")
         @Override
         @NotNull BookMetaBuilder pages(java.util.@NotNull Collection<net.kyori.adventure.text.Component> pages);
 
+        /**
+         * @deprecated BookMeta is mutable, there is no need for a builder.
+         */
+        @Deprecated(forRemoval = true, since = "1.21.11")
         @Override
         @NotNull BookMeta build();
     }
 
+    /**
+     * @deprecated BookMeta is mutable, there is no need for a builder.
+     */
+    @Deprecated(forRemoval = true, since = "1.21.11")
     @Override
     @NotNull BookMetaBuilder toBuilder();
     // Paper end

--- a/paper-api/src/main/java/org/bukkit/inventory/meta/BookMeta.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/meta/BookMeta.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
  * the meta instance is not sufficient due to unusual inheritance
  * with relation to {@link WritableBookMeta}.
  * <p>
- * <b>Warning: </b> in an upcoming version of Paper, this interface will no
+ * <b>Warning:</b> in an upcoming version of Paper, this interface will no
  * longer extend Adventure's {@link net.kyori.adventure.inventory.Book}.
  */
 public interface BookMeta extends WritableBookMeta, net.kyori.adventure.inventory.Book { // Paper - adventure


### PR DESCRIPTION
This PR contains changes that need to be made _before_ the Adventure 5.0 update.

The following changes are made:
* **Preparations for the removal of the "Book-ness" of BookMeta**
As Adventure's `Book` is now sealed, we need to prepare for this. `BookMeta` erroneously implements Adventure's `Book` so a note is added that this will be removed. The builder will also be deprecated for removal as meta is mutable anyway, so a builder is completely useless. The `#toBuilder` method doesn't even work, it just returns an empty builder, so I doubt the builder will be missed.
* **Deprecate the "Examinable-ness" of AsyncTabCompleteEvent.Completion**
The examination library is removed in Adventure 5.0, so we'll just deprecate this for removal in the one place it is used in Paper.
* **Bump adventure to 4.26.1**
This includes deprecations and changes to the adventure library that will prepare users for the upcoming 5.0 update.