### PR TITLE
Prevent Happy Ghast from playing mount/dismount noises when silenced

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/happyghast/HappyGhast.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/happyghast/HappyGhast.java.patch
@@ -1,6 +1,15 @@
 --- a/net/minecraft/world/entity/animal/happyghast/HappyGhast.java
 +++ b/net/minecraft/world/entity/animal/happyghast/HappyGhast.java
-@@ -314,8 +_,12 @@
+@@ -299,7 +_,7 @@
+ 
+     @Override
+     protected void addPassenger(final Entity passenger) {
+-        if (!this.isVehicle()) {
++        if (!this.isVehicle() && !this.isSilent()) { // Paper - don't play sound if silenced
+             this.level().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.HARNESS_GOGGLES_DOWN, this.getSoundSource(), 1.0F, 1.0F);
+         }
+ 
+@@ -314,16 +_,25 @@
      }
  
      @Override
@@ -15,9 +24,15 @@
          if (!this.level().isClientSide()) {
              this.setServerStillTimeout(10);
          }
-@@ -324,6 +_,7 @@
+ 
+         if (!this.isVehicle()) {
              this.clearHome();
-             this.level().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.HARNESS_GOGGLES_UP, this.getSoundSource(), 1.0F, 1.0F);
+-            this.level().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.HARNESS_GOGGLES_UP, this.getSoundSource(), 1.0F, 1.0F);
++            // Paper start - don't play sound if silenced
++            if (!this.isSilent()) {
++                this.level().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.HARNESS_GOGGLES_UP, this.getSoundSource(), 1.0F, 1.0F);
++            }
++            // Paper end - don't play sound if silenced
          }
 +        return true; // Paper - cancellable passengers
      }

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/happyghast/HappyGhast.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/happyghast/HappyGhast.java.patch
@@ -1,15 +1,15 @@
 --- a/net/minecraft/world/entity/animal/happyghast/HappyGhast.java
 +++ b/net/minecraft/world/entity/animal/happyghast/HappyGhast.java
-@@ -299,7 +_,7 @@
- 
+@@ -300,7 +_,7 @@
      @Override
      protected void addPassenger(final Entity passenger) {
--        if (!this.isVehicle()) {
-+        if (!this.isVehicle() && !this.isSilent()) { // Paper - don't play sound if silenced
-             this.level().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.HARNESS_GOGGLES_DOWN, this.getSoundSource(), 1.0F, 1.0F);
+         if (!this.isVehicle()) {
+-            this.level().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.HARNESS_GOGGLES_DOWN, this.getSoundSource(), 1.0F, 1.0F);
++            this.playSound(SoundEvents.HARNESS_GOGGLES_DOWN, 1.0F, 1.0F); // Paper - don't play sound if silenced - https://bugs.mojang.com/browse/MC/issues/MC-297169
          }
  
-@@ -314,16 +_,25 @@
+         super.addPassenger(passenger);
+@@ -314,16 +_,21 @@
      }
  
      @Override
@@ -28,11 +28,7 @@
          if (!this.isVehicle()) {
              this.clearHome();
 -            this.level().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.HARNESS_GOGGLES_UP, this.getSoundSource(), 1.0F, 1.0F);
-+            // Paper start - don't play sound if silenced
-+            if (!this.isSilent()) {
-+                this.level().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.HARNESS_GOGGLES_UP, this.getSoundSource(), 1.0F, 1.0F);
-+            }
-+            // Paper end - don't play sound if silenced
++            playSound(SoundEvents.HARNESS_GOGGLES_UP, 1.0F, 1.0F); // Paper - don't play sound if silenced - https://bugs.mojang.com/browse/MC/issues/MC-297169
          }
 +        return true; // Paper - cancellable passengers
      }

--- a/paper-server/patches/sources/net/minecraft/world/entity/animal/happyghast/HappyGhast.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/animal/happyghast/HappyGhast.java.patch
@@ -5,7 +5,7 @@
      protected void addPassenger(final Entity passenger) {
          if (!this.isVehicle()) {
 -            this.level().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.HARNESS_GOGGLES_DOWN, this.getSoundSource(), 1.0F, 1.0F);
-+            this.playSound(SoundEvents.HARNESS_GOGGLES_DOWN, 1.0F, 1.0F); // Paper - don't play sound if silenced - https://bugs.mojang.com/browse/MC/issues/MC-297169
++            this.playSound(SoundEvents.HARNESS_GOGGLES_DOWN, 1.0F, 1.0F); // Paper - don't play sound if silenced (Fixes MC-297169)
          }
  
          super.addPassenger(passenger);
@@ -28,7 +28,7 @@
          if (!this.isVehicle()) {
              this.clearHome();
 -            this.level().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.HARNESS_GOGGLES_UP, this.getSoundSource(), 1.0F, 1.0F);
-+            playSound(SoundEvents.HARNESS_GOGGLES_UP, 1.0F, 1.0F); // Paper - don't play sound if silenced - https://bugs.mojang.com/browse/MC/issues/MC-297169
++            this.playSound(SoundEvents.HARNESS_GOGGLES_UP, 1.0F, 1.0F); // Paper - don't play sound if silenced (Fixes MC-297169)
          }
 +        return true; // Paper - cancellable passengers
      }


### PR DESCRIPTION
Fixes https://bugs.mojang.com/browse/MC/issues/MC-297169, where mount/dismount noises would play even though the ghast was silenced.