### PR TITLE
Fix infinite loop after cancelling PlayerVelocityEvent

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/level/ServerEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerEntity.java.patch
@@ -61,27 +61,22 @@
                  Packet<ClientGamePacketListener> packet = null;
                  boolean pos = positionChanged || this.tickCount % 60 == 0;
                  boolean sentPosition = false;
-@@ -223,6 +_,25 @@
+@@ -223,6 +_,20 @@
  
          this.tickCount++;
          if (this.entity.hurtMarked) {
 +            // CraftBukkit start - Create PlayerVelocity event
-+            boolean cancelled = false;
++            if (this.entity.getBukkitEntity() instanceof org.bukkit.entity.Player player) {
++                final org.bukkit.util.Vector velocity = player.getVelocity();
 +
-+            if (this.entity instanceof ServerPlayer) {
-+                org.bukkit.entity.Player player = (org.bukkit.entity.Player) this.entity.getBukkitEntity();
-+                org.bukkit.util.Vector velocity = player.getVelocity();
-+
-+                org.bukkit.event.player.PlayerVelocityEvent event = new org.bukkit.event.player.PlayerVelocityEvent(player, velocity.clone());
-+                if (!event.callEvent()) {
-+                    cancelled = true;
-+                } else if (!velocity.equals(event.getVelocity())) {
++                final org.bukkit.event.player.PlayerVelocityEvent event = new org.bukkit.event.player.PlayerVelocityEvent(player, velocity.clone());
++                if (event.callEvent()) {
++                    this.entity.hurtMarked = false; // Paper - avoid bucle if was called for knockback
++                    return;
++                }
++                if (!velocity.equals(event.getVelocity())) {
 +                    player.setVelocity(event.getVelocity());
 +                }
-+            }
-+
-+            if (cancelled) {
-+                return;
 +            }
 +            // CraftBukkit end
              this.entity.hurtMarked = false;

--- a/paper-server/patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -290,7 +290,7 @@
              return true;
          } else {
              return false;
-@@ -1127,20 +_,41 @@
+@@ -1127,20 +_,39 @@
          if (knockbackAmount > 0.0F) {
              if (entity instanceof LivingEntity livingTarget) {
                  livingTarget.knockback(
@@ -311,26 +311,26 @@
          }
  
          if (entity instanceof ServerPlayer serverPlayer && entity.hurtMarked) {
-+            // CraftBukkit start - Add Velocity Event
-+            boolean cancelled = false;
-+            org.bukkit.entity.Player player = (org.bukkit.entity.Player) entity.getBukkitEntity();
-+            org.bukkit.util.Vector velocity = org.bukkit.craftbukkit.util.CraftVector.toBukkit(oldMovement);
+-            serverPlayer.connection.send(new ClientboundSetEntityMotionPacket(entity));
++            // Paper start - Add Velocity Event
++            final org.bukkit.entity.Player player = serverPlayer.getBukkitEntity();
++            final org.bukkit.util.Vector velocity = org.bukkit.craftbukkit.util.CraftVector.toBukkit(oldMovement);
++            Vec3 oldMovementVec = oldMovement;
 +
-+            org.bukkit.event.player.PlayerVelocityEvent event = new org.bukkit.event.player.PlayerVelocityEvent(player, velocity.clone());
-+            this.level().getCraftServer().getPluginManager().callEvent(event);
++            final org.bukkit.event.player.PlayerVelocityEvent event = new org.bukkit.event.player.PlayerVelocityEvent(player, velocity.clone());
 +
-+            if (event.isCancelled()) {
-+                cancelled = true;
-+            } else if (!velocity.equals(event.getVelocity())) {
-+                player.setVelocity(event.getVelocity());
-+            }
-+
-+            if (!cancelled) {
-             serverPlayer.connection.send(new ClientboundSetEntityMotionPacket(entity));
              entity.hurtMarked = false;
-             entity.setDeltaMovement(oldMovement);
+-            entity.setDeltaMovement(oldMovement);
++            if (!event.callEvent()) {
++                return;
++            } else if (!velocity.equals(event.getVelocity())) {
++                oldMovementVec = org.bukkit.craftbukkit.util.CraftVector.toVec3(event.getVelocity());
 +            }
-+            // CraftBukkit end
++
++            // Paper end
++            serverPlayer.connection.send(new ClientboundSetEntityMotionPacket(entity));
++            // entity.hurtMarked = false; // Paper - move before PlayerVelocityEvent call
++            entity.setDeltaMovement(oldMovementVec); // Paper - set DeltaMovement based on the method or the velocity event override
          }
      }
  


### PR DESCRIPTION
Related to https://github.com/PaperMC/Paper/pull/13842 this PR fix an issue where if you try to cancel PlayerVelocityEvent the event is still called again and again.