### PR TITLE
Fix MC-151857: wrong translation key in /give command

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/GiveCommand.java.patch
@@ -36,7 +36,7 @@
                  );
              } else {
 -                source.sendSuccess(() -> Component.translatable("commands.give.success.single", count, itemStack.getDisplayName(), targets.size()), true);
-+                source.sendSuccess(() -> Component.translatable("commands.give.success.single", count, displayName, targets.size()), true); // Paper - use cached display name
++                source.sendSuccess(() -> Component.translatable("commands.give.success.multiple", count, displayName, targets.size()), true); // Paper - use cached display name // Paper - MC-151857
              }
  
              return targets.size();


### PR DESCRIPTION
The wrong translation key was used in 2017 and never got fixed. The translation exists in the 10 language that I checked.

https://bugs.mojang.com/browse/MC/issues/MC-151857

With this change
`[CHAT] Gave 1 [Acacia Boat] to 2`
becomes
`[CHAT] Gave 1 [Acacia Boat] to 2 players`