### PR TITLE
fix: killing server during startup crashes it

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -23838,7 +23838,7 @@ index 3c1490ac7c259da04031db2f170e0c0a5f512191..470d7c770ae9d045b97e2df145cfe3cf
          }
      }
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 9566334f019ff3c9469f06c784d122b5d35f3e24..e11862c7e0617acfb36212cfe349bdade3a5164b 100644
+index 07dcba08ef40e46b05239668a7d9ebc928cd921a..1fd7c7c21c71e822d51fae7fab32b7fc47ec5a47 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -191,7 +191,7 @@ import net.minecraft.world.scores.ScoreboardSaveData;
@@ -23850,7 +23850,7 @@ index 9566334f019ff3c9469f06c784d122b5d35f3e24..e11862c7e0617acfb36212cfe349bdad
      private static MinecraftServer SERVER; // Paper
      public static final Logger LOGGER = LogUtils.getLogger();
      public static final net.kyori.adventure.text.logger.slf4j.ComponentLogger COMPONENT_LOGGER = net.kyori.adventure.text.logger.slf4j.ComponentLogger.logger(LOGGER.getName()); // Paper
-@@ -425,6 +425,92 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -426,6 +426,92 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          };
      }
      // Paper end - improve tick loop
@@ -23943,7 +23943,7 @@ index 9566334f019ff3c9469f06c784d122b5d35f3e24..e11862c7e0617acfb36212cfe349bdad
  
      public MinecraftServer(
          // CraftBukkit start
-@@ -842,7 +928,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -848,7 +934,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          level.setSpawnSettings(level.isSpawningMonsters()); // Paper - per level difficulty (from setDifficulty(ServerLevel, Difficulty, boolean))
          this.updateEffectiveRespawnData();
          this.forceTicks = false; // CraftBukkit
@@ -23952,7 +23952,7 @@ index 9566334f019ff3c9469f06c784d122b5d35f3e24..e11862c7e0617acfb36212cfe349bdad
          new org.bukkit.event.world.WorldLoadEvent(level.getWorld()).callEvent(); // Paper - call WorldLoadEvent
      }
  
-@@ -865,6 +951,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -871,6 +957,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      public abstract boolean shouldRconBroadcast();
  
      public boolean saveAllChunks(final boolean silent, final boolean flush, final boolean force) {
@@ -23964,7 +23964,7 @@ index 9566334f019ff3c9469f06c784d122b5d35f3e24..e11862c7e0617acfb36212cfe349bdad
          this.scoreboard.storeToSaveDataIfDirty(this.getDataStorage().computeIfAbsent(ScoreboardSaveData.TYPE));
          boolean result = false;
  
-@@ -873,7 +964,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -879,7 +970,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  LOGGER.info("Saving chunks for level '{}'/{}", level, level.dimension().identifier());
              }
  
@@ -23973,7 +23973,7 @@ index 9566334f019ff3c9469f06c784d122b5d35f3e24..e11862c7e0617acfb36212cfe349bdad
              result = true;
          }
  
-@@ -970,7 +1061,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -976,7 +1067,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              }
          }
  
@@ -23982,7 +23982,7 @@ index 9566334f019ff3c9469f06c784d122b5d35f3e24..e11862c7e0617acfb36212cfe349bdad
              this.nextTickTimeNanos = Util.getNanos() + TimeUtil.NANOSECONDS_PER_MILLISECOND;
  
              for (ServerLevel levelx : this.getAllLevels()) {
-@@ -981,17 +1072,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -987,17 +1078,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.waitUntilNextTick();
          }
  
@@ -24007,7 +24007,7 @@ index 9566334f019ff3c9469f06c784d122b5d35f3e24..e11862c7e0617acfb36212cfe349bdad
  
          this.isSaving = false;
          this.savedDataStorage.close();
-@@ -1012,6 +1100,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1018,6 +1106,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.services().nameToIdCache().save(false); // Paper - Perf: Async GameProfileCache saving
          }
          // Spigot end
@@ -24022,7 +24022,7 @@ index 9566334f019ff3c9469f06c784d122b5d35f3e24..e11862c7e0617acfb36212cfe349bdad
          // Paper start - Improved watchdog support - move final shutdown items here
          Util.shutdownExecutors();
          this.onServerExit();
