### PR TITLE
Don't try to save scoreboard if there is no world loaded

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -23059,7 +23059,7 @@ index cda915fcb4822689f42b25280eb99aee082ddb74..094d2d528cb74b8f1d277cd780bba7f4
                  thread1 -> {
                      DedicatedServer dedicatedServer1 = new DedicatedServer(
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index f17335bbfca936292d89c12ca8ccd6f46513837a..0b5acce88545a1775b87cc6be3ed137e91c95a96 100644
+index 0c9690298abeaa1e01a3e13d09bfaf39a375116f..df34832f5f35376a77aaecd802c70fa093e0d539 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -185,7 +185,7 @@ import net.minecraft.world.scores.ScoreboardSaveData;
@@ -23183,10 +23183,10 @@ index f17335bbfca936292d89c12ca8ccd6f46513837a..0b5acce88545a1775b87cc6be3ed137e
 +    }
 +    public boolean saveAllChunks(boolean suppressLogs, boolean flush, boolean force, boolean close) {
 +        // Paper end - add close param
-         if (!this.levels.isEmpty()) // Paper - don't try to save if there is no level loaded
-         this.scoreboard.storeToSaveDataIfDirty(this.overworld().getDataStorage().computeIfAbsent(ScoreboardSaveData.TYPE));
+         if (this.overworld() != null) this.scoreboard.storeToSaveDataIfDirty(this.overworld().getDataStorage().computeIfAbsent(ScoreboardSaveData.TYPE)); // Paper - don't try to save if the overworld was not loaded, generally during early startup failures
          boolean flag = false;
-@@ -859,7 +951,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+ 
+@@ -858,7 +950,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  LOGGER.info("Saving chunks for level '{}'/{}", serverLevel, serverLevel.dimension().identifier());
              }
  
@@ -23195,7 +23195,7 @@ index f17335bbfca936292d89c12ca8ccd6f46513837a..0b5acce88545a1775b87cc6be3ed137e
              flag = true;
          }
  
-@@ -949,7 +1041,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -948,7 +1040,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              }
          }
  
@@ -23204,7 +23204,7 @@ index f17335bbfca936292d89c12ca8ccd6f46513837a..0b5acce88545a1775b87cc6be3ed137e
              this.nextTickTimeNanos = Util.getNanos() + TimeUtil.NANOSECONDS_PER_MILLISECOND;
  
              for (ServerLevel serverLevelx : this.getAllLevels()) {
-@@ -959,18 +1051,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -958,18 +1050,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
              this.waitUntilNextTick();
          }
@@ -23230,7 +23230,7 @@ index f17335bbfca936292d89c12ca8ccd6f46513837a..0b5acce88545a1775b87cc6be3ed137e
  
          this.isSaving = false;
          this.resources.close();
-@@ -990,6 +1078,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -989,6 +1077,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.services().nameToIdCache().save(false); // Paper - Perf: Async GameProfileCache saving
          }
          // Spigot end
