### PR TITLE
Fix backward compat for World#setPVP

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -27028,7 +27028,7 @@ index 061bc47972d9c67375c0ff9461c506625c80108c..7656665352632fc718bea91dcfd3dd41
      }
  
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 80ee52cb77d079cda66b12e7d3fe683ccb47d7dc..9d4d70369907c3d18c15289ef6630cade8fc74fe 100644
+index 01266919bba228e6d5a1b4f376b11ad8a3eea6d3..aa48c77f1010f9ac7f31889fe554834c6708396c 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -201,7 +201,7 @@ import net.minecraft.world.scores.criteria.ObjectiveCriteria;
@@ -29259,7 +29259,7 @@ index d4c78c7f521b31ea9ce0cf7d62978b8e324b5d10..bcbe39eed2d254861689c95f7040f27b
  
      // Paper start - Affects Spawning API
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225e3f0eb8f 100644
+index a38e63a78be72438a3073ad780063c5e59723482..49aca568407523d95d5801988fe153d71c9dc768 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -82,6 +82,7 @@ import net.minecraft.world.level.storage.LevelData;
@@ -29288,7 +29288,7 @@ index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225
      @Deprecated
      private final RandomSource threadSafeRandom = RandomSource.createThreadSafe();
      private final Holder<DimensionType> dimensionTypeRegistration;
-@@ -188,6 +189,629 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -187,6 +188,629 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      public abstract ResourceKey<net.minecraft.world.level.dimension.LevelStem> getTypeKey();
  
@@ -29918,7 +29918,7 @@ index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225
      protected Level(
          WritableLevelData levelData,
          ResourceKey<Level> dimension,
-@@ -203,6 +827,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -202,6 +826,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          java.util.function.Function<org.spigotmc.SpigotWorldConfig, // Spigot - create per world config
          io.papermc.paper.configuration.WorldConfiguration> paperWorldConfigCreator // Paper - create paper world config
      ) {
@@ -29934,7 +29934,7 @@ index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) levelData).getLevelName()); // Spigot
          this.paperConfig = paperWorldConfigCreator.apply(this.spigotConfig); // Paper - create paper world config
          this.generator = generator;
-@@ -225,6 +858,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -224,6 +857,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.registryAccess = registryAccess;
          this.palettedContainerFactory = PalettedContainerFactory.create(registryAccess);
          this.damageSources = new DamageSources(registryAccess);
@@ -29942,7 +29942,7 @@ index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225
      }
  
      // Paper start - Cancel hit for vanished players
-@@ -506,7 +1140,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -505,7 +1139,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  this.setBlocksDirty(pos, blockState, blockState1);
              }
  
@@ -29951,7 +29951,7 @@ index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225
                  this.sendBlockUpdated(pos, blockState, state, flags);
              }
  
-@@ -757,6 +1391,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -756,6 +1390,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          // Spigot start
          boolean runsNormally = this.tickRateManager().runsNormally();
  
@@ -29959,7 +29959,7 @@ index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225
          var toRemove = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<TickingBlockEntity>(); // Paper - Fix MC-117075; use removeAll
          toRemove.add(null); // Paper - Fix MC-117075
          for (this.tileTickPosition = 0; this.tileTickPosition < this.blockEntityTickers.size(); this.tileTickPosition++) { // Paper - Disable tick limiters
-@@ -766,6 +1401,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -765,6 +1400,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  toRemove.add(tickingBlockEntity); // Paper - Fix MC-117075; use removeAll
              } else if (runsNormally && this.shouldTickBlocksAt(tickingBlockEntity.getPos())) {
                  tickingBlockEntity.tick();
@@ -29971,7 +29971,7 @@ index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225
              }
          }
          this.blockEntityTickers.removeAll(toRemove); // Paper - Fix MC-117075
-@@ -785,6 +1425,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -784,6 +1424,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              entity.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DISCARD);
              // Paper end - Prevent block entity and entity crashes
          }
@@ -29979,7 +29979,7 @@ index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225
      }
  
      // Paper start - Option to prevent armor stands from doing entity lookups
-@@ -792,7 +1433,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -791,7 +1432,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean noCollision(@Nullable Entity entity, AABB box) {
          if (entity instanceof net.minecraft.world.entity.decoration.ArmorStand && !entity.level().paperConfig().entities.armorStands.doCollisionEntityLookups)
              return false;
@@ -29995,7 +29995,7 @@ index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225
      }
      // Paper end - Option to prevent armor stands from doing entity lookups
  
