### PR TITLE
Fix BlockType occlusion check

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
@@ -16,7 +16,6 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Fallable;
@@ -200,7 +199,7 @@ public class CraftBlockType<B extends @NonNull BlockData> extends HolderableBase
 
     @Override
     public boolean isOccluding() {
-        return this.getHandle().defaultBlockState().isRedstoneConductor(EmptyBlockGetter.INSTANCE, BlockPos.ZERO);
+        return this.getHandle().defaultBlockState().canOcclude();
     }
 
     @Override

--- a/paper-server/src/test/java/org/bukkit/craftbukkit/block/BlockTypeTest.java
+++ b/paper-server/src/test/java/org/bukkit/craftbukkit/block/BlockTypeTest.java
@@ -21,4 +21,13 @@ public class BlockTypeTest {
             assertThat(actual, is(expected));
         }
     }
+
+    @Test
+    public void testOcclusionMatchesDefaultBlockData() throws Exception {
+        for (Field f : BlockType.class.getDeclaredFields()) {
+            BlockType type = (BlockType) f.get(null);
+
+            assertThat(type.isOccluding(), is(type.createBlockData().isOccluding()), type.getKey() + " should match its default BlockData occlusion");
+        }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/13790

`BlockType#isOccluding()` now matches `BlockData#isOccluding()` by using `BlockState#canOcclude()` instead of the redstone-conductor predicate.