### PR TITLE
Fix Mob#isInDaylight not being accurate

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Mob.java.patch
@@ -141,6 +141,25 @@
                      this.pickUpItem(serverLevel, itemEntity);
                  }
              }
+@@ -488,12 +_,17 @@
+     }
+ 
+     public boolean isSunBurnTick() {
++        // Paper start - Add boolean parameter to skip random for isInDaylight
++        return isSunBurnTick(false);
++    }
++    public boolean isSunBurnTick(boolean skipRandom) {
++        // Paper end - Add boolean parameter to skip random for isInDaylight
+         if (!this.level().isClientSide() && this.level().environmentAttributes().getValue(EnvironmentAttributes.MONSTERS_BURN, this.position())) {
+             float lightLevelDependentMagicValue = this.getLightLevelDependentMagicValue();
+             BlockPos blockPos = BlockPos.containing(this.getX(), this.getEyeY(), this.getZ());
+             boolean flag = this.isInWaterOrRain() || this.isInPowderSnow || this.wasInPowderSnow;
+             if (lightLevelDependentMagicValue > 0.5F
+-                && this.random.nextFloat() * 30.0F < (lightLevelDependentMagicValue - 0.4F) * 2.0F
++                && (skipRandom || this.random.nextFloat() * 30.0F < (lightLevelDependentMagicValue - 0.4F) * 2.0F) // Paper - Add boolean parameter to skip random for isInDaylight
+                 && !flag
+                 && this.level().canSeeSky(blockPos)) {
+                 return true;
 @@ -509,18 +_,24 @@
  
      protected void pickUpItem(ServerLevel level, ItemEntity entity) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
@@ -109,24 +109,9 @@ public abstract class CraftMob extends CraftLivingEntity implements Mob, io.pape
         return this.getHandle().lootTableSeed;
     }
 
-    /**
-     * @see net.minecraft.world.entity.Mob#isSunBurnTick()
-     */
     @Override
     public boolean isInDaylight() {
-        final net.minecraft.world.entity.Mob handle = getHandle();
-
-        if (handle.isInPowderSnow || handle.wasInPowderSnow || handle.isInWaterOrRain()) {
-            return false;
-        }
-
-        final float lightLevelDependentMagicValue = handle.getLightLevelDependentMagicValue();
-        if (lightLevelDependentMagicValue < 0.5F) {
-            return false;
-        }
-
-        final BlockPos blockPos = BlockPos.containing(this.getX(), handle.getEyeY(), this.getZ());
-        return handle.level().canSeeSky(blockPos);
+        return this.getHandle().isSunBurnTick(true);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
@@ -3,6 +3,7 @@ package org.bukkit.craftbukkit.entity;
 import com.google.common.base.Preconditions;
 import java.util.Optional;
 import net.kyori.adventure.util.TriState;
+import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundEvent;
 import org.bukkit.Sound;
 import org.bukkit.craftbukkit.CraftLootTable;
@@ -108,9 +109,24 @@ public abstract class CraftMob extends CraftLivingEntity implements Mob, io.pape
         return this.getHandle().lootTableSeed;
     }
 
+    /**
+     * @see net.minecraft.world.entity.Mob#isSunBurnTick()
+     */
     @Override
     public boolean isInDaylight() {
-        return getHandle().isSunBurnTick();
+        final net.minecraft.world.entity.Mob handle = getHandle();
+
+        if (handle.isInPowderSnow || handle.wasInPowderSnow || handle.isInWaterOrRain()) {
+            return false;
+        }
+
+        final float lightLevelDependentMagicValue = handle.getLightLevelDependentMagicValue();
+        if (lightLevelDependentMagicValue < 0.5F) {
+            return false;
+        }
+
+        final BlockPos blockPos = BlockPos.containing(this.getX(), handle.getEyeY(), this.getZ());
+        return handle.level().canSeeSky(blockPos);
     }
 
     @Override


### PR DESCRIPTION
isSunBurnTick includes a call to random, which makes this method return false for most of the time all the while the enitty is in full daylight. This new implementation partly copies that method, minus the monsters burn environment attribute check and the random call, to be more accurate and useful.