### PR TITLE
Move scoreboard overrides to a separate field

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -246,7 +246,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     private CraftWorldBorder clientWorldBorder = null;
     private BorderChangeListener clientWorldBorderListener = this.createWorldBorderListener();
     private long lastSaveTime; // Paper - getLastPlayed replacement API
-    private CraftScoreboard scoreboardOverride;
+    private @Nullable CraftScoreboard scoreboardOverride;
 
     public CraftPlayer(CraftServer server, ServerPlayer entity) {
         super(server, entity);
@@ -2518,11 +2518,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         return this.server.getScoreboardManager().getPlayerBoard(this);
     }
 
-    public CraftScoreboard getScoreboardOverride() {
+    public @Nullable CraftScoreboard getScoreboardOverride() {
         return this.scoreboardOverride;
     }
 
-    public void setScoreboardOverride(CraftScoreboard scoreboardOverride) {
+    public void setScoreboardOverride(@Nullable CraftScoreboard scoreboardOverride) {
         this.scoreboardOverride = scoreboardOverride;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -246,6 +246,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     private CraftWorldBorder clientWorldBorder = null;
     private BorderChangeListener clientWorldBorderListener = this.createWorldBorderListener();
     private long lastSaveTime; // Paper - getLastPlayed replacement API
+    private CraftScoreboard scoreboardOverride;
 
     public CraftPlayer(CraftServer server, ServerPlayer entity) {
         super(server, entity);
@@ -2515,6 +2516,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     @Override
     public CraftScoreboard getScoreboard() {
         return this.server.getScoreboardManager().getPlayerBoard(this);
+    }
+
+    public CraftScoreboard getScoreboardOverride() {
+        return scoreboardOverride;
+    }
+
+    public void setScoreboardOverride(CraftScoreboard scoreboardOverride) {
+        this.scoreboardOverride = scoreboardOverride;
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -2519,7 +2519,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
 
     public CraftScoreboard getScoreboardOverride() {
-        return scoreboardOverride;
+        return this.scoreboardOverride;
     }
 
     public void setScoreboardOverride(CraftScoreboard scoreboardOverride) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardManager.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardManager.java
@@ -23,7 +23,6 @@ public final class CraftScoreboardManager implements ScoreboardManager {
     private final CraftScoreboard mainScoreboard;
     private final MinecraftServer server;
     private final Collection<CraftScoreboard> scoreboards = new WeakCollection<>();
-    private final Map<CraftPlayer, CraftScoreboard> playerBoards = new HashMap<>();
 
     public CraftScoreboardManager(MinecraftServer server, net.minecraft.world.scores.Scoreboard scoreboard) {
         this.mainScoreboard = new CraftScoreboard(scoreboard);
@@ -54,7 +53,7 @@ public final class CraftScoreboardManager implements ScoreboardManager {
     }
 
     public CraftScoreboard getPlayerBoard(CraftPlayer player) {
-        CraftScoreboard board = this.playerBoards.get(player);
+        CraftScoreboard board = player.getScoreboardOverride();
         return board == null ? this.getMainScoreboard() : board;
     }
 
@@ -66,9 +65,9 @@ public final class CraftScoreboardManager implements ScoreboardManager {
         }
 
         if (scoreboard == this.mainScoreboard) {
-            this.playerBoards.remove(player);
+            player.setScoreboardOverride(null);
         } else {
-            this.playerBoards.put(player, scoreboard);
+            player.setScoreboardOverride(scoreboard);
         }
 
         ServerPlayer serverPlayer = player.getHandle();
@@ -94,7 +93,7 @@ public final class CraftScoreboardManager implements ScoreboardManager {
 
     // CraftBukkit method
     public void removePlayer(CraftPlayer player) {
-        this.playerBoards.remove(player);
+        player.setScoreboardOverride(null);
     }
 
     // CraftBukkit method


### PR DESCRIPTION
Speeds up scoreboard fetching a bit, most notably when mutating scoreboard fields, which iterate over each player in the world