### PR TITLE
Add getVelocity to ExplosionPrimeEvent

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/entity/ExplosionPrimeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/ExplosionPrimeEvent.java
@@ -17,18 +17,21 @@ public class ExplosionPrimeEvent extends EntityEvent implements Cancellable {
     private float radius;
     private boolean fire;
 
+    private final float velocity;
+
     private boolean cancelled;
 
     @ApiStatus.Internal
-    public ExplosionPrimeEvent(@NotNull final Entity entity, final float radius, final boolean fire) {
+    public ExplosionPrimeEvent(@NotNull final Entity entity, final float radius, final boolean fire, final float velocity) {
         super(entity);
         this.radius = radius;
         this.fire = fire;
+        this.velocity = velocity;
     }
 
     @ApiStatus.Internal
     public ExplosionPrimeEvent(@NotNull final Explosive explosive) {
-        this(explosive, explosive.getYield(), explosive.isIncendiary());
+        this(explosive, explosive.getYield(), explosive.isIncendiary(), 0);
     }
 
     /**
@@ -65,6 +68,17 @@ public class ExplosionPrimeEvent extends EntityEvent implements Cancellable {
      */
     public void setFire(boolean fire) {
         this.fire = fire;
+    }
+
+    /**
+     * Gets the velocity used in the explosion. This is zero for all entities except a TNT minecart, in which case it
+     * represents the velocity of the minecart when it explodes, the fall distance divided by ten,
+     * or the velocity of the arrow that caused the minecart to explode.
+     *
+     * @return returns the velocity of the explosion
+     */
+    public float getVelocity() {
+        return this.velocity;
     }
 
     @Override

--- a/paper-server/patches/sources/net/minecraft/world/entity/boss/enderdragon/EndCrystal.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/boss/enderdragon/EndCrystal.java.patch
@@ -62,7 +62,7 @@
                      DamageSource damageSource1 = damageSource.getEntity() != null ? this.damageSources().explosion(this, damageSource.getEntity()) : null;
 -                    level.explode(this, damageSource1, null, this.getX(), this.getY(), this.getZ(), 6.0F, false, Level.ExplosionInteraction.BLOCK);
 +                    // CraftBukkit start
-+                    org.bukkit.event.entity.ExplosionPrimeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callExplosionPrimeEvent(this, 6.0F, false);
++                    org.bukkit.event.entity.ExplosionPrimeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callExplosionPrimeEvent(this, 6.0F, false, 0);
 +                    if (event.isCancelled()) {
 +                        return false;
 +                    }

--- a/paper-server/patches/sources/net/minecraft/world/entity/boss/wither/WitherBoss.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/boss/wither/WitherBoss.java.patch
@@ -14,7 +14,7 @@
              if (i <= 0) {
 -                level.explode(this, this.getX(), this.getEyeY(), this.getZ(), 7.0F, false, Level.ExplosionInteraction.MOB);
 +                // CraftBukkit start
-+                org.bukkit.event.entity.ExplosionPrimeEvent event = new org.bukkit.event.entity.ExplosionPrimeEvent(this.getBukkitEntity(), 7.0F, false);
++                org.bukkit.event.entity.ExplosionPrimeEvent event = new org.bukkit.event.entity.ExplosionPrimeEvent(this.getBukkitEntity(), 7.0F, false, 0);
 +                level.getCraftServer().getPluginManager().callEvent(event);
 +
 +                if (!event.isCancelled()) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/Creeper.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/Creeper.java.patch
@@ -68,7 +68,7 @@
          if (this.level() instanceof ServerLevel serverLevel) {
              float f = this.isPowered() ? 2.0F : 1.0F;
 +            // CraftBukkit start
-+            org.bukkit.event.entity.ExplosionPrimeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callExplosionPrimeEvent(this, this.explosionRadius * f, false);
++            org.bukkit.event.entity.ExplosionPrimeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callExplosionPrimeEvent(this, this.explosionRadius * f, false, 0);
 +            if (!event.isCancelled()) {
 +            // CraftBukkit end
              this.dead = true;

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/hurtingprojectile/WitherSkull.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/hurtingprojectile/WitherSkull.java.patch
@@ -30,7 +30,7 @@
 -            this.level().explode(this, this.getX(), this.getY(), this.getZ(), 1.0F, false, Level.ExplosionInteraction.MOB);
 -            this.discard();
 +            // CraftBukkit start
-+            org.bukkit.event.entity.ExplosionPrimeEvent event = new org.bukkit.event.entity.ExplosionPrimeEvent(this.getBukkitEntity(), 1.0F, false);
++            org.bukkit.event.entity.ExplosionPrimeEvent event = new org.bukkit.event.entity.ExplosionPrimeEvent(this.getBukkitEntity(), 1.0F, false, 0);
 +            if (event.callEvent()) {
 +                this.level().explode(this, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.MOB);
 +            }

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/hurtingprojectile/windcharge/BreezeWindCharge.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/hurtingprojectile/windcharge/BreezeWindCharge.java.patch
@@ -5,7 +5,7 @@
      @Override
      public void explode(Vec3 pos) {
 +        // Paper start - Fire event for WindCharge explosions
-+        org.bukkit.event.entity.ExplosionPrimeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callExplosionPrimeEvent(this, RADIUS, false);
++        org.bukkit.event.entity.ExplosionPrimeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callExplosionPrimeEvent(this, RADIUS, false, 0);
 +        if (event.isCancelled()) {
 +            return;
 +        }

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/hurtingprojectile/windcharge/WindCharge.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/hurtingprojectile/windcharge/WindCharge.java.patch
@@ -5,7 +5,7 @@
      @Override
      public void explode(Vec3 pos) {
 +        // Paper start - Fire event for WindCharge explosions
-+        org.bukkit.event.entity.ExplosionPrimeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callExplosionPrimeEvent(this, RADIUS, false);
++        org.bukkit.event.entity.ExplosionPrimeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callExplosionPrimeEvent(this, RADIUS, false,  0);
 +        if (event.isCancelled()) {
 +            return;
 +        }

--- a/paper-server/patches/sources/net/minecraft/world/entity/vehicle/minecart/MinecartTNT.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/vehicle/minecart/MinecartTNT.java.patch
@@ -21,7 +21,7 @@
              this.fuse--;
              this.level().addParticle(ParticleTypes.SMOKE, this.getX(), this.getY() + 0.5, this.getZ(), 0.0, 0.0, 0.0);
          } else if (this.fuse == 0) {
-@@ -104,6 +_,17 @@
+@@ -104,6 +_,18 @@
          if (this.level() instanceof ServerLevel serverLevel) {
              if (serverLevel.getGameRules().get(GameRules.TNT_EXPLODES)) {
                  double min = Math.min(Math.sqrt(radiusModifier), 5.0);
@@ -29,7 +29,8 @@
 +                org.bukkit.event.entity.ExplosionPrimeEvent event = new org.bukkit.event.entity.ExplosionPrimeEvent(
 +                    this.getBukkitEntity(),
 +                    (float) (this.explosionPowerBase + this.explosionSpeedFactor * this.random.nextDouble() * 1.5 * min),
-+                    this.isIncendiary
++                    this.isIncendiary,
++                    (float) min
 +                );
 +                if (!event.callEvent()) {
 +                    this.fuse = -1;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -2160,8 +2160,8 @@ public class CraftEventFactory {
         return event;
     }
 
-    public static ExplosionPrimeEvent callExplosionPrimeEvent(Entity nmsEntity, float size, boolean fire) {
-        ExplosionPrimeEvent event = new ExplosionPrimeEvent(nmsEntity.getBukkitEntity(), size, fire);
+    public static ExplosionPrimeEvent callExplosionPrimeEvent(Entity nmsEntity, float size, boolean fire, float velocity) {
+        ExplosionPrimeEvent event = new ExplosionPrimeEvent(nmsEntity.getBukkitEntity(), size, fire, velocity);
         Bukkit.getPluginManager().callEvent(event);
         return event;
     }


### PR DESCRIPTION
Currently it's not possible to change the RNG behind how TNT minecart damage is calculated without listening to a prior event, figuring out the velocity manually, and cancelling the real ExplosionPrimeEvent. This PR will expose the velocity from the minecart/bow/falling damage which a plugin can use to change the ExplosionPrimeEvent radius.