### PR TITLE
Not apply oversized sanitizers in components disabled by config

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -187,7 +187,7 @@ public class GlobalConfiguration extends ConfigurationPart {
         public CompressionFormat compressionFormat = CompressionFormat.ZLIB;
         @Comment("This setting controls if equipment should be updated when handling certain player actions.")
         public boolean updateEquipmentOnPlayerActions = true;
-        @Comment("This setting controls what components dont need to be sanitized in oversized item obfuscation. (Expected: minecraft:container, minecraft:charged_projectiles and minecraft:bundle_contents)")
+        @Comment("This setting controls what item data components don't need to be sanitized in oversized item obfuscation. Adding them re-enables exploits, but may be needed for certain resource packs. (Expected: minecraft:container, minecraft:charged_projectiles and minecraft:bundle_contents)")
         public OversizedItemComponentSanitizer.AssetOversizedItemComponentSanitizerConfiguration oversizedItemComponentSanitizer = new OversizedItemComponentSanitizer.AssetOversizedItemComponentSanitizerConfiguration(Set.of());
 
         public enum CompressionFormat {

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -7,6 +7,7 @@ import io.papermc.paper.configuration.serializer.collection.map.WriteKeyBack;
 import io.papermc.paper.configuration.type.number.DoubleOr;
 import io.papermc.paper.configuration.type.number.IntOr;
 import io.papermc.paper.util.sanitizer.ItemObfuscationBinding;
+import io.papermc.paper.util.sanitizer.OversizedItemComponentSanitizer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.minecraft.core.component.DataComponents;
@@ -186,6 +187,8 @@ public class GlobalConfiguration extends ConfigurationPart {
         public CompressionFormat compressionFormat = CompressionFormat.ZLIB;
         @Comment("This setting controls if equipment should be updated when handling certain player actions.")
         public boolean updateEquipmentOnPlayerActions = true;
+        @Comment("This setting controls what components dont need to be sanitized in oversized item obfuscation. (Expected: minecraft:container, minecraft:charged_projectiles and minecraft:bundle_contents)")
+        public OversizedItemComponentSanitizer.AssetOversizedItemComponentSanitizerConfiguration oversizedItemComponentSanitizer = new OversizedItemComponentSanitizer.AssetOversizedItemComponentSanitizerConfiguration(Set.of());
 
         public enum CompressionFormat {
             GZIP,

--- a/paper-server/src/main/java/io/papermc/paper/util/sanitizer/OversizedItemComponentSanitizer.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/sanitizer/OversizedItemComponentSanitizer.java
@@ -4,7 +4,9 @@ import io.papermc.paper.configuration.GlobalConfiguration;
 import io.papermc.paper.util.SafeAutoClosable;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.function.UnaryOperator;
+import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -15,6 +17,7 @@ import net.minecraft.world.item.component.BundleContents;
 import net.minecraft.world.item.component.ChargedProjectiles;
 import net.minecraft.world.item.component.ItemContainerContents;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 public final class OversizedItemComponentSanitizer {
 
@@ -52,7 +55,7 @@ public final class OversizedItemComponentSanitizer {
             return projectiles;
         }
 
-        if (GlobalConfiguration.get().anticheat.obfuscation.items.allModels.dontObfuscate().contains(DataComponents.CHARGED_PROJECTILES)) {
+        if (GlobalConfiguration.get().unsupportedSettings.oversizedItemComponentSanitizer.dontSanitizer().contains(DataComponents.CHARGED_PROJECTILES)) {
             return projectiles;
         }
 
@@ -65,7 +68,7 @@ public final class OversizedItemComponentSanitizer {
     }
 
     private static ItemContainerContents sanitizeItemContainerContents(final ItemContainerContents contents) {
-        if (GlobalConfiguration.get().anticheat.obfuscation.items.allModels.dontObfuscate().contains(DataComponents.CONTAINER)) {
+        if (GlobalConfiguration.get().unsupportedSettings.oversizedItemComponentSanitizer.dontSanitizer().contains(DataComponents.CONTAINER)) {
             return contents;
         }
         return ItemContainerContents.EMPTY;
@@ -77,7 +80,7 @@ public final class OversizedItemComponentSanitizer {
             return contents;
         }
 
-        if (GlobalConfiguration.get().anticheat.obfuscation.items.allModels.dontObfuscate().contains(DataComponents.BUNDLE_CONTENTS)) {
+        if (GlobalConfiguration.get().unsupportedSettings.oversizedItemComponentSanitizer.dontSanitizer().contains(DataComponents.BUNDLE_CONTENTS)) {
             return contents;
         }
 
@@ -118,6 +121,10 @@ public final class OversizedItemComponentSanitizer {
                 this.delegate.encode(buf, this.sanitizer.apply(value));
             }
         }
+    }
+
+    @ConfigSerializable
+    public record AssetOversizedItemComponentSanitizerConfiguration(Set<DataComponentType<?>> dontSanitizer) {
     }
 
 }

--- a/paper-server/src/main/java/io/papermc/paper/util/sanitizer/OversizedItemComponentSanitizer.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/sanitizer/OversizedItemComponentSanitizer.java
@@ -55,7 +55,7 @@ public final class OversizedItemComponentSanitizer {
             return projectiles;
         }
 
-        if (GlobalConfiguration.get().unsupportedSettings.oversizedItemComponentSanitizer.dontSanitizer().contains(DataComponents.CHARGED_PROJECTILES)) {
+        if (GlobalConfiguration.get().unsupportedSettings.oversizedItemComponentSanitizer.dontSanitize().contains(DataComponents.CHARGED_PROJECTILES)) {
             return projectiles;
         }
 
@@ -68,7 +68,7 @@ public final class OversizedItemComponentSanitizer {
     }
 
     private static ItemContainerContents sanitizeItemContainerContents(final ItemContainerContents contents) {
-        if (GlobalConfiguration.get().unsupportedSettings.oversizedItemComponentSanitizer.dontSanitizer().contains(DataComponents.CONTAINER)) {
+        if (GlobalConfiguration.get().unsupportedSettings.oversizedItemComponentSanitizer.dontSanitize().contains(DataComponents.CONTAINER)) {
             return contents;
         }
         return ItemContainerContents.EMPTY;
@@ -80,7 +80,7 @@ public final class OversizedItemComponentSanitizer {
             return contents;
         }
 
-        if (GlobalConfiguration.get().unsupportedSettings.oversizedItemComponentSanitizer.dontSanitizer().contains(DataComponents.BUNDLE_CONTENTS)) {
+        if (GlobalConfiguration.get().unsupportedSettings.oversizedItemComponentSanitizer.dontSanitize().contains(DataComponents.BUNDLE_CONTENTS)) {
             return contents;
         }
 
@@ -124,7 +124,7 @@ public final class OversizedItemComponentSanitizer {
     }
 
     @ConfigSerializable
-    public record AssetOversizedItemComponentSanitizerConfiguration(Set<DataComponentType<?>> dontSanitizer) {
+    public record AssetOversizedItemComponentSanitizerConfiguration(Set<DataComponentType<?>> dontSanitize) {
     }
 
 }


### PR DESCRIPTION
This PR closes https://github.com/PaperMC/Paper/issues/13265 where currently the anticheat-obfuscation in Paper make a sanitization of the item droped causing issues when in this case a texture pack try to check values in the item and the sanitization mess with that, the PR make the config for `dont-obfuscate` apply for this case then you can make like
```yml
unsupported-settings:
  allow-headless-pistons: false
  allow-permanent-block-break-exploits: false
  allow-piston-duplication: false
  allow-unsafe-end-portal-teleportation: false
  compression-format: ZLIB
  oversized-item-component-sanitizer:
    dont-sanitize:
      - minecraft:container
```
and avoid the issue for lose that info in the process.