### PR TITLE
add check for null player name in Team methods

### DIFF
--- a/paper-api/src/main/java/org/bukkit/scoreboard/Team.java
+++ b/paper-api/src/main/java/org/bukkit/scoreboard/Team.java
@@ -446,9 +446,9 @@ public interface Team extends net.kyori.adventure.audience.ForwardingAudience { 
      * @param player the player to search for
      * @return true if the player is a member of this team
      * @throws IllegalStateException if this team has been unregistered
+     * @throws IllegalArgumentException if {@link OfflinePlayer#getName()} is null
      * @see #hasEntry(String)
      */
-    // @Deprecated(since = "1.8.6") // Paper
     boolean hasPlayer(@NotNull OfflinePlayer player);
     /**
      * Checks to see if the specified entry is a member of this team.

--- a/paper-api/src/main/java/org/bukkit/scoreboard/Team.java
+++ b/paper-api/src/main/java/org/bukkit/scoreboard/Team.java
@@ -294,9 +294,9 @@ public interface Team extends net.kyori.adventure.audience.ForwardingAudience { 
      *
      * @param player the player to add
      * @throws IllegalStateException if this team has been unregistered
+     * @throws IllegalArgumentException if {@link OfflinePlayer#getName()} is null
      * @see #addEntry(String)
      */
-    // @Deprecated(since = "1.8.6") // Paper
     void addPlayer(@NotNull OfflinePlayer player);
 
     /**

--- a/paper-api/src/main/java/org/bukkit/scoreboard/Team.java
+++ b/paper-api/src/main/java/org/bukkit/scoreboard/Team.java
@@ -369,9 +369,9 @@ public interface Team extends net.kyori.adventure.audience.ForwardingAudience { 
      * @param player the player to remove
      * @return if the player was on this team
      * @throws IllegalStateException if this team has been unregistered
+     * @throws IllegalArgumentException if {@link OfflinePlayer#getName()} is null
      * @see #removeEntry(String)
      */
-    // @Deprecated(since = "1.8.6") // Paper
     boolean removePlayer(@NotNull OfflinePlayer player);
 
     /**

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
@@ -257,6 +257,7 @@ final class CraftTeam extends CraftScoreboardComponent implements Team {
     @Override
     public boolean removePlayer(OfflinePlayer player) {
         Preconditions.checkArgument(player != null, "OfflinePlayer cannot be null");
+        Preconditions.checkArgument(player.getName() != null, "OfflinePlayer must have a name");
         return this.removeEntry(player.getName());
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
@@ -297,6 +297,7 @@ final class CraftTeam extends CraftScoreboardComponent implements Team {
     @Override
     public boolean hasPlayer(OfflinePlayer player) throws IllegalArgumentException, IllegalStateException {
         Preconditions.checkArgument(player != null, "OfflinePlayer cannot be null");
+        Preconditions.checkArgument(player.getName() != null, "OfflinePlayer must have a name");
         return this.hasEntry(player.getName());
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
@@ -229,6 +229,7 @@ final class CraftTeam extends CraftScoreboardComponent implements Team {
     @Override
     public void addPlayer(OfflinePlayer player) {
         Preconditions.checkArgument(player != null, "OfflinePlayer cannot be null");
+        Preconditions.checkArgument(player.getName() != null, "OfflinePlayer must have a name");
         this.addEntry(player.getName());
     }
 


### PR DESCRIPTION
Close https://github.com/PaperMC/Paper/issues/13467
This PR just mention in docs the behaviour for null player name and make the check in the method before the later check in addEntry.

You can test this with
```java
this.getServer().getCommandMap().register("fallback", new BukkitCommand("test", "cool hi command", "<>", List.of()) {
            @Override
            public boolean execute(@NotNull CommandSender sender, @NotNull String commandLabel, @NotNull String[] args) {
                if (sender instanceof Player player) {
                    Team team = player.getScoreboard().getTeam("DOC");
                    if (team == null) {
                        team = player.getScoreboard().registerNewTeam("DOC");
                    }
                    OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(UUID.fromString("00000000-0000-0000-0000-000000000000"));
                    player.sendMessage(Component.text("Offline player: " + offlinePlayer.getName()));
                    team.addPlayer(offlinePlayer);
                }
                return true;
            }
        });
```