### PR TITLE
[ci skip] Clarify Metadata API deprecation message

### DIFF
--- a/paper-api/src/main/java/org/bukkit/metadata/FixedMetadataValue.java
+++ b/paper-api/src/main/java/org/bukkit/metadata/FixedMetadataValue.java
@@ -15,7 +15,8 @@ import org.jetbrains.annotations.Nullable;
  *
  * @deprecated This system is extremely misleading and does not cleanup values for metadatable entities that have been
  * removed. It is recommended that when wanting persistent metadata, you use {@link org.bukkit.persistence.PersistentDataContainer}.
- * If you want temporary values on an entity, just use the entity lifecycle events. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent}0
+ * <p>
+ * If you want temporary values on an entity, use the entity lifecycle events and a {@link java.util.Map} of your own. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent} and {@link com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent})
  */
 @Deprecated
 public class FixedMetadataValue extends LazyMetadataValue {

--- a/paper-api/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
+++ b/paper-api/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
@@ -20,7 +20,8 @@ import org.jetbrains.annotations.Nullable;
  *
  * @deprecated This system is extremely misleading and does not cleanup values for metadatable entities that have been
  * removed. It is recommended that when wanting persistent metadata, you use {@link org.bukkit.persistence.PersistentDataContainer}.
- * If you want temporary values on an entity, just use the entity lifecycle events. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent}0
+ * <p>
+ * If you want temporary values on an entity, use the entity lifecycle events and a {@link java.util.Map} of your own. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent} and {@link com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent})
  */
 @Deprecated
 public class LazyMetadataValue extends MetadataValueAdapter {

--- a/paper-api/src/main/java/org/bukkit/metadata/MetadataConversionException.java
+++ b/paper-api/src/main/java/org/bukkit/metadata/MetadataConversionException.java
@@ -7,7 +7,8 @@ package org.bukkit.metadata;
  *
  * @deprecated This system is extremely misleading and does not cleanup values for metadatable entities that have been
  * removed. It is recommended that when wanting persistent metadata, you use {@link org.bukkit.persistence.PersistentDataContainer}.
- * If you want temporary values on an entity, just use the entity lifecycle events. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent}0
+ * <p>
+ * If you want temporary values on an entity, use the entity lifecycle events and a {@link java.util.Map} of your own. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent} and {@link com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent})
  */
 @Deprecated
 @SuppressWarnings("serial")

--- a/paper-api/src/main/java/org/bukkit/metadata/MetadataEvaluationException.java
+++ b/paper-api/src/main/java/org/bukkit/metadata/MetadataEvaluationException.java
@@ -7,7 +7,8 @@ package org.bukkit.metadata;
  *
  * @deprecated This system is extremely misleading and does not cleanup values for metadatable entities that have been
  * removed. It is recommended that when wanting persistent metadata, you use {@link org.bukkit.persistence.PersistentDataContainer}.
- * If you want temporary values on an entity, just use the entity lifecycle events. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent}0
+ * <p>
+ * If you want temporary values on an entity, use the entity lifecycle events and a {@link java.util.Map} of your own. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent} and {@link com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent})
  */
 @Deprecated
 @SuppressWarnings("serial")

--- a/paper-api/src/main/java/org/bukkit/metadata/MetadataStore.java
+++ b/paper-api/src/main/java/org/bukkit/metadata/MetadataStore.java
@@ -7,7 +7,8 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @deprecated This system is extremely misleading and does not cleanup values for metadatable entities that have been
  * removed. It is recommended that when wanting persistent metadata, you use {@link org.bukkit.persistence.PersistentDataContainer}.
