### PR TITLE
OldEnum#valueOf check for valid NamespacedKey

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentTypes.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentTypes.java
@@ -48,12 +48,12 @@ import io.papermc.paper.item.MapPostProcessing;
 import io.papermc.paper.registry.tag.TagKey;
 import java.util.List;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Art;
 import org.bukkit.DyeColor;
 import org.bukkit.FireworkEffect;
 import org.bukkit.MusicInstrument;
-import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.block.banner.PatternType;
 import org.bukkit.damage.DamageType;
@@ -81,8 +81,6 @@ import org.checkerframework.checker.index.qual.Positive;
 import org.checkerframework.common.value.qual.IntRange;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * All the different types of data that {@link org.bukkit.inventory.ItemStack ItemStacks}
@@ -392,21 +390,21 @@ public final class DataComponentTypes {
     public static final DataComponentType.Valued<DyeColor> SHEEP_COLOR = valued("sheep/color");
     public static final DataComponentType.Valued<DyeColor> SHULKER_COLOR = valued("shulker/color");
 
-    private static DataComponentType.NonValued unvalued(final String name) {
-        final DataComponentType dataComponentType = requireNonNull(Registry.DATA_COMPONENT_TYPE.get(NamespacedKey.minecraft(name)), name + " unvalued data component type couldn't be found, this is a bug.");
+    private static DataComponentType.NonValued unvalued(final @KeyPattern.Value String key) {
+        final DataComponentType dataComponentType = Registry.DATA_COMPONENT_TYPE.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         if (dataComponentType instanceof DataComponentType.NonValued) {
             return (DataComponentType.NonValued) dataComponentType;
         }
-        throw new IllegalStateException(name + " is not a valid unvalued type, it is a " + dataComponentType.getClass().getTypeName());
+        throw new IllegalStateException(key + " is not a valid unvalued type, it is a " + dataComponentType.getClass().getTypeName());
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> DataComponentType.Valued<T> valued(final String name) {
-        DataComponentType dataComponentType =  requireNonNull(Registry.DATA_COMPONENT_TYPE.get(NamespacedKey.minecraft(name)), name + " valued data component type couldn't be found, this is a bug.");
+    private static <T> DataComponentType.Valued<T> valued(final @KeyPattern.Value String key) {
+        DataComponentType dataComponentType =  Registry.DATA_COMPONENT_TYPE.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         if (dataComponentType instanceof DataComponentType.Valued) {
             return (DataComponentType.Valued<T>) dataComponentType;
         }
-        throw new IllegalStateException(name + " is not a valid valued type, it is a " + dataComponentType.getClass().getTypeName());
+        throw new IllegalStateException(key + " is not a valid valued type, it is a " + dataComponentType.getClass().getTypeName());
 
     }
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentTypes.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentTypes.java
@@ -400,12 +400,11 @@ public final class DataComponentTypes {
 
     @SuppressWarnings("unchecked")
     private static <T> DataComponentType.Valued<T> valued(final @KeyPattern.Value String key) {
-        DataComponentType dataComponentType =  Registry.DATA_COMPONENT_TYPE.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
+        final DataComponentType dataComponentType = Registry.DATA_COMPONENT_TYPE.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         if (dataComponentType instanceof DataComponentType.Valued) {
             return (DataComponentType.Valued<T>) dataComponentType;
         }
         throw new IllegalStateException(key + " is not a valid valued type, it is a " + dataComponentType.getClass().getTypeName());
-
     }
 
     private DataComponentTypes() {

--- a/paper-api/src/main/java/org/bukkit/Art.java
+++ b/paper-api/src/main/java/org/bukkit/Art.java
@@ -231,8 +231,10 @@ public interface Art extends OldEnum<Art>, Keyed {
     @Nullable
     static Art getByName(@NotNull String name) {
         Preconditions.checkArgument(name != null, "Name cannot be null");
+        final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+        Preconditions.checkArgument(key != null, "Invalid name %s", name);
 
-        return Bukkit.getUnsafe().get(RegistryKey.PAINTING_VARIANT, NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+        return Bukkit.getUnsafe().get(RegistryKey.PAINTING_VARIANT, key);
     }
 
     /**
@@ -243,9 +245,7 @@ public interface Art extends OldEnum<Art>, Keyed {
     @NotNull
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Art valueOf(@NotNull String name) {
-        final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
-        Preconditions.checkArgument(key != null, "Invalid name %s", name);
-        Art art = Bukkit.getUnsafe().get(RegistryKey.PAINTING_VARIANT, key);
+        Art art = Art.getByName(name);
         Preconditions.checkArgument(art != null, "No art found with the name %s", name);
         return art;
     }

--- a/paper-api/src/main/java/org/bukkit/Art.java
+++ b/paper-api/src/main/java/org/bukkit/Art.java
@@ -1,16 +1,12 @@
 package org.bukkit;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import io.papermc.paper.registry.RegistryAccess;
-import io.papermc.paper.registry.RegistryBuilderFactory;
 import io.papermc.paper.registry.RegistryKey;
-import io.papermc.paper.registry.data.InlinedRegistryBuilderProvider;
-import io.papermc.paper.registry.data.PaintingVariantRegistryEntry;
 import java.util.Locale;
-import java.util.function.Consumer;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.util.OldEnum;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -129,8 +125,8 @@ public interface Art extends OldEnum<Art>, Keyed {
     // End generate - Art
 
     @NotNull
-    private static Art getArt(@NotNull String key) {
-        return RegistryAccess.registryAccess().getRegistry(RegistryKey.PAINTING_VARIANT).getOrThrow(NamespacedKey.minecraft(key));
+    private static Art getArt(@NotNull @KeyPattern.Value String key) {
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.PAINTING_VARIANT).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     /**
@@ -209,7 +205,7 @@ public interface Art extends OldEnum<Art>, Keyed {
     @Deprecated(since = "1.6.2", forRemoval = true)
     @Nullable
     static Art getById(int id) {
-        for (Art art : Registry.ART) {
+        for (Art art : RegistryAccess.registryAccess().getRegistry(RegistryKey.PAINTING_VARIANT)) {
             if (id == art.getId()) {
                 return art;
             }
@@ -232,7 +228,9 @@ public interface Art extends OldEnum<Art>, Keyed {
     static Art getByName(@NotNull String name) {
         Preconditions.checkArgument(name != null, "Name cannot be null");
         final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
-        Preconditions.checkArgument(key != null, "Invalid name %s", name);
+        if (key == null) {
+            return null;
+        }
 
         return Bukkit.getUnsafe().get(RegistryKey.PAINTING_VARIANT, key);
     }
@@ -245,18 +243,19 @@ public interface Art extends OldEnum<Art>, Keyed {
     @NotNull
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Art valueOf(@NotNull String name) {
-        Art art = Art.getByName(name);
+        final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+        final Art art = key == null ? null : Bukkit.getUnsafe().get(RegistryKey.PAINTING_VARIANT, key);
         Preconditions.checkArgument(art != null, "No art found with the name %s", name);
         return art;
     }
 
     /**
      * @return an array of all known arts.
-     * @deprecated use {@link Registry#iterator()}.
+     * @deprecated use {@link Registry#stream()}.
      */
     @NotNull
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Art[] values() {
-        return Lists.newArrayList(Registry.ART).toArray(new Art[0]);
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.PAINTING_VARIANT).stream().toArray(Art[]::new);
     }
 }

--- a/paper-api/src/main/java/org/bukkit/Art.java
+++ b/paper-api/src/main/java/org/bukkit/Art.java
@@ -243,7 +243,9 @@ public interface Art extends OldEnum<Art>, Keyed {
     @NotNull
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Art valueOf(@NotNull String name) {
-        Art art = Bukkit.getUnsafe().get(RegistryKey.PAINTING_VARIANT, NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+        final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+        Preconditions.checkArgument(key != null, "Invalid name %s", name);
+        Art art = Bukkit.getUnsafe().get(RegistryKey.PAINTING_VARIANT, key);
         Preconditions.checkArgument(art != null, "No art found with the name %s", name);
         return art;
     }

--- a/paper-api/src/main/java/org/bukkit/Fluid.java
+++ b/paper-api/src/main/java/org/bukkit/Fluid.java
@@ -1,9 +1,10 @@
 package org.bukkit;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import io.papermc.paper.registry.RegistryKey;
 import java.util.Locale;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.util.OldEnum;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,8 +26,8 @@ public interface Fluid extends OldEnum<Fluid>, Keyed {
     // End generate - Fluid
 
     @NotNull
-    private static Fluid getFluid(@NotNull String key) {
-        return Registry.FLUID.getOrThrow(NamespacedKey.minecraft(key));
+    private static Fluid getFluid(@NotNull @KeyPattern.Value String key) {
+        return Registry.FLUID.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     /**
@@ -38,19 +39,18 @@ public interface Fluid extends OldEnum<Fluid>, Keyed {
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Fluid valueOf(@NotNull String name) {
         final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
-        Preconditions.checkArgument(key != null, "Invalid name %s", name);
-        Fluid fluid = Bukkit.getUnsafe().get(RegistryKey.FLUID, key);
+        Fluid fluid = key == null ? null : Bukkit.getUnsafe().get(RegistryKey.FLUID, key);
         Preconditions.checkArgument(fluid != null, "No fluid found with the name %s", name);
         return fluid;
     }
 
     /**
      * @return an array of all known fluids.
-     * @deprecated use {@link Registry#iterator()}.
+     * @deprecated use {@link Registry#stream()}.
      */
     @NotNull
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Fluid[] values() {
-        return Lists.newArrayList(Registry.FLUID).toArray(new Fluid[0]);
+        return Registry.FLUID.stream().toArray(Fluid[]::new);
     }
 }

--- a/paper-api/src/main/java/org/bukkit/Fluid.java
+++ b/paper-api/src/main/java/org/bukkit/Fluid.java
@@ -37,7 +37,9 @@ public interface Fluid extends OldEnum<Fluid>, Keyed {
     @NotNull
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Fluid valueOf(@NotNull String name) {
-        Fluid fluid = Bukkit.getUnsafe().get(RegistryKey.FLUID, NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+        final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+        Preconditions.checkArgument(key != null, "Invalid name %s", name);
+        Fluid fluid = Bukkit.getUnsafe().get(RegistryKey.FLUID, key);
         Preconditions.checkArgument(fluid != null, "No fluid found with the name %s", name);
         return fluid;
     }

--- a/paper-api/src/main/java/org/bukkit/GameEvent.java
+++ b/paper-api/src/main/java/org/bukkit/GameEvent.java
@@ -1,8 +1,8 @@
 package org.bukkit;
 
-import com.google.common.collect.Lists;
 import java.util.Collection;
-import java.util.Collections;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -250,17 +250,17 @@ public abstract class GameEvent implements Keyed {
      * Returns the set of all GameEvents.
      *
      * @return the memoryKeys
-     * @deprecated use {@link Registry#iterator()}.
+     * @deprecated use {@link Registry#stream()}.
      */
     @NotNull
     @Deprecated(since = "1.20.1")
     public static Collection<GameEvent> values() {
-        return Collections.unmodifiableCollection(Lists.newArrayList(Registry.GAME_EVENT));
+        return Registry.GAME_EVENT.stream().toList();
     }
 
     @NotNull
-    private static GameEvent getEvent(@NotNull String key) {
-        return Registry.GAME_EVENT.getOrThrow(NamespacedKey.minecraft(key));
+    private static GameEvent getEvent(@NotNull @KeyPattern.Value String key) {
+        return Registry.GAME_EVENT.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
     // Paper start
     /**

--- a/paper-api/src/main/java/org/bukkit/GameRules.java
+++ b/paper-api/src/main/java/org/bukkit/GameRules.java
@@ -1,5 +1,6 @@
 package org.bukkit;
 
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
@@ -132,8 +133,9 @@ public final class GameRules {
     public static final GameRule<Boolean> WATER_SOURCE_CONVERSION = getRule("water_source_conversion");
     // End generate - GameRules
 
+    @SuppressWarnings("unchecked")
     private static <T> GameRule<T> getRule(@KeyPattern.Value String key) {
-        return (GameRule<T>) Registry.GAME_RULE.getOrThrow(NamespacedKey.minecraft(key));
+        return (GameRule<T>) Registry.GAME_RULE.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     private GameRules() {

--- a/paper-api/src/main/java/org/bukkit/JukeboxSong.java
+++ b/paper-api/src/main/java/org/bukkit/JukeboxSong.java
@@ -2,6 +2,8 @@ package org.bukkit;
 
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import net.kyori.adventure.text.Component;
 import org.jspecify.annotations.NullMarked;
 
@@ -55,8 +57,8 @@ public interface JukeboxSong extends Keyed, Translatable {
     JukeboxSong WARD = get("ward");
     // End generate - JukeboxSong
 
-    private static JukeboxSong get(String key) {
-        return RegistryAccess.registryAccess().getRegistry(RegistryKey.JUKEBOX_SONG).getOrThrow(NamespacedKey.minecraft(key));
+    private static JukeboxSong get(@KeyPattern.Value String key) {
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.JUKEBOX_SONG).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/MusicInstrument.java
+++ b/paper-api/src/main/java/org/bukkit/MusicInstrument.java
@@ -1,14 +1,14 @@
 package org.bukkit;
 
-import com.google.common.collect.Lists;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryBuilderFactory;
 import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.data.InlinedRegistryBuilderProvider;
 import io.papermc.paper.registry.data.InstrumentRegistryEntry;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.function.Consumer;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
@@ -46,8 +46,8 @@ public abstract class MusicInstrument implements Keyed, net.kyori.adventure.tran
     public static final MusicInstrument YEARN_GOAT_HORN = getInstrument("yearn_goat_horn");
     // End generate - MusicInstrument
 
-    private static MusicInstrument getInstrument(final String key) {
-        return RegistryAccess.registryAccess().getRegistry(RegistryKey.INSTRUMENT).getOrThrow(NamespacedKey.minecraft(key));
+    private static MusicInstrument getInstrument(final @KeyPattern.Value String key) {
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.INSTRUMENT).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     /**
@@ -60,7 +60,7 @@ public abstract class MusicInstrument implements Keyed, net.kyori.adventure.tran
     @Nullable
     @Deprecated(since = "1.20.1")
     public static MusicInstrument getByKey(final NamespacedKey namespacedKey) {
-        return Registry.INSTRUMENT.get(namespacedKey);
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.INSTRUMENT).get(namespacedKey);
     }
 
     /**
@@ -71,7 +71,7 @@ public abstract class MusicInstrument implements Keyed, net.kyori.adventure.tran
      */
     @Deprecated(since = "1.20.1")
     public static Collection<MusicInstrument> values() {
-        return Collections.unmodifiableCollection(Lists.newArrayList(Registry.INSTRUMENT));
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.INSTRUMENT).stream().toList();
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/Sound.java
+++ b/paper-api/src/main/java/org/bukkit/Sound.java
@@ -3713,9 +3713,14 @@ public interface Sound extends OldEnum<Sound>, Keyed, net.kyori.adventure.sound.
     @NotNull
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Sound valueOf(@NotNull String name) {
-        Sound sound = Bukkit.getUnsafe().get(RegistryKey.SOUND_EVENT, NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
-        if (sound != null) {
-            return sound;
+        final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+        Sound sound;
+
+        if (key != null) {
+            sound = Bukkit.getUnsafe().get(RegistryKey.SOUND_EVENT, key);
+            if (sound != null) {
+                return sound;
+            }
         }
 
         // Sound keys can have dots in them which where converted to _. Since converting

--- a/paper-api/src/main/java/org/bukkit/Sound.java
+++ b/paper-api/src/main/java/org/bukkit/Sound.java
@@ -1,9 +1,10 @@
 package org.bukkit;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import io.papermc.paper.registry.RegistryKey;
 import java.util.Locale;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.util.OldEnum;
 import org.jetbrains.annotations.NotNull;
 
@@ -3701,8 +3702,8 @@ public interface Sound extends OldEnum<Sound>, Keyed, net.kyori.adventure.sound.
     // End generate - Sound
 
     @NotNull
-    private static Sound getSound(@NotNull String key) {
-        return Registry.SOUNDS.getOrThrow(NamespacedKey.minecraft(key));
+    private static Sound getSound(@NotNull @KeyPattern.Value String key) {
+        return Registry.SOUNDS.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     /**
@@ -3747,12 +3748,12 @@ public interface Sound extends OldEnum<Sound>, Keyed, net.kyori.adventure.sound.
 
     /**
      * @return an array of all known sounds.
-     * @deprecated use {@link Registry#iterator()}.
+     * @deprecated use {@link Registry#stream()}.
      */
     @NotNull
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Sound[] values() {
-        return Lists.newArrayList(Registry.SOUNDS).toArray(new Sound[0]);
+        return Registry.SOUNDS.stream().toArray(Sound[]::new);
     }
 
     // Paper start

--- a/paper-api/src/main/java/org/bukkit/UnsafeValues.java
+++ b/paper-api/src/main/java/org/bukkit/UnsafeValues.java
@@ -7,7 +7,6 @@ import net.kyori.adventure.text.event.HoverEvent;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
-import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.damage.DamageType;
@@ -142,7 +141,7 @@ public interface UnsafeValues {
     String get(Class<?> aClass, String value);
 
     @ApiStatus.Internal
-    <B extends Keyed> B get(RegistryKey<B> registry, NamespacedKey key);
+    @Nullable <B extends Keyed> B get(RegistryKey<B> registry, NamespacedKey key);
 
     // Paper start
     @Deprecated(forRemoval = true)

--- a/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
+++ b/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
@@ -177,7 +177,9 @@ public interface Attribute extends OldEnum<Attribute>, Keyed, Translatable, net.
     @NotNull
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Attribute valueOf(@NotNull String name) {
-        Attribute attribute = Bukkit.getUnsafe().get(RegistryKey.ATTRIBUTE, NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+        final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+        Preconditions.checkArgument(key != null, "Invalid name %s", name);
+        Attribute attribute = Bukkit.getUnsafe().get(RegistryKey.ATTRIBUTE, key);
         Preconditions.checkArgument(attribute != null, "No attribute found with the name %s", name);
         return attribute;
     }

--- a/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
+++ b/paper-api/src/main/java/org/bukkit/attribute/Attribute.java
@@ -1,9 +1,10 @@
 package org.bukkit.attribute;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import io.papermc.paper.registry.RegistryKey;
 import java.util.Locale;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
@@ -159,8 +160,8 @@ public interface Attribute extends OldEnum<Attribute>, Keyed, Translatable, net.
     Attribute WAYPOINT_RECEIVE_RANGE = getAttribute("waypoint_receive_range");
 
     @NotNull
-    private static Attribute getAttribute(@NotNull String key) {
-        return Registry.ATTRIBUTE.getOrThrow(NamespacedKey.minecraft(key));
+    private static Attribute getAttribute(@NotNull @KeyPattern.Value String key) {
+        return Registry.ATTRIBUTE.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     /**
@@ -178,20 +179,19 @@ public interface Attribute extends OldEnum<Attribute>, Keyed, Translatable, net.
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Attribute valueOf(@NotNull String name) {
         final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
-        Preconditions.checkArgument(key != null, "Invalid name %s", name);
-        Attribute attribute = Bukkit.getUnsafe().get(RegistryKey.ATTRIBUTE, key);
+        Attribute attribute = key == null ? null : Bukkit.getUnsafe().get(RegistryKey.ATTRIBUTE, key);
         Preconditions.checkArgument(attribute != null, "No attribute found with the name %s", name);
         return attribute;
     }
 
     /**
      * @return an array of all known attributes.
-     * @deprecated use {@link Registry#iterator()}.
+     * @deprecated use {@link Registry#stream()}.
      */
     @NotNull
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Attribute[] values() {
-        return Lists.newArrayList(Registry.ATTRIBUTE).toArray(new Attribute[0]);
+        return Registry.ATTRIBUTE.stream().toArray(Attribute[]::new);
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/block/Biome.java
+++ b/paper-api/src/main/java/org/bukkit/block/Biome.java
@@ -1,11 +1,12 @@
 package org.bukkit.block;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import io.papermc.paper.InternalAPIBridge;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import java.util.Locale;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Bukkit;
 import org.bukkit.FeatureFlag;
 import org.bukkit.Keyed;
@@ -165,8 +166,8 @@ public interface Biome extends OldEnum<Biome>, Keyed, net.kyori.adventure.transl
     Biome CUSTOM = InternalAPIBridge.get().constructLegacyCustomBiome();
 
     @NotNull
-    private static Biome getBiome(@NotNull String key) {
-        return RegistryAccess.registryAccess().getRegistry(RegistryKey.BIOME).getOrThrow(NamespacedKey.minecraft(key));
+    private static Biome getBiome(@NotNull @KeyPattern.Value String key) {
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.BIOME).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     /**
@@ -182,20 +183,19 @@ public interface Biome extends OldEnum<Biome>, Keyed, net.kyori.adventure.transl
         }
 
         final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
-        Preconditions.checkArgument(key != null, "Invalid name %s", name);
-        Biome biome = Bukkit.getUnsafe().get(RegistryKey.BIOME, key);
+        Biome biome = key == null ? null : Bukkit.getUnsafe().get(RegistryKey.BIOME, key);
         Preconditions.checkArgument(biome != null, "No biome found with the name %s", name);
         return biome;
     }
 
     /**
      * @return an array of all known biomes.
-     * @deprecated use {@link Registry#iterator()}.
+     * @deprecated use {@link Registry#stream()}.
      */
     @NotNull
     @Deprecated(since = "1.21.3", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static Biome[] values() {
-        return Lists.newArrayList(Registry.BIOME).toArray(new Biome[0]);
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.BIOME).stream().toArray(Biome[]::new);
     }
 
     // Paper start

--- a/paper-api/src/main/java/org/bukkit/block/Biome.java
+++ b/paper-api/src/main/java/org/bukkit/block/Biome.java
@@ -181,7 +181,9 @@ public interface Biome extends OldEnum<Biome>, Keyed, net.kyori.adventure.transl
             return Biome.CUSTOM;
         }
 
-        Biome biome = Bukkit.getUnsafe().get(RegistryKey.BIOME, NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+        final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+        Preconditions.checkArgument(key != null, "Invalid name %s", name);
+        Biome biome = Bukkit.getUnsafe().get(RegistryKey.BIOME, key);
         Preconditions.checkArgument(biome != null, "No biome found with the name %s", name);
         return biome;
     }

--- a/paper-api/src/main/java/org/bukkit/block/banner/PatternType.java
+++ b/paper-api/src/main/java/org/bukkit/block/banner/PatternType.java
@@ -174,7 +174,9 @@ public interface PatternType extends OldEnum<PatternType>, Keyed {
     @NotNull
     @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static PatternType valueOf(@NotNull String name) {
-        PatternType type = Registry.BANNER_PATTERN.get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+        final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+        Preconditions.checkArgument(key != null, "Invalid name %s", name);
+        PatternType type = Registry.BANNER_PATTERN.get(key);
         Preconditions.checkArgument(type != null, "No pattern type found with the name %s", name);
         return type;
     }

--- a/paper-api/src/main/java/org/bukkit/block/banner/PatternType.java
+++ b/paper-api/src/main/java/org/bukkit/block/banner/PatternType.java
@@ -1,10 +1,11 @@
 package org.bukkit.block.banner;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import java.util.Locale;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -152,7 +153,7 @@ public interface PatternType extends OldEnum<PatternType>, Keyed {
             return null;
         }
 
-        for (PatternType type : Registry.BANNER_PATTERN) {
+        for (PatternType type : RegistryAccess.registryAccess().getRegistry(RegistryKey.BANNER_PATTERN)) {
             if (identifier.equals(type.getIdentifier())) {
                 return type;
             }
@@ -162,8 +163,8 @@ public interface PatternType extends OldEnum<PatternType>, Keyed {
     }
 
     @NotNull
-    private static PatternType getType(@NotNull String key) {
-        return RegistryAccess.registryAccess().getRegistry(RegistryKey.BANNER_PATTERN).getOrThrow(NamespacedKey.minecraft(key));
+    private static PatternType getType(@NotNull @KeyPattern.Value String key) {
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.BANNER_PATTERN).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     /**
@@ -175,19 +176,18 @@ public interface PatternType extends OldEnum<PatternType>, Keyed {
     @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static PatternType valueOf(@NotNull String name) {
         final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
-        Preconditions.checkArgument(key != null, "Invalid name %s", name);
-        PatternType type = Registry.BANNER_PATTERN.get(key);
+        PatternType type = key == null ? null : RegistryAccess.registryAccess().getRegistry(RegistryKey.BANNER_PATTERN).get(key);
         Preconditions.checkArgument(type != null, "No pattern type found with the name %s", name);
         return type;
     }
 
     /**
      * @return an array of all known pattern types.
-     * @deprecated use {@link Registry#iterator()}.
+     * @deprecated use {@link Registry#stream()}.
      */
     @NotNull
     @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
     static PatternType[] values() {
-        return Lists.newArrayList(Registry.BANNER_PATTERN).toArray(new PatternType[0]);
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.BANNER_PATTERN).stream().toArray(PatternType[]::new);
     }
 }

--- a/paper-api/src/main/java/org/bukkit/damage/DamageType.java
+++ b/paper-api/src/main/java/org/bukkit/damage/DamageType.java
@@ -2,8 +2,9 @@ package org.bukkit.damage;
 
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
-import org.bukkit.NamespacedKey;
 import org.bukkit.Translatable;
 import org.jetbrains.annotations.NotNull;
 
@@ -121,8 +122,8 @@ public interface DamageType extends Keyed, Translatable {
     // End generate - DamageType
 
     @NotNull
-    private static DamageType getDamageType(@NotNull String key) {
-        return RegistryAccess.registryAccess().getRegistry(RegistryKey.DAMAGE_TYPE).getOrThrow(NamespacedKey.minecraft(key));
+    private static DamageType getDamageType(@NotNull @KeyPattern.Value String key) {
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.DAMAGE_TYPE).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/enchantments/Enchantment.java
+++ b/paper-api/src/main/java/org/bukkit/enchantments/Enchantment.java
@@ -1,9 +1,10 @@
 package org.bukkit.enchantments;
 
-import com.google.common.collect.Lists;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import java.util.Locale;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -235,8 +236,8 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
     public static final Enchantment LUNGE = getEnchantment("lunge");
 
     @NotNull
-    private static Enchantment getEnchantment(@NotNull String key) {
-        return RegistryAccess.registryAccess().getRegistry(RegistryKey.ENCHANTMENT).getOrThrow(NamespacedKey.minecraft(key));
+    private static Enchantment getEnchantment(@NotNull @KeyPattern.Value String key) {
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.ENCHANTMENT).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     /**
@@ -513,7 +514,7 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
         if (key == null) {
             return null;
         }
-        return Registry.ENCHANTMENT.get(key);
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.ENCHANTMENT).get(key);
     }
 
     /**
@@ -543,6 +544,6 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
     @NotNull
     @Deprecated(since = "1.20.3")
     public static Enchantment[] values() {
-        return Lists.newArrayList(Registry.ENCHANTMENT).toArray(new Enchantment[0]);
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.ENCHANTMENT).stream().toArray(Enchantment[]::new);
     }
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Cat.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Cat.java
@@ -1,10 +1,11 @@
 package org.bukkit.entity;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import java.util.Locale;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import java.util.Locale;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.DyeColor;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
@@ -79,8 +80,8 @@ public interface Cat extends Tameable, Sittable, io.papermc.paper.entity.CollarC
         // End generate - CatType
 
         @NotNull
-        private static Type getType(@NotNull String key) {
-            return RegistryAccess.registryAccess().getRegistry(RegistryKey.CAT_VARIANT).getOrThrow(NamespacedKey.minecraft(key));
+        private static Type getType(@NotNull @KeyPattern.Value String key) {
+            return RegistryAccess.registryAccess().getRegistry(RegistryKey.CAT_VARIANT).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         }
 
         /**
@@ -92,20 +93,19 @@ public interface Cat extends Tameable, Sittable, io.papermc.paper.entity.CollarC
         @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Type valueOf(@NotNull String name) {
             final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
-            Preconditions.checkArgument(key != null, "Invalid name %s", name);
-            Type type = RegistryAccess.registryAccess().getRegistry(RegistryKey.CAT_VARIANT).get(key);
+            Type type = key == null ? null : RegistryAccess.registryAccess().getRegistry(RegistryKey.CAT_VARIANT).get(key);
             Preconditions.checkArgument(type != null, "No cat type found with the name %s", name);
             return type;
         }
 
         /**
          * @return an array of all known cat types.
-         * @deprecated use {@link Registry#iterator()}.
+         * @deprecated use {@link Registry#stream()}.
          */
         @NotNull
         @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Type[] values() {
-            return Lists.newArrayList(RegistryAccess.registryAccess().getRegistry(RegistryKey.CAT_VARIANT)).toArray(new Type[0]);
+            return RegistryAccess.registryAccess().getRegistry(RegistryKey.CAT_VARIANT).stream().toArray(Type[]::new);
         }
     }
 

--- a/paper-api/src/main/java/org/bukkit/entity/Cat.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Cat.java
@@ -91,7 +91,9 @@ public interface Cat extends Tameable, Sittable, io.papermc.paper.entity.CollarC
         @NotNull
         @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Type valueOf(@NotNull String name) {
-            Type type = RegistryAccess.registryAccess().getRegistry(RegistryKey.CAT_VARIANT).get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+            final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+            Preconditions.checkArgument(key != null, "Invalid name %s", name);
+            Type type = RegistryAccess.registryAccess().getRegistry(RegistryKey.CAT_VARIANT).get(key);
             Preconditions.checkArgument(type != null, "No cat type found with the name %s", name);
             return type;
         }

--- a/paper-api/src/main/java/org/bukkit/entity/Chicken.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Chicken.java
@@ -2,8 +2,9 @@ package org.bukkit.entity;
 
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -67,8 +68,8 @@ public interface Chicken extends Animals {
         Variant WARM = getVariant("warm");
         // End generate - ChickenVariant
 
-        private static Variant getVariant(String key) {
-            return RegistryAccess.registryAccess().getRegistry(RegistryKey.CHICKEN_VARIANT).getOrThrow(NamespacedKey.minecraft(key));
+        private static Variant getVariant(@KeyPattern.Value String key) {
+            return RegistryAccess.registryAccess().getRegistry(RegistryKey.CHICKEN_VARIANT).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         }
     }
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Cow.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Cow.java
@@ -2,8 +2,9 @@ package org.bukkit.entity;
 
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -39,8 +40,8 @@ public interface Cow extends AbstractCow {
         Variant WARM = getVariant("warm");
         // End generate - CowVariant
 
-        private static Variant getVariant(String key) {
-            return RegistryAccess.registryAccess().getRegistry(RegistryKey.COW_VARIANT).getOrThrow(NamespacedKey.minecraft(key));
+        private static Variant getVariant(@KeyPattern.Value String key) {
+            return RegistryAccess.registryAccess().getRegistry(RegistryKey.COW_VARIANT).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         }
     }
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Frog.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Frog.java
@@ -73,7 +73,9 @@ public interface Frog extends Animals {
         @NotNull
         @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Variant valueOf(@NotNull String name) {
-            Variant variant = RegistryAccess.registryAccess().getRegistry(RegistryKey.FROG_VARIANT).get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+            final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+            Preconditions.checkArgument(key != null, "Invalid name %s", name);
+            Variant variant = RegistryAccess.registryAccess().getRegistry(RegistryKey.FROG_VARIANT).get(key);
             Preconditions.checkArgument(variant != null, "No frog variant found with the name %s", name);
             return variant;
         }

--- a/paper-api/src/main/java/org/bukkit/entity/Frog.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Frog.java
@@ -1,10 +1,11 @@
 package org.bukkit.entity;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import java.util.Locale;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import java.util.Locale;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -61,8 +62,8 @@ public interface Frog extends Animals {
         // End generate - FrogVariant
 
         @NotNull
-        private static Variant getVariant(@NotNull String key) {
-            return RegistryAccess.registryAccess().getRegistry(RegistryKey.FROG_VARIANT).getOrThrow(NamespacedKey.minecraft(key));
+        private static Variant getVariant(@NotNull @KeyPattern.Value String key) {
+            return RegistryAccess.registryAccess().getRegistry(RegistryKey.FROG_VARIANT).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         }
 
         /**
@@ -74,20 +75,19 @@ public interface Frog extends Animals {
         @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Variant valueOf(@NotNull String name) {
             final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
-            Preconditions.checkArgument(key != null, "Invalid name %s", name);
-            Variant variant = RegistryAccess.registryAccess().getRegistry(RegistryKey.FROG_VARIANT).get(key);
+            Variant variant = key == null ? null : RegistryAccess.registryAccess().getRegistry(RegistryKey.FROG_VARIANT).get(key);
             Preconditions.checkArgument(variant != null, "No frog variant found with the name %s", name);
             return variant;
         }
 
         /**
          * @return an array of all known frog variants.
-         * @deprecated use {@link Registry#iterator()}.
+         * @deprecated use {@link Registry#stream()}.
          */
         @NotNull
         @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Variant[] values() {
-            return Lists.newArrayList(RegistryAccess.registryAccess().getRegistry(RegistryKey.FROG_VARIANT)).toArray(new Variant[0]);
+            return RegistryAccess.registryAccess().getRegistry(RegistryKey.FROG_VARIANT).stream().toArray(Variant[]::new);
         }
     }
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Pig.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Pig.java
@@ -2,8 +2,9 @@ package org.bukkit.entity;
 
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -39,8 +40,8 @@ public interface Pig extends Steerable, Vehicle {
         Variant WARM = getVariant("warm");
         // End generate - PigVariant
 
-        private static Variant getVariant(String key) {
-            return RegistryAccess.registryAccess().getRegistry(RegistryKey.PIG_VARIANT).getOrThrow(NamespacedKey.minecraft(key));
+        private static Variant getVariant(@KeyPattern.Value String key) {
+            return RegistryAccess.registryAccess().getRegistry(RegistryKey.PIG_VARIANT).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         }
     }
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Villager.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Villager.java
@@ -200,7 +200,9 @@ public interface Villager extends AbstractVillager {
         @NotNull
         @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Type valueOf(@NotNull String name) {
-            Type type = Registry.VILLAGER_TYPE.get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+            final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+            Preconditions.checkArgument(key != null, "Invalid name %s", name);
+            Type type = Registry.VILLAGER_TYPE.get(key);
             Preconditions.checkArgument(type != null, "No villager type found with the name %s", name);
             return type;
         }
@@ -323,7 +325,9 @@ public interface Villager extends AbstractVillager {
         @NotNull
         @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Profession valueOf(@NotNull String name) {
-            Profession profession = Registry.VILLAGER_PROFESSION.get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+            final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+            Preconditions.checkArgument(key != null, "Invalid name %s", name);
+            Profession profession = Registry.VILLAGER_PROFESSION.get(key);
             Preconditions.checkArgument(profession != null, "No villager profession found with the name %s", name);
             return profession;
         }

--- a/paper-api/src/main/java/org/bukkit/entity/Villager.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Villager.java
@@ -1,10 +1,11 @@
 package org.bukkit.entity;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import java.util.Locale;
 import java.util.Map; // Paper
 import java.util.UUID; // Paper
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -188,8 +189,8 @@ public interface Villager extends AbstractVillager {
         // End generate - VillagerType
 
         @NotNull
-        private static Type getType(@NotNull String key) {
-            return Registry.VILLAGER_TYPE.getOrThrow(NamespacedKey.minecraft(key));
+        private static Type getType(@NotNull @KeyPattern.Value String key) {
+            return Registry.VILLAGER_TYPE.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         }
 
         /**
@@ -201,20 +202,19 @@ public interface Villager extends AbstractVillager {
         @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Type valueOf(@NotNull String name) {
             final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
-            Preconditions.checkArgument(key != null, "Invalid name %s", name);
-            Type type = Registry.VILLAGER_TYPE.get(key);
+            Type type = key == null ? null : Registry.VILLAGER_TYPE.get(key);
             Preconditions.checkArgument(type != null, "No villager type found with the name %s", name);
             return type;
         }
 
         /**
          * @return an array of all known villager types.
-         * @deprecated use {@link Registry#iterator()}.
+         * @deprecated use {@link Registry#stream()}.
          */
         @NotNull
         @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Type[] values() {
-            return Lists.newArrayList(Registry.VILLAGER_TYPE).toArray(new Type[0]);
+            return Registry.VILLAGER_TYPE.stream().toArray(Type[]::new);
         }
     }
 
@@ -313,8 +313,8 @@ public interface Villager extends AbstractVillager {
         // End generate - VillagerProfession
 
         @NotNull
-        private static Profession getProfession(@NotNull String key) {
-            return Registry.VILLAGER_PROFESSION.getOrThrow(NamespacedKey.minecraft(key));
+        private static Profession getProfession(@NotNull @KeyPattern.Value String key) {
+            return Registry.VILLAGER_PROFESSION.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         }
 
         /**
@@ -326,20 +326,19 @@ public interface Villager extends AbstractVillager {
         @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Profession valueOf(@NotNull String name) {
             final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
-            Preconditions.checkArgument(key != null, "Invalid name %s", name);
-            Profession profession = Registry.VILLAGER_PROFESSION.get(key);
+            Profession profession = key == null ? null : Registry.VILLAGER_PROFESSION.get(key);
             Preconditions.checkArgument(profession != null, "No villager profession found with the name %s", name);
             return profession;
         }
 
         /**
          * @return an array of all known villager professions.
-         * @deprecated use {@link Registry#iterator()}.
+         * @deprecated use {@link Registry#stream()}.
          */
         @NotNull
         @Deprecated(since = "1.21", forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Profession[] values() {
-            return Lists.newArrayList(Registry.VILLAGER_PROFESSION).toArray(new Profession[0]);
+            return Registry.VILLAGER_PROFESSION.stream().toArray(Profession[]::new);
         }
 
         // Paper start

--- a/paper-api/src/main/java/org/bukkit/entity/Wolf.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Wolf.java
@@ -2,9 +2,10 @@ package org.bukkit.entity;
 
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.DyeColor;
 import org.bukkit.Keyed;
-import org.bukkit.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -131,8 +132,8 @@ public interface Wolf extends Tameable, Sittable, io.papermc.paper.entity.Collar
         // End generate - WolfVariant
 
         @NotNull
-        private static Variant getVariant(@NotNull String key) {
-            return RegistryAccess.registryAccess().getRegistry(RegistryKey.WOLF_VARIANT).getOrThrow(NamespacedKey.minecraft(key));
+        private static Variant getVariant(@NotNull @KeyPattern.Value String key) {
+            return RegistryAccess.registryAccess().getRegistry(RegistryKey.WOLF_VARIANT).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         }
     }
 
@@ -158,8 +159,8 @@ public interface Wolf extends Tameable, Sittable, io.papermc.paper.entity.Collar
         // End generate - WolfSoundVariant
 
         @NotNull
-        private static SoundVariant getSoundVariant(@NotNull String key) {
-            return RegistryAccess.registryAccess().getRegistry(RegistryKey.WOLF_SOUND_VARIANT).getOrThrow(NamespacedKey.minecraft(key));
+        private static SoundVariant getSoundVariant(@NotNull @KeyPattern.Value String key) {
+            return RegistryAccess.registryAccess().getRegistry(RegistryKey.WOLF_SOUND_VARIANT).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         }
     }
 }

--- a/paper-api/src/main/java/org/bukkit/entity/ZombieNautilus.java
+++ b/paper-api/src/main/java/org/bukkit/entity/ZombieNautilus.java
@@ -2,8 +2,9 @@ package org.bukkit.entity;
 
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -34,8 +35,8 @@ public interface ZombieNautilus extends AbstractNautilus {
         Variant WARM = getVariant("warm");
         // End generate - ZombieNautilusVariant
 
-        private static Variant getVariant(String key) {
-            return RegistryAccess.registryAccess().getRegistry(RegistryKey.ZOMBIE_NAUTILUS_VARIANT).getOrThrow(NamespacedKey.minecraft(key));
+        private static Variant getVariant(@KeyPattern.Value String key) {
+            return RegistryAccess.registryAccess().getRegistry(RegistryKey.ZOMBIE_NAUTILUS_VARIANT).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         }
     }
 }

--- a/paper-api/src/main/java/org/bukkit/generator/structure/Structure.java
+++ b/paper-api/src/main/java/org/bukkit/generator/structure/Structure.java
@@ -2,6 +2,8 @@ package org.bukkit.generator.structure;
 
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -9,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Represent a Structure from the world.
- *
+ * <p>
  * Listed structures are present in the default server. Depending on the server
  * there might be additional structures present (for example structures added by
  * data packs), which can be received via {@link io.papermc.paper.registry.RegistryAccess#getRegistry(io.papermc.paper.registry.RegistryKey)} and {@link io.papermc.paper.registry.RegistryKey#STRUCTURE}.
@@ -87,8 +89,8 @@ public abstract class Structure implements Keyed {
     // End generate - Structure
 
     @NotNull
-    private static Structure getStructure(@NotNull String name) {
-        return RegistryAccess.registryAccess().getRegistry(RegistryKey.STRUCTURE).getOrThrow(NamespacedKey.minecraft(name));
+    private static Structure getStructure(@NotNull @KeyPattern.Value String key) {
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.STRUCTURE).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/generator/structure/StructureType.java
+++ b/paper-api/src/main/java/org/bukkit/generator/structure/StructureType.java
@@ -1,13 +1,14 @@
 package org.bukkit.generator.structure;
 
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
-import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Represent a StructureType of a {@link Structure}.
- *
+ * <p>
  * Listed structure types are present in the default server. Depending on the
  * server there might be additional structure types present (for example
  * structure types added by data packs), which can be received via
@@ -50,7 +51,7 @@ public abstract class StructureType implements Keyed {
     // End generate - StructureType
 
     @NotNull
-    private static StructureType getStructureType(@NotNull String name) {
-        return Registry.STRUCTURE_TYPE.getOrThrow(NamespacedKey.minecraft(name));
+    private static StructureType getStructureType(@NotNull @KeyPattern.Value String key) {
+        return Registry.STRUCTURE_TYPE.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 }

--- a/paper-api/src/main/java/org/bukkit/inventory/MenuType.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/MenuType.java
@@ -1,8 +1,9 @@
 package org.bukkit.inventory;
 
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Keyed;
-import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.inventory.view.AnvilView;
@@ -234,7 +235,8 @@ public interface MenuType extends Keyed, io.papermc.paper.world.flag.FeatureDepe
      */
     Class<? extends InventoryView> getInventoryViewClass();
 
-    private static <T extends MenuType> T get(final String key) {
-        return (T) Registry.MENU.getOrThrow(NamespacedKey.minecraft(key));
+    @SuppressWarnings("unchecked")
+    private static <T extends MenuType> T get(final @KeyPattern.Value String key) {
+        return (T) Registry.MENU.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 }

--- a/paper-api/src/main/java/org/bukkit/inventory/meta/trim/TrimMaterial.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/meta/trim/TrimMaterial.java
@@ -2,9 +2,9 @@ package org.bukkit.inventory.meta.trim;
 
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
-import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.Translatable;
 import org.jetbrains.annotations.NotNull;
@@ -39,8 +39,8 @@ public interface TrimMaterial extends Keyed, Translatable {
     // End generate - TrimMaterial
 
     @NotNull
-    private static TrimMaterial getTrimMaterial(@NotNull String key) {
-        return RegistryAccess.registryAccess().getRegistry(RegistryKey.TRIM_MATERIAL).getOrThrow(NamespacedKey.minecraft(key));
+    private static TrimMaterial getTrimMaterial(@NotNull @KeyPattern.Value String key) {
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.TRIM_MATERIAL).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     // Paper start - adventure

--- a/paper-api/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
@@ -2,9 +2,9 @@ package org.bukkit.inventory.meta.trim;
 
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
-import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.Translatable;
 import org.jetbrains.annotations.NotNull;
@@ -53,8 +53,8 @@ public interface TrimPattern extends Keyed, Translatable {
     // End generate - TrimPattern
 
     @NotNull
-    private static TrimPattern getTrimPattern(@NotNull String key) {
-        return RegistryAccess.registryAccess().getRegistry(RegistryKey.TRIM_PATTERN).getOrThrow(NamespacedKey.minecraft(key));
+    private static TrimPattern getTrimPattern(@NotNull @KeyPattern.Value String key) {
+        return RegistryAccess.registryAccess().getRegistry(RegistryKey.TRIM_PATTERN).getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
     }
 
     // Paper start - adventure

--- a/paper-api/src/main/java/org/bukkit/map/MapCursor.java
+++ b/paper-api/src/main/java/org/bukkit/map/MapCursor.java
@@ -398,7 +398,9 @@ public final class MapCursor {
         @NotNull
         @Deprecated(since = "1.21", forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Type valueOf(@NotNull String name) {
-            Type type = Registry.MAP_DECORATION_TYPE.get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+            final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+            Preconditions.checkArgument(key != null, "Invalid name %s", name);
+            Type type = Registry.MAP_DECORATION_TYPE.get(key);
             Preconditions.checkArgument(type != null, "No Type found with the name %s", name);
             return type;
         }

--- a/paper-api/src/main/java/org/bukkit/map/MapCursor.java
+++ b/paper-api/src/main/java/org/bukkit/map/MapCursor.java
@@ -1,8 +1,9 @@
 package org.bukkit.map;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import java.util.Locale;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -361,8 +362,8 @@ public final class MapCursor {
         // End generate - MapCursorType
 
         @NotNull
-        private static Type getType(@NotNull String key) {
-            return Registry.MAP_DECORATION_TYPE.getOrThrow(NamespacedKey.minecraft(key));
+        private static Type getType(@NotNull @KeyPattern.Value String key) {
+            return Registry.MAP_DECORATION_TYPE.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
         }
 
         /**
@@ -399,20 +400,19 @@ public final class MapCursor {
         @Deprecated(since = "1.21", forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Type valueOf(@NotNull String name) {
             final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
-            Preconditions.checkArgument(key != null, "Invalid name %s", name);
-            Type type = Registry.MAP_DECORATION_TYPE.get(key);
+            Type type = key == null ? null : Registry.MAP_DECORATION_TYPE.get(key);
             Preconditions.checkArgument(type != null, "No Type found with the name %s", name);
             return type;
         }
 
         /**
          * @return an array of all known map cursor types.
-         * @deprecated use {@link Registry#iterator()}.
+         * @deprecated use {@link Registry#stream()}.
          */
         @NotNull
         @Deprecated(since = "1.21", forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.22") // Paper - will be removed via asm-utils
         static Type[] values() {
-            return Lists.newArrayList(Registry.MAP_DECORATION_TYPE).toArray(new Type[0]);
+            return Registry.MAP_DECORATION_TYPE.stream().toArray(Type[]::new);
         }
     }
 

--- a/paper-api/src/main/java/org/bukkit/potion/PotionEffectType.java
+++ b/paper-api/src/main/java/org/bukkit/potion/PotionEffectType.java
@@ -3,8 +3,9 @@ package org.bukkit.potion;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import com.google.common.collect.Lists;
 import java.util.Locale;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Color;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
@@ -226,8 +227,8 @@ public abstract class PotionEffectType implements Keyed, Translatable, net.kyori
     public static final PotionEffectType BREATH_OF_THE_NAUTILUS = getPotionEffectType(40, "breath_of_the_nautilus");
 
     @NotNull
-    private static PotionEffectType getPotionEffectType(int typeId, @NotNull String key) {
-        PotionEffectType potionEffectType = Registry.EFFECT.getOrThrow(NamespacedKey.minecraft(key));
+    private static PotionEffectType getPotionEffectType(int typeId, @NotNull @KeyPattern.Value String key) {
+        PotionEffectType potionEffectType = Registry.MOB_EFFECT.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));
 
         if (typeId > 0) {
             ID_MAP.put(typeId, potionEffectType);
@@ -242,7 +243,6 @@ public abstract class PotionEffectType implements Keyed, Translatable, net.kyori
      * @param duration time in ticks
      * @param amplifier the effect's amplifier
      * @return a resulting potion effect
-     * @see PotionBrewer#createEffect(PotionEffectType, int, int)
      */
     @NotNull
     public abstract PotionEffect createEffect(int duration, int amplifier);
@@ -313,7 +313,7 @@ public abstract class PotionEffectType implements Keyed, Translatable, net.kyori
             return null;
         }
 
-        return Registry.EFFECT.get(key);
+        return Registry.MOB_EFFECT.get(key);
     }
 
     /**
@@ -332,7 +332,7 @@ public abstract class PotionEffectType implements Keyed, Translatable, net.kyori
             return type;
         }
 
-        for (PotionEffectType other : Registry.EFFECT) {
+        for (PotionEffectType other : Registry.MOB_EFFECT) {
             if (other.getId() == id) {
                 ID_MAP.put(id, other);
                 return other;
@@ -353,17 +353,21 @@ public abstract class PotionEffectType implements Keyed, Translatable, net.kyori
     @Deprecated(since = "1.20.3")
     public static PotionEffectType getByName(@NotNull String name) {
         Preconditions.checkArgument(name != null, "name cannot be null");
-        return Registry.EFFECT.get(NamespacedKey.fromString(name.toLowerCase(Locale.ROOT)));
+        final NamespacedKey key = NamespacedKey.fromString(name.toLowerCase(Locale.ROOT));
+        if (key == null) {
+            return null;
+        }
+        return Registry.MOB_EFFECT.get(key);
     }
 
     /**
      * @return an array of all known PotionEffectTypes.
-     * @deprecated use {@link Registry#iterator()}.
+     * @deprecated use {@link Registry#stream()}.
      */
     @NotNull
     @Deprecated(since = "1.20.3")
     public static PotionEffectType[] values() {
-        return Lists.newArrayList(Registry.EFFECT).toArray(new PotionEffectType[0]);
+        return Registry.MOB_EFFECT.stream().toArray(PotionEffectType[]::new);
     }
 
     // Paper start

--- a/paper-server/src/main/java/io/papermc/paper/registry/set/NamedRegistryKeySetImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/set/NamedRegistryKeySetImpl.java
@@ -2,6 +2,7 @@ package io.papermc.paper.registry.set;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import io.papermc.paper.adventure.PaperAdventure;
 import io.papermc.paper.registry.PaperRegistries;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
@@ -53,7 +54,7 @@ public record NamedRegistryKeySetImpl<T extends Keyed, M>( // TODO remove Keyed
     public @Unmodifiable Collection<T> resolve(final Registry<T> registry) {
         final ImmutableList.Builder<T> builder = ImmutableList.builder();
         for (final Holder<M> holder : this.namedSet) {
-            builder.add(registry.getOrThrow(CraftNamespacedKey.fromMinecraft(((Holder.Reference<?>) holder).key().identifier())));
+            builder.add(registry.getOrThrow(PaperAdventure.asAdventure(((Holder.Reference<?>) holder).key().identifier())));
         }
         return builder.build();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
@@ -14,7 +14,7 @@ import com.mojang.serialization.Dynamic;
 import com.mojang.serialization.JavaOps;
 import com.mojang.serialization.JsonOps;
 import io.papermc.paper.adventure.AdventureCodecs;
-import io.papermc.paper.adventure.PaperAdventure;
+import io.papermc.paper.entity.EntitySerializationFlag;
 import io.papermc.paper.registry.RegistryKey;
 import java.io.File;
 import java.io.IOException;
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Stream;
-import io.papermc.paper.entity.EntitySerializationFlag;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.minecraft.SharedConstants;
 import net.minecraft.advancements.AdvancementHolder;
@@ -61,7 +60,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.Registry;
 import org.bukkit.UnsafeValues;
 import org.bukkit.World;
 import org.bukkit.advancement.Advancement;
@@ -824,7 +822,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
 
     @Override
     public void setBiomeKey(org.bukkit.RegionAccessor accessor, int x, int y, int z, org.bukkit.NamespacedKey biomeKey) {
-        accessor.setBiome(x, y, z, org.bukkit.Registry.BIOME.getOrThrow(biomeKey));
+        accessor.setBiome(x, y, z, io.papermc.paper.registry.RegistryAccess.registryAccess().getRegistry(RegistryKey.BIOME).getOrThrow(biomeKey));
     }
 
     @Override

--- a/paper-server/src/test/java/io/papermc/paper/item/ItemStackDataComponentTest.java
+++ b/paper-server/src/test/java/io/papermc/paper/item/ItemStackDataComponentTest.java
@@ -17,10 +17,9 @@ import io.papermc.paper.datacomponent.item.MapItemColor;
 import io.papermc.paper.datacomponent.item.PotDecorations;
 import io.papermc.paper.datacomponent.item.Tool;
 import io.papermc.paper.datacomponent.item.TooltipDisplay;
-import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.keys.tags.BlockTypeTagKeys;
 import io.papermc.paper.registry.set.RegistrySet;
-import io.papermc.paper.registry.tag.TagKey;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -226,7 +225,7 @@ class ItemStackDataComponentTest {
                     TriState.TRUE
                 ),
                 Tool.rule(
-                    RegistryAccess.registryAccess().getRegistry(RegistryKey.BLOCK).getTag(TagKey.create(RegistryKey.BLOCK, NamespacedKey.minecraft("bamboo_blocks"))),
+                    Registry.BLOCK.getTag(BlockTypeTagKeys.create(Key.key(Key.MINECRAFT_NAMESPACE, "bamboo_blocks"))),
                     2F,
                     TriState.TRUE
                 )

--- a/paper-server/src/test/java/io/papermc/paper/item/ItemStackDataComponentTest.java
+++ b/paper-server/src/test/java/io/papermc/paper/item/ItemStackDataComponentTest.java
@@ -225,7 +225,7 @@ class ItemStackDataComponentTest {
                     TriState.TRUE
                 ),
                 Tool.rule(
-                    Registry.BLOCK.getTag(BlockTypeTagKeys.create(Key.key(Key.MINECRAFT_NAMESPACE, "bamboo_blocks"))),
+                    Registry.BLOCK.getTag(BlockTypeTagKeys.BAMBOO_BLOCKS),
                     2F,
                     TriState.TRUE
                 )


### PR DESCRIPTION
This PR fix https://github.com/PaperMC/Paper/issues/13594 where the OldEnum#valueOf (its a reference i know its not like that) can take invalid name like "@" and throw a NPE in the Registry class because the NamespaceKey generated before is null for the invalid characters, the change its just check the NamespaceKey and throw an issue, the only exception its the Sound where another check is made later then just avoid check Registry if the key was invalid