### PR TITLE
Don't print missing profile stacktrace

### DIFF
--- a/paper-server/patches/sources/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java.patch
+++ b/paper-server/patches/sources/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java.patch
@@ -21,12 +21,22 @@
  
                      try {
                          Thread.sleep(DELAY_BETWEEN_PAGES);
-@@ -109,7 +_,7 @@
+@@ -109,7 +_,17 @@
          try {
              return Optional.ofNullable(client.get(HttpAuthenticationService.constantURL(nameLookupUrl + normalizeName(name)), NameAndId.class));
          } catch (final MinecraftClientException e) {
 -            LOGGER.warn("Couldn't find profile with name: {}", name, e);
-+            LOGGER.warn("Couldn't find profile with name: {}", name); // Paper - don't log stacktrace
++            // Paper start - only log details when debug is enabled
++            if (net.minecraft.server.MinecraftServer.getServer().isDebugging()) {
++                LOGGER.warn("Couldn't find profile with name: {}", name, e);
++
++            } else {
++                LOGGER.warn("Couldn't find profile with name: {}", name);
++            }
++            if (e instanceof com.mojang.authlib.exceptions.MinecraftClientHttpException httpException) {
++                LOGGER.warn("Received status {} while attempting to lookup the profile. Reason: {}", httpException.getStatus(), httpException.getMessage());
++            }
++            // Paper end - only log details when debug is enabled
              return Optional.empty();
          }
      }

--- a/paper-server/patches/sources/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java.patch
+++ b/paper-server/patches/sources/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java.patch
@@ -21,20 +21,18 @@
  
                      try {
                          Thread.sleep(DELAY_BETWEEN_PAGES);
-@@ -109,7 +_,17 @@
+@@ -109,7 +_,15 @@
          try {
              return Optional.ofNullable(client.get(HttpAuthenticationService.constantURL(nameLookupUrl + normalizeName(name)), NameAndId.class));
          } catch (final MinecraftClientException e) {
 -            LOGGER.warn("Couldn't find profile with name: {}", name, e);
 +            // Paper start - only log details when debug is enabled
-+            if (net.minecraft.server.MinecraftServer.getServer().isDebugging()) {
++            if (net.minecraft.server.MinecraftServer.getServer().isDebugging() && e instanceof com.mojang.authlib.exceptions.MinecraftClientHttpException httpException) {
++                LOGGER.warn("Couldn't find profile with name: {}. Received status {} - {}", name, httpException.getStatus(), httpException.getMessage(), e);
++            } else if (net.minecraft.server.MinecraftServer.getServer().isDebugging()) {
 +                LOGGER.warn("Couldn't find profile with name: {}", name, e);
-+
 +            } else {
 +                LOGGER.warn("Couldn't find profile with name: {}", name);
-+            }
-+            if (e instanceof com.mojang.authlib.exceptions.MinecraftClientHttpException httpException) {
-+                LOGGER.warn("Received status {} while attempting to lookup the profile. Reason: {}", httpException.getStatus(), httpException.getMessage());
 +            }
 +            // Paper end - only log details when debug is enabled
              return Optional.empty();

--- a/paper-server/patches/sources/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java.patch
+++ b/paper-server/patches/sources/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java.patch
@@ -21,3 +21,12 @@
  
                      try {
                          Thread.sleep(DELAY_BETWEEN_PAGES);
+@@ -109,7 +_,7 @@
+         try {
+             return Optional.ofNullable(client.get(HttpAuthenticationService.constantURL(nameLookupUrl + normalizeName(name)), NameAndId.class));
+         } catch (final MinecraftClientException e) {
+-            LOGGER.warn("Couldn't find profile with name: {}", name, e);
++            LOGGER.warn("Couldn't find profile with name: {}", name); // Paper - don't log stacktrace
+             return Optional.empty();
+         }
+     }


### PR DESCRIPTION
For some reason Mojang thought it'd be a good idea to log the entire error. 