### PR TITLE
Position riders before API teleportation

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -24589,7 +24589,7 @@ index 5e5aad112058b567214c28ccd719271f12240a35..cd5a325d37f617431ceb568a65570160
  
      @FunctionalInterface
 diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
-index 095617b58c955121e1dcf84246691c20fb3c5b74..513d6ea15d2b3577c649182422f051639d7fea49 100644
+index 4a9e9707bebe85e26d28260b389e236156ba5637..c3da011196e9cac1d90b2ae40952680e0fbd90a1 100644
 --- a/net/minecraft/server/level/ChunkMap.java
 +++ b/net/minecraft/server/level/ChunkMap.java
 @@ -124,10 +124,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
@@ -26459,7 +26459,7 @@ index a701288146a1d7cd258faae69f959edf466ec71c..3509df9dd423b38d1ca3e4a420d1352a
      }
  
 diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
-index 5e0d2bbd9223f727ec337357ee7d0088eff11ab8..3d6765f284d1817d68db4d9ae0d90c7e73e6e068 100644
+index 229035e15113419080187263c7fa5e004a12c3f3..550b915d4ed457231605247c3e21844fed2f67b6 100644
 --- a/net/minecraft/server/level/ServerChunkCache.java
 +++ b/net/minecraft/server/level/ServerChunkCache.java
 @@ -54,7 +54,7 @@ import net.minecraft.world.level.storage.SavedDataStorage;
@@ -27757,7 +27757,7 @@ index ce5bd957dbfe52cd81e571359c6de1028dc11cde..5bb8ddc9490ce6c7bc4544ef0ea05484
              "Server weather",
              () -> String.format(
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 82ba52a9a265c113ed01ecd60957e97a6172445a..88173a3775734ca271d9ff6a7a253eeb343a82a4 100644
+index b569df775fcc9885b7cfee1b8280b68f33f4cd71..220409fd6335e17445e1acdbfac8d83ae36a99b4 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -206,7 +206,7 @@ import net.minecraft.world.scores.criteria.ObjectiveCriteria;
@@ -28864,7 +28864,7 @@ index 09b6da207530987b483444cebeadc2f1c9a15247..3666c3efd188508153b6482db425648e
 +    // Paper end - block counting
  }
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 745aa8356fca102c6980363d126bfd6b23415b12..ba0cdbd064ad3e0cf645c50ab14adcddef48e932 100644
+index d8e2adefabb1de2506faa0e6789801b3d1f0203a..0682b5a6d828141f50c62ff5ea56d5bbb25e1004 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -164,7 +164,7 @@ public abstract class Entity
@@ -29332,7 +29332,7 @@ index 745aa8356fca102c6980363d126bfd6b23415b12..ba0cdbd064ad3e0cf645c50ab14adcdd
      }
  
      public InteractionResult interact(final Player player, final InteractionHand hand, final Vec3 location) {
-@@ -4440,15 +4677,17 @@ public abstract class Entity
+@@ -4447,15 +4684,17 @@ public abstract class Entity
      }
  
      public Iterable<Entity> getIndirectPassengers() {
@@ -29358,7 +29358,7 @@ index 745aa8356fca102c6980363d126bfd6b23415b12..ba0cdbd064ad3e0cf645c50ab14adcdd
      }
  
      public int countPlayerPassengers() {
-@@ -4759,6 +4998,15 @@ public abstract class Entity
+@@ -4766,6 +5005,15 @@ public abstract class Entity
      }
  
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
@@ -29374,7 +29374,7 @@ index 745aa8356fca102c6980363d126bfd6b23415b12..ba0cdbd064ad3e0cf645c50ab14adcdd
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4908,6 +5156,12 @@ public abstract class Entity
+@@ -4915,6 +5163,12 @@ public abstract class Entity
  
      @Override
      public final void setRemoved(final Entity.RemovalReason reason, org.bukkit.event.entity.EntityRemoveEvent.@Nullable Cause cause) { // CraftBukkit - add Bukkit remove cause
@@ -29387,7 +29387,7 @@ index 745aa8356fca102c6980363d126bfd6b23415b12..ba0cdbd064ad3e0cf645c50ab14adcdd
          org.bukkit.craftbukkit.event.CraftEventFactory.callEntityRemoveEvent(this, cause); // CraftBukkit
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
          if (this.removalReason == null) {
-@@ -4918,7 +5172,7 @@ public abstract class Entity
+@@ -4925,7 +5179,7 @@ public abstract class Entity
              this.stopRiding();
          }
  
@@ -29396,7 +29396,7 @@ index 745aa8356fca102c6980363d126bfd6b23415b12..ba0cdbd064ad3e0cf645c50ab14adcdd
          this.levelCallback.onRemove(reason);
          this.onRemoval(reason);
          // Paper start - Folia schedulers
-@@ -4952,7 +5206,7 @@ public abstract class Entity
+@@ -4959,7 +5213,7 @@ public abstract class Entity
      public boolean shouldBeSaved() {
          return (this.removalReason == null || this.removalReason.shouldSave())
              && !this.isPassenger()

--- a/paper-server/patches/features/0017-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0017-Optimise-EntityScheduler-ticking.patch
@@ -66,10 +66,10 @@ index b1f5741d5d714f57795c53605db87d86ebb07051..b71f2e181334ad8646afb48c704c30b6
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.ADVENTURE_CLICK_MANAGER.handleQueue(this.tickCount); // Paper
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.DIALOG_CLICK_MANAGER.handleQueue(this.tickCount); // Paper
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 68855c16d2cb3e5b7d7a86f05e7bb2e7922a5ba0..1530810cdb74810e37e3e22ce4fcda4ee7511055 100644
+index abd46a9bdfa6d387e866e192230aa1f07e5c8936..0fa6006a7c344f9f12972008e586b4c1f03c470e 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -5223,6 +5223,11 @@ public abstract class Entity
+@@ -5230,6 +5230,11 @@ public abstract class Entity
          this.getBukkitEntity().taskScheduler.retire();
      }
      // Paper end - Folia schedulers

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -597,7 +597,7 @@
      }
  
      @Override
