### PR TITLE
Add getLastPing to PlayerCommonConnection

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/connection/PlayerCommonConnection.java
+++ b/paper-api/src/main/java/io/papermc/paper/connection/PlayerCommonConnection.java
@@ -43,4 +43,31 @@ public interface PlayerCommonConnection extends WritablePlayerCookieConnection, 
      * @return the client option value of the player
      */
     <T> T getClientOption(ClientOption<T> type);
+
+    /**
+     * Gets the player's estimated ping in milliseconds.
+     * <p>
+     * In Vanilla this value represents a weighted average of the response time
+     * to application layer ping packets sent. This value does not represent the
+     * network round trip time and as such may have less granularity and be
+     * impacted by other sources. For these reasons it <b>should not</b> be used
+     * for anti-cheat purposes. Its recommended use is only as a
+     * <b>qualitative</b> indicator of connection quality (Vanilla uses it for
+     * this purpose in the tab list).
+     *
+     * @return player ping
+     * @see #getLastPing()
+     */
+    int getPing();
+
+    /**
+     * Gets the player's most recent measured ping.
+     * <p>
+     * This differs from {@link #getPing()} as it represents an average of ping over time,
+     * whereas this represents simply the most recent ping.
+     *
+     * @return player's most recent ping
+     * @see #getPing()
+     */
+    int getLastPing();
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -3363,6 +3363,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      */
     java.util.Locale locale();
     // Paper end
+
     /**
      * Gets the player's estimated ping in milliseconds.
      *
@@ -3375,6 +3376,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      * this purpose in the tab list).
      *
      * @return player ping
+     * @see io.papermc.paper.connection.PlayerCommonConnection#getLastPing()
      */
     public int getPing();
 

--- a/paper-server/patches/features/0024-Improve-keepalive-ping-system.patch
+++ b/paper-server/patches/features/0024-Improve-keepalive-ping-system.patch
@@ -117,10 +117,10 @@ index d87a00ee3cd04ce25dbe46ae6b386b7f0799102c..ace440c2b82a6368aa27a85ff433ba2c
      }
  }
 diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index abeca4714053fd0a4fa489d496e2e0b844de40a8..7ed50fc00c58c7781c958df1d828a67adf696f3e 100644
+index 0dbb349dcb49da03cb555ffc3b2411f722490a39..56eddbf779fb9b68d5f8a17992d8ae9a1d3f31c5 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-@@ -39,12 +39,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -39,13 +39,14 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      protected final MinecraftServer server;
      public final Connection connection; // Paper
      private final boolean transferred;
@@ -133,20 +133,23 @@ index abeca4714053fd0a4fa489d496e2e0b844de40a8..7ed50fc00c58c7781c958df1d828a67a
      private long closedListenerTime;
      private boolean closed = false;
 -    private int latency;
+-    public int lastLatency; // Paper - Keep most recent latency in millis
 +    private volatile int latency; // Paper - improve keepalives - make volatile
++    public volatile int lastLatency; // Paper - Keep most recent latency in millis
 +    private final io.papermc.paper.util.KeepAlive keepAlive; // Paper - improve keepalives
      private volatile boolean suspendFlushingOnServerThread = false;
      // CraftBukkit start
      public final org.bukkit.craftbukkit.CraftServer cserver;
-@@ -60,13 +61,14 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -61,7 +62,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      public ServerCommonPacketListenerImpl(final MinecraftServer server, final Connection connection, final CommonListenerCookie cookie) {
          this.server = server;
          this.connection = connection;
 -        this.keepAliveTime = Util.getMillis();
 +        //this.keepAliveTime = Util.getMillis(); // Paper - improve keepalives
          this.latency = cookie.latency();
+         this.lastLatency = this.latency; // Paper - Keep most recent latency in millis
          this.transferred = cookie.transferred();
-         // Paper start
+@@ -69,6 +70,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          this.playerBrand = cookie.brandName();
          this.cserver = server.server;
          this.pluginMessagerChannels = cookie.channels();
@@ -154,13 +157,14 @@ index abeca4714053fd0a4fa489d496e2e0b844de40a8..7ed50fc00c58c7781c958df1d828a67a
          // Paper end
      }
  
