### PR TITLE
Fixed blocks_attacks non-vanilla behaviour

### DIFF
--- a/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
@@ -464,7 +464,7 @@ index 5461bd9a39bb20ad29d3bc110c38860cf35a770a..75f80787966cdda6f51f55a8f6cb2218
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 9ba74df17cad8b5039e4657d97daefae8c3524e9..e683302032e1fb4e38eb674472ef7fd22c7ae6e8 100644
+index 473d07ac3f9c640beb7594e5c540e730c0d6421e..5ccb613f9c44bcd9f6b6fe7123f32bb1d3e9554c 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -368,6 +368,15 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
@@ -523,10 +523,10 @@ index 9ba74df17cad8b5039e4657d97daefae8c3524e9..e683302032e1fb4e38eb674472ef7fd2
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index bf7d0552efd961ffe19e69e8ab194502f3a747c9..730bf0cfdc9698a74b269b76fed614e08e058153 100644
+index de46c72365cec89150cf73c7c2dc8b1003305471..7457d6a076a48802145ddfcb8bf25a343a0f8af6 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3318,6 +3318,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3320,6 +3320,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
      protected void playAttackSound() {
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -571,19 +571,34 @@
                  this.hurtDuration = 10;
                  this.hurtTime = this.hurtDuration;
              }
-@@ -1215,7 +_,7 @@
+@@ -1209,17 +_,17 @@
+             this.resolvePlayerResponsibleForDamage(damageSource);
+             if (flag1) {
+                 BlocksAttacks blocksAttacks = useItem.get(DataComponents.BLOCKS_ATTACKS);
+-                if (flag && blocksAttacks != null) {
++                if (flag && blocksAttacks != null && amount <= 0.0F) {
+                     blocksAttacks.onBlocked(level, this);
+                 } else {
                      level.broadcastDamageEvent(this, damageSource);
                  }
  
 -                if (!damageSource.is(DamageTypeTags.NO_IMPACT) && (!flag || amount > 0.0F)) {
-+                if (!damageSource.is(DamageTypeTags.NO_IMPACT) && !flag) { // CraftBukkit - Prevent marking hurt if the damage is blocked
++                if (!damageSource.is(DamageTypeTags.NO_IMPACT) && (!flag || amount > 0.0F)) { // CraftBukkit - Prevent marking hurt if the damage is blocked // Paper - fix vanilla parity: play hurt animation if damage > 0 even if blocked
                      this.markHurt();
                  }
  
-@@ -1230,8 +_,16 @@
+-                if (!damageSource.is(DamageTypeTags.NO_KNOCKBACK)) {
++                if (amount > 0.0F && !damageSource.is(DamageTypeTags.NO_KNOCKBACK)) { // Paper - fix vanilla parity: only apply knockback if damage > 0
+                     double d = 0.0;
+                     double d1 = 0.0;
+                     if (damageSource.getDirectEntity() instanceof Projectile projectile) {
+@@ -1230,9 +_,19 @@
                          d = damageSource.getSourcePosition().x() - this.getX();
                          d1 = damageSource.getSourcePosition().z() - this.getZ();
                      }
+-
+-                    this.knockback(0.4F, d, d1);
+-                    if (!flag) {
 +                    // Paper start - Check distance in entity interactions; see for loop in knockback method
 +                    if (Math.abs(d) > 200) {
 +                        d = Math.random() - Math.random();
@@ -592,12 +607,14 @@
 +                        d1 = Math.random() - Math.random();
 +                    }
 +                    // Paper end - Check distance in entity interactions
- 
--                    this.knockback(0.4F, d, d1);
++
 +                    this.knockback(0.4F, d, d1, damageSource.getDirectEntity(), damageSource.getDirectEntity() == null ? io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.DAMAGE : io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.ENTITY_ATTACK); // CraftBukkit // Paper - knockback events
-                     if (!flag) {
++
++                    // MODIFICATION 3 : On envoie le packet de mouvement même si "flag" est vrai (bloqué), tant qu'on a pris des dégâts
++                    if (!flag || amount > 0.0F) { // Paper - fix vanilla parity: indicate damage if damage > 0 even if blocked
                          this.indicateDamage(d, d1);
                      }
+                 }
 @@ -1240,19 +_,19 @@
  
              if (this.isDeadOrDying()) {


### PR DESCRIPTION
Fixes #13426 : This PR fixes an issue where partially blocked attacks (when damage is reduced but still > 0) were treated as fully blocked