### PR TITLE
Add Direct Remover to HangingBreakByEntityEvent

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/hanging/HangingBreakByEntityEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/hanging/HangingBreakByEntityEvent.java
@@ -12,16 +12,18 @@ import org.jetbrains.annotations.Nullable;
 public class HangingBreakByEntityEvent extends HangingBreakEvent {
 
     private final Entity remover;
+    private final Entity directRemover; // Paper
 
     @ApiStatus.Internal
     public HangingBreakByEntityEvent(@NotNull final Hanging hanging, @NotNull final Entity remover) {
-        this(hanging, remover, HangingBreakEvent.RemoveCause.ENTITY);
+        this(hanging, remover, null, HangingBreakEvent.RemoveCause.ENTITY); // Paper
     }
 
     @ApiStatus.Internal
-    public HangingBreakByEntityEvent(@NotNull final Hanging hanging, @NotNull final Entity remover, @NotNull final HangingBreakEvent.RemoveCause cause) {
+    public HangingBreakByEntityEvent(@NotNull final Hanging hanging, @NotNull final Entity remover, @Nullable Entity directRemover, @NotNull final HangingBreakEvent.RemoveCause cause) { // Slice
         super(hanging, cause);
         this.remover = remover;
+        this.directRemover = directRemover; // Paper
     }
 
     /**
@@ -33,4 +35,19 @@ public class HangingBreakByEntityEvent extends HangingBreakEvent {
     public Entity getRemover() {
         return this.remover;
     }
+
+    // Paper start
+    /**
+     * Gets the {@link org.bukkit.damage.DamageSource#getDirectEntity()} entity that removed the hanging entity.
+     * <p>
+     * A good example of this is when a Player throws an Ender Pearl at an Item Frame. {@link #getRemover()}
+     * will return the Player that threw the Ender Pearl, whereas {@link #getDirectRemover()} will return the Pearl.
+     *
+     * @return the entity that removed the hanging entity
+     */
+    @Nullable
+    public Entity getDirectRemover() {
+        return this.directRemover;
+    }
+    // Paper end
 }

--- a/paper-server/patches/features/0032-Add-directRemover-to-HangingBreakByEntityEvent.patch
+++ b/paper-server/patches/features/0032-Add-directRemover-to-HangingBreakByEntityEvent.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cryptite <cryptite@gmail.com>
+Date: Wed, 14 Jan 2026 21:51:34 -0600
+Subject: [PATCH] Add directRemover to HangingBreakByEntityEvent
+
+
+diff --git a/net/minecraft/world/entity/decoration/BlockAttachedEntity.java b/net/minecraft/world/entity/decoration/BlockAttachedEntity.java
+index a1ad3c95eec470cbae6e47ea2f0063b42cb1271e..9925d75eca741115a480e57955868c1562128b2d 100644
+--- a/net/minecraft/world/entity/decoration/BlockAttachedEntity.java
++++ b/net/minecraft/world/entity/decoration/BlockAttachedEntity.java
+@@ -95,7 +95,7 @@ public abstract class BlockAttachedEntity extends Entity {
+                 Entity damager = (!damageSource.isDirect() && damageSource.getEntity() != null) ? damageSource.getEntity() : damageSource.getDirectEntity(); // Paper - fix DamageSource API
+                 org.bukkit.event.hanging.HangingBreakEvent event;
+                 if (damager != null) {
+-                    event = new org.bukkit.event.hanging.HangingBreakByEntityEvent((org.bukkit.entity.Hanging) this.getBukkitEntity(), damager.getBukkitEntity(), damageSource.is(net.minecraft.tags.DamageTypeTags.IS_EXPLOSION) ? org.bukkit.event.hanging.HangingBreakEvent.RemoveCause.EXPLOSION : org.bukkit.event.hanging.HangingBreakEvent.RemoveCause.ENTITY);
++                    event = new org.bukkit.event.hanging.HangingBreakByEntityEvent((org.bukkit.entity.Hanging) this.getBukkitEntity(), damager.getBukkitEntity(), damageSource.getDirectEntity() != null ? damageSource.getDirectEntity().getBukkitEntity() : null, damageSource.is(net.minecraft.tags.DamageTypeTags.IS_EXPLOSION) ? org.bukkit.event.hanging.HangingBreakEvent.RemoveCause.EXPLOSION : org.bukkit.event.hanging.HangingBreakEvent.RemoveCause.ENTITY); // Paper - add direct damage source
+                 } else {
+                     event = new org.bukkit.event.hanging.HangingBreakEvent((org.bukkit.entity.Hanging) this.getBukkitEntity(), damageSource.is(net.minecraft.tags.DamageTypeTags.IS_EXPLOSION) ? org.bukkit.event.hanging.HangingBreakEvent.RemoveCause.EXPLOSION : org.bukkit.event.hanging.HangingBreakEvent.RemoveCause.DEFAULT);
+                 }


### PR DESCRIPTION
From the provided javadocs, a good example of this is when a Player throws an Ender Pearl at an Item Frame. `getRemover()` will return the _Player_ that threw the Ender Pearl, whereas `getDirectRemover()` will return the _Pearl_ projectile itself.