### PR TITLE
Add EntityTouchWaterEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityTouchWaterEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityTouchWaterEvent.java
@@ -1,0 +1,40 @@
+package io.papermc.paper.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Event when an Entity starts touching water or not. This includes even small amounts of flowing water.
+ */
+@NullMarked
+public class EntityTouchWaterEvent extends EntityEvent{
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private boolean inWater;
+
+    @ApiStatus.Internal
+    public EntityTouchWaterEvent(final Entity entity, final boolean inWater) {
+        super(entity);
+        this.inWater = inWater;
+    }
+
+    /**
+     * @return If the entity is now touching water.
+     */
+    public boolean isInWater() {
+        return inWater;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/paper-server/patches/features/0032-Add-EntityTouchWaterEvent.patch
+++ b/paper-server/patches/features/0032-Add-EntityTouchWaterEvent.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cryptite <cryptite@gmail.com>
+Date: Wed, 14 Jan 2026 21:13:11 -0600
+Subject: [PATCH] Add EntityTouchWaterEvent
+
+
+diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
+index 3bf618f1d756bad7755a87803132bd731e7c41be..de4fde4bb4164cd009edc7c5273dc10d60418209 100644
+--- a/net/minecraft/world/entity/Entity.java
++++ b/net/minecraft/world/entity/Entity.java
+@@ -2044,11 +2044,13 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+         } else if (this.updateFluidHeightAndDoFluidPushing(FluidTags.WATER, 0.014)) {
+             if (!this.wasTouchingWater && !this.firstTick) {
+                 this.doWaterSplashEffect();
++                new io.papermc.paper.event.entity.EntityTouchWaterEvent(getBukkitEntity(), true).callEvent(); // Paper
+             }
+ 
+             this.resetFallDistance();
+             this.wasTouchingWater = true;
+         } else {
++            if (this.wasTouchingWater) new io.papermc.paper.event.entity.EntityTouchWaterEvent(getBukkitEntity(), false).callEvent(); // Paper
+             this.wasTouchingWater = false;
+         }
+     }


### PR DESCRIPTION
While this is a particularly niche event, the logic was already all there in the source.

Use case for us is status effects when touching (corrupted) water and applying damage, etc.