### PR TITLE
Reimplement int based gamerule access

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/gamerules/GameRule.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/gamerules/GameRule.java.patch
@@ -6,10 +6,10 @@
          this.requiredFeatures = requiredFeatures;
 +    // Paper start - array backed gamerule access
 +    // Is expected to work as gamerules are in BuiltInRegistries and hence are not re-created during the servers' lifecycle.
-+        this.continuousInterleagueId = NEXT_GAMERULE_INT_ID++;
++        this.gameRuleIndex = LAST_GAMERULE_INDEX++;
      }
-+    public final int continuousInterleagueId;
-+    public static int NEXT_GAMERULE_INT_ID = 0;
++    public final int gameRuleIndex;
++    public static int LAST_GAMERULE_INDEX = 0;
 +    // Paper end - array backed gamerule access
  
      @Override

--- a/paper-server/patches/sources/net/minecraft/world/level/gamerules/GameRule.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/gamerules/GameRule.java.patch
@@ -8,7 +8,7 @@
 +    // Is expected to work as gamerules are in BuiltInRegistries and hence are not re-created during the servers' lifecycle.
 +        this.continuousInterleagueId = NEXT_GAMERULE_INT_ID++;
      }
-+    public int continuousInterleagueId;
++    public final int continuousInterleagueId;
 +    public static int NEXT_GAMERULE_INT_ID = 0;
 +    // Paper end - array backed gamerule access
  

