### PR TITLE
Fix ItemType#isEdible to also check for DataComponents#CONSUMABLE

### DIFF
--- a/paper-api/src/main/java/org/bukkit/Material.java
+++ b/paper-api/src/main/java/org/bukkit/Material.java
@@ -3001,13 +3001,14 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
     }
 
     /**
-     * Checks if this Material is edible.
+     * Checks if this Material provides the {@link io.papermc.paper.datacomponent.DataComponentTypes#FOOD} and
+     * {@link io.papermc.paper.datacomponent.DataComponentTypes#CONSUMABLE} and, thereby, is edible by a player.
      *
      * @return true if this Material is edible.
      */
     public boolean isEdible() {
         ItemType type = asItemType();
-        return type == null ? false : type.isEdible();
+        return type != null && type.isEdible();
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemType.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemType.java
@@ -3189,7 +3189,8 @@ public interface ItemType extends Keyed, Translatable, net.kyori.adventure.trans
     short getMaxDurability();
 
     /**
-     * Checks if this item type is edible.
+     * Checks if this item type provides the {@link io.papermc.paper.datacomponent.DataComponentTypes#FOOD} and
+     * {@link io.papermc.paper.datacomponent.DataComponentTypes#CONSUMABLE} and, thereby, is edible by a player.
      *
      * @return true if this item type is edible.
      */

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemType.java
@@ -143,7 +143,7 @@ public class CraftItemType<M extends ItemMeta> extends HolderableBase<Item> impl
 
     @Override
     public boolean isEdible() {
-        return this.getHandle().components().has(DataComponents.FOOD);
+        return this.getHandle().components().has(DataComponents.FOOD) && this.getHandle().components().has(DataComponents.CONSUMABLE);
     }
 
     @Override


### PR DESCRIPTION
This fix only allows items that can actually be eaten by the player. For example, since version 1.21.11, fish buckets have also provided the FOOD component, but they cannot be eaten.

I wasn't sure if this was worth dealing with right now, so I asked about it on Discord [here](https://discord.com/channels/289587909051416579/289587909051416579/1442586109736652935), but it seemed to go unnoticed. If PRs aren't welcome yet, please close it; I just didn't want it to be overlooked.