### PR TITLE
Fix crash when explosion has no power

### DIFF
--- a/paper-server/patches/features/0032-Fix-crash-when-explosion-has-no-power.patch
+++ b/paper-server/patches/features/0032-Fix-crash-when-explosion-has-no-power.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Brokkonaut <hannos17@gmx.de>
+Date: Sun, 23 Nov 2025 04:54:17 +0100
+Subject: [PATCH] Fix crash when explosion has no power
+
+
+diff --git a/net/minecraft/world/level/ServerExplosion.java b/net/minecraft/world/level/ServerExplosion.java
+index 1c521f9f32340cf75310686c90777e521ac3ae5c..b08e767061f3177ca60ab332ba3ac43f13da33be 100644
+--- a/net/minecraft/world/level/ServerExplosion.java
++++ b/net/minecraft/world/level/ServerExplosion.java
+@@ -478,6 +478,11 @@ public class ServerExplosion implements Explosion {
+     }
+ 
+     private void hurtEntities() {
++        // Paper start - fix crash when explosion has no power
++        if (this.radius <= 0) {
++            return;
++        }
++        // Paper end - fix crash when explosion has no power
+         float f = this.radius * 2.0F;
+         int floor = Mth.floor(this.center.x - f - 1.0);
+         int floor1 = Mth.floor(this.center.x + f + 1.0);


### PR DESCRIPTION
Fix a crash when creating explosions with no power, this happens for example with the following code:
```
Fireball rocket = (Fireball) world.spawnEntity(spawnLoc, EntityType.FIREBALL);
rocket.setYield(0F);
rocket.setVelocity(something);
```
This code worked fine in paper 1.21.8 and I think there is no reason why it should not work.

If there is an entity (in the log below it is a projectile) nearby (less than 1 block distance to the explosion of the fireball) it would otherwise get a push with a NaN vector (in the code d is NaN -> d2 is NaN -> vec32 has NaN components) setting the entities velocity to NaN what crashes the server the next time that entity ticks.

Stacktrace without the fix is something like this:
```
[19:53:48] [Paper Watchdog Thread/ERROR]: The server has not responded for 65 seconds! Creating thread dump
[19:53:48] [Paper Watchdog Thread/ERROR]: ------------------------------
[19:53:48] [Paper Watchdog Thread/ERROR]: Server thread dump (Look for plugins here before reporting to Paper!):
[19:53:48] [Paper Watchdog Thread/ERROR]: ------------------------------
[19:53:48] [Paper Watchdog Thread/ERROR]: Current Thread: Server thread
[19:53:48] [Paper Watchdog Thread/ERROR]: 	PID: 53 | Suspended: false | Native: false | State: RUNNABLE
[19:53:48] [Paper Watchdog Thread/ERROR]: 	Stack:
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase.getShape(BlockBehaviour.java:789)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase.getShape(BlockBehaviour.java:785)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.block.state.BlockBehaviour.getCollisionShape(BlockBehaviour.java:332)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase.getCollisionShape(BlockBehaviour.java:797)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.ClipContext$Block$$Lambda/0x00007f85a29ff6d8.get(Unknown Source)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.ClipContext$Block.get(ClipContext.java:91)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.ClipContext.getBlockShape(ClipContext.java:48)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.Level.fastClip(Level.java:443)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.Level.clip(Level.java:502)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.CollisionGetter.clipIncludingBorder(CollisionGetter.java:114)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.entity.projectile.ProjectileUtil.getHitResult(ProjectileUtil.java:49)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.entity.projectile.ProjectileUtil.getHitResultOnMoveVector(ProjectileUtil.java:28)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.entity.projectile.ThrowableProjectile.tick(ThrowableProjectile.java:50)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.level.ServerLevel.tickNonPassenger(ServerLevel.java:1316)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.level.ServerLevel$$Lambda/0x00007f85a28d76c8.accept(Unknown Source)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.Level.guardEntityTick(Level.java:1434)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.level.ServerLevel.lambda$tick$4(ServerLevel.java:839)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.level.ServerLevel$$Lambda/0x00007f85a27c6dd8.accept(Unknown Source)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.entity.EntityTickList.forEach(EntityTickList.java:39)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.level.ServerLevel.tick(ServerLevel.java:821)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1807)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1618)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:430)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1338)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:384)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.MinecraftServer$$Lambda/0x00007f85a0f32f48.run(Unknown Source)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		java.base@21.0.3/java.lang.Thread.runWith(Thread.java:1596)
[19:53:48] [Paper Watchdog Thread/ERROR]: 		java.base@21.0.3/java.lang.Thread.run(Thread.java:1583)
```

The fix just skips the entity hurt logic when there is no explosion power