### PR TITLE
[ci skip] Clarify AsyncPlayerPreLoginEvent is post authentication

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
@@ -16,6 +16,9 @@ import org.jetbrains.annotations.NotNull;
  * <p>
  * This event is asynchronous, and not run using main thread.
  * <p>
+ * This event is fired after the server has successfully completed
+ * Mojang authentication.
+ * <p>
  * When this event is fired, the player's locale is not
  * available. Therefore, any translatable component will be
  * rendered with the default locale, {@link java.util.Locale#US}.

--- a/paper-api/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
  * This event is asynchronous, and not run using main thread.
  * <p>
  * This event is fired after the server has successfully completed
- * Mojang authentication.
+ * Mojang authentication. The event is still fired if the server is in offline mode.
  * <p>
  * When this event is fired, the player's locale is not
  * available. Therefore, any translatable component will be


### PR DESCRIPTION
Small change in the javadoc to confirm that AsyncPlayerPreLoginEvent is fired after Mojang auth.

RP suggested by MiniDigger: https://discord.com/channels/289587909051416579/555462289851940864/1458878325090029740