### PR TITLE
fix: bump netty-codec-haproxy in order to match mojang's bump in mc netty deps

### DIFF
--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -148,7 +148,7 @@ dependencies {
     implementation("com.velocitypowered:velocity-native:3.4.0-SNAPSHOT") {
         isTransitive = false
     }
-    implementation("io.netty:netty-codec-haproxy:4.1.118.Final") // Add support for proxy protocol
+    implementation("io.netty:netty-codec-haproxy:4.2.7.Final") // Add support for proxy protocol
     implementation("org.apache.logging.log4j:log4j-iostreams:2.24.1")
     implementation("org.ow2.asm:asm-commons:9.8")
     implementation("org.spongepowered:configurate-yaml:4.2.0")


### PR DESCRIPTION
snippet from mache's `.module` file
```gradle
          "group": "io.netty",
          "module": "netty-common",
          "version": {
            "requires": "4.2.7.Final"
          },
```