### PR TITLE
Fix LivingEntity#knockback ignored when its Player

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
@@ -1030,7 +1030,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
     public void knockback(final double strength, final double directionX, final double directionZ) {
         Preconditions.checkArgument(strength > 0, "Knockback strength must be > 0");
         this.getHandle().knockback(strength, directionX, directionZ);
-    };
+    }
 
     public void broadcastSlotBreak(final org.bukkit.inventory.EquipmentSlot slot) {
         this.getHandle().level().broadcastEntityEvent(this.getHandle(), net.minecraft.world.entity.LivingEntity.entityEventForEquipmentBreak(org.bukkit.craftbukkit.CraftEquipmentSlot.getNMS(slot)));

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -3361,4 +3361,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
             entity.remove();
         }
     }
+
+    @Override
+    public void knockback(final double strength, final double directionX, final double directionZ) {
+        super.knockback(strength, directionX, directionZ);
+        this.entity.hurtMarked = true;
+    }
 }


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/13840 by using the player hurtMarked for apply the update to movement, this its only necesary for Players.

PS: In this PR i notice a bucle when try to cancel PlayerVelocityEvent when test this, because the method cause a call of that event.. but this is related to another thing in a sync step...