-@@ -1106,16 +1202,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1112,16 +1208,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              // execute small amounts of other tasks just in case the number of tasks we are
              // draining is large - chunk system and packet processing may be latency sensitive
  
@@ -24057,7 +24057,7 @@ index 9566334f019ff3c9469f06c784d122b5d35f3e24..e11862c7e0617acfb36212cfe349bdad
          profiler.pop(); // moonrise:run_all_chunk
          profiler.pop(); // moonrise:run_all_tasks
  
-@@ -1416,6 +1527,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1422,6 +1533,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      private boolean pollTaskInternal() {
          if (super.pollTask()) {
@@ -24065,7 +24065,7 @@ index 9566334f019ff3c9469f06c784d122b5d35f3e24..e11862c7e0617acfb36212cfe349bdad
              return true;
          } else {
              boolean ret = false; // Paper - force execution of all worlds, do not just bias the first
-@@ -1557,6 +1669,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1563,6 +1675,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // Paper - improve tick loop - moved into runAllTasksAtTickStart
          this.runAllTasksAtTickStart(); // Paper - improve tick loop
          this.tickServer(sprinting ? () -> false : this::haveTime);
@@ -24079,7 +24079,7 @@ index 9566334f019ff3c9469f06c784d122b5d35f3e24..e11862c7e0617acfb36212cfe349bdad
          this.tickFrame.end();
          this.recordEndOfTick(); // Paper - improve tick loop
          profiler.pop();
-@@ -2599,6 +2718,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2605,6 +2724,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
  

--- a/paper-server/patches/features/0002-Rewrite-dataconverter-system.patch
+++ b/paper-server/patches/features/0002-Rewrite-dataconverter-system.patch
@@ -33491,10 +33491,10 @@ index 109d7b563ee799d998a5773c5a36e61ca3607d46..747755082639436731989d3ee4b3c30a
          return structureTemplate.save(new CompoundTag());
      }
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 1b064f00c33712c3d2d85ed8520f1eda02abfbf9..65a971379f35c4b1b519b93787f690d891e29523 100644
+index 1fd7c7c21c71e822d51fae7fab32b7fc47ec5a47..71c7ee278a474c14bfaa34e360b1923b4424a82e 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -299,6 +299,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -300,6 +300,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      private final ServerClockManager clockManager;
  
      public static <S extends MinecraftServer> S spin(final Function<Thread, S> factory) {

--- a/paper-server/patches/features/0020-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0020-Incremental-chunk-and-player-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Incremental chunk and player saving
 
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 65a971379f35c4b1b519b93787f690d891e29523..dadad4106e774884bc32af0ce37591b08c6d9a4c 100644
+index 71c7ee278a474c14bfaa34e360b1923b4424a82e..d92430a8c41b40eac9e2d4abd76538cfc4632c76 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -957,7 +957,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -963,7 +963,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      }
      public boolean saveAllChunks(final boolean silent, final boolean flush, final boolean force, final boolean close) {
          // Paper end - add close param
@@ -17,7 +17,7 @@ index 65a971379f35c4b1b519b93787f690d891e29523..dadad4106e774884bc32af0ce37591b0
          boolean result = false;
  
          for (ServerLevel level : this.getAllLevels()) {
-@@ -969,13 +969,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -975,13 +975,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              result = true;
          }
  
@@ -32,7 +32,7 @@ index 65a971379f35c4b1b519b93787f690d891e29523..dadad4106e774884bc32af0ce37591b0
  
          if (flush) {
              for (ServerLevel level : this.getAllLevels()) {
-@@ -989,11 +983,25 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -995,11 +989,25 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          return result;
      }
  
@@ -59,7 +59,7 @@ index 65a971379f35c4b1b519b93787f690d891e29523..dadad4106e774884bc32af0ce37591b0
              boolean result = this.saveAllChunks(silent, flush, force);
              this.warnOnLowDiskSpace();
              var5 = result;
-@@ -1640,9 +1648,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1646,9 +1654,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
  
          this.ticksUntilAutosave--;
@@ -94,7 +94,7 @@ index 65a971379f35c4b1b519b93787f690d891e29523..dadad4106e774884bc32af0ce37591b0
          ProfilerFiller profiler = Profiler.get();
          this.server.spark.executeMainThreadTasks(); // Paper - spark
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 18eb79f76fb558a1ba9f989f59d2f273975be3a1..7a55657f9fb106dc3e95ef808d103a66cf2e56bd 100644
+index 8d691aab8eb8db16074d2f46c448f5366d850b8c..b1bfa9d912778ca97cb16207c61740f684710d06 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -1441,6 +1441,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet

--- a/paper-server/patches/features/0025-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0025-Optimise-EntityScheduler-ticking.patch
@@ -20,10 +20,10 @@ index 2bc436cdf5180a7943c45fabb9fbbedae6f7db56..f312a7f5b1b2a777ab36b94ce7cbf387
  
      @Override
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index dadad4106e774884bc32af0ce37591b08c6d9a4c..b7a0963390540c283cede90108f96437bfdd4dab 100644
+index d92430a8c41b40eac9e2d4abd76538cfc4632c76..6d729ead4083ef949eb58521bba547de7a4cfe9b 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1783,32 +1783,22 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1789,32 +1789,22 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
  

--- a/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -58,7 +58,11 @@
      private final ServerFunctionManager functionManager;
      private boolean enforceWhitelist;
      private boolean usingWhitelist;
-@@ -292,13 +_,14 @@
+@@ -289,16 +_,18 @@
+     private FuelValues fuelValues;
+     private int emptyTicks;
+     private volatile boolean isSaving;
++    public volatile boolean cancelStartup = false; // Paper - cancel startup if server shut down
      private final SuppressedExceptionCollector suppressedExceptions = new SuppressedExceptionCollector();
      private final DiscontinuousFrame tickFrame;
      private final PacketProcessor packetProcessor;
@@ -300,7 +304,7 @@
          if (profiledDuration != null) {
              profiledDuration.finish(true);
          }
-@@ -422,33 +_,139 @@
+@@ -422,33 +_,144 @@
          }
      }
  
@@ -320,6 +324,11 @@
 +        }
 +        // Paper end - Configurable player collision; Handle collideRule team for player collision toggle
 +        this.server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.POSTWORLD);
