### PR TITLE
Use default SpawnReason if the entity has none

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -11,7 +11,7 @@ import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.entity.TeleportFlag;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -1187,7 +1187,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
 
     @Override
     public CreatureSpawnEvent.SpawnReason getEntitySpawnReason() {
-        return Optional.ofNullable(this.getHandle().spawnReason).orElse(CreatureSpawnEvent.SpawnReason.DEFAULT);
+        return Objects.requireNonNullElse(this.getHandle().spawnReason, CreatureSpawnEvent.SpawnReason.DEFAULT);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -11,6 +11,7 @@ import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.entity.TeleportFlag;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -1185,8 +1186,8 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     }
 
     @Override
-    public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason getEntitySpawnReason() {
-        return this.getHandle().spawnReason;
+    public CreatureSpawnEvent.SpawnReason getEntitySpawnReason() {
+        return Optional.ofNullable(this.getHandle().spawnReason).orElse(CreatureSpawnEvent.SpawnReason.DEFAULT);
     }
 
     @Override


### PR DESCRIPTION
getEntitySpawnReason is supposed to be NotNull, but can return null if it's called on an entity at a bad time (i.e. in an event before the entity is fully added to the world). This PR makes it return DEFAULT in such cases to indicate that it's missing a spawn reason.