### PR TITLE
fix: Player#setPlayerTime sends time update packet to client

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1532,6 +1532,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public void setPlayerTime(long time, boolean relative) {
         this.getHandle().timeOffset = time;
         this.getHandle().relativeTime = relative;
+
+        if (this.getHandle().connection == null) {
+            return;
+        }
+
+        final long gameTime = this.getHandle().level().getGameTime();
+        final long dayTime = this.getHandle().getPlayerTime();
+        final boolean tickDayTime = this.getHandle().relativeTime && this.getHandle().level().getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_DAYLIGHT);
+        this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSetTimePacket(gameTime, dayTime, tickDayTime));
     }
 
     @Override


### PR DESCRIPTION
Player#setPlayerTime only updates fields timeOffset and relativeTime, 
which means the client may not immediately reflect the new time. This PR ensures that whenever 
setPlayerTime is called, a ClientboundSetTimePacket is sent to the player so the client is synced immediately.