### PR TITLE
Fix tracking depth in Scope

### DIFF
--- a/paper-server/patches/sources/net/minecraft/util/parsing/packrat/Scope.java.patch
+++ b/paper-server/patches/sources/net/minecraft/util/parsing/packrat/Scope.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/util/parsing/packrat/Scope.java
 +++ b/net/minecraft/util/parsing/packrat/Scope.java
-@@ -279,4 +_,33 @@
+@@ -279,4 +_,31 @@
  
          return true;
      }
@@ -10,15 +10,13 @@
 +
 +    private static final Term<?> INCREASING_DEPTH_TERM = (parseState, scope, control) -> {
 +        if (++scope.depth > 512) {
-+            parseState.errorCollector()
-+                .store(parseState.mark(),
-+                    new IllegalStateException("Too deep"));
++            parseState.errorCollector().store(parseState.mark(), new IllegalStateException("Too deep"));
 +            return false;
 +        }
 +        return true;
 +    };
 +
-+    @SuppressWarnings({"unchecked","rawtypes"})
++    @SuppressWarnings({"unchecked"})
 +    public static <S> Term<S> increaseDepth() {
 +        return (Term<S>) INCREASING_DEPTH_TERM;
 +    }
@@ -28,7 +26,7 @@
 +        return true;
 +    };
 +
-+    @SuppressWarnings({"unchecked","rawtypes"})
++    @SuppressWarnings({"unchecked"})
 +    public static <S> Term<S> decreaseDepth() {
 +        return (Term<S>) DECREASING_DEPTH_TERM;
 +    }

--- a/paper-server/patches/sources/net/minecraft/util/parsing/packrat/Scope.java.patch
+++ b/paper-server/patches/sources/net/minecraft/util/parsing/packrat/Scope.java.patch
@@ -1,39 +1,36 @@
 --- a/net/minecraft/util/parsing/packrat/Scope.java
 +++ b/net/minecraft/util/parsing/packrat/Scope.java
-@@ -279,4 +_,36 @@
+@@ -279,4 +_,33 @@
  
          return true;
      }
 +
 +    // Paper start - track depth
 +    private int depth;
++
++    private static final Term<?> INCREASING_DEPTH_TERM = (parseState, scope, control) -> {
++        if (++scope.depth > 512) {
++            parseState.errorCollector()
++                .store(parseState.mark(),
++                    new IllegalStateException("Too deep"));
++            return false;
++        }
++        return true;
++    };
++
 +    @SuppressWarnings({"unchecked","rawtypes"})
 +    public static <S> Term<S> increaseDepth() {
-+        class IncreasingDepthTerm<W> implements Term<W> {
-+            public static final IncreasingDepthTerm INSTANCE = new IncreasingDepthTerm();
-+            @Override
-+            public boolean parse(final ParseState<W> parseState, final Scope scope, final Control control) {
-+                if (++scope.depth > 512) {
-+                    parseState.errorCollector().store(parseState.mark(), new IllegalStateException("Too deep"));
-+                    return false;
-+                }
-+                return true;
-+            }
-+        }
-+        return (Term<S>) IncreasingDepthTerm.INSTANCE;
++        return (Term<S>) INCREASING_DEPTH_TERM;
 +    }
++
++    private static final Term<?> DECREASING_DEPTH_TERM = (parseState, scope, control) -> {
++        scope.depth--;
++        return true;
++    };
 +
 +    @SuppressWarnings({"unchecked","rawtypes"})
 +    public static <S> Term<S> decreaseDepth() {
-+        class DecreasingDepthTerm<W> implements Term<W> {
-+            public static final DecreasingDepthTerm INSTANCE = new DecreasingDepthTerm();
-+            @Override
-+            public boolean parse(final ParseState<W> parseState, final Scope scope, final Control control) {
-+                scope.depth--;
-+                return true;
-+            }
-+        }
-+        return (Term<S>) DecreasingDepthTerm.INSTANCE;
++        return (Term<S>) DECREASING_DEPTH_TERM;
 +    }
 +    // Paper end - track depth
  }


### PR DESCRIPTION
Refactors the code in Scope. The existing code shouldn't even compile, because static fields in local classes that are not compile-time-constant aren't allowed and were never allowed, but up to Java 24 this was apparently not enforced.

The new code compiles in Java 25+, is shorter and it's much easier to see what is happening.