### PR TITLE
Fix inverted logic in SwellGoal (MC-179072)

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/SwellGoal.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/SwellGoal.java.patch
@@ -1,18 +1,22 @@
 --- a/net/minecraft/world/entity/ai/goal/SwellGoal.java
 +++ b/net/minecraft/world/entity/ai/goal/SwellGoal.java
-@@ -20,6 +_,15 @@
+@@ -20,6 +_,7 @@
          return this.creeper.getSwellDir() > 0 || target != null && this.creeper.distanceToSqr(target) < 9.0;
      }
  
-+    // Paper start - Fix MC-179072
-+    @Override
-+    public boolean canContinueToUse() {
-+        LivingEntity target = this.creeper.getTarget();
-+        return target != null && net.minecraft.world.entity.EntitySelector.NO_CREATIVE_OR_SPECTATOR.test(target) && this.canUse();
-+    }
-+    // Paper end
-+
 +
      @Override
      public void start() {
          this.creeper.getNavigation().stop();
+@@ -40,8 +_,10 @@
+     public void tick() {
+         if (this.target == null) {
+             this.creeper.setSwellDir(-1);
+-        } else if (this.creeper.distanceToSqr(this.target) > 49.0) {
++        // Paper start - Fix MC-179072
++        } else if (this.creeper.distanceToSqr(this.target) > 49.0 || !net.minecraft.world.entity.EntitySelector.NO_CREATIVE_OR_SPECTATOR.test(this.target)) {
+             this.creeper.setSwellDir(-1);
++        // Paper end
+         } else if (!this.creeper.getSensing().hasLineOfSight(this.target)) {
+             this.creeper.setSwellDir(-1);
+         } else {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/SwellGoal.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/SwellGoal.java.patch
@@ -1,13 +1,14 @@
 --- a/net/minecraft/world/entity/ai/goal/SwellGoal.java
 +++ b/net/minecraft/world/entity/ai/goal/SwellGoal.java
-@@ -20,6 +_,14 @@
+@@ -20,6 +_,15 @@
          return this.creeper.getSwellDir() > 0 || target != null && this.creeper.distanceToSqr(target) < 9.0;
      }
  
 +    // Paper start - Fix MC-179072
 +    @Override
 +    public boolean canContinueToUse() {
-+        return !net.minecraft.world.entity.EntitySelector.NO_CREATIVE_OR_SPECTATOR.test(this.creeper.getTarget()) && this.canUse();
++        LivingEntity target = this.creeper.getTarget();
++        return target != null && net.minecraft.world.entity.EntitySelector.NO_CREATIVE_OR_SPECTATOR.test(target) && this.canUse();
 +    }
 +    // Paper end
 +

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/SwellGoal.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/SwellGoal.java.patch
@@ -8,15 +8,12 @@
      @Override
      public void start() {
          this.creeper.getNavigation().stop();
-@@ -40,8 +_,10 @@
+@@ -40,7 +_,7 @@
      public void tick() {
          if (this.target == null) {
              this.creeper.setSwellDir(-1);
 -        } else if (this.creeper.distanceToSqr(this.target) > 49.0) {
-+        // Paper start - Fix MC-179072
-+        } else if (this.creeper.distanceToSqr(this.target) > 49.0 || !net.minecraft.world.entity.EntitySelector.NO_CREATIVE_OR_SPECTATOR.test(this.target)) {
++        } else if (this.creeper.distanceToSqr(this.target) > 49.0 || !net.minecraft.world.entity.EntitySelector.NO_CREATIVE_OR_SPECTATOR.test(this.target)) { // Paper - Fix MC-179072 - consider creative / spectator players as out of reach
              this.creeper.setSwellDir(-1);
-+        // Paper end
          } else if (!this.creeper.getSensing().hasLineOfSight(this.target)) {
              this.creeper.setSwellDir(-1);
-         } else {


### PR DESCRIPTION
The previous logic inadvertently negated the entity selector check. EntitySelector.NO_CREATIVE_OR_SPECTATOR returns true for valid targets (non-creative/non-spectator). This change removes the negation to correctly fix MC-179072.