### PR TITLE
Fix WorldBorder#setCenter ignoring new values on 26.1.1

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/border/WorldBorder.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/border/WorldBorder.java.patch
@@ -38,7 +38,7 @@
 +    // Paper start - Add worldborder events
 +    public void setCenter(double x, double z) {
 +        if (this.world != null) {
-+            io.papermc.paper.event.world.border.WorldBorderCenterChangeEvent event = new io.papermc.paper.event.world.border.WorldBorderCenterChangeEvent(this.world.getWorld(), this.world.getWorld().getWorldBorder(), new org.bukkit.Location(this.world.getWorld(), this.getCenterX(), 0, this.getCenterZ()), new org.bukkit.Location(this.world.getWorld(), this.centerX, 0, this.centerZ));
++            io.papermc.paper.event.world.border.WorldBorderCenterChangeEvent event = new io.papermc.paper.event.world.border.WorldBorderCenterChangeEvent(this.world.getWorld(), this.world.getWorld().getWorldBorder(), new org.bukkit.Location(this.world.getWorld(), this.getCenterX(), 0, this.getCenterZ()), new org.bukkit.Location(this.world.getWorld(), x, 0, z));
 +            if (!event.callEvent()) return;
 +            x = event.getNewCenter().getX();
 +            z = event.getNewCenter().getZ();


### PR DESCRIPTION
## Problem
*Coming from Discord: https://discord.com/channels/289587909051416579/555462289851940864/1489771414998220892*

While working on updating to Paper 26.1.1, I noticed that WorldBorder#setCenter was no longer working correctly. Searching around, I found that the event call was updated, and it no longer uses the `x` and `z` parameters for the "new" location.
<https://github.com/PaperMC/Paper/blob/50303a0eb6e953d549f824ab07cc311259bfa0a5/paper-server/patches/sources/net/minecraft/world/level/border/WorldBorder.java.patch#L41>
Current main branch:
```java
io.papermc.paper.event.world.border.WorldBorderCenterChangeEvent event = new io.papermc.paper.event.world.border.WorldBorderCenterChangeEvent(world.getWorld(), world.getWorld().getWorldBorder(), new org.bukkit.Location(world.getWorld(), this.getCenterX(), 0, this.getCenterZ()), new org.bukkit.Location(world.getWorld(), x, 0, z));
```
Current dev/26.1 branch:
```java
io.papermc.paper.event.world.border.WorldBorderCenterChangeEvent event = new io.papermc.paper.event.world.border.WorldBorderCenterChangeEvent(this.world.getWorld(), this.world.getWorld().getWorldBorder(), new org.bukkit.Location(this.world.getWorld(), this.getCenterX(), 0, this.getCenterZ()), new org.bukkit.Location(this.world.getWorld(), this.centerX, 0, this.centerZ));
```
Notice how the second location now mistakenly uses the current values instead. As a result, the new values are essentially ignored.

## Solution
I have updated the second location to use the method parameters again. I haven't contributed before nor worked with the patch system, but going through the CONTRIBUTING walkthrough, I believe I have done this correctly.