++        // Paper start - Cancel server startup if shut down
++        if (cancelStartup) {
++            return;
++        }
++        // Paper end
 +        this.server.spark.registerCommandBeforePlugins(this.server); // Paper - spark
 +        this.server.spark.enableAfterPlugins(this.server); // Paper - spark
 +        io.papermc.paper.command.brigadier.PaperCommands.INSTANCE.setValid(); // Paper - reset invalid state for event fire below
@@ -605,7 +614,8 @@
 +        // CraftBukkit end
          this.getConnection().stop();
          this.isSaving = true;
-         if (this.playerList != null) {
+-        if (this.playerList != null) {
++        if (this.playerList != null && !cancelStartup) { // Paper - Cancel player list save on shutdown during server start
              LOGGER.info("Saving players");
              this.playerList.saveAll();
 -            this.playerList.removeAll();

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -590,6 +590,10 @@ public final class CraftServer implements Server {
         Plugin[] plugins = this.pluginManager.getPlugins();
 
         for (Plugin plugin : plugins) {
+            if (console.cancelStartup) {
+                // Startup was canceled, cancel loading plugins
+                return;
+            }
             if ((!plugin.isEnabled()) && (plugin.getDescription().getLoad() == type)) {
                 this.enablePlugin(plugin);
             }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
@@ -14,6 +14,7 @@ public class ServerShutdownThread extends Thread {
     public void run() {
         try {
             // Paper start - try to shutdown on main
+            server.cancelStartup = true;
             server.safeShutdown(false, false);
             for (int i = 1000; i > 0 && !server.hasStopped(); i -= 100) {
                 Thread.sleep(100);


### PR DESCRIPTION
This pull request fixes a problem often encountered during rapid starting/stopping of servers in debug environments. If you kill the server process, which runs the shutdown hooks, during the server's startup, instead of gracefully shutting down, the server throws an `IllegalStateException`. This is due to an attempted async save on the player list.

The fix introduced in this PR consists of two parts:
  1. Introduce a new `cancelStartup` boolean variable, which tells the server to cancel loading/enabling any additional plugins to not waste any time.
  2. Cancel the player list save if `cancelStartup` is set.

This variable is set at the start of the main shutdown hook. In my testing this correctly ensured that no matter when a server is restarted, it was never exited in an unsafe state (i.e. any world folder locks left due to no cleanup).