- * If you want temporary values on an entity, just use the entity lifecycle events. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent}0
+ * <p>
+ * If you want temporary values on an entity, use the entity lifecycle events and a {@link java.util.Map} of your own. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent} and {@link com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent})
  */
 @Deprecated
 public interface MetadataStore<T> {

--- a/paper-api/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+++ b/paper-api/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
@@ -15,7 +15,8 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @deprecated This system is extremely misleading and does not cleanup values for metadatable entities that have been
  * removed. It is recommended that when wanting persistent metadata, you use {@link org.bukkit.persistence.PersistentDataContainer}.
- * If you want temporary values on an entity, just use the entity lifecycle events. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent}0
+ * <p>
+ * If you want temporary values on an entity, use the entity lifecycle events and a {@link java.util.Map} of your own. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent} and {@link com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent})
  */
 @Deprecated
 public abstract class MetadataStoreBase<T> {

--- a/paper-api/src/main/java/org/bukkit/metadata/MetadataValue.java
+++ b/paper-api/src/main/java/org/bukkit/metadata/MetadataValue.java
@@ -7,7 +7,8 @@ import org.jetbrains.annotations.Nullable;
 /**
  * @deprecated This system is extremely misleading and does not cleanup values for metadatable entities that have been
  * removed. It is recommended that when wanting persistent metadata, you use {@link org.bukkit.persistence.PersistentDataContainer}.
- * If you want temporary values on an entity, just use the entity lifecycle events. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent}0
+ * <p>
+ * If you want temporary values on an entity, use the entity lifecycle events and a {@link java.util.Map} of your own. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent} and {@link com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent})
  */
 @Deprecated
 public interface MetadataValue {

--- a/paper-api/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
+++ b/paper-api/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
@@ -16,7 +16,8 @@ import org.jetbrains.annotations.Nullable;
  *
  * @deprecated This system is extremely misleading and does not cleanup values for metadatable entities that have been
  * removed. It is recommended that when wanting persistent metadata, you use {@link org.bukkit.persistence.PersistentDataContainer}.
- * If you want temporary values on an entity, just use the entity lifecycle events. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent}0
+ * <p>
+ * If you want temporary values on an entity, use the entity lifecycle events and a {@link java.util.Map} of your own. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent} and {@link com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent})
  */
 @Deprecated
 public abstract class MetadataValueAdapter implements MetadataValue {

--- a/paper-api/src/main/java/org/bukkit/metadata/Metadatable.java
+++ b/paper-api/src/main/java/org/bukkit/metadata/Metadatable.java
@@ -10,7 +10,8 @@ import org.jetbrains.annotations.NotNull;
  *
  * @deprecated This system is extremely misleading and does not cleanup values for metadatable entities that have been
  * removed. It is recommended that when wanting persistent metadata, you use {@link org.bukkit.persistence.PersistentDataContainer}.
- * If you want temporary values on an entity, just use the entity lifecycle events. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent}0
+ * <p>
+ * If you want temporary values on an entity, use the entity lifecycle events and a {@link java.util.Map} of your own. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent} and {@link com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent})
  */
 @Deprecated
 public interface Metadatable {

--- a/paper-api/src/main/java/org/bukkit/metadata/package-info.java
+++ b/paper-api/src/main/java/org/bukkit/metadata/package-info.java
@@ -4,7 +4,8 @@
  *
  * @deprecated This system is extremely misleading and does not cleanup values for metadatable entities that have been
  * removed. It is recommended that when wanting persistent metadata, you use {@link org.bukkit.persistence.PersistentDataContainer}.
- * If you want temporary values on an entity, just use the entity lifecycle events. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent}0
+ * <p>
+ * If you want temporary values on an entity, use the entity lifecycle events and a {@link java.util.Map} of your own. (See {@link com.destroystokyo.paper.event.entity.EntityAddToWorldEvent} and {@link com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent})
  */
 @Deprecated
 package org.bukkit.metadata;


### PR DESCRIPTION
I've noticed based on messages on discord that there's still some confusion about what to use as a replacement for the metadata API when you want to store non persistent/temporary values for an entity, this PR tries to clarify that a bit by explicitly mentioning using your own Map and linking to the second entity lifecycle event to use.