### PR TITLE
Enables it to display custom paper goals to be visible via debug flags above the entity heads.

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
@@ -443,7 +443,7 @@
                  availableGoals.forEach(
                      wrappedGoal -> list.add(
 -                        new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), wrappedGoal.getGoal().getClass().getSimpleName())
-+                        new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), wrappedGoal.getGoal() instanceof com.destroystokyo.paper.entity.ai.PaperCustomGoal<?> customGoal ? customGoal.getHandle().getClass().getSimpleName() + "*" : wrappedGoal.getGoal().getClass().getSimpleName()) // Paper - display right custom goal in debugging
+1+                        new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), wrappedGoal.getGoal() instanceof final com.destroystokyo.paper.entity.ai.PaperCustomGoal<?> customGoal ? customGoal.getHandle().getClass().getSimpleName() + "*" : wrappedGoal.getGoal().getClass().getSimpleName()) // Paper - display right custom goal in debugging
                      )
                  );
                  return new DebugGoalInfo(list);

--- a/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
@@ -438,16 +438,12 @@
          }
  
          return flag;
-@@ -1426,7 +_,11 @@
+@@ -1426,7 +_,7 @@
                  List<DebugGoalInfo.DebugGoal> list = new ArrayList<>(availableGoals.size());
                  availableGoals.forEach(
                      wrappedGoal -> list.add(
 -                        new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), wrappedGoal.getGoal().getClass().getSimpleName())
-+                        // paper start - display right custom goal in debugging
-+                        switch (wrappedGoal.getGoal()) {
-+                            case com.destroystokyo.paper.entity.ai.PaperCustomGoal<?> customGoal -> new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), customGoal.getHandle().getClass().getSimpleName()+"*");
-+                            default -> new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), wrappedGoal.getGoal().getClass().getSimpleName());
-+                        } // paper end - display right custom goal in debugging
++                        new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), wrappedGoal.getGoal() instanceof com.destroystokyo.paper.entity.ai.PaperCustomGoal<?> customGoal ? customGoal.getHandle().getClass().getSimpleName() + "*" : wrappedGoal.getGoal().getClass().getSimpleName()) // Paper - display right custom goal in debugging
                      )
                  );
                  return new DebugGoalInfo(list);

--- a/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
@@ -438,3 +438,16 @@
          }
  
          return flag;
+@@ -1426,7 +_,11 @@
+                 List<DebugGoalInfo.DebugGoal> list = new ArrayList<>(availableGoals.size());
+                 availableGoals.forEach(
+                     wrappedGoal -> list.add(
+-                        new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), wrappedGoal.getGoal().getClass().getSimpleName())
++                        // paper start - display right custom goal in debugging
++                        switch (wrappedGoal.getGoal()) {
++                            case com.destroystokyo.paper.entity.ai.PaperCustomGoal<?> customGoal -> new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), customGoal.getHandle().getClass().getSimpleName()+"*");
++                            default -> new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), wrappedGoal.getGoal().getClass().getSimpleName());
++                        } // paper end - display right custom goal in debugging
+                     )
+                 );
+                 return new DebugGoalInfo(list);

--- a/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
@@ -443,7 +443,7 @@
                  availableGoals.forEach(
                      wrappedGoal -> list.add(
 -                        new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), wrappedGoal.getGoal().getClass().getSimpleName())
-1+                        new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), wrappedGoal.getGoal() instanceof final com.destroystokyo.paper.entity.ai.PaperCustomGoal<?> customGoal ? customGoal.getHandle().getClass().getSimpleName() + "*" : wrappedGoal.getGoal().getClass().getSimpleName()) // Paper - display right custom goal in debugging
++                        new DebugGoalInfo.DebugGoal(wrappedGoal.getPriority(), wrappedGoal.isRunning(), wrappedGoal.getGoal() instanceof final com.destroystokyo.paper.entity.ai.PaperCustomGoal<?> customGoal ? customGoal.getHandle().getClass().getSimpleName() + "*" : wrappedGoal.getGoal().getClass().getSimpleName()) // Paper - display right custom goal in debugging
                      )
                  );
                  return new DebugGoalInfo(list);


### PR DESCRIPTION
Enables it to display custom paper goals to be visible via debug flags above the entity heads.

Makes debugging of custom goals easier. Also suffixes the Paper goal with a * to allow differentiation.


Reference: https://minecraft.wiki/w/Debug_property

To see the difference 
0. add a plugin that has a command to spawn a mob with a custom defined Mob Goal.
1. enable the following debug flags in the minecraft client: `-DMC_DEBUG_ENABLED -DMC_DEBUG_GOAL_SELECTOR`
2.  join a paper server having the plugin installed
3. Execute the command to spawn the mob
4. See that the MobGoal is called PaperCustomGoal with the current state of Paper.
5. Repeat the steps but this time run a paper instance based on that branch. The name of the custom MobGoal should be the name of the class now.