### PR TITLE
Add nautilus to type of entities to send updated equipment data

### DIFF
--- a/paper-server/patches/features/0002-Rewrite-dataconverter-system.patch
+++ b/paper-server/patches/features/0002-Rewrite-dataconverter-system.patch
@@ -33353,7 +33353,7 @@ index c9bbf15b75ac4516c7d7fdfaf2390351702ca415..372030b78d25b4ff0b18575d151b0a63
          return structureTemplate.save(new CompoundTag());
      }
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index bdaca3647425711ee8b10eb0593a9c3cb4037ede..bd910d8263ba8c2bdbeadf33ef5244464a32f8eb 100644
+index df34832f5f35376a77aaecd802c70fa093e0d539..3cb08ede3a46ac6f54d301a1ea01f3960dcd0c0d 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -383,6 +383,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
@@ -354,7 +354,7 @@ index 0000000000000000000000000000000000000000..c18823746ab2edcab536cb1589b7720e
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 5494b92ab1c3c202a640e483e8a4bcb64395ed99..d7238270a6df8d1182874b46b588b971ca6f7a0e 100644
+index 7656665352632fc718bea91dcfd3dd41fc436e1f..bdbc15bfbbfeae2bc5b884e300b86cb25c88840f 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -830,6 +830,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -464,7 +464,7 @@ index 5461bd9a39bb20ad29d3bc110c38860cf35a770a..75f80787966cdda6f51f55a8f6cb2218
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 92ad0b17ff735801b9a4c840f14b4c12db729427..06837062905e08a3e9c29ee030ce199ce1d540b1 100644
+index 57cff20212f6d5f83d4b0169bf6aa185a403e1d3..1b554121a550f0a2c7e5d6b041450b4bcba781c5 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -368,6 +368,15 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
@@ -523,7 +523,7 @@ index 92ad0b17ff735801b9a4c840f14b4c12db729427..06837062905e08a3e9c29ee030ce199c
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 38eac6d27ebf3497fc1c2dfb600a7cbf4f9da7f4..9dacf9cef03ecb87464bfecf2399f2864be6d6ba 100644
+index 5b6020de0848458f5576113e690b5a6435f35d05..6f49b5e5888a6296b929e465a5ef87dc49bd4516 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
 @@ -3330,6 +3330,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
@@ -818,7 +818,7 @@ index 4a6384a668546371f4ffa13927be4bd462d47c60..3c961b76769f16160caedce8ec32bb2a
 +
  }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index c94eae678dd55fced81fcee683ca3c0e16443c7c..3d5a869d1d7da490ec843ab2137ceeddc0a5fa0d 100644
+index 77b8f0f18748fc6a3c8c44f8eb496225e3f0eb8f..345f3eab21b569f322ef188f16608b87d0bb184e 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -150,6 +150,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
@@ -835,7 +835,7 @@ index c94eae678dd55fced81fcee683ca3c0e16443c7c..3d5a869d1d7da490ec843ab2137ceedd
      public final org.spigotmc.SpigotWorldConfig spigotConfig; // Spigot
      // Paper start - add paper world config
 diff --git a/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java b/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
