### PR TITLE
Fix World#locateNearestStructure using not supported direct holder for Structure

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/chunk/ChunkGenerator.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/chunk/ChunkGenerator.java.patch
@@ -25,12 +25,12 @@
 +                    return null;
 +                }
 +                if (event.getResult() != null) {
-+                    return Pair.of(io.papermc.paper.util.MCUtil.toBlockPos(event.getResult().pos()), level.registryAccess().lookupOrThrow(Registries.STRUCTURE).wrapAsHolder(org.bukkit.craftbukkit.generator.structure.CraftStructure.bukkitToMinecraft(event.getResult().structure())));
++                    return Pair.of(io.papermc.paper.util.MCUtil.toBlockPos(event.getResult().pos()), org.bukkit.craftbukkit.generator.structure.CraftStructure.bukkitToMinecraftHolder(event.getResult().structure()));
 +                }
 +                pos = org.bukkit.craftbukkit.util.CraftLocation.toBlockPosition(event.getOrigin());
 +                radius = event.getRadius();
 +                skipKnownStructures = event.shouldFindUnexplored();
-+                structure = HolderSet.direct(api -> level.registryAccess().lookupOrThrow(Registries.STRUCTURE).wrapAsHolder(org.bukkit.craftbukkit.generator.structure.CraftStructure.bukkitToMinecraft(api)), event.getStructures());
++                structure = HolderSet.direct(org.bukkit.craftbukkit.generator.structure.CraftStructure::bukkitToMinecraftHolder, event.getStructures());
 +            }
 +            // Paper end
              ChunkGeneratorStructureState generatorState = level.getChunkSource().getGeneratorState();

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1852,7 +1852,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
         List<Holder<net.minecraft.world.level.levelgen.structure.Structure>> holders = new ArrayList<>();
 
         for (Structure structure : structures) {
-            holders.add(Holder.direct(CraftStructure.bukkitToMinecraft(structure)));
+            holders.add(CraftStructure.bukkitToMinecraftHolder(structure));
         }
 
         Pair<BlockPos, Holder<net.minecraft.world.level.levelgen.structure.Structure>> found = this.getHandle().getChunkSource().getGenerator().findNearestMapStructure(this.getHandle(), HolderSet.direct(holders), originPos, radius, findUnexplored);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -57,8 +57,8 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
-import net.minecraft.world.attribute.BedRule;
 import net.minecraft.util.NullOps;
+import net.minecraft.world.attribute.BedRule;
 import net.minecraft.world.attribute.EnvironmentAttributes;
 import net.minecraft.world.entity.EntitySpawnReason;
 import net.minecraft.world.entity.EntityType;
@@ -1848,14 +1848,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
     }
 
     private StructureSearchResult locateNearestStructure(Location origin, List<Structure> structures, int radius, boolean findUnexplored) {
-        BlockPos originPos = BlockPos.containing(origin.getX(), origin.getY(), origin.getZ());
-        List<Holder<net.minecraft.world.level.levelgen.structure.Structure>> holders = new ArrayList<>();
-
-        for (Structure structure : structures) {
-            holders.add(CraftStructure.bukkitToMinecraftHolder(structure));
-        }
-
-        Pair<BlockPos, Holder<net.minecraft.world.level.levelgen.structure.Structure>> found = this.getHandle().getChunkSource().getGenerator().findNearestMapStructure(this.getHandle(), HolderSet.direct(holders), originPos, radius, findUnexplored);
+        Pair<BlockPos, Holder<net.minecraft.world.level.levelgen.structure.Structure>> found = this.getHandle().getChunkSource().getGenerator().findNearestMapStructure(
+            this.getHandle(),
+            HolderSet.direct(CraftStructure::bukkitToMinecraftHolder, structures),
+            CraftLocation.toBlockPosition(origin),
+            radius,
+            findUnexplored
+        );
         if (found == null) {
             return null;
         }
@@ -1887,7 +1886,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
 
     @Override
     public BiomeSearchResult locateNearestBiome(Location origin, int radius, int horizontalInterval, int verticalInterval, Biome... biomes) {
-        BlockPos originPos = BlockPos.containing(origin.getX(), origin.getY(), origin.getZ());
+        BlockPos originPos = CraftLocation.toBlockPosition(origin);
         Set<Holder<net.minecraft.world.level.biome.Biome>> holders = new HashSet<>();
 
         for (Biome biome : biomes) {


### PR DESCRIPTION
Fix https://github.com/PaperMC/Paper/issues/13431
Mentioned by MachineMaker this method try to use directo holder for the conversion of Bukkit Structure to NMS Structure in Registry causing the issue.