### PR TITLE
Expand mobs-can-always-pick-up-loot.zombies for husk

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/zombie/Husk.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/zombie/Husk.java.patch
@@ -9,3 +9,12 @@
          }
  
          return flag;
+@@ -86,7 +_,7 @@
+         spawnGroupData = super.finalizeSpawn(level, difficulty, spawnReason, spawnGroupData);
+         float specialMultiplier = difficulty.getSpecialMultiplier();
+         if (spawnReason != EntitySpawnReason.CONVERSION) {
+-            this.setCanPickUpLoot(random.nextFloat() < 0.55F * specialMultiplier);
++            this.setCanPickUpLoot(level.getLevel().paperConfig().entities.behavior.mobsCanAlwaysPickUpLoot.zombies || random.nextFloat() < 0.55F * specialMultiplier); // Paper - Add world settings for mobs picking up loot
+         }
+ 
+         if (spawnGroupData != null) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/zombie/Zombie.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/zombie/Zombie.java.patch
@@ -212,7 +212,7 @@
          float specialMultiplier = difficulty.getSpecialMultiplier();
          if (spawnReason != EntitySpawnReason.CONVERSION) {
 -            this.setCanPickUpLoot(random.nextFloat() < 0.55F * specialMultiplier);
-+            this.setCanPickUpLoot(this.level().paperConfig().entities.behavior.mobsCanAlwaysPickUpLoot.zombies || random.nextFloat() < 0.55F * specialMultiplier); // Paper - Add world settings for mobs picking up loot
++            this.setCanPickUpLoot(level.getLevel().paperConfig().entities.behavior.mobsCanAlwaysPickUpLoot.zombies || random.nextFloat() < 0.55F * specialMultiplier); // Paper - Add world settings for mobs picking up loot
          }
  
          if (spawnGroupData == null) {


### PR DESCRIPTION
Not sure if it's an oversight of mojang but at least the config works again for them.