### PR TITLE
fix: killing server during startup crashes it

### DIFF
--- a/paper-server/patches/features/0031-Cancel-player-list-save-on-shutdown-during-server-st.patch
+++ b/paper-server/patches/features/0031-Cancel-player-list-save-on-shutdown-during-server-st.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Strokkur24 <strokkur.24@gmail.com>
+Date: Sat, 11 Apr 2026 22:11:34 +0200
+Subject: [PATCH] Cancel player list save on shutdown during server start
+
+
+diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
+index 0848c9ef4c5935b9d528146a16169f8b9142de75..978006d7392cb6e182ed391b1ab5977d97483912 100644
+--- a/net/minecraft/server/MinecraftServer.java
++++ b/net/minecraft/server/MinecraftServer.java
+@@ -292,6 +292,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+     private FuelValues fuelValues;
+     private int emptyTicks;
+     private volatile boolean isSaving;
++    public volatile boolean cancelStartup = false; // Paper - cancel startup if server shut down
+     private final SuppressedExceptionCollector suppressedExceptions = new SuppressedExceptionCollector();
+     private final DiscontinuousFrame tickFrame;
+     private final PacketProcessor packetProcessor;
+@@ -678,6 +679,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         }
+         // Paper end - Configurable player collision; Handle collideRule team for player collision toggle
+         this.server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.POSTWORLD);
++        // Paper start - Cancel server startup if shut down
++        if (cancelStartup) {
++            return;
++        }
++        // Paper end
+         this.server.spark.registerCommandBeforePlugins(this.server); // Paper - spark
+         this.server.spark.enableAfterPlugins(this.server); // Paper - spark
+         io.papermc.paper.command.brigadier.PaperCommands.INSTANCE.setValid(); // Paper - reset invalid state for event fire below
+@@ -1055,7 +1061,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         // CraftBukkit end
+         this.getConnection().stop();
+         this.isSaving = true;
+-        if (this.playerList != null) {
++        if (this.playerList != null && !cancelStartup) { // Paper - Cancel player list save on shutdown during server start
+             LOGGER.info("Saving players");
+             this.playerList.saveAll();
+             this.playerList.removeAll(this.isRestarting); // Paper

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -590,6 +590,10 @@ public final class CraftServer implements Server {
         Plugin[] plugins = this.pluginManager.getPlugins();
 
         for (Plugin plugin : plugins) {
+            if (console.cancelStartup) {
+                // Startup was canceled, cancel loading plugins
+                return;
+            }
             if ((!plugin.isEnabled()) && (plugin.getDescription().getLoad() == type)) {
                 this.enablePlugin(plugin);
             }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
@@ -14,6 +14,7 @@ public class ServerShutdownThread extends Thread {
     public void run() {
         try {
             // Paper start - try to shutdown on main
+            server.cancelStartup = true;
             server.safeShutdown(false, false);
             for (int i = 1000; i > 0 && !server.hasStopped(); i -= 100) {
                 Thread.sleep(100);


### PR DESCRIPTION
This PR is a reopen of the closed #13755. I've decided to go with a feature patch this time in order to reduce diff noise from the other feature patches. The description below is directly copied from the original PR.

----

This pull request fixes a problem often encountered during rapid starting/stopping of servers in debug environments. If you kill the server process, which runs the shutdown hooks, during the server's startup, instead of gracefully shutting down, the server throws an `IllegalStateException`. This is due to an attempted async save on the player list.

The fix introduced in this PR consists of two parts:
  1. Introduce a new `cancelStartup` boolean variable, which tells the server to cancel loading/enabling any additional plugins to not waste any time.
  2. Cancel the player list save if `cancelStartup` is set.

This variable is set at the start of the main shutdown hook. In my testing this correctly ensured that no matter when a server is restarted, it was never exited in an unsafe state (i.e. any world folder locks left due to no cleanup).