### PR TITLE
Make SkinSource Player implementation reflect profile changes

### DIFF
--- a/paper-api/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/paper-api/src/main/java/org/bukkit/OfflinePlayer.java
@@ -12,7 +12,6 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.ServerOperator;
 import org.bukkit.profile.PlayerProfile;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -589,7 +588,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
     // Paper end - add pdc to offline player
 
     @Override
-    default void applySkinToPlayerHeadContents(final PlayerHeadObjectContents.@NonNull Builder builder) {
-        builder.id(this.getUniqueId());
+    default void applySkinToPlayerHeadContents(final PlayerHeadObjectContents.Builder builder) {
+        builder.skin(this.getPlayerProfile());
     }
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -1,5 +1,6 @@
 package org.bukkit.entity;
 
+import com.destroystokyo.paper.ClientOption;
 import io.papermc.paper.connection.PlayerGameConnection;
 import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.entity.PlayerGiveResult;
@@ -15,6 +16,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.object.PlayerHeadObjectContents;
 import org.bukkit.BanEntry;
 import org.bukkit.DyeColor;
 import org.bukkit.Effect;
@@ -3557,6 +3559,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
     }
     // Paper end
 
+    @Override
+    default void applySkinToPlayerHeadContents(final PlayerHeadObjectContents.Builder builder) {
+        OfflinePlayer.super.applySkinToPlayerHeadContents(builder);
+        builder.hat(this.getClientOption(ClientOption.SKIN_PARTS).hasHatsEnabled());
+    }
+
     // Paper start - Player Profile API
     /**
      * Gets a copy of this players profile
@@ -3603,7 +3611,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
     /**
      * @return the client option value of the player
      */
-    <T> T getClientOption(com.destroystokyo.paper.ClientOption<T> option);
+    <T> T getClientOption(ClientOption<T> option);
     // Paper end - client option API
 
     // Paper start - elytra boost API


### PR DESCRIPTION
This PR ensures that the `PlayerHeadObjectContents` created by the `SkinSource` implementation on `Player` accurately reflect the player's current skin as seen by other players.

The previous implementation always used the player's UUID, which caused profile changes made via the API and the player's hat layer setting to be ignored.