-@@ -927,7 +1575,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -926,7 +1574,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          if (!this.isInValidBounds(pos)) {
              return null;
          } else {
@@ -30004,7 +30004,7 @@ index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225
                  ? null
                  : this.getChunkAt(pos).getBlockEntity(pos, LevelChunk.EntityCreationType.IMMEDIATE);
          }
-@@ -1017,22 +1665,16 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1016,22 +1664,16 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public List<Entity> getEntities(@Nullable Entity entity, AABB boundingBox, Predicate<? super Entity> predicate) {
          Profiler.get().incrementCounter("getEntities");
          List<Entity> list = Lists.newArrayList();
@@ -30035,7 +30035,7 @@ index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225
      }
  
      @Override
-@@ -1046,33 +1688,94 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1045,33 +1687,94 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.getEntities(entityTypeTest, bounds, predicate, output, Integer.MAX_VALUE);
      }
  
@@ -30150,7 +30150,7 @@ index e57358f03da2a6be5997abbd895fafb768140e69..77b8f0f18748fc6a3c8c44f8eb496225
  
      public <T extends Entity> boolean hasEntities(EntityTypeTest<Entity, T> entityTypeTest, AABB bounds, Predicate<? super T> predicate) {
          Profiler.get().incrementCounter("hasEntities");
-@@ -1364,13 +2067,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1363,13 +2066,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      // Paper start - allow patching this logic
      public final int getEntityCount() {

--- a/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
@@ -354,7 +354,7 @@ index 0000000000000000000000000000000000000000..c18823746ab2edcab536cb1589b7720e
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 5494b92ab1c3c202a640e483e8a4bcb64395ed99..d7238270a6df8d1182874b46b588b971ca6f7a0e 100644
+index 7656665352632fc718bea91dcfd3dd41fc436e1f..bdbc15bfbbfeae2bc5b884e300b86cb25c88840f 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -830,6 +830,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -464,7 +464,7 @@ index 5461bd9a39bb20ad29d3bc110c38860cf35a770a..75f80787966cdda6f51f55a8f6cb2218
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 92ad0b17ff735801b9a4c840f14b4c12db729427..06837062905e08a3e9c29ee030ce199ce1d540b1 100644
+index 57cff20212f6d5f83d4b0169bf6aa185a403e1d3..1b554121a550f0a2c7e5d6b041450b4bcba781c5 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -368,6 +368,15 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
@@ -523,7 +523,7 @@ index 92ad0b17ff735801b9a4c840f14b4c12db729427..06837062905e08a3e9c29ee030ce199c
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 38eac6d27ebf3497fc1c2dfb600a7cbf4f9da7f4..9dacf9cef03ecb87464bfecf2399f2864be6d6ba 100644
+index 5b6020de0848458f5576113e690b5a6435f35d05..6f49b5e5888a6296b929e465a5ef87dc49bd4516 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
 @@ -3330,6 +3330,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
@@ -818,10 +818,10 @@ index 4a6384a668546371f4ffa13927be4bd462d47c60..3c961b76769f16160caedce8ec32bb2a
 +
  }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index c94eae678dd55fced81fcee683ca3c0e16443c7c..3d5a869d1d7da490ec843ab2137ceeddc0a5fa0d 100644
+index 49aca568407523d95d5801988fe153d71c9dc768..9e88d83b31129cc853afe60d841838852a33fc45 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
-@@ -150,6 +150,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
+@@ -149,6 +149,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
      @Nullable
      public List<net.minecraft.world.entity.item.ItemEntity> captureDrops;
      public final it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<SpawnCategory> ticksPerSpawnCategory = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
@@ -835,7 +835,7 @@ index c94eae678dd55fced81fcee683ca3c0e16443c7c..3d5a869d1d7da490ec843ab2137ceedd
      public final org.spigotmc.SpigotWorldConfig spigotConfig; // Spigot
      // Paper start - add paper world config
 diff --git a/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java b/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
-index 182b803ed17d6bd580f55a6b2ec08001edc533fd..59a002711531f8337a86d85b6e8b11b5fad8ced7 100644
+index 9f50e86a637aab8b5c34913e226807990c1891a4..bc42a6c678987a39b0a70a1a3e96eb90340ffea5 100644
 --- a/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 +++ b/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 @@ -152,6 +152,10 @@ public class PistonMovingBlockEntity extends BlockEntity {

--- a/paper-server/patches/features/0016-Add-Alternate-Current-redstone-implementation.patch
+++ b/paper-server/patches/features/0016-Add-Alternate-Current-redstone-implementation.patch
@@ -2326,7 +2326,7 @@ index 0000000000000000000000000000000000000000..298076a0db4e6ee6e4775ac43bf749d9
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index d7238270a6df8d1182874b46b588b971ca6f7a0e..db2054e84f5717a37683d57890dcd585769effbc 100644
+index bdbc15bfbbfeae2bc5b884e300b86cb25c88840f..ef7e24716c2fc6a643d107cadcf743f80b39af41 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -227,6 +227,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -2352,10 +2352,10 @@ index d7238270a6df8d1182874b46b588b971ca6f7a0e..db2054e84f5717a37683d57890dcd585
          return level.dimension() != Level.NETHER || this.getGameRules().get(GameRules.ALLOW_ENTERING_NETHER_USING_PORTALS);
      }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 3d5a869d1d7da490ec843ab2137ceeddc0a5fa0d..66f15154fa59435650f3881f50b45b5756088a2f 100644
+index 9e88d83b31129cc853afe60d841838852a33fc45..935aacd607bb1960bc5f01b3fd025603edd1dbd6 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
-@@ -2050,6 +2050,17 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
+@@ -2049,6 +2049,17 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
          return this.palettedContainerFactory;
      }
  