@@ -23245,7 +23245,7 @@ index f17335bbfca936292d89c12ca8ccd6f46513837a..0b5acce88545a1775b87cc6be3ed137e
          // Paper start - Improved watchdog support - move final shutdown items here
          Util.shutdownExecutors();
          try {
-@@ -1084,16 +1180,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1083,16 +1179,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              // execute small amounts of other tasks just in case the number of tasks we are
              // draining is large - chunk system and packet processing may be latency sensitive
  
@@ -23280,7 +23280,7 @@ index f17335bbfca936292d89c12ca8ccd6f46513837a..0b5acce88545a1775b87cc6be3ed137e
          profiler.pop(); // moonrise:run_all_chunk
          profiler.pop(); // moonrise:run_all_tasks
  
-@@ -1394,6 +1505,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1393,6 +1504,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      private boolean pollTaskInternal() {
          if (super.pollTask()) {
@@ -23288,7 +23288,7 @@ index f17335bbfca936292d89c12ca8ccd6f46513837a..0b5acce88545a1775b87cc6be3ed137e
              return true;
          } else {
              boolean ret = false; // Paper - force execution of all worlds, do not just bias the first
-@@ -1535,6 +1647,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1534,6 +1646,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // Paper - improve tick loop - moved into runAllTasksAtTickStart
          this.runAllTasksAtTickStart(); // Paper - improve tick loop
          this.tickServer(sprinting ? () -> false : this::haveTime);
@@ -23302,7 +23302,7 @@ index f17335bbfca936292d89c12ca8ccd6f46513837a..0b5acce88545a1775b87cc6be3ed137e
          this.tickFrame.end();
          this.recordEndOfTick(); // Paper - improve tick loop
          profilerFiller.pop();
-@@ -2560,6 +2679,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2559,6 +2678,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
  

--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -23059,7 +23059,7 @@ index cda915fcb4822689f42b25280eb99aee082ddb74..094d2d528cb74b8f1d277cd780bba7f4
                  thread1 -> {
                      DedicatedServer dedicatedServer1 = new DedicatedServer(
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index cab1ab613dd081e9472de515a19e1b4738e4fba3..96f7f37c42cecea1d714f7b16276f430fe35d6bc 100644
+index f17335bbfca936292d89c12ca8ccd6f46513837a..0b5acce88545a1775b87cc6be3ed137e91c95a96 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -185,7 +185,7 @@ import net.minecraft.world.scores.ScoreboardSaveData;
@@ -23183,10 +23183,10 @@ index cab1ab613dd081e9472de515a19e1b4738e4fba3..96f7f37c42cecea1d714f7b16276f430
 +    }
 +    public boolean saveAllChunks(boolean suppressLogs, boolean flush, boolean force, boolean close) {
 +        // Paper end - add close param
+         if (!this.levels.isEmpty()) // Paper - don't try to save if there is no level loaded
          this.scoreboard.storeToSaveDataIfDirty(this.overworld().getDataStorage().computeIfAbsent(ScoreboardSaveData.TYPE));
          boolean flag = false;
- 
-@@ -858,7 +950,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -859,7 +951,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  LOGGER.info("Saving chunks for level '{}'/{}", serverLevel, serverLevel.dimension().identifier());
              }
  
@@ -23195,7 +23195,7 @@ index cab1ab613dd081e9472de515a19e1b4738e4fba3..96f7f37c42cecea1d714f7b16276f430
              flag = true;
          }
  
-@@ -948,7 +1040,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -949,7 +1041,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              }
          }
  
@@ -23204,7 +23204,7 @@ index cab1ab613dd081e9472de515a19e1b4738e4fba3..96f7f37c42cecea1d714f7b16276f430
              this.nextTickTimeNanos = Util.getNanos() + TimeUtil.NANOSECONDS_PER_MILLISECOND;
  
              for (ServerLevel serverLevelx : this.getAllLevels()) {
-@@ -958,18 +1050,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -959,18 +1051,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
              this.waitUntilNextTick();
          }
@@ -23230,7 +23230,7 @@ index cab1ab613dd081e9472de515a19e1b4738e4fba3..96f7f37c42cecea1d714f7b16276f430
  
          this.isSaving = false;
          this.resources.close();
-@@ -989,6 +1077,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -990,6 +1078,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.services().nameToIdCache().save(false); // Paper - Perf: Async GameProfileCache saving
          }
          // Spigot end
