### PR TITLE
Fix memory leak on constantly damage

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/damagesource/CombatTracker.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/damagesource/CombatTracker.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/damagesource/CombatTracker.java
 +++ b/net/minecraft/world/damagesource/CombatTracker.java
-@@ -29,15 +_,24 @@
+@@ -29,15 +_,25 @@
      private int combatEndTime;
      public boolean inCombat;
      public boolean takingDamage;
@@ -22,6 +22,7 @@
 +    public void recordDamageAndCheckCombatState(final CombatEntry combatEntry) {
 +        final DamageSource source = combatEntry.source();
 +    // Paper end - Combat tracker API
++        if (this.entries.size() >= 256) this.entries.clear(); // Paper - Fix memory leak on constantly damage
          this.entries.add(combatEntry);
          this.lastDamageTime = this.mob.tickCount;
          this.takingDamage = true;


### PR DESCRIPTION
This patch is to address the memory leak, where an entity is being attacked constantly, and the combat status never resets.

After this patch, only the newly added CombatEntry is kept after hitting the max cap.
<img width="918" height="913" alt="image" src="https://github.com/user-attachments/assets/00c6833f-c2af-493b-995c-c693f5e7b5d0" />
