### PR TITLE
Handle null ServerLevel in fromGlobalPos

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftLocation.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftLocation.java
@@ -2,11 +2,14 @@ package org.bukkit.craftbukkit.util;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.pathfinder.Node;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.jspecify.annotations.Nullable;
 
 public final class CraftLocation {
 
@@ -65,8 +68,9 @@ public final class CraftLocation {
         return net.minecraft.core.GlobalPos.of(((org.bukkit.craftbukkit.CraftWorld) loc.getWorld()).getHandle().dimension(), toBlockPosition(loc));
     }
 
-    public static Location fromGlobalPos(net.minecraft.core.GlobalPos globalPos) {
-        return CraftLocation.toBukkit(globalPos.pos(), net.minecraft.server.MinecraftServer.getServer().getLevel(globalPos.dimension()));
+    public static @Nullable Location fromGlobalPos(net.minecraft.core.GlobalPos globalPos) {
+        ServerLevel level = MinecraftServer.getServer().getLevel(globalPos.dimension());
+        return level != null ? CraftLocation.toBukkit(globalPos.pos(), level) : null;
     }
 
     public static Vec3 toVec3(Location loc) {


### PR DESCRIPTION
getLevel returns nullable but toBukkit doesnt allow for null values causing an NPE
All four uses of this method are in `Optional`s so it is safe to return null