### PR TITLE
Fix EntityLungeEvent#setLungePower being ignored

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityLungeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityLungeEvent.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Called when a living entity tries to lunge with a spear
+ * Called when a living entity tries to lunge with a spear.
  */
 @NullMarked
 public class EntityLungeEvent extends EntityEvent implements Cancellable {
@@ -19,7 +19,7 @@ public class EntityLungeEvent extends EntityEvent implements Cancellable {
     private boolean cancelled;
 
     @ApiStatus.Internal
-    public EntityLungeEvent(final LivingEntity entity, int lungePower) {
+    public EntityLungeEvent(final LivingEntity entity, final int lungePower) {
         super(entity);
         this.lungePower = lungePower;
     }
@@ -30,7 +30,7 @@ public class EntityLungeEvent extends EntityEvent implements Cancellable {
      * @return the lunge power
      */
     public int getLungePower() {
-        return lungePower;
+        return this.lungePower;
     }
 
     /**
@@ -38,6 +38,7 @@ public class EntityLungeEvent extends EntityEvent implements Cancellable {
      * <p>
      * If set higher than 3, the power of the lunge will continue to scale like normal, as if the max enchantment
      * level is higher.
+     *
      * @param lungePower the new lunge power
      */
     public void setLungePower(final int lungePower) {
@@ -46,11 +47,12 @@ public class EntityLungeEvent extends EntityEvent implements Cancellable {
 
     @Override
     public boolean isCancelled() {
-        return cancelled;
+        return this.cancelled;
     }
 
     /**
      * Set whether to cancel the lunge. If cancelled, the living entity will not lunge forward.
+     *
      * @param cancel {@code true} if you wish to cancel this event
      */
     @Override

--- a/paper-server/patches/sources/net/minecraft/world/item/enchantment/Enchantment.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/enchantment/Enchantment.java.patch
@@ -1,15 +1,24 @@
 --- a/net/minecraft/world/item/enchantment/Enchantment.java
 +++ b/net/minecraft/world/item/enchantment/Enchantment.java
-@@ -352,7 +_,13 @@
+@@ -352,7 +_,22 @@
          applyEffects(
              this.getEffects(EnchantmentEffectComponents.POST_PIERCING_ATTACK),
              entityContext(serverLevel, enchantmentLevel, user, user.position()),
 -            e -> e.apply(serverLevel, enchantmentLevel, item, user, user.position())
 +            // Paper start - EntityLungeEvent
 +            e -> {
-+                if (!(user instanceof LivingEntity livingEntity) || new io.papermc.paper.event.entity.EntityLungeEvent(livingEntity.getBukkitLivingEntity(), enchantmentLevel).callEvent()) {
-+                    e.apply(serverLevel, enchantmentLevel, item, user, user.position());
++                int level = enchantmentLevel;
++                if (user instanceof LivingEntity livingEntity) {
++                    final io.papermc.paper.event.entity.EntityLungeEvent event = new io.papermc.paper.event.entity.EntityLungeEvent(livingEntity.getBukkitLivingEntity(), level);
++
++                    if (!event.callEvent()) {
++                        return;
++                    }
++
++                    level = event.getLungePower();
 +                }
++
++                e.apply(serverLevel, level, item, user, user.position());
 +            }
 +            // Paper end - EntityLungeEvent
          );

--- a/paper-server/patches/sources/net/minecraft/world/item/enchantment/Enchantment.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/enchantment/Enchantment.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/enchantment/Enchantment.java
 +++ b/net/minecraft/world/item/enchantment/Enchantment.java
-@@ -352,7 +_,22 @@
+@@ -352,7 +_,21 @@
          applyEffects(
              this.getEffects(EnchantmentEffectComponents.POST_PIERCING_ATTACK),
              entityContext(serverLevel, enchantmentLevel, user, user.position()),
@@ -10,7 +10,6 @@
 +                int level = enchantmentLevel;
 +                if (user instanceof LivingEntity livingEntity) {
 +                    final io.papermc.paper.event.entity.EntityLungeEvent event = new io.papermc.paper.event.entity.EntityLungeEvent(livingEntity.getBukkitLivingEntity(), level);
-+
 +                    if (!event.callEvent()) {
 +                        return;
 +                    }


### PR DESCRIPTION
I accidentally introduced a bug in the original PR by dropping the getter for the lunge power during a merge