--- a/paper-server/patches/sources/net/minecraft/world/level/gamerules/GameRule.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/gamerules/GameRule.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/world/level/gamerules/GameRule.java
++++ b/net/minecraft/world/level/gamerules/GameRule.java
+@@ -41,7 +_,13 @@
+         this.commandResultFunction = commandResultFunction;
+         this.defaultValue = defaultValue;
+         this.requiredFeatures = requiredFeatures;
++    // Paper start - array backed gamerule access
++    // Is expected to work as gamerules are in BuiltInRegistries and hence are not re-created during the servers' lifecycle.
++        this.continuousInterleagueId = NEXT_GAMERULE_INT_ID++;
+     }
++    public int continuousInterleagueId;
++    public static int NEXT_GAMERULE_INT_ID = 0;
++    // Paper end - array backed gamerule access
+ 
+     @Override
+     public String toString() {

--- a/paper-server/patches/sources/net/minecraft/world/level/gamerules/GameRuleMap.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/gamerules/GameRuleMap.java.patch
@@ -1,0 +1,42 @@
+--- a/net/minecraft/world/level/gamerules/GameRuleMap.java
++++ b/net/minecraft/world/level/gamerules/GameRuleMap.java
+@@ -15,9 +_,16 @@
+     public static final Codec<GameRuleMap> CODEC = Codec.<GameRule<?>, Object>dispatchedMap(BuiltInRegistries.GAME_RULE.byNameCodec(), GameRule::valueCodec)
+         .xmap(GameRuleMap::ofTrusted, GameRuleMap::map);
+     private final Reference2ObjectMap<GameRule<?>, Object> map;
++    private final @Nullable Object[] idAccess; // Paper - array backed gamerule access - array storage
+ 
+     GameRuleMap(Reference2ObjectMap<GameRule<?>, Object> map) {
+         this.map = map;
++        // Paper start - array backed gamerule access - array storage
++        idAccess = new Object[GameRule.NEXT_GAMERULE_INT_ID];
++        for (final Map.Entry<GameRule<?>, Object> entry : map.entrySet()) {
++            idAccess[entry.getKey().continuousInterleagueId] = entry.getValue();
++        }
++        // Paper end - array backed gamerule access - array storage
+     }
+ 
+     private static GameRuleMap ofTrusted(Map<GameRule<?>, Object> rules) {
+@@ -39,18 +_,20 @@
+     }
+ 
+     public boolean has(GameRule<?> rule) {
+-        return this.map.containsKey(rule);
++        return this.idAccess[rule.continuousInterleagueId] != null; // Paper - array backed gamerule access - the gamerule map does not allow null values, so this suffices for a contains check (see net.minecraft.world.level.gamerules.GameRuleMap.setGameRule's non-null checks)
+     }
+ 
+     public <T> @Nullable T get(GameRule<T> rule) {
+-        return (T)this.map.get(rule);
++        return (T) this.idAccess[rule.continuousInterleagueId]; // Paper - array backed gamerule access
+     }
+ 
+     public <T> void set(GameRule<T> rule, T value) {
+         this.map.put(rule, value);
++        this.idAccess[rule.continuousInterleagueId] = value; // Paper - array backed gamerule access - above map is kept in sync instead of fully removing the map, which needs more diff.
+     }
+ 
+     public <T> @Nullable T remove(GameRule<T> rule) {
++        this.idAccess[rule.continuousInterleagueId] = null; // Paper - array backed gamerule access
+         return (T)this.map.remove(rule);
+     }
+ 

--- a/paper-server/patches/sources/net/minecraft/world/level/gamerules/GameRuleMap.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/gamerules/GameRuleMap.java.patch
@@ -9,9 +9,9 @@
      GameRuleMap(Reference2ObjectMap<GameRule<?>, Object> map) {
          this.map = map;
 +        // Paper start - array backed gamerule access - array storage
-+        idAccess = new Object[GameRule.NEXT_GAMERULE_INT_ID];
++        idAccess = new Object[GameRule.LAST_GAMERULE_INDEX];
 +        for (final Map.Entry<GameRule<?>, Object> entry : map.entrySet()) {
-+            idAccess[entry.getKey().continuousInterleagueId] = entry.getValue();
++            idAccess[entry.getKey().gameRuleIndex] = entry.getValue();
 +        }
 +        // Paper end - array backed gamerule access - array storage
      }
@@ -22,21 +22,21 @@
  
      public boolean has(GameRule<?> rule) {
 -        return this.map.containsKey(rule);
-+        return this.idAccess[rule.continuousInterleagueId] != null; // Paper - array backed gamerule access - the gamerule map does not allow null values, so this suffices for a contains check (see net.minecraft.world.level.gamerules.GameRuleMap.setGameRule's non-null checks)
++        return this.idAccess[rule.gameRuleIndex] != null; // Paper - array backed gamerule access - the gamerule map does not allow null values, so this suffices for a contains check (see net.minecraft.world.level.gamerules.GameRuleMap.setGameRule's non-null checks)
      }
  
      public <T> @Nullable T get(GameRule<T> rule) {
 -        return (T)this.map.get(rule);
-+        return (T) this.idAccess[rule.continuousInterleagueId]; // Paper - array backed gamerule access
++        return (T) this.idAccess[rule.gameRuleIndex]; // Paper - array backed gamerule access
      }
  
      public <T> void set(GameRule<T> rule, T value) {
          this.map.put(rule, value);
-+        this.idAccess[rule.continuousInterleagueId] = value; // Paper - array backed gamerule access - above map is kept in sync instead of fully removing the map, which needs more diff.
++        this.idAccess[rule.gameRuleIndex] = value; // Paper - array backed gamerule access - above map is kept in sync instead of fully removing the map, which needs more diff.
      }
  
      public <T> @Nullable T remove(GameRule<T> rule) {
-+        this.idAccess[rule.continuousInterleagueId] = null; // Paper - array backed gamerule access
++        this.idAccess[rule.gameRuleIndex] = null; // Paper - array backed gamerule access
          return (T)this.map.remove(rule);
      }
  


### PR DESCRIPTION
Reimplementation of the <=1.21.10 changes to move game rule reads/writes
to a plain array access instead of a hashmap.

The implementation did not fully remove the backing hashmap, instead
it is kept up-to-date on writes. This decision aims to reduce
the diff needed for this change. The backing map is required in the
codec, merging operations and copies.
This means that writes carry the overhead of updating the map, however
they should be rare enough to not actually matter.
