### PR TITLE
Fix arrow immunity loophole

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
@@ -26,6 +26,19 @@
      }
  
      public void setSoundEvent(SoundEvent soundEvent) {
+@@ -146,7 +_,11 @@
+     @Override
+     public void lerpMotion(Vec3 movement) {
+         super.lerpMotion(movement);
+-        this.life = 0;
++        // Paper start - Fix loophole for arrow immunity
++        if (!this.level().paperConfig().entities.spawning.maxArrowDespawnInvulnerability.enabled()) {
++            this.life = 0;
++        }
++        // Paper end - Fix loophole for arrow immunity
+         if (this.isInGround() && movement.lengthSqr() > 0.0) {
+             this.setInGround(false);
+         }
 @@ -207,6 +_,10 @@
                  this.setSharedFlagOnFire(this.getRemainingFireTicks() > 0);
              }
@@ -55,7 +68,7 @@
              if (!this.isAlive() || projectileDeflection != ProjectileDeflection.NONE) {
                  return projectileDeflection;
              }
-@@ -325,13 +_,26 @@
+@@ -325,20 +_,37 @@
          }
      }
  
@@ -83,6 +96,18 @@
      }
  
      private void startFalling() {
+         this.setInGround(false);
+         Vec3 deltaMovement = this.getDeltaMovement();
+         this.setDeltaMovement(deltaMovement.multiply(this.random.nextFloat() * 0.2F, this.random.nextFloat() * 0.2F, this.random.nextFloat() * 0.2F));
+-        this.life = 0;
++        // Paper start - Fix loophole for arrow immunity
++        if (!this.level().paperConfig().entities.spawning.maxArrowDespawnInvulnerability.enabled()) {
++            this.life = 0;
++        }
++        // Paper end - Fix loophole for arrow immunity
+     }
+ 
+     public boolean isInGround() {
 @@ -364,8 +_,8 @@
  
      protected void tickDespawn() {


### PR DESCRIPTION
AbstractArrow.startFalling() and AbstractArrow.lerpMotion() reset AbstractArrow.life to 0. This patch disables this when maxArrowDespawnInvulnerability is enabled and prevents players from keeping an arrow alive by letting it periodically fall (e.g. with an up-facing piston on a timer)

Related to #13409 and fixes a loophole for the fix in #3859