### PR TITLE
Fix EntityTargetLivingEntityEvent spam in TemptGoal

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/TemptGoal.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/TemptGoal.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/ai/goal/TemptGoal.java
 +++ b/net/minecraft/world/entity/ai/goal/TemptGoal.java
-@@ -23,7 +_,7 @@
+@@ -23,12 +_,13 @@
      private double pz;
      private double pRotX;
      private double pRotY;
@@ -9,17 +9,25 @@
      private int calmDown;
      private boolean isRunning;
      private final Predicate<ItemStack> items;
-@@ -54,8 +_,21 @@
+     private final boolean canScare;
+     private final double stopDistance;
++    private int temptEventCooldown; // Paper
+ 
+     public TemptGoal(PathfinderMob mob, double speedModifier, Predicate<ItemStack> items, boolean canScare) {
+         this((Mob)mob, speedModifier, items, canScare, 2.5);
+@@ -54,8 +_,23 @@
              this.calmDown--;
              return false;
          } else {
 -            this.player = getServerLevel(this.mob)
 +            // this.player = getServerLevel(this.mob).getNearestPlayer(this.targetingConditions.range(this.mob.getAttributeValue(Attributes.TEMPT_RANGE)), this.mob);
-+            // Paper start - Fix EntityTargetLivingEntityEvent spam
++            // Paper start - Throttle EntityTargetLivingEntityEvent
 +            LivingEntity candidate = getServerLevel(this.mob)
                  .getNearestPlayer(this.targetingConditions.range(this.mob.getAttributeValue(Attributes.TEMPT_RANGE)), this.mob);
 +
-+            if (candidate != null && this.player != candidate) {
++            if (candidate != null && (candidate != this.player || --this.temptEventCooldown <= 0)) {
++                this.temptEventCooldown = 10;
++
 +                org.bukkit.event.entity.EntityTargetLivingEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTargetLivingEvent(this.mob, candidate, org.bukkit.event.entity.EntityTargetEvent.TargetReason.TEMPT);
 +                if (event.isCancelled()) {
 +                    return false;
@@ -28,7 +36,7 @@
 +            }
 +
 +            this.player = candidate;
-+            // Paper end - Fix EntityTargetLivingEntityEvent spam
++            // Paper end - Throttle EntityTargetLivingEntityEvent
              return this.player != null;
          }
      }

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/TemptGoal.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/TemptGoal.java.patch
@@ -9,19 +9,26 @@
      private int calmDown;
      private boolean isRunning;
      private final Predicate<ItemStack> items;
-@@ -56,6 +_,15 @@
+@@ -54,8 +_,21 @@
+             this.calmDown--;
+             return false;
          } else {
-             this.player = getServerLevel(this.mob)
+-            this.player = getServerLevel(this.mob)
++            // this.player = getServerLevel(this.mob).getNearestPlayer(this.targetingConditions.range(this.mob.getAttributeValue(Attributes.TEMPT_RANGE)), this.mob);
++            // Paper start - Fix EntityTargetLivingEntityEvent spam
++            LivingEntity candidate = getServerLevel(this.mob)
                  .getNearestPlayer(this.targetingConditions.range(this.mob.getAttributeValue(Attributes.TEMPT_RANGE)), this.mob);
-+            // CraftBukkit start
-+            if (this.player != null) {
-+                org.bukkit.event.entity.EntityTargetLivingEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTargetLivingEvent(this.mob, this.player, org.bukkit.event.entity.EntityTargetEvent.TargetReason.TEMPT);
++
++            if (candidate != null && this.player != candidate) {
++                org.bukkit.event.entity.EntityTargetLivingEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTargetLivingEvent(this.mob, candidate, org.bukkit.event.entity.EntityTargetEvent.TargetReason.TEMPT);
 +                if (event.isCancelled()) {
 +                    return false;
 +                }
-+                this.player = (event.getTarget() == null) ? null : ((org.bukkit.craftbukkit.entity.CraftLivingEntity) event.getTarget()).getHandle();
++                candidate = (event.getTarget() == null) ? null : ((org.bukkit.craftbukkit.entity.CraftLivingEntity) event.getTarget()).getHandle();
 +            }
-+            // CraftBukkit end
++
++            this.player = candidate;
++            // Paper end - Fix EntityTargetLivingEntityEvent spam
              return this.player != null;
          }
      }


### PR DESCRIPTION
Currently, TemptGoal#canUse fires EntityTargetLivingEntityEvent unconditionally every time a valid target is found. Since canContinueToUse delegates to canUse to verify if the player is still valid/holding the item, this results in the event being fired every single tick for every mob being tempted. This creates significant unnecessary overhead and spams plugins that listen to target changes.

This patch adds a check to ensure EntityTargetLivingEntityEvent is only fired when the target actually changes (or is initially found), rather than on every tick of the goal execution.