### PR TITLE
[1.21.10] Correctly read per-world gamerule for command blocks

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -23067,7 +23067,7 @@ index 13424bce076493f146bdc5fd0b1f2e09805bd5e7..2de7072c8ccc005e514673bba494b64d
                  thread1 -> {
                      DedicatedServer dedicatedServer1 = new DedicatedServer(
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 0a5d39bb84d3abefb37f7a0aaf56cdde10029596..8c5ddf67eaf04a1e67de21af25a8fadd19005281 100644
+index 09272efcb581a849e093a368be2fa40eec53088c..f7d1237343833e2cf8af388acbfd49304258fae4 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -177,7 +177,7 @@ import net.minecraft.world.phys.Vec2;
@@ -23315,7 +23315,7 @@ index 0a5d39bb84d3abefb37f7a0aaf56cdde10029596..8c5ddf67eaf04a1e67de21af25a8fadd
              return true;
          } else {
              boolean ret = false; // Paper - force execution of all worlds, do not just bias the first
-@@ -2577,6 +2693,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2579,6 +2695,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
  
@@ -26253,7 +26253,7 @@ index 9dbb7c744030fb8d6891780a0928c8cca2a2b68d..f019f1330f9f1e6aa98ef3f914833769
          if (!passengers.equals(this.lastPassengers)) {
              this.synchronizer
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index f33692697c33fd475f40e8074413e481ea4781f7..629b00ee85f10bfb60acbbe7ac16f130bfe99376 100644
+index 436e1c7ead4dd815fc7d5f8114b6b9bff3e9d4c7..168c29e3f251ec85cc1b25682f6588f39fdd7958 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -175,7 +175,7 @@ import net.minecraft.world.ticks.LevelTicks;
@@ -29257,7 +29257,7 @@ index 300f3ed58109219d97846082941b860585f66fed..9175a7e4e6076626cb46144c5858c2f2
  
      // Paper start - Affects Spawning API
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 2a25f07c536890cf73dfce01bf043c5ec36480c3..39947ac2fae9a088d1fbc5c72d6ac520bfb97cf3 100644
+index 1a2755fe70e970fd3da2ca74191bf8b83a5b6e3c..7a249a82c884e52304bb35d92fff87109a7d9aa3 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -82,6 +82,7 @@ import net.minecraft.world.level.storage.LevelData;

--- a/paper-server/patches/features/0016-Add-Alternate-Current-redstone-implementation.patch
+++ b/paper-server/patches/features/0016-Add-Alternate-Current-redstone-implementation.patch
@@ -2326,7 +2326,7 @@ index 0000000000000000000000000000000000000000..298076a0db4e6ee6e4775ac43bf749d9
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 3e5a9db2316be9f614844ae185cd2b1e1238f975..f32cc24c073f86464434890c7437c212c732437e 100644
+index e5365cad2b8476b6054f89ff3a0ba0d51431590d..c4aed8a8c4d4a02a960478882c8d670075011a73 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -221,6 +221,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -2352,13 +2352,14 @@ index 3e5a9db2316be9f614844ae185cd2b1e1238f975..f32cc24c073f86464434890c7437c212
          @Override
          public void onCreated(Entity entity) {
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 439abba4f371343dfd8e5ede7c20050ca049fcd2..96fa7390a4bcfa7bdf2cf5346f2de895ac085203 100644
+index 7ba08b317b0ac7ed15ecbc477f2402a2dbe526d5..b75c6ae764d88640ddd520c1345634b0365fff60 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
-@@ -2078,6 +2078,17 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
-         return this.palettedContainerFactory;
-     }
- 
+@@ -2082,6 +2082,17 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
+     public abstract boolean isCommandBlockEnabled();
+     public abstract boolean isSpawnerBlockEnabled();
+     // Paper end - per level game rules
++    
 +    // Paper start - optimize redstone (Alternate Current)
 +    public alternate.current.wire.WireHandler getWireHandler() {
 +        // This method is overridden in ServerLevel.
@@ -2369,10 +2370,9 @@ index 439abba4f371343dfd8e5ede7c20050ca049fcd2..96fa7390a4bcfa7bdf2cf5346f2de895
 +        return null;
 +    }
 +    // Paper end - optimize redstone (Alternate Current)
-+
+ 
      public static enum ExplosionInteraction implements StringRepresentable {
          NONE("none"),
-         BLOCK("block"),
 diff --git a/net/minecraft/world/level/block/RedStoneWireBlock.java b/net/minecraft/world/level/block/RedStoneWireBlock.java
 index 07d2b9b7ebea9827ef7a535c090b311a3c27d5c6..a07d9237d227fe6d419d8a9bc44fc623b244ad3e 100644
 --- a/net/minecraft/world/level/block/RedStoneWireBlock.java

--- a/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -1225,7 +1225,19 @@
      public boolean isPvpAllowed() {
          return this.getGameRules().getBoolean(GameRules.RULE_PVP);
      }
-@@ -1415,10 +_,20 @@
+@@ -1405,20 +_,32 @@
+         return true;
+     }
+ 
++    @io.papermc.paper.annotation.DoNotUse // Paper - do not use server wide gamerule, instead use server level specific one
+     public boolean isCommandBlockEnabled() {
+         return this.getGameRules().getBoolean(GameRules.RULE_COMMAND_BLOCKS_ENABLED);
+     }
+ 
++    @io.papermc.paper.annotation.DoNotUse // Paper - do not use server wide gamerule, instead use server level specific one
+     public boolean isSpawnerBlockEnabled() {
+         return this.getGameRules().getBoolean(GameRules.RULE_SPAWNER_BLOCKS_ENABLED);
+     }
  
      @Override
      public String getMotd() {

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -1190,7 +1190,7 @@
          }
  
          @Override
-@@ -1892,4 +_,24 @@
+@@ -1892,4 +_,34 @@
              entity.updateDynamicGameEventListener(DynamicGameEventListener::move);
          }
      }
@@ -1214,4 +1214,14 @@
 +        this.lagCompensationTick = (System.nanoTime() - MinecraftServer.SERVER_INIT) / (java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(50L));
 +    }
 +    // Paper end - lag compensation
