### PR TITLE
Fix backward compat for EnchantmentTarget.WEAPON

### DIFF
--- a/paper-api/src/main/java/org/bukkit/enchantments/EnchantmentTarget.java
+++ b/paper-api/src/main/java/org/bukkit/enchantments/EnchantmentTarget.java
@@ -87,7 +87,7 @@ public enum EnchantmentTarget {
     WEAPON {
         @Override
         public boolean includes(@NotNull Material item) {
-            return Tag.ITEMS_ENCHANTABLE_SHARP_WEAPON.isTagged(item);
+            return Tag.ITEMS_ENCHANTABLE_MELEE_WEAPON.isTagged(item);
         }
     },
 


### PR DESCRIPTION
The correct tag to check is #enchantable/melee_weapon to not includes axes which are already in the TOOL category and were never considered as a weapon previously.