### PR TITLE
Allow Locator Bar Waypoint Transmission While Not Receiving

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -713,6 +713,22 @@
      }
  
      public boolean isReceivingWaypoints() {
+@@ -1025,6 +_,15 @@
+             }
+         }
+ 
++        if (attribute.is(Attributes.WAYPOINT_TRANSMIT_RANGE)) {
++            ServerWaypointManager waypointManager = this.level().getWaypointManager();
++            if (this.getAttributes().getValue(attribute) > 0.0) {
++                waypointManager.trackWaypoint(this);
++            } else {
++                waypointManager.untrackWaypoint(this);
++            }
++        }
++
+         super.onAttributeUpdated(attribute);
+     }
+ 
 @@ -1042,14 +_,16 @@
              && (flag || blockState.getValue(RespawnAnchorBlock.CHARGE) > 0)
              && RespawnAnchorBlock.canSetSpawn(level, blockPos)) {

--- a/paper-server/patches/sources/net/minecraft/server/waypoints/ServerWaypointManager.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/waypoints/ServerWaypointManager.java.patch
@@ -1,0 +1,21 @@
+--- a/net/minecraft/server/waypoints/ServerWaypointManager.java
++++ b/net/minecraft/server/waypoints/ServerWaypointManager.java
+@@ -58,10 +_,6 @@
+         for (WaypointTransmitter waypointTransmitter : this.waypoints) {
+             this.createConnection(player, waypointTransmitter);
+         }
+-
+-        if (player.isTransmittingWaypoint()) {
+-            this.trackWaypoint((WaypointTransmitter)player);
+-        }
+     }
+ 
+     public void updatePlayer(ServerPlayer player) {
+@@ -82,7 +_,6 @@
+             connection.disconnect();
+             return true;
+         });
+-        this.untrackWaypoint((WaypointTransmitter)player);
+         this.players.remove(player);
+     }
+ 


### PR DESCRIPTION
There's a bug in the official server that disables waypoint transmission if `waypoint_receive_range` is set to 0. This pull request aims to fix this.

https://report.bugs.mojang.com/servicedesk/customer/portal/2/MC-305340