### PR TITLE
Fix MC-17876

### DIFF
--- a/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
@@ -354,7 +354,7 @@ index 0000000000000000000000000000000000000000..c18823746ab2edcab536cb1589b7720e
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 5494b92ab1c3c202a640e483e8a4bcb64395ed99..d7238270a6df8d1182874b46b588b971ca6f7a0e 100644
+index 7656665352632fc718bea91dcfd3dd41fc436e1f..bdbc15bfbbfeae2bc5b884e300b86cb25c88840f 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -830,6 +830,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -464,7 +464,7 @@ index 5461bd9a39bb20ad29d3bc110c38860cf35a770a..75f80787966cdda6f51f55a8f6cb2218
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 92ad0b17ff735801b9a4c840f14b4c12db729427..06837062905e08a3e9c29ee030ce199ce1d540b1 100644
+index 57cff20212f6d5f83d4b0169bf6aa185a403e1d3..1b554121a550f0a2c7e5d6b041450b4bcba781c5 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -368,6 +368,15 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
@@ -523,10 +523,10 @@ index 92ad0b17ff735801b9a4c840f14b4c12db729427..06837062905e08a3e9c29ee030ce199c
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 38eac6d27ebf3497fc1c2dfb600a7cbf4f9da7f4..9dacf9cef03ecb87464bfecf2399f2864be6d6ba 100644
+index 3778f8b75fc0e8c846a2ce600d926ef23c01f99c..4eec1434bd57ba2519bed910a55fadd878b18e46 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3330,6 +3330,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3338,6 +3338,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
      protected void playAttackSound() {
      }
  
@@ -818,7 +818,7 @@ index 4a6384a668546371f4ffa13927be4bd462d47c60..3c961b76769f16160caedce8ec32bb2a
 +
  }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index c94eae678dd55fced81fcee683ca3c0e16443c7c..3d5a869d1d7da490ec843ab2137ceeddc0a5fa0d 100644
+index 77b8f0f18748fc6a3c8c44f8eb496225e3f0eb8f..345f3eab21b569f322ef188f16608b87d0bb184e 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -150,6 +150,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
@@ -835,7 +835,7 @@ index c94eae678dd55fced81fcee683ca3c0e16443c7c..3d5a869d1d7da490ec843ab2137ceedd
      public final org.spigotmc.SpigotWorldConfig spigotConfig; // Spigot
      // Paper start - add paper world config
 diff --git a/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java b/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
