### PR TITLE
Add ENTITY_DATA data component type

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentTypes.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentTypes.java
@@ -61,6 +61,7 @@ import org.bukkit.entity.Axolotl;
 import org.bukkit.entity.Cat;
 import org.bukkit.entity.Chicken;
 import org.bukkit.entity.Cow;
+import org.bukkit.entity.EntitySnapshot;
 import org.bukkit.entity.Fox;
 import org.bukkit.entity.Frog;
 import org.bukkit.entity.Horse;
@@ -393,6 +394,7 @@ public final class DataComponentTypes {
     public static final DataComponentType.Valued<DyeColor> CAT_COLLAR = valued("cat/collar");
     public static final DataComponentType.Valued<DyeColor> SHEEP_COLOR = valued("sheep/color");
     public static final DataComponentType.Valued<DyeColor> SHULKER_COLOR = valued("shulker/color");
+    public static final DataComponentType.Valued<EntitySnapshot> ENTITY_DATA = valued("entity_data");
 
     private static DataComponentType.NonValued unvalued(final @KeyPattern.Value String key) {
         final DataComponentType dataComponentType = Registry.DATA_COMPONENT_TYPE.getOrThrow(Key.key(Key.MINECRAFT_NAMESPACE, key));

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/DataComponentAdapters.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/DataComponentAdapters.java
@@ -67,6 +67,7 @@ import org.bukkit.craftbukkit.damage.CraftDamageType;
 import org.bukkit.craftbukkit.entity.CraftCat;
 import org.bukkit.craftbukkit.entity.CraftChicken;
 import org.bukkit.craftbukkit.entity.CraftCow;
+import org.bukkit.craftbukkit.entity.CraftEntitySnapshot;
 import org.bukkit.craftbukkit.entity.CraftFrog;
 import org.bukkit.craftbukkit.entity.CraftPig;
 import org.bukkit.craftbukkit.entity.CraftVillager;
@@ -213,6 +214,7 @@ public final class DataComponentAdapters {
         register(DataComponents.CAT_COLLAR, nms -> DyeColor.getByWoolData((byte) nms.getId()), api -> net.minecraft.world.item.DyeColor.byId(api.getWoolData()));
         register(DataComponents.SHEEP_COLOR, nms -> DyeColor.getByWoolData((byte) nms.getId()), api -> net.minecraft.world.item.DyeColor.byId(api.getWoolData()));
         register(DataComponents.SHULKER_COLOR, nms -> DyeColor.getByWoolData((byte) nms.getId()), api -> net.minecraft.world.item.DyeColor.byId(api.getWoolData()));
+        register(DataComponents.ENTITY_DATA, CraftEntitySnapshot::minecraftToBukkit, CraftEntitySnapshot::bukkitToMinecraft);
 
         for (final ResourceKey<DataComponentType<?>> key : BuiltInRegistries.DATA_COMPONENT_TYPE.registryKeySet()) {
             if (!ADAPTERS.containsKey(key)) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntitySnapshot.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntitySnapshot.java
@@ -7,6 +7,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.ProblemReporter;
 import net.minecraft.world.entity.EntityProcessor;
 import net.minecraft.world.entity.EntitySpawnReason;
+import net.minecraft.world.item.component.TypedEntityData;
 import net.minecraft.world.level.storage.TagValueInput;
 import net.minecraft.world.level.storage.TagValueOutput;
 import org.bukkit.Location;
@@ -111,5 +112,13 @@ public class CraftEntitySnapshot implements EntitySnapshot {
             ).map(CraftEntityType::minecraftToBukkit).orElse(null);
             return CraftEntitySnapshot.create(tag, type);
         }
+    }
+
+    public static CraftEntitySnapshot minecraftToBukkit(TypedEntityData<net.minecraft.world.entity.EntityType<?>> data) {
+        return CraftEntitySnapshot.create(data.copyTagWithEntityId(), CraftEntityType.minecraftToBukkit(data.type()));
+    }
+
+    public static TypedEntityData<net.minecraft.world.entity.EntityType<?>> bukkitToMinecraft(CraftEntitySnapshot snapshot) {
+        return TypedEntityData.of(CraftEntityType.bukkitToMinecraft(snapshot.getEntityType()), snapshot.getData().copy());
     }
 }

--- a/paper-server/src/test/java/org/bukkit/registry/RegistryConstantsTest.java
+++ b/paper-server/src/test/java/org/bukkit/registry/RegistryConstantsTest.java
@@ -50,7 +50,6 @@ public class RegistryConstantsTest {
     public static void populateIgnored() {
         ignore(Registries.DATA_COMPONENT_TYPE, Set.of(
             DataComponents.CUSTOM_DATA,
-            DataComponents.ENTITY_DATA,
             DataComponents.BEES,
             DataComponents.DEBUG_STICK_STATE,
             DataComponents.BLOCK_ENTITY_DATA,


### PR DESCRIPTION
Implements `DataComponentTypes.ENTITY_DATA`.

Tested with armor stands and spawn eggs (also in combination with `SpawnEggMeta`).