### PR TITLE
Scheduler optimization

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/util/concurrent/ScheduledTask.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/concurrent/ScheduledTask.java
@@ -1,0 +1,5 @@
+package io.papermc.paper.util.concurrent;
+
+public interface ScheduledTask {
+    long getNextRun();
+}

--- a/paper-server/src/main/java/io/papermc/paper/util/concurrent/TickBoundTask.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/concurrent/TickBoundTask.java
@@ -1,5 +1,5 @@
 package io.papermc.paper.util.concurrent;
 
-public interface ScheduledTask {
+public interface TickBoundTask {
     long getNextRun();
 }

--- a/paper-server/src/main/java/io/papermc/paper/util/concurrent/TickBoundTask.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/concurrent/TickBoundTask.java
@@ -3,4 +3,5 @@ package io.papermc.paper.util.concurrent;
 public interface TickBoundTask {
     long getNextRun();
     void setNextRun(long next);
+    long getCreatedAt();
 }

--- a/paper-server/src/main/java/io/papermc/paper/util/concurrent/TickBoundTask.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/concurrent/TickBoundTask.java
@@ -2,4 +2,5 @@ package io.papermc.paper.util.concurrent;
 
 public interface TickBoundTask {
     long getNextRun();
+    void setNextRun(long next);
 }

--- a/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Predicate;
@@ -23,16 +24,16 @@ import java.util.function.Predicate;
 public class TimingWheel<T extends TickBoundTask> implements Iterable<T> {
     private final int wheelSize;
     private final long mask;
-    private final ArrayDeque<T>[] wheel;
+    private final LinkedList<T>[] wheel;
 
     @SuppressWarnings("unchecked")
     public TimingWheel(int exponent) {
         this.wheelSize = 1 << exponent;
         this.mask = wheelSize - 1L;
 
-        this.wheel = (ArrayDeque<T>[]) new ArrayDeque[wheelSize];
+        this.wheel = (LinkedList<T>[]) new LinkedList[wheelSize];
         for (int i = 0; i < wheelSize; i++) {
-            wheel[i] = new ArrayDeque<>();
+            wheel[i] = new LinkedList<>();
         }
     }
 
@@ -49,7 +50,7 @@ public class TimingWheel<T extends TickBoundTask> implements Iterable<T> {
 
     public @NotNull List<T> popValid(long currentTick) {
         int slot = (int) (currentTick & mask);
-        ArrayDeque<T> bucket = wheel[slot];
+        LinkedList<T> bucket = wheel[slot];
         if (bucket.isEmpty()) return Collections.emptyList();
 
         Iterator<T> iter = bucket.iterator();
@@ -68,7 +69,7 @@ public class TimingWheel<T extends TickBoundTask> implements Iterable<T> {
 
     public boolean isReady(long currentTick) {
         int slot = (int) (currentTick & mask);
-        ArrayDeque<T> bucket = wheel[slot];
+        LinkedList<T> bucket = wheel[slot];
         if (bucket.isEmpty()) return false;
 
         for (final T task : bucket) {

--- a/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Predicate;
 
 /**
@@ -21,7 +20,7 @@ import java.util.function.Predicate;
  * We are using power of 2 for faster operations than modulo.
  *
  */
-public class TimingWheel<T extends ScheduledTask> implements Iterable<T> {
+public class TimingWheel<T extends TickBoundTask> implements Iterable<T> {
     private final int wheelSize;
     private final long mask;
     private final ArrayDeque<T>[] wheel;

--- a/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -26,6 +27,8 @@ public class TimingWheel<T extends TickBoundTask> implements Iterable<T> {
     private final long mask;
     private final LinkedList<T>[] wheel;
 
+    private static final Comparator<TickBoundTask> ORDERING = Comparator.comparingLong(TickBoundTask::getCreatedAt);
+
     @SuppressWarnings("unchecked")
     public TimingWheel(int exponent) {
         this.wheelSize = 1 << exponent;
@@ -47,23 +50,7 @@ public class TimingWheel<T extends TickBoundTask> implements Iterable<T> {
 
         int slot = (int) (nextRun & mask);
         LinkedList<T> bucket = wheel[slot];
-
-        if (bucket.isEmpty() || bucket.getLast().getCreatedAt() <= task.getCreatedAt()) {
-            bucket.addLast(task); // append if newest
-            return;
-        }
-
-        ListIterator<T> it = bucket.listIterator(bucket.size());
-        while (it.hasPrevious()) {
-            T t = it.previous();
-            if (t.getCreatedAt() <= task.getCreatedAt()) {
-                it.next();
-                it.add(task);
-                return;
-            }
-        }
-
-        bucket.addFirst(task); // oldest goes to front
+        bucket.add(task);
     }
 
     public void addAll(Collection<? extends T> tasks, int currentTick) {
@@ -88,6 +75,7 @@ public class TimingWheel<T extends TickBoundTask> implements Iterable<T> {
             }
         }
 
+        list.sort(ORDERING);
         return list;
     }
 

--- a/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
@@ -36,18 +36,25 @@ public class TimingWheel<T extends TickBoundTask> implements Iterable<T> {
         }
     }
 
-    public void add(T task) {
-        int slot = (int) (task.getNextRun() & mask);
+    public void add(T task, int currentTick) {
+        long nextRun = task.getNextRun();
+
+        if (nextRun <= currentTick) {
+            nextRun = currentTick;
+            task.setNextRun(nextRun);
+        }
+
+        int slot = (int) (nextRun & mask);
         wheel[slot].addLast(task);
     }
 
-    public void addAll(Collection<? extends T> tasks) {
+    public void addAll(Collection<? extends T> tasks, int currentTick) {
         for (T task : tasks) {
-            this.add(task);
+            this.add(task, currentTick);
         }
     }
 
-    public @NotNull List<T> popValid(long currentTick) {
+    public @NotNull List<T> popValid(int currentTick) {
         int slot = (int) (currentTick & mask);
         LinkedList<T> bucket = wheel[slot];
         if (bucket.isEmpty()) return Collections.emptyList();
@@ -66,7 +73,7 @@ public class TimingWheel<T extends TickBoundTask> implements Iterable<T> {
         return list;
     }
 
-    public boolean isReady(long currentTick) {
+    public boolean isReady(int currentTick) {
         int slot = (int) (currentTick & mask);
         LinkedList<T> bucket = wheel[slot];
         if (bucket.isEmpty()) return false;

--- a/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
@@ -1,0 +1,147 @@
+package io.papermc.paper.util.concurrent;
+
+import org.jetbrains.annotations.NotNull;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Predicate;
+
+/**
+ * This class schedules tasks in ticks and executes them efficiently using a circular array (the wheel).
+ * Each slot in the wheel represents a specific tick modulo the wheel size.
+ * Tasks are placed into slots based on their target execution tick.
+ * On each tick, the wheel checks the current slot and runs any tasks whose execute tick has been reached.
+ *
+ * O(1) task scheduling and retrieval within a single wheel rotation.
+ * We are using power of 2 for faster operations than modulo.
+ *
+ */
+public class TimingWheel<T extends ScheduledTask> implements Iterable<T> {
+    private final int wheelSize;
+    private final long mask;
+    private final ArrayDeque<T>[] wheel;
+
+    @SuppressWarnings("unchecked")
+    public TimingWheel(int exponent) {
+        this.wheelSize = 1 << exponent;
+        this.mask = wheelSize - 1L;
+
+        this.wheel = (ArrayDeque<T>[]) new ArrayDeque[wheelSize];
+        for (int i = 0; i < wheelSize; i++) {
+            wheel[i] = new ArrayDeque<>();
+        }
+    }
+
+    public void add(T task) {
+        int slot = (int) (task.getNextRun() & mask);
+        wheel[slot].add(task);
+    }
+
+    public void addAll(Collection<? extends T> tasks) {
+        for (T task : tasks) {
+            this.add(task);
+        }
+    }
+
+    public @NotNull List<T> popValid(long currentTick) {
+        int slot = (int) (currentTick & mask);
+        ArrayDeque<T> bucket = wheel[slot];
+        if (bucket.isEmpty()) return Collections.emptyList();
+
+        Iterator<T> iter = bucket.iterator();
+        List<T> list = new ArrayList<>();
+        while (iter.hasNext()) {
+            T task = iter.next();
+
+            if (task.getNextRun() <= currentTick) {
+                iter.remove();
+                list.add(task);
+            }
+        }
+
+        return list;
+    }
+
+    public boolean isReady(long currentTick) {
+        int slot = (int) (currentTick & mask);
+        ArrayDeque<T> bucket = wheel[slot];
+        if (bucket.isEmpty()) return false;
+
+        for (final T task : bucket) {
+            if (task.getNextRun() <= currentTick) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public void removeIf(Predicate<T> apply) {
+        Iterator<T> itr = iterator();
+        while (itr.hasNext()) {
+            T next = itr.next();
+            if (apply.test(next)) {
+                itr.remove();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private class Itr implements Iterator<T> {
+        private int index = 0;
+        private Iterator<T> current = Collections.emptyIterator();
+        private Iterator<T> lastIterator = null;
+
+        @Override
+        public boolean hasNext() {
+            if (current.hasNext()) {
+                return true;
+            }
+
+            for (int i = index; i < wheelSize; i++) {
+                if (!wheel[i].isEmpty()) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        @Override
+        public T next() {
+            while (true) {
+                if (current.hasNext()) {
+                    lastIterator = current;
+                    return current.next();
+                }
+
+                if (index >= wheelSize) {
+                    throw new NoSuchElementException();
+                }
+
+                current = wheel[index++].iterator();
+            }
+        }
+
+        @Override
+        public void remove() {
+            if (lastIterator == null) {
+                throw new NoSuchElementException();
+            }
+
+            lastIterator.remove();
+            lastIterator = null;
+        }
+    }
+
+
+    @Override
+    public @NotNull Iterator<T> iterator() {
+        return new Itr();
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
@@ -1,7 +1,6 @@
 package io.papermc.paper.util.concurrent;
 
 import org.jetbrains.annotations.NotNull;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,7 +38,7 @@ public class TimingWheel<T extends TickBoundTask> implements Iterable<T> {
 
     public void add(T task) {
         int slot = (int) (task.getNextRun() & mask);
-        wheel[slot].add(task);
+        wheel[slot].addLast(task);
     }
 
     public void addAll(Collection<? extends T> tasks) {

--- a/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/concurrent/TimingWheel.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.function.Predicate;
 
@@ -45,7 +46,24 @@ public class TimingWheel<T extends TickBoundTask> implements Iterable<T> {
         }
 
         int slot = (int) (nextRun & mask);
-        wheel[slot].addLast(task);
+        LinkedList<T> bucket = wheel[slot];
+
+        if (bucket.isEmpty() || bucket.getLast().getCreatedAt() <= task.getCreatedAt()) {
+            bucket.addLast(task); // append if newest
+            return;
+        }
+
+        ListIterator<T> it = bucket.listIterator(bucket.size());
+        while (it.hasPrevious()) {
+            T t = it.previous();
+            if (t.getCreatedAt() <= task.getCreatedAt()) {
+                it.next();
+                it.add(task);
+                return;
+            }
+        }
+
+        bucket.addFirst(task); // oldest goes to front
     }
 
     public void addAll(Collection<? extends T> tasks, int currentTick) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java
@@ -75,8 +75,10 @@ public class CraftAsyncScheduler extends CraftScheduler {
 
     private synchronized void runTasks(int currentTick) {
         parsePending();
-        while (!this.pending.isEmpty() && this.pending.peek().getNextRun() <= currentTick) {
-            CraftTask task = this.pending.remove();
+        // Paper start - Timing Wheel
+        List<CraftTask> tasks = this.pending.popValid(currentTick);
+        for (CraftTask task : tasks) {
+            // Paper end - Timing Wheel
             if (executeTask(task)) {
                 final long period = task.getPeriod();
                 if (period > 0) {
@@ -84,8 +86,9 @@ public class CraftAsyncScheduler extends CraftScheduler {
                     temp.add(task);
                 }
             }
-            parsePending();
         }
+        parsePending();
+
         this.pending.addAll(temp);
         temp.clear();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java
@@ -57,7 +57,7 @@ public class CraftAsyncScheduler extends CraftScheduler {
     }
 
     private synchronized void removeTask(int taskId) {
-        parsePending(this.currentTick);
+        parsePending();
         this.pending.removeIf((task) -> {
             if (task.getTaskId() == taskId) {
                 task.cancel0();
@@ -74,7 +74,7 @@ public class CraftAsyncScheduler extends CraftScheduler {
     }
 
     private synchronized void runTasks(int currentTick) {
-        parsePending(this.currentTick);
+        parsePending();
         while (true) {
             List<CraftTask> tasks = this.pending.popValid(currentTick);
             if (tasks.isEmpty()) break;
@@ -89,7 +89,7 @@ public class CraftAsyncScheduler extends CraftScheduler {
                 }
             }
 
-            parsePending(this.currentTick);
+            parsePending();
         }
 
         this.pending.addAll(temp, this.currentTick);
@@ -107,7 +107,7 @@ public class CraftAsyncScheduler extends CraftScheduler {
 
     @Override
     public synchronized void cancelTasks(Plugin plugin) {
-        parsePending(this.currentTick);
+        parsePending();
         for (Iterator<CraftTask> iterator = this.pending.iterator(); iterator.hasNext(); ) {
             CraftTask task = iterator.next();
             if (task.getTaskId() != -1 && (plugin == null || task.getOwner().equals(plugin))) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java
@@ -75,10 +75,8 @@ public class CraftAsyncScheduler extends CraftScheduler {
 
     private synchronized void runTasks(int currentTick) {
         parsePending();
-        // Paper start - Timing Wheel
         List<CraftTask> tasks = this.pending.popValid(currentTick);
         for (CraftTask task : tasks) {
-            // Paper end - Timing Wheel
             if (executeTask(task)) {
                 final long period = task.getPeriod();
                 if (period > 0) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java
@@ -57,7 +57,7 @@ public class CraftAsyncScheduler extends CraftScheduler {
     }
 
     private synchronized void removeTask(int taskId) {
-        parsePending();
+        parsePending(this.currentTick);
         this.pending.removeIf((task) -> {
             if (task.getTaskId() == taskId) {
                 task.cancel0();
@@ -74,20 +74,25 @@ public class CraftAsyncScheduler extends CraftScheduler {
     }
 
     private synchronized void runTasks(int currentTick) {
-        parsePending();
-        List<CraftTask> tasks = this.pending.popValid(currentTick);
-        for (CraftTask task : tasks) {
-            if (executeTask(task)) {
-                final long period = task.getPeriod();
-                if (period > 0) {
-                    task.setNextRun(currentTick + period);
-                    temp.add(task);
+        parsePending(this.currentTick);
+        while (true) {
+            List<CraftTask> tasks = this.pending.popValid(currentTick);
+            if (tasks.isEmpty()) break;
+
+            for (CraftTask task : tasks) {
+                if (executeTask(task)) {
+                    final long period = task.getPeriod();
+                    if (period > 0) {
+                        task.setNextRun(currentTick + period);
+                        temp.add(task);
+                    }
                 }
             }
-        }
-        parsePending();
 
-        this.pending.addAll(temp);
+            parsePending(this.currentTick);
+        }
+
+        this.pending.addAll(temp, this.currentTick);
         temp.clear();
     }
 
@@ -102,7 +107,7 @@ public class CraftAsyncScheduler extends CraftScheduler {
 
     @Override
     public synchronized void cancelTasks(Plugin plugin) {
-        parsePending();
+        parsePending(this.currentTick);
         for (Iterator<CraftTask> iterator = this.pending.iterator(); iterator.hasNext(); ) {
             CraftTask task = iterator.next();
             if (task.getTaskId() != -1 && (plugin == null || task.getOwner().equals(plugin))) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
@@ -75,16 +75,7 @@ public class CraftScheduler implements BukkitScheduler {
     /**
      * Main thread logic only
      */
-    final PriorityQueue<CraftTask> pending = new PriorityQueue<CraftTask>(10, // Paper
-            new Comparator<CraftTask>() {
-                @Override
-                public int compare(final CraftTask o1, final CraftTask o2) {
-                    int value = Long.compare(o1.getNextRun(), o2.getNextRun());
-
-                    // If the tasks should run on the same tick they should be run FIFO
-                    return value != 0 ? value : Long.compare(o1.getCreatedAt(), o2.getCreatedAt());
-                }
-            });
+    final io.papermc.paper.util.concurrent.TimingWheel<CraftTask> pending = new io.papermc.paper.util.concurrent.TimingWheel<>(12); // Paper - Timing wheel
     /**
      * Main thread logic only
      */
@@ -459,8 +450,10 @@ public class CraftScheduler implements BukkitScheduler {
         // Paper end
         final List<CraftTask> temp = this.temp;
         this.parsePending();
-        while (this.isReady(this.currentTick)) {
-            final CraftTask task = this.pending.remove();
+        // Paper start - Timing Wheel
+        final List<CraftTask> tasks = this.pending.popValid(this.currentTick);
+        for (CraftTask task : tasks) {
+            // Paper end - Timing Wheel
             if (task.getPeriod() < CraftTask.NO_REPEATING) {
                 if (task.isSync()) {
                     this.runners.remove(task.getTaskId(), task);
@@ -564,7 +557,8 @@ public class CraftScheduler implements BukkitScheduler {
     }
 
     private boolean isReady(final int currentTick) {
-        return !this.pending.isEmpty() && this.pending.peek().getNextRun() <= currentTick;
+        // return !this.pending.isEmpty() && this.pending.peek().getNextRun() <= currentTick;
+        return this.pending.isReady(currentTick); // Paper - Timing wheel
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
@@ -42,7 +42,7 @@ import org.bukkit.scheduler.BukkitWorker;
  * <li>Async tasks are responsible for removing themselves from runners</li>
  * <li>Sync tasks are only to be removed from runners on the main thread when coupled with a removal from pending and temp.</li>
  * <li>Most of the design in this scheduler relies on queuing special tasks to perform any data changes on the main thread.
- *     When executed from inside a synchronous method, the scheduler will be updated before next execution by virtue of the frequent {@link #parsePending(int)} calls.</li>
+ *     When executed from inside a synchronous method, the scheduler will be updated before next execution by virtue of the frequent {@link #parsePending()} calls.</li>
  * </ul>
  */
 public class CraftScheduler implements BukkitScheduler {
@@ -451,7 +451,7 @@ public class CraftScheduler implements BukkitScheduler {
         // Paper end
         final List<CraftTask> temp = this.temp;
         while (true) {
-            this.parsePending(this.currentTick);
+            this.parsePending();
 
             final List<CraftTask> tasks = this.pending.popValid(this.currentTick);
             if (tasks.isEmpty()) break;
@@ -461,7 +461,7 @@ public class CraftScheduler implements BukkitScheduler {
                     if (task.isSync()) {
                         this.runners.remove(task.getTaskId(), task);
                     }
-                    this.parsePending(this.currentTick);
+                    this.parsePending();
                     continue;
                 }
                 if (task.isSync()) {
@@ -484,7 +484,7 @@ public class CraftScheduler implements BukkitScheduler {
                     } finally {
                         this.currentTask = null;
                     }
-                    this.parsePending(this.currentTick);
+                    this.parsePending();
                 } else {
                     // this.debugTail = this.debugTail.setNext(new CraftAsyncDebugger(this.currentTick + CraftScheduler.RECENT_TICKS, task.getOwner(), task.getTaskClass())); // Paper
                     task.getOwner().getLogger().log(Level.SEVERE, "Unexpected Async Task in the Sync Scheduler. Report this to Paper"); // Paper
@@ -539,7 +539,7 @@ public class CraftScheduler implements BukkitScheduler {
         return id;
     }
 
-    void parsePending(int currentTick) { // Paper
+    void parsePending() { // Paper
         CraftTask head = this.head;
         CraftTask task = head.getNext();
         CraftTask lastTask = head;
@@ -547,7 +547,7 @@ public class CraftScheduler implements BukkitScheduler {
             if (task.getTaskId() == -1) {
                 task.run();
             } else if (task.getPeriod() >= CraftTask.NO_REPEATING) {
-                this.pending.add(task, currentTick);
+                this.pending.add(task, this.currentTick);
                 this.runners.put(task.getTaskId(), task);
             }
         }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.IntUnaryOperator;
 import java.util.logging.Level;
+import io.papermc.paper.util.concurrent.TimingWheel;
 import org.bukkit.plugin.IllegalPluginAccessException;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -75,7 +76,7 @@ public class CraftScheduler implements BukkitScheduler {
     /**
      * Main thread logic only
      */
-    final io.papermc.paper.util.concurrent.TimingWheel<CraftTask> pending = new io.papermc.paper.util.concurrent.TimingWheel<>(12); // Paper - Timing wheel
+    final TimingWheel<CraftTask> pending = new TimingWheel<>(12);
     /**
      * Main thread logic only
      */
@@ -450,10 +451,8 @@ public class CraftScheduler implements BukkitScheduler {
         // Paper end
         final List<CraftTask> temp = this.temp;
         this.parsePending();
-        // Paper start - Timing Wheel
         final List<CraftTask> tasks = this.pending.popValid(this.currentTick);
         for (CraftTask task : tasks) {
-            // Paper end - Timing Wheel
             if (task.getPeriod() < CraftTask.NO_REPEATING) {
                 if (task.isSync()) {
                     this.runners.remove(task.getTaskId(), task);
@@ -557,8 +556,7 @@ public class CraftScheduler implements BukkitScheduler {
     }
 
     private boolean isReady(final int currentTick) {
-        // return !this.pending.isEmpty() && this.pending.peek().getNextRun() <= currentTick;
-        return this.pending.isReady(currentTick); // Paper - Timing wheel
+        return this.pending.isReady(currentTick);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
@@ -42,7 +42,7 @@ import org.bukkit.scheduler.BukkitWorker;
  * <li>Async tasks are responsible for removing themselves from runners</li>
  * <li>Sync tasks are only to be removed from runners on the main thread when coupled with a removal from pending and temp.</li>
  * <li>Most of the design in this scheduler relies on queuing special tasks to perform any data changes on the main thread.
- *     When executed from inside a synchronous method, the scheduler will be updated before next execution by virtue of the frequent {@link #parsePending()} calls.</li>
+ *     When executed from inside a synchronous method, the scheduler will be updated before next execution by virtue of the frequent {@link #parsePending(int)} calls.</li>
  * </ul>
  */
 public class CraftScheduler implements BukkitScheduler {
@@ -450,54 +450,59 @@ public class CraftScheduler implements BukkitScheduler {
         }
         // Paper end
         final List<CraftTask> temp = this.temp;
-        this.parsePending();
-        final List<CraftTask> tasks = this.pending.popValid(this.currentTick);
-        for (CraftTask task : tasks) {
-            if (task.getPeriod() < CraftTask.NO_REPEATING) {
+        while (true) {
+            this.parsePending(this.currentTick);
+
+            final List<CraftTask> tasks = this.pending.popValid(this.currentTick);
+            if (tasks.isEmpty()) break;
+
+            for (CraftTask task : tasks) {
+                if (task.getPeriod() < CraftTask.NO_REPEATING) {
+                    if (task.isSync()) {
+                        this.runners.remove(task.getTaskId(), task);
+                    }
+                    this.parsePending(this.currentTick);
+                    continue;
+                }
                 if (task.isSync()) {
-                    this.runners.remove(task.getTaskId(), task);
-                }
-                this.parsePending();
-                continue;
-            }
-            if (task.isSync()) {
-                this.currentTask = task;
-                try {
-                    task.run();
-                } catch (final Throwable throwable) {
-                    // Paper start
-                    final String logMessage = String.format(
-                        "Task #%s for %s generated an exception",
-                        task.getTaskId(),
-                        task.getOwner().getDescription().getFullName());
-                    task.getOwner().getLogger().log(
+                    this.currentTask = task;
+                    try {
+                        task.run();
+                    } catch (final Throwable throwable) {
+                        // Paper start
+                        final String logMessage = String.format(
+                            "Task #%s for %s generated an exception",
+                            task.getTaskId(),
+                            task.getOwner().getDescription().getFullName());
+                        task.getOwner().getLogger().log(
                             Level.WARNING,
-                        logMessage,
+                            logMessage,
                             throwable);
-                    org.bukkit.Bukkit.getServer().getPluginManager().callEvent(
-                        new com.destroystokyo.paper.event.server.ServerExceptionEvent(new com.destroystokyo.paper.exception.ServerSchedulerException(logMessage, throwable, task)));
-                    // Paper end
-                } finally {
-                    this.currentTask = null;
+                        org.bukkit.Bukkit.getServer().getPluginManager().callEvent(
+                            new com.destroystokyo.paper.event.server.ServerExceptionEvent(new com.destroystokyo.paper.exception.ServerSchedulerException(logMessage, throwable, task)));
+                        // Paper end
+                    } finally {
+                        this.currentTask = null;
+                    }
+                    this.parsePending(this.currentTick);
+                } else {
+                    // this.debugTail = this.debugTail.setNext(new CraftAsyncDebugger(this.currentTick + CraftScheduler.RECENT_TICKS, task.getOwner(), task.getTaskClass())); // Paper
+                    task.getOwner().getLogger().log(Level.SEVERE, "Unexpected Async Task in the Sync Scheduler. Report this to Paper"); // Paper
+                    // We don't need to parse pending
+                    // (async tasks must live with race-conditions if they attempt to cancel between these few lines of code)
                 }
-                this.parsePending();
-            } else {
-                // this.debugTail = this.debugTail.setNext(new CraftAsyncDebugger(this.currentTick + CraftScheduler.RECENT_TICKS, task.getOwner(), task.getTaskClass())); // Paper
-                task.getOwner().getLogger().log(Level.SEVERE, "Unexpected Async Task in the Sync Scheduler. Report this to Paper"); // Paper
-                // We don't need to parse pending
-                // (async tasks must live with race-conditions if they attempt to cancel between these few lines of code)
+                final long period = task.getPeriod(); // State consistency
+                if (period > 0) {
+                    task.setNextRun(this.currentTick + period);
+                    temp.add(task);
+                } else if (task.isSync()) {
+                    this.runners.remove(task.getTaskId());
+                }
             }
-            final long period = task.getPeriod(); // State consistency
-            if (period > 0) {
-                task.setNextRun(this.currentTick + period);
-                temp.add(task);
-            } else if (task.isSync()) {
-                this.runners.remove(task.getTaskId());
-            }
+            this.pending.addAll(temp, this.currentTick);
+            temp.clear();
+            //this.debugHead = this.debugHead.getNextHead(this.currentTick); // Paper
         }
-        this.pending.addAll(temp);
-        temp.clear();
-        //this.debugHead = this.debugHead.getNextHead(this.currentTick); // Paper
     }
 
     protected void addTask(final CraftTask task) {
@@ -534,7 +539,7 @@ public class CraftScheduler implements BukkitScheduler {
         return id;
     }
 
-    void parsePending() { // Paper
+    void parsePending(int currentTick) { // Paper
         CraftTask head = this.head;
         CraftTask task = head.getNext();
         CraftTask lastTask = head;
@@ -542,7 +547,7 @@ public class CraftScheduler implements BukkitScheduler {
             if (task.getTaskId() == -1) {
                 task.run();
             } else if (task.getPeriod() >= CraftTask.NO_REPEATING) {
-                this.pending.add(task);
+                this.pending.add(task, currentTick);
                 this.runners.put(task.getTaskId(), task);
             }
         }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
@@ -6,7 +6,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
 
-public class CraftTask implements BukkitTask, Runnable { // Spigot
+// Paper - Timing Wheel
+public class CraftTask implements BukkitTask, Runnable, io.papermc.paper.util.concurrent.ScheduledTask { // Spigot
 
     private volatile CraftTask next = null;
     public static final int ERROR = 0;
@@ -93,7 +94,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
         this.period = period;
     }
 
-    long getNextRun() {
+    public long getNextRun() { // Paper - Timing Wheel
         return this.nextRun;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
@@ -2,12 +2,12 @@ package org.bukkit.craftbukkit.scheduler;
 
 import java.util.function.Consumer;
 
+import io.papermc.paper.util.concurrent.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
 
-// Paper - Timing Wheel
-public class CraftTask implements BukkitTask, Runnable, io.papermc.paper.util.concurrent.ScheduledTask { // Spigot
+public class CraftTask implements BukkitTask, Runnable, ScheduledTask {
 
     private volatile CraftTask next = null;
     public static final int ERROR = 0;
@@ -94,7 +94,7 @@ public class CraftTask implements BukkitTask, Runnable, io.papermc.paper.util.co
         this.period = period;
     }
 
-    public long getNextRun() { // Paper - Timing Wheel
+    public long getNextRun() {
         return this.nextRun;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
@@ -2,12 +2,12 @@ package org.bukkit.craftbukkit.scheduler;
 
 import java.util.function.Consumer;
 
-import io.papermc.paper.util.concurrent.ScheduledTask;
+import io.papermc.paper.util.concurrent.TickBoundTask;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
 
-public class CraftTask implements BukkitTask, Runnable, ScheduledTask {
+public class CraftTask implements BukkitTask, Runnable, TickBoundTask {
 
     private volatile CraftTask next = null;
     public static final int ERROR = 0;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
@@ -82,7 +82,7 @@ public class CraftTask implements BukkitTask, Runnable, TickBoundTask {
         }
     }
 
-    long getCreatedAt() {
+    public long getCreatedAt() {
         return this.createdAt;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
@@ -98,7 +98,7 @@ public class CraftTask implements BukkitTask, Runnable, TickBoundTask {
         return this.nextRun;
     }
 
-    void setNextRun(long nextRun) {
+    public void setNextRun(long nextRun) {
         this.nextRun = nextRun;
     }
 


### PR DESCRIPTION
An optimization for the task scheduler, instead of using PriorityQueue (which has O(log n) operations), use a Timing Wheel (which has O(1) within one round execution).

I tested this in one of the plugins I work with and had good improvements from it.

I tested and spawned 100_000 tasks using a plugin, the server has 8GB max ram and `/spark profiler start --timeout 60 --thread *`

1.21.11 paper build 127 [PriorityQueue]
https://spark.lucko.me/ghhGHA8Pq7
`CraftScheduler#mainThreadHeartbeat()` took 23.49ms of which
18.14ms for removal and 1.33ms for insertion

1.21.11 paper opt/timing-wheel branch [TimingWheel]
https://spark.lucko.me/HUNomOcLXC
`CraftScheduler#mainThreadHeartbeat()` took 9.49ms of which
2.64ms for removal and 2.12ms for insertion

Plugin's testing code:
```java
public final class TaskSpawner extends JavaPlugin {

    @Override
    public void onEnable() {
        var schdl = Bukkit.getScheduler();

        schdl.runTaskLater(
            this,
            () -> {
                Random rndDelay = new Random();
                for (int i = 0; i < 100_000; i++) {
                    schdl.runTaskTimer(
                        this,
                        new Runnable() {
                            long x = new Random().nextLong();

                            @Override
                            public void run() {
                                if (x % 2 == 0) {
                                    x /= 2;
                                } else {
                                    x *= 3;
                                    x++;
                                }
                            }
                        }, rndDelay.nextInt(1, 5000), 1L
                    );
                }

                schdl.runTaskLater(this, () -> Bukkit.broadcast(Component.text("Completed")), 5000L);
            }, 40L
        );
    }
}
```
