### PR TITLE
chore: Don't log errors for accepting the EULA via the system property

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/Main.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/Main.java.patch
@@ -12,7 +12,7 @@
          OptionParser parser = new OptionParser();
          OptionSpec<Void> nogui = parser.accepts("nogui");
          OptionSpec<Void> initSettings = parser.accepts("initSettings", "Initializes 'server.properties' and 'eula.txt', then quits");
-@@ -89,39 +_,96 @@
+@@ -89,39 +_,94 @@
                  parser.printHelpOn(System.err);
                  return;
              }
@@ -72,17 +72,15 @@
              }
  
 -            if (!eula.hasAgreedToEULA()) {
-+            // Spigot start
++            // Paper start - eula system property
 +            boolean eulaAgreed = Boolean.getBoolean("com.mojang.eula.agree");
 +            if (eulaAgreed) {
-+                // Paper start - not Spigot anymore and warn instead of error
 +                LOGGER.warn("You have used the Paper command line EULA agreement flag.");
 +                LOGGER.warn("By using this setting you are indicating your agreement to Mojang's EULA (https://aka.ms/MinecraftEULA).");
 +                LOGGER.warn("If you do not agree to the above EULA please stop your server and remove this flag immediately.");
-+                // Paper end - not Spigot anymore and warn instead of error
 +            }
 +            if (!eula.hasAgreedToEULA() && !eulaAgreed) {
-+                // Spigot end
++                // Paper end - eula system property
                  LOGGER.info("You need to agree to the EULA in order to run the server. Go to eula.txt for more info.");
                  return;
              }

--- a/paper-server/patches/sources/net/minecraft/server/Main.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/Main.java.patch
@@ -12,7 +12,7 @@
          OptionParser parser = new OptionParser();
          OptionSpec<Void> nogui = parser.accepts("nogui");
          OptionSpec<Void> initSettings = parser.accepts("initSettings", "Initializes 'server.properties' and 'eula.txt', then quits");
-@@ -89,39 +_,94 @@
+@@ -89,39 +_,95 @@
                  parser.printHelpOn(System.err);
                  return;
              }
@@ -78,8 +78,7 @@
 +                LOGGER.warn("You have used the Paper command line EULA agreement flag.");
 +                LOGGER.warn("By using this setting you are indicating your agreement to Mojang's EULA (https://aka.ms/MinecraftEULA).");
 +                LOGGER.warn("If you do not agree to the above EULA please stop your server and remove this flag immediately.");
-+            }
-+            if (!eula.hasAgreedToEULA() && !eulaAgreed) {
++            } else if (!eula.hasAgreedToEULA()) {
 +                // Paper end - eula system property
                  LOGGER.info("You need to agree to the EULA in order to run the server. Go to eula.txt for more info.");
                  return;

--- a/paper-server/patches/sources/net/minecraft/server/Main.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/Main.java.patch
@@ -75,9 +75,11 @@
 +            // Spigot start
 +            boolean eulaAgreed = Boolean.getBoolean("com.mojang.eula.agree");
 +            if (eulaAgreed) {
-+                LOGGER.error("You have used the Spigot command line EULA agreement flag.");
-+                LOGGER.error("By using this setting you are indicating your agreement to Mojang's EULA (https://aka.ms/MinecraftEULA).");
-+                LOGGER.error("If you do not agree to the above EULA please stop your server and remove this flag immediately.");
++                // Paper start - not Spigot anymore and warn instead of error
++                LOGGER.warn("You have used the Paper command line EULA agreement flag.");
++                LOGGER.warn("By using this setting you are indicating your agreement to Mojang's EULA (https://aka.ms/MinecraftEULA).");
++                LOGGER.warn("If you do not agree to the above EULA please stop your server and remove this flag immediately.");
++                // Paper end - not Spigot anymore and warn instead of error
 +            }
 +            if (!eula.hasAgreedToEULA() && !eulaAgreed) {
 +                // Spigot end


### PR DESCRIPTION
It's not really necessary to log this as an error, plus we can rename it now.