-@@ -1004,24 +_,98 @@
+@@ -1004,24 +_,87 @@
          return this.level().isPvpAllowed();
      }
  
@@ -684,18 +684,7 @@
 +        location = respawnEvent.getRespawnLocation();
 +
 +        return new RespawnResult(
-+            new TeleportTransition(
-+                ((org.bukkit.craftbukkit.CraftWorld) location.getWorld()).getHandle(),
-+                org.bukkit.craftbukkit.util.CraftLocation.toVec3(location),
-+                teleportTransition.deltaMovement(),
-+                location.getYaw(),
-+                location.getPitch(),
-+                teleportTransition.missingRespawnBlock(),
-+                teleportTransition.asPassenger(),
-+                teleportTransition.relatives(),
-+                teleportTransition.postTeleportTransition(),
-+                teleportTransition.cause()
-+            ),
++            teleportTransition.withChangedLocation(location),
 +            isBedSpawn,
 +            isAnchorSpawn
 +        );
@@ -744,7 +733,7 @@
          if (this.isRemoved()) {
              return null;
          }
-@@ -1103,12 +_,46 @@
+@@ -1103,12 +_,36 @@
          ServerLevel newLevel = transition.newLevel();
          ServerLevel oldLevel = this.level();
          ResourceKey<Level> lastDimension = oldLevel.dimension();
@@ -769,17 +758,7 @@
 +        }
 +        if (!newExit.equals(exit)) {
 +            newLevel = ((org.bukkit.craftbukkit.CraftWorld) newExit.getWorld()).getHandle();
-+            transition = new TeleportTransition(
-+                newLevel,
-+                org.bukkit.craftbukkit.util.CraftLocation.toVec3(newExit),
-+                Vec3.ZERO,
-+                newExit.getYaw(),
-+                newExit.getPitch(),
-+                transition.missingRespawnBlock(),
-+                transition.asPassenger(),
-+                Set.of(),
-+                transition.postTeleportTransition(),
-+                transition.cause());
++            transition = transition.withChangedLocation(newExit).withVelocity(Vec3.ZERO).withRelatives(Set.of());
 +        }
 +        // CraftBukkit end
          if (!transition.asPassenger()) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1486,7 +1486,7 @@
 +            }
 +            if (!to.equals(teleEvent.getTo())) {
 +                to = teleEvent.getTo();
-+                transition = new TeleportTransition(((org.bukkit.craftbukkit.CraftWorld) to.getWorld()).getHandle(), org.bukkit.craftbukkit.util.CraftLocation.toVec3(to), Vec3.ZERO, to.getYaw(), to.getPitch(), transition.missingRespawnBlock(), transition.asPassenger(), Set.of(), transition.postTeleportTransition(), transition.cause());
++                transition = transition.withChangedLocation(to).withVelocity(Vec3.ZERO).withRelatives(Set.of());
 +                // Paper start - Call EntityPortalExitEvent
 +                velocity = Vec3.ZERO;
 +            }
