### PR TITLE
chore: remove unneeded task configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,11 +14,6 @@ subprojects {
             languageVersion = JavaLanguageVersion.of(21)
         }
     }
-
-    tasks.withType<AbstractArchiveTask>().configureEach {
-        isPreserveFileTimestamps = false
-        isReproducibleFileOrder = true
-    }
 }
 
 val paperMavenPublicUrl = "https://repo.papermc.io/repository/maven-public/"


### PR DESCRIPTION
Gradle 9+ produces reproducible archives by default, rendering this configuration unneeded