### PR TITLE
Fix canHold returning incorrect amount for empty slots

### DIFF
--- a/paper-server/patches/features/0030-Improve-exact-choice-recipe-ingredients.patch
+++ b/paper-server/patches/features/0030-Improve-exact-choice-recipe-ingredients.patch
@@ -204,10 +204,10 @@ index 6d3e3ec045d5b15a435f7217369968b33e082724..b7a3758af337270737041f84d10eb437
          int i = this.inventory.findSlotMatchingCraftingIngredient(item, item1);
          if (i == -1) {
 diff --git a/net/minecraft/world/entity/player/Inventory.java b/net/minecraft/world/entity/player/Inventory.java
-index 76eda3bd8c513c7e42ceedf1aa605fb6df8b7019..41e59f3739945ca7f6ab710c993b5c0f15fcd529 100644
+index ae5bce250e5942de8cb08c397efe1b012afdd2a2..e48a80b3b5b6d0098833cd4e0ae3fef75b442ff2 100644
 --- a/net/minecraft/world/entity/player/Inventory.java
 +++ b/net/minecraft/world/entity/player/Inventory.java
-@@ -252,12 +252,12 @@ public class Inventory implements Container, Nameable {
+@@ -264,12 +264,12 @@ public class Inventory implements Container, Nameable {
          return !stack.isDamaged() && !stack.isEnchanted() && !stack.has(DataComponents.CUSTOM_NAME);
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/player/Inventory.java.patch
@@ -81,7 +81,7 @@
  
      public Inventory(Player player, EntityEquipment equipment) {
          this.player = player;
-@@ -93,10 +_,39 @@
+@@ -93,10 +_,51 @@
  
      private boolean hasRemainingSpaceForItem(ItemStack destination, ItemStack origin) {
          return !destination.isEmpty()
@@ -96,15 +96,21 @@
 +    // CraftBukkit start - Watch method above! :D
 +    public int canHold(ItemStack itemStack) {
 +        int remains = itemStack.getCount();
++        int maxStackSize = Math.min(this.getMaxStackSize(), itemStack.getMaxStackSize());
++
 +        for (int slot = 0; slot < this.items.size(); ++slot) {
 +            ItemStack itemInSlot = this.getItem(slot);
 +            if (itemInSlot.isEmpty()) {
-+                return itemStack.getCount();
++                remains -= maxStackSize;
++            } else if (this.hasRemainingSpaceForItem(itemInSlot, itemStack)) {
++                int currentItemMaxStack = Math.min(this.getMaxStackSize(), itemInSlot.getMaxStackSize());
++                int space = currentItemMaxStack - itemInSlot.getCount();
++
++                if (space > 0) {
++                    remains -= space;
++                }
 +            }
 +
-+            if (this.hasRemainingSpaceForItem(itemInSlot, itemStack)) {
-+                remains -= (itemInSlot.getMaxStackSize() < this.getMaxStackSize() ? itemInSlot.getMaxStackSize() : this.getMaxStackSize()) - itemInSlot.getCount();
-+            }
 +            if (remains <= 0) {
 +                return itemStack.getCount();
 +            }
@@ -112,8 +118,14 @@
 +
 +        ItemStack itemInOffhand = this.equipment.get(EquipmentSlot.OFFHAND);
 +        if (this.hasRemainingSpaceForItem(itemInOffhand, itemStack)) {
-+            remains -= (itemInOffhand.getMaxStackSize() < this.getMaxStackSize() ? itemInOffhand.getMaxStackSize() : this.getMaxStackSize()) - itemInOffhand.getCount();
++            int offHandMaxStack = Math.min(this.getMaxStackSize(), itemInOffhand.getMaxStackSize());
++            int space = offHandMaxStack - itemInOffhand.getCount();
++
++            if (space > 0) {
++                remains -= space;
++            }
 +        }
++
 +        if (remains <= 0) {
 +            return itemStack.getCount();
 +        }


### PR DESCRIPTION
Previously, the method returned the total item count immediately upon finding a single empty slot. Now it correctly subtracts the stack size from the remaining amount and continues the loop.