### PR TITLE
Improve GameRule API

### DIFF
--- a/paper-api/src/main/java/org/bukkit/GameRule.java
+++ b/paper-api/src/main/java/org/bukkit/GameRule.java
@@ -489,6 +489,14 @@ public abstract class GameRule<T> implements net.kyori.adventure.translation.Tra
     public abstract Class<T> getType();
 
     /**
+     * Get the default value of this rule.
+     *
+     * @return the default value
+     */
+    @NotNull
+    public abstract T getDefaultValue();
+
+    /**
      * Get a {@link GameRule} by its name.
      *
      * @param rule the name of the GameRule

--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -3802,8 +3802,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * @param <T> the GameRule's type
      * @return the current value
      */
-    @Nullable
-    public <T> T getGameRuleValue(@NotNull GameRule<T> rule);
+    public @NotNull <T> T getGameRuleValue(@NotNull GameRule<T> rule);
 
     /**
      * Get the default value for a given {@link GameRule}. This value is not
@@ -3812,9 +3811,12 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * @param rule the rule to return a default value for
      * @param <T> the type of GameRule
      * @return the default value
+     * @deprecated use {@link GameRule#getDefaultValue()} instead
      */
-    @Nullable
-    public <T> T getGameRuleDefault(@NotNull GameRule<T> rule);
+    @Deprecated(since = "1.21.11")
+    default <T> @NotNull T getGameRuleDefault(@NotNull GameRule<T> rule) {
+        return rule.getDefaultValue();
+    }
 
     /**
      * Set the given {@link GameRule}'s new value.

--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -3813,7 +3813,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * @return the default value
      * @deprecated use {@link GameRule#getDefaultValue()} instead
      */
-    @Deprecated(since = "1.21.11")
+    @Deprecated(since = "26.1.2")
     default <T> @NotNull T getGameRuleDefault(@NotNull GameRule<T> rule) {
         return rule.getDefaultValue();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftGameRule.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftGameRule.java
@@ -87,11 +87,10 @@ public class CraftGameRule<T> extends GameRule<T> implements PaperFeatureDepende
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public static <T> T shimLegacyValue(T value, GameRule<?> rule){
-        if (rule instanceof CraftGameRule.LegacyGameRuleWrapper wrapper) {
+    public static <T> T shimLegacyValue(T value, GameRule<?> rule) {
+        if (rule instanceof LegacyGameRuleWrapper wrapper) {
             return (T) wrapper.getToLegacyFromModern().apply(value);
         }
-
         return value;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftGameRule.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftGameRule.java
@@ -77,8 +77,22 @@ public class CraftGameRule<T> extends GameRule<T> implements PaperFeatureDepende
     }
 
     @Override
+    public T getDefaultValue() {
+        return shimLegacyValue(this.getHandle().defaultValue(), this);
+    }
+
+    @Override
     public String translationKey() {
         return this.getHandle().getDescriptionId();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T> T shimLegacyValue(T value, GameRule<?> rule){
+        if (rule instanceof CraftGameRule.LegacyGameRuleWrapper wrapper) {
+            return (T) wrapper.getToLegacyFromModern().apply(value);
+        }
+
+        return value;
     }
 
     public static class LegacyGameRuleWrapper<LEGACY, MODERN> extends CraftGameRule<LEGACY> {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1688,30 +1688,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
         return this.getHandle().getGameRules().rules.has(CraftGameRule.bukkitToMinecraft(bukkit));
     }
 
-    public static <T> T shimLegacyValue(T value, org.bukkit.GameRule<?> gameRule){
-        //noinspection rawtypes unchecked
-        if (gameRule instanceof CraftGameRule.LegacyGameRuleWrapper legacyGameRuleWrapper) {
-            //noinspection unchecked
-            return (T) legacyGameRuleWrapper.getToLegacyFromModern().apply(value);
-        }
-
-        return value;
-    }
-
     @Override
-    public <T> @Nullable T getGameRuleValue(org.bukkit.@NotNull GameRule<T> rule) {
+    public <T> @NotNull T getGameRuleValue(org.bukkit.@NotNull GameRule<T> rule) {
         Preconditions.checkArgument(rule != null, "GameRule cannot be null");
 
         T value = this.getHandle().getGameRules().get(CraftGameRule.bukkitToMinecraft(rule));
-        return shimLegacyValue(value, rule);
-    }
-
-    @Override
-    public <T> @Nullable T getGameRuleDefault(org.bukkit.@NotNull GameRule<T> rule) {
-        Preconditions.checkArgument(rule != null, "GameRule cannot be null");
-        T value = CraftGameRule.bukkitToMinecraft(rule).defaultValue();
-
-        return shimLegacyValue(value, rule);
+        return CraftGameRule.shimLegacyValue(value, rule);
     }
 
     @Override


### PR DESCRIPTION
Partially replaces https://github.com/PaperMC/Paper/pull/7244/

> Getting a gamerule's default value shouldn't be tied to needing a world instance since it's the same without a world. Also, the methods to get the gamerule's value for a world and default world should be notnull.