### PR TITLE
chore(jd): corrected ChunkGenerator#shouldGenerateDecorations

### DIFF
--- a/paper-api/src/main/java/org/bukkit/generator/ChunkGenerator.java
+++ b/paper-api/src/main/java/org/bukkit/generator/ChunkGenerator.java
@@ -501,7 +501,7 @@ public abstract class ChunkGenerator {
      * The Vanilla decoration are generated <b>before</b> any
      * {@link BlockPopulator} are called.
      * <p>
-     * This is method is not called (and has therefore no effect), if
+     * This method is not called (and has therefore no effect), if
      * {@link #shouldGenerateDecorations(WorldInfo, Random, int, int)} is overridden.
      *
      * @return true if the server should generate Vanilla decorations


### PR DESCRIPTION
It’s definitely not a big deal, but it bothered me when I read it, so I opened a PR to fix it.