### PR TITLE
moving piston block entities are missing progressO read, causing desyncs and dupes

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java.patch
@@ -18,3 +18,24 @@
                          Block.updateOrDestroy(entity.movedState, newState, level, pos, Block.UPDATE_ALL);
                      } else {
                          if (newState.hasProperty(BlockStateProperties.WATERLOGGED) && newState.getValue(BlockStateProperties.WATERLOGGED)) {
+@@ -347,8 +_,10 @@
+         super.loadAdditional(input);
+         this.movedState = input.read("blockState", BlockState.CODEC).orElse(DEFAULT_BLOCK_STATE);
+         this.direction = input.read("facing", Direction.LEGACY_ID_CODEC).orElse(Direction.DOWN);
+-        this.progress = input.getFloatOr("progress", 0.0F);
+-        this.progressO = this.progress;
++        // Paper start - Fix #9220 missing progressO read, causing desyncs and dupes
++        this.progressO = input.getFloatOr("progress", 0.0F);
++        this.progress = input.getFloatOr("progressCurrent", this.progressO);
++        // Paper end - Fix #9220 missing progressO read, causing desyncs and dupes
+         this.extending = input.getBooleanOr("extending", false);
+         this.isSourcePiston = input.getBooleanOr("source", false);
+     }
+@@ -359,6 +_,7 @@
+         output.store("blockState", BlockState.CODEC, this.movedState);
+         output.store("facing", Direction.LEGACY_ID_CODEC, this.direction);
+         output.putFloat("progress", this.progressO);
++        output.putFloat("progressCurrent", this.progress); // Paper - Fix #9220 missing progressO read, causing desyncs and dupes
+         output.putBoolean("extending", this.extending);
+         output.putBoolean("source", this.isSourcePiston);
+     }


### PR DESCRIPTION
Fixes #9220


Since the class `net.minecraft.world.level.block.piston.PistonMovingBlockEntity` is responsible for saving the moving blocks on a flying machine, I took a look there. As far as I could test and reproduce, the root cause is that `saveAdditional` only persists `progressO` (previous-tick progress) but not `progress` (current-tick progress):

```java
output.putFloat("progress", this.progressO);
```

On load, both fields are set to the same value:

```java
this.progress = input.getFloatOr("progress", 0.0F);
this.progressO = this.progress;
```

This means up to half a tick of movement is lost every time a chunk unloads and reloads mid-extension. For flying machines crossing chunk boundaries, this causes the desync.

If you instead save just `this.progress` in the existing `progress` field, flying machines always strictly cut off at the chunk border:

<img width="2560" height="1441" alt="Image" src="https://github.com/user-attachments/assets/0f0aab0e-e273-481c-99a0-cb1e87c7b5cb" />

### Proposed fix

Save both values independently:

**`saveAdditional`:**
```java
output.putFloat("progress", this.progressO);
output.putFloat("progressCurrent", this.progress);
```

**`loadAdditional`:**
```java
this.progressO = input.getFloatOr("progress", 0.0F);
this.progress = input.getFloatOr("progressCurrent", this.progressO);
```

This preserves backward compatibility - old saves without `progressCurrent` fall back to `progressO`. With this change, the full piston state is restored correctly and the flying machine resumes from the exact position it was at when the chunk unloaded. 