@@ -1512,7 +1512,7 @@
 +                        to = event.getTo().clone();
 +                        velocity = org.bukkit.craftbukkit.util.CraftVector.toVec3(event.getAfter());
 +                    }
-+                    transition = new TeleportTransition(((org.bukkit.craftbukkit.CraftWorld) to.getWorld()).getHandle(), org.bukkit.craftbukkit.util.CraftLocation.toVec3(to), velocity, to.getYaw(), to.getPitch(), transition.missingRespawnBlock(), transition.asPassenger(), Set.of(), transition.postTeleportTransition(), transition.cause());
++                    transition = transition.withChangedLocation(to).withRelatives(Set.of()).withVelocity(velocity);
 +                }
 +            }
 +            if (this.isRemoved()) {
@@ -1540,6 +1540,20 @@
  
          for (Entity newPassenger : newPassengers) {
              newPassenger.startRiding(newEntity, true, false);
+@@ -3126,6 +_,13 @@
+     private TeleportTransition calculatePassengerTransition(final TeleportTransition transition, final Entity passenger) {
+         float passengerYRot = transition.yRot() + (transition.relatives().contains(Relative.Y_ROT) ? 0.0F : passenger.getYRot() - this.getYRot());
+         float passengerXRot = transition.xRot() + (transition.relatives().contains(Relative.X_ROT) ? 0.0F : passenger.getXRot() - this.getXRot());
++        // Paper start - reposition entity as rider when teleporting via API call
++        // This change is mostly required for plugins teleporting entities *every* tick with passengers, specifically player passengers.
++        // The relative teleport of players, which base their location on the server -> client -> server teleport packet cycle, means player
++        // positions can quickly be desynced from their rider position, leading to infinitely growing offsets from their vehicle.
++        // The addition to the teleport transition allows existing callers to this method to not accidentally mutate the entity state.
++        if (transition.passengerTeleportationMode() == TeleportTransition.PassengerTeleportationMode.POSITION_RIDER) this.positionRider(passenger);
++        // Paper end - reposition entity as rider when teleporting via API call
+         Vec3 passengerOffset = passenger.position().subtract(this.position());
+         Vec3 passengerPos = transition.position()
+             .add(
 @@ -3187,9 +_,17 @@
      }
  
@@ -1600,7 +1614,7 @@
 +        // CraftBukkit end
          Entity newEntity = this.teleport(
 -            new TeleportTransition(level, new Vec3(x, y, z), Vec3.ZERO, newYRot, newXRot, relatives, TeleportTransition.DO_NOTHING)
-+            new TeleportTransition(level, new Vec3(x, y, z), Vec3.ZERO, newYRot, newXRot, relatives, TeleportTransition.DO_NOTHING, cause) // CraftBukkit
++            new TeleportTransition(level, new Vec3(x, y, z), Vec3.ZERO, newYRot, newXRot, relatives, TeleportTransition.DO_NOTHING).withCause(cause) // CraftBukkit
          );
          return newEntity != null;
      }

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java.patch
@@ -9,7 +9,7 @@
 +                        final double preTeleportX = player.getX(), preTeleportY = player.getY(), preTeleportZ = player.getZ();
 +                        final float preTeleportYRot = player.getYRot(), preTeleportXRot = player.getXRot();
 +                        ServerPlayer newOwner = player.teleport(new TeleportTransition(
-+                            level, teleportPos, Vec3.ZERO, 0.0F, 0.0F, Relative.union(Relative.ROTATION, Relative.DELTA), TeleportTransition.DO_NOTHING, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.ENDER_PEARL));
++                            level, teleportPos, Vec3.ZERO, 0.0F, 0.0F, Relative.union(Relative.ROTATION, Relative.DELTA), TeleportTransition.DO_NOTHING).withCause(org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.ENDER_PEARL));
 +                        if (newOwner == null) {
 +                            this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.HIT);
 +                            return;

