### PR TITLE
Add option to skip tracking for entities out of client render range

### DIFF
--- a/paper-server/patches/features/0032-Skip-Entity-Tracking-Out-Of-Render-Range.patch
+++ b/paper-server/patches/features/0032-Skip-Entity-Tracking-Out-Of-Render-Range.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Newwind <support@newwindserver.com>
+Date: Fri, 28 Dec 2025 19:17:32 +0200
+Subject: [PATCH] Skip entity tracking out of render range
+
+
+diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
+index ab88931..38985c1 100644
+--- a/net/minecraft/server/level/ChunkMap.java
++++ b/net/minecraft/server/level/ChunkMap.java
+@@ -1045,6 +1045,9 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+     private void newTrackerTick() {
+         final ca.spottedleaf.moonrise.patches.chunk_system.level.entity.server.ServerEntityLookup entityLookup = (ca.spottedleaf.moonrise.patches.chunk_system.level.entity.server.ServerEntityLookup)((ca.spottedleaf.moonrise.patches.chunk_system.level.ChunkSystemServerLevel)this.level).moonrise$getEntityLookup();;
+ 
++        // Client entity view distance scale heuristic copied from LevelRenderer.extractVisibleEntities()
++        Entity.setViewScale(Mth.clamp(serverViewDistance / 8.0, 1.0, 2.5) * level.paperConfig().misc.skipTrackingOutOfRenderRangeEntitiesClientDistanceScaling);
++
+         final ca.spottedleaf.moonrise.common.list.ReferenceList<net.minecraft.world.entity.Entity> trackerEntities = entityLookup.trackerEntities;
+         final Entity[] trackerEntitiesRaw = trackerEntities.getRawDataUnchecked();
+         for (int i = 0, len = trackerEntities.size(); i < len; ++i) {
+@@ -1381,6 +1384,13 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+                 if (flag && !player.getBukkitEntity().canSee(this.entity.getBukkitEntity())) { // Paper - only consider hits
+                     flag = false;
+                 }
++                if (flag && level.paperConfig().misc.skipTrackingOutOfRenderRangeEntities) {
++                    double vec3_dy = player.getY() - this.entity.getY();
++                    double sqrDistance = d1 + (vec3_dy * vec3_dy);
++                    if (!this.entity.shouldRenderAtSqrDistance(sqrDistance)) {
++                        flag = false;
++                    }
++                }
+                 // CraftBukkit end
+                 if (flag) {
+                     if (this.seenBy.add(player.connection)) {

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -578,6 +578,8 @@ public class WorldConfiguration extends ConfigurationPart {
         public boolean disableRelativeProjectileVelocity = false;
         public boolean legacyEnderPearlBehavior = false;
         public boolean allowRemoteEnderDragonRespawning = false;
+        public boolean skipTrackingOutOfRenderRangeEntities = false;
+        public float skipTrackingOutOfRenderRangeEntitiesClientDistanceScaling = 1.0f;
 
         public enum RedstoneImplementation {
             VANILLA, EIGENCRAFT, ALTERNATE_CURRENT


### PR DESCRIPTION
The client uses a built in heuristic to decide whether an entity should be rendered, completely independent of tracking range:

```
view scale = clamp(server render distance / 8, 1.0, 2.5) x entity distance scaling (controlled in client settings, almost always the default, 1.0)
entity render distance = 64 * bounding box size * view scale
```

Currently, the server still tracks these entities and sends packets about then despite them not being rendered by the client, this is especially noticeable for item entities due to their small bounding box size:

item entities on a server with 8 view distance will only render from 16 blocks away despite it being tracked from 96 blocks flat distance away by default (misc category)

This PR fixes that by adding the option to skip tracking entities that would be out of render range for clients, since we can't know what distance scaling the clients have set, there is also an option to set a custom one, although it is almost always set to 100% (the default)
