### PR TITLE
Fix loading of plugins from "add-plugin-dir" flag

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java
+++ b/paper-server/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java
@@ -109,8 +109,16 @@ public class PluginInitializerManager {
         io.papermc.paper.plugin.util.EntrypointUtil.registerProvidersFromSource(io.papermc.paper.plugin.provider.source.PluginFlagProviderSource.INSTANCE, files);
 
         @SuppressWarnings("unchecked")
-        java.util.List<Path> dirs = ((java.util.List<File>) optionSet.valuesOf("add-plugin-dir")).stream().map(File::toPath).toList();
-        dirs.forEach(pluginDir -> io.papermc.paper.plugin.util.EntrypointUtil.registerProvidersFromSource(io.papermc.paper.plugin.provider.source.DirectoryProviderSource.INSTANCE_NO_CREATE, pluginDir));
+        java.util.List<Path> pluginList = ((java.util.List<File>) optionSet.valuesOf("add-plugin-dir")).stream()
+            .filter(java.util.Objects::nonNull)
+            .map(f -> f.listFiles(file -> file.getName().endsWith(".jar")))
+            .filter(java.util.Objects::nonNull)
+            .flatMap(java.util.Arrays::stream)
+            .filter(File::isFile)
+            .map(File::toPath)
+            .toList();
+
+        io.papermc.paper.plugin.util.EntrypointUtil.registerProvidersFromSource(io.papermc.paper.plugin.provider.source.PluginFlagProviderSource.INSTANCE, pluginList);
 
         final Set<String> paperPluginNames = new TreeSet<>();
         final Set<String> legacyPluginNames = new TreeSet<>();

--- a/paper-server/src/main/java/io/papermc/paper/plugin/provider/source/DirectoryProviderSource.java
+++ b/paper-server/src/main/java/io/papermc/paper/plugin/provider/source/DirectoryProviderSource.java
@@ -16,25 +16,14 @@ import org.slf4j.Logger;
  */
 public class DirectoryProviderSource implements ProviderSource<Path, List<Path>> {
 
-    public static final DirectoryProviderSource INSTANCE = new DirectoryProviderSource(true);
-    public static final DirectoryProviderSource INSTANCE_NO_CREATE = new DirectoryProviderSource(false);
+    public static final DirectoryProviderSource INSTANCE = new DirectoryProviderSource();
     private static final FileProviderSource FILE_PROVIDER_SOURCE = new FileProviderSource("Directory '%s'"::formatted);
     private static final Logger LOGGER = LogUtils.getClassLogger();
-
-    private final boolean createDirectory;
-
-    public DirectoryProviderSource(final boolean createDirectory) {
-        this.createDirectory = createDirectory;
-    }
 
     @Override
     public List<Path> prepareContext(Path context) throws IOException {
         // Symlink happy, create file if missing.
         if (!Files.isDirectory(context)) {
-            if (!this.createDirectory) {
-                return List.of();
-            }
-
             Files.createDirectories(context);
         }
 


### PR DESCRIPTION
Fixes loading of plugins in a extra plugin directory from this PR #13447.

I've done quick testing on windows with 1.21.11 and 26.1.2-19 and on 1.21.11 it fails to load plugin from extra directory at all and on 26.1.2 it works fine but I had this exact impl since 1.21.1 in my fork ([direct link to the patch](https://github.com/Basic-Land/BasicLandMC/blob/1.21.1/patches/server/0001-load-plugins-from-folder.patch)) there I had 0 issues with it. I'm using it on pterodactyl with shared folder. When testing paper impl on the exact same setup it fails to load nearly all plugins if not all I'm not sure.
I have no issues backporting this to 1.21.11 if anyone would be interested.