### PR TITLE
Configurable max waypoint range

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -36100,10 +36100,10 @@ index 5fa7b312bf3bdd1ea0900dc7c599f88542115329..0b13971259f58876b778c0d28ad20c35
  
              for (SavedTick<T> savedTick : this.pendingTicks) {
 diff --git a/net/minecraft/world/waypoints/WaypointTransmitter.java b/net/minecraft/world/waypoints/WaypointTransmitter.java
-index d66f7afa03790d54caac726063aff4a995002d8a..df85e70a7a2bb2591cab7879b9910f6aa60ad166 100644
+index a1a1a56710f0e4d97b8cf72682a5f8cf173e89e1..050250dbd095e827ec9c033d5bfec17b1f1fbe26 100644
 --- a/net/minecraft/world/waypoints/WaypointTransmitter.java
 +++ b/net/minecraft/world/waypoints/WaypointTransmitter.java
-@@ -32,7 +32,10 @@ public interface WaypointTransmitter extends Waypoint {
+@@ -38,7 +38,10 @@ public interface WaypointTransmitter extends Waypoint {
      }
  
      static boolean isChunkVisible(ChunkPos pos, ServerPlayer player) {

--- a/paper-server/patches/sources/net/minecraft/world/waypoints/WaypointTransmitter.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/waypoints/WaypointTransmitter.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/waypoints/WaypointTransmitter.java
 +++ b/net/minecraft/world/waypoints/WaypointTransmitter.java
-@@ -20,6 +_,7 @@
+@@ -20,10 +_,17 @@
      Waypoint.Icon waypointIcon();
  
      static boolean doesSourceIgnoreReceiver(LivingEntity entity, ServerPlayer player) {
@@ -8,3 +8,13 @@
          if (player.isSpectator()) {
              return false;
          } else if (!entity.isSpectator() && !entity.hasIndirectPassenger(player)) {
+             double min = Math.min(entity.getAttributeValue(Attributes.WAYPOINT_TRANSMIT_RANGE), player.getAttributeValue(Attributes.WAYPOINT_RECEIVE_RANGE));
++            // Paper start - Configurable max entity waypoint range
++            double maxRange = entity.level().paperConfig().misc.maxEntityWaypointRange.or(-1);
++            if (maxRange != -1) {
++                min = Math.min(min, maxRange);
++            }
++            // Paper End
+             return entity.distanceTo(player) >= min;
+         } else {
+             return true;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -577,6 +577,7 @@ public class WorldConfiguration extends ConfigurationPart {
         public boolean disableRelativeProjectileVelocity = false;
         public boolean legacyEnderPearlBehavior = false;
         public boolean allowRemoteEnderDragonRespawning = false;
+        public DoubleOr.Default maxEntityWaypointRange = DoubleOr.Default.USE_DEFAULT;
 
         public enum RedstoneImplementation {
             VANILLA, EIGENCRAFT, ALTERNATE_CURRENT


### PR DESCRIPTION
For servers (like Newwind) with no land-claims that want to use new features like the locator bar but don't want to leak the locations of bases.

This patch should allow a range limit to be set for entities on the locator bar.