### PR TITLE
Fix PlayerProfile applySkinToPlayerHeadContents

### DIFF
--- a/paper-api/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
@@ -257,16 +257,16 @@ public interface PlayerProfile extends org.bukkit.profile.PlayerProfile, PlayerH
 
     @Override
     default void applySkinToPlayerHeadContents(final PlayerHeadObjectContents.Builder builder) {
-        if (this.getProperties().isEmpty() && (this.getName() != null) != (this.getId() != null)) {
+        if (this.getProperties().isEmpty()) {
             if (this.getId() != null) {
                 builder.id(this.getId());
-            } else {
+            } else if (this.getName() != null) {
                 builder.name(this.getName());
             }
-            return;
+        } else {
+            builder.id(this.getId())
+                .name(this.getName())
+                .profileProperties(this.getProperties().stream().map(prop -> property(prop.getName(), prop.getValue(), prop.getSignature())).toList());
         }
-        builder.id(this.getId())
-            .name(this.getName())
-            .profileProperties(this.getProperties().stream().map(prop -> property(prop.getName(), prop.getValue(), prop.getSignature())).toList());
     }
 }


### PR DESCRIPTION
Since https://github.com/PaperMC/Paper/pull/13585 `Player` and `OfflinePlayer` correctly set their full profile as `SkinSource`. When using a profile without texture properties, but with a name AND an id the current behavior sets both even when no properties are set, which results in the displayed player head being rendered as a default skin. I suggest that in the case that no properties are present the client should fetch the profile, which is only possible when id OR name are set (not both).

This fixes the displayed skin head of offline players (letting the client fetch the profile) as OfflinePlayers have no skin data stored.

```java
OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(UUID.fromString("25081653-ae35-4316-b723-7cb435fc7892"));
Component head = Component.object(ObjectContents.playerHead(offlinePlayer));
player.sendMessage(head);
```
^ currently displays some default skin, but with this PR let's the client fetch the profile and displays the correct skin

Theoretically the current code could work, but only if either name or id is null, however this is not the case for offline players, dunno if this is another bug or intentional, but the PlayerProfiles of OfflinePlayers have an empty (not null, but empty) string as name (when get by UUID, when get by name they have their correct name) and a uuid. Thats weird as the `org.bukkit.craftbukkit.profile.CraftPlayerProfile` (imo) correctly checks if the name is empty and returns null instead, but if this is not intended the correct fix would prob. be to set the name instead of letting it return null instead of an empty string.

I only changed the behavior of `PlayerProfile#applySkinToPlayerHeadContents` to fix this issue and did not change the empty string name. The only behavior change is noticeable when having id AND name set and no properties (in that case it prefers the uuid and ignores the name to let the client fetch the profile).