--- a/paper-server/patches/features/0029-Anti-Xray.patch
+++ b/paper-server/patches/features/0029-Anti-Xray.patch
@@ -143,7 +143,7 @@ index 3c0f0a612cc57c9f03abfb0ccb1f891305d03d45..9f43cfbdd49df61de869fd65fb2cbea3
  
      private ClientboundLevelChunkWithLightPacket(RegistryFriendlyByteBuf buffer) {
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index f0bfc37a0802397da1462e545e48f83d42b3d0c0..ab5efa15a1f56feda7d3e91009a517e98216e734 100644
+index 45550619778b6a6b7f1f03467ece6bfe3d7b1e51..dc65503a2d785d64d37b76b0303f51cf66d9769a 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -615,7 +615,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -156,7 +156,7 @@ index f0bfc37a0802397da1462e545e48f83d42b3d0c0..ab5efa15a1f56feda7d3e91009a517e9
          this.uuid = org.bukkit.craftbukkit.util.WorldUUID.getOrCreate(levelStorageAccess.levelDirectory.path().toFile());
          this.levelLoadListener = new net.minecraft.server.level.progress.LoggingLevelLoadListener(false, this);
 diff --git a/net/minecraft/server/level/ServerPlayerGameMode.java b/net/minecraft/server/level/ServerPlayerGameMode.java
-index e22368b036c35d32dca79b0e840f1008dce830a4..6771cbbae863fa181e19c5fb74d2018d3559ef4e 100644
+index 1d11f936dfda6cdcae0c4193eed2e5b1e8a793dc..84d19d79e77cec6a5d64f59fbcce703e467b2407 100644
 --- a/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -313,6 +313,7 @@ public class ServerPlayerGameMode {
@@ -184,7 +184,7 @@ index c65b274b965b95eae33690e63c5da2d5a9f2981a..644948d64791d0ffa4166375d0f4419f
          if (io.papermc.paper.event.packet.PlayerChunkLoadEvent.getHandlerList().getRegisteredListeners().length > 0) {
              new io.papermc.paper.event.packet.PlayerChunkLoadEvent(new org.bukkit.craftbukkit.CraftChunk(chunk), packetListener.getPlayer().getBukkitEntity()).callEvent();
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index a17d021269c65d98a2ba847c0059a421ea051863..9f86d1fc4ea4c6987fa207644573565aea7edead 100644
+index dec9dd8e42f90ccf7e5e3ad945e459d07159250d..989ac565c47a70c7947cb7315d0f5c2cfecd0363 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -329,7 +329,7 @@ public abstract class PlayerList {
@@ -197,7 +197,7 @@ index a17d021269c65d98a2ba847c0059a421ea051863..9f86d1fc4ea4c6987fa207644573565a
          }
          // Paper end - Send empty chunk
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 66f15154fa59435650f3881f50b45b5756088a2f..0df3a12f64f9c48561d64059289727b18239d6ce 100644
+index 935aacd607bb1960bc5f01b3fd025603edd1dbd6..579bbba4e823d4d0318e58759ca732b7c8e4d865 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -139,6 +139,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
@@ -206,9 +206,9 @@ index 66f15154fa59435650f3881f50b45b5756088a2f..0df3a12f64f9c48561d64059289727b1
      // CraftBukkit start
 +    public final io.papermc.paper.antixray.ChunkPacketBlockController chunkPacketBlockController; // Paper - Anti-Xray
      private final CraftWorld world;
-     public net.kyori.adventure.util.TriState pvpMode = net.kyori.adventure.util.TriState.NOT_SET;
      public org.bukkit.generator.@Nullable ChunkGenerator generator;
-@@ -831,7 +832,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
+ 
+@@ -830,7 +831,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
          org.bukkit.generator.@Nullable BiomeProvider biomeProvider, // Paper
          org.bukkit.World.Environment environment, // Paper
          java.util.function.Function<org.spigotmc.SpigotWorldConfig, // Spigot - create per world config
@@ -218,7 +218,7 @@ index 66f15154fa59435650f3881f50b45b5756088a2f..0df3a12f64f9c48561d64059289727b1
      ) {
          // Paper start - getblock optimisations - cache world height/sections
          final DimensionType dimType = dimensionTypeRegistration.value();
-@@ -865,6 +867,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
+@@ -864,6 +866,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
          this.palettedContainerFactory = PalettedContainerFactory.create(registryAccess);
          this.damageSources = new DamageSources(registryAccess);
          this.entityLookup = new ca.spottedleaf.moonrise.patches.chunk_system.level.entity.dfl.DefaultEntityLookup(this); // Paper - rewrite chunk system
@@ -226,7 +226,7 @@ index 66f15154fa59435650f3881f50b45b5756088a2f..0df3a12f64f9c48561d64059289727b1
      }
  
      // Paper start - Cancel hit for vanished players
-@@ -1078,6 +1081,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
+@@ -1077,6 +1080,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
                  snapshot.setFlags(flags); // Paper - always set the flag of the most recent call to mitigate issues with multiple update at the same pos with different flags
              }
              BlockState blockState = chunkAt.setBlockState(pos, state, flags);
@@ -261,7 +261,7 @@ index a49a06662de4062a77112e358f536d45d65bf91f..54ddcf92e72b9cbd0eb442e5d0faa83c
          }
      }
 diff --git a/net/minecraft/world/level/chunk/LevelChunk.java b/net/minecraft/world/level/chunk/LevelChunk.java
