### PR TITLE
Add missing Nullable annotation for KineticWeapon.Builder methods

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/KineticWeapon.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/KineticWeapon.java
@@ -98,9 +98,9 @@ public interface KineticWeapon {
         Builder damageMultiplier(float damageMultiplier);
 
         @Contract(value = "_ -> this", mutates = "this")
-        Builder sound(Key sound);
+        Builder sound(@Nullable Key sound);
 
         @Contract(value = "_ -> this", mutates = "this")
-        Builder hitSound(Key sound);
+        Builder hitSound(@Nullable Key sound);
     }
 }


### PR DESCRIPTION
Mentioned in Discord the implementation use allow nullable for sound and hitSound but the API not include that annotation.