### PR TITLE
fix using experience bottle does not award item used stat

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/item/ExperienceBottleItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/ExperienceBottleItem.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/ExperienceBottleItem.java
 +++ b/net/minecraft/world/item/ExperienceBottleItem.java
-@@ -21,22 +_,36 @@
+@@ -21,22 +_,37 @@
      @Override
      public InteractionResult use(Level level, Player player, InteractionHand hand) {
          ItemStack itemInHand = player.getItemInHand(hand);
@@ -37,6 +37,7 @@
 +                    0.5F,
 +                    0.4F / (level.getRandom().nextFloat() * 0.4F + 0.8F)
 +                );
++                player.awardStat(Stats.ITEM_USED.get(this));
 +            } else {
 +                player.containerMenu.forceHeldSlot(hand);
 +                return InteractionResult.FAIL;


### PR DESCRIPTION
Fixes a long standing (7+ years) bug that throwing an experience bottle doesn't increase the `item used` stat for the experience bottle.
This issue got introduced while implementing or updating the `PlayerLaunchProjectileEvent` for the experience bottle.