### PR TITLE
Call blocking events on virtual threads

### DIFF
--- a/paper-server/patches/features/0008-Use-Velocity-compression-and-cipher-natives.patch
+++ b/paper-server/patches/features/0008-Use-Velocity-compression-and-cipher-natives.patch
@@ -318,7 +318,7 @@ index 104976b3eb04d80e5be5bd020cf16c647b1cde27..5a23f95aff982ecc58d2e2bc994f4e49
              this.channel.pipeline().fireUserEventTriggered(io.papermc.paper.network.ConnectionEvent.COMPRESSION_THRESHOLD_SET); // Paper - Add Channel initialization listeners
          } else {
 diff --git a/net/minecraft/server/network/ServerConnectionListener.java b/net/minecraft/server/network/ServerConnectionListener.java
-index 9ae7c79e5088d9e1e3fb7e0dca00bb15fee118b6..eb0d51ffcc888204881b48a8b1408d0b54b252e4 100644
+index 391435cf3d279c8f5a889702b50f57626864c7bb..19a77c8269c3f1998985d533d9099c7e6cf76af4 100644
 --- a/net/minecraft/server/network/ServerConnectionListener.java
 +++ b/net/minecraft/server/network/ServerConnectionListener.java
 @@ -77,6 +77,10 @@ public class ServerConnectionListener {
@@ -333,10 +333,10 @@ index 9ae7c79e5088d9e1e3fb7e0dca00bb15fee118b6..eb0d51ffcc888204881b48a8b1408d0b
                  .add(
                      new ServerBootstrap()
 diff --git a/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index fb2ed24931c2f468ab6f228a202f22562784febd..72bf241ee7ebd02781b539a24c1df8e7f62fb94d 100644
+index c1edad046cbdd1627edba58bc06aef5c058e79eb..3a0d47a716ce5c5345640ed67ac306101791892b 100644
 --- a/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -253,11 +253,9 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener,
+@@ -251,11 +251,9 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener,
              }
  
              SecretKey secretKey = packet.getSecretKey(serverPrivateKey);

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerLoginPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerLoginPacketListenerImpl.java.patch
@@ -13,7 +13,7 @@
  public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener, TickablePacketListener {
      private static final AtomicInteger UNIQUE_THREAD_ID = new AtomicInteger(0);
      private static final Logger LOGGER = LogUtils.getLogger();
-+    private static final java.util.concurrent.ExecutorService authenticatorPool = java.util.concurrent.Executors.newCachedThreadPool(new com.google.common.util.concurrent.ThreadFactoryBuilder().setNameFormat("User Authenticator #%d").setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(LOGGER)).build()); // Paper - Cache authenticator threads
++    private static final java.util.concurrent.ExecutorService authenticatorPool = java.util.concurrent.Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("User Authenticator #", 0).uncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(LOGGER)).factory()); // Paper - Virtual authenticator threads
      private static final int MAX_TICKS_BEFORE_LOGIN = 600;
      private final byte[] challenge;
      private final MinecraftServer server;
@@ -111,7 +111,7 @@
          this.requestedUsername = packet.name();
          GameProfile singleplayerProfile = this.server.getSingleplayerProfile();
          if (singleplayerProfile != null && this.requestedUsername.equalsIgnoreCase(singleplayerProfile.name())) {
-@@ -127,7 +_,32 @@
+@@ -127,7 +_,30 @@
                  this.state = ServerLoginPacketListenerImpl.State.KEY;
                  this.connection.send(new ClientboundHelloPacket("", this.server.getKeyPair().getPublic().getEncoded(), this.challenge, true));
              } else {
@@ -126,8 +126,7 @@
 +                    return;
 +                }
 +                // Paper end - Add Velocity IP Forwarding Support
-+                // CraftBukkit start
-+                // Paper start - Cache authenticator threads
++                // Paper start - Virtual authenticator threads
 +                authenticatorPool.execute(() -> {
 +                    try {
 +                        GameProfile gameprofile = ServerLoginPacketListenerImpl.this.createOfflineProfile(ServerLoginPacketListenerImpl.this.requestedUsername); // Spigot
@@ -140,8 +139,7 @@
 +                        ServerLoginPacketListenerImpl.this.server.server.getLogger().log(java.util.logging.Level.WARNING, "Exception verifying " + ServerLoginPacketListenerImpl.this.requestedUsername, ex);
 +                    }
 +                });
-+                // Paper end - Cache authenticator threads
-+                // CraftBukkit end
++                // Paper end - Virtual authenticator threads
              }
          }
      }
@@ -179,7 +177,7 @@
          }
  
 -        Thread thread = new Thread("User Authenticator #" + UNIQUE_THREAD_ID.incrementAndGet()) {
-+        // Paper start - Cache authenticator threads
++        // Paper start - Virtual authenticator threads
 +        authenticatorPool.execute(new Runnable() {
              {
                  Objects.requireNonNull(ServerLoginPacketListenerImpl.this);
@@ -232,7 +230,7 @@
 -        thread.start();
 -    }
 +        });
-+        // Paper end - Cache authenticator threads
++        // Paper end - Virtual authenticator threads
 +    }
 +
 +    // CraftBukkit start

--- a/paper-server/src/main/java/io/papermc/paper/connection/PaperConfigurationTask.java
+++ b/paper-server/src/main/java/io/papermc/paper/connection/PaperConfigurationTask.java
@@ -1,6 +1,5 @@
 package io.papermc.paper.connection;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.mojang.logging.LogUtils;
 import io.papermc.paper.event.connection.configuration.AsyncPlayerConnectionConfigureEvent;
 import java.util.concurrent.ExecutorService;
@@ -15,8 +14,9 @@ import org.slf4j.Logger;
 public class PaperConfigurationTask implements ConfigurationTask {
     private static final Logger LOGGER = LogUtils.getClassLogger();
 
-    public static final ExecutorService CONFIGURATION_POOL = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("Configuration Thread #%d")
-        .setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(LOGGER)).build());
+    public static final ExecutorService CONFIGURATION_POOL = Executors.newThreadPerTaskExecutor(
+        Thread.ofVirtual().name("Configuration Thread #", 0).uncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(LOGGER)).factory()
+    );
 
     public static final ConfigurationTask.Type TYPE = new ConfigurationTask.Type("paper_event_handling");
 


### PR DESCRIPTION
As briefly mentioned on discord, bukkit currently doesn't have support for proper async events. Currently events where it is recommended to block the thread (like async configuration event in order to wait for a dialog response) will block a platform thread until the plugin is finished/user decided to respond. As an alternative calling those events from virtual threads makes blocking much cheaper.

`CONFIGURATION_POOL` is currently used for:
- calling AsyncPlayerConnectionConfigureEvent (potential blocking for dialog response waiting, resource pack response waiting)
- calling AsyncPlayerSpawnLocationEvent (potential blocking for database lookup of a spawn location, no join event happened for preload)

`authenticatorPool` is currently used for:
- http calls for mojang authentication (guaranteed blocking)
- AsyncPlayerPreLoginEvent (potential blocking for data load as it's first event)
- Profile completion (blocking)
- waiting for PlayerPreLoginEvent to finish (guaranteed blocking if has listeners)

Both have no workload that would require a platform thread, and both benefits from calling the blocking logic in a virtual thread