### PR TITLE
Fix ThrownPotion#splash NPE when called from API

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/AbstractThrownPotion.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/AbstractThrownPotion.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/projectile/throwableitemprojectile/AbstractThrownPotion.java
 +++ b/net/minecraft/world/entity/projectile/throwableitemprojectile/AbstractThrownPotion.java
-@@ -68,56 +_,97 @@
+@@ -68,56 +_,98 @@
      @Override
      protected void onHit(HitResult result) {
          super.onHit(result);
@@ -10,6 +10,7 @@
 +
 +    public void splash(HitResult result) {
 +        // Paper end - More projectile API
++        if (result == null) result = BlockHitResult.miss(this.position(), Direction.UP, this.blockPosition()); // Paper - More projectile API; default to entity position for API calls
          if (this.level() instanceof ServerLevel serverLevel) {
              ItemStack item = this.getItem();
              PotionContents potionContents = item.getOrDefault(DataComponents.POTION_CONTENTS, PotionContents.EMPTY);


### PR DESCRIPTION
Calling ThrownPotion#splash() from a plugin always throws a NPE because CraftThrownPotion passes null as the HitResult, and onHitAsPotion tries to call getLocation() on it.

Fixed by defaulting to a BlockHitResult at the entity's position when the result is null, so the splash area is just centered on the potion itself which makes sense for programmatic calls.

Fixes #13611