### PR TITLE
Fix insomniaStartTicks option being ignored for phantom spawning

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -5,7 +5,7 @@
          if (spawnEnemies) {
              if (level.getGameRules().get(GameRules.SPAWN_PHANTOMS)) {
 +                // Paper start - Ability to control player's insomnia and phantoms
-+                if (level.paperConfig().entities.behavior.phantomsSpawnAttemptMaxSeconds <= 0) {
++                if (level.paperConfig().entities.behavior.phantomsSpawnAttemptMaxSeconds <= 0 || level.paperConfig().entities.behavior.playerInsomniaStartTicks < 0) {
 +                    return;
 +                }
 +                // Paper end - Ability to control player's insomnia and phantoms

--- a/paper-server/patches/sources/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/levelgen/PhantomSpawner.java.patch
@@ -25,6 +25,15 @@
                                  BlockPos playerPos = player.blockPosition();
                                  if (!level.dimensionType().hasSkyLight() || playerPos.getY() >= level.getSeaLevel() && level.canSeeSky(playerPos)) {
                                      DifficultyInstance difficulty = level.getCurrentDifficultyAt(playerPos);
+@@ -39,7 +_,7 @@
+                                         ServerStatsCounter stats = player.getStats();
+                                         int value = Mth.clamp(stats.getValue(Stats.CUSTOM.get(Stats.TIME_SINCE_REST)), 1, Integer.MAX_VALUE);
+                                         int dayLength = 24000;
+-                                        if (random.nextInt(value) >= 72000) {
++                                        if (random.nextInt(value) >= level.paperConfig().entities.behavior.playerInsomniaStartTicks) { // Paper - Ability to control player's insomnia and phantoms
+                                             BlockPos spawnPos = playerPos.above(20 + random.nextInt(15))
+                                                 .east(-10 + random.nextInt(21))
+                                                 .south(-10 + random.nextInt(21));
 @@ -50,11 +_,21 @@
                                                  int groupSize = 1 + random.nextInt(difficulty.getDifficulty().getId() + 1);
  


### PR DESCRIPTION
This option is currently only taken into account during phantom targeting, the diff where it was used as the tick count inside the PhantomSpawner must've been accidentally dropped.