### PR TITLE
reset pending keepalive state on listener handoff during reconfiguration

### DIFF
--- a/paper-server/patches/features/0024-Improve-keepalive-ping-system.patch
+++ b/paper-server/patches/features/0024-Improve-keepalive-ping-system.patch
@@ -13,7 +13,7 @@ average over the last 5 seconds of keepalive transactions.
 
 diff --git a/io/papermc/paper/util/KeepAlive.java b/io/papermc/paper/util/KeepAlive.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4a2520f554c2ee74faf86d7c93baccf0f391a6b3
+index 0000000000000000000000000000000000000000..66d6af2833d76af28fbeb2ce70c194a559572460
 --- /dev/null
 +++ b/io/papermc/paper/util/KeepAlive.java
 @@ -0,0 +1,84 @@
@@ -117,7 +117,7 @@ index 21d50675bfe90c2276890779eb23de58ac915b9a..7be34e37562875313b8e43357921b5fe
      }
  }
 diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index 079ab378920c0e52ef4e42ef20b37bd389f40870..b8a4b4cc02a2fc6b70f4b840796eed501aad6239 100644
+index 079ab378920c0e52ef4e42ef20b37bd389f40870..dc9020f210c21a626c948d013cc6c972cbc093f3 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 @@ -39,12 +39,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
@@ -240,7 +240,7 @@ index 079ab378920c0e52ef4e42ef20b37bd389f40870..b8a4b4cc02a2fc6b70f4b840796eed50
              }
          }
  
-@@ -427,6 +460,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -427,6 +460,14 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      }
  
      protected CommonListenerCookie createCookie(ClientInformation clientInformation) {

--- a/paper-server/patches/features/0024-Improve-keepalive-ping-system.patch
+++ b/paper-server/patches/features/0024-Improve-keepalive-ping-system.patch
@@ -16,7 +16,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..4a2520f554c2ee74faf86d7c93baccf0f391a6b3
 --- /dev/null
 +++ b/io/papermc/paper/util/KeepAlive.java
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,84 @@
 +package io.papermc.paper.util;
 +
 +public class KeepAlive {
@@ -34,6 +34,14 @@ index 0000000000000000000000000000000000000000..4a2520f554c2ee74faf86d7c93baccf0
 +    public final PingCalculator pingCalculator1m = new PingCalculator(java.util.concurrent.TimeUnit.MINUTES.toNanos(1L));
 +    public final PingCalculator pingCalculator5s = new PingCalculator(java.util.concurrent.TimeUnit.SECONDS.toNanos(5L));
 +
++    public KeepAlive copyForListenerHandoff() {
++        KeepAlive copy = new KeepAlive();
++        copy.lastKeepAliveTx = this.lastKeepAliveTx;
++        copy.pingCalculator1m.copyFrom(this.pingCalculator1m);
++        copy.pingCalculator5s.copyFrom(this.pingCalculator5s);
++        return copy;
++    }
++
 +    public static final class PingCalculator {
 +
 +        private final long intervalNS;
@@ -45,6 +53,15 @@ index 0000000000000000000000000000000000000000..4a2520f554c2ee74faf86d7c93baccf0
 +
 +        public PingCalculator(long intervalNS) {
 +            this.intervalNS = intervalNS;
++        }
++
++        private void copyFrom(PingCalculator other) {
++            for (KeepAliveResponse response : other.responses) {
++                this.responses.add(response);
++            }
++            this.timeSumNS = other.timeSumNS;
++            this.timeSumCount = other.timeSumCount;
++            this.lastAverageNS = other.lastAverageNS;
 +        }
 +
 +        public void update(KeepAliveResponse response) {
@@ -223,11 +240,19 @@ index 079ab378920c0e52ef4e42ef20b37bd389f40870..b8a4b4cc02a2fc6b70f4b840796eed50
              }
          }
  
-@@ -427,6 +460,6 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -427,6 +460,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      }
  
      protected CommonListenerCookie createCookie(ClientInformation clientInformation) {
 -        return new CommonListenerCookie(this.playerProfile(), this.latency, clientInformation, this.transferred, this.playerBrand, this.pluginMessagerChannels); // Paper
-+        return new CommonListenerCookie(this.playerProfile(), this.latency, clientInformation, this.transferred, this.playerBrand, this.pluginMessagerChannels, this.keepAlive); // Paper
++        return new CommonListenerCookie(
++            this.playerProfile(),
++            this.latency,
++            clientInformation,
++            this.transferred,
++            this.playerBrand,
++            this.pluginMessagerChannels,
++            this.keepAlive.copyForListenerHandoff()
++        ); // Paper - listener handoff should reset pending keepalive expectations
      }
  }