-index 182b803ed17d6bd580f55a6b2ec08001edc533fd..59a002711531f8337a86d85b6e8b11b5fad8ced7 100644
+index 9f50e86a637aab8b5c34913e226807990c1891a4..bc42a6c678987a39b0a70a1a3e96eb90340ffea5 100644
 --- a/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 +++ b/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 @@ -152,6 +152,10 @@ public class PistonMovingBlockEntity extends BlockEntity {

--- a/paper-server/patches/features/0006-Use-Velocity-compression-and-cipher-natives.patch
+++ b/paper-server/patches/features/0006-Use-Velocity-compression-and-cipher-natives.patch
@@ -335,7 +335,7 @@ index 309845b28306dfa5946e79b80e5b1dde82dd68cd..33e1cdb00d648c992af03a9768992531
                  .add(
                      new ServerBootstrap()
 diff --git a/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index ec5bd4568872c48addd26dd652868e0e5df57038..31bc0a105152a7f24a4126542bea7dbebc3e037c 100644
+index 9ce883c9d3ebdb8163e33a1c06ff204f5b63317b..51a29ab542136e67741be10bbc5c6377715a207c 100644
 --- a/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -245,11 +245,9 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener,

--- a/paper-server/patches/features/0007-Optimize-GoalSelector-Goal.Flag-Set-operations.patch
+++ b/paper-server/patches/features/0007-Optimize-GoalSelector-Goal.Flag-Set-operations.patch
@@ -154,7 +154,7 @@ index 674966c580220a4e0c83a628c763aaea8bfd0b1c..859b859d29b637200cf7c9a0bd52d9f7
  
      public void setControlFlag(Goal.Flag flag, boolean enabled) {
 diff --git a/net/minecraft/world/entity/ai/goal/WrappedGoal.java b/net/minecraft/world/entity/ai/goal/WrappedGoal.java
-index 4bdbd323b642ed3422948fe24780be8b503602dc..2c2ab6a1df9d3d23773e44ce4041cc1c21b55163 100644
+index d0249ae3fee041245445a087dee2bb15a4067fc6..44a7c97164ac7ee731068f909372218350a8682d 100644
 --- a/net/minecraft/world/entity/ai/goal/WrappedGoal.java
 +++ b/net/minecraft/world/entity/ai/goal/WrappedGoal.java
 @@ -69,7 +69,7 @@ public class WrappedGoal extends Goal {

--- a/paper-server/patches/features/0009-Handle-Oversized-block-entities-in-chunks.patch
+++ b/paper-server/patches/features/0009-Handle-Oversized-block-entities-in-chunks.patch
@@ -9,7 +9,7 @@ creating too large of a packet to sed.
 Co-authored-by: Spottedleaf <Spottedleaf@users.noreply.github.com>
 
 diff --git a/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java b/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
-index de234f220ba09ad9b5e0c8215b49d20ca51d0ac7..e216a9d70be5a3da7c03ee99a8986391ef2dbd5b 100644
+index 7cdac4a18b13805aea60495d369ee7cdd1db784f..919eaac837298c1936ec7aa06375c72a7acd2daa 100644
 --- a/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
 +++ b/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
 @@ -32,6 +32,14 @@ public class ClientboundLevelChunkPacketData {
@@ -47,7 +47,7 @@ index de234f220ba09ad9b5e0c8215b49d20ca51d0ac7..e216a9d70be5a3da7c03ee99a8986391
          }
      }
 diff --git a/net/minecraft/network/protocol/game/ClientboundLevelChunkWithLightPacket.java b/net/minecraft/network/protocol/game/ClientboundLevelChunkWithLightPacket.java
-index 3a384175f8e7f204234bbaf3081bdc20c47a0d4b..fdd164cd45a26c7ef25f1153ab8985ba50c01b14 100644
+index 8475c1c3d79e7fae9ab83dea1ac18f7a28ff60bb..3c0f0a612cc57c9f03abfb0ccb1f891305d03d45 100644
 --- a/net/minecraft/network/protocol/game/ClientboundLevelChunkWithLightPacket.java
 +++ b/net/minecraft/network/protocol/game/ClientboundLevelChunkWithLightPacket.java
 @@ -71,4 +71,11 @@ public class ClientboundLevelChunkWithLightPacket implements Packet<ClientGamePa

--- a/paper-server/patches/features/0016-Add-Alternate-Current-redstone-implementation.patch
+++ b/paper-server/patches/features/0016-Add-Alternate-Current-redstone-implementation.patch
@@ -2326,7 +2326,7 @@ index 0000000000000000000000000000000000000000..298076a0db4e6ee6e4775ac43bf749d9
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index d7238270a6df8d1182874b46b588b971ca6f7a0e..db2054e84f5717a37683d57890dcd585769effbc 100644
+index bdbc15bfbbfeae2bc5b884e300b86cb25c88840f..ef7e24716c2fc6a643d107cadcf743f80b39af41 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -227,6 +227,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -2352,7 +2352,7 @@ index d7238270a6df8d1182874b46b588b971ca6f7a0e..db2054e84f5717a37683d57890dcd585
          return level.dimension() != Level.NETHER || this.getGameRules().get(GameRules.ALLOW_ENTERING_NETHER_USING_PORTALS);
      }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 3d5a869d1d7da490ec843ab2137ceeddc0a5fa0d..66f15154fa59435650f3881f50b45b5756088a2f 100644
+index 345f3eab21b569f322ef188f16608b87d0bb184e..259c6ecde58aaf2da470adc7ffec0a7ee1ea37ce 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -2050,6 +2050,17 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl

--- a/paper-server/patches/features/0020-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0020-Incremental-chunk-and-player-saving.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Incremental chunk and player saving
 
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 532ac3cb01773d5537a5a27cdeb279ed77bd1c6c..0f2364c24a95d773e568ceaa1e9e4a8be2f5406a 100644
+index 3cb08ede3a46ac6f54d301a1ea01f3960dcd0c0d..709d60077f2fb208026a9265705b0bb2a08ef456 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -974,7 +974,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/paper-server/patches/features/0021-Optimise-general-POI-access.patch
+++ b/paper-server/patches/features/0021-Optimise-general-POI-access.patch
@@ -1011,7 +1011,7 @@ index 42699c82321233eaa3647ca0ac4d1f24b6a6227f..0f8e1dcdd8de00c7669de0b0d2329b6d
              return Optional.empty();
          } else {
 diff --git a/net/minecraft/world/level/portal/PortalForcer.java b/net/minecraft/world/level/portal/PortalForcer.java
-index 491affe4343b3843bcdcbae0cca670d120ea24d0..9c552437faa20d10bb5bf67a15282b1e8dec94c5 100644
+index ad676255b03467d91fb0ef18c1801cd897cfa9f6..c67b58594327276ca0189e341c489b7a773bd673 100644
 --- a/net/minecraft/world/level/portal/PortalForcer.java
 +++ b/net/minecraft/world/level/portal/PortalForcer.java
 @@ -49,13 +49,38 @@ public class PortalForcer {

--- a/paper-server/patches/features/0023-Optimise-collision-checking-in-player-move-packet-ha.patch
+++ b/paper-server/patches/features/0023-Optimise-collision-checking-in-player-move-packet-ha.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Optimise collision checking in player move packet handling
 Move collision logic to just the hasNewCollision call instead of getCubes + hasNewCollision
 
 diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a778e994c6cdfedd0f3574b7a27f2387af11d5b2..1feb7e47b3aeb840676cf90ed3f62a42f4b03306 100644
+index 9cefb0744530547fb5f28df983b1ced7a73e2a68..b87e345d14ad1646dd1c2b7cdbe7bb4693183a58 100644
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -623,6 +623,7 @@ public class ServerGamePacketListenerImpl

--- a/paper-server/patches/features/0025-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0025-Optimise-EntityScheduler-ticking.patch
@@ -20,7 +20,7 @@ index 2bc436cdf5180a7943c45fabb9fbbedae6f7db56..f312a7f5b1b2a777ab36b94ce7cbf387
  
      @Override
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 0f2364c24a95d773e568ceaa1e9e4a8be2f5406a..711261a67b2ebd9e672092e0dc6250b4b9419630 100644
+index 709d60077f2fb208026a9265705b0bb2a08ef456..816f3bd59544dd66070be65ae869b0d2dab431af 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -1750,33 +1750,22 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/paper-server/patches/features/0026-Optional-per-player-mob-spawns.patch
+++ b/paper-server/patches/features/0026-Optional-per-player-mob-spawns.patch
@@ -77,7 +77,7 @@ index 75fe6e026e3f91b66dcf5b97a86491d5277f7661..9b8222bda0f119f272d90f980c9f9540
              profiler.popPush("tickSpawningChunks");
  
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index d4466c7d30f47614a70d9ef24002a2d39182b8f6..a98eb760677b0337d2da9560148a55862fc4d721 100644
+index 37bb332f285888a48e0c556d492f8861efd33611..7ebf7df5f6dcfe62bc710120afc000012df616d7 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -409,6 +409,10 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc

--- a/paper-server/patches/features/0027-Improve-cancelling-PreCreatureSpawnEvent-with-per-pl.patch
+++ b/paper-server/patches/features/0027-Improve-cancelling-PreCreatureSpawnEvent-with-per-pl.patch
@@ -60,7 +60,7 @@ index 9b8222bda0f119f272d90f980c9f9540211af84a..af67b07722bb0125acd081dab767d7e7
              spawnState = NaturalSpawner.createState(naturalSpawnChunkCount, this.level.getAllEntities(), this::getFullChunk, null, true);
          } else {
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index a98eb760677b0337d2da9560148a55862fc4d721..c855c48ede60eb744cc65e1b560b9a7a3417d8aa 100644
+index 7ebf7df5f6dcfe62bc710120afc000012df616d7..785045f119ee2f9b9df4efc6e2f10134a1cbb160 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -413,6 +413,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc

--- a/paper-server/patches/features/0028-Optimize-Hoppers.patch
+++ b/paper-server/patches/features/0028-Optimize-Hoppers.patch
@@ -48,7 +48,7 @@ index 0000000000000000000000000000000000000000..24a2090e068ad3c0d08705050944abdf
 +    }
 +}
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 711261a67b2ebd9e672092e0dc6250b4b9419630..cf8c8e859f8217d7760c31b9af825278e82015be 100644
+index 816f3bd59544dd66070be65ae869b0d2dab431af..4dd4cd13d8650b60332cff9c2677ec217affc60d 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -1805,6 +1805,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/paper-server/patches/features/0029-Anti-Xray.patch
+++ b/paper-server/patches/features/0029-Anti-Xray.patch
@@ -143,7 +143,7 @@ index 3c0f0a612cc57c9f03abfb0ccb1f891305d03d45..9f43cfbdd49df61de869fd65fb2cbea3
  
      private ClientboundLevelChunkWithLightPacket(RegistryFriendlyByteBuf buffer) {
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index f0bfc37a0802397da1462e545e48f83d42b3d0c0..ab5efa15a1f56feda7d3e91009a517e98216e734 100644
+index 45550619778b6a6b7f1f03467ece6bfe3d7b1e51..dc65503a2d785d64d37b76b0303f51cf66d9769a 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -615,7 +615,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -156,7 +156,7 @@ index f0bfc37a0802397da1462e545e48f83d42b3d0c0..ab5efa15a1f56feda7d3e91009a517e9
          this.uuid = org.bukkit.craftbukkit.util.WorldUUID.getOrCreate(levelStorageAccess.levelDirectory.path().toFile());
          this.levelLoadListener = new net.minecraft.server.level.progress.LoggingLevelLoadListener(false, this);
 diff --git a/net/minecraft/server/level/ServerPlayerGameMode.java b/net/minecraft/server/level/ServerPlayerGameMode.java
-index e22368b036c35d32dca79b0e840f1008dce830a4..6771cbbae863fa181e19c5fb74d2018d3559ef4e 100644
+index 1d11f936dfda6cdcae0c4193eed2e5b1e8a793dc..84d19d79e77cec6a5d64f59fbcce703e467b2407 100644
 --- a/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -313,6 +313,7 @@ public class ServerPlayerGameMode {
@@ -184,7 +184,7 @@ index c65b274b965b95eae33690e63c5da2d5a9f2981a..644948d64791d0ffa4166375d0f4419f
          if (io.papermc.paper.event.packet.PlayerChunkLoadEvent.getHandlerList().getRegisteredListeners().length > 0) {
              new io.papermc.paper.event.packet.PlayerChunkLoadEvent(new org.bukkit.craftbukkit.CraftChunk(chunk), packetListener.getPlayer().getBukkitEntity()).callEvent();
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index a17d021269c65d98a2ba847c0059a421ea051863..9f86d1fc4ea4c6987fa207644573565aea7edead 100644
+index dec9dd8e42f90ccf7e5e3ad945e459d07159250d..989ac565c47a70c7947cb7315d0f5c2cfecd0363 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -329,7 +329,7 @@ public abstract class PlayerList {
@@ -197,7 +197,7 @@ index a17d021269c65d98a2ba847c0059a421ea051863..9f86d1fc4ea4c6987fa207644573565a
          }
          // Paper end - Send empty chunk
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 66f15154fa59435650f3881f50b45b5756088a2f..0df3a12f64f9c48561d64059289727b18239d6ce 100644
+index 259c6ecde58aaf2da470adc7ffec0a7ee1ea37ce..107be743e3d1ddf8e965798027ab339849b37b9a 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -139,6 +139,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
@@ -261,7 +261,7 @@ index a49a06662de4062a77112e358f536d45d65bf91f..54ddcf92e72b9cbd0eb442e5d0faa83c
          }
      }
 diff --git a/net/minecraft/world/level/chunk/LevelChunk.java b/net/minecraft/world/level/chunk/LevelChunk.java
-index 356a89ef2396f245e438d59d65edd0445693cb8b..7f2fa1978c2ca5620f0f3c1f26570d924d7fb3e5 100644
+index ea6a9306cf7b0c1b0a4f69eb2f1d604c95efb967..3acc1374a7ef968d88e9f566ce7b812fb8d580af 100644
 --- a/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -151,7 +151,7 @@ public class LevelChunk extends ChunkAccess implements DebugValueSource, ca.spot

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1856,7 +1856,7 @@
 +                                        // Refresh the current entity metadata
 +                                        target.refreshEntityData(ServerGamePacketListenerImpl.this.player);
 +                                        // SPIGOT-7136 - Allays
-+                                        if (target instanceof net.minecraft.world.entity.animal.allay.Allay || target instanceof net.minecraft.world.entity.animal.equine.AbstractHorse) { // Paper - Fix horse armor desync
++                                        if (target instanceof net.minecraft.world.entity.animal.allay.Allay || target instanceof net.minecraft.world.entity.animal.equine.AbstractHorse || target instanceof net.minecraft.world.entity.animal.nautilus.AbstractNautilus) { // Paper - Fix horse armor desync
 +                                            ServerGamePacketListenerImpl.this.send(new net.minecraft.network.protocol.game.ClientboundSetEquipmentPacket(
 +                                                target.getId(), java.util.Arrays.stream(net.minecraft.world.entity.EquipmentSlot.values())
 +                                                .map((slot) -> com.mojang.datafixers.util.Pair.of(slot, ((LivingEntity) target).getItemBySlot(slot).copy()))


### PR DESCRIPTION
Cancelled interactions cause desync with nautilus armor/saddles. So simply added them alongside horses where the entity equipment is resynced on cancelled interactions. There is a general lack of interface/etc that ties these types of entities together. The only thing internally is `HasCustomInventoryScreen` But that isn't really appropriate and would over-contain chest boats.

This fix does resolve the desync I experience when I cancel shearing or placing equipment on Nautilus.

Let me know if you think there should be any adjustments to this PR.