### PR TITLE
moved refresh projectile source from protected method

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/Projectile.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/Projectile.java.patch
@@ -12,11 +12,11 @@
  
      protected void setOwner(@Nullable EntityReference<Entity> owner) {
          this.owner = owner;
-+        this.refreshProjectileSource(false); // Paper
      }
  
      public void setOwner(@Nullable Entity owner) {
          this.setOwner(EntityReference.of(owner));
++        this.refreshProjectileSource(false); // Paper
      }
  
 +    // Paper start - Refresh ProjectileSource for projectiles


### PR DESCRIPTION
moved refreshProjectileSource() call from setOwner(EntityReference) to public setOwner(EntityReference)

during async chunk generation structure templates load projectile entities via readAdditionalSaveData() which called the protected setOwner(EntityReference) method. 