### PR TITLE
Add zip error reporting to PaperPluginClassLoader, too

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperSimplePluginClassLoader.java
+++ b/paper-server/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperSimplePluginClassLoader.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.security.CodeSigner;
 import java.security.CodeSource;
 import java.util.Enumeration;
+import java.util.Objects;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -59,7 +60,13 @@ public class PaperSimplePluginClassLoader extends URLClassLoader {
 
         // See UrlClassLoader#findClass(String)
         String path = name.replace('.', '/').concat(".class");
-        JarEntry entry = this.jar.getJarEntry(path);
+        JarEntry entry;
+        try {
+            entry = this.jar.getJarEntry(path);
+        } catch (IllegalStateException zipFileClosed) {
+            String pluginName = Objects.requireNonNullElse(configuration.getName(), "<uninit>");
+            throw new IllegalStateException("The paper plugin classloader for " + pluginName + " has thrown a zip file error.", zipFileClosed);
+        }
         if (entry == null) {
             throw new ClassNotFoundException(name);
         }


### PR DESCRIPTION
This is an analogue to #12580 , but for Paper plugin classloaders.

More debug info can never hurt, and besides, the same rationale holds as for that PR.