### PR TITLE
Add options to disable chunk and block entity ticking

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -26479,7 +26479,7 @@ index 045d4b0ab26622e2763d1583e1e8fcb83ba44427..ddffd36d8213a40dc3f6cbb0ef0f33a0
      }
  
 diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
-index 319335341617051c5b78578465f2224f78c3ea3d..fcb23814c2539f4e31ed5191e03cc28f4e7f9c2d 100644
+index bf8496c8cadb29db9c46015e202e7d59e2ed2f5e..f4e033fb5e5b116245dd4a381366c4e749a73f93 100644
 --- a/net/minecraft/server/level/ServerChunkCache.java
 +++ b/net/minecraft/server/level/ServerChunkCache.java
 @@ -54,7 +54,7 @@ import net.minecraft.world.level.storage.SavedDataStorage;
@@ -27004,7 +27004,7 @@ index de75dda2e6f17f0ae6e7f6a5620fd3eac9d389e5..6774d12d04fa848624fb8bf7a3c2b8bc
          List<Entity> passengers = this.entity.getPassengers();
          if (!passengers.equals(this.lastPassengers)) {
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19e2e87fc1 100644
+index f39d48821d728232472ebc5bd6868e6a0d644721..91d27b90a9c9c348d3f93624ff8dbff8a70f522c 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -182,7 +182,7 @@ import net.minecraft.world.waypoints.WaypointTransmitter;
@@ -27430,7 +27430,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
                                      Entity vehicle = entity.getVehicle();
                                      if (vehicle != null) {
                                          if (!vehicle.isRemoved() && vehicle.hasPassenger(entity)) {
-@@ -639,7 +896,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -642,7 +899,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          }
  
          profiler.push("entityManagement");
@@ -27439,7 +27439,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
          profiler.pop();
          profiler.push("debugSynchronizers");
          if (this.debugSynchronizers.hasAnySubscriberFor(DebugSubscriptions.NEIGHBOR_UPDATES)) {
-@@ -656,7 +913,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -659,7 +916,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      @Override
      public boolean shouldTickBlocksAt(final long chunkPos) {
@@ -27451,7 +27451,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
      }
  
      protected void tickTime() {
-@@ -680,7 +940,60 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -683,7 +943,60 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          this.players.stream().filter(LivingEntity::isSleeping).collect(Collectors.toList()).forEach(player -> player.stopSleepInBed(false, false));
      }
  
@@ -27512,7 +27512,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
          ChunkPos chunkPos = chunk.getPos();
          int minX = chunkPos.getMinBlockX();
          int minZ = chunkPos.getMinBlockZ();
-@@ -689,7 +1002,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -692,7 +1005,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
          if (!this.paperConfig().environment.disableIceAndSnow) { // Paper - Option to disable ice and snow
          for (int i = 0; i < tickSpeed; i++) {
@@ -27521,7 +27521,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
                  this.tickPrecipitation(this.getBlockRandomPos(minX, 0, minZ, 15));
              }
          }
-@@ -697,31 +1010,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -700,31 +1013,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
          profiler.popPush("tickBlocks");
          if (tickSpeed > 0) {
@@ -27554,7 +27554,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
          }
  
          profiler.pop();
-@@ -1044,6 +1333,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1047,6 +1336,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          if (fluidState.is(type)) {
              fluidState.tick(this, pos, blockState);
          }
@@ -27567,7 +27567,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
      }
  
      private void tickBlock(final BlockPos pos, final Block type) {
-@@ -1051,6 +1346,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1054,6 +1349,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          if (state.is(type)) {
              state.tick(this, pos, this.random);
          }
@@ -27580,7 +27580,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
      }
  
      // Paper start - log detailed entity tick information
-@@ -1135,6 +1436,11 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1138,6 +1439,11 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      }
  
      public void save(final @Nullable ProgressListener progressListener, final boolean flush, final boolean noSave) {
@@ -27592,7 +27592,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
          ServerChunkCache chunkSource = this.getChunkSource();
          if (!noSave) {
              new org.bukkit.event.world.WorldSaveEvent(this.getWorld()).callEvent(); // CraftBukkit
-@@ -1147,13 +1453,18 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1150,13 +1456,18 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                  progressListener.progressStage(Component.translatable("menu.savingChunks"));
              }
  
@@ -27616,7 +27616,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
      }
  
      private void saveLevelData(final boolean sync) {
-@@ -1274,7 +1585,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1277,7 +1588,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              this.removePlayerImmediately((ServerPlayer)existing, Entity.RemovalReason.DISCARDED);
          }
  
@@ -27625,7 +27625,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
      }
  
      // CraftBukkit start
