### PR TITLE
update connection hostname after player handshake event

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java.patch
@@ -29,7 +29,7 @@
          switch (packet.intention()) {
              case LOGIN:
                  this.beginLogin(packet, false);
-@@ -50,22 +_,118 @@
+@@ -50,22 +_,119 @@
              default:
                  throw new UnsupportedOperationException("Invalid intention " + packet.intention());
          }
@@ -115,6 +115,7 @@
 +                            packet.port(),
 +                            packet.intention()
 +                        );
++                        this.connection.hostname = event.getServerHostname();
 +                    }
 +                    if (event.getSocketAddressHostname() != null) this.connection.address = new java.net.InetSocketAddress(event.getSocketAddressHostname(), socketAddress instanceof java.net.InetSocketAddress ? ((java.net.InetSocketAddress) socketAddress).getPort() : 0);
 +                    this.connection.spoofedUUID = event.getUniqueId();

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerLoginPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerLoginPacketListenerImpl.java.patch
@@ -213,7 +213,7 @@
                  }
              }
  
-@@ -225,18 +_,113 @@
+@@ -225,18 +_,123 @@
                      ? ((InetSocketAddress)remoteAddress).getAddress()
                      : null;
              }
@@ -279,6 +279,16 @@
      @Override
      public void handleCustomQueryPacket(ServerboundCustomQueryAnswerPacket packet) {
 +        // Paper start - Add Velocity IP Forwarding Support
++        try {
++            this.handleCustomQueryPacket0(packet);
++        } finally {
++            ServerboundCustomQueryAnswerPacket.QueryAnswerPayload payload = (ServerboundCustomQueryAnswerPacket.QueryAnswerPayload) packet.payload();
++            if (payload != null) {
++                payload.buffer.release();
++            }
++        }
++    }
++    private void handleCustomQueryPacket0(ServerboundCustomQueryAnswerPacket packet) {
 +        if (io.papermc.paper.configuration.GlobalConfiguration.get().proxies.velocity.enabled && packet.transactionId() == this.velocityLoginMessageId) {
 +            ServerboundCustomQueryAnswerPacket.QueryAnswerPayload payload = (ServerboundCustomQueryAnswerPacket.QueryAnswerPayload)packet.payload();
 +            if (payload == null) {


### PR DESCRIPTION
Currently setting a hostname in the PlayerHandshakeEvent does not update the connection hostname field. This causes the AsyncPlayerPreLoginEvent and PlayerLoginEvent to both fire with an incorrect hostname. 