### PR TITLE
Handle item use when block interaction is denied

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -330,7 +330,7 @@
                  }
  
                  return result;
-@@ -340,17 +_,55 @@
+@@ -340,17 +_,59 @@
          }
      }
  
@@ -366,7 +366,8 @@
 +        this.interactHand = hand;
 +        this.interactItemStack = itemStack.copy();
 +
-+        if (event.useInteractedBlock() == org.bukkit.event.Event.Result.DENY) {
++        final boolean deniedBlockInteraction = event.useInteractedBlock() == org.bukkit.event.Event.Result.DENY; // Paper - Allow item use when denying block interaction
++        if (deniedBlockInteraction) { // Paper - Allow item use when denying block interaction
 +            // Block acks will take care of most of it, just handle some special cases here
 +            if (state.getBlock() instanceof net.minecraft.world.level.block.CakeBlock) {
 +                player.getBukkitEntity().sendHealthUpdate(); // SPIGOT-1341 - reset health for cake
@@ -381,13 +382,25 @@
 +            }
 +            // Paper end - Fix inventory desync
 +            this.player.resyncUsingItem(this.player); // Paper - Properly cancel usable items
-+            return (event.useItemInHand() != org.bukkit.event.Event.Result.ALLOW) ? InteractionResult.SUCCESS : InteractionResult.PASS;
-+        } else if (this.gameModeForPlayer == GameType.SPECTATOR) {
++            if (event.useItemInHand() != org.bukkit.event.Event.Result.ALLOW) return InteractionResult.SUCCESS; // Paper - Allow item use when denying block interaction
++        }
++
++        if (this.gameModeForPlayer == GameType.SPECTATOR) {
++            if (deniedBlockInteraction) return InteractionResult.PASS; // Paper - Allow item use when denying block interaction
 +            MenuProvider menuProvider = state.getMenuProvider(level, pos);
 +            if (menuProvider != null && player.openMenu(menuProvider).isPresent()) { // Paper - Fix InventoryOpenEvent cancellation
                  return InteractionResult.CONSUME;
              } else {
                  return InteractionResult.PASS;
+@@ -359,7 +_,7 @@
+             boolean haveSomethingInOurHands = !player.getMainHandItem().isEmpty() || !player.getOffhandItem().isEmpty();
+             boolean suppressUsingBlock = player.isSecondaryUseActive() && haveSomethingInOurHands;
+             ItemStack usedItemStack = itemStack.copy();
+-            if (!suppressUsingBlock) {
++            if (!deniedBlockInteraction && !suppressUsingBlock) { // Paper - Allow item use when denying block interaction
+                 InteractionResult itemUse = state.useItemOn(player.getItemInHand(hand), level, player, hand, hitResult);
+                 if (itemUse.consumesAction()) {
+                     CriteriaTriggers.ITEM_USED_ON_BLOCK.trigger(player, pos, usedItemStack);
 @@ -375,7 +_,7 @@
                  }
              }


### PR DESCRIPTION
Fixes #13707.

When a `PlayerInteractEvent` denies the interacted block but explicitly allows the item in hand, Paper now skips the block interaction while still allowing the item-use path to run. This restores placement behavior for plugins that deny block use without denying the item.

Validation:
- `./gradlew rebuildPatches --stacktrace`
- `./gradlew :paper-server:compileJava --stacktrace`