### PR TITLE
Don't show entities from hideEntity API when changing dimension

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -1217,7 +1217,7 @@
              ServerLevel.this.debugSynchronizers.dropEntity(entity);
 +            // CraftBukkit start
 +            entity.valid = false;
-+            if (!(entity instanceof ServerPlayer)) {
++            if (!(entity instanceof ServerPlayer) && entity.getRemovalReason() != net.minecraft.world.entity.Entity.RemovalReason.CHANGED_DIMENSION) {
 +                for (ServerPlayer player : ServerLevel.this.server.getPlayerList().getPlayers()) { // Paper - call onEntityRemove for all online players
 +                    player.getBukkitEntity().onEntityRemove(entity);
 +                }


### PR DESCRIPTION
This PR aims to fix an issue where if the Entity hidden change dimension its removed from the hidden list causing can be see again. this was based in another patches where (like scheulders) this check is made.

Close https://github.com/PaperMC/Paper/issues/12599
Close https://github.com/PaperMC/Paper/issues/13335