### PR TITLE
Update Player#getClientViewDistance

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -3349,8 +3349,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
     /**
      * Get the player's current client side view distance.
      * <br>
-     * Will default to the server view distance if the client has not yet
-     * communicated this information,
+     * Will default to 2 if the client has not yet communicated this information.
      *
      * @return client view distance as above
      */

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -2690,7 +2690,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
 
     @Override
     public int getClientViewDistance() {
-        return (this.getHandle().requestedViewDistance() == 0) ? Bukkit.getViewDistance() : this.getHandle().requestedViewDistance();
+        return this.getHandle().requestedViewDistance();
     }
 
     // Paper start

--- a/paper-server/src/test/java/org/bukkit/craftbukkit/entity/EntityTypesTest.java
+++ b/paper-server/src/test/java/org/bukkit/craftbukkit/entity/EntityTypesTest.java
@@ -1,6 +1,5 @@
 package org.bukkit.craftbukkit.entity;
 
-import static org.junit.jupiter.api.Assertions.*;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -42,7 +41,6 @@ import org.bukkit.entity.Golem;
 import org.bukkit.entity.Hanging;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Illager;
-import org.bukkit.entity.LingeringPotion;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Mob;
@@ -54,7 +52,6 @@ import org.bukkit.entity.Raider;
 import org.bukkit.entity.Sittable;
 import org.bukkit.entity.SizedFireball;
 import org.bukkit.entity.Spellcaster;
-import org.bukkit.entity.SplashPotion;
 import org.bukkit.entity.Steerable;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.ThrowableProjectile;
@@ -70,6 +67,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 @AllFeatures
 public class EntityTypesTest {
 
@@ -79,6 +80,7 @@ public class EntityTypesTest {
             AbstractArrow.class,
             AbstractCow.class,
             AbstractHorse.class,
+            AbstractNautilus.class,
             AbstractSkeleton.class,
             AbstractVillager.class,
             AbstractWindCharge.class,
@@ -123,8 +125,7 @@ public class EntityTypesTest {
             ThrownPotion.class,
             TippedArrow.class,
             Vehicle.class,
-            WaterMob.class,
-            AbstractNautilus.class
+            WaterMob.class
     );
 
     static {


### PR DESCRIPTION
Currently the method wrongly state that it will return the server view distance when the information is not yet known by the server but the default value is never set to zero.
~Also fetch the required features for gamerules more properly using the new FeatureElement interface from the class.~