### PR TITLE
Add option to skip compression when serializing item bytes

### DIFF
--- a/paper-api/src/main/java/org/bukkit/UnsafeValues.java
+++ b/paper-api/src/main/java/org/bukkit/UnsafeValues.java
@@ -164,7 +164,11 @@ public interface UnsafeValues {
 
     byte[] serializeItem(ItemStack item);
 
+    byte[] serializeItem(ItemStack item, boolean compressed);
+
     ItemStack deserializeItem(byte[] data);
+
+    ItemStack deserializeItem(byte[] data, boolean compressed);
 
     /**
      * Serializes this itemstack to json format.

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -761,20 +761,48 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      *
      * This expects that the DataVersion was stored on the root of the Compound, as saved from
      * the {@link #serializeAsBytes()} API returned.
+     *
+     * This goes through mojang's compression stream.
      * @param bytes bytes representing an item in NBT
      * @return ItemStack migrated to this version of Minecraft if needed.
      */
     public static @NotNull ItemStack deserializeBytes(final byte @NotNull [] bytes) {
-        return org.bukkit.Bukkit.getUnsafe().deserializeItem(bytes);
+        return deserializeBytes(bytes, true);
+    }
+
+    /**
+     * Deserializes this itemstack from raw NBT bytes. NBT is safer for data migrations as it will
+     * use the built in data converter instead of bukkits dangerous serialization system.
+     *
+     * This expects that the DataVersion was stored on the root of the Compound, as saved from
+     * the {@link #serializeAsBytes()} API returned.
+     * @param bytes bytes representing an item in NBT
+     * @param compressed whether the data goes through mojang's compression stream. You must use the same value when serializing.
+     * @return ItemStack migrated to this version of Minecraft if needed.
+     */
+    public static @NotNull ItemStack deserializeBytes(final byte @NotNull [] bytes, final boolean compressed) {
+        return org.bukkit.Bukkit.getUnsafe().deserializeItem(bytes, compressed);
     }
 
     /**
      * Serializes this itemstack to raw bytes in NBT. NBT is safer for data migrations as it will
      * use the built in data converter instead of bukkits dangerous serialization system.
+     *
+     * This goes through mojang's compression stream.
      * @return bytes representing this item in NBT.
      */
     public byte @NotNull [] serializeAsBytes() {
-        return org.bukkit.Bukkit.getUnsafe().serializeItem(this);
+        return serializeAsBytes(true);
+    }
+
+    /**
+     * Serializes this itemstack to raw bytes in NBT. NBT is safer for data migrations as it will
+     * use the built in data converter instead of bukkits dangerous serialization system.
+     * @param compressed whether the data goes through mojang's compression stream. You must use the same value when deserializing.
+     * @return bytes representing this item in NBT.
+     */
+    public byte @NotNull [] serializeAsBytes(final boolean compressed) {
+        return org.bukkit.Bukkit.getUnsafe().serializeItem(this, compressed);
     }
 
     /**


### PR DESCRIPTION
Current paper item serialization and deserialization methods - `ItemStack#serializeAsBytes()` and `ItemStack.deserializeBytes(byte[])` go through mojangs GZIP compression stream.

This is most likely fine for most users who don’t go into the details, but quite problematic in some cases. For example, if you serialize more items or use custom data format that the serialized bytes are written into, and then everything is compressed, the result weighs even more than raw/uncompressed data, when it should weigh less.

This PR adds overloaded methods that allow for disabling compression, while old methods are not touched to not introduce any API breakages.

I tested the changes using following code: [https://pastes.dev/uO00wJSTf6](https://pastes.dev/uO00wJSTf6); and they seem to work fine.