-@@ -1305,7 +1616,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1308,7 +1619,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              }
              // CraftBukkit end
  
@@ -27634,7 +27634,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
          }
      }
  
-@@ -1316,7 +1627,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1319,7 +1630,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      public boolean tryAddFreshEntityWithPassengers(final Entity entity, final org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason) {
          // CraftBukkit end
@@ -27643,7 +27643,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
              return false;
          } else {
              this.addFreshEntityWithPassengers(entity, reason); // CraftBukkit
-@@ -2109,7 +2420,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2112,7 +2423,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                  }
              }
  
@@ -27652,7 +27652,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
              output.write(String.format(Locale.ROOT, "block_entity_tickers: %d\n", this.blockEntityTickers.size()));
              output.write(String.format(Locale.ROOT, "block_ticks: %d\n", this.getBlockTicks().count()));
              output.write(String.format(Locale.ROOT, "fluid_ticks: %d\n", this.getFluidTicks().count()));
-@@ -2127,13 +2438,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2130,13 +2441,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          Path chunks = rootDir.resolve("chunks.csv");
  
          try (Writer output = Files.newBufferedWriter(chunks)) {
@@ -27668,7 +27668,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
          }
  
          Path entities = rootDir.resolve("entities.csv");
-@@ -2228,8 +2539,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2231,8 +2542,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              Locale.ROOT,
              "players: %s, entities: %s [%s], block_entities: %d [%s], block_ticks: %d, fluid_ticks: %d, chunk_source: %s",
              this.players.size(),
@@ -27679,7 +27679,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
              this.blockEntityTickers.size(),
              getTypeCount(this.blockEntityTickers, TickingBlockEntity::getType),
              this.getBlockTicks().count(),
