### PR TITLE
fix(script): check correct file when detecting merge conflicts

### DIFF
--- a/scripts/apatch.sh
+++ b/scripts/apatch.sh
@@ -49,7 +49,7 @@ fi
 	done
 	for i in $($gitcmd status --porcelain | awk '{print $2}'); do
 		filedata=$(cat "$i")
-		if [ -f "$file" ] && [[ "$filedata" == *"<<<<<"* ]]; then
+		if [ -f "$i" ] && [[ "$filedata" == *"<<<<<"* ]]; then
 			export summaryfail="$summaryfail\nFAILED TO APPLY: $i"
 		else
 			$gitcmd add --force "$i"


### PR DESCRIPTION
Fixes checking the patch file instead of the processed file when detecting merge conflicts in apatch.sh.