++
++    // Paper start - per level game rules
++    public boolean isCommandBlockEnabled() {
++        return this.getGameRules().getBoolean(GameRules.RULE_COMMAND_BLOCKS_ENABLED);
++    }
++
++    public boolean isSpawnerBlockEnabled() {
++        return this.getGameRules().getBoolean(GameRules.RULE_SPAWNER_BLOCKS_ENABLED);
++    }
++    // Paper end - per level game rules
  }

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -519,18 +519,24 @@
                  }
              );
      }
-@@ -596,7 +_,7 @@
+@@ -594,9 +_,9 @@
+     @Override
+     public void handleSetCommandBlock(ServerboundSetCommandBlockPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
-         if (!this.server.isCommandBlockEnabled()) {
+-        if (!this.server.isCommandBlockEnabled()) {
++        if (!player.level().isCommandBlockEnabled()) { // Paper - per level game rules - enabled command blocks
              this.player.sendSystemMessage(Component.translatable("advMode.notEnabled"));
 -        } else if (!this.player.canUseGameMasterBlocks()) {
 +        } else if (!this.player.canUseGameMasterBlocks() && (!this.player.isCreative() || !this.player.getBukkitEntity().hasPermission("minecraft.commandblock"))) { // Paper - command block permission
              this.player.sendSystemMessage(Component.translatable("advMode.notAllowed"));
          } else {
              BaseCommandBlock baseCommandBlock = null;
-@@ -651,7 +_,7 @@
+@@ -649,9 +_,9 @@
+     @Override
+     public void handleSetCommandMinecart(ServerboundSetCommandMinecartPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
-         if (!this.server.isCommandBlockEnabled()) {
+-        if (!this.server.isCommandBlockEnabled()) {
++        if (!this.player.level().isCommandBlockEnabled()) { // Paper - per level game rules - enabled command blocks
              this.player.sendSystemMessage(Component.translatable("advMode.notEnabled"));
 -        } else if (!this.player.canUseGameMasterBlocks()) {
 +        } else if (!this.player.canUseGameMasterBlocks() && (!this.player.isCreative() || !this.player.getBukkitEntity().hasPermission("minecraft.commandblock"))) { // Paper - command block permission

--- a/paper-server/patches/sources/net/minecraft/world/item/SpawnEggItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/SpawnEggItem.java.patch
@@ -1,6 +1,14 @@
 --- a/net/minecraft/world/item/SpawnEggItem.java
 +++ b/net/minecraft/world/item/SpawnEggItem.java
-@@ -68,6 +_,7 @@
+@@ -61,13 +_,14 @@
+                 EntityType<?> type = this.getType(itemInHand);
+                 if (type == null) {
+                     return InteractionResult.FAIL;
+-                } else if (!serverLevel.getServer().isSpawnerBlockEnabled()) {
++                } else if (!serverLevel.isSpawnerBlockEnabled()) { // Paper - per level game rules - spawner block enabled
+                     if (context.getPlayer() instanceof ServerPlayer serverPlayer) {
+                         serverPlayer.sendSystemMessage(Component.translatable("advMode.notEnabled.spawner"));
+                     }
  
                      return InteractionResult.FAIL;
                  } else {

--- a/paper-server/patches/sources/net/minecraft/world/level/BaseCommandBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/BaseCommandBlock.java.patch
@@ -10,6 +10,15 @@
  
      public int getSuccessCount() {
          return this.successCount;
+@@ -101,7 +_,7 @@
+         } else {
+             this.successCount = 0;
+             MinecraftServer server = this.getLevel().getServer();
+-            if (server.isCommandBlockEnabled() && !StringUtil.isNullOrEmpty(this.command)) {
++            if (level.isCommandBlockEnabled() && !StringUtil.isNullOrEmpty(this.command)) { // Paper - per level game rules - enabled command blocks
+                 try {
+                     this.lastOutput = null;
+ 
 @@ -112,7 +_,13 @@
                                  this.successCount++;
                              }

--- a/paper-server/patches/sources/net/minecraft/world/level/BaseSpawner.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/BaseSpawner.java.patch
@@ -21,14 +21,15 @@
      }
  
      public void serverTick(ServerLevel level, BlockPos pos) {
+-        if (this.isNearPlayer(level, pos) && level.getServer().isSpawnerBlockEnabled()) {
+-            if (this.spawnDelay == -1) {
 +        if (spawnCount <= 0 || maxNearbyEntities <= 0) return; // Paper - Ignore impossible spawn tick
 +        // Paper start - Configurable mob spawner tick rate
 +        if (spawnDelay > 0 && --tickDelay > 0) return;
 +        tickDelay = level.paperConfig().tickRates.mobSpawner;
 +        if (tickDelay == -1) { return; } // If disabled
 +        // Paper end - Configurable mob spawner tick rate
-         if (this.isNearPlayer(level, pos) && level.getServer().isSpawnerBlockEnabled()) {
--            if (this.spawnDelay == -1) {
++        if (this.isNearPlayer(level, pos) && level.isSpawnerBlockEnabled()) { // Paper - per level game rules - spawner block enabled
 +            if (this.spawnDelay < -tickDelay) { // Paper - Configurable mob spawner tick rate
                  this.delay(level, pos);
              }

--- a/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
@@ -518,7 +518,17 @@
              this.getChunkAt(blockPos).addAndRegisterBlockEntity(blockEntity);
          }
      }
-@@ -1039,7 +_,8 @@
+@@ -1034,12 +_,18 @@
+         return this.palettedContainerFactory;
+     }
+ 
++    // Paper start - per level game rules
++    public abstract boolean isCommandBlockEnabled();
++    public abstract boolean isSpawnerBlockEnabled();
++    // Paper end - per level game rules
++
+     public static enum ExplosionInteraction implements StringRepresentable {
+         NONE("none"),
          BLOCK("block"),
          MOB("mob"),
          TNT("tnt"),


### PR DESCRIPTION
The introduced gamerules for command block and spawner block were
reading from the servers gamerules instead of the level gamerules.

This is already fixed in .11 as mojang completely removed the gamerule
access on MinecraftServer, however needs fixing in .10.
