### PR TITLE
Prevent ticking virtual world borders multiple times per server tick

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/border/WorldBorder.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/border/WorldBorder.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/world/level/border/WorldBorder.java
 +++ b/net/minecraft/world/level/border/WorldBorder.java
-@@ -33,6 +_,7 @@
+@@ -33,6 +_,8 @@
      double centerZ;
      int absoluteMaxSize = 29999984;
      WorldBorder.BorderExtent extent = new WorldBorder.StaticBorderExtent(5.999997E7F);
 +    public net.minecraft.server.level.@org.jspecify.annotations.Nullable ServerLevel world; // CraftBukkit
++    private int lastTick = -1; // Paper - Prevent ticking virtual world borders multiple times per server tick
  
      public WorldBorder() {
          this(WorldBorder.Settings.DEFAULT);
@@ -89,6 +90,19 @@
      public void addListener(BorderChangeListener listener) {
 +        if (this.listeners.contains(listener)) return; // CraftBukkit
          this.listeners.add(listener);
+     }
+ 
+@@ -278,6 +_,12 @@
+     }
+ 
+     public void tick() {
++        // Paper start - Prevent ticking virtual world borders multiple times per server tick
++        if (this.lastTick == net.minecraft.server.MinecraftServer.currentTick) {
++            return;
++        }
++        this.lastTick = net.minecraft.server.MinecraftServer.currentTick;
++        // Paper end - Prevent ticking virtual world borders multiple times per server tick
+         this.extent = this.extent.update();
      }
  
 @@ -298,6 +_,22 @@


### PR DESCRIPTION
Fixes #13511 by checking whether the world border in question has already been ticked during the current tick.

1.21.11 added some additional lerping logic into `WorldBorder.MovingBorderExtent#update()`. Virtual (per-player) world borders are ticked by `ServerPlayer#tick()`, meaning that each player viewing the world border ticks it. In <=1.21.10 this worked fine since there was no logic being done if the lerp was in progress, however, the added logic in .11 causes the server-side lerp speed to multiply based on the amount of players viewing the border.