### PR TITLE
Use tick rate from /tick command

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -1198,7 +1198,7 @@
 +    }
 +
 +    public void updateLagCompensationTick() {
-+        this.lagCompensationTick = (System.nanoTime() - MinecraftServer.SERVER_INIT) / (java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(50L));
++        this.lagCompensationTick = (System.nanoTime() - MinecraftServer.SERVER_INIT) / (this.server.tickRateManager().nanosecondsPerTick());
 +    }
 +    // Paper end - lag compensation
  }


### PR DESCRIPTION
Fixes blocks reappearing when tick rate differs from normal.

Reproduction steps:
/tick rate 100
break block
block reappears 