### PR TITLE
Implement deprecated getItemStack method in ItemTypeRecipeChoice

### DIFF
--- a/paper-api/src/main/java/org/bukkit/inventory/EmptyRecipeChoice.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/EmptyRecipeChoice.java
@@ -9,6 +9,7 @@ record EmptyRecipeChoice() implements RecipeChoice {
 
     static final RecipeChoice INSTANCE = new EmptyRecipeChoice();
     @Override
+    @Deprecated(since = "1.13.1")
     public ItemStack getItemStack() {
         throw new UnsupportedOperationException("This is an empty RecipeChoice");
     }

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemTypeRecipeChoiceImpl.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemTypeRecipeChoiceImpl.java
@@ -1,7 +1,6 @@
 package org.bukkit.inventory;
 
 import com.google.common.base.Preconditions;
-import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import io.papermc.paper.registry.keys.ItemTypeKeys;
@@ -34,7 +33,7 @@ final class ItemTypeRecipeChoiceImpl extends RecipeChoice.MaterialChoice impleme
     @Override
     @Deprecated(since = "1.13.1")
     public ItemStack getItemStack() {
-        final ItemType type = RegistryAccess.registryAccess().getRegistry(RegistryKey.ITEM).getOrThrow(this.itemTypes.iterator().next());
+        final ItemType type = Registry.ITEM.getOrThrow(this.itemTypes.iterator().next());
         final ItemStack item = type.createItemStack();
 
         // legacy compat

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemTypeRecipeChoiceImpl.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemTypeRecipeChoiceImpl.java
@@ -1,6 +1,7 @@
 package org.bukkit.inventory;
 
 import com.google.common.base.Preconditions;
+import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.TypedKey;
 import io.papermc.paper.registry.keys.ItemTypeKeys;
@@ -31,8 +32,17 @@ final class ItemTypeRecipeChoiceImpl extends RecipeChoice.MaterialChoice impleme
     }
 
     @Override
+    @Deprecated(since = "1.13.1")
     public ItemStack getItemStack() {
-        throw new UnsupportedOperationException("ItemTypeChoice does not support this");
+        final ItemType type = RegistryAccess.registryAccess().getRegistry(RegistryKey.ITEM).getOrThrow(this.itemTypes.iterator().next());
+        final ItemStack item = type.createItemStack();
+
+        // legacy compat
+        if (this.itemTypes.size() > 1) {
+            item.setDurability(Short.MAX_VALUE);
+        }
+
+        return item;
     }
 
     @Override

--- a/paper-api/src/main/java/org/bukkit/inventory/RecipeChoice.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/RecipeChoice.java
@@ -152,6 +152,7 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
         }
 
         @Override
+        @Deprecated(since = "1.13.1")
         public ItemStack getItemStack() {
             ItemStack stack = new ItemStack(choices.get(0));
 
@@ -247,6 +248,7 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
         }
 
         @Override
+        @Deprecated(since = "1.13.1")
         public ItemStack getItemStack() {
             return choices.get(0).clone();
         }


### PR DESCRIPTION
Fixes plugins that still rely on the deprecated RecipeChoice#getItemStack or one of the deprecated methods that use it. Adds extra deprecations where needed to prevent the warning from being hidden.