### PR TITLE
Add configuration for skipping hurting-projectile explosion when the entity is dead

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/hurtingprojectile/LargeFireball.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/hurtingprojectile/LargeFireball.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/projectile/hurtingprojectile/LargeFireball.java
 +++ b/net/minecraft/world/entity/projectile/hurtingprojectile/LargeFireball.java
-@@ -20,20 +_,27 @@
+@@ -20,20 +_,31 @@
  
      public LargeFireball(EntityType<? extends LargeFireball> type, Level level) {
          super(type, level);
@@ -24,7 +24,11 @@
 +            // CraftBukkit start - fire ExplosionPrimeEvent
 +            org.bukkit.event.entity.ExplosionPrimeEvent event = new org.bukkit.event.entity.ExplosionPrimeEvent((org.bukkit.entity.Explosive) this.getBukkitEntity());
 +            if (event.callEvent()) {
-+                this.level().explode(this, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.MOB);
++                //Paper start - skip hurting-projectile explosion on dead entity
++                if(!io.papermc.paper.configuration.GlobalConfiguration.get().misc.skipHurtingProjectileExplosionOnDeadEntity || !(result instanceof EntityHitResult entityHitResult) || entityHitResult.getEntity().isAlive()) {
++                        this.level().explode(this, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.MOB);
++                }
++                //Paper end
 +            }
 +            // CraftBukkit end - fire ExplosionPrimeEvent
 +            this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/hurtingprojectile/WitherSkull.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/hurtingprojectile/WitherSkull.java.patch
@@ -37,7 +37,7 @@
 +                    this.level().explode(this, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.MOB);
 +                }
 +                //Paper end
-+            }l
++            }
 +            // CraftBukkit end
 +            this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
          }

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/hurtingprojectile/WitherSkull.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/hurtingprojectile/WitherSkull.java.patch
@@ -23,7 +23,7 @@
                  }
              }
          }
-@@ -93,8 +_,13 @@
+@@ -93,8 +_,17 @@
      protected void onHit(HitResult result) {
          super.onHit(result);
          if (!this.level().isClientSide()) {
@@ -32,8 +32,12 @@
 +            // CraftBukkit start
 +            org.bukkit.event.entity.ExplosionPrimeEvent event = new org.bukkit.event.entity.ExplosionPrimeEvent(this.getBukkitEntity(), 1.0F, false);
 +            if (event.callEvent()) {
-+                this.level().explode(this, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.MOB);
-+            }
++                //Paper start - skip hurting-projectile explosion on dead entity
++                if(!io.papermc.paper.configuration.GlobalConfiguration.get().misc.skipHurtingProjectileExplosionOnDeadEntity || !(result instanceof EntityHitResult entityHitResult) || entityHitResult.getEntity().isAlive()) {
++                    this.level().explode(this, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.MOB);
++                }
++                //Paper end
++            }l
 +            // CraftBukkit end
 +            this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
          }

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -345,6 +345,8 @@ public class GlobalConfiguration extends ConfigurationPart {
         public boolean preventNegativeVillagerDemand = false;
         @Comment("Whether the nether dimension is enabled and will be loaded.")
         public boolean enableNether = true;
+        @Comment("Weather hurting projectiles like LargeFireBall from Ghast or WitherSkull from Wither explodes when entity is dead")
+        public boolean skipHurtingProjectileExplosionOnDeadEntity = false;
     }
 
     public BlockUpdates blockUpdates;


### PR DESCRIPTION
fixes issue #12487 

Currently when a WitherSkull or a LargeFireBall hits a player and the player dies due to its damage the dropped loot is instantly destroyed by the explosion of the projectile.

This PR, delays the death drop by a tick and hence prevents the destruction of loot.

The configuration for this is set to be false by default .