-@@ -2262,15 +2573,25 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2265,15 +2576,25 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      @Override
      public LevelEntityGetter<Entity> getEntities() {
          org.spigotmc.AsyncCatcher.catchOp("Chunk getEntities call"); // Spigot
@@ -27708,7 +27708,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
      }
  
      public void startTickingChunk(final LevelChunk levelChunk) {
-@@ -2287,8 +2608,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2290,8 +2611,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      public void waitForEntities(final ChunkPos centerChunk, final int radius) {
          List<ChunkPos> chunks = ChunkPos.rangeClosed(centerChunk, radius).toList();
@@ -27719,7 +27719,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
  
              for (ChunkPos chunk : chunks) {
                  if (!this.areEntitiesLoaded(chunk.pack())) {
-@@ -2309,28 +2630,38 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2312,28 +2633,38 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      @Override
      public void close() throws IOException {
          super.close();
@@ -27764,7 +27764,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
      }
  
      public boolean anyPlayerCloseEnoughForSpawning(final BlockPos pos) {
-@@ -2347,7 +2678,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2350,7 +2681,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      }
  
      public boolean canSpawnEntitiesInChunk(final ChunkPos pos) {
@@ -27776,7 +27776,7 @@ index cebead9e2d11f03e3c854113230c3b74dfe9f02e..c26c0e20f788d96cf491ee5cf27c7b19
      }
  
      @Override
-@@ -2395,7 +2729,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2398,7 +2732,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      public CrashReportCategory fillReportDetails(final CrashReport report) {
          CrashReportCategory category = super.fillReportDetails(report);
          WeatherData weatherData = this.getWeatherData();
@@ -30053,7 +30053,7 @@ index e07a7bda45146686a6ac2d20507df9fc8630514f..f84e651e2a34e76a0a71993332e4be1b
  
      // Paper start - Affects Spawning API
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 30183d8752aa397a5c1fc554da49f595be286534..5566f449fb79b04822e533df4fd6de42116ffd14 100644
+index 2fd4e73ed16d2d11267156840d7d9859d040317e..b8d56c7a14521cb77ba2cf619be826fb06be81da 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -87,6 +87,7 @@ import net.minecraft.world.level.storage.LevelData;
@@ -30745,7 +30745,7 @@ index 30183d8752aa397a5c1fc554da49f595be286534..5566f449fb79b04822e533df4fd6de42
                  this.sendBlockUpdated(pos, blockState, state, flags);
              }
  
-@@ -844,6 +1478,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -845,6 +1479,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          // Paper - Fix MC-117075 use removeAll - remove iterator in favour of indexed for loop, ensuring compile error if something uses iter incorrectly
          boolean tickBlockEntities = this.tickRateManager().runsNormally();
  
@@ -30753,7 +30753,7 @@ index 30183d8752aa397a5c1fc554da49f595be286534..5566f449fb79b04822e533df4fd6de42
          // Paper start - Fix MC-117075 use removeAll
          final it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<@Nullable TickingBlockEntity> toRemove = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<>();
          toRemove.add(null);
-@@ -854,6 +1489,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -855,6 +1490,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  toRemove.add(ticker); // Paper - Fix MC-117075 use removeAll
              } else if (tickBlockEntities && this.shouldTickBlocksAt(ticker.getPos())) {
                  ticker.tick();
@@ -32693,7 +32693,7 @@ index 54d57f80b1cca351cac2aa59477a0e57334816e7..94652b00e18ffcbe02f1ad0578d671e2
      public @Nullable BlockEntity getBlockEntity(final BlockPos pos) {
          return this.wrapped.getBlockEntity(pos);
 diff --git a/net/minecraft/world/level/chunk/LevelChunk.java b/net/minecraft/world/level/chunk/LevelChunk.java
-index 1bbb8ca0c4a5087cf35c8af8362d867ef868cbd3..b5b514b292f9fdbe410aba5facec1638682c9075 100644
+index d747e7058f78ac1fd02f3dc8e06670ed484cd42b..c0c212fd50cf97ae311035b370e8b4d40d82229e 100644
 --- a/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -64,7 +64,7 @@ import net.minecraft.world.ticks.TickContainerAccess;

--- a/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
@@ -354,7 +354,7 @@ index 0000000000000000000000000000000000000000..ce6b57eeeeb1bd652f4bb53c19dcfbc0
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 16ed1b0057e74e2fd84060d5b00bf68c4a887816..3741607fa3ba755b3a9983ced08460053b75e17f 100644
+index 91d27b90a9c9c348d3f93624ff8dbff8a70f522c..f4bbccee849ee3711a3b838884e4bcf4e24da039 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -864,6 +864,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
@@ -365,7 +365,7 @@ index 16ed1b0057e74e2fd84060d5b00bf68c4a887816..3741607fa3ba755b3a9983ced0846005
              this.entityTickList
                  .forEach(
                      entity -> {
-@@ -1380,12 +1381,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1383,12 +1384,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          entity.totalEntityAge++; // Paper - age-like counter for all entities
          profiler.push(entity.typeHolder()::getRegisteredName);
          profiler.incrementCounter("tickNonPassenger");
@@ -382,7 +382,7 @@ index 16ed1b0057e74e2fd84060d5b00bf68c4a887816..3741607fa3ba755b3a9983ced0846005
          }
          // Paper start - log detailed entity tick information
          } finally {
-@@ -1396,7 +1400,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1399,7 +1403,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          // Paper end - log detailed entity tick information
      }
  
@@ -391,7 +391,7 @@ index 16ed1b0057e74e2fd84060d5b00bf68c4a887816..3741607fa3ba755b3a9983ced0846005
          if (entity.isRemoved() || entity.getVehicle() != vehicle) {
              entity.stopRiding();
          } else if (entity instanceof Player || this.entityTickList.contains(entity)) {
-@@ -1406,12 +1410,21 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1409,12 +1413,21 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              ProfilerFiller profiler = Profiler.get();
              profiler.push(entity.typeHolder()::getRegisteredName);
              profiler.incrementCounter("tickPassenger");
@@ -817,7 +817,7 @@ index 3a590d4dc980a2912e9cc043d8c8db4cf9d60803..06ab7c48b18c03af494ab10fc2b584ce
 +
  }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 0958fe0438c3e934b885acf78a0f8003ef8bb694..31c7223d2d01573c24d4ad83737fa2c2752db028 100644
+index b8d56c7a14521cb77ba2cf619be826fb06be81da..2b3ec0a012918815ed0eda8b40647c2274a5b418 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -155,6 +155,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl

--- a/paper-server/patches/features/0016-Add-Alternate-Current-redstone-implementation.patch
+++ b/paper-server/patches/features/0016-Add-Alternate-Current-redstone-implementation.patch
@@ -2326,7 +2326,7 @@ index 0000000000000000000000000000000000000000..298076a0db4e6ee6e4775ac43bf749d9
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index f1341c78e90e0f7d6d2b27e6fff57bf6999f7176..12e6162e82dd639ac34da6466fc201623f4682c5 100644
+index f4bbccee849ee3711a3b838884e4bcf4e24da039..0b9fbf0ae658f0b3e9c6106a42fb70948b6fb9be 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -233,6 +233,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
@@ -2337,7 +2337,7 @@ index f1341c78e90e0f7d6d2b27e6fff57bf6999f7176..12e6162e82dd639ac34da6466fc20162
  
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
-@@ -2772,6 +2773,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2775,6 +2776,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          return this.debugSynchronizers;
      }
  
@@ -2352,7 +2352,7 @@ index f1341c78e90e0f7d6d2b27e6fff57bf6999f7176..12e6162e82dd639ac34da6466fc20162
          return toLevel.dimension() != Level.NETHER || this.getGameRules().get(GameRules.ALLOW_ENTERING_NETHER_USING_PORTALS);
      }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 31c7223d2d01573c24d4ad83737fa2c2752db028..8df070a7135411806d42ea692b566c4d8389a47b 100644
+index 2b3ec0a012918815ed0eda8b40647c2274a5b418..e60717b486756f66660e88055eea0f4735f351ef 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -2152,6 +2152,17 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl

--- a/paper-server/patches/features/0020-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0020-Incremental-chunk-and-player-saving.patch
@@ -94,10 +94,10 @@ index 248a01f06ec822737a741873166aa4e502a7ba07..c4eb56fc227afd7e9631624537dd8e67
          ProfilerFiller profiler = Profiler.get();
          this.server.spark.executeMainThreadTasks(); // Paper - spark
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 12e6162e82dd639ac34da6466fc201623f4682c5..179014dc4a7b99f7292f6255f0430503267faa76 100644
+index 0b9fbf0ae658f0b3e9c6106a42fb70948b6fb9be..bbeb0f673f2b23d1748e33364dc12ac16528d4c4 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1448,6 +1448,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1451,6 +1451,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      public boolean mayInteract(final Entity entity, final BlockPos pos) {
          return !(entity instanceof Player player && (this.server.isUnderSpawnProtection(this, pos, player) || !this.getWorldBorder().isWithinBounds(pos)));
      }

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -189,6 +189,15 @@
              this.ticketStorage.purgeStaleTickets(this.chunkMap);
          }
  
+@@ -344,7 +_,7 @@
+         if (!this.level.isDebug()) {
+             ProfilerFiller profiler = Profiler.get();
+             profiler.push("pollingChunks");
+-            if (this.level.tickRateManager().runsNormally()) {
++            if (this.level.tickRateManager().runsNormally() && this.level.paperConfig().unsupportedSettings.ticking.chunks) { // Paper - option to disable ticking
+                 profiler.push("tickingChunks");
+                 this.tickChunks(profiler, timeDiff);
+                 profiler.pop();
 @@ -376,12 +_,20 @@
              chunkCount, this.level.getAllEntities(), this::getFullChunk, new LocalMobCapCalculator(this.chunkMap)
          );

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -326,6 +326,18 @@
          if (isActive) {
              this.resetEmptyTime();
          }
+@@ -437,9 +_,11 @@
+                         }
+                     }
+                 );
++            if (this.paperConfig().unsupportedSettings.ticking.blockEntities) { // Paper - option to disable ticking
+             profiler.popPush("blockEntities");
+             this.tickBlockEntities();
+             profiler.pop();
++            } // Paper - option to disable ticking
+         }
+ 
+         profiler.push("entityManagement");
 @@ -468,7 +_,7 @@
              long time = this.levelData.getGameTime() + 1L;
              this.serverLevelData.setGameTime(time);

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -326,7 +326,7 @@
          if (isActive) {
              this.resetEmptyTime();
          }
