### PR TITLE
Fix lost items in open containers when player death

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -444,7 +444,7 @@
              this.connection
                  .send(
                      new ClientboundPlayerCombatKillPacket(this.getId(), deathMessage),
-@@ -891,6 +_,65 @@
+@@ -891,6 +_,66 @@
                          }
                      )
                  );
@@ -461,6 +461,12 @@
 +        if (this.isRemoved()) {
 +            return;
 +        }
++
++        // SPIGOT-943 - only call if they have an inventory open
++        if (this.containerMenu != this.inventoryMenu) {
++            this.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DEATH); // Paper - Inventory close reason
++        }
++
 +        List<DefaultDrop> loot = new java.util.ArrayList<>(this.getInventory().getContainerSize()); // Paper - Restore vanilla drops behavior
 +        boolean keepInventory = this.level().getGameRules().get(GameRules.KEEP_INVENTORY) || this.isSpectator();
 +        if (!keepInventory) {
@@ -493,11 +499,6 @@
 +        }
 +        this.gameEvent(GameEvent.ENTITY_DIE); // moved from the top of this method
 +        // Paper end
-+
-+        // SPIGOT-943 - only call if they have an inventory open
-+        if (this.containerMenu != this.inventoryMenu) {
-+            this.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DEATH); // Paper - Inventory close reason
-+        }
 +
 +        net.kyori.adventure.text.Component apiDeathMessage = event.deathMessage() != null ? event.deathMessage() : net.kyori.adventure.text.Component.empty(); // Paper - Adventure
 +        Component deathScreenMessage = io.papermc.paper.adventure.PaperAdventure.asVanilla(event.deathScreenMessageOverride() != null ? event.deathScreenMessageOverride() : apiDeathMessage); // Paper - Expand PlayerDeathEvent API


### PR DESCRIPTION
Fix https://github.com/PaperMC/Paper/issues/13381

Currently the logic when player die related to containers open is
- Player die
- Server take the items for keep logic and events
- Server close the containers and return items to player
- Server works with the items based in the event called
With this the items from containers are ignored and lost because the drops in passed in events override that.. this PR just change the logic for close the containers and apply the logic for return items before the server try to take the items from player for the event and future logic.