### PR TITLE
Fix cancelled rooted dirt drops being duped

### DIFF
--- a/paper-server/patches/features/0028-Optimize-Hoppers.patch
+++ b/paper-server/patches/features/0028-Optimize-Hoppers.patch
@@ -60,10 +60,10 @@ index 9c6e5c3be20dff800938445c31523a8bac86ab06..21500194b5c92baa6ab82503165b1131
              /* Drop global time updates
              if (this.tickCount % 20 == 0) {
 diff --git a/net/minecraft/world/item/ItemStack.java b/net/minecraft/world/item/ItemStack.java
-index 3b13fd6b9da2fe201ce3e67545c13d33e5304d55..3b86fc9e2a1bd28b66fa721841542911f1a64a18 100644
+index 3898d48017e1a4672ac38482a6b58c7d81848e8d..49ed9675da40eb5c11deb8985023de1cf72e1579 100644
 --- a/net/minecraft/world/item/ItemStack.java
 +++ b/net/minecraft/world/item/ItemStack.java
-@@ -833,10 +833,16 @@ public final class ItemStack implements DataComponentHolder {
+@@ -825,10 +825,16 @@ public final class ItemStack implements DataComponentHolder {
      }
  
      public ItemStack copy() {

--- a/paper-server/patches/features/0028-Optimize-Hoppers.patch
+++ b/paper-server/patches/features/0028-Optimize-Hoppers.patch
@@ -60,10 +60,10 @@ index 9c6e5c3be20dff800938445c31523a8bac86ab06..21500194b5c92baa6ab82503165b1131
              /* Drop global time updates
              if (this.tickCount % 20 == 0) {
 diff --git a/net/minecraft/world/item/ItemStack.java b/net/minecraft/world/item/ItemStack.java
-index f2747ca200ae1f0bc5d744167487feb1161ce7ea..ed06cffe8a5eba2ca4a34ade81f8185e21d7b651 100644
+index 3b13fd6b9da2fe201ce3e67545c13d33e5304d55..3b86fc9e2a1bd28b66fa721841542911f1a64a18 100644
 --- a/net/minecraft/world/item/ItemStack.java
 +++ b/net/minecraft/world/item/ItemStack.java
-@@ -813,10 +813,16 @@ public final class ItemStack implements DataComponentHolder {
+@@ -833,10 +833,16 @@ public final class ItemStack implements DataComponentHolder {
      }
  
      public ItemStack copy() {

--- a/paper-server/patches/sources/net/minecraft/world/item/ItemStack.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/ItemStack.java.patch
@@ -23,7 +23,7 @@
                  }
              }
          };
-@@ -371,10 +_,166 @@
+@@ -371,10 +_,186 @@
              return InteractionResult.PASS;
          } else {
              Item item = this.getItem();
@@ -40,11 +40,23 @@
 +                    serverLevel.captureTreeGeneration = true;
 +                }
 +            }
++            // Paper start - Fix cancelled rooted dirt drops being duped
++            List<ItemEntity> capturedDrops = null;
++            if (item instanceof HoeItem) {
++                capturedDrops = new java.util.ArrayList<>();
++                serverLevel.captureDrops = capturedDrops;
++            }
++            // Paper end - Fix cancelled rooted dirt drops being duped
 +            InteractionResult interactionResult;
 +            try {
 +                interactionResult = item.useOn(context);
 +            } finally {
 +                serverLevel.captureBlockStates = false;
++                // Paper start - Fix cancelled rooted dirt drops being duped
++                if (capturedDrops != null) {
++                    serverLevel.captureDrops = null;
++                }
++                // Paper end - Fix cancelled rooted dirt drops being duped
 +            }
 +            DataComponentPatch newPatch = this.components.asPatch();
 +            int newCount = this.getCount();
@@ -182,6 +194,14 @@
 +                        // Paper end - Fix spigot sound playing for BlockItem ItemStacks
 +                        serverLevel.playSound(player, clickedPos, soundType.getPlaceSound(), net.minecraft.sounds.SoundSource.BLOCKS, (soundType.getVolume() + 1.0F) / 2.0F, soundType.getPitch() * 0.8F);
 +                    }
++
++                    // Paper start - Fix cancelled rooted dirt drops being duped
++                    if (capturedDrops != null) {
++                        for (ItemEntity drop : capturedDrops) {
++                            serverLevel.addFreshEntity(drop);
++                        }
++                    }
++                    // Paper end - Fix cancelled rooted dirt drops being duped
 +
 +                    player.awardStat(Stats.ITEM_USED.get(item));
 +                }

--- a/paper-server/patches/sources/net/minecraft/world/item/ItemStack.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/ItemStack.java.patch
@@ -23,7 +23,7 @@
                  }
              }
          };
-@@ -371,10 +_,186 @@
+@@ -371,10 +_,178 @@
              return InteractionResult.PASS;
          } else {
              Item item = this.getItem();
@@ -40,23 +40,17 @@
 +                    serverLevel.captureTreeGeneration = true;
 +                }
 +            }
-+            // Paper start - Fix cancelled rooted dirt drops being duped
-+            List<ItemEntity> capturedDrops = null;
++            List<ItemEntity> capturedDrops;
 +            if (item instanceof HoeItem) {
-+                capturedDrops = new java.util.ArrayList<>();
-+                serverLevel.captureDrops = capturedDrops;
++                serverLevel.captureDrops = new java.util.ArrayList<>();
 +            }
-+            // Paper end - Fix cancelled rooted dirt drops being duped
 +            InteractionResult interactionResult;
 +            try {
 +                interactionResult = item.useOn(context);
 +            } finally {
 +                serverLevel.captureBlockStates = false;
-+                // Paper start - Fix cancelled rooted dirt drops being duped
-+                if (capturedDrops != null) {
-+                    serverLevel.captureDrops = null;
-+                }
-+                // Paper end - Fix cancelled rooted dirt drops being duped
++                capturedDrops = serverLevel.captureDrops;
++                serverLevel.captureDrops = null;
 +            }
 +            DataComponentPatch newPatch = this.components.asPatch();
 +            int newCount = this.getCount();
@@ -195,13 +189,11 @@
 +                        serverLevel.playSound(player, clickedPos, soundType.getPlaceSound(), net.minecraft.sounds.SoundSource.BLOCKS, (soundType.getVolume() + 1.0F) / 2.0F, soundType.getPitch() * 0.8F);
 +                    }
 +
-+                    // Paper start - Fix cancelled rooted dirt drops being duped
 +                    if (capturedDrops != null) {
 +                        for (ItemEntity drop : capturedDrops) {
 +                            serverLevel.addFreshEntity(drop);
 +                        }
 +                    }
-+                    // Paper end - Fix cancelled rooted dirt drops being duped
 +
 +                    player.awardStat(Stats.ITEM_USED.get(item));
 +                }


### PR DESCRIPTION
This PR fixes #13536, cancelled rooted dirt drops being duped

## Analysis

```java
protected static final Map<Block, Pair<Predicate<UseOnContext>, Consumer<UseOnContext>>> TILLABLES = Maps.newHashMap(
        ImmutableMap.of(
            Blocks.GRASS_BLOCK,
            Pair.of(HoeItem::onlyIfAirAbove, changeIntoState(Blocks.FARMLAND.defaultBlockState())),
            Blocks.DIRT_PATH,
            Pair.of(HoeItem::onlyIfAirAbove, changeIntoState(Blocks.FARMLAND.defaultBlockState())),
            Blocks.DIRT,
            Pair.of(HoeItem::onlyIfAirAbove, changeIntoState(Blocks.FARMLAND.defaultBlockState())),
            Blocks.COARSE_DIRT,
            Pair.of(HoeItem::onlyIfAirAbove, changeIntoState(Blocks.DIRT.defaultBlockState())),
            Blocks.ROOTED_DIRT,
            Pair.of(useOnContext -> true, changeIntoStateAndDropItem(Blocks.DIRT.defaultBlockState(), Items.HANGING_ROOTS))
        )
    );
```
The rooted dirt item drop logic is being processed in `HoeItem#useOn`, the drop capturing isn't enabled in this path, causing hanging roots to still be dropped even `BlockPlaceEvent` is cancelled.
This bug has existed since 1.19, after Mojang added the rooted dirt.
