### PR TITLE
Allow Persistent Data Container API to accept Adventure `Key`

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/persistence/PersistentDataContainerView.java
+++ b/paper-api/src/main/java/io/papermc/paper/persistence/PersistentDataContainerView.java
@@ -1,6 +1,7 @@
 package io.papermc.paper.persistence;
 
 import java.util.Set;
+import net.kyori.adventure.key.Key;
 import org.bukkit.NamespacedKey;
 import org.bukkit.persistence.PersistentDataAdapterContext;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -47,7 +48,53 @@ public interface PersistentDataContainerView {
      * @throws IllegalArgumentException if the type to cast the found object to is
      * null
      */
+    <P, C> boolean has(Key key, PersistentDataType<P, C> type);
+
+    /**
+     * Returns if the persistent metadata provider has metadata registered
+     * matching the provided parameters.
+     * <p>
+     * This method will only return true if the found value has the same primitive
+     * data type as the provided key.
+     * <p>
+     * Storing a value using a custom {@link PersistentDataType} implementation
+     * will not store the complex data type. Therefore storing a UUID (by
+     * storing a byte[]) will match has("key" ,
+     * {@link PersistentDataType#BYTE_ARRAY}). Likewise a stored byte[] will
+     * always match your UUID {@link PersistentDataType} even if it is not 16
+     * bytes long.
+     * <p>
+     * This method is only usable for custom object keys. Overwriting existing
+     * tags, like the display name, will not work as the values are stored
+     * using your namespace.
+     *
+     * @param key the key the value is stored under
+     * @param type the type the primitive stored value has to match
+     * @param <P> the generic type of the stored primitive
+     * @param <C> the generic type of the eventually created complex object
+     * @return if a value with the provided key and type exists
+     * @throws IllegalArgumentException if the key to look up is null
+     * @throws IllegalArgumentException if the type to cast the found object to is
+     * null
+     */
     <P, C> boolean has(NamespacedKey key, PersistentDataType<P, C> type);
+
+    /**
+     * Returns if the persistent metadata provider has metadata registered matching
+     * the provided parameters.
+     * <p>
+     * This method will return true as long as a value with the given key exists,
+     * regardless of its type.
+     * <p>
+     * This method is only usable for custom object keys. Overwriting existing tags,
+     * like the display name, will not work as the values are stored using your
+     * namespace.
+     *
+     * @param key the key the value is stored under
+     * @return if a value with the provided key exists
+     * @throws IllegalArgumentException if the key to look up is null
+     */
+    boolean has(Key key);
 
     /**
      * Returns if the persistent metadata provider has metadata registered matching
@@ -85,7 +132,51 @@ public interface PersistentDataContainerView {
      * the {@link
      * PersistentDataType#getPrimitiveType()}
      */
+    <P, C> @Nullable C get(Key key, PersistentDataType<P, C> type);
+
+    /**
+     * Returns the metadata value that is stored on the
+     * {@link PersistentDataHolder} instance.
+     *
+     * @param key the key to look up in the custom tag map
+     * @param type the type the value must have and will be cast to
+     * @param <P> the generic type of the stored primitive
+     * @param <C> the generic type of the eventually created complex object
+     * @return the value or {@code null} if no value was mapped under the given
+     * value
+     * @throws IllegalArgumentException if the key to look up is null
+     * @throws IllegalArgumentException if the type to cast the found object to is
+     * null
+     * @throws IllegalArgumentException if a value exists under the given key,
+     * but cannot be accessed using the given type
+     * @throws IllegalArgumentException if no suitable adapter was found for
+     * the {@link
+     * PersistentDataType#getPrimitiveType()}
+     */
     <P, C> @Nullable C get(NamespacedKey key, PersistentDataType<P, C> type);
+
+    /**
+     * Returns the metadata value that is stored on the
+     * {@link PersistentDataHolder} instance. If the value does not exist in the
+     * container, the default value provided is returned.
+     *
+     * @param key the key to look up in the custom tag map
+     * @param type the type the value must have and will be cast to
+     * @param defaultValue the default value to return if no value was found for
+     * the provided key
+     * @param <P> the generic type of the stored primitive
+     * @param <C> the generic type of the eventually created complex object
+     * @return the value or the default value if no value was mapped under the
+     * given key
+     * @throws IllegalArgumentException if the key to look up is null
+     * @throws IllegalArgumentException if the type to cast the found object to is
+     * null
+     * @throws IllegalArgumentException if a value exists under the given key,
+     * but cannot be accessed using the given type
+     * @throws IllegalArgumentException if no suitable adapter was found for
+     * the {@link PersistentDataType#getPrimitiveType()}
+     */
+    <P, C> C getOrDefault(Key key, PersistentDataType<P, C> type, C defaultValue);
 
     /**
      * Returns the metadata value that is stored on the

--- a/paper-api/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
+++ b/paper-api/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
@@ -1,5 +1,6 @@
 package org.bukkit.persistence;
 
+import net.kyori.adventure.key.Key;
 import org.bukkit.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,12 +27,44 @@ public interface PersistentDataContainer extends io.papermc.paper.persistence.Pe
      * @throws IllegalArgumentException if the key is null
      * @throws IllegalArgumentException if the type is null
      * @throws IllegalArgumentException if the value is null. Removing a tag should
+     * be done using {@link #remove(Key)}
+     * @throws IllegalArgumentException if no suitable adapter was found for
+     * the {@link PersistentDataType#getPrimitiveType()}
+     */
+    <P, C> void set(@NotNull Key key, @NotNull PersistentDataType<P, C> type, @NotNull C value);
+    // Paper - move to PersistentDataContainerView
+
+    /**
+     * Stores a metadata value on the {@link PersistentDataHolder} instance.
+     * <p>
+     * This API cannot be used to manipulate minecraft data, as the values will
+     * be stored using your namespace. This method will override any existing
+     * value the {@link PersistentDataHolder} may have stored under the provided
+     * key.
+     *
+     * @param key the key this value will be stored under
+     * @param type the type this tag uses
+     * @param value the value to store in the tag
+     * @param <P> the generic java type of the tag value
+     * @param <C> the generic type of the object to store
+     *
+     * @throws IllegalArgumentException if the key is null
+     * @throws IllegalArgumentException if the type is null
+     * @throws IllegalArgumentException if the value is null. Removing a tag should
      * be done using {@link #remove(NamespacedKey)}
      * @throws IllegalArgumentException if no suitable adapter was found for
      * the {@link PersistentDataType#getPrimitiveType()}
      */
     <P, C> void set(@NotNull NamespacedKey key, @NotNull PersistentDataType<P, C> type, @NotNull C value);
-    // Paper - move to PersistentDataContainerView
+
+    /**
+     * Removes a custom key from the {@link PersistentDataHolder} instance.
+     *
+     * @param key the key to remove
+     *
+     * @throws IllegalArgumentException if the provided key is null
+     */
+    void remove(@NotNull Key key);
 
     /**
      * Removes a custom key from the {@link PersistentDataHolder} instance.

--- a/paper-server/src/main/java/io/papermc/paper/persistence/PaperPersistentDataContainerView.java
+++ b/paper-server/src/main/java/io/papermc/paper/persistence/PaperPersistentDataContainerView.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import net.kyori.adventure.key.Key;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.Tag;
@@ -36,8 +37,8 @@ public abstract class PaperPersistentDataContainerView implements PersistentData
     public abstract CompoundTag toTagCompound();
 
     @Override
-    public <P, C> boolean has(final NamespacedKey key, final PersistentDataType<P, C> type) {
-        Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+    public <P, C> boolean has(final Key key, final PersistentDataType<P, C> type) {
+        Preconditions.checkArgument(key != null, "The provided key cannot be null");
         Preconditions.checkArgument(type != null, "The provided type cannot be null");
 
         final Tag value = this.getTag(key.toString());
@@ -49,14 +50,24 @@ public abstract class PaperPersistentDataContainerView implements PersistentData
     }
 
     @Override
-    public boolean has(final NamespacedKey key) {
+    public <P, C> boolean has(final NamespacedKey key, final PersistentDataType<P, C> type) {
+        return has((Key) key, type);
+    }
+
+    @Override
+    public boolean has(final Key key) {
         Preconditions.checkArgument(key != null, "The provided key for the custom value was null"); // Paper
         return this.getTag(key.toString()) != null;
     }
 
     @Override
-    public <P, C> @Nullable C get(final NamespacedKey key, final PersistentDataType<P, C> type) {
-        Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+    public boolean has(final NamespacedKey key) {
+        return has((Key) key);
+    }
+
+    @Override
+    public <P, C> @Nullable C get(final Key key, final PersistentDataType<P, C> type) {
+        Preconditions.checkArgument(key != null, "The provided key cannot be null");
         Preconditions.checkArgument(type != null, "The provided type cannot be null");
 
         final Tag value = this.getTag(key.toString());
@@ -68,9 +79,19 @@ public abstract class PaperPersistentDataContainerView implements PersistentData
     }
 
     @Override
-    public <P, C> C getOrDefault(final NamespacedKey key, final PersistentDataType<P, C> type, final C defaultValue) {
+    public <P, C> @Nullable C get(final NamespacedKey key, final PersistentDataType<P, C> type) {
+        return get((Key) key, type);
+    }
+
+    @Override
+    public <P, C> C getOrDefault(final Key key, final PersistentDataType<P, C> type, final C defaultValue) {
         final C c = this.get(key, type);
         return c != null ? c : defaultValue;
+    }
+
+    @Override
+    public <P, C> C getOrDefault(final NamespacedKey key, final PersistentDataType<P, C> type, final C defaultValue) {
+        return getOrDefault((Key) key, type, defaultValue);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import net.kyori.adventure.key.Key;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import org.bukkit.NamespacedKey;
@@ -36,12 +37,17 @@ public class CraftPersistentDataContainer extends io.papermc.paper.persistence.P
     }
 
     @Override
-    public <T, Z> void set(@NotNull NamespacedKey key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value) {
-        Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+    public <T, Z> void set(@NotNull Key key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value) {
+        Preconditions.checkArgument(key != null, "The provided key cannot be null");
         Preconditions.checkArgument(type != null, "The provided type cannot be null");
         Preconditions.checkArgument(value != null, "The provided value cannot be null");
 
         this.customDataTags.put(key.toString(), this.registry.wrap(type, type.toPrimitive(value, this.adapterContext)));
+    }
+
+    @Override
+    public <T, Z> void set(@NotNull NamespacedKey key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value) {
+        set((Key) key, type, value);
     }
 
     @NotNull
@@ -60,10 +66,15 @@ public class CraftPersistentDataContainer extends io.papermc.paper.persistence.P
     }
 
     @Override
-    public void remove(@NotNull NamespacedKey key) {
-        Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+    public void remove(@NotNull Key key) {
+        Preconditions.checkArgument(key != null, "The provided key cannot be null");
 
         this.customDataTags.remove(key.toString());
+    }
+
+    @Override
+    public void remove(@NotNull NamespacedKey key) {
+        remove((Key) key);
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/persistence/DirtyCraftPersistentDataContainer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/persistence/DirtyCraftPersistentDataContainer.java
@@ -1,9 +1,9 @@
 package org.bukkit.craftbukkit.persistence;
 
 import java.util.Map;
+import net.kyori.adventure.key.Key;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
-import org.bukkit.NamespacedKey;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,13 +32,13 @@ public final class DirtyCraftPersistentDataContainer extends CraftPersistentData
     }
 
     @Override
-    public <T, Z> void set(@NotNull NamespacedKey key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value) {
+    public <T, Z> void set(@NotNull Key key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value) {
         super.set(key, type, value);
         this.dirty(true);
     }
 
     @Override
-    public void remove(@NotNull NamespacedKey key) {
+    public void remove(@NotNull Key key) {
         super.remove(key);
         this.dirty(true);
     }


### PR DESCRIPTION
Allows the PDC API to accept Adventure `Key`s making it more consistent with the rest of the API by making new versions of the functions which accept `Key` directly; making it a non-breaking change. The return types of `getKeys()` were not changed as that can already be handled as `Key` anyway.