### PR TITLE
Flying monster tracking range

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -345,6 +345,7 @@ public class WorldConfiguration extends ConfigurationPart {
             public IntOr.Default monster = IntOr.Default.USE_DEFAULT;
             public IntOr.Default misc = IntOr.Default.USE_DEFAULT;
             public IntOr.Default display = IntOr.Default.USE_DEFAULT;
+            public IntOr.Default flyingMonster = IntOr.Default.USE_DEFAULT;
             public IntOr.Default other = IntOr.Default.USE_DEFAULT;
 
             public int get(Entity entity, int def) {
@@ -361,8 +362,11 @@ public class WorldConfiguration extends ConfigurationPart {
                     case ANIMAL, WATER, VILLAGER -> {
                         return animal.or(def);
                     }
-                    case MONSTER, FLYING_MONSTER, RAIDER -> {
+                    case MONSTER, RAIDER -> {
                         return monster.or(def);
+                    }
+                    case FLYING_MONSTER -> {
+                        return flyingMonster.or(monster.or(def)); // default to the old behaviour
                     }
                     default -> {
                         return other.or(def);

--- a/paper-server/src/main/java/io/papermc/paper/entity/activation/ActivationType.java
+++ b/paper-server/src/main/java/io/papermc/paper/entity/activation/ActivationType.java
@@ -4,11 +4,12 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ambient.AmbientCreature;
 import net.minecraft.world.entity.animal.AgeableWaterCreature;
-import net.minecraft.world.entity.animal.fish.WaterAnimal;
+import net.minecraft.world.entity.animal.HappyGhast;
+import net.minecraft.world.entity.animal.WaterAnimal;
 import net.minecraft.world.entity.monster.Enemy;
 import net.minecraft.world.entity.monster.Ghast;
 import net.minecraft.world.entity.monster.Phantom;
-import net.minecraft.world.entity.npc.villager.Villager;
+import net.minecraft.world.entity.npc.Villager;
 import net.minecraft.world.entity.raid.Raider;
 import net.minecraft.world.phys.AABB;
 
@@ -34,7 +35,7 @@ public enum ActivationType {
             return ActivationType.WATER;
         } else if (entity instanceof Villager) {
             return ActivationType.VILLAGER;
-        } else if (entity instanceof Ghast || entity instanceof Phantom) { // TODO: some kind of better distinction here?
+        } else if (entity instanceof Ghast || entity instanceof HappyGhast || entity instanceof Phantom) { // TODO: some kind of better distinction here?
             return ActivationType.FLYING_MONSTER;
         } else if (entity instanceof Raider) {
             return ActivationType.RAIDER;

--- a/paper-server/src/main/java/org/spigotmc/SpigotWorldConfig.java
+++ b/paper-server/src/main/java/org/spigotmc/SpigotWorldConfig.java
@@ -248,7 +248,7 @@ public class SpigotWorldConfig {
     public int monsterTrackingRange = 96;
     public int miscTrackingRange = 96;
     public int displayTrackingRange = 128;
-    public int flyingMonsterTrackingRange = 128; // Paper - Flying monster tracking range
+    public int flyingMonsterTrackingRange = 128;
     public int otherTrackingRange = 64;
     private void trackingRange() {
         this.playerTrackingRange = this.getInt("entity-tracking-range.players", this.playerTrackingRange);
@@ -256,7 +256,7 @@ public class SpigotWorldConfig {
         this.monsterTrackingRange = this.getInt("entity-tracking-range.monsters", this.monsterTrackingRange);
         this.miscTrackingRange = this.getInt("entity-tracking-range.misc", this.miscTrackingRange);
         this.displayTrackingRange = this.getInt("entity-tracking-range.display", this.displayTrackingRange);
-        this.flyingMonsterTrackingRange = this.getInt("entity-tracking-range.flying-monsters", this.monsterTrackingRange); // Paper - Flying monster tracking range, defaults to old monsterTrackingRange
+        this.flyingMonsterTrackingRange = this.getInt("entity-tracking-range.flying-monsters", this.monsterTrackingRange); // Default to old monsterTrackingRange
         this.otherTrackingRange = this.getInt("entity-tracking-range.other", this.otherTrackingRange);
         this.log("Entity Tracking Range: Pl " + this.playerTrackingRange + " / An " + this.animalTrackingRange + " / Mo " + this.monsterTrackingRange + " / Mi " + this.miscTrackingRange + " / Di " + this.displayTrackingRange + " / Fl " + this.flyingMonsterTrackingRange + " / Other " + this.otherTrackingRange); // Paper
     }

--- a/paper-server/src/main/java/org/spigotmc/SpigotWorldConfig.java
+++ b/paper-server/src/main/java/org/spigotmc/SpigotWorldConfig.java
@@ -258,7 +258,7 @@ public class SpigotWorldConfig {
         this.displayTrackingRange = this.getInt("entity-tracking-range.display", this.displayTrackingRange);
         this.flyingMonsterTrackingRange = this.getInt("entity-tracking-range.flying-monsters", this.monsterTrackingRange); // Default to old monsterTrackingRange
         this.otherTrackingRange = this.getInt("entity-tracking-range.other", this.otherTrackingRange);
-        this.log("Entity Tracking Range: Pl " + this.playerTrackingRange + " / An " + this.animalTrackingRange + " / Mo " + this.monsterTrackingRange + " / Mi " + this.miscTrackingRange + " / Di " + this.displayTrackingRange + " / Fl " + this.flyingMonsterTrackingRange + " / Other " + this.otherTrackingRange); // Paper
+        this.log("Entity Tracking Range: Pl " + this.playerTrackingRange + " / An " + this.animalTrackingRange + " / Mo " + this.monsterTrackingRange + " / Mi " + this.miscTrackingRange + " / Di " + this.displayTrackingRange + " / Fl " + this.flyingMonsterTrackingRange + " / Other " + this.otherTrackingRange);
     }
 
     public int hopperTransfer;

--- a/paper-server/src/main/java/org/spigotmc/SpigotWorldConfig.java
+++ b/paper-server/src/main/java/org/spigotmc/SpigotWorldConfig.java
@@ -248,6 +248,7 @@ public class SpigotWorldConfig {
     public int monsterTrackingRange = 96;
     public int miscTrackingRange = 96;
     public int displayTrackingRange = 128;
+    public int flyingMonsterTrackingRange = 128; // Paper - Flying monster tracking range
     public int otherTrackingRange = 64;
     private void trackingRange() {
         this.playerTrackingRange = this.getInt("entity-tracking-range.players", this.playerTrackingRange);
@@ -255,8 +256,9 @@ public class SpigotWorldConfig {
         this.monsterTrackingRange = this.getInt("entity-tracking-range.monsters", this.monsterTrackingRange);
         this.miscTrackingRange = this.getInt("entity-tracking-range.misc", this.miscTrackingRange);
         this.displayTrackingRange = this.getInt("entity-tracking-range.display", this.displayTrackingRange);
+        this.flyingMonsterTrackingRange = this.getInt("entity-tracking-range.flying-monsters", this.monsterTrackingRange); // Paper - Flying monster tracking range, defaults to old monsterTrackingRange
         this.otherTrackingRange = this.getInt("entity-tracking-range.other", this.otherTrackingRange);
-        this.log("Entity Tracking Range: Pl " + this.playerTrackingRange + " / An " + this.animalTrackingRange + " / Mo " + this.monsterTrackingRange + " / Mi " + this.miscTrackingRange + " / Di " + this.displayTrackingRange + " / Other " + this.otherTrackingRange);
+        this.log("Entity Tracking Range: Pl " + this.playerTrackingRange + " / An " + this.animalTrackingRange + " / Mo " + this.monsterTrackingRange + " / Mi " + this.miscTrackingRange + " / Di " + this.displayTrackingRange + " / Fl " + this.flyingMonsterTrackingRange + " / Other " + this.otherTrackingRange); // Paper
     }
 
     public int hopperTransfer;

--- a/paper-server/src/main/java/org/spigotmc/TrackingRange.java
+++ b/paper-server/src/main/java/org/spigotmc/TrackingRange.java
@@ -38,8 +38,9 @@ public final class TrackingRange {
         switch (entity.activationType) {
             case RAIDER:
             case MONSTER:
-            case FLYING_MONSTER:
                 return config.monsterTrackingRange;
+            case FLYING_MONSTER:
+                return config.flyingMonsterTrackingRange;
             case WATER:
             case VILLAGER:
             case ANIMAL:


### PR DESCRIPTION
Flying monsters are their own category for entity activation, but, for some strange reason they are bundled with regular monsters for entity tracking. 

This is a problem because ghasts pop in very noticeably due to their size, this PR adds a way to increase their tracking range specifically to alleviate this issue.

If not set in the config, it will default to the old behavior of using monster tracking range.