### PR TITLE
Use correct explosion type for TNT in the createExplosion API

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -856,6 +856,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
             explosionType = net.minecraft.world.level.Level.ExplosionInteraction.NONE; // Don't break blocks
         } else if (source == null) {
             explosionType = net.minecraft.world.level.Level.ExplosionInteraction.STANDARD; // Break blocks, don't decay drops
+        } else if (source instanceof org.bukkit.entity.minecart.ExplosiveMinecart || source instanceof org.bukkit.entity.TNTPrimed) {
+            explosionType = net.minecraft.world.level.Level.ExplosionInteraction.TNT;
         } else {
             explosionType = net.minecraft.world.level.Level.ExplosionInteraction.MOB; // Respect mobGriefing gamerule
         }


### PR DESCRIPTION
`World#createExplosion` would use `ExplosionInteraction.MOB` for explosions created from TNT minecarts or primed TNT. This would then not use the tntExplosionDropDecay gamerule to determine if it drops blocks, and would instead use the mobExplosionDropDecay gamerule.

Possibly a dropBlocks option could be added to the API instead of relying on these gamerules at all? Would need some input on this though as it would a more substantial change.