### PR TITLE
Support for Kill damageable entities

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Damageable.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Damageable.java
@@ -2,12 +2,15 @@ package org.bukkit.entity;
 
 import org.bukkit.attribute.Attribute;
 import org.bukkit.damage.DamageSource;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.bukkit.damage.DamageType;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents an {@link Entity} that has health and can take damage.
  */
+@NullMarked
 public interface Damageable extends Entity {
     /**
      * Deals the given amount of damage to this entity.
@@ -32,7 +35,24 @@ public interface Damageable extends Entity {
      * @param amount amount of damage to deal
      * @param damageSource source to which the damage should be attributed
      */
-    void damage(double amount, @NotNull DamageSource damageSource);
+    void damage(double amount, DamageSource damageSource);
+
+    /**
+     * Sets the entity's health to 0 and kill the entity with a generic DamageSource.
+     *
+     * @throws IllegalStateException if is used in world generation
+     */
+    default void kill() {
+        this.kill(DamageSource.builder(DamageType.GENERIC_KILL).build());
+    }
+
+    /**
+     * Sets the entity's health to 0 and kill the entity with the specified DamageSource.
+     *
+     * @param damageSource the DamageSource to use for the kill
+     * @throws IllegalStateException if is used in world generation
+     */
+    void kill(DamageSource damageSource);
 
     /**
      * Gets the entity's health from 0 to {@link #getMaxHealth()}, where 0 is dead.
@@ -57,7 +77,7 @@ public interface Damageable extends Entity {
      * @param amount heal amount
      */
     default void heal(final double amount) {
-        this.heal(amount, org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason.CUSTOM);
+        this.heal(amount, EntityRegainHealthEvent.RegainReason.CUSTOM);
     }
 
     /**
@@ -66,7 +86,7 @@ public interface Damageable extends Entity {
      * @param amount heal amount
      * @param reason heal reason
      */
-    void heal(double amount, @NotNull org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason reason);
+    void heal(double amount, EntityRegainHealthEvent.RegainReason reason);
 
     /**
      * Gets the entity's absorption amount.

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderDragonPart.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEnderDragonPart.java
@@ -32,6 +32,11 @@ public class CraftEnderDragonPart extends CraftComplexPart implements EnderDrago
     }
 
     @Override
+    public void kill(DamageSource damageSource) {
+        this.getParent().kill(damageSource);
+    }
+
+    @Override
     public double getHealth() {
         return this.getParent().getHealth();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
@@ -90,6 +90,7 @@ import org.bukkit.entity.Trident;
 import org.bukkit.entity.WitherSkull;
 import org.bukkit.entity.memory.MemoryKey;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -145,12 +146,10 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
         }
     }
 
-    // Paper start - entity heal API
     @Override
-    public void heal(final double amount, final org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason reason) {
+    public void heal(final double amount, final EntityRegainHealthEvent.RegainReason reason) {
         this.getHandle().heal((float) amount, reason);
     }
-    // Paper end - entity heal API
 
     @Override
     public double getAbsorptionAmount() {
@@ -398,6 +397,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
     public void setBeeStingersInBody(int count) {
         Preconditions.checkArgument(count >= 0, "New bee stinger amount must be >= 0");
         this.getHandle().setStingerCount(count);
+    }
+
+    @Override
+    public void kill(org.bukkit.damage.DamageSource damageSource) {
+        Preconditions.checkState(!this.getHandle().generation, "Cannot kill entity during world generation");
+        Preconditions.checkArgument(damageSource != null, "damageSource cannot be null");
+
+        this.getHandle().setHealth(0);
+        this.getHandle().die(((CraftDamageSource) damageSource).getHandle());
     }
 
     @Override


### PR DESCRIPTION
Close https://github.com/PaperMC/Paper/issues/13666 by adding a way in the API for just kill the entity (not discard like the remove method), the kill method just set the health of entity to 0 and pass a DamageSource generic or provided by the user.