### PR TITLE
Make arrow despawn rate override configurable

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java
 +++ b/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java
+@@ -2,6 +_,7 @@
+ 
+ import com.google.common.collect.Lists;
+ import com.mojang.serialization.Codec;
++import io.papermc.paper.configuration.type.number.IntOr;
+ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+ import java.util.ArrayList;
+ import java.util.Collection;
 @@ -86,7 +_,14 @@
      protected AbstractArrow(
          EntityType<? extends AbstractArrow> type, double x, double y, double z, Level level, ItemStack pickupItemStack, @Nullable ItemStack firedFromWeapon
@@ -31,8 +39,8 @@
              }
          } else {
 +            // Paper start - tick life regardless after X seconds
-+            int arrowDespawnOverrideRate = this.level().paperConfig().entities.spawning.arrowDespawnOverrideRate;
-+            if (arrowDespawnOverrideRate > 0 && this.tickCount > arrowDespawnOverrideRate) this.tickDespawn();
++            IntOr.Disabled arrowDespawnOverrideRate = this.level().paperConfig().entities.spawning.arrowDespawnOverrideRate;
++            if (arrowDespawnOverrideRate.enabled() && this.tickCount > arrowDespawnOverrideRate.intValue()) this.tickDespawn();
 +            // Paper end - tick life regardless after X seconds
              this.inGroundTime = 0;
              Vec3 vec31 = this.position();

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java
 +++ b/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java
-@@ -2,6 +_,7 @@
- 
- import com.google.common.collect.Lists;
- import com.mojang.serialization.Codec;
-+import io.papermc.paper.configuration.type.number.IntOr;
- import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
- import java.util.ArrayList;
- import java.util.Collection;
 @@ -86,7 +_,14 @@
      protected AbstractArrow(
          EntityType<? extends AbstractArrow> type, double x, double y, double z, Level level, ItemStack pickupItemStack, @Nullable ItemStack firedFromWeapon
@@ -39,7 +31,7 @@
              }
          } else {
 +            // Paper start - tick life regardless after X seconds
-+            IntOr.Disabled arrowDespawnOverrideRate = this.level().paperConfig().entities.spawning.arrowDespawnOverrideRate;
++            io.papermc.paper.configuration.type.number.IntOr.Disabled arrowDespawnOverrideRate = this.level().paperConfig().entities.spawning.arrowDespawnOverrideRate;
 +            if (arrowDespawnOverrideRate.enabled() && this.tickCount > arrowDespawnOverrideRate.intValue()) this.tickDespawn();
 +            // Paper end - tick life regardless after X seconds
              this.inGroundTime = 0;

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
@@ -26,11 +26,14 @@
      }
  
      public void setSoundEvent(SoundEvent soundEvent) {
-@@ -207,6 +_,7 @@
+@@ -207,6 +_,10 @@
                  this.setSharedFlagOnFire(this.getRemainingFireTicks() > 0);
              }
          } else {
-+            if (this.tickCount > 200) this.tickDespawn(); // Paper - tick life regardless after 10 seconds
++            // Paper start - tick life regardless after X seconds
++            int arrowDespawnOverrideRate = this.level().paperConfig().entities.spawning.arrowDespawnOverrideRate;
++            if (arrowDespawnOverrideRate > 0 && this.tickCount > arrowDespawnOverrideRate) this.tickDespawn();
++            // Paper end - tick life regardless after X seconds
              this.inGroundTime = 0;
              Vec3 vec31 = this.position();
              if (this.isInWater()) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
@@ -31,8 +31,8 @@
              }
          } else {
 +            // Paper start - tick life regardless after X seconds
-+            io.papermc.paper.configuration.type.number.IntOr.Disabled arrowDespawnOverrideRate = this.level().paperConfig().entities.spawning.arrowDespawnOverrideRate;
-+            if (arrowDespawnOverrideRate.enabled() && this.tickCount > arrowDespawnOverrideRate.intValue()) this.tickDespawn();
++            final io.papermc.paper.configuration.type.number.IntOr.Disabled maxArrowDespawnInvulnerability = this.level().paperConfig().entities.spawning.maxArrowDespawnInvulnerability;
++            if (maxArrowDespawnInvulnerability.enabled() && this.tickCount > maxArrowDespawnInvulnerability.intValue()) this.tickDespawn();
 +            // Paper end - tick life regardless after X seconds
              this.inGroundTime = 0;
              Vec3 vec31 = this.position();

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -171,7 +171,7 @@ public class WorldConfiguration extends ConfigurationPart {
         public class Spawning extends ConfigurationPart {
             public ArrowDespawnRate nonPlayerArrowDespawnRate = ArrowDespawnRate.def(WorldConfiguration.this.spigotConfig);
             public ArrowDespawnRate creativeArrowDespawnRate = ArrowDespawnRate.def(WorldConfiguration.this.spigotConfig);
-            public IntOr.Disabled arrowDespawnOverrideRate = new IntOr.Disabled(OptionalInt.of(200));
+            public IntOr.Disabled maxArrowDespawnInvulnerability = new IntOr.Disabled(OptionalInt.of(200));
             public boolean filterBadTileEntityNbtFromFallingBlocks = true;
             public List<NbtPathArgument.NbtPath> filteredEntityTagNbtPaths = NbtPathSerializer.fromString(List.of("Pos", "Motion", "sleeping_pos"));
             public boolean disableMobSpawnerSpawnEggTransformation = false;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -171,7 +171,7 @@ public class WorldConfiguration extends ConfigurationPart {
         public class Spawning extends ConfigurationPart {
             public ArrowDespawnRate nonPlayerArrowDespawnRate = ArrowDespawnRate.def(WorldConfiguration.this.spigotConfig);
             public ArrowDespawnRate creativeArrowDespawnRate = ArrowDespawnRate.def(WorldConfiguration.this.spigotConfig);
-            public int arrowDespawnOverrideRate = 200;
+            public IntOr.Disabled arrowDespawnOverrideRate = new IntOr.Disabled(OptionalInt.of(200));
             public boolean filterBadTileEntityNbtFromFallingBlocks = true;
             public List<NbtPathArgument.NbtPath> filteredEntityTagNbtPaths = NbtPathSerializer.fromString(List.of("Pos", "Motion", "sleeping_pos"));
             public boolean disableMobSpawnerSpawnEggTransformation = false;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -171,6 +171,7 @@ public class WorldConfiguration extends ConfigurationPart {
         public class Spawning extends ConfigurationPart {
             public ArrowDespawnRate nonPlayerArrowDespawnRate = ArrowDespawnRate.def(WorldConfiguration.this.spigotConfig);
             public ArrowDespawnRate creativeArrowDespawnRate = ArrowDespawnRate.def(WorldConfiguration.this.spigotConfig);
+            public int arrowDespawnOverrideRate = 200;
             public boolean filterBadTileEntityNbtFromFallingBlocks = true;
             public List<NbtPathArgument.NbtPath> filteredEntityTagNbtPaths = NbtPathSerializer.fromString(List.of("Pos", "Motion", "sleeping_pos"));
             public boolean disableMobSpawnerSpawnEggTransformation = false;


### PR DESCRIPTION
Change #3859 forces all arrows to despawn after 10 seconds to fix MC-125757, but this was marks as works-as-intended. This change allows admins to configure this value (or disable with -1) while keeping the existing behaviour