--- a/paper-server/patches/sources/net/minecraft/world/level/block/EndGatewayBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/EndGatewayBlock.java.patch
@@ -21,17 +21,16 @@
              } else {
                  return entity instanceof ThrownEnderpearl
 -                    ? new TeleportTransition(currentLevel, teleportPosition, Vec3.ZERO, 0.0F, 0.0F, Set.of(), TeleportTransition.PLACE_PORTAL_TICKET)
-+                    ? new TeleportTransition(currentLevel, teleportPosition, Vec3.ZERO, 0.0F, 0.0F, Set.of(), TeleportTransition.PLACE_PORTAL_TICKET, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.END_GATEWAY) // CraftBukkit
++                    ? new TeleportTransition(currentLevel, teleportPosition, Vec3.ZERO, 0.0F, 0.0F, Set.of(), TeleportTransition.PLACE_PORTAL_TICKET).withCause(org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.END_GATEWAY) // CraftBukkit
                      : new TeleportTransition(
                          currentLevel,
                          teleportPosition,
-@@ -119,7 +_,8 @@
-                         0.0F,
+@@ -120,7 +_,7 @@
                          0.0F,
                          Relative.union(Relative.DELTA, Relative.ROTATION),
--                        TeleportTransition.PLACE_PORTAL_TICKET
-+                        TeleportTransition.PLACE_PORTAL_TICKET,
-+                        org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.END_GATEWAY // CraftBukkit
-                     );
+                         TeleportTransition.PLACE_PORTAL_TICKET
+-                    );
++                    ).withCause(org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.END_GATEWAY);  // CraftBukkit;
              }
          } else {
+             return null;

--- a/paper-server/patches/sources/net/minecraft/world/level/block/EndPortalBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/EndPortalBlock.java.patch
@@ -34,7 +34,7 @@
              yRot = Direction.WEST.toYRot();
              xRot = 0.0F;
              relatives = Relative.union(Relative.DELTA, Set.of(Relative.X_ROT));
-@@ -104,15 +_,26 @@
+@@ -104,15 +_,32 @@
              xRot = respawnData.pitch();
              relatives = Relative.union(Relative.DELTA, Relative.ROTATION);
              if (entity instanceof ServerPlayer serverPlayer) {
@@ -57,8 +57,15 @@
 +
          return new TeleportTransition(
 -            newLevel, spawnPos, Vec3.ZERO, yRot, xRot, relatives, TeleportTransition.PLAY_PORTAL_SOUND.then(TeleportTransition.PLACE_PORTAL_TICKET)
-+            ((org.bukkit.craftbukkit.CraftWorld) to.getWorld()).getHandle(), org.bukkit.craftbukkit.util.CraftLocation.toVec3(to), Vec3.ZERO, to.getYaw(), to.getPitch(), relatives, TeleportTransition.PLAY_PORTAL_SOUND.then(TeleportTransition.PLACE_PORTAL_TICKET), org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.END_PORTAL
-         );
+-        );
++            ((org.bukkit.craftbukkit.CraftWorld) to.getWorld()).getHandle(),
++            org.bukkit.craftbukkit.util.CraftLocation.toVec3(to),
++            Vec3.ZERO,
++            to.getYaw(),
++            to.getPitch(),
++            relatives,
++            TeleportTransition.PLAY_PORTAL_SOUND.then(TeleportTransition.PLACE_PORTAL_TICKET)
++        ).withCause(org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.END_PORTAL);
 +        // CraftBukkit end
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/level/block/NetherPortalBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/NetherPortalBlock.java.patch
@@ -119,12 +119,12 @@
  
          return getDimensionTransitionFromExit(entity, portalEntryPos, exitPortal, newLevel, post);
      }
