### PR TITLE
Normalize TODO comments in registry-related code

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/registry/set/RegistryKeySet.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/set/RegistryKeySet.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Unmodifiable;
  * @param <T> registry value type
  */
 @ApiStatus.NonExtendable
-public non-sealed interface RegistryKeySet<T extends Keyed> extends Iterable<TypedKey<T>>, RegistrySet<T> { // TODO remove Keyed
+public non-sealed interface RegistryKeySet<T extends Keyed> extends Iterable<TypedKey<T>>, RegistrySet<T> { // TODO: Remove Keyed once the registry-based API is finalized
 
     @Override
     default int size() {

--- a/paper-api/src/main/java/io/papermc/paper/registry/tag/Tag.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/tag/Tag.java
@@ -15,7 +15,7 @@ import org.jspecify.annotations.NullMarked;
  */
 @ApiStatus.Experimental
 @NullMarked
-public interface Tag<T extends Keyed> extends RegistryKeySet<T> { // TODO remove Keyed
+public interface Tag<T extends Keyed> extends RegistryKeySet<T> { // TODO: Remove Keyed once the registry-based API is finalized
 
     /**
      * Get the identifier for this named set.

--- a/paper-server/src/main/java/io/papermc/paper/registry/entry/RegistryEntry.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/entry/RegistryEntry.java
@@ -7,7 +7,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import org.bukkit.Keyed;
 
-public interface RegistryEntry<M, A extends Keyed> { // TODO remove Keyed
+public interface RegistryEntry<M, A extends Keyed> { // TODO: Remove Keyed once the registry-based API is finalized
 
     RegistryHolder<A> createRegistryHolder(Registry<M> nmsRegistry);
 

--- a/paper-server/src/main/java/io/papermc/paper/registry/set/PaperRegistrySets.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/set/PaperRegistrySets.java
@@ -16,7 +16,7 @@ import org.bukkit.craftbukkit.CraftRegistry;
 
 public final class PaperRegistrySets {
 
-    public static <A extends Keyed, M> HolderSet<M> convertToNms(final ResourceKey<? extends Registry<M>> resourceKey, final RegistryOps.RegistryInfoLookup lookup, final RegistryKeySet<A> registryKeySet) { // TODO remove Keyed
+    public static <A extends Keyed, M> HolderSet<M> convertToNms(final ResourceKey<? extends Registry<M>> resourceKey, final RegistryOps.RegistryInfoLookup lookup, final RegistryKeySet<A> registryKeySet) { // TODO: Remove Keyed once the registry-based API is finalized
         if (registryKeySet instanceof NamedRegistryKeySetImpl<A, ?>) {
             return ((NamedRegistryKeySetImpl<A, M>) registryKeySet).namedSet();
         } else {
@@ -27,7 +27,7 @@ public final class PaperRegistrySets {
         }
     }
 
-    public static <A extends Keyed, M> HolderSet<M> convertToNmsWithDirects(final ResourceKey<? extends Registry<M>> resourceKey, final RegistryOps.RegistryInfoLookup lookup, final RegistrySet<A> registrySet) { // TODO remove Keyed
+    public static <A extends Keyed, M> HolderSet<M> convertToNmsWithDirects(final ResourceKey<? extends Registry<M>> resourceKey, final RegistryOps.RegistryInfoLookup lookup, final RegistrySet<A> registrySet) { // TODO: Remove Keyed once the registry-based API is finalized
         if (registrySet instanceof NamedRegistryKeySetImpl<A, ?>) {
             return ((NamedRegistryKeySetImpl<A, M>) registrySet).namedSet();
         } else if (registrySet.isEmpty()) {
@@ -51,7 +51,7 @@ public final class PaperRegistrySets {
         }
     }
 
-    public static <A extends Keyed, M> RegistryKeySet<A> convertToApi(final RegistryKey<A> registryKey, final HolderSet<M> holders) { // TODO remove Keyed
+    public static <A extends Keyed, M> RegistryKeySet<A> convertToApi(final RegistryKey<A> registryKey, final HolderSet<M> holders) { // TODO: Remove Keyed once the registry-based API is finalized
         if (holders instanceof final HolderSet.Named<M> named) {
             return new NamedRegistryKeySetImpl<>(PaperRegistries.fromNms(named.key()), named);
         } else {
@@ -66,7 +66,7 @@ public final class PaperRegistrySets {
         }
     }
 
-    public static <A extends Keyed, M> RegistrySet<A> convertToApiWithDirects(final RegistryKey<A> registryKey, final HolderSet<M> holders) { // TODO remove Keyed
+    public static <A extends Keyed, M> RegistrySet<A> convertToApiWithDirects(final RegistryKey<A> registryKey, final HolderSet<M> holders) { // TODO: Remove Keyed once the registry-based API is finalized
         if (holders instanceof final HolderSet.Named<M> named) {
             return new NamedRegistryKeySetImpl<>(PaperRegistries.fromNms(named.key()), named);
         } else {


### PR DESCRIPTION
This PR normalizes TODO comments related to the planned removal of Keyed
across registry-related code, without changing behavior or API.
