### PR TITLE
Remove spectator players' cameras when teleporting

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1317,7 +1317,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
             return false;
         }
 
-        return super.teleport0(location, cause, flags);
+        // Paper start - stop spectating other entities on teleport
+        // return super.teleport0(location, cause, flags);
+        // Attempt to set the camera first
+        Entity camera = this.getHandle().getCamera();
+        this.getHandle().setCamera(null);
+        if (camera != this.getHandle() && camera == this.getHandle().getCamera()) {
+            // If the camera hasn't changed, it was likely cancelled by an event, so stop the teleport
+            return false;
+        }
+
+        boolean teleported = super.teleport0(location, cause, flags);
+        if (!teleported) {
+            // If the teleport doesn't go through, restore the original camera
+            this.getHandle().setCamera(camera);
+        }
+        return teleported;
+        // Paper end - stop spectating other entities on teleport
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -1317,13 +1317,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
             return false;
         }
 
-        // Paper start - stop spectating other entities on teleport
-        // return super.teleport0(location, cause, flags);
-        // Attempt to set the camera first
         Entity camera = this.getHandle().getCamera();
         this.getHandle().setCamera(null);
-        if (camera != this.getHandle() && camera == this.getHandle().getCamera()) {
-            // If the camera hasn't changed, it was likely cancelled by an event, so stop the teleport
+        if (this.getHandle() != this.getHandle().getCamera()) {
+            // If the camera is not the player after setting, the stop spectating event was likely cancelled, so stop the teleport
             return false;
         }
 
@@ -1333,7 +1330,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
             this.getHandle().setCamera(camera);
         }
         return teleported;
-        // Paper end - stop spectating other entities on teleport
     }
 
     @Override


### PR DESCRIPTION
This fixes #13473 by mirroring vanilla behaviour.