-index 356a89ef2396f245e438d59d65edd0445693cb8b..7f2fa1978c2ca5620f0f3c1f26570d924d7fb3e5 100644
+index ea6a9306cf7b0c1b0a4f69eb2f1d604c95efb967..3acc1374a7ef968d88e9f566ce7b812fb8d580af 100644
 --- a/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -151,7 +151,7 @@ public class LevelChunk extends ChunkAccess implements DebugValueSource, ca.spot

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -609,17 +609,11 @@
          }
      }
  
-@@ -989,25 +_,95 @@
+@@ -992,22 +_,92 @@
+         return this.level().isPvpAllowed();
      }
  
-     private boolean isPvpAllowed() {
--        return this.level().isPvpAllowed();
--    }
--
 -    public TeleportTransition findRespawnPositionAndUseSpawnBlock(boolean useCharge, TeleportTransition.PostTeleportTransition postTeleportTransition) {
-+        return this.level().getWorld().getPVP(); // CraftBukkit - this.level().isPvpAllowed() -> this.level().getWorld().getPVP()
-+    }
-+
 +    // Paper start
 +    public record RespawnResult(TeleportTransition transition, boolean isBedSpawn, boolean isAnchorSpawn) {
 +    }

--- a/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
@@ -17,13 +17,12 @@
  public abstract class Level implements LevelAccessor, AutoCloseable {
      public static final Codec<ResourceKey<Level>> RESOURCE_KEY_CODEC = ResourceKey.codec(Registries.DIMENSION);
      public static final ResourceKey<Level> OVERWORLD = ResourceKey.create(Registries.DIMENSION, Identifier.withDefaultNamespace("overworld"));
-@@ -127,6 +_,57 @@
+@@ -127,6 +_,56 @@
      private final PalettedContainerFactory palettedContainerFactory;
      private long subTickCount;
  
 +    // CraftBukkit start
 +    private final CraftWorld world;
-+    public net.kyori.adventure.util.TriState pvpMode = net.kyori.adventure.util.TriState.NOT_SET;
 +    public org.bukkit.generator.@Nullable ChunkGenerator generator;
 +
 +    public boolean captureBlockStates = false;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1255,15 +1255,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
 
     @Override
     public boolean getPVP() {
-        return this.world.pvpMode.toBooleanOrElseGet(() -> this.world.getGameRules().get(GameRules.PVP));
+        return this.world.isPvpAllowed();
     }
 
     @Override
     public void setPVP(boolean pvp) {
-        if (this.world.getGameRules().get(GameRules.PVP) == pvp) {
-            return;
-        }
-        this.world.pvpMode = TriState.byBoolean(pvp);
+        this.world.getGameRules().set(GameRules.PVP, pvp, this.world);
     }
 
     @Override


### PR DESCRIPTION
The current method will fail to apply the last operation in the following sequences (with the gamerule set to true initially):
setPVP(false) -> setPVP(true)