-index 182b803ed17d6bd580f55a6b2ec08001edc533fd..59a002711531f8337a86d85b6e8b11b5fad8ced7 100644
+index 9f50e86a637aab8b5c34913e226807990c1891a4..bc42a6c678987a39b0a70a1a3e96eb90340ffea5 100644
 --- a/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 +++ b/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 @@ -152,6 +152,10 @@ public class PistonMovingBlockEntity extends BlockEntity {

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -446,7 +446,7 @@
          if (mobEffectInstance != null) {
              this.onEffectsRemoved(List.of(mobEffectInstance));
              return true;
-@@ -1134,19 +_,72 @@
+@@ -1134,18 +_,71 @@
      }
  
      public void heal(float amount) {
@@ -486,7 +486,8 @@
          return this.entityData.get(DATA_HEALTH_ID);
      }
  
-+    private void setHealth(float health, boolean noClamp) { // Paper - Fix MC-17876
++    // Paper start - Fix MC-17876
++    private void setHealth(float health, boolean noClamp) {
 +        // Paper start - Check for NaN
 +        if (Float.isNaN(health)) { health = getMaxHealth(); if (this.valid) {
 +            System.err.println("[NAN-HEALTH] " + getScoreboardName() + " had NaN health set");
@@ -497,7 +498,7 @@
 +            // Squeeze
 +            if (health < 0.0F) {
 +                player.setRealHealth(0.0D);
-+            } else if (!noClamp && health > player.getMaxHealth()) { // Paper - Fix MC-17876
++            } else if (!noClamp && health > player.getMaxHealth()) {
 +                player.setRealHealth(player.getMaxHealth());
 +            } else {
 +                player.setRealHealth(health);
@@ -507,20 +508,18 @@
 +            return;
 +        }
 +        // CraftBukkit end
-+        // Paper start - Fix MC-17876
 +        if (!noClamp) health = Mth.clamp(health, 0.0F, this.getMaxHealth());
 +        else health = Math.max(health, 0.0F);
 +        this.entityData.set(DATA_HEALTH_ID, health);
 +    }
++    // Paper end - Fix MC-17876
 +
      public void setHealth(float health) {
 -        this.entityData.set(DATA_HEALTH_ID, Mth.clamp(health, 0.0F, this.getMaxHealth()));
-+        this.setHealth(health, false);
++        this.setHealth(health, false); // Paper - Fix MC-17876
      }
-+    // Paper end - Fix MC-17876
  
      public boolean isDeadOrDying() {
-         return this.getHealth() <= 0.0F;
 @@ -1156,7 +_,7 @@
      public boolean hurtServer(ServerLevel level, DamageSource damageSource, float amount) {
          if (this.isInvulnerableTo(level, damageSource)) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -198,19 +198,20 @@
          if (this.level() != null && !this.level().isClientSide()) {
              input.read("attributes", AttributeInstance.Packed.LIST_CODEC).ifPresent(this.getAttributes()::apply);
          }
-@@ -791,6 +_,11 @@
+@@ -791,13 +_,19 @@
              this.effectsDirty = true;
          }
  
+-        this.setHealth(input.getFloatOr("Health", this.getMaxHealth()));
 +        // CraftBukkit start
 +        input.read("Bukkit.MaxHealth", com.mojang.serialization.Codec.DOUBLE).ifPresent(maxHealth -> {
 +            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(maxHealth);
 +        });
 +        // CraftBukkit end
-         this.setHealth(input.getFloatOr("Health", this.getMaxHealth()));
++        this.setHealth(input.getFloatOr("Health", this.getMaxHealth()), true); // Paper - Fix MC-17876
          this.hurtTime = input.getShortOr("HurtTime", (short)0);
          this.deathTime = input.getShortOr("DeathTime", (short)0);
-@@ -798,6 +_,7 @@
+         this.lastHurtByMobTimestamp = input.getIntOr("HurtByTimestamp", 0);
          input.getString("Team").ifPresent(string -> {
              Scoreboard scoreboard = this.level().getScoreboard();
              PlayerTeam playerTeam = scoreboard.getPlayerTeam(string);
@@ -445,7 +446,7 @@
          if (mobEffectInstance != null) {
              this.onEffectsRemoved(List.of(mobEffectInstance));
              return true;
-@@ -1134,17 +_,62 @@
+@@ -1134,19 +_,72 @@
      }
  
      public void heal(float amount) {
@@ -485,7 +486,7 @@
          return this.entityData.get(DATA_HEALTH_ID);
      }
  
-     public void setHealth(float health) {
++    private void setHealth(float health, boolean noClamp) { // Paper - Fix MC-17876
 +        // Paper start - Check for NaN
 +        if (Float.isNaN(health)) { health = getMaxHealth(); if (this.valid) {
 +            System.err.println("[NAN-HEALTH] " + getScoreboardName() + " had NaN health set");
@@ -496,7 +497,7 @@
 +            // Squeeze
 +            if (health < 0.0F) {
 +                player.setRealHealth(0.0D);
-+            } else if (health > player.getMaxHealth()) {
++            } else if (!noClamp && health > player.getMaxHealth()) { // Paper - Fix MC-17876
 +                player.setRealHealth(player.getMaxHealth());
 +            } else {
 +                player.setRealHealth(health);
@@ -506,9 +507,20 @@
 +            return;
 +        }
 +        // CraftBukkit end
-         this.entityData.set(DATA_HEALTH_ID, Mth.clamp(health, 0.0F, this.getMaxHealth()));
++        // Paper start - Fix MC-17876
++        if (!noClamp) health = Mth.clamp(health, 0.0F, this.getMaxHealth());
++        else health = Math.max(health, 0.0F);
++        this.entityData.set(DATA_HEALTH_ID, health);
++    }
++
+     public void setHealth(float health) {
+-        this.entityData.set(DATA_HEALTH_ID, Mth.clamp(health, 0.0F, this.getMaxHealth()));
++        this.setHealth(health, false);
      }
++    // Paper end - Fix MC-17876
  
+     public boolean isDeadOrDying() {
+         return this.getHealth() <= 0.0F;
 @@ -1156,7 +_,7 @@
      public boolean hurtServer(ServerLevel level, DamageSource damageSource, float amount) {
          if (this.isInvulnerableTo(level, damageSource)) {


### PR DESCRIPTION
This pull request fixes [MC-17876](https://bugs.mojang.com/browse/MC/issues/MC-17876), attribute modifiers of equipment are applied after the entity health is set, leading to health value loss on entity reload/player rejoin.

This PR fixed the issue by loading equipment attributes before the max health is determined to prevent the health from being clamped to the base value. Treats `Player` separately, as the inventory is not loaded yet.

### To reproduce

Type command `/item replace entity @s armor.head with iron_helmet[minecraft:attribute_modifiers=[ {id:"test",type:"max_health",amount:6,operation:"add_value"}]]`, quit the server after health regen, the extra health will be lost upon rejoin without this fix.

### API Changes

Shouldn't introduce any API behavior change with `EntityEquipmentChangedEvent`.

The added method `loadEquipmentAttributeChanges` logic was extracted from `collectEquipmentChanges` with only attribute modifiers application kept