### PR TITLE
Update MOJIRA reference in DeOp command response for multiple targets [ci skip]

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/commands/DeOpCommands.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/commands/DeOpCommands.java.patch
@@ -5,7 +5,7 @@
                  list.deop(player);
                  count++;
 -                source.sendSuccess(() -> Component.translatable("commands.deop.success", players.iterator().next().name()), true);
-+                source.sendSuccess(() -> Component.translatable("commands.deop.success", player.name()), true); // Paper - fixes MC-253721
++                source.sendSuccess(() -> Component.translatable("commands.deop.success", player.name()), true); // Paper - fixes MC-307513
              }
          }
  


### PR DESCRIPTION
This PR just update the comment in a fix for DeOp command where if the command take many targets all the messages use the name of the first target, the original comment point to a issue for the Op command and that was fixed, then i make a new mojira ticket for this.

https://mojira.dev/MC-307513