### PR TITLE
Fix boat and minecart inventories on region switch

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftChestBoat.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftChestBoat.java
@@ -6,11 +6,9 @@ import org.bukkit.craftbukkit.inventory.CraftInventory;
 import org.bukkit.inventory.Inventory;
 
 public abstract class CraftChestBoat extends CraftBoat implements org.bukkit.entity.ChestBoat, com.destroystokyo.paper.loottable.PaperLootableEntityInventory { // Paper
-    private final Inventory inventory;
 
     public CraftChestBoat(CraftServer server, AbstractChestBoat entity) {
         super(server, entity);
-        this.inventory = new CraftInventory(entity);
     }
 
     @Override
@@ -20,6 +18,6 @@ public abstract class CraftChestBoat extends CraftBoat implements org.bukkit.ent
 
     @Override
     public Inventory getInventory() {
-        return this.inventory;
+        return new CraftInventory(getHandle());
     }
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java
@@ -8,15 +8,12 @@ import org.bukkit.inventory.Inventory;
 
 public class CraftMinecartChest extends CraftMinecartContainer implements StorageMinecart, com.destroystokyo.paper.loottable.PaperLootableEntityInventory { // Paper
 
-    private final CraftInventory inventory;
-
     public CraftMinecartChest(CraftServer server, MinecartChest entity) {
         super(server, entity);
-        this.inventory = new CraftInventory(entity);
     }
 
     @Override
     public Inventory getInventory() {
-        return this.inventory;
+        return new CraftInventory(getHandle());
     }
 }


### PR DESCRIPTION
This PR fixes an inconsistency in the Craft implementations of a few entity inventory holders. While this doesn't rly do anything on Paper, it does cause issues on Folia based forks, which is how this was found. This just fixes the inconsistency furthest upstream since it just makes sense to have it up here.

Link to the original patch - https://github.com/CraftCanvasMC/Canvas/pull/199/changes/b04a0941bec22a0eac316d4f042e224214e9994f