@@ -23245,7 +23245,7 @@ index cab1ab613dd081e9472de515a19e1b4738e4fba3..96f7f37c42cecea1d714f7b16276f430
          // Paper start - Improved watchdog support - move final shutdown items here
          Util.shutdownExecutors();
          try {
-@@ -1083,16 +1179,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1084,16 +1180,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              // execute small amounts of other tasks just in case the number of tasks we are
              // draining is large - chunk system and packet processing may be latency sensitive
  
@@ -23280,7 +23280,7 @@ index cab1ab613dd081e9472de515a19e1b4738e4fba3..96f7f37c42cecea1d714f7b16276f430
          profiler.pop(); // moonrise:run_all_chunk
          profiler.pop(); // moonrise:run_all_tasks
  
-@@ -1393,6 +1504,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1394,6 +1505,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      private boolean pollTaskInternal() {
          if (super.pollTask()) {
@@ -23288,7 +23288,7 @@ index cab1ab613dd081e9472de515a19e1b4738e4fba3..96f7f37c42cecea1d714f7b16276f430
              return true;
          } else {
              boolean ret = false; // Paper - force execution of all worlds, do not just bias the first
-@@ -1534,6 +1646,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1535,6 +1647,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // Paper - improve tick loop - moved into runAllTasksAtTickStart
          this.runAllTasksAtTickStart(); // Paper - improve tick loop
          this.tickServer(sprinting ? () -> false : this::haveTime);
@@ -23302,7 +23302,7 @@ index cab1ab613dd081e9472de515a19e1b4738e4fba3..96f7f37c42cecea1d714f7b16276f430
          this.tickFrame.end();
          this.recordEndOfTick(); // Paper - improve tick loop
          profilerFiller.pop();
-@@ -2559,6 +2678,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2560,6 +2679,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
  

--- a/paper-server/patches/features/0020-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0020-Incremental-chunk-and-player-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Incremental chunk and player saving
 
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index bd910d8263ba8c2bdbeadf33ef5244464a32f8eb..47f34dfddfb1cce87e08c9eb93ad5b2b23c1075b 100644
+index 41b3f63619db96dc7dc9ee453dc27508b3e59605..4c2238ef51523e9055428e1c338d24621f54c3da 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -974,7 +974,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -975,7 +975,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          boolean var4;
          try {
              this.isSaving = true;
@@ -17,7 +17,7 @@ index bd910d8263ba8c2bdbeadf33ef5244464a32f8eb..47f34dfddfb1cce87e08c9eb93ad5b2b
              var4 = this.saveAllChunks(suppressLogs, flush, force);
          } finally {
              this.isSaving = false;
-@@ -1617,9 +1617,29 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1618,9 +1618,29 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
  
          this.ticksUntilAutosave--;
@@ -50,7 +50,7 @@ index bd910d8263ba8c2bdbeadf33ef5244464a32f8eb..47f34dfddfb1cce87e08c9eb93ad5b2b
          ProfilerFiller profilerFiller = Profiler.get();
          this.server.spark.executeMainThreadTasks(); // Paper - spark
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index db2054e84f5717a37683d57890dcd585769effbc..f0bfc37a0802397da1462e545e48f83d42b3d0c0 100644
+index ef7e24716c2fc6a643d107cadcf743f80b39af41..45550619778b6a6b7f1f03467ece6bfe3d7b1e51 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -1416,6 +1416,26 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -81,7 +81,7 @@ index db2054e84f5717a37683d57890dcd585769effbc..f0bfc37a0802397da1462e545e48f83d
          // Paper start - add close param
          this.save(progress, flush, skipSave, false);
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 55d27aa4cff91ea61ff2ab9256acd2cd8694304a..d4466c7d30f47614a70d9ef24002a2d39182b8f6 100644
+index 9d4d70369907c3d18c15289ef6630cade8fc74fe..37bb332f285888a48e0c556d492f8861efd33611 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -203,6 +203,7 @@ import org.slf4j.Logger;
@@ -93,7 +93,7 @@ index 55d27aa4cff91ea61ff2ab9256acd2cd8694304a..d4466c7d30f47614a70d9ef24002a2d3
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      private static final int FLY_STAT_RECORDING_SPEED = 25;
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 12ab84ddce4868ddb9e480a2bb8f322bc3346cce..a17d021269c65d98a2ba847c0059a421ea051863 100644
+index 38c30d98a200dd2a5c888cc080e9c77795f0e0c4..dec9dd8e42f90ccf7e5e3ad945e459d07159250d 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -412,6 +412,7 @@ public abstract class PlayerList {

--- a/paper-server/patches/features/0020-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0020-Incremental-chunk-and-player-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Incremental chunk and player saving
 
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 41b3f63619db96dc7dc9ee453dc27508b3e59605..4c2238ef51523e9055428e1c338d24621f54c3da 100644
+index 532ac3cb01773d5537a5a27cdeb279ed77bd1c6c..0f2364c24a95d773e568ceaa1e9e4a8be2f5406a 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -975,7 +975,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -974,7 +974,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          boolean var4;
          try {
              this.isSaving = true;
@@ -17,7 +17,7 @@ index 41b3f63619db96dc7dc9ee453dc27508b3e59605..4c2238ef51523e9055428e1c338d2462
              var4 = this.saveAllChunks(suppressLogs, flush, force);
          } finally {
              this.isSaving = false;
-@@ -1618,9 +1618,29 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1617,9 +1617,29 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
  
          this.ticksUntilAutosave--;

--- a/paper-server/patches/features/0025-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0025-Optimise-EntityScheduler-ticking.patch
@@ -20,10 +20,10 @@ index 2bc436cdf5180a7943c45fabb9fbbedae6f7db56..f312a7f5b1b2a777ab36b94ce7cbf387
  
      @Override
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 4c2238ef51523e9055428e1c338d24621f54c3da..66fdd74fa84b796690171b4d021eaa17abccbb76 100644
+index 0f2364c24a95d773e568ceaa1e9e4a8be2f5406a..711261a67b2ebd9e672092e0dc6250b4b9419630 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1751,33 +1751,22 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1750,33 +1750,22 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
  

--- a/paper-server/patches/features/0025-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0025-Optimise-EntityScheduler-ticking.patch
@@ -20,10 +20,10 @@ index 2bc436cdf5180a7943c45fabb9fbbedae6f7db56..f312a7f5b1b2a777ab36b94ce7cbf387
  
      @Override
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 47f34dfddfb1cce87e08c9eb93ad5b2b23c1075b..9934055a994c10d646d97a2d042d0e8b1e7e76c9 100644
+index 4c2238ef51523e9055428e1c338d24621f54c3da..66fdd74fa84b796690171b4d021eaa17abccbb76 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1750,33 +1750,22 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1751,33 +1751,22 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
  
@@ -67,7 +67,7 @@ index 47f34dfddfb1cce87e08c9eb93ad5b2b23c1075b..9934055a994c10d646d97a2d042d0e8b
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.DIALOG_CLICK_MANAGER.handleQueue(this.tickCount); // Paper
          profilerFiller.push("commandFunctions");
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 5ccb613f9c44bcd9f6b6fe7123f32bb1d3e9554c..cd434d5a6e37a525611fd0b44b9a859435c4d157 100644
+index 1b554121a550f0a2c7e5d6b041450b4bcba781c5..21d0de44d9055a5e80c551402abdb7e352dcb0c9 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -5217,6 +5217,11 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name

--- a/paper-server/patches/features/0028-Optimize-Hoppers.patch
+++ b/paper-server/patches/features/0028-Optimize-Hoppers.patch
@@ -48,10 +48,10 @@ index 0000000000000000000000000000000000000000..24a2090e068ad3c0d08705050944abdf
 +    }
 +}
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 66fdd74fa84b796690171b4d021eaa17abccbb76..d239e97c928180d64dcbb565826a839e84a1ca89 100644
+index 711261a67b2ebd9e672092e0dc6250b4b9419630..cf8c8e859f8217d7760c31b9af825278e82015be 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1806,6 +1806,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1805,6 +1805,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              serverLevel.hasPhysicsEvent = org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
              serverLevel.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - Add EntityMoveEvent
              serverLevel.updateLagCompensationTick(); // Paper - lag compensation

--- a/paper-server/patches/features/0028-Optimize-Hoppers.patch
+++ b/paper-server/patches/features/0028-Optimize-Hoppers.patch
@@ -48,10 +48,10 @@ index 0000000000000000000000000000000000000000..24a2090e068ad3c0d08705050944abdf
 +    }
 +}
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 9934055a994c10d646d97a2d042d0e8b1e7e76c9..e7d9306dfde918c1abb9e5320d7315810a66a4d7 100644
+index 66fdd74fa84b796690171b4d021eaa17abccbb76..d239e97c928180d64dcbb565826a839e84a1ca89 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1805,6 +1805,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1806,6 +1806,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              serverLevel.hasPhysicsEvent = org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
              serverLevel.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - Add EntityMoveEvent
              serverLevel.updateLagCompensationTick(); // Paper - lag compensation
@@ -60,7 +60,7 @@ index 9934055a994c10d646d97a2d042d0e8b1e7e76c9..e7d9306dfde918c1abb9e5320d731581
              /* Drop global time updates
              if (this.tickCount % 20 == 0) {
 diff --git a/net/minecraft/world/item/ItemStack.java b/net/minecraft/world/item/ItemStack.java
-index c91797613b68cd9c624779a2c7cd3e76edf9423e..b00ad17852e9890f848fc2124e2287885c2b9c5d 100644
+index f2747ca200ae1f0bc5d744167487feb1161ce7ea..ed06cffe8a5eba2ca4a34ade81f8185e21d7b651 100644
 --- a/net/minecraft/world/item/ItemStack.java
 +++ b/net/minecraft/world/item/ItemStack.java
 @@ -813,10 +813,16 @@ public final class ItemStack implements DataComponentHolder {

--- a/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -526,6 +526,14 @@
      }
  
      protected GlobalPos selectLevelLoadFocusPos() {
+@@ -610,6 +_,7 @@
+     public abstract boolean shouldRconBroadcast();
+ 
+     public boolean saveAllChunks(boolean suppressLogs, boolean flush, boolean force) {
++        if (!this.levels.isEmpty()) // Paper - don't try to save if there is no level loaded
+         this.scoreboard.storeToSaveDataIfDirty(this.overworld().getDataStorage().computeIfAbsent(ScoreboardSaveData.TYPE));
+         boolean flag = false;
+ 
 @@ -622,8 +_,10 @@
              flag = true;
          }

--- a/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -526,14 +526,15 @@
      }
  
      protected GlobalPos selectLevelLoadFocusPos() {
-@@ -610,6 +_,7 @@
+@@ -610,7 +_,7 @@
      public abstract boolean shouldRconBroadcast();
  
      public boolean saveAllChunks(boolean suppressLogs, boolean flush, boolean force) {
-+        if (!this.levels.isEmpty()) // Paper - don't try to save if there is no level loaded
-         this.scoreboard.storeToSaveDataIfDirty(this.overworld().getDataStorage().computeIfAbsent(ScoreboardSaveData.TYPE));
+-        this.scoreboard.storeToSaveDataIfDirty(this.overworld().getDataStorage().computeIfAbsent(ScoreboardSaveData.TYPE));
++        if (this.overworld() != null) this.scoreboard.storeToSaveDataIfDirty(this.overworld().getDataStorage().computeIfAbsent(ScoreboardSaveData.TYPE)); // Paper - don't try to save if the overworld was not loaded, generally during early startup failures
          boolean flag = false;
  
+         for (ServerLevel serverLevel : this.getAllLevels()) {
 @@ -622,8 +_,10 @@
              flag = true;
          }


### PR DESCRIPTION
Fixes the server erroring on shutdown (and hanging indefinitely) if there was an error during startup (before worlds were loaded)

The issue can be reproduced by simply trying to start the server on a port which is already in use
See https://haste.pinofett.de/lmqujqrd1u.txt for an example stacktrace