### PR TITLE
Fix block entity ticking list

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
@@ -449,7 +449,7 @@
 -        while (iterator.hasNext()) {
 -            TickingBlockEntity ticker = iterator.next();
 +        // Paper start - Fix MC-117075 use removeAll
-+        final it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<TickingBlockEntity> toRemove = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<>();
++        final it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<@Nullable TickingBlockEntity> toRemove = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<>();
 +        toRemove.add(null);
 +        for (int tickerIndex = 0; tickerIndex < this.blockEntityTickers.size(); tickerIndex++) {
 +            final TickingBlockEntity ticker = this.blockEntityTickers.get(tickerIndex);

--- a/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
@@ -443,26 +443,26 @@
          }
  
 -        Iterator<TickingBlockEntity> iterator = this.blockEntityTickers.iterator();
++        // Paper - Fix MC-117075 use removeAll - remove iterator in favour of indexed for loop, ensuring compile error if something uses iter incorrectly
          boolean tickBlockEntities = this.tickRateManager().runsNormally();
  
 -        while (iterator.hasNext()) {
 -            TickingBlockEntity ticker = iterator.next();
-+        // Paper start - Fix MC-117075; use removeAll
-+        final java.util.Set<@Nullable TickingBlockEntity> toRemove = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<>();
++        // Paper start - Fix MC-117075 use removeAll
++        final it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<TickingBlockEntity> toRemove = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<>();
 +        toRemove.add(null);
-+
-+        for (final TickingBlockEntity ticker : this.blockEntityTickers) {
++        for (int tickerIndex = 0; tickerIndex < this.blockEntityTickers.size(); tickerIndex++) {
++            final TickingBlockEntity ticker = this.blockEntityTickers.get(tickerIndex);
++        // Paper end - Fix MC-117075 use removeAll
              if (ticker.isRemoved()) {
 -                iterator.remove();
-+                toRemove.add(ticker);
++                toRemove.add(ticker); // Paper - Fix MC-117075 use removeAll
              } else if (tickBlockEntities && this.shouldTickBlocksAt(ticker.getPos())) {
                  ticker.tick();
              }
          }
  
-+        this.blockEntityTickers.removeAll(toRemove);
-+        // Paper end - Fix MC-117075; use removeAll
-+
++        this.blockEntityTickers.removeAll(toRemove); // Paper - Fix MC-117075 use removeAll
          this.tickingBlockEntities = false;
 +        this.spigotConfig.currentPrimedTnt = 0; // Spigot
      }

--- a/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
@@ -451,7 +451,7 @@
 +        final java.util.Set<@Nullable TickingBlockEntity> toRemove = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<>();
 +        toRemove.add(null);
 +
-+        for (final TickingBlockEntity ticker : this.pendingBlockEntityTickers) {
++        for (final TickingBlockEntity ticker : this.blockEntityTickers) {
              if (ticker.isRemoved()) {
 -                iterator.remove();
 +                toRemove.add(ticker);


### PR DESCRIPTION
Fixes the block entity tick loop iterating pendingBlockEntityTickers instead of blockEntityTickers in 26.1. pendingBlockEntityTickers is a staging list that’s merged/cleared before ticking, so iterating it prevents active block entities from ticking (furnaces/campfires/hoppers).