### PR TITLE
Api for deserializing items with partially invalid data

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/persistence/DataResult.java
+++ b/paper-api/src/main/java/io/papermc/paper/persistence/DataResult.java
@@ -1,0 +1,175 @@
+package io.papermc.paper.persistence;
+
+import org.jspecify.annotations.NullMarked;
+import java.util.Optional;
+
+/**
+ * Represents the result of data-based operations like serialization, which
+ * can be in either of three states. These different states are encoded as
+ * records in this class in order to allow pattern matching over the result.
+ * <p>
+ * These different cases are:
+ * <ul>
+ *     <li>
+ *         {@link Success} - the operation was executed without any errors
+ *     </li>
+ *     <li>
+ *         {@link ErrorWithPartialResult} - an error occurred, but a
+ *          partial result was produced (this might, for example, have
+ *          unrecognized attributes missing)
+ *     </li>
+ *     <li>
+ *         {@link Error} - a fatal error occurred preventing any type of
+ *          result from being produced
+ *     </li>
+ * </ul>
+ *
+ * @param <R> type of the result
+ */
+@NullMarked
+public sealed interface DataResult<R> {
+    /**
+     * Class used as a return value for data operations that were successful
+     * and produced a result without errors.
+     *
+     * @param result result of the operation
+     * @param <R> type of the result
+     */
+    @NullMarked
+    record Success<R>(
+        R result
+    ) implements DataResult<R> {
+        @Override
+        public Optional<R> getResult() {
+            return Optional.of(result);
+        }
+
+        @Override
+        public Optional<R> getPartialResult() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> getErrorMessage() {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Class used as a return value for data operations, which encountered
+     * an error, but produced a partial result despite those errors.
+     * This partial result might have attributes, which were not recognized
+     * missing.
+     * <p>
+     * For example: If an item with a custom enchantment called "foo:bar"
+     * was serialized and then deserialized in an environment, where "foo"
+     * is no longer present, the partial result would be the item with
+     * this specific enchantment removed.
+     *
+     * @param errorMessage error message encountered during the operation
+     * @param partialResult partial result produced by the operation
+     * @param <R> type of the partial result
+     */
+    @NullMarked
+    record ErrorWithPartialResult<R>(
+        String errorMessage,
+        R partialResult
+    ) implements DataResult<R> {
+        @Override
+        public Optional<R> getResult() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<R> getPartialResult() {
+            return Optional.of(partialResult);
+        }
+
+        @Override
+        public Optional<String> getErrorMessage() {
+            return Optional.of(errorMessage);
+        }
+    }
+
+    /**
+     * Class used as a return value for data operations, which encountered
+     * a fatal error, which prevented the operation from producing any
+     * result at all.
+     *
+     * @param errorMessage error message encountered during the operation
+     * @param <R> type of the partial result
+     */
+    @NullMarked
+    record Error<R>(
+        String errorMessage
+    ) implements DataResult<R> {
+        @Override
+        public Optional<R> getResult() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<R> getPartialResult() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> getErrorMessage() {
+            return Optional.of(errorMessage);
+        }
+    }
+
+    /**
+     * Returns an {@link Optional} containing the result of the operation
+     * if the operation was executed with no errors. Otherwise, the returned
+     * {@link Optional} will be empty.
+     *
+     * @return the result if successful; empty optional otherwise
+     */
+    Optional<R> getResult();
+
+    /**
+     * Returns an {@link Optional} containing any result the operation might
+     * have produced. This includes partial results, where an error occurred
+     * during the operation, but a value was still produced.
+     *
+     * @return the result or partial result present; empty optional otherwise
+     * @see ErrorWithPartialResult
+     */
+    Optional<R> getPartialResult();
+
+    /**
+     * Returns the error message describing what specifically went wrong
+     * during the operation. Note, that even if an error occurred, a partial
+     * result might have been produced (see {@link #getPartialResult()}).
+     *
+     * @return empty optional if the operation was successful; error message
+     *  describing what went wrong otherwise
+     */
+    Optional<String> getErrorMessage();
+
+    /**
+     * Returns the result if the operation was executed successfully. If any
+     * error occurred, an {@link IllegalStateException} with the appropriate
+     * error message will be thrown.
+     *
+     * @return the result of the operation
+     * @throws IllegalStateException if any error occurred during the operation
+     */
+    default R resultOrThrow() {
+        return getResult().orElseThrow(() -> new IllegalStateException(getErrorMessage().orElseThrow()));
+    }
+
+    /**
+     * Returns the result of the operation if it was executed successfully or
+     * returns a partial result, produced despite an error. If not even a
+     * partial result is available, throws an {@link IllegalStateException}.
+     *
+     * @return the result or partial result of the operation
+     * @throws IllegalStateException if no partial result was produced
+     * @see ErrorWithPartialResult
+     */
+    default R partialResultOrThrow() {
+        return getPartialResult().orElseThrow(() -> new IllegalStateException(getErrorMessage().orElseThrow()));
+    }
+}

--- a/paper-api/src/main/java/org/bukkit/UnsafeValues.java
+++ b/paper-api/src/main/java/org/bukkit/UnsafeValues.java
@@ -2,6 +2,7 @@ package org.bukkit;
 
 import com.google.common.collect.Multimap;
 import io.papermc.paper.entity.EntitySerializationFlag;
+import io.papermc.paper.persistence.DataResult;
 import io.papermc.paper.registry.RegistryKey;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.attribute.Attribute;
@@ -163,7 +164,11 @@ public interface UnsafeValues {
 
     byte[] serializeItem(ItemStack item);
 
-    ItemStack deserializeItem(byte[] data);
+    default ItemStack deserializeItem(byte[] data) {
+        return deserializeItemSafely(data).resultOrThrow();
+    }
+
+    DataResult<ItemStack> deserializeItemSafely(byte[] data);
 
     /**
      * Serializes this itemstack to json format.

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -2,6 +2,7 @@ package org.bukkit.inventory;
 
 import com.google.common.base.Preconditions;
 import io.papermc.paper.datacomponent.DataComponentHolder;
+import io.papermc.paper.persistence.DataResult;
 import io.papermc.paper.registry.RegistryKey;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -756,16 +757,36 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
     }
 
     /**
-     * Deserializes this itemstack from raw NBT bytes. NBT is safer for data migrations as it will
-     * use the built in data converter instead of bukkits dangerous serialization system.
-     *
+     * Deserializes this ItemStack from raw NBT bytes. NBT is safer for data migrations as it will
+     * use the builtin data converter instead of Bukkits dangerous serialization system.
      * This expects that the DataVersion was stored on the root of the Compound, as saved from
-     * the {@link #serializeAsBytes()} API returned.
+     * the {@link #serializeAsBytes()} API returned. Throws an {@link IllegalStateException} if an
+     * error occurred during deserialization.
+     *
      * @param bytes bytes representing an item in NBT
      * @return ItemStack migrated to this version of Minecraft if needed.
+     * @see #deserializeBytesSafely(byte[])
      */
     public static @NotNull ItemStack deserializeBytes(final byte @NotNull [] bytes) {
         return org.bukkit.Bukkit.getUnsafe().deserializeItem(bytes);
+    }
+
+    /**
+     * Deserializes this ItemStack from raw NBT bytes. NBT is safer for data
+     * migrations as it will use the built-in data converter instead of
+     * Bukkits dangerous serialization system. This expects that the
+     * DataVersion was stored on the root of the Compound, as saved from the
+     * {@link #serializeAsBytes()} API returned. If an error occurs during
+     * serialization, the {@link DataResult} that is returned will contain
+     * both the error message and potentially a "partial result", representing
+     * an item with all the invalid properties removed.
+     *
+     * @param bytes bytes representing an item in NBT
+     * @return DataResult with the ItemStack migrated to this
+     *  version of Minecraft if needed
+     */
+    public static @NotNull DataResult<ItemStack> deserializeBytesSafely(final byte @NotNull [] bytes) {
+        return org.bukkit.Bukkit.getUnsafe().deserializeItemSafely(bytes);
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR introduces a safe deserialization method for `ItemStack` to handle items containing unknown data without throwing exceptions, ensuring parity with vanilla behavior for inventory handling.

## Background

In vanilla Minecraft, when a player joins with an item containing enchantments from a missing namespace (e.g., customenchant:autosmelt), the server logs a warning and allows the player to keep the item with the invalid enchantment stripped. Currently, ItemStack.deserializeBytes throws a hard error in these cases, providing no way to access this partial result. 

Of course, ideally, plugin developers would implement their own data versioning system, where data from things like custom enchantments is migrated to a valid format automatically, but that is more complex to support. Allowing access to the vanilla-type behavior should be good enough for now.

## This PR

A new method, deserializeBytesSafely, has been added alongside the standard deserializeBytes. This method returns a DataResult instead of throwing an exception, allowing the API to provide a partial result even when specific components fail to deserialize.

## DataResult API

The DataResult API is implemented as a sealed class hierarchy, which is easy for pattern matching and restricts invalid usages. However, I also included several convenience methods on the top-level interface to simplify common operations. Other than that, it mimics the semantics of the `com.mojang.serialization.DataResult` from Mojang's DataFixerUpper.

This is what the API looks like in a simplified fashion:
```JAVA
public sealed interface DataResult<R> {
    record Success<R>(
        R result
    ) implements DataResult<R> {}

    record ErrorWithPartialResult<R>(
        String errorMessage,
        R partialResult
    ) implements DataResult<R> {}

    record Error<R>(
        String errorMessage
    ) implements DataResult<R> {}
    
    Optional<R> getResult();

    Optional<R> getPartialResult();

    Optional<String> getErrorMessage();

    R resultOrThrow();

    R partialResultOrThrow();
}
```