### PR TITLE
Add the Vehicle interface to Nautilus

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/AbstractNautilus.java
+++ b/paper-api/src/main/java/org/bukkit/entity/AbstractNautilus.java
@@ -5,7 +5,7 @@ import org.bukkit.inventory.InventoryHolder;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public interface AbstractNautilus extends Animals, InventoryHolder, Tameable, Vehicle {
+public interface AbstractNautilus extends Tameable, InventoryHolder, Vehicle {
 
     @Override
     ArmoredSaddledMountInventory getInventory();

--- a/paper-api/src/main/java/org/bukkit/entity/AbstractNautilus.java
+++ b/paper-api/src/main/java/org/bukkit/entity/AbstractNautilus.java
@@ -5,7 +5,7 @@ import org.bukkit.inventory.InventoryHolder;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public interface AbstractNautilus extends Animals, InventoryHolder, Tameable {
+public interface AbstractNautilus extends Animals, InventoryHolder, Tameable, Vehicle {
 
     @Override
     ArmoredSaddledMountInventory getInventory();


### PR DESCRIPTION
As I create this, I become aware that the Vehicle interface is strange since almost all entities are rideable with commands. And there is an internal class called `VehicleEntity` which is only applicable to boats and minecarts. Regardless of this oddity, to be consistent with the existing other uses of the Vehicle interface, I recommend it get added here.

Other entities with the Vehicle Interface:

- AbstractHorse
- HappyGhast
- Strider
- Pig

Main advantage to this change is access to events such as the following for API consistency till their use is deprecated.

- VehicleBlockCollisionEvent
- VehicleEnterEvent
- VehicleExitEvent

Noting that many of the other "Vehicle" events are specific to boats/minecarts.