### PR TITLE
Prevent server crash due to infinite velocity when calculating 0 radius explosion knockback

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -30173,7 +30173,7 @@ index 93110c815abe7baef61b1eaacfe28ebb1fc821f7..564c5064ec105a4f59476f2d21d3664b
      ChunkAccess getChunk(int x, int z, ChunkStatus chunkStatus, boolean requireChunk);
  
 diff --git a/net/minecraft/world/level/ServerExplosion.java b/net/minecraft/world/level/ServerExplosion.java
-index c132a3bfff7cf020e7fe4be616daa763b83e4b25..1c521f9f32340cf75310686c90777e521ac3ae5c 100644
+index d0286d25ea641ceb7642213067bc737175ea9d29..222ae660d2a74f708f13ba1e715bc810f433f48f 100644
 --- a/net/minecraft/world/level/ServerExplosion.java
 +++ b/net/minecraft/world/level/ServerExplosion.java
 @@ -62,6 +62,249 @@ public class ServerExplosion implements Explosion {
@@ -30576,7 +30576,7 @@ index c132a3bfff7cf020e7fe4be616daa763b83e4b25..1c521f9f32340cf75310686c90777e52
      }
  
      private void hurtEntities() {
-@@ -346,6 +628,14 @@ public class ServerExplosion implements Explosion {
+@@ -347,6 +629,14 @@ public class ServerExplosion implements Explosion {
      }
  
      public int explode() {
@@ -30591,7 +30591,7 @@ index c132a3bfff7cf020e7fe4be616daa763b83e4b25..1c521f9f32340cf75310686c90777e52
          this.level.gameEvent(this.source, GameEvent.EXPLODE, this.center);
          List<BlockPos> list = this.calculateExplodedPositions();
          this.hurtEntities();
-@@ -360,6 +650,13 @@ public class ServerExplosion implements Explosion {
+@@ -361,6 +651,13 @@ public class ServerExplosion implements Explosion {
              this.createFire(list);
          }
  
@@ -30605,7 +30605,7 @@ index c132a3bfff7cf020e7fe4be616daa763b83e4b25..1c521f9f32340cf75310686c90777e52
          return list.size();
      }
  
-@@ -449,12 +746,12 @@ public class ServerExplosion implements Explosion {
+@@ -450,12 +747,12 @@ public class ServerExplosion implements Explosion {
      // Paper start - Optimize explosions
      private float getBlockDensity(Vec3 vec3d, Entity entity) {
          if (!this.level.paperConfig().environment.optimizeExplosions) {

--- a/paper-server/patches/sources/net/minecraft/world/level/ServerExplosion.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/ServerExplosion.java.patch
@@ -64,7 +64,7 @@
                              }
  
                              d3 += d * 0.3F;
-@@ -176,8 +_,8 @@
+@@ -176,27 +_,64 @@
          int floor3 = Mth.floor(this.center.y + f + 1.0);
          int floor4 = Mth.floor(this.center.z - f - 1.0);
          int floor5 = Mth.floor(this.center.z + f + 1.0);
@@ -74,8 +74,9 @@
 +        for (Entity entity : list) { // Paper - used in loop
              if (!entity.ignoreExplosion(this)) {
                  double d = Math.sqrt(entity.distanceToSqr(this.center)) / f;
++                if (Double.isNaN(d)) d = Double.POSITIVE_INFINITY; // Paper - avoid infinite damage/velocity when distance and radius are 0 - +inf is chosen as 0+h / 0 is evaluated to +inf for all positive h, which distanceSqrt complies with
                  if (!(d > 1.0)) {
-@@ -185,18 +_,54 @@
+                     Vec3 vec3 = entity instanceof PrimedTnt ? entity.position() : entity.getEyePosition();
                      Vec3 vec31 = vec3.subtract(this.center).normalize();
                      boolean shouldDamageEntity = this.damageCalculator.shouldDamageEntity(this, entity);
                      float knockbackMultiplier = this.damageCalculator.getKnockbackMultiplier(entity);


### PR DESCRIPTION
When creating an explosion of force/radius 0 at the exact coordinates of an entity, `ServerExplosion#hurtEntities()` would calculate a NaN value for `d` (!(d > 1) = damage, d > 1 = too far, no damage), since the distance is 0 and the radius is 0 (0/0). This would cause a server crash due to invalid velocity:
```
[12:29:10 ERROR]: Encountered an unexpected exception
net.minecraft.ReportedException: Exception ticking world
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1689) ~[paper-1.21.10.jar:1.21.10-DEV-080a72f]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1506) ~[paper-1.21.10.jar:1.21.10-DEV-080a72f]
        at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:430) ~[paper-1.21.10.jar:1.21.10-DEV-080a72f]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1234) ~[paper-1.21.10.jar:1.21.10-DEV-080a72f]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:382) ~[paper-1.21.10.jar:1.21.10-DEV-080a72f]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.lang.IllegalArgumentException: x not finite
        at org.bukkit.util.NumberConversions.checkFinite(NumberConversions.java:118) ~[paper-api-1.21.10-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.util.Vector.checkFinite(Vector.java:872) ~[paper-api-1.21.10-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.entity.CraftEntity.setVelocity(CraftEntity.java:200) ~[paper-1.21.10.jar:1.21.10-DEV-080a72f]
        at net.minecraft.server.level.ServerEntity.sendChanges(ServerEntity.java:246) ~[paper-1.21.10.jar:1.21.10-DEV-080a72f]
        at net.minecraft.server.level.ChunkMap.tick(ChunkMap.java:1260) ~[paper-1.21.10.jar:1.21.10-DEV-080a72f]
        at net.minecraft.server.level.ServerChunkCache.tick(ServerChunkCache.java:433) ~[paper-1.21.10.jar:1.21.10-DEV-080a72f]
        at net.minecraft.server.level.ServerLevel.tick(ServerLevel.java:535) ~[paper-1.21.10.jar:1.21.10-DEV-080a72f]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1685) ~[paper-1.21.10.jar:1.21.10-DEV-080a72f]
        ... 5 more
```

For any other distance from the explosion, the value is positive infinity. I added a check to force `d` to be positive infinity if it spits out NaN, as the radius being 0 should imply nothing is ever within its damage radius:
```java
                double d = Math.sqrt(entity.distanceToSqr(this.center)) / f;
                // Paper start - avoid infinite damage/velocity when distance and radius are 0
                if (Double.isNaN(d)) {
                    d = Double.POSITIVE_INFINITY;
                }
                // Paper end
                if (!(d > 1.0)) {
```

This could also be solved by switching the if statement to `if (d <= 1.0)`, but I didn't want to rely on NaN behavior.