### PR TITLE
Add getBlockStandingOn() to Entity

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -1322,4 +1322,27 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      */
     void broadcastHurtAnimation(@NotNull java.util.Collection<Player> players);
     // Paper end - broadcast hurt animation
+
+    // Paper start
+    /**
+     * Returns the Block that is currently supporting the player, particularly in the case of
+     * crouching over the edge of a block.
+     */
+    org.bukkit.block.Block getBlockStandingOn();
+    // Paper end
+
+    // Slice start
+    /**
+     * Returns true if the entity can be saved. If false, the entity will never be serialized or saved.
+     */
+    boolean isSaveable();
+
+    /**
+     * Sets whether the entity can be serialized and saved to disk.
+     *
+     * @param saveable the saveable status
+     * @see #isSaveable()
+     */
+    void setSaveable(boolean saveable);
+    // Slice end
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -1322,4 +1322,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      */
     void broadcastHurtAnimation(@NotNull java.util.Collection<Player> players);
     // Paper end - broadcast hurt animation
+
+    // Paper start
+    /**
+     * Returns the Block that is currently supporting the player, particularly in the case of
+     * crouching over the edge of a block.
+     */
+    org.bukkit.block.Block getBlockStandingOn();
+    // Paper end
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -1331,4 +1331,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
         return this.entity.get(io.papermc.paper.datacomponent.PaperDataComponentType.bukkitToMinecraft(type)) != null;
     }
 
+    // Paper start
+    @Override
+    public org.bukkit.block.Block getBlockStandingOn() {
+        net.minecraft.core.BlockPos pos = this.entity.getBlockPosBelowThatAffectsMyMovement();
+        return this.entity.level().getWorld().getBlockAt(pos.getX(), pos.getY(), pos.getZ());
+    }
+    // Paper end
 }


### PR DESCRIPTION
Already existed in nms as `getBlockPosBelowThatAffectsMyMovement`, so found it useful to know the exact Block an entity is standing on, especially where otherwise `getLocation()` would return which block they're crouched _into_.