### PR TITLE
Add config for chunk unload drains per tick

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -6731,10 +6731,10 @@ index 0000000000000000000000000000000000000000..7eafc5b7cba23d8dec92ecc1050afe3f
 \ No newline at end of file
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java b/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..467065e3b40df17f38716499259b46663c174fd0
+index 0000000000000000000000000000000000000000..35f10335830c457dbe689a62c433bad2c9aaa39d
 --- /dev/null
 +++ b/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java
-@@ -0,0 +1,1565 @@
+@@ -0,0 +1,1566 @@
 +package ca.spottedleaf.moonrise.patches.chunk_system.scheduling;
 +
 +import ca.spottedleaf.concurrentutil.collection.MultiThreadedQueue;
@@ -7918,7 +7918,8 @@ index 0000000000000000000000000000000000000000..467065e3b40df17f38716499259b4666
 +        // We do need to process updates here so that any addTicket that is synchronised before this call does not go missed.
 +        this.processTicketUpdates();
 +
-+        final int toUnloadCount = Math.max(50, (int)(unloadCountTentative * 0.05));
++        io.papermc.paper.configuration.WorldConfiguration.Chunks chunks = world.paperConfig().chunks;
++        final int toUnloadCount = Math.max(chunks.minUnloadChunksPerTick, (int)(unloadCountTentative * chunks.maxUnloadChunksPerTickFactor));
 +        int processedCount = 0;
 +
 +        for (final ChunkUnloadQueue.SectionToUnload sectionRef : unloadSectionsForRegion) {
@@ -28137,7 +28138,7 @@ index 8cc5c0716392ba06501542ff5cbe71ee43979e5d..09fd99c9cbd23b5f3c899bfb00c9b896
 +    // Paper end - block counting
  }
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index eac79f778c33f323859543012565df36060d35d2..473d07ac3f9c640beb7594e5c540e730c0d6421e 100644
+index f0121f13e73d4417a93812713956f7ab98420d6d..92ad0b17ff735801b9a4c840f14b4c12db729427 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -152,7 +152,7 @@ import org.jetbrains.annotations.Contract;
@@ -31715,7 +31716,7 @@ index 9dc13a5b6cc1afc118a261802c71da25ae577fe5..a49a06662de4062a77112e358f536d45
  
      public static ProblemReporter.PathElement problemPath(ChunkPos pos) {
 diff --git a/net/minecraft/world/level/chunk/ChunkGenerator.java b/net/minecraft/world/level/chunk/ChunkGenerator.java
-index 2acee7d7211c4e7b9ac02e9a48d6c3ea239e6949..78600f4c583056403c93e72ec0996b00ec6d1284 100644
+index faf8f53bdcaa69fbbd816739dd4f1e812ced2165..7b98964eb77a619bdaaf5a9d331e3cfe080b52a4 100644
 --- a/net/minecraft/world/level/chunk/ChunkGenerator.java
 +++ b/net/minecraft/world/level/chunk/ChunkGenerator.java
 @@ -116,7 +116,7 @@ public abstract class ChunkGenerator {

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -4,6 +4,7 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import com.mojang.logging.LogUtils;
 import io.papermc.paper.FeatureHooks;
+import io.papermc.paper.configuration.constraint.Constraints;
 import io.papermc.paper.configuration.legacy.MaxEntityCollisionsInitializer;
 import io.papermc.paper.configuration.legacy.RequiresSpigotInitialization;
 import io.papermc.paper.configuration.mapping.MergeMap;
@@ -503,6 +504,7 @@ public class WorldConfiguration extends ConfigurationPart {
     public class Chunks extends ConfigurationPart {
         public AutosavePeriod autoSaveInterval = AutosavePeriod.def();
         public int maxAutoSaveChunksPerTick = 24;
+        @Constraints.Min(1)
         public int minUnloadChunksPerTick = 50;
         public double maxUnloadChunksPerTickFactor = 0.05;
         public int fixedChunkInhabitedTime = -1;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -503,6 +503,8 @@ public class WorldConfiguration extends ConfigurationPart {
     public class Chunks extends ConfigurationPart {
         public AutosavePeriod autoSaveInterval = AutosavePeriod.def();
         public int maxAutoSaveChunksPerTick = 24;
+        public int minUnloadChunksPerTick = 50;
+        public double maxUnloadChunksPerTickFactor = 0.05;
         public int fixedChunkInhabitedTime = -1;
         public boolean preventMovingIntoUnloadedChunks = false;
         public Duration delayChunkUnloadsBy = Duration.of("10s");


### PR DESCRIPTION
After checking my memory dump, I found that the pending unlock chunks takes up most of my memory. I have a lot of players who love to travel around with elytra.

There's a `maxAutoSaveChunksPerTick` option, so I think these `UnloadChunksPerTick` options make sense.

After setting `maxUnloadChunksPerTickFactor` to 1.0 on my server, my memory comes very healthy.