-@@ -236,7 +_,7 @@
-         );
+@@ -237,7 +_,7 @@
          Vec3 collisionFreePos = PortalShape.findCollisionFreePosition(targetPos, newLevel, entity, dimensions);
          return new TeleportTransition(
--            newLevel, collisionFreePos, Vec3.ZERO, outputRotation, 0.0F, Relative.union(Relative.DELTA, Relative.ROTATION), postTeleportTransition
-+            newLevel, collisionFreePos, Vec3.ZERO, outputRotation, 0.0F, Relative.union(Relative.DELTA, Relative.ROTATION), postTeleportTransition, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.NETHER_PORTAL // CraftBukkit
-         );
+             newLevel, collisionFreePos, Vec3.ZERO, outputRotation, 0.0F, Relative.union(Relative.DELTA, Relative.ROTATION), postTeleportTransition
+-        );
++        ).withCause(org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.NETHER_PORTAL); // CraftBukkit
      }
  
+     @Override

--- a/paper-server/patches/sources/net/minecraft/world/level/portal/TeleportTransition.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/portal/TeleportTransition.java.patch
@@ -1,74 +1,144 @@
 --- a/net/minecraft/world/level/portal/TeleportTransition.java
 +++ b/net/minecraft/world/level/portal/TeleportTransition.java
-@@ -21,11 +_,18 @@
+@@ -21,7 +_,108 @@
      boolean asPassenger,
      Set<Relative> relatives,
      TeleportTransition.PostTeleportTransition postTeleportTransition
-+    , org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause // CraftBukkit
++    // Paper start - additional transition data
++    , org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause,
++    PassengerTeleportationMode passengerTeleportationMode
  ) {
++
++    public enum PassengerTeleportationMode {
++        RELATIVE,
++        POSITION_RIDER
++    }
++
++    // Vanilla compat constructor
++    public TeleportTransition(
++        final ServerLevel newLevel,
++        final Vec3 position,
++        final Vec3 deltaMovement,
++        final float yRot,
++        final float xRot,
++        final boolean missingRespawnBlock,
++        final boolean asPassenger,
++        final Set<Relative> relatives,
++        final TeleportTransition.PostTeleportTransition postTeleportTransition
++    ) {
++        this(
++            newLevel,
++            position,
++            deltaMovement,
++            yRot,
++            xRot,
++            missingRespawnBlock,
++            asPassenger,
++            relatives,
++            postTeleportTransition,
++            org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.UNKNOWN,
++            PassengerTeleportationMode.RELATIVE
++        );
++    }
++
++    public TeleportTransition withChangedLocation(final org.bukkit.Location location) {
++        return new TeleportTransition(
++            ((org.bukkit.craftbukkit.CraftWorld) location.getWorld()).getHandle(),
++            org.bukkit.craftbukkit.util.CraftLocation.toVec3(location),
++            this.deltaMovement(),
++            location.getYaw(),
++            location.getPitch(),
++            this.missingRespawnBlock(),
++            this.asPassenger(),
++            this.relatives(),
++            this.postTeleportTransition(),
++            this.cause(),
++            this.passengerTeleportationMode()
++        );
++    }
++
++    public TeleportTransition withVelocity(final Vec3 velocity) {
++        return new TeleportTransition(
++            this.newLevel(),
++            this.position(),
++            velocity,
++            this.yRot(),
++            this.xRot(),
++            this.missingRespawnBlock(),
++            this.asPassenger(),
++            this.relatives(),
++            this.postTeleportTransition(),
++            this.cause(),
++            this.passengerTeleportationMode()
++        );
++    }
++
++    public TeleportTransition withRelatives(final Set<Relative> relatives) {
++        return new TeleportTransition(
++            this.newLevel(),
++            this.position(),
++            this.deltaMovement(),
++            this.yRot(),
++            this.xRot(),
++            this.missingRespawnBlock(),
++            this.asPassenger(),
++            relatives,
++            this.postTeleportTransition(),
++            this.cause(),
++            this.passengerTeleportationMode()
++        );
++    }
++
++    public TeleportTransition withCause(final org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause) {
++        return new TeleportTransition(
++            this.newLevel(),
++            this.position(),
++            this.deltaMovement(),
++            this.yRot(),
++            this.xRot(),
++            this.missingRespawnBlock(),
++            this.asPassenger(),
++            this.relatives(),
++            this.postTeleportTransition(),
++            cause,
++            this.passengerTeleportationMode()
++        );
++    }
++    // Paper end - additional transition data
++
      public static final TeleportTransition.PostTeleportTransition DO_NOTHING = entity -> {};
      public static final TeleportTransition.PostTeleportTransition PLAY_PORTAL_SOUND = TeleportTransition::playPortalSound;
      public static final TeleportTransition.PostTeleportTransition PLACE_PORTAL_TICKET = TeleportTransition::placePortalTicket;
- 
-+    // CraftBukkit start
-+    public TeleportTransition(ServerLevel newLevel, Vec3 position, Vec3 deltaMovement, float yRot, float xRot, boolean missingRespawnBlock, boolean asPassenger, Set<Relative> relatives, TeleportTransition.PostTeleportTransition postTeleportTransition) {
-+        this(newLevel, position, deltaMovement, yRot, xRot, missingRespawnBlock, asPassenger, relatives, postTeleportTransition, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.UNKNOWN);
-+    }
-+    // CraftBukkit end
-+
-     public TeleportTransition(
-         final ServerLevel newLevel,
-         final Vec3 pos,
-@@ -46,7 +_,21 @@
-         final Set<Relative> relatives,
-         final TeleportTransition.PostTeleportTransition postTeleportTransition
-     ) {
--        this(newLevel, pos, speed, yRot, xRot, false, false, relatives, postTeleportTransition);
-+        // CraftBukkit start
-+        this(newLevel, pos, speed, yRot, xRot, relatives, postTeleportTransition, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.UNKNOWN);
-+    }
-+    public TeleportTransition(
-+        ServerLevel newLevel,
-+        Vec3 position,
-+        Vec3 deltaMovement,
-+        float yRot,
-+        float xRot,
-+        Set<Relative> relatives,
-+        TeleportTransition.PostTeleportTransition postTeleportTransition,
-+        org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause
-+    ) {
-+        this(newLevel, position, deltaMovement, yRot, xRot, false, false, relatives, postTeleportTransition, cause);
-+        // CraftBukkit end
-     }
- 
-     private static void playPortalSound(final Entity entity) {
-@@ -105,7 +_,8 @@
-             this.missingRespawnBlock(),
+@@ -106,6 +_,10 @@
              this.asPassenger(),
              this.relatives(),
--            this.postTeleportTransition()
-+            this.postTeleportTransition(),
-+            this.cause() // Paper - keep cause
+             this.postTeleportTransition()
++            // Paper start - keep additional data
++            , this.cause(),
++            this.passengerTeleportationMode()
++            // Paper end - keep additional data
          );
      }
  
