### PR TITLE
Add event for Copper Golem deciding whether an item belongs in a chest

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/entity/ItemTransportingEntitySortEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/ItemTransportingEntitySortEvent.java
@@ -21,10 +21,15 @@ import org.jspecify.annotations.NullMarked;
 public class ItemTransportingEntitySortEvent extends EntityEvent {
     protected static final HandlerList HANDLER_LIST = new HandlerList();
 
+    public enum ItemTransportingEntityDecision {
+        ALLOW_DESTINATION,
+        REJECT_DESTINATION,
+        USE_VANILLA_BEHAVIOUR
+    }
+
     private final ItemStack itemStack;
     private final Inventory containerInventory;
-    private boolean overrideDefaultBehaviour = false;
-    private boolean itemBelongs = true;
+    private ItemTransportingEntityDecision decision;
 
     @ApiStatus.Internal
     public ItemTransportingEntitySortEvent(
@@ -35,37 +40,25 @@ public class ItemTransportingEntitySortEvent extends EntityEvent {
         super(entity);
         this.containerInventory = containerInventory;
         this.itemStack = itemStack;
+        this.decision = ItemTransportingEntityDecision.USE_VANILLA_BEHAVIOUR;
     }
 
     /**
      * Sets if the item belongs in the container.
      *
-     * @param belongs Whether the item belongs or not
+     * @param d Whether the item belongs in the chest.
      */
-    public void setItemBelongs(boolean belongs) {
-        this.overrideDefaultBehaviour = true;
-        this.itemBelongs = belongs;
+    public void setDecision(boolean d) {
+        this.decision = d ? ItemTransportingEntityDecision.ALLOW_DESTINATION : ItemTransportingEntityDecision.REJECT_DESTINATION;
     }
 
     /**
      * Gets if the held item stack belongs in the container.
      *
-     * @return Whether the item stack belongs.
+     * @return Whether the item stack belongs in the chest.
      */
-    public boolean itemBelongs() {
-        return this.itemBelongs;
-    }
-
-    /**
-     * Whether this event will override the default behavior of the entity.
-     * For example, if {@link ItemTransportingEntitySortEvent#setItemBelongs(boolean)} is not called, the entity
-     * will use the default behavior of adding to empty chests and chests containing a matching item stack.
-     * Once the function is called, the entity will defer to the plugin's decision.
-     *
-     * @return Whether the default behavior is being overridden.
-     */
-    public boolean isOverridingDefaultBehaviour() {
-        return this.overrideDefaultBehaviour;
+    public ItemTransportingEntityDecision getDecision() {
+        return this.decision;
     }
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/ItemTransportingEntitySortEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/ItemTransportingEntitySortEvent.java
@@ -1,0 +1,97 @@
+package io.papermc.paper.event.entity;
+
+import org.bukkit.block.Container;
+import org.bukkit.entity.CopperGolem;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Called when an item-transporting entity (typically a {@link CopperGolem},
+ * although other entities may be possible through non-API means)
+ * is inspecting a destination {@link Container} to decide if the item it is holding
+ * belongs in said container. This gives plugin developers an opportunity to
+ * override the {@link CopperGolem}'s sorting behavior.
+ */
+@NullMarked
+public class ItemTransportingEntitySortEvent extends EntityEvent {
+    protected static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final ItemStack itemStack;
+    private final Inventory containerInventory;
+    private boolean overrideDefaultBehaviour = false;
+    private boolean itemBelongs = true;
+
+    @ApiStatus.Internal
+    public ItemTransportingEntitySortEvent(
+        final Entity entity,
+        final ItemStack itemStack,
+        final Inventory containerInventory
+    ) {
+        super(entity);
+        this.containerInventory = containerInventory;
+        this.itemStack = itemStack;
+    }
+
+    /**
+     * Sets if the item belongs in the container.
+     *
+     * @param belongs Whether the item belongs or not
+     */
+    public void setItemBelongs(boolean belongs) {
+        this.overrideDefaultBehaviour = true;
+        this.itemBelongs = belongs;
+    }
+
+    /**
+     * Gets if the held item stack belongs in the container.
+     *
+     * @return Whether the item stack belongs.
+     */
+    public boolean itemBelongs() {
+        return this.itemBelongs;
+    }
+
+    /**
+     * Whether this event will override the default behavior of the entity.
+     * For example, if {@link ItemTransportingEntitySortEvent#setItemBelongs(boolean)} is not called, the entity
+     * will use the default behavior of adding to empty chests and chests containing a matching item stack.
+     * Once the function is called, the entity will defer to the plugin's decision.
+     *
+     * @return Whether the default behavior is being overridden.
+     */
+    public boolean isOverridingDefaultBehaviour() {
+        return this.overrideDefaultBehaviour;
+    }
+
+    /**
+     * Gets the container the entity is comparing to the held item.
+     *
+     * @return The potential destination container
+     */
+    public Inventory getContainerInventory() {
+        return this.containerInventory;
+    }
+
+    /**
+     * Gets the held item stack being compared against the container.
+     *
+     * @return The held item stack
+     */
+    public ItemStack getHeldItemStack() {
+        return this.itemStack;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/event/entity/ItemTransportingEntitySortEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/ItemTransportingEntitySortEvent.java
@@ -24,7 +24,7 @@ public class ItemTransportingEntitySortEvent extends EntityEvent {
     public enum ItemTransportingEntityDecision {
         ALLOW_DESTINATION,
         REJECT_DESTINATION,
-        USE_VANILLA_BEHAVIOUR
+        DEFAULT
     }
 
     private final ItemStack itemStack;
@@ -40,7 +40,7 @@ public class ItemTransportingEntitySortEvent extends EntityEvent {
         super(entity);
         this.containerInventory = containerInventory;
         this.itemStack = itemStack;
-        this.decision = ItemTransportingEntityDecision.USE_VANILLA_BEHAVIOUR;
+        this.decision = ItemTransportingEntityDecision.DEFAULT;
     }
 
     /**

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
@@ -12,3 +12,18 @@
                  return isValidTarget ? transportItemTarget : null;
              }
          }
+@@ -505,7 +_,13 @@
+     }
+ 
+     private static boolean matchesLeavingItemsRequirement(final PathfinderMob body, final Container container) {
+-        return container.isEmpty() || hasItemMatchingHandItem(body, container);
++        io.papermc.paper.event.entity.ItemTransportingEntitySortEvent sortEvent = org.bukkit.craftbukkit.event.CraftEventFactory.createItemTransportingEntitySortEvent(body, container);
++        sortEvent.callEvent();
++        if (sortEvent.isOverridingDefaultBehaviour()) {
++            return sortEvent.itemBelongs();
++        } else {
++            return container.isEmpty() || hasItemMatchingHandItem(body, container);
++        }
+     }
+ 
+     private static boolean hasItemMatchingHandItem(final PathfinderMob body, final Container container) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
@@ -12,11 +12,12 @@
                  return isValidTarget ? transportItemTarget : null;
              }
          }
-@@ -505,7 +_,13 @@
+@@ -505,7 +_,15 @@
      }
  
      private static boolean matchesLeavingItemsRequirement(final PathfinderMob body, final Container container) {
 -        return container.isEmpty() || hasItemMatchingHandItem(body, container);
++        // Paper start - Add event for container assessment
 +        io.papermc.paper.event.entity.ItemTransportingEntitySortEvent sortEvent = org.bukkit.craftbukkit.event.CraftEventFactory.createItemTransportingEntitySortEvent(body, container);
 +        sortEvent.callEvent();
 +        if (sortEvent.isOverridingDefaultBehaviour()) {
@@ -24,6 +25,7 @@
 +        } else {
 +            return container.isEmpty() || hasItemMatchingHandItem(body, container);
 +        }
++        // Paper end - Add event for container assessment
      }
  
      private static boolean hasItemMatchingHandItem(final PathfinderMob body, final Container container) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
@@ -12,7 +12,7 @@
                  return isValidTarget ? transportItemTarget : null;
              }
          }
-@@ -505,7 +_,15 @@
+@@ -505,7 +_,17 @@
      }
  
      private static boolean matchesLeavingItemsRequirement(final PathfinderMob body, final Container container) {
@@ -20,8 +20,10 @@
 +        // Paper start - Add event for container assessment
 +        io.papermc.paper.event.entity.ItemTransportingEntitySortEvent sortEvent = org.bukkit.craftbukkit.event.CraftEventFactory.createItemTransportingEntitySortEvent(body, container);
 +        sortEvent.callEvent();
-+        if (sortEvent.isOverridingDefaultBehaviour()) {
-+            return sortEvent.itemBelongs();
++        if (sortEvent.getDecision() !=
++            io.papermc.paper.event.entity.ItemTransportingEntitySortEvent.ItemTransportingEntityDecision.USE_VANILLA_BEHAVIOUR) {
++            return sortEvent.getDecision()
++                == io.papermc.paper.event.entity.ItemTransportingEntitySortEvent.ItemTransportingEntityDecision.ALLOW_DESTINATION;
 +        } else {
 +            return container.isEmpty() || hasItemMatchingHandItem(body, container);
 +        }

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
@@ -21,7 +21,7 @@
 +        io.papermc.paper.event.entity.ItemTransportingEntitySortEvent sortEvent = org.bukkit.craftbukkit.event.CraftEventFactory.createItemTransportingEntitySortEvent(body, container);
 +        sortEvent.callEvent();
 +        if (sortEvent.getDecision() !=
-+            io.papermc.paper.event.entity.ItemTransportingEntitySortEvent.ItemTransportingEntityDecision.USE_VANILLA_BEHAVIOUR) {
++            io.papermc.paper.event.entity.ItemTransportingEntitySortEvent.ItemTransportingEntityDecision.DEFAULT) {
 +            return sortEvent.getDecision()
 +                == io.papermc.paper.event.entity.ItemTransportingEntitySortEvent.ItemTransportingEntityDecision.ALLOW_DESTINATION;
 +        } else {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -7,11 +7,13 @@ import com.google.common.collect.Lists;
 import com.mojang.authlib.GameProfile;
 import com.mojang.datafixers.util.Either;
 import io.papermc.paper.adventure.PaperAdventure;
+import io.papermc.paper.block.TileStateInventoryHolder;
 import io.papermc.paper.block.bed.BedEnterProblem;
 import io.papermc.paper.connection.HorriblePlayerLoginEventHack;
 import io.papermc.paper.connection.PlayerConnection;
 import io.papermc.paper.event.block.BlockLockCheckEvent;
 import io.papermc.paper.event.connection.PlayerConnectionValidateLoginEvent;
+import io.papermc.paper.event.entity.ItemTransportingEntitySortEvent;
 import io.papermc.paper.event.entity.ItemTransportingEntityValidateTargetEvent;
 import io.papermc.paper.event.player.PlayerBedFailEnterEvent;
 import io.papermc.paper.event.player.PlayerToggleEntityAgeLockEvent;
@@ -104,6 +106,8 @@ import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.craftbukkit.entity.CraftSpellcaster;
+import org.bukkit.craftbukkit.inventory.CraftContainer;
+import org.bukkit.craftbukkit.inventory.CraftInventory;
 import org.bukkit.craftbukkit.inventory.CraftInventoryCrafting;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.inventory.CraftItemType;
@@ -2416,5 +2420,9 @@ public class CraftEventFactory {
             return false;
         }
         return true;
+    }
+
+    public static ItemTransportingEntitySortEvent createItemTransportingEntitySortEvent(PathfinderMob mob, Container container) {
+        return new ItemTransportingEntitySortEvent(mob.getBukkitEntity(), mob.getMainHandItem().asBukkitCopy(), new CraftInventory(container));
     }
 }


### PR DESCRIPTION
This event is triggered before the golem makes a final decision on whether to add the item to the chest. It exposes the chest's inventory and the item being held by the golem, and allows plugins to override the golem's decision with custom logic.