### PR TITLE
Fix NPE when unsetting leash holder in EntityUnleashEvent

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/Leashable.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Leashable.java.patch
@@ -72,7 +72,7 @@
      default double leashSnapDistance() {
          return 12.0;
      }
-@@ -195,7 +_,25 @@
+@@ -195,7 +_,27 @@
      }
  
      default void leashTooFarBehaviour() {
@@ -85,9 +85,11 @@
 +            if (!event.callEvent()) return;
 +
 +            Entity leashHolder = this.getLeashHolder();
-+            Level level = leashHolder.level();
++            if (leashHolder != null) {
++                Level level = leashHolder.level();
++                level.playSound(null, leashHolder.getX(), leashHolder.getY(), leashHolder.getZ(), SoundEvents.LEAD_BREAK, SoundSource.NEUTRAL, 1.0F, 1.0F); // Moved from Leashable#tickLeash
++            }
 +            dropLeash = event.isDropLeash();
-+            level.playSound(null, leashHolder.getX(), leashHolder.getY(), leashHolder.getZ(), SoundEvents.LEAD_BREAK, SoundSource.NEUTRAL, 1.0F, 1.0F); // Moved from Leashable#tickLeash
 +        }
 +        // CraftBukkit end
 +        if (dropLeash) {


### PR DESCRIPTION
This resolves #13645, where a NPE may result if a plugin unsets the leash holder of the entity in question during the `EntityUnleashEvent`. This is resolved by simply checking if the `leashHolder` is null before attempting to play the sound.