### PR TITLE
chore: add @Pattern key annotations to dialog builder methods

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/DialogInstancesProvider.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/DialogInstancesProvider.java
@@ -24,6 +24,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickCallback;
 import net.kyori.adventure.text.event.ClickEvent;
 import org.bukkit.inventory.ItemStack;
+import org.intellij.lang.annotations.Pattern;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 
@@ -62,15 +63,15 @@ public interface DialogInstancesProvider {
     PlainMessageDialogBody plainMessageDialogBody(Component component, int width);
 
     // inputs
-    BooleanDialogInput.Builder booleanBuilder(String key, Component label);
+    BooleanDialogInput.Builder booleanBuilder(@Pattern("^[a-zA-Z0-9_]+$") String key, Component label);
 
-    NumberRangeDialogInput.Builder numberRangeBuilder(String key, Component label, float start, float end);
+    NumberRangeDialogInput.Builder numberRangeBuilder(@Pattern("^[a-zA-Z0-9_]+$") String key, Component label, float start, float end);
 
-    SingleOptionDialogInput.Builder singleOptionBuilder(String key, Component label, List<SingleOptionDialogInput.OptionEntry> entries);
+    SingleOptionDialogInput.Builder singleOptionBuilder(@Pattern("^[a-zA-Z0-9_]+$") String key, Component label, List<SingleOptionDialogInput.OptionEntry> entries);
 
     SingleOptionDialogInput.OptionEntry singleOptionEntry(String id, @Nullable Component display, boolean initial);
 
-    TextDialogInput.Builder textBuilder(String key, Component label);
+    TextDialogInput.Builder textBuilder(@Pattern("^[a-zA-Z0-9_]+$") String key, Component label);
 
     TextDialogInput.MultilineOptions multilineOptions(@Nullable Integer maxLines, @Nullable Integer height);
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/DialogInput.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/DialogInput.java
@@ -4,6 +4,7 @@ import io.papermc.paper.registry.data.dialog.DialogInstancesProvider;
 import java.util.List;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.index.qual.Positive;
+import org.intellij.lang.annotations.Pattern;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Range;
 import org.jspecify.annotations.Nullable;
@@ -24,7 +25,7 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
      * @return a new boolean dialog input instance
      */
     @Contract(pure = true, value = "_, _, _, _, _ -> new")
-    static BooleanDialogInput bool(final String key, final Component label, final boolean initial, final String onTrue, final String onFalse) {
+    static BooleanDialogInput bool(@Pattern("^[a-zA-Z0-9_]+$") final String key, final Component label, final boolean initial, final String onTrue, final String onFalse) {
         return bool(key, label)
             .initial(initial)
             .onTrue(onTrue)
@@ -40,7 +41,7 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
      * @return a new builder instance
      */
     @Contract(pure = true, value = "_, _ -> new")
-    static BooleanDialogInput.Builder bool(final String key, final Component label) {
+    static BooleanDialogInput.Builder bool(@Pattern("^[a-zA-Z0-9_]+$") final String key, final Component label) {
         return DialogInstancesProvider.instance().booleanBuilder(key, label);
     }
 
@@ -59,7 +60,7 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
      */
     @Contract(pure = true, value = "_, _, _, _, _, _, _, _ -> new")
     static NumberRangeDialogInput numberRange(
-        final String key,
+        @Pattern("^[a-zA-Z0-9_]+$") final String key,
         final @Range(from = 1, to = 1024) int width,
         final Component label,
         final String labelFormat,
@@ -81,7 +82,7 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
      * @return a new builder instance
      */
     @Contract(pure = true, value = "_, _, _, _ -> new")
-    static NumberRangeDialogInput.Builder numberRange(final String key, final Component label, final float start, final float end) {
+    static NumberRangeDialogInput.Builder numberRange(@Pattern("^[a-zA-Z0-9_]+$") final String key, final Component label, final float start, final float end) {
         return DialogInstancesProvider.instance().numberRangeBuilder(key, label, start, end);
     }
 
@@ -97,7 +98,7 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
      */
     @Contract(pure = true, value = "_, _, _, _, _ -> new")
     static SingleOptionDialogInput singleOption(
-        final String key,
+        @Pattern("^[a-zA-Z0-9_]+$") final String key,
         final @Range(from = 1, to = 1024) int width,
         final List<SingleOptionDialogInput.OptionEntry> entries,
         final Component label,
@@ -115,7 +116,7 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
      * @return a new builder instance
      */
     @Contract(pure = true, value = "_, _, _ -> new")
-    static SingleOptionDialogInput.Builder singleOption(final String key, final Component label, final List<SingleOptionDialogInput.OptionEntry> entries) {
+    static SingleOptionDialogInput.Builder singleOption(@Pattern("^[a-zA-Z0-9_]+$") final String key, final Component label, final List<SingleOptionDialogInput.OptionEntry> entries) {
         return DialogInstancesProvider.instance().singleOptionBuilder(key, label, entries);
     }
 
@@ -133,7 +134,7 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
      */
     @Contract(pure = true, value = "_, _, _, _, _, _, _ -> new")
     static TextDialogInput text(
-        final String key,
+        @Pattern("^[a-zA-Z0-9_]+$") final String key,
         final @Range(from = 1, to = 1024) int width,
         final Component label,
         final boolean labelVisible,
@@ -152,7 +153,7 @@ public sealed interface DialogInput permits BooleanDialogInput, NumberRangeDialo
      * @return a new builder instance
      */
     @Contract(value = "_, _ -> new", pure = true)
-    static TextDialogInput.Builder text(final String key, final Component label) {
+    static TextDialogInput.Builder text(@Pattern("^[a-zA-Z0-9_]+$") final String key, final Component label) {
         return DialogInstancesProvider.instance().textBuilder(key, label);
     }
 

--- a/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/PaperDialogInstancesProvider.java
+++ b/paper-server/src/main/java/io/papermc/paper/registry/data/dialog/PaperDialogInstancesProvider.java
@@ -41,6 +41,7 @@ import net.kyori.adventure.text.event.ClickEvent;
 import net.minecraft.core.UUIDUtil;
 import net.minecraft.nbt.CompoundTag;
 import org.bukkit.inventory.ItemStack;
+import org.intellij.lang.annotations.Pattern;
 import org.jspecify.annotations.Nullable;
 
 public final class PaperDialogInstancesProvider implements DialogInstancesProvider {
@@ -94,17 +95,17 @@ public final class PaperDialogInstancesProvider implements DialogInstancesProvid
     }
 
     @Override
-    public BooleanDialogInput.Builder booleanBuilder(final String key, final Component label) {
+    public BooleanDialogInput.Builder booleanBuilder(@Pattern("^[a-zA-Z0-9_]+$") final String key, final Component label) {
         return new BooleanDialogInputImpl.BuilderImpl(key, label);
     }
 
     @Override
-    public NumberRangeDialogInput.Builder numberRangeBuilder(final String key, final Component label, final float start, final float end) {
+    public NumberRangeDialogInput.Builder numberRangeBuilder(@Pattern("^[a-zA-Z0-9_]+$") final String key, final Component label, final float start, final float end) {
         return new NumberRangeDialogInputImpl.BuilderImpl(key, label, start, end);
     }
 
     @Override
-    public SingleOptionDialogInput.Builder singleOptionBuilder(final String key, final Component label, final List<SingleOptionDialogInput.OptionEntry> entries) {
+    public SingleOptionDialogInput.Builder singleOptionBuilder(@Pattern("^[a-zA-Z0-9_]+$") final String key, final Component label, final List<SingleOptionDialogInput.OptionEntry> entries) {
         return new SingleOptionDialogInputImpl.BuilderImpl(key, entries, label);
     }
 
@@ -114,7 +115,7 @@ public final class PaperDialogInstancesProvider implements DialogInstancesProvid
     }
 
     @Override
-    public TextDialogInput.Builder textBuilder(final String key, final Component label) {
+    public TextDialogInput.Builder textBuilder(@Pattern("^[a-zA-Z0-9_]+$") final String key, final Component label) {
         return new TextDialogInputImpl.BuilderImpl(key, label);
     }
 


### PR DESCRIPTION
Adds `@Pattern("^[a-zA-Z0-9_]+$")` to all dialog input builder `key` parameters in both API and implementation.

This enforces consistent validation at the annotation level, ensuring keys only contain alphanumeric characters and underscores, matching the existing runtime checks. Improves static analysis, IDE feedback, and API clarity.