-@@ -99,13 +101,35 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -101,14 +103,36 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
  
      @Override
      public void handleKeepAlive(final ServerboundKeepAlivePacket packet) {
 -        if (this.keepAlivePending && packet.getId() == this.keepAliveChallenge) {
 -            int time = (int)(Util.getMillis() - this.keepAliveTime);
 -            this.latency = (this.latency * 3 + time) / 4;
+-            this.lastLatency = time; // Paper - Keep most recent latency in millis
 -            this.keepAlivePending = false;
 -        } else if (!this.isSingleplayerOwner()) {
 -            this.disconnectAsync(TIMEOUT_DISCONNECTION_MESSAGE, io.papermc.paper.connection.DisconnectionReason.TIMEOUT); // Paper - add proper async disconnect
@@ -176,6 +180,7 @@ index abeca4714053fd0a4fa489d496e2e0b844de40a8..7ed50fc00c58c7781c958df1d828a67a
 +            this.keepAlive.pingCalculator5s.update(response);
 +
 +            this.latency = this.keepAlive.pingCalculator5s.getAvgLatencyMS();
++            this.lastLatency = (int) java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(response.latencyNS()); // Paper - Keep most recent latency in millis
 +            return;
 +        }
 +
@@ -196,7 +201,7 @@ index abeca4714053fd0a4fa489d496e2e0b844de40a8..7ed50fc00c58c7781c958df1d828a67a
      }
  
      @Override
-@@ -232,20 +256,23 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -235,20 +259,23 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      protected void keepConnectionAlive() {
          Profiler.get().push("keepAlive");
          long now = Util.getMillis();
@@ -234,7 +239,7 @@ index abeca4714053fd0a4fa489d496e2e0b844de40a8..7ed50fc00c58c7781c958df1d828a67a
              }
          }
  
-@@ -420,6 +447,16 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -423,6 +450,16 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      }
  
      protected CommonListenerCookie createCookie(final ClientInformation clientInformation) {

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
@@ -9,9 +9,11 @@
      private final boolean transferred;
      private long keepAliveTime;
      private boolean keepAlivePending;
-@@ -46,6 +_,16 @@
+@@ -45,15 +_,38 @@
+     private long closedListenerTime;
      private boolean closed = false;
      private int latency;
++    public int lastLatency; // Paper - Keep most recent latency in millis
      private volatile boolean suspendFlushingOnServerThread = false;
 +    // CraftBukkit start
 +    public final org.bukkit.craftbukkit.CraftServer cserver;
@@ -26,9 +28,10 @@
  
      public ServerCommonPacketListenerImpl(final MinecraftServer server, final Connection connection, final CommonListenerCookie cookie) {
          this.server = server;
-@@ -53,7 +_,18 @@
+         this.connection = connection;
          this.keepAliveTime = Util.getMillis();
          this.latency = cookie.latency();
++        this.lastLatency = this.latency; // Paper - Keep most recent latency in millis
          this.transferred = cookie.transferred();
 +        // Paper start
 +        this.playerBrand = cookie.brandName();
@@ -45,8 +48,11 @@
  
      private void close() {
          if (!this.closed) {
-@@ -83,7 +_,7 @@
+@@ -81,9 +_,10 @@
+         if (this.keepAlivePending && packet.getId() == this.keepAliveChallenge) {
+             int time = (int)(Util.getMillis() - this.keepAliveTime);
              this.latency = (this.latency * 3 + time) / 4;
++            this.lastLatency = time; // Paper - Keep most recent latency in millis
              this.keepAlivePending = false;
          } else if (!this.isSingleplayerOwner()) {
 -            this.disconnect(TIMEOUT_DISCONNECTION_MESSAGE);

--- a/paper-server/src/main/java/io/papermc/paper/connection/PaperCommonConnection.java
+++ b/paper-server/src/main/java/io/papermc/paper/connection/PaperCommonConnection.java
@@ -109,5 +109,15 @@ public abstract class PaperCommonConnection<T extends ServerCommonPacketListener
         this.packetListener.send(new ClientboundStoreCookiePacket(CraftNamespacedKey.toMinecraft(key), value));
     }
 
+    @Override
+    public int getPing() {
+        return this.packetListener.latency();
+    }
+
+    @Override
+    public int getLastPing() {
+        return this.packetListener.lastLatency;
+    }
+
     public abstract ClientInformation getClientInformation();
 }

--- a/paper-server/src/main/java/io/papermc/paper/connection/PaperPlayerGameConnection.java
+++ b/paper-server/src/main/java/io/papermc/paper/connection/PaperPlayerGameConnection.java
@@ -8,8 +8,8 @@ import org.bukkit.plugin.Plugin;
 
 public class PaperPlayerGameConnection extends PaperCommonConnection<ServerGamePacketListenerImpl> implements PlayerGameConnection {
 
-    public PaperPlayerGameConnection(final ServerGamePacketListenerImpl serverConfigurationPacketListenerImpl) {
-        super(serverConfigurationPacketListenerImpl);
+    public PaperPlayerGameConnection(final ServerGamePacketListenerImpl packetListener) {
+        super(packetListener);
     }
 
     @Override


### PR DESCRIPTION
This exposes most recent ping in milliseconds on a Player. The default `Player.getPing()` represents an average over time, but it is very nice to be able to actually see their most recent ping. 