### PR TITLE
Fix SpawnReason for entity when spawning using SPAWN_EGG

### DIFF
--- a/paper-server/patches/features/0025-Entity-load-save-limit-per-chunk.patch
+++ b/paper-server/patches/features/0025-Entity-load-save-limit-per-chunk.patch
@@ -33,10 +33,10 @@ index 0cfdbdee091f43ca011bc68f7479eb7b84801b09..8d9ce3d301d5f7e4106587ae00adb8dd
                      scopedCollector.forChild(entity.problemPath()), entity.registryAccess()
                  );
 diff --git a/net/minecraft/world/entity/EntityType.java b/net/minecraft/world/entity/EntityType.java
-index c19491a2d04e673ace441e5582bab4d7551f3d97..a23e4b5e1ddc78d3fec6ab84bbac0a15dc485350 100644
+index 4eec40172200d8d7344d786366f40c577fdec283..bd38ad0d873b81a6b263c231ebe9802867fbab92 100644
 --- a/net/minecraft/world/entity/EntityType.java
 +++ b/net/minecraft/world/entity/EntityType.java
-@@ -491,7 +491,18 @@ public class EntityType<T extends Entity> implements EntityTypeTest<Entity, T>,
+@@ -498,7 +498,18 @@ public class EntityType<T extends Entity> implements EntityTypeTest<Entity, T>,
      }
  
      public static Stream<Entity> loadEntitiesRecursive(final ValueInput.ValueInputList entities, final Level level, final EntitySpawnReason reason) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/EntityType.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/EntityType.java.patch
@@ -8,7 +8,7 @@
      private static final Logger LOGGER = LogUtils.getLogger();
      private final Holder.Reference<EntityType<?>> builtInRegistryHolder = BuiltInRegistries.ENTITY_TYPE.createIntrusiveHolder(this);
      public static final Codec<EntityType<?>> CODEC = BuiltInRegistries.ENTITY_TYPE.byNameCodec();
-@@ -120,6 +_,22 @@
+@@ -120,14 +_,37 @@
          final boolean tryMoveDown,
          final boolean movedUp
      ) {
@@ -30,8 +30,16 @@
 +        // CraftBukkit end
          PostSpawnProcessor<T> postSpawnConfig;
          if (itemStack != null) {
-             postSpawnConfig = createDefaultStackConfig(level, itemStack, user);
-@@ -127,7 +_,7 @@
+-            postSpawnConfig = createDefaultStackConfig(level, itemStack, user);
++            // Paper start - override spawnReason with createSpawnReason if not Paper.SpawnReason it's used to avoid bad fallback reason behavior
++            TypedEntityData<EntityType<?>> typedEntityData = itemStack.get(DataComponents.ENTITY_DATA);
++            if (typedEntityData != null && !typedEntityData.copyTagWithEntityId().contains("Paper.SpawnReason")) {
++                postSpawnConfig = appendCustomEntityStackConfig(appendComponentsConfig(entity -> entity.spawnReason = createSpawnReason, itemStack), level, itemStack, user);
++            } else {
++                postSpawnConfig = createDefaultStackConfig(level, itemStack, user);
++            }
++            // Paper end
+         } else {
              postSpawnConfig = PostSpawnProcessor.nop();
          }
  


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/13397 

Currently the Entity when its created by spawn egg (item or dispenser) call the logic for add all the data from the item to the entity this cause the spawnReason can be override with a default reason and ignoring any future change causing events show the correct reason but the entity method `getEntitySpawnReason()` show another, this PR check the item before create the entity and in case a not reason was put in the item then override the reason with a proper fallback.