### PR TITLE
Prevent negative anger level for neutral mobs

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
@@ -64,7 +64,7 @@ public class CraftBee extends CraftAnimals implements Bee {
 
     @Override
     public int getAnger() {
-        return (int) (this.getHandle().getPersistentAngerEndTime() - this.getHandle().level().getGameTime());
+        return (int) Math.max(this.getHandle().getPersistentAngerEndTime() - this.getHandle().level().getGameTime(), 0);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPigZombie.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPigZombie.java
@@ -17,7 +17,7 @@ public class CraftPigZombie extends CraftZombie implements PigZombie {
 
     @Override
     public int getAnger() {
-        return (int) (this.getHandle().getPersistentAngerEndTime() - this.getHandle().level().getGameTime());
+        return (int) Math.max(this.getHandle().getPersistentAngerEndTime() - this.getHandle().level().getGameTime(), 0);
     }
 
     @Override


### PR DESCRIPTION
It doesn't really makes sense to expose negative value here and seems to be more an artifact of the update.