### PR TITLE
Prevent NPE on ThrownPotion#splash

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/AbstractThrownPotion.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/AbstractThrownPotion.java.patch
@@ -8,7 +8,7 @@
 +        this.splash(hitResult);
 +    }
 +
-+    public void splash(final HitResult hitResult) {
++    public void splash(final @org.jspecify.annotations.Nullable HitResult hitResult) { // Paper
 +        // Paper end - More projectile API
          if (this.level() instanceof ServerLevel level) {
              ItemStack potionItemStack = this.getItem();
@@ -37,7 +37,7 @@
 -    private void onHitAsWater(final ServerLevel level) {
 +    private static final Predicate<LivingEntity> APPLY_WATER_GET_ENTITIES_PREDICATE = AbstractThrownPotion.WATER_SENSITIVE_OR_ON_FIRE.or(Axolotl.class::isInstance); // Paper - Fix potions splash events
 +
-+    private boolean onHitAsWater(final ServerLevel level, final HitResult hitResult) { // Paper - Fix potions splash events
++    private boolean onHitAsWater(final ServerLevel level, final @org.jspecify.annotations.Nullable HitResult hitResult) { // Paper - Fix potions splash events
          AABB aabb = this.getBoundingBox().inflate(4.0, 2.0, 4.0);
  
 -        for (LivingEntity entity : this.level().getEntitiesOfClass(LivingEntity.class, aabb, WATER_SENSITIVE_OR_ON_FIRE)) {
@@ -88,7 +88,7 @@
      }
  
 -    protected abstract void onHitAsPotion(ServerLevel level, ItemStack potionItem, HitResult hitResult);
-+    protected abstract boolean onHitAsPotion(ServerLevel level, ItemStack potionItem, HitResult hitResult); // Paper - Fix potions splash events & More Projectile API
++    protected abstract boolean onHitAsPotion(ServerLevel level, ItemStack potionItem, @org.jspecify.annotations.Nullable HitResult hitResult); // Paper - Fix potions splash events & More Projectile API
  
      private void dowseFire(final BlockPos pos) {
          BlockState blockState = this.level().getBlockState(pos);

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownLingeringPotion.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownLingeringPotion.java.patch
@@ -5,7 +5,7 @@
  
      @Override
 -    public void onHitAsPotion(final ServerLevel level, final ItemStack potionItem, final HitResult hitResult) {
-+    public boolean onHitAsPotion(final ServerLevel level, final ItemStack potionItem, final HitResult hitResult) { // Paper - More projectile API
++    public boolean onHitAsPotion(final ServerLevel level, final ItemStack potionItem, final @org.jspecify.annotations.Nullable HitResult hitResult) { // Paper - More projectile API
          AreaEffectCloud cloud = new AreaEffectCloud(this.level(), this.getX(), this.getY(), this.getZ());
          if (this.getOwner() instanceof LivingEntity owner) {
              cloud.setOwner(owner);

--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownSplashPotion.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownSplashPotion.java.patch
@@ -5,11 +5,12 @@
  
      @Override
 -    public void onHitAsPotion(final ServerLevel level, final ItemStack potionItem, final HitResult hitResult) {
-+    public boolean onHitAsPotion(final ServerLevel level, final ItemStack potionItem, final HitResult hitResult) { // Paper - More projectile API
++    public boolean onHitAsPotion(final ServerLevel level, final ItemStack potionItem, final @org.jspecify.annotations.Nullable HitResult hitResult) { // Paper - More projectile API
          PotionContents contents = potionItem.getOrDefault(DataComponents.POTION_CONTENTS, PotionContents.EMPTY);
          float durationScale = potionItem.getOrDefault(DataComponents.POTION_DURATION_SCALE, 1.0F);
          Iterable<MobEffectInstance> mobEffects = contents.getAllEffects();
-         AABB potionAabb = this.getBoundingBox().move(hitResult.getLocation().subtract(this.position()));
+-        AABB potionAabb = this.getBoundingBox().move(hitResult.getLocation().subtract(this.position()));
++        AABB potionAabb = hitResult == null ? this.getBoundingBox() : this.getBoundingBox().move(hitResult.getLocation().subtract(this.position())); // Paper - More projectile API
          AABB effectAabb = potionAabb.inflate(4.0, 2.0, 4.0);
          List<LivingEntity> entities = this.level().getEntitiesOfClass(LivingEntity.class, effectAabb);
 +        java.util.Map<org.bukkit.entity.LivingEntity, Double> affected = new java.util.HashMap<>(); // CraftBukkit


### PR DESCRIPTION
`ThrownPotion#splash` calls internal splash with `null` hit result:

https://github.com/PaperMC/Paper/blob/3f5728e24942a470a428c60839eda5340f85f9f8/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownPotion.java#L48-L51

Which leads to NPE in case of thrown non-water splash potions. Other parts of code expect and handle nullability, but this one was missed.