### PR TITLE
[1.21.11] Fix spear jab attack not connecting after charge attack

### DIFF
--- a/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
@@ -521,10 +521,10 @@ index 34ef15867759ebc7296256a6d5ec286eb3a5f895..d3d97b0b6ff6312f1deb0bb8b1beef8b
              movement = this.maybeBackOffFromEdge(movement, type);
              Vec3 vec3 = this.collide(movement);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 5b6020de0848458f5576113e690b5a6435f35d05..6f49b5e5888a6296b929e465a5ef87dc49bd4516 100644
+index 4d8c57f1b3b14362496a27a6bfef75cdfcc340a1..4fe32da147cc1cec36cab2b4a5d4fc60738eb65a 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3330,6 +3330,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3333,6 +3333,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
      protected void playAttackSound() {
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -1051,7 +1051,7 @@
                  int i = (this.getEffect(MobEffects.RESISTANCE).getAmplifier() + 1) * 5;
                  int i1 = 25 - i;
                  float f = damageAmount * i1;
-@@ -1863,24 +_,201 @@
+@@ -1863,24 +_,204 @@
          }
      }
  
@@ -1151,16 +1151,17 @@
 +                return false;
 +            }
 +
-+            if (damageSource.getEntity() instanceof net.minecraft.world.entity.player.Player) {
++            if (damageSource.getEntity() instanceof net.minecraft.world.entity.player.Player attackingPlayer) {
 +                // Paper start - PlayerAttackEntityCooldownResetEvent
 +                //((net.minecraft.world.entity.player.Player) damagesource.getEntity()).resetOnlyAttackStrengthTicker(); // Moved from Player in order to make the cooldown reset get called after the damage event is fired
-+                if (damageSource.getEntity() instanceof ServerPlayer) {
-+                    ServerPlayer player = (ServerPlayer) damageSource.getEntity();
-+                    if (new com.destroystokyo.paper.event.player.PlayerAttackEntityCooldownResetEvent(player.getBukkitEntity(), this.getBukkitEntity(), player.getAttackStrengthScale(0F)).callEvent()) {
-+                        player.resetOnlyAttackStrengthTicker();
++                if (!attackingPlayer.isUsingItem() || !attackingPlayer.getUseItem().has(DataComponents.KINETIC_WEAPON)) { // Paper - Preserve vanilla spear charge cooldown
++                    if (attackingPlayer instanceof ServerPlayer player) {
++                        if (new com.destroystokyo.paper.event.player.PlayerAttackEntityCooldownResetEvent(player.getBukkitEntity(), this.getBukkitEntity(), player.getAttackStrengthScale(0F)).callEvent()) {
++                            player.resetOnlyAttackStrengthTicker();
++                        }
++                    } else {
++                        attackingPlayer.resetOnlyAttackStrengthTicker();
 +                    }
-+                } else {
-+                    ((net.minecraft.world.entity.player.Player) damageSource.getEntity()).resetOnlyAttackStrengthTicker();
 +                }
 +                // Paper end - PlayerAttackEntityCooldownResetEvent
 +            }


### PR DESCRIPTION
In vanilla it is possible to use the jab attack immediately after a charge attack, paper does not allow the 2nd attack which heavily impacts the PvP experience. This issue stemmed from paper incorrectly resetting the player's attack cooldown after a charge attack. Fix for https://github.com/PaperMC/Paper/issues/13838 (ver/1.21.11)