### PR TITLE
fix #12576: end crystal placement triggers BlockMultiPlaceEvent because of end portal regeneration

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/item/ItemStack.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/ItemStack.java.patch
@@ -33,7 +33,7 @@
 +            int oldCount = this.getCount();
 +            ServerLevel serverLevel = (ServerLevel) context.getLevel();
 +
-+            if (!(item instanceof BucketItem/* || item instanceof SolidBucketItem*/)) { // if not bucket // Paper - Fix cancelled powdered snow bucket placement
++            if (!(item instanceof BucketItem || item instanceof EndCrystalItem/* || item instanceof SolidBucketItem*/)) { // if not bucket // Paper - Fix cancelled powdered snow bucket placement // Paper - Fix capturing blocks on end crystal placement
 +                serverLevel.captureBlockStates = true;
 +                // special case bonemeal
 +                if (item == Items.BONE_MEAL) {


### PR DESCRIPTION
This pull request tries to prevent capturing blocks when an end crystal is being placed down. 

The problem with the current logic is that when we try to cancel a BlockPlaceEvent, we get back an EndCrystal (see the example code below).

```java
public class BlockPlaceListener implements Listener {

    @EventHandler
    public void onBlockPlace(BlockPlaceEvent event) {
        final Player player = event.getPlayer();

        if (player.getGameMode() != GameMode.CREATIVE && event.getBlock().getType() == Material.BEDROCK) {
            event.setCancelled(true);
        }
    }
}
```