### PR TITLE
Improvement to Vehicle damage events

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/vehicle/VehicleDamageEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/vehicle/VehicleDamageEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.vehicle;
 
+import org.bukkit.damage.DamageSource;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.event.Cancellable;
@@ -15,16 +16,28 @@ public class VehicleDamageEvent extends VehicleEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
+    private final DamageSource damageSource;
     private final Entity attacker;
     private double damage;
 
     private boolean cancelled;
 
     @ApiStatus.Internal
-    public VehicleDamageEvent(@NotNull final Vehicle vehicle, @Nullable final Entity attacker, final double damage) {
+    public VehicleDamageEvent(final @NotNull Vehicle vehicle, final @NotNull DamageSource damageSource, final @Nullable Entity attacker, final double damage) {
         super(vehicle);
+        this.damageSource = damageSource;
         this.attacker = attacker;
         this.damage = damage;
+    }
+
+    /**
+     * Gets the DamageSource that caused the damage.
+     *
+     * @return the DamageSource that caused the damage
+     */
+    @NotNull
+    public DamageSource getDamageSource() {
+        return this.damageSource;
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/event/vehicle/VehicleDestroyEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/vehicle/VehicleDestroyEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.vehicle;
 
+import org.bukkit.damage.DamageSource;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.event.Cancellable;
@@ -17,13 +18,25 @@ public class VehicleDestroyEvent extends VehicleEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
+    private final DamageSource damageSource;
     private final Entity attacker;
     private boolean cancelled;
 
     @ApiStatus.Internal
-    public VehicleDestroyEvent(@NotNull final Vehicle vehicle, @Nullable final Entity attacker) {
+    public VehicleDestroyEvent(final @NotNull Vehicle vehicle, final @NotNull DamageSource damageSource, final @Nullable Entity attacker) {
         super(vehicle);
+        this.damageSource = damageSource;
         this.attacker = attacker;
+    }
+
+    /**
+     * Gets the DamageSource that has destroyed the vehicle.
+     *
+     * @return the DamageSource that has destroyed the vehicle
+     */
+    @NotNull
+    public DamageSource getDamageSource() {
+        return this.damageSource;
     }
 
     /**

--- a/paper-server/patches/sources/net/minecraft/world/entity/vehicle/VehicleEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/vehicle/VehicleEntity.java.patch
@@ -13,11 +13,13 @@
          } else {
 +            // CraftBukkit start
 +            org.bukkit.entity.Vehicle vehicle = (org.bukkit.entity.Vehicle) this.getBukkitEntity();
-+            org.bukkit.entity.Entity attacker = (source.getEntity() == null) ? null : source.getEntity().getBukkitEntity();
-+
-+            org.bukkit.event.vehicle.VehicleDamageEvent event = new org.bukkit.event.vehicle.VehicleDamageEvent(vehicle, attacker, damage);
++            org.bukkit.craftbukkit.damage.CraftDamageSource damageSourceBukkit = new org.bukkit.craftbukkit.damage.CraftDamageSource(source);
++            org.bukkit.entity.Entity attacker = net.minecraft.Optionull.map(
++                source.eventEntityDamager() != null ? source.eventEntityDamager() : source.getDirectEntity(), Entity::getBukkitEntity
++            );
++            org.bukkit.event.vehicle.VehicleDamageEvent event = new org.bukkit.event.vehicle.VehicleDamageEvent(vehicle, damageSourceBukkit, attacker, amount);
 +            if (!event.callEvent()) return false;
-+            damage = (float) event.getDamage();
++            amount = (float) event.getDamage();
 +            // CraftBukkit end
              this.setHurtDir(-this.getHurtDir());
              this.setHurtTime(10);
@@ -28,7 +30,7 @@
                  if (creativePlayer) {
 -                    this.discard();
 +                    // CraftBukkit start
-+                    org.bukkit.event.vehicle.VehicleDestroyEvent destroyEvent = new org.bukkit.event.vehicle.VehicleDestroyEvent(vehicle, attacker);
++                    org.bukkit.event.vehicle.VehicleDestroyEvent destroyEvent = new org.bukkit.event.vehicle.VehicleDestroyEvent(vehicle, damageSourceBukkit, attacker);
 +                    if (!destroyEvent.callEvent()) {
 +                        this.setDamage(40.0F); // Maximize damage so this doesn't get triggered again right away
 +                        return true;
@@ -38,7 +40,7 @@
                  }
              } else {
 +                // CraftBukkit start
-+                org.bukkit.event.vehicle.VehicleDestroyEvent destroyEvent = new org.bukkit.event.vehicle.VehicleDestroyEvent(vehicle, attacker);
++                org.bukkit.event.vehicle.VehicleDestroyEvent destroyEvent = new org.bukkit.event.vehicle.VehicleDestroyEvent(vehicle, damageSourceBukkit, attacker);
 +                if (!destroyEvent.callEvent()) {
 +                    this.setDamage(40.0F); // Maximize damage so this doesn't get triggered again right away
 +                    return true;

--- a/paper-server/patches/sources/net/minecraft/world/entity/vehicle/VehicleEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/vehicle/VehicleEntity.java.patch
@@ -17,9 +17,9 @@
 +            org.bukkit.entity.Entity attacker = net.minecraft.Optionull.map(
 +                source.eventEntityDamager() != null ? source.eventEntityDamager() : source.getDirectEntity(), Entity::getBukkitEntity
 +            );
-+            org.bukkit.event.vehicle.VehicleDamageEvent event = new org.bukkit.event.vehicle.VehicleDamageEvent(vehicle, damageSourceBukkit, attacker, amount);
++            org.bukkit.event.vehicle.VehicleDamageEvent event = new org.bukkit.event.vehicle.VehicleDamageEvent(vehicle, damageSourceBukkit, attacker, damage);
 +            if (!event.callEvent()) return false;
-+            amount = (float) event.getDamage();
++            damage = (float) event.getDamage();
 +            // CraftBukkit end
              this.setHurtDir(-this.getHurtDir());
              this.setHurtTime(10);

--- a/paper-server/patches/sources/net/minecraft/world/entity/vehicle/VehicleEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/vehicle/VehicleEntity.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/vehicle/VehicleEntity.java
 +++ b/net/minecraft/world/entity/vehicle/VehicleEntity.java
-@@ -32,12 +_,20 @@
+@@ -32,12 +_,22 @@
      }
  
      @Override


### PR DESCRIPTION
Close https://github.com/PaperMC/Paper/issues/13571 by adding the DamageSource to the Vehicle events related to damage for allow check more details for the damage rather than just the entity who cause the damage also change the Attacker passed to events for include the internal event damager used in a few places if exists.