### PR TITLE
Fixes zombie 'shouldBurnInDay' API no longer being implemented

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/zombie/Zombie.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/zombie/Zombie.java.patch
@@ -90,7 +90,7 @@
      public void startUnderWaterConversion(int conversionTime) {
          this.conversionTime = conversionTime;
          this.getEntityData().set(DATA_DROWNED_CONVERSION_ID, true);
-@@ -240,31 +_,50 @@
+@@ -240,31 +_,54 @@
      }
  
      protected void convertToZombieType(ServerLevel level, EntityType<? extends Zombie> entityType) {
@@ -145,6 +145,10 @@
 +    // Paper start - Add more Zombie API
 +    public void setShouldBurnInDay(boolean shouldBurnInDay) {
 +        this.shouldBurnInDay = shouldBurnInDay;
++    }
++    @Override
++    public boolean isSunBurnTick() {
++        return this.shouldBurnInDay && super.isSunBurnTick();
 +    }
 +    // Paper end - Add more Zombie API
  


### PR DESCRIPTION
This is how it's being handled by Skeletons and Phantoms but somehow it was missed for Zombies