### PR TITLE
[ci skip] Update README and CONTRIBUTING for 26.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ On Windows, remove the `./` the beginning of `gradlew` commands;
 **Only changes made in `paper-server/src/minecraft` have to deal with the patch system.**
 
 `paper-server/src/minecraft` is not a git repositories in the traditional sense. Its
-initial commits are the decompiled and deobfuscated Minecraft source files. The per-file
+initial commits are the decompiled Minecraft source files. The per-file
 patches are applied on top of these files as a single, large commit, which is then followed
 by the individual feature-patch commits.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,8 +184,7 @@ These steps assume the `origin` remote is your fork of this repository and `upst
 ## PR Policy
 
 We'll accept changes that make sense. You should be able to justify their
-existence, along with any maintenance costs that come with them. Using
-[obfuscation helpers](#obfuscation-helpers) aids in the maintenance costs.
+existence, along with any maintenance costs that come with them.
 Remember that these changes will affect everyone who runs Paper, not just you
 and your server.
 
@@ -381,26 +380,6 @@ index a92bf8967..d0ab87d0f 100644
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 ```
 -->
-
-## Obfuscation Helpers
-
-While rarely needed, obfuscation helpers are sometimes useful when it comes
-to unmapped local variables, or poorly named method parameters. In an effort
-to make future updates easier on ourselves, Paper tries to use obfuscation
-helpers wherever it makes sense. The purpose of these helpers is to make the
-code more readable and maintainable. These helpers should be made easy to
-inline by the JVM wherever possible.
-
-An example of an obfuscation helper for a local variable:
-```java
-double d0 = entity.getX(); final double fromX = d0; // Paper - OBFHELPER
-// ...   
-this.someMethod(fromX); // Paper
-```
-
-While they may not always be done in exactly the same way, the general goal is
-always to improve readability and maintainability. Use your best judgment and do
-what fits best in your situation.
 
 ## Configuration files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ you will most likely use this for WSL), `homebrew` (macOS / Linux), and more:
   - [Adoptium](https://adoptium.net/) has builds for most operating systems.
   - Paper requires JDK 25 to build, however, makes use of Gradle's
     [Toolchains](https://docs.gradle.org/current/userguide/toolchains.html)
-    feature to allow building with only JRE 17 or later installed. (Gradle will
+    feature to allow building with only JRE 21 or later installed. (Gradle will
     automatically provision JDK 25 for compilation if it cannot find an existing
     installation).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,7 +280,7 @@ public class SomeVanillaClass {
 
 We are in the process of switching nullability annotation libraries, so you might need to use one or the other:
 
-**For classes we add**: Fields, method parameters and return types that are nullable should be marked via the
+**For classes, we add or modifications to Vanilla Files**: Fields, method parameters and return types that are nullable should be marked via the
 `@Nullable` annotation from `org.jspecify.annotations`. Whenever you create a new class, add `@NullMarked`, meaning types
 are assumed to be non-null by default. For less obvious placing such as on generics or arrays, see the [JSpecify docs](https://jspecify.dev/docs/user-guide/).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,12 +21,12 @@ which can be obtained in (most) package managers such as `apt` (Debian / Ubuntu;
 you will most likely use this for WSL), `homebrew` (macOS / Linux), and more:
 
 - `git` (package `git` everywhere);
-- A Java 21 or later JDK (packages vary, use Google/DuckDuckGo/etc.).
+- A Java 25 or later JDK (packages vary, use Google/DuckDuckGo/etc.).
   - [Adoptium](https://adoptium.net/) has builds for most operating systems.
-  - Paper requires JDK 21 to build, however, makes use of Gradle's
+  - Paper requires JDK 25 to build, however, makes use of Gradle's
     [Toolchains](https://docs.gradle.org/current/userguide/toolchains.html)
     feature to allow building with only JRE 17 or later installed. (Gradle will
-    automatically provision JDK 21 for compilation if it cannot find an existing
+    automatically provision JDK 25 for compilation if it cannot find an existing
     installation).
 
 If you're on Windows, check
@@ -36,11 +36,11 @@ If you're compiling with Docker, you can use Adoptium's
 [`eclipse-temurin`](https://hub.docker.com/_/eclipse-temurin/) images like so:
 
 ```console
-# docker run -it -v "$(pwd)":/data --rm eclipse-temurin:21.0.5_11-jdk bash
+# docker run -it -v "$(pwd)":/data --rm eclipse-temurin:25.0.2_10-jdk bash
 Pulling image...
 
 root@abcdefg1234:/# javac -version
-javac 21.0.5
+javac 25.0.2
 ```
 
 ## Understanding Patches

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ java {
 <dependency>
     <groupId>io.papermc.paper</groupId>
     <artifactId>paper-api</artifactId>
-    <version>[26.1.1,)</version>
+    <version>[26.1.1.build,)</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ How To (Plugin Developers)
 * See upcoming, pending, and recently added API [here](https://github.com/orgs/PaperMC/projects/2/views/4)
 * Paper API javadocs here: [papermc.io/javadocs](https://papermc.io/javadocs/)
 #### Repository (for paper-api)
-> You can read more about adding paper as repository [here](https://docs.papermc.io/paper/dev/project-setup/#adding-paper-as-a-dependency) for more details.
+> See [the docs](https://docs.papermc.io/paper/dev/project-setup/#adding-paper-as-a-dependency) for more details, including Maven caveats.
 ##### Maven
 
 ```xml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-Paper [![Paper Build Status](https://img.shields.io/github/actions/workflow/status/PaperMC/Paper/build.yml?branch=main)](https://github.com/PaperMC/Paper/actions)
-[![Version](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fartifactory.papermc.io%2Fartifactory%2Funiverse%2Fio%2Fpapermc%2Fpaper%2Fpaper-api%2Fmaven-metadata.xml&strategy=highestVersion&filter=26.1*&label=version&color=%236fa8dc
+Paper [![Version](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fartifactory.papermc.io%2Fartifactory%2Funiverse%2Fio%2Fpapermc%2Fpaper%2Fpaper-api%2Fmaven-metadata.xml&strategy=highestVersion&filter=26.1*&label=version&color=%23344ceb
 )](https://papermc.io/downloads/paper)
+[![Paper Build Status](https://img.shields.io/github/actions/workflow/status/PaperMC/Paper/build.yml?branch=main)](https://github.com/PaperMC/Paper/actions)
 [![Discord](https://img.shields.io/discord/289587909051416579.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/papermc)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/papermc?label=GitHub%20Sponsors)](https://github.com/sponsors/PaperMC)
 [![Open Collective](https://img.shields.io/opencollective/all/papermc?label=OpenCollective%20Sponsors)](https://opencollective.com/papermc)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ How To (Plugin Developers)
 <dependency>
     <groupId>io.papermc.paper</groupId>
     <artifactId>paper-api</artifactId>
-    <version>1.21.11-R0.1-SNAPSHOT</version>
+    <version>26.1.1.build.+</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -53,19 +53,19 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:26.1.1.build.+")
 }
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(25))
 }
 ```
 
 How To (Compiling Jar From Source)
 ------
-To compile Paper, you need JDK 21 and an internet connection.
+To compile Paper, you need JDK 25 and an internet connection.
 
-Clone this repo, run `./gradlew applyPatches`, then `./gradlew createMojmapBundlerJar` from your terminal. You can find the compiled jar in the `paper-server/build/libs` directory.
+Clone this repo, run `./gradlew applyPatches`, then `./gradlew createPaperclipJar` from your terminal. You can find the compiled jar in the `paper-server/build/libs` directory.
 
 To get a full list of tasks, run `./gradlew tasks`.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 Paper [![Paper Build Status](https://img.shields.io/github/actions/workflow/status/PaperMC/Paper/build.yml?branch=main)](https://github.com/PaperMC/Paper/actions)
+[![Version](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fartifactory.papermc.io%2Fartifactory%2Funiverse%2Fio%2Fpapermc%2Fpaper%2Fpaper-api%2Fmaven-metadata.xml&strategy=highestVersion&filter=26.1*&label=version&color=%236fa8dc
+)](https://papermc.io/downloads/paper)
 [![Discord](https://img.shields.io/discord/289587909051416579.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/papermc)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/papermc?label=GitHub%20Sponsors)](https://github.com/sponsors/PaperMC)
 [![Open Collective](https://img.shields.io/opencollective/all/papermc?label=OpenCollective%20Sponsors)](https://opencollective.com/papermc)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ How To (Plugin Developers)
 * See upcoming, pending, and recently added API [here](https://github.com/orgs/PaperMC/projects/2/views/4)
 * Paper API javadocs here: [papermc.io/javadocs](https://papermc.io/javadocs/)
 #### Repository (for paper-api)
-See [the docs](https://docs.papermc.io/paper/dev/project-setup/#adding-paper-as-a-dependency) for more details, including Maven caveats.
+See [the docs](https://docs.papermc.io/paper/dev/project-setup/#adding-paper-as-a-dependency) for more details.
 ##### Gradle
 ```kotlin
 repositories {
@@ -59,7 +59,7 @@ java {
 <dependency>
     <groupId>io.papermc.paper</groupId>
     <artifactId>paper-api</artifactId>
-    <version>VERSION</version>
+    <version>[26.1.1,)</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,23 @@ How To (Plugin Developers)
 * See upcoming, pending, and recently added API [here](https://github.com/orgs/PaperMC/projects/2/views/4)
 * Paper API javadocs here: [papermc.io/javadocs](https://papermc.io/javadocs/)
 #### Repository (for paper-api)
-> See [the docs](https://docs.papermc.io/paper/dev/project-setup/#adding-paper-as-a-dependency) for more details, including Maven caveats.
+See [the docs](https://docs.papermc.io/paper/dev/project-setup/#adding-paper-as-a-dependency) for more details, including Maven caveats.
+##### Gradle
+```kotlin
+repositories {
+    maven {
+        url = uri("https://repo.papermc.io/repository/maven-public/")
+    }
+}
+
+dependencies {
+    compileOnly("io.papermc.paper:paper-api:26.1.1.build.+")
+}
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(25))
+}
+```
 ##### Maven
 
 ```xml
@@ -46,22 +62,6 @@ How To (Plugin Developers)
     <version>VERSION</version>
     <scope>provided</scope>
 </dependency>
-```
-##### Gradle
-```kotlin
-repositories {
-    maven {
-        url = uri("https://repo.papermc.io/repository/maven-public/")
-    }
-}
-
-dependencies {
-    compileOnly("io.papermc.paper:paper-api:26.1.1.build.+")
-}
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(25))
-}
 ```
 
 How To (Compiling Jar From Source)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ How To (Plugin Developers)
 * See upcoming, pending, and recently added API [here](https://github.com/orgs/PaperMC/projects/2/views/4)
 * Paper API javadocs here: [papermc.io/javadocs](https://papermc.io/javadocs/)
 #### Repository (for paper-api)
+> You can read more about adding paper as repository [here](https://docs.papermc.io/paper/dev/project-setup/#adding-paper-as-a-dependency) for more details.
 ##### Maven
 
 ```xml
@@ -40,7 +41,7 @@ How To (Plugin Developers)
 <dependency>
     <groupId>io.papermc.paper</groupId>
     <artifactId>paper-api</artifactId>
-    <version>26.1.1.build.+</version>
+    <version>VERSION</version>
     <scope>provided</scope>
 </dependency>
 ```


### PR DESCRIPTION
This update README and CONTRIBUTION for the last changes in 26.1 releases

- Add version badge with filter for major version
- Modify the repository reference, with a placeholder for maven related to the new no-snapshot versions
- Modify the requirements for JDK
- Update task for build