-@@ -119,7 +_,8 @@
-             this.missingRespawnBlock(),
+@@ -120,6 +_,10 @@
              this.asPassenger(),
              this.relatives(),
--            this.postTeleportTransition()
-+            this.postTeleportTransition(),
-+            this.cause() // Paper - keep cause
+             this.postTeleportTransition()
++            // Paper start - keep additional data
++            , this.cause(),
++            this.passengerTeleportationMode()
++            // Paper end - keep additional data
          );
      }
  
-@@ -133,7 +_,8 @@
-             this.missingRespawnBlock(),
+@@ -134,6 +_,10 @@
              true,
              this.relatives(),
--            this.postTeleportTransition()
-+            this.postTeleportTransition(),
-+            this.cause() // Paper - keep cause
+             this.postTeleportTransition()
++            // Paper start - keep additional data
++            , this.cause(),
++            this.passengerTeleportationMode()
++            // Paper end - keep additional data
          );
      }
  

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -314,9 +314,12 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
             Vec3.ZERO,
             location.getYaw(),
             location.getPitch(),
+            false,
+            false,
             relativeFlags,
             TeleportTransition.DO_NOTHING,
-            cause
+            cause,
+            TeleportTransition.PassengerTeleportationMode.POSITION_RIDER
         )) != null;
     }
 


### PR DESCRIPTION
The previous teleportation logic would call Entity#positionRider for the
"teleportation" of passengers in the same dimension.
This prevented plugins that aggressively teleport entities on a per-tick
basis from allowing players to get out of sync with their vehicles as
the vanilla teleport logic simply performs a relative repositioning of
the passengers to the vehicle location.

The introduced diff now repositions the passengers onto their vehicle
before computing their relative offset and repositioning.

Resolves: #13239
