### PR TITLE
Fix GameRules per-world in load of Management Protocol

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -3,6 +3,7 @@
 private-f net.minecraft.network.CompressionDecoder inflater
 private-f net.minecraft.server.MinecraftServer connection
 private-f net.minecraft.server.MinecraftServer levels
+private-f net.minecraft.server.jsonrpc.internalapi.MinecraftGameRuleServiceImpl gameRules
 private-f net.minecraft.world.item.ItemStack components
 private-f net.minecraft.world.item.ItemStack item
 private-f net.minecraft.world.level.block.entity.BeehiveBlockEntity stored

--- a/paper-server/patches/sources/net/minecraft/server/jsonrpc/internalapi/MinecraftGameRuleServiceImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/jsonrpc/internalapi/MinecraftGameRuleServiceImpl.java.patch
@@ -1,20 +1,51 @@
 --- a/net/minecraft/server/jsonrpc/internalapi/MinecraftGameRuleServiceImpl.java
 +++ b/net/minecraft/server/jsonrpc/internalapi/MinecraftGameRuleServiceImpl.java
-@@ -15,7 +_,7 @@
+@@ -10,21 +_,30 @@
+ 
+ public class MinecraftGameRuleServiceImpl implements MinecraftGameRuleService {
+     private final DedicatedServer server;
+-    private GameRules gameRules;
++    private @org.jspecify.annotations.Nullable GameRules gameRules; // Paper - per-world game rules
+     private final JsonRpcLogger jsonrpcLogger;
  
      public MinecraftGameRuleServiceImpl(final DedicatedServer server, final JsonRpcLogger jsonrpcLogger) {
          this.server = server;
 -        this.gameRules = server.getGameRules();
-+        this.gameRules = server.overworld().getGameRules(); // Paper - per-world game rules - use overworld for vanilla protocol
++        this.gameRules = null; // Paper - per-world game rules - cannot get game rules until server is started
          this.jsonrpcLogger = jsonrpcLogger;
      }
  
-@@ -24,7 +_,7 @@
++    // Paper start - per-world game rules
++    public GameRules getGameRules() {
++        if (this.gameRules == null) {
++            this.gameRules = this.server.overworld().getGameRules();
++        }
++        return this.gameRules;
++    }
++    // Paper end
++
+     @Override
+     public <T> GameRulesService.GameRuleUpdate<T> updateGameRule(final GameRulesService.GameRuleUpdate<T> update, final ClientInfo clientInfo) {
          GameRule<T> gameRule = update.gameRule();
-         T oldValue = this.gameRules.get(gameRule);
+-        T oldValue = this.gameRules.get(gameRule);
++        T oldValue = this.getGameRules().get(gameRule); // Paper - per-world game rules
          T newValue = update.value();
 -        this.gameRules.set(gameRule, newValue, this.server);
-+        this.gameRules.set(gameRule, newValue, this.server.overworld()); // Paper - per-world game rules - use overworld for vanilla protocol
++        this.getGameRules().set(gameRule, newValue, this.server.overworld()); // Paper - per-world game rules - use overworld for vanilla protocol
          this.jsonrpcLogger
              .log(clientInfo, "Game rule '{}' updated from '{}' to '{}'", gameRule.id(), gameRule.serialize(oldValue), gameRule.serialize(newValue));
          return update;
+@@ -37,11 +_,11 @@
+ 
+     @Override
+     public Stream<GameRule<?>> getAvailableGameRules() {
+-        return this.gameRules.availableRules();
++        return this.getGameRules().availableRules(); // Paper - per-world game rules
+     }
+ 
+     @Override
+     public <T> T getRuleValue(final GameRule<T> gameRule) {
+-        return this.gameRules.get(gameRule);
++        return this.getGameRules().get(gameRule); // Paper - per-world game rules
+     }
+ }


### PR DESCRIPTION
Close https://github.com/PaperMC/Paper/issues/13752 where if the Management Protocol is enabled the GameRule service try to load the overworld before the server start, this PR change the way to get the gamerules for avoid early calls