### PR TITLE
Handle missing mcVersion gradle property safely

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ subprojects {
 tasks.register("printMinecraftVersion") {
     val mcVersion = providers.gradleProperty("mcVersion")
     doLast {
-        println(mcVersion.get().trim())
+        mcVersion.orNull?.let { println(it.trim()) }
     }
 }
 


### PR DESCRIPTION
Avoid crash when mcVersion property is missing
