### PR TITLE
Add LEGACY_BARRIER to isTransparent

### DIFF
--- a/paper-api/src/main/java/org/bukkit/Material.java
+++ b/paper-api/src/main/java/org/bukkit/Material.java
@@ -3325,6 +3325,7 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
             case LEGACY_REDSTONE_COMPARATOR_OFF:
             case LEGACY_REDSTONE_COMPARATOR_ON:
             case LEGACY_ACTIVATOR_RAIL:
+            case LEGACY_BARRIER:
             case LEGACY_CARPET:
             case LEGACY_DOUBLE_PLANT:
             case LEGACY_END_ROD:


### PR DESCRIPTION
Add LEGACY_BARRIER to the values that are transparent according to the Bukkit API. As it should be, as I believe.

This fixes an issue that probably no-one will ever experience apart from me (with a legacy Bukkit plugin).