### PR TITLE
expose pusher in EntityKnockbackByEntityEvent

### DIFF
--- a/paper-api/src/main/java/com/destroystokyo/paper/event/entity/EntityKnockbackByEntityEvent.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/event/entity/EntityKnockbackByEntityEvent.java
@@ -15,11 +15,19 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class EntityKnockbackByEntityEvent extends EntityPushedByEntityAttackEvent {
 
+    private final Entity directHitter;
     private final float knockbackStrength;
 
     @ApiStatus.Internal
+    @Deprecated(forRemoval = true)
     public EntityKnockbackByEntityEvent(final LivingEntity entity, final Entity hitBy, final EntityKnockbackEvent.Cause cause, final float knockbackStrength, final Vector knockback) {
+        this(entity, hitBy, hitBy, cause, knockbackStrength, knockback);
+    }
+
+    @ApiStatus.Internal
+    public EntityKnockbackByEntityEvent(final LivingEntity entity, final Entity hitBy, final Entity directHitter, final EntityKnockbackEvent.Cause cause, final float knockbackStrength, final Vector knockback) {
         super(entity, cause, hitBy, knockback);
+        this.directHitter = directHitter;
         this.knockbackStrength = knockbackStrength;
     }
 
@@ -41,7 +49,8 @@ public class EntityKnockbackByEntityEvent extends EntityPushedByEntityAttackEven
     }
 
     /**
-     * Gets the causing entity. Same as {@link #getPushedBy()}.
+     * Gets the entity that initiated the hit. This can be, for example, the player that fired the arrow which hit the
+     * entity. Same as {@link #getPushedBy()}.
      *
      * @return the Entity which hit
      */
@@ -49,4 +58,13 @@ public class EntityKnockbackByEntityEvent extends EntityPushedByEntityAttackEven
         return super.getPushedBy();
     }
 
+    /**
+     * Get the entity that caused the knockback to occur. Where {@link #getHitBy()} would return the player that fired
+     * the arrow, this method would return the arrow entity.
+     *
+     * @return the direct hitter responsible for the knockback.
+     */
+    public Entity getDirectHitter() {
+        return this.directHitter;
+    }
 }

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -608,7 +608,7 @@
 +                    // Paper end - Check distance in entity interactions
  
 -                    this.knockback(0.4F, d, d1);
-+                    this.knockback(0.4F, d, d1, damageSource.getDirectEntity(), damageSource.getDirectEntity() == null ? io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.DAMAGE : io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.ENTITY_ATTACK); // CraftBukkit // Paper - knockback events
++                    this.knockback(0.4F, d, d1, damageSource.getEntity(), damageSource.getDirectEntity(), damageSource.getDirectEntity() == null ? io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.DAMAGE : io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.ENTITY_ATTACK); // CraftBukkit // Paper - knockback events
                      if (!flag) {
                          this.indicateDamage(d, d1);
                      }
