### PR TITLE
Prevent async projectile owner lookup during world gen

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/Projectile.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/Projectile.java.patch
@@ -8,7 +8,7 @@
  
      protected Projectile(EntityType<? extends Projectile> type, Level level) {
          super(type, level);
-@@ -51,12 +_,25 @@
+@@ -51,12 +_,29 @@
  
      protected void setOwner(@Nullable EntityReference<Entity> owner) {
          this.owner = owner;
@@ -21,6 +21,10 @@
  
 +    // Paper start - Refresh ProjectileSource for projectiles
 +    public void refreshProjectileSource(boolean fillCache) {
++        // Prevent async owner lookup during world gen,
++        // saved structures with entity inside will cause this to throw an exception.
++        // In this situation, owner lookup will be handled by CB's AbstractProjecile#getShooter
++        if (this.generation) return;
 +        if (fillCache) {
 +            this.getOwner();
 +        }


### PR DESCRIPTION
Closes #13475.

Saved structures with projectile entity inside (some datapack structures) will cause AsyncCatcher to throw an exception.
After skipping the bukkit owner lookup in worldgen, it will be handled by [CB's AbstractProjecile#getShooter](https://github.com/PaperMC/Paper/blob/main/paper-server/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java#L66). So it shouldn't cause plugin behavior inconsistencies.