### PR TITLE
Fix spear jab attack not connecting after charge attack

### DIFF
--- a/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
@@ -521,10 +521,10 @@ index e087d5596979044fe7fbcf7f2cccdae4e81a3d3a..fea6c3b48c4eb162fbdc099fa775bc31
              delta = this.maybeBackOffFromEdge(delta, moverType);
              Vec3 movement = this.collide(delta);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index c4da41f3b5ba6d8492d3776654b1ce62a5015895..6a0ebbdfcc0bc07915574c1cf87463e82213ca7e 100644
+index 78689b3e22fd4fdef957eb5e56e78fc77566fb73..669a17430fc7a7d43ff10f87a69cfcee6209f7ff 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3385,6 +3385,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3387,6 +3387,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
      protected void playAttackSound() {
      }
  
@@ -817,7 +817,7 @@ index 3a590d4dc980a2912e9cc043d8c8db4cf9d60803..06ab7c48b18c03af494ab10fc2b584ce
 +
  }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index b8d56c7a14521cb77ba2cf619be826fb06be81da..2b3ec0a012918815ed0eda8b40647c2274a5b418 100644
+index c0f901c4ac61a0aa2b480f102feb3669b111f4c0..07c301ba02c7f2c032a29a0ae3bdf95fc522c03b 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -155,6 +155,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -1150,7 +1150,7 @@
 +            if (source.getEntity() instanceof net.minecraft.world.entity.player.Player attackingPlayer) {
 +                // Paper start - PlayerAttackEntityCooldownResetEvent
 +                //((net.minecraft.world.entity.player.Player) damagesource.getEntity()).resetOnlyAttackStrengthTicker(); // Moved from Player in order to make the cooldown reset get called after the damage event is fired
-+                if (!source.is(DamageTypes.SPEAR) || !attackingPlayer.isUsingItem() || !attackingPlayer.getUseItem().has(DataComponents.KINETIC_WEAPON)) { // Paper - Preserve vanilla spear charge cooldown
++                if (!attackingPlayer.isUsingItem() || !attackingPlayer.getUseItem().has(DataComponents.KINETIC_WEAPON)) { // Paper - Preserve vanilla spear charge cooldown
 +                    if (attackingPlayer instanceof ServerPlayer player) {
 +                        if (new com.destroystokyo.paper.event.player.PlayerAttackEntityCooldownResetEvent(player.getBukkitEntity(), this.getBukkitEntity(), player.getAttackStrengthScale(0F)).callEvent()) {
 +                            player.resetOnlyAttackStrengthTicker();

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -1053,7 +1053,7 @@
                  int absorbValue = (this.getEffect(MobEffects.RESISTANCE).getAmplifier() + 1) * 5;
                  int absorb = 25 - absorbValue;
                  float v = damage * absorb;
-@@ -1915,24 +_,194 @@
+@@ -1915,24 +_,196 @@
          }
      }
  
@@ -1147,15 +1147,17 @@
 +                return false;
 +            }
 +
-+            if (source.getEntity() instanceof net.minecraft.world.entity.player.Player) {
++            if (source.getEntity() instanceof net.minecraft.world.entity.player.Player attackingPlayer) {
 +                // Paper start - PlayerAttackEntityCooldownResetEvent
 +                //((net.minecraft.world.entity.player.Player) damagesource.getEntity()).resetOnlyAttackStrengthTicker(); // Moved from Player in order to make the cooldown reset get called after the damage event is fired
-+                if (source.getEntity() instanceof ServerPlayer player) {
-+                    if (new com.destroystokyo.paper.event.player.PlayerAttackEntityCooldownResetEvent(player.getBukkitEntity(), this.getBukkitEntity(), player.getAttackStrengthScale(0F)).callEvent()) {
-+                        player.resetOnlyAttackStrengthTicker();
++                if (!source.is(DamageTypes.SPEAR) || !attackingPlayer.isUsingItem() || !attackingPlayer.getUseItem().has(DataComponents.KINETIC_WEAPON)) { // Paper - Preserve vanilla spear charge cooldown
++                    if (attackingPlayer instanceof ServerPlayer player) {
++                        if (new com.destroystokyo.paper.event.player.PlayerAttackEntityCooldownResetEvent(player.getBukkitEntity(), this.getBukkitEntity(), player.getAttackStrengthScale(0F)).callEvent()) {
++                            player.resetOnlyAttackStrengthTicker();
++                        }
++                    } else {
++                        attackingPlayer.resetOnlyAttackStrengthTicker();
 +                    }
-+                } else {
-+                    ((net.minecraft.world.entity.player.Player)source.getEntity()).resetOnlyAttackStrengthTicker();
 +                }
 +                // Paper end - PlayerAttackEntityCooldownResetEvent
 +            }


### PR DESCRIPTION
In vanilla it is possible to use the jab attack immediately after a charge attack, paper does not allow the 2nd attack which heavily impacts the PvP experience. This issue stemmed from paper incorrectly resetting the player's attack cooldown after a charge attack. Fix for https://github.com/PaperMC/Paper/issues/13838