### PR TITLE
Change thrown trident item to use copy of ItemStack of count 1

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/item/TridentItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/TridentItem.java.patch
@@ -22,9 +22,9 @@
 +                            }
 +                            ThrownTrident thrownTrident = tridentDelayed.projectile(); // Paper - PlayerLaunchProjectileEvent
 +                            if (event.shouldConsume()) {
-+                                itemStack.hurtWithoutBreaking(1, player); // Paper - PlayerLaunchProjectileEvent // Paper use itemStack; pickup item damage
++                                itemStack.hurtWithoutBreaking(1, player); // Paper - PlayerLaunchProjectileEvent - use itemStack; pickup item damage
 +                            }
-+                            thrownTrident.pickupItemStack = itemStack.copy(); // SPIGOT-4511 update since damage call moved // Paper use itemStack; count = 1
++                            thrownTrident.pickupItemStack = itemStack.copy(); // SPIGOT-4511 update since damage call moved - use itemStack; count = 1
 +                            if (event.shouldConsume()) {
 +                                stack.consume(1, player);
 +                            }

--- a/paper-server/patches/sources/net/minecraft/world/item/TridentItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/TridentItem.java.patch
@@ -22,9 +22,9 @@
 +                            }
 +                            ThrownTrident thrownTrident = tridentDelayed.projectile(); // Paper - PlayerLaunchProjectileEvent
 +                            if (event.shouldConsume()) {
-+                                stack.hurtWithoutBreaking(1, player); // Paper - PlayerLaunchProjectileEvent
++                                itemStack.hurtWithoutBreaking(1, player); // Paper - PlayerLaunchProjectileEvent // Paper use itemStack; pickup item damage
 +                            }
-+                            thrownTrident.pickupItemStack = stack.copy(); // SPIGOT-4511 update since damage call moved
++                            thrownTrident.pickupItemStack = itemStack.copy(); // SPIGOT-4511 update since damage call moved // Paper use itemStack; count = 1
 +                            if (event.shouldConsume()) {
 +                                stack.consume(1, player);
 +                            }


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/13390

New change uses the defined `itemStack` variable to set the trident pick up item. The `itemStack` variable is a fixed value of 1.

The `hurtWithoutBreaking` call is also switched over, this is to allow regular tridents to still take durability damage.