-@@ -437,9 +_,11 @@
+@@ -437,9 +_,12 @@
                          }
                      }
                  );
@@ -335,6 +335,7 @@
              this.tickBlockEntities();
              profiler.pop();
 +            } // Paper - option to disable ticking
++            this.spigotConfig.currentPrimedTnt = 0; // Spigot
          }
  
          profiler.push("entityManagement");

--- a/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
@@ -445,6 +445,14 @@
              return chunk.getBlockState(pos);
          }
      }
+@@ -523,6 +_,7 @@
+     }
+ 
+     public void addBlockEntityTicker(final TickingBlockEntity ticker) {
++        if (!this.paperConfig().unsupportedSettings.ticking.blockEntities) return; // Paper - option to disable ticking
+         (this.tickingBlockEntities ? this.pendingBlockEntityTickers : this.blockEntityTickers).add(ticker);
+     }
+ 
 @@ -533,31 +_,48 @@
              this.pendingBlockEntityTickers.clear();
          }

--- a/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/Level.java.patch
@@ -453,7 +453,7 @@
          (this.tickingBlockEntities ? this.pendingBlockEntityTickers : this.blockEntityTickers).add(ticker);
      }
  
-@@ -533,31 +_,48 @@
+@@ -533,18 +_,23 @@
              this.pendingBlockEntityTickers.clear();
          }
  