@@ -746,7 +746,7 @@
  
      protected void blockedByItem(LivingEntity entity) {
 -        entity.knockback(0.5, entity.getX() - this.getX(), entity.getZ() - this.getZ());
-+        entity.knockback(0.5, entity.getX() - this.getX(), entity.getZ() - this.getZ(), this, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.SHIELD_BLOCK); // CraftBukkit // Paper - fix attacker & knockback events
++        entity.knockback(0.5, entity.getX() - this.getX(), entity.getZ() - this.getZ(), this, this, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.SHIELD_BLOCK); // CraftBukkit // Paper - fix attacker & knockback events
      }
  
      private boolean checkTotemDeathProtection(DamageSource damageSource) {
@@ -971,10 +971,10 @@
  
      public void knockback(double strength, double x, double z) {
 +        // CraftBukkit start - EntityKnockbackEvent
-+        this.knockback(strength, x, z, null, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.UNKNOWN); // Paper - knockback events
++        this.knockback(strength, x, z, null, null, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.UNKNOWN); // Paper - knockback events
 +    }
 +
-+    public void knockback(double strength, double x, double z, @Nullable Entity attacker, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause eventCause) { // Paper - knockback events
++    public void knockback(double strength, double x, double z, @Nullable Entity source, @Nullable Entity directCause, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause eventCause) { // Paper - knockback events
          strength *= 1.0 - this.getAttributeValue(Attributes.KNOCKBACK_RESISTANCE);
 -        if (!(strength <= 0.0)) {
 -            this.needsSync = true;
@@ -995,7 +995,7 @@
                  deltaMovement.z / 2.0 - vec3.z
              );
 +            Vec3 diff = finalVelocity.subtract(deltaMovement);
-+            io.papermc.paper.event.entity.EntityKnockbackEvent event = CraftEventFactory.callEntityKnockbackEvent((org.bukkit.craftbukkit.entity.CraftLivingEntity) this.getBukkitEntity(), attacker, attacker, eventCause, strength, diff);
++            io.papermc.paper.event.entity.EntityKnockbackEvent event = CraftEventFactory.callEntityKnockbackEvent((org.bukkit.craftbukkit.entity.CraftLivingEntity) this.getBukkitEntity(), directCause, source, eventCause, strength, diff);
 +            // Paper end - knockback events
 +            if (event.isCancelled()) {
 +                return;
@@ -1362,7 +1362,7 @@
      public void causeExtraKnockback(Entity target, float strength, Vec3 currentMovement) {
          if (strength > 0.0F && target instanceof LivingEntity livingEntity) {
 -            livingEntity.knockback(strength, Mth.sin(this.getYRot() * (float) (Math.PI / 180.0)), -Mth.cos(this.getYRot() * (float) (Math.PI / 180.0)));
-+            livingEntity.knockback(strength, Mth.sin(this.getYRot() * (float) (Math.PI / 180.0)), -Mth.cos(this.getYRot() * (float) (Math.PI / 180.0)), this, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.ENTITY_ATTACK); // Paper - knockback events
++            livingEntity.knockback(strength, Mth.sin(this.getYRot() * (float) (Math.PI / 180.0)), -Mth.cos(this.getYRot() * (float) (Math.PI / 180.0)), this, this, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.ENTITY_ATTACK); // Paper - knockback events
              this.setDeltaMovement(this.getDeltaMovement().multiply(0.6, 1.0, 0.6));
          }
      }

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/RamTarget.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/RamTarget.java.patch
@@ -5,7 +5,7 @@
              float f3 = livingEntity.applyItemBlocking(level, damageSource1, f);
              float f4 = f3 > 0.0F ? 0.5F : 1.0F;
 -            livingEntity.knockback(f4 * f2 * this.getKnockbackForce.applyAsDouble(owner), this.ramDirection.x(), this.ramDirection.z());
-+            livingEntity.knockback(f4 * f2 * this.getKnockbackForce.applyAsDouble(owner), this.ramDirection.x(), this.ramDirection.z(), owner, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.ENTITY_ATTACK); // Paper - Add EntityKnockbackByEntityEvent and EntityPushedByEntityAttackEvent
++            livingEntity.knockback(f4 * f2 * this.getKnockbackForce.applyAsDouble(owner), this.ramDirection.x(), this.ramDirection.z(), owner, owner, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.ENTITY_ATTACK); // Paper - Add EntityKnockbackByEntityEvent and EntityPushedByEntityAttackEvent
              this.finishRam(level, owner);
              level.playSound(null, owner, this.getImpactSound.apply(owner), SoundSource.NEUTRAL, 1.0F, 1.0F);
          } else if (this.hasRammedHornBreakingBlock(level, owner)) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/creaking/Creaking.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/creaking/Creaking.java.patch
@@ -26,10 +26,10 @@
  
      @Override
 -    public void knockback(double strength, double x, double z) {
-+    public void knockback(double strength, double x, double z, @Nullable Entity attacker, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause cause) { // Paper - knockback events
++    public void knockback(double strength, double x, double z, @Nullable Entity source, @Nullable Entity directCause, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause cause) { // Paper - knockback events
          if (this.canMove()) {
 -            super.knockback(strength, x, z);
-+            super.knockback(strength, x, z, attacker, cause); // Paper - knockback events
++            super.knockback(strength, x, z, source, directCause, cause); // Paper - knockback events
          }
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -286,7 +286,7 @@
          if (strength > 0.0F) {
              if (target instanceof LivingEntity livingEntity) {
 -                livingEntity.knockback(strength, Mth.sin(this.getYRot() * (float) (Math.PI / 180.0)), -Mth.cos(this.getYRot() * (float) (Math.PI / 180.0)));
-+                livingEntity.knockback(strength, Mth.sin(this.getYRot() * (float) (Math.PI / 180.0)), -Mth.cos(this.getYRot() * (float) (Math.PI / 180.0)), this, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.ENTITY_ATTACK); // Paper - knockback events
++                livingEntity.knockback(strength, Mth.sin(this.getYRot() * (float) (Math.PI / 180.0)), -Mth.cos(this.getYRot() * (float) (Math.PI / 180.0)), this, this, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.ENTITY_ATTACK); // Paper - knockback events
              } else {
                  target.push(
                      -Mth.sin(this.getYRot() * (float) (Math.PI / 180.0)) * strength, 0.1, Mth.cos(this.getYRot() * (float) (Math.PI / 180.0)) * strength
@@ -336,7 +336,7 @@
 +                    livingEntity.lastDamageCancelled = false;
 +                    if (livingEntity.hurtServer(serverLevel, damageSource.knownCause(org.bukkit.event.entity.EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK), f1) && !livingEntity.lastDamageCancelled) {
 +                        // Paper end - Only apply knockback if the event is not canceled
-+                        livingEntity.knockback(0.4F, Mth.sin(this.getYRot() * (float) (Math.PI / 180.0)), -Mth.cos(this.getYRot() * (float) (Math.PI / 180.0)), this, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.SWEEP_ATTACK); // Paper - knockback events
++                        livingEntity.knockback(0.4F, Mth.sin(this.getYRot() * (float) (Math.PI / 180.0)), -Mth.cos(this.getYRot() * (float) (Math.PI / 180.0)), this, this, io.papermc.paper.event.entity.EntityKnockbackEvent.Cause.SWEEP_ATTACK); // Paper - knockback events
                          EnchantmentHelper.doPostAttackEffects(serverLevel, livingEntity, damageSource);
                      }
                  }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -2186,8 +2186,8 @@ public class CraftEventFactory {
 
         final io.papermc.paper.event.entity.EntityKnockbackEvent event;
         apiKnockback = legacyEvent.getFinalKnockback().subtract(currentVelocity);
-        if (attacker != null) {
-            event = new com.destroystokyo.paper.event.entity.EntityKnockbackByEntityEvent(entity, attacker.getBukkitEntity(), cause, (float) force, apiKnockback);
+        if (attacker != null && pusher != null) {
+            event = new com.destroystokyo.paper.event.entity.EntityKnockbackByEntityEvent(entity, attacker.getBukkitEntity(), pusher.getBukkitEntity(), cause, (float) force, apiKnockback);
         } else {
             event = new io.papermc.paper.event.entity.EntityKnockbackEvent(entity, cause, apiKnockback);
         }


### PR DESCRIPTION
Added an extra method to the EntityKnockbackByEntityEvent that returns the entity that actually caused the push of the hit entity.
Not very happy with the naming, but I was unable to find a better name given that the obvious "hitBy" name is already taken. Maybe it's a good idea to deprecate `getHitBy()` and introduce a new method with a better name as it's really confusing that the method does not, for example, return the projecticle that hit. But maybe the javadoc changes are enough to clarify this.

Fixes #7168