### PR TITLE
fix: correct enclosing method null-check in TimedEventExecutor

### DIFF
--- a/paper-api/src/main/java/co/aikar/timings/TimedEventExecutor.java
+++ b/paper-api/src/main/java/co/aikar/timings/TimedEventExecutor.java
@@ -56,7 +56,7 @@ public class TimedEventExecutor implements EventExecutor {
         String id;
 
         if (method == null) {
-            if (executor.getClass().getEnclosingClass() != null) { // Oh Skript, how we love you
+            if (executor.getClass().getEnclosingMethod() != null) { // Oh Skript, how we love you
                 method = executor.getClass().getEnclosingMethod();
             }
         }


### PR DESCRIPTION
Fix incorrect null-check when resolving enclosing method in TimedEventExecutor fallback logic