### PR TITLE
Use per-world difficulty and gamerules for monster spawn check

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -26253,7 +26253,7 @@ index 9dbb7c744030fb8d6891780a0928c8cca2a2b68d..f019f1330f9f1e6aa98ef3f914833769
          if (!passengers.equals(this.lastPassengers)) {
              this.synchronizer
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 704733ff5e558a12f2f9dde924ab4c507745595d..5e305c9a64e856de70ed787901c01d09e68aa979 100644
+index f33692697c33fd475f40e8074413e481ea4781f7..629b00ee85f10bfb60acbbe7ac16f130bfe99376 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -175,7 +175,7 @@ import net.minecraft.world.ticks.LevelTicks;
@@ -26970,7 +26970,7 @@ index 704733ff5e558a12f2f9dde924ab4c507745595d..5e305c9a64e856de70ed787901c01d09
  
              for (ChunkPos chunkPos1 : list) {
                  if (!this.areEntitiesLoaded(chunkPos1.toLong())) {
-@@ -2208,28 +2527,38 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2212,28 +2531,38 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      @Override
      public void close() throws IOException {
          super.close();
@@ -27015,7 +27015,7 @@ index 704733ff5e558a12f2f9dde924ab4c507745595d..5e305c9a64e856de70ed787901c01d09
      }
  
      public boolean anyPlayerCloseEnoughForSpawning(BlockPos pos) {
-@@ -2241,7 +2570,10 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2245,7 +2574,10 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      }
  
      public boolean canSpawnEntitiesInChunk(ChunkPos chunkPos) {
@@ -27027,7 +27027,7 @@ index 704733ff5e558a12f2f9dde924ab4c507745595d..5e305c9a64e856de70ed787901c01d09
      }
  
      @Override
-@@ -2296,7 +2628,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2300,7 +2632,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      @Override
      public CrashReportCategory fillReportDetails(CrashReport report) {
          CrashReportCategory crashReportCategory = super.fillReportDetails(report);

--- a/paper-server/patches/features/0016-Add-Alternate-Current-redstone-implementation.patch
+++ b/paper-server/patches/features/0016-Add-Alternate-Current-redstone-implementation.patch
@@ -2326,7 +2326,7 @@ index 0000000000000000000000000000000000000000..298076a0db4e6ee6e4775ac43bf749d9
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index ce6f83c83b0235d59b4cadd248ff218985978ab5..71de8d8920eb33d15a18653dcef370c8e1a43712 100644
+index 3e5a9db2316be9f614844ae185cd2b1e1238f975..f32cc24c073f86464434890c7437c212c732437e 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -221,6 +221,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -2337,7 +2337,7 @@ index ce6f83c83b0235d59b4cadd248ff218985978ab5..71de8d8920eb33d15a18653dcef370c8
  
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
-@@ -2660,6 +2661,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2664,6 +2665,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          return this.debugSynchronizers;
      }
  

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -1027,6 +1027,19 @@
          return this.entityManager.getEntityGetter();
      }
  
+@@ -1703,7 +_,11 @@
+     }
+ 
+     public boolean isSpawningMonsters() {
+-        return this.server.isSpawningMonsters();
++        // Paper start - per world difficulty and game rules
++        return this.getDifficulty() != net.minecraft.world.Difficulty.PEACEFUL
++            && this.getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING)
++            && this.getGameRules().getBoolean(GameRules.RULE_SPAWN_MONSTERS);
++        // Paper end - per world difficulty and game rules
+     }
+ 
+     @Override
 @@ -1772,6 +_,28 @@
          return this.serverLevelData.getGameRules();
      }


### PR DESCRIPTION
This fixes that on 1.21.10 the check whether or not monsters should spawn in certain conditions (piglins from nether portals, creaking, zombie reinforcements, endermite from ender pearls) would use the difficulty and game rules from the default level instead of from the world the entity should spawn in, leading to them not spawning in any world if the default world had those gamerules turned off or was in peaceful. 

This is basically the same adjustment back-ported from 1.21.11 where this was fixed silently by Mojang already without mentioning it in the update notes. (Although I only noticed that afterwards)