@@ -479,10 +479,9 @@
  
 +        this.blockEntityTickers.removeAll(toRemove); // Paper - Fix MC-117075 use removeAll
          this.tickingBlockEntities = false;
-+        this.spigotConfig.currentPrimedTnt = 0; // Spigot
      }
  
-     public <T extends Entity> void guardEntityTick(final Consumer<T> tick, final T entity) {
+@@ -552,12 +_,23 @@
          try {
              tick.accept(entity);
          } catch (Throwable var6) {

--- a/paper-server/patches/sources/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -246,6 +246,14 @@
      public boolean isEmpty() {
          return false;
      }
+@@ -703,6 +_,7 @@
+     }
+ 
+     private <T extends BlockEntity> void updateBlockEntityTicker(final T blockEntity) {
++        if (!this.level.paperConfig().unsupportedSettings.ticking.blockEntities) return; // Paper - option to disable ticking
+         BlockState state = blockEntity.getBlockState();
+         BlockEntityTicker<T> ticker = state.getTicker(this.level, (BlockEntityType<T>)blockEntity.getType());
+         if (ticker == null) {
 @@ -752,23 +_,24 @@
                          if (this.blockEntity.getType().isValid(blockState)) {
                              this.ticker.tick(LevelChunk.this.level, this.blockEntity.getBlockPos(), blockState, this.blockEntity);

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -477,6 +477,12 @@ public class WorldConfiguration extends ConfigurationPart {
     public class UnsupportedSettings extends ConfigurationPart {
         public boolean fixInvulnerableEndCrystalExploit = true;
         public boolean disableWorldTickingWhenEmpty = false;
+        public Ticking ticking;
+
+        public class Ticking extends ConfigurationPart {
+            public boolean chunks = true;
+            public boolean blockEntities = true;
+        }
     }
 
     public Hopper hopper;


### PR DESCRIPTION
Blanket config options to disable large chunks of server ticking. Mainly targets lobby servers that make heavy use of block entities for decoration and that don't need mob spawning or random block ticking (or thunder or ice and snow handling). Entity ticking is a bit more involved, but may be added later. Block and fluid ticks would be other candidates, but need a deeper look too (setting max ticks to 0 somewhat helps already)

This is in some ways better than freezing server ticks (which still has to keep track of a lot of state in case ticking is re-enabled), but in other ways far less broad

Game rules that work well on their own and will reduce more ticking blocks are are: advance_time, advance_weather. The other level ticking seemed negligible