### PR TITLE
Fix inverted check in Rotations

### DIFF
--- a/paper-server/patches/sources/net/minecraft/core/Rotations.java.patch
+++ b/paper-server/patches/sources/net/minecraft/core/Rotations.java.patch
@@ -4,7 +4,7 @@
              buffer.writeFloat(value.z);
          }
      };
-+    // Paper start - add internal method for skipping validation for plugins
++    // Paper start - add internal method for skipping validation for plugins using userdev
 +    private static boolean SKIP_VALIDATION = false;
 +    public static Rotations createWithoutValidityChecks(float x, float y, float z) {
 +        SKIP_VALIDATION = true;
@@ -12,14 +12,14 @@
 +        SKIP_VALIDATION = false;
 +        return rotations;
 +    }
-+    // Paper end  - add internal method for skipping validation for plugins
++    // Paper end  - add internal method for skipping validation for plugins using userdev
  
      public Rotations(float x, float y, float z) {
-+        if (SKIP_VALIDATION) { // Paper - add internal method for skipping validation for plugins
++        if (!SKIP_VALIDATION) { // Paper - add internal method for skipping validation for plugins using userdev
          x = !Float.isInfinite(x) && !Float.isNaN(x) ? x % 360.0F : 0.0F;
          y = !Float.isInfinite(y) && !Float.isNaN(y) ? y % 360.0F : 0.0F;
          z = !Float.isInfinite(z) && !Float.isNaN(z) ? z % 360.0F : 0.0F;
-+        } // Paper - add internal method for skipping validation for plugins
++        } // Paper - add internal method for skipping validation for plugins using userdev
          this.x = x;
          this.y = y;
          this.z = z;


### PR DESCRIPTION
This is mainly used by [BKCommonLib](https://github.com/bergerhealer/BKCommonLib/blob/master/src/main/templates/com/bergerkiller/templates/net/minecraft/core_vector3f.txt#L35) and seems to be some kind of "internal api".