--- a/paper-server/patches/features/0024-Improve-keepalive-ping-system.patch
+++ b/paper-server/patches/features/0024-Improve-keepalive-ping-system.patch
@@ -16,7 +16,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..4a2520f554c2ee74faf86d7c93baccf0f391a6b3
 --- /dev/null
 +++ b/io/papermc/paper/util/KeepAlive.java
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,84 @@
 +package io.papermc.paper.util;
 +
 +public class KeepAlive {
@@ -34,6 +34,14 @@ index 0000000000000000000000000000000000000000..4a2520f554c2ee74faf86d7c93baccf0
 +    public final PingCalculator pingCalculator1m = new PingCalculator(java.util.concurrent.TimeUnit.MINUTES.toNanos(1L));
 +    public final PingCalculator pingCalculator5s = new PingCalculator(java.util.concurrent.TimeUnit.SECONDS.toNanos(5L));
 +
++    public KeepAlive copyForListenerHandoff() {
++        KeepAlive copy = new KeepAlive();
++        copy.lastKeepAliveTx = this.lastKeepAliveTx;
++        copy.pingCalculator1m.copyFrom(this.pingCalculator1m);
++        copy.pingCalculator5s.copyFrom(this.pingCalculator5s);
++        return copy;
++    }
++
 +    public static final class PingCalculator {
 +
 +        private final long intervalNS;
@@ -45,6 +53,15 @@ index 0000000000000000000000000000000000000000..4a2520f554c2ee74faf86d7c93baccf0
 +
 +        public PingCalculator(long intervalNS) {
 +            this.intervalNS = intervalNS;
++        }
++
++        private void copyFrom(PingCalculator other) {
++            for (KeepAliveResponse response : other.responses) {
++                this.responses.add(response);
++            }
++            this.timeSumNS = other.timeSumNS;
++            this.timeSumCount = other.timeSumCount;
++            this.lastAverageNS = other.lastAverageNS;
 +        }
 +
 +        public void update(KeepAliveResponse response) {
@@ -223,11 +240,19 @@ index f54d99c59bbca7fb5e0615f8fee9c3f6fbffa18a..d9b6f3826e2126d339e926afed782f6d
              }
          }
  
-@@ -424,6 +457,6 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -424,6 +457,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      }
  
      protected CommonListenerCookie createCookie(final ClientInformation clientInformation) {
 -        return new CommonListenerCookie(this.playerProfile(), this.latency, clientInformation, this.transferred, this.playerBrand, this.pluginMessagerChannels); // Paper
-+        return new CommonListenerCookie(this.playerProfile(), this.latency, clientInformation, this.transferred, this.playerBrand, this.pluginMessagerChannels, this.keepAlive); // Paper // Paper
++        return new CommonListenerCookie(
++            this.playerProfile(),
++            this.latency,
++            clientInformation,
++            this.transferred,
++            this.playerBrand,
++            this.pluginMessagerChannels,
++            this.keepAlive.copyForListenerHandoff()
++        ); // Paper - listener handoff should reset pending keepalive expectations
      }
  }

--- a/paper-server/patches/features/0024-Improve-keepalive-ping-system.patch
+++ b/paper-server/patches/features/0024-Improve-keepalive-ping-system.patch
@@ -13,7 +13,7 @@ average over the last 5 seconds of keepalive transactions.
 
 diff --git a/io/papermc/paper/util/KeepAlive.java b/io/papermc/paper/util/KeepAlive.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4a2520f554c2ee74faf86d7c93baccf0f391a6b3
+index 0000000000000000000000000000000000000000..66d6af2833d76af28fbeb2ce70c194a559572460
 --- /dev/null
 +++ b/io/papermc/paper/util/KeepAlive.java
 @@ -0,0 +1,84 @@
@@ -117,7 +117,7 @@ index d87a00ee3cd04ce25dbe46ae6b386b7f0799102c..ace440c2b82a6368aa27a85ff433ba2c
      }
  }
 diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index f54d99c59bbca7fb5e0615f8fee9c3f6fbffa18a..d9b6f3826e2126d339e926afed782f6d0e890508 100644
+index 079ab378920c0e52ef4e42ef20b37bd389f40870..dc9020f210c21a626c948d013cc6c972cbc093f3 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 @@ -39,12 +39,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
@@ -240,7 +240,7 @@ index f54d99c59bbca7fb5e0615f8fee9c3f6fbffa18a..d9b6f3826e2126d339e926afed782f6d
              }
          }
  
-@@ -424,6 +457,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -424,6 +457,14 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      }
  
      protected CommonListenerCookie createCookie(final ClientInformation clientInformation) {


### PR DESCRIPTION
Fixes PaperMC/Velocity#1723. (The backend side)

During mid session reconfiguration behind Velocity, Paper was carrying the same `KeepAlive` tracker across listener handoff. That allowed a pending PLAY keepalive expectation to survive into the CONFIG listener.

In the failing case, the sequence was:
1. the PLAY listener issued keepalive `A`
2. listener handoff moved the player into CONFIG
3. the CONFIG listener inherited the pending expectation for `A`
4. the CONFIG listener issued keepalive `B`
5. the reply for `B` arrived while the backend still considered `A` outstanding
6. Paper rejected `B` as stale or out-of-order and disconnected the player with `disconnect.timeout`

The key signal from backend logging was that `listener_handoff` showed the CONFIG listener inheriting the prior PLAY `expectedId`, and the next CONFIG keepalive reply was then rejected as `stale_or_out_of_order`.

So the failure was not that Velocity dropped the CONFIG reply (the backend received it). The problem was that stale pending PLAY keepalive state leaked across the PLAY -> CONFIG handoff.

## the fix:
`ServerCommonPacketListenerImpl#createCookie(...)` now gives the next listener a fresh `KeepAlive` instance instead of reusing the current listener's pending tracker. This preserves latency/history state, but intentionally resets inflight keepalive challenge state across listener handoff. In other words:
- preserve ping history
- reset pending keepalive expectations

That restores the expected protocol boundary between PLAY and CONFIG.

## testing:

Tested locally with the Velocity reproduction from PaperMC/Velocity#1723.

Before this fix:
- repeated config/unconfig cycles would eventually fail
- failures were much easier to trigger with added latency
- backend logs showed CONFIG replies being rejected as out-of-order because the old PLAY expectation was still present

After this fix:
- no disconnects at 0 ms added latency
- no disconnects at 200 ms added latency
- no disconnects at 800 ms added latency
- backend logs show the CONFIG listener no longer inherits the stale PLAY pending keepalive expectation