### PR TITLE
Prevent spawn location getters from allowing making the location invalid

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/player/AsyncPlayerSpawnLocationEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/AsyncPlayerSpawnLocationEvent.java
@@ -53,7 +53,7 @@ public class AsyncPlayerSpawnLocationEvent extends Event {
      * @return the spawn location
      */
     public Location getSpawnLocation() {
-        return this.spawnLocation;
+        return this.spawnLocation.clone();
     }
 
     /**

--- a/paper-server/patches/sources/net/minecraft/server/network/config/PrepareSpawnTask.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/config/PrepareSpawnTask.java.patch
@@ -125,7 +125,7 @@
 +                        );
 +                        ev.callEvent();
 +                        spawnPosition = io.papermc.paper.util.MCUtil.toVec3(ev.getSpawnLocation());
-+                        this.spawnLevel = ((org.bukkit.craftbukkit.CraftWorld) ev.getSpawnLocation().getWorld()).getHandle();
++                        if (ev.getSpawnLocation().getWorld() != null) this.spawnLevel = ((org.bukkit.craftbukkit.CraftWorld) ev.getSpawnLocation().getWorld()).getHandle();
 +                        this.spawnPosition = CompletableFuture.completedFuture(spawnPosition);
 +                        this.spawnAngle = new Vec2(ev.getSpawnLocation().getYaw(), ev.getSpawnLocation().getPitch());
 +                    }


### PR DESCRIPTION
For the legacy event to minimize plugin breaking, it just ignores the modified world if it's null. For the experimental event it will now clone the location in the getter to not allow modifying it without passing it to the setter