### PR TITLE
Add PlayerCodeOfConductSendEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/connection/configuration/PlayerCodeOfConductSendEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/connection/configuration/PlayerCodeOfConductSendEvent.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.Nullable;
 /**
  * This event is called when the code of conduct is potentially sent to the player.
  */
-@ApiStatus.Experimental
 @NullMarked
 public class PlayerCodeOfConductSendEvent extends Event {
 

--- a/paper-api/src/main/java/io/papermc/paper/event/connection/configuration/PlayerCodeOfConductSendEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/connection/configuration/PlayerCodeOfConductSendEvent.java
@@ -1,4 +1,4 @@
-package io.papermc.paper.event.player;
+package io.papermc.paper.event.connection.configuration;
 
 import io.papermc.paper.connection.PlayerCommonConnection;
 import io.papermc.paper.connection.PlayerConfigurationConnection;

--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerCodeOfConductSendEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerCodeOfConductSendEvent.java
@@ -1,0 +1,64 @@
+package io.papermc.paper.event.player;
+
+import io.papermc.paper.connection.PlayerCommonConnection;
+import io.papermc.paper.connection.PlayerConfigurationConnection;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * This event is called when the code of conduct is potentially sent to the player.
+ */
+@ApiStatus.Experimental
+@NullMarked
+public class PlayerCodeOfConductSendEvent extends Event {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private @Nullable String codeOfConduct;
+    private final PlayerCommonConnection connection;
+
+    @ApiStatus.Internal
+    public PlayerCodeOfConductSendEvent(final PlayerConfigurationConnection connection, final @Nullable String codeOfConduct) {
+        this.connection = connection;
+        this.codeOfConduct = codeOfConduct;
+    }
+
+    /**
+     * Gets the connection that will receive the code of conduct.
+     *
+     * @return connection
+     */
+    public PlayerCommonConnection getConnection() {
+        return connection;
+    }
+
+    /**
+     * Gets the code of conduct to be sent.
+     *
+     * @return the code of conduct or null if none will be sent
+     */
+    public @Nullable String getCodeOfConduct() {
+        return this.codeOfConduct;
+    }
+
+    /**
+     * Sets the code of conduct to be sent.
+     *
+     * @param codeOfConduct the code of conduct or null to not send one
+     */
+    public void setCodeOfConduct(final @Nullable String codeOfConduct) {
+        this.codeOfConduct = codeOfConduct;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
@@ -71,6 +71,35 @@
          this.configurationTasks.add(this.prepareSpawnTask);
          this.configurationTasks.add(new JoinWorldTask());
          this.startNextTask();
+@@ -109,7 +_,7 @@
+ 
+     private void addOptionalTasks() {
+         Map<String, String> codeOfConducts = this.server.getCodeOfConducts();
+-        if (!codeOfConducts.isEmpty()) {
++        if (io.papermc.paper.event.player.PlayerCodeOfConductSendEvent.getHandlerList().getRegisteredListeners().length > 0 || !codeOfConducts.isEmpty()) { // Paper Code of Conduct event - Fire even if empty, if there are event listeners to potentially send one
+             this.configurationTasks.add(new ServerCodeOfConductConfigurationTask(() -> {
+                 String codeOfConduct = codeOfConducts.get(this.clientInformation.language().toLowerCase(Locale.ROOT));
+                 if (codeOfConduct == null) {
+@@ -117,9 +_,19 @@
+                 }
+ 
+                 if (codeOfConduct == null) {
++                    if (!codeOfConducts.isEmpty()) // Paper Code of Conduct event - Only if there are any - needed because we make this lambda run even if it's empty
+                     codeOfConduct = codeOfConducts.values().iterator().next();
+                 }
+ 
++                // Paper start - Code of Conduct event
++                io.papermc.paper.event.player.PlayerCodeOfConductSendEvent event = new io.papermc.paper.event.player.PlayerCodeOfConductSendEvent(this.paperConnection, codeOfConduct);
++                event.callEvent();
++                codeOfConduct = event.getCodeOfConduct();
++                if (codeOfConduct == null) {
++                    // Immediately bail out of this task. On MC updates, double check it's still okay to finish task within startNextTask.
++                    this.finishCurrentTask(ServerCodeOfConductConfigurationTask.TYPE);
++                }
++                // Paper end - Code of Conduct event
+                 return codeOfConduct;
+             }));
+         }
 @@ -130,12 +_,14 @@
      @Override
      public void handleClientInformation(final ServerboundClientInformationPacket packet) {

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
@@ -76,7 +76,7 @@
      private void addOptionalTasks() {
          Map<String, String> codeOfConducts = this.server.getCodeOfConducts();
 -        if (!codeOfConducts.isEmpty()) {
-+        if (io.papermc.paper.event.player.PlayerCodeOfConductSendEvent.getHandlerList().getRegisteredListeners().length > 0 || !codeOfConducts.isEmpty()) { // Paper - Code of Conduct event - Fire even if empty, if there are event listeners to potentially send one
++        if (io.papermc.paper.event.connection.configuration.PlayerCodeOfConductSendEvent.getHandlerList().getRegisteredListeners().length > 0 || !codeOfConducts.isEmpty()) { // Paper - Code of Conduct event - Fire even if empty, if there are event listeners to potentially send one
              this.configurationTasks.add(new ServerCodeOfConductConfigurationTask(() -> {
                  String codeOfConduct = codeOfConducts.get(this.clientInformation.language().toLowerCase(Locale.ROOT));
                  if (codeOfConduct == null) {
@@ -89,7 +89,7 @@
                  }
  
 +                // Paper start - Code of Conduct event
-+                io.papermc.paper.event.player.PlayerCodeOfConductSendEvent event = new io.papermc.paper.event.player.PlayerCodeOfConductSendEvent(this.paperConnection, codeOfConduct);
++                io.papermc.paper.event.connection.configuration.PlayerCodeOfConductSendEvent event = new io.papermc.paper.event.connection.configuration.PlayerCodeOfConductSendEvent(this.paperConnection, codeOfConduct);
 +                event.callEvent();
 +                codeOfConduct = event.getCodeOfConduct();
 +                if (codeOfConduct == null) {

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
@@ -71,20 +71,20 @@
          this.configurationTasks.add(this.prepareSpawnTask);
          this.configurationTasks.add(new JoinWorldTask());
          this.startNextTask();
-@@ -109,7 +_,7 @@
+@@ -109,17 +_,26 @@
  
      private void addOptionalTasks() {
          Map<String, String> codeOfConducts = this.server.getCodeOfConducts();
 -        if (!codeOfConducts.isEmpty()) {
-+        if (io.papermc.paper.event.player.PlayerCodeOfConductSendEvent.getHandlerList().getRegisteredListeners().length > 0 || !codeOfConducts.isEmpty()) { // Paper Code of Conduct event - Fire even if empty, if there are event listeners to potentially send one
++        if (io.papermc.paper.event.player.PlayerCodeOfConductSendEvent.getHandlerList().getRegisteredListeners().length > 0 || !codeOfConducts.isEmpty()) { // Paper - Code of Conduct event - Fire even if empty, if there are event listeners to potentially send one
              this.configurationTasks.add(new ServerCodeOfConductConfigurationTask(() -> {
                  String codeOfConduct = codeOfConducts.get(this.clientInformation.language().toLowerCase(Locale.ROOT));
                  if (codeOfConduct == null) {
-@@ -117,9 +_,19 @@
+                     codeOfConduct = codeOfConducts.get("en_us");
                  }
  
-                 if (codeOfConduct == null) {
-+                    if (!codeOfConducts.isEmpty()) // Paper Code of Conduct event - Only if there are any - needed because we make this lambda run even if it's empty
+-                if (codeOfConduct == null) {
++                if (codeOfConduct == null && !codeOfConducts.isEmpty()) { // Paper - Code of Conduct event - Only if there are any - needed because we make this lambda run even if it's empty
                      codeOfConduct = codeOfConducts.values().iterator().next();
                  }
  

--- a/paper-server/patches/sources/net/minecraft/server/network/config/ServerCodeOfConductConfigurationTask.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/config/ServerCodeOfConductConfigurationTask.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/server/network/config/ServerCodeOfConductConfigurationTask.java
++++ b/net/minecraft/server/network/config/ServerCodeOfConductConfigurationTask.java
+@@ -16,7 +_,15 @@
+ 
+     @Override
+     public void start(final Consumer<Packet<?>> connection) {
+-        connection.accept(new ClientboundCodeOfConductPacket(this.codeOfConduct.get()));
++        // Paper start - Code of Conduct event
++        // Null code of conduct cancels the send
++        // See ServerConfigurationPacketListenerImpl section where the task is immediately completed when a null is sent here
++        String codeOC = this.codeOfConduct.get();
++        if (codeOC == null) {
++            return;
++        }
++        connection.accept(new ClientboundCodeOfConductPacket(codeOC));
++        // Paper end - Code of Conduct event
+     }
+ 
+     @Override


### PR DESCRIPTION
Enables customizing the code of conduct per send.

Just throwing the idea out there. Draft because I'm not sure we even want this and because I haven't bothered to test it yet (but I can't see it blowing up).

Possible uses:
1. Presently, code of conduct attempts to be based on user locale, then defaults to en_us. Perhaps someone would want to try some other locales first based on their locale. 
2. Separate code of conduct for users once they're staff.
3. Separate code of conduct for visitors vs members in a "greylist" server.
4. Forcing users to always accept the code of conduct each join, or every X days, by adding a unique value to the end of the code of conduct.