### PR TITLE
Add missing deprecation for Material#getCreativeCategory

### DIFF
--- a/paper-api/src/main/java/org/bukkit/Material.java
+++ b/paper-api/src/main/java/org/bukkit/Material.java
@@ -3555,7 +3555,8 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
      * Get the {@link CreativeCategory} to which this material belongs.
      *
      * @return the creative category. null if it does not belong to a category
-     * @deprecated items can belong to multiple creative categories
+     * @deprecated items can belong to multiple creative categories and this is no
+     * longer implemented, will always be {@link CreativeCategory#BUILDING_BLOCKS} if not null
      */
     @Deprecated(since = "1.20.6", forRemoval = true)
     public @Nullable CreativeCategory getCreativeCategory() {

--- a/paper-api/src/main/java/org/bukkit/Material.java
+++ b/paper-api/src/main/java/org/bukkit/Material.java
@@ -3554,10 +3554,11 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
     /**
      * Get the {@link CreativeCategory} to which this material belongs.
      *
-     * @return the creative category. null if does not belong to a category
+     * @return the creative category. null if it does not belong to a category
+     * @deprecated items can belong to multiple creative categories
      */
-    @Nullable
-    public CreativeCategory getCreativeCategory() {
+    @Deprecated(since = "1.20.6", forRemoval = true)
+    public @Nullable CreativeCategory getCreativeCategory() {
         ItemType type = asItemType();
         return type == null ? null : type.getCreativeCategory();
     }

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemType.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemType.java
@@ -3279,8 +3279,8 @@ public interface ItemType extends Keyed, Translatable, net.kyori.adventure.trans
     /**
      * Get the {@link CreativeCategory} to which this item type belongs.
      *
-     * @return the creative category. null if does not belong to a category
-     <!-- * @deprecated use #getCreativeCategories() -->
+     * @return the creative category. null if it does not belong to a category
+     * @deprecated items can belong to multiple creative categories
      */
     @Deprecated(since = "1.20.6", forRemoval = true)
     @Nullable CreativeCategory getCreativeCategory();

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemType.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemType.java
@@ -3280,7 +3280,8 @@ public interface ItemType extends Keyed, Translatable, net.kyori.adventure.trans
      * Get the {@link CreativeCategory} to which this item type belongs.
      *
      * @return the creative category. null if it does not belong to a category
-     * @deprecated items can belong to multiple creative categories
+     * @deprecated items can belong to multiple creative categories and this is no
+     * longer implemented, will always be {@link CreativeCategory#BUILDING_BLOCKS}
      */
     @Deprecated(since = "1.20.6", forRemoval = true)
     @Nullable CreativeCategory getCreativeCategory();


### PR DESCRIPTION
With https://github.com/PaperMC/Paper/pull/12150 in queue this PR just take the part about the deprecate docs for put in the Material and include the details for why its deprecated.