### PR TITLE
Remove unused event constructors

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/block/BlockBurnEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/BlockBurnEvent.java
@@ -20,12 +20,6 @@ public class BlockBurnEvent extends BlockEvent implements Cancellable {
     private final Block ignitingBlock;
     private boolean cancelled;
 
-    @Deprecated(since = "1.11.2", forRemoval = true)
-    @ApiStatus.Internal
-    public BlockBurnEvent(@NotNull final Block block) {
-        this(block, null);
-    }
-
     @ApiStatus.Internal
     public BlockBurnEvent(@NotNull final Block block, @Nullable final Block ignitingBlock) {
         super(block);

--- a/paper-api/src/main/java/org/bukkit/event/block/BlockCanBuildEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/BlockCanBuildEvent.java
@@ -29,18 +29,6 @@ public class BlockCanBuildEvent extends BlockEvent {
     protected BlockData blockData;
     protected boolean buildable;
 
-    @Deprecated(since = "1.13.2", forRemoval = true)
-    @ApiStatus.Internal
-    public BlockCanBuildEvent(@NotNull final Block block, @NotNull final BlockData type, final boolean canBuild) {
-        this(block, null, type, canBuild, org.bukkit.inventory.EquipmentSlot.HAND); // Paper - expose hand
-    }
-
-    @Deprecated(forRemoval = true)
-    @ApiStatus.Internal
-    public BlockCanBuildEvent(@NotNull final Block block, @Nullable final Player player, @NotNull final BlockData type, final boolean canBuild) {
-        this(block, player, type, canBuild, org.bukkit.inventory.EquipmentSlot.HAND); // Paper start - expose hand
-    }
-
     @ApiStatus.Internal
     public BlockCanBuildEvent(@NotNull final Block block, @Nullable final Player player, @NotNull final BlockData type, final boolean canBuild, @NotNull final org.bukkit.inventory.EquipmentSlot hand) { // Paper end - expose hand
         super(block);

--- a/paper-api/src/main/java/org/bukkit/event/block/BlockPistonExtendEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/BlockPistonExtendEvent.java
@@ -21,14 +21,6 @@ public class BlockPistonExtendEvent extends BlockPistonEvent {
     private List<Block> blocks;
 
     @ApiStatus.Internal
-    @Deprecated(since = "1.8", forRemoval = true)
-    public BlockPistonExtendEvent(@NotNull final Block block, final int length, @NotNull final BlockFace direction) {
-        super(block, direction);
-
-        this.length = length;
-    }
-
-    @ApiStatus.Internal
     public BlockPistonExtendEvent(@NotNull final Block block, @NotNull final List<Block> blocks, @NotNull final BlockFace direction) {
         super(block, direction);
 

--- a/paper-api/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
@@ -29,12 +29,6 @@ public class BlockPlaceEvent extends BlockEvent implements Cancellable {
     protected boolean cancelled;
 
     @ApiStatus.Internal
-    @Deprecated(since = "1.9", forRemoval = true)
-    public BlockPlaceEvent(@NotNull final Block placedBlock, @NotNull final BlockState replacedState, @NotNull final Block placedAgainst, @NotNull final ItemStack itemInHand, @NotNull final Player thePlayer, final boolean canBuild) {
-        this(placedBlock, replacedState, placedAgainst, itemInHand, thePlayer, canBuild, EquipmentSlot.HAND);
-    }
-
-    @ApiStatus.Internal
     public BlockPlaceEvent(@NotNull final Block placedBlock, @NotNull final BlockState replacedState, @NotNull final Block placedAgainst, @NotNull final ItemStack itemInHand, @NotNull final Player thePlayer, final boolean canBuild, @NotNull final EquipmentSlot hand) {
         super(placedBlock);
         this.placedAgainst = placedAgainst;

--- a/paper-api/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/SignChangeEvent.java
@@ -34,30 +34,6 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
         this.side = side;
     }
 
-    @ApiStatus.Internal
-    @Deprecated(forRemoval = true)
-    public SignChangeEvent(@NotNull final Block sign, @NotNull final Player player, @NotNull final java.util.List<net.kyori.adventure.text.Component> adventure$lines) {
-        this(sign, player, adventure$lines, Side.FRONT);
-    }
-
-    @ApiStatus.Internal
-    @Deprecated(since = "1.19.4", forRemoval = true)
-    public SignChangeEvent(@NotNull final Block sign, @NotNull final Player thePlayer, @NotNull final String[] theLines) {
-        this(sign, thePlayer, theLines, Side.FRONT);
-    }
-
-    @ApiStatus.Internal
-    @Deprecated(forRemoval = true)
-    public SignChangeEvent(@NotNull final Block sign, @NotNull final Player thePlayer, @NotNull final String[] theLines, @NotNull Side side) {
-        super(sign);
-        this.player = thePlayer;
-        this.adventure$lines = new java.util.ArrayList<>();
-        for (String theLine : theLines) {
-            this.adventure$lines.add(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(theLine));
-        }
-        this.side = side;
-    }
-
     /**
      * Gets the player changing the sign involved in this event.
      *

--- a/paper-api/src/main/java/org/bukkit/event/entity/ItemSpawnEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/ItemSpawnEvent.java
@@ -1,6 +1,5 @@
 package org.bukkit.event.entity;
 
-import org.bukkit.Location;
 import org.bukkit.entity.Item;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -9,12 +8,6 @@ import org.jetbrains.annotations.NotNull;
  * Called when an item is spawned into a world
  */
 public class ItemSpawnEvent extends EntitySpawnEvent {
-
-    @ApiStatus.Internal
-    @Deprecated(since = "1.13.2", forRemoval = true)
-    public ItemSpawnEvent(@NotNull final Item spawnee, final Location loc) {
-        this(spawnee);
-    }
 
     @ApiStatus.Internal
     public ItemSpawnEvent(@NotNull final Item spawnee) {

--- a/paper-api/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java
@@ -14,12 +14,6 @@ import org.jetbrains.annotations.Nullable;
 public class SheepDyeWoolEvent extends EntityDyeEvent {
 
     @ApiStatus.Internal
-    @Deprecated(since = "1.17.1", forRemoval = true)
-    public SheepDyeWoolEvent(@NotNull final Sheep sheep, @NotNull final DyeColor color) {
-        this(sheep, color, null);
-    }
-
-    @ApiStatus.Internal
     public SheepDyeWoolEvent(@NotNull final Sheep sheep, @NotNull final DyeColor color, @Nullable Player player) {
         super(sheep, color, player);
     }

--- a/paper-api/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
@@ -40,35 +40,6 @@ public class AsyncPlayerPreLoginEvent extends Event {
     private final PlayerLoginConnection playerLoginConnection;
 
     @ApiStatus.Internal
-    @Deprecated(since = "1.7.5", forRemoval = true)
-    public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress) {
-        this(name, ipAddress, null);
-    }
-
-    @ApiStatus.Internal
-    @Deprecated(since = "1.20.5", forRemoval = true)
-    public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final UUID uniqueId) {
-        this(name, ipAddress, uniqueId, false);
-    }
-
-    @ApiStatus.Internal
-    public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final UUID uniqueId, boolean transferred) {
-        this(name, ipAddress, uniqueId, transferred, org.bukkit.Bukkit.createProfile(uniqueId, name));
-    }
-
-    @ApiStatus.Internal
-    @Deprecated(forRemoval = true)
-    public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final UUID uniqueId, boolean transferred, @NotNull com.destroystokyo.paper.profile.PlayerProfile profile) {
-        this(name, ipAddress, ipAddress, uniqueId, transferred, profile);
-    }
-
-    @ApiStatus.Internal
-    @Deprecated(forRemoval = true)
-    public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final InetAddress rawAddress, @NotNull final UUID uniqueId, boolean transferred, @NotNull com.destroystokyo.paper.profile.PlayerProfile profile) {
-        this(name, ipAddress, rawAddress, uniqueId, transferred, profile, "", null);
-    }
-
-    @ApiStatus.Internal
     public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final InetAddress rawAddress, @NotNull final UUID uniqueId, boolean transferred, @NotNull com.destroystokyo.paper.profile.PlayerProfile profile, @NotNull String hostname, final PlayerLoginConnection playerLoginConnection) {
         super(true);
         this.result = Result.ALLOWED;

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerBucketEmptyEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerBucketEmptyEvent.java
@@ -18,18 +18,6 @@ public class PlayerBucketEmptyEvent extends PlayerBucketEvent {
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     @ApiStatus.Internal
-    @Deprecated(since = "1.14.4", forRemoval = true)
-    public PlayerBucketEmptyEvent(@NotNull final Player player, @NotNull final Block blockClicked, @NotNull final BlockFace blockFace, @NotNull final Material bucket, @NotNull final ItemStack itemInHand) {
-        super(player, blockClicked, blockFace, bucket, itemInHand);
-    }
-
-    @ApiStatus.Internal
-    @Deprecated(since = "1.19.2", forRemoval = true)
-    public PlayerBucketEmptyEvent(@NotNull final Player player, @NotNull final Block block, @NotNull final Block blockClicked, @NotNull final BlockFace blockFace, @NotNull final Material bucket, @NotNull final ItemStack itemInHand) {
-        super(player, block, blockClicked, blockFace, bucket, itemInHand);
-    }
-
-    @ApiStatus.Internal
     public PlayerBucketEmptyEvent(@NotNull final Player player, @NotNull final Block block, @NotNull final Block blockClicked, @NotNull final BlockFace blockFace, @NotNull final Material bucket, @NotNull final ItemStack itemInHand, @NotNull final EquipmentSlot hand) {
         super(player, block, blockClicked, blockFace, bucket, itemInHand, hand);
     }

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerBucketEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerBucketEvent.java
@@ -28,18 +28,6 @@ public abstract class PlayerBucketEvent extends PlayerEvent implements Cancellab
     private boolean cancelled;
 
     @ApiStatus.Internal
-    @Deprecated(since = "1.14.4", forRemoval = true)
-    public PlayerBucketEvent(@NotNull final Player player, @NotNull final Block blockClicked, @NotNull final BlockFace blockFace, @NotNull final Material bucket, @NotNull final ItemStack itemInHand) {
-        this(player, null, blockClicked.getRelative(blockFace), blockFace, bucket, itemInHand, EquipmentSlot.HAND);
-    }
-
-    @ApiStatus.Internal
-    @Deprecated(since = "1.19.2", forRemoval = true)
-    public PlayerBucketEvent(@NotNull final Player player, @NotNull final Block block, @NotNull final Block blockClicked, @NotNull final BlockFace blockFace, @NotNull final Material bucket, @NotNull final ItemStack itemInHand) {
-        this(player, block, blockClicked, blockFace, bucket, itemInHand, EquipmentSlot.HAND);
-    }
-
-    @ApiStatus.Internal
     public PlayerBucketEvent(@NotNull final Player player, @NotNull final Block block, @NotNull final Block blockClicked, @NotNull final BlockFace blockFace, @NotNull final Material bucket, @NotNull final ItemStack itemInHand, @NotNull final EquipmentSlot hand) {
         super(player);
         this.block = block;

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerBucketFillEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerBucketFillEvent.java
@@ -18,18 +18,6 @@ public class PlayerBucketFillEvent extends PlayerBucketEvent {
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     @ApiStatus.Internal
-    @Deprecated(since = "1.14.4", forRemoval = true)
-    public PlayerBucketFillEvent(@NotNull final Player player, @NotNull final Block blockClicked, @NotNull final BlockFace blockFace, @NotNull final Material bucket, @NotNull final ItemStack itemInHand) {
-        super(player, blockClicked, blockFace, bucket, itemInHand);
-    }
-
-    @ApiStatus.Internal
-    @Deprecated(since = "1.19.2", forRemoval = true)
-    public PlayerBucketFillEvent(@NotNull final Player player, @NotNull final Block block, @NotNull final Block blockClicked, @NotNull final BlockFace blockFace, @NotNull final Material bucket, @NotNull final ItemStack itemInHand) {
-        super(player, block, blockClicked, blockFace, bucket, itemInHand);
-    }
-
-    @ApiStatus.Internal
     public PlayerBucketFillEvent(@NotNull final Player player, @NotNull final Block block, @NotNull final Block blockClicked, @NotNull final BlockFace blockFace, @NotNull final Material bucket, @NotNull final ItemStack itemInHand, @NotNull final EquipmentSlot hand) {
         super(player, block, blockClicked, blockFace, bucket, itemInHand, hand);
     }

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
@@ -37,12 +37,6 @@ public class PlayerPreLoginEvent extends Event {
     private Component message;
 
     @ApiStatus.Internal
-    @Deprecated(since = "1.7.5", forRemoval = true)
-    public PlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress) {
-        this(name, ipAddress, null);
-    }
-
-    @ApiStatus.Internal
     public PlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final UUID uniqueId) {
         this.result = Result.ALLOWED;
         this.message = Component.empty();

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java
@@ -7,8 +7,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Unmodifiable;
-import java.util.Set;
 
 /**
  * Called when a player respawns.
@@ -19,18 +17,6 @@ import java.util.Set;
 public class PlayerRespawnEvent extends AbstractRespawnEvent {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
-
-    @ApiStatus.Internal
-    @Deprecated(since = "1.16.1", forRemoval = true)
-    public PlayerRespawnEvent(@NotNull final Player respawnPlayer, @NotNull final Location respawnLocation, final boolean isBedSpawn) {
-        this(respawnPlayer, respawnLocation, isBedSpawn, false);
-    }
-
-    @ApiStatus.Internal
-    @Deprecated(since = "1.19.4", forRemoval = true)
-    public PlayerRespawnEvent(@NotNull final Player respawnPlayer, @NotNull final Location respawnLocation, final boolean isBedSpawn, final boolean isAnchorSpawn) {
-        this(respawnPlayer, respawnLocation, isBedSpawn, isAnchorSpawn, false, RespawnReason.PLUGIN);
-    }
 
     @ApiStatus.Internal
     public PlayerRespawnEvent(@NotNull final Player respawnPlayer, @NotNull final Location respawnLocation, final boolean isBedSpawn, final boolean isAnchorSpawn, final boolean missingRespawnBlock, @NotNull final RespawnReason respawnReason) {

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerShearEntityEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerShearEntityEvent.java
@@ -1,6 +1,5 @@
 package org.bukkit.event.player;
 
-import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -33,12 +32,6 @@ public class PlayerShearEntityEvent extends PlayerEvent implements Cancellable {
         this.item = item;
         this.hand = hand;
         this.drops = drops;
-    }
-
-    @ApiStatus.Internal
-    @Deprecated(since = "1.15.2", forRemoval = true)
-    public PlayerShearEntityEvent(@NotNull final Player player, @NotNull final Entity entity) {
-        this(player, entity, new ItemStack(Material.SHEARS), EquipmentSlot.HAND, java.util.Collections.emptyList());
     }
 
     /**

--- a/paper-api/src/main/java/org/bukkit/event/server/BroadcastMessageEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/server/BroadcastMessageEvent.java
@@ -27,26 +27,6 @@ public class BroadcastMessageEvent extends ServerEvent implements Cancellable {
     private boolean cancelled;
 
     @ApiStatus.Internal
-    @Deprecated(since = "1.14", forRemoval = true)
-    public BroadcastMessageEvent(@NotNull String message, @NotNull Set<CommandSender> recipients) {
-        this(false, message, recipients);
-    }
-
-    @ApiStatus.Internal
-    @Deprecated(forRemoval = true)
-    public BroadcastMessageEvent(boolean isAsync, @NotNull String message, @NotNull Set<CommandSender> recipients) {
-        super(isAsync);
-        this.message = LegacyComponentSerializer.legacySection().deserialize(message);
-        this.recipients = recipients;
-    }
-
-    @ApiStatus.Internal
-    @Deprecated(forRemoval = true)
-    public BroadcastMessageEvent(@NotNull Component message, @NotNull Set<CommandSender> recipients) {
-        this(false, message, recipients);
-    }
-
-    @ApiStatus.Internal
     public BroadcastMessageEvent(boolean isAsync, @NotNull Component message, @NotNull Set<CommandSender> recipients) {
         super(isAsync);
         this.message = message;

--- a/paper-api/src/main/java/org/bukkit/event/weather/LightningStrikeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/weather/LightningStrikeEvent.java
@@ -20,12 +20,6 @@ public class LightningStrikeEvent extends WeatherEvent implements Cancellable {
     private boolean cancelled;
 
     @ApiStatus.Internal
-    @Deprecated(since = "1.13.1", forRemoval = true)
-    public LightningStrikeEvent(@NotNull final World world, @NotNull final LightningStrike bolt) {
-        this(world, bolt, Cause.UNKNOWN);
-    }
-
-    @ApiStatus.Internal
     public LightningStrikeEvent(@NotNull final World world, @NotNull final LightningStrike bolt, @NotNull final Cause cause) {
         super(world);
         this.bolt = bolt;

--- a/paper-api/src/main/java/org/bukkit/event/weather/ThunderChangeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/weather/ThunderChangeEvent.java
@@ -25,12 +25,6 @@ public class ThunderChangeEvent extends WeatherEvent implements Cancellable {
         this.cause = cause;
     }
 
-    @ApiStatus.Internal
-    @Deprecated(forRemoval = true)
-    public ThunderChangeEvent(@NotNull final World world, final boolean newThunderState) {
-        this(world, newThunderState, Cause.UNKNOWN);
-    }
-
     /**
      * Gets the state of thunder that the world is being set to
      *

--- a/paper-api/src/main/java/org/bukkit/event/weather/WeatherChangeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/weather/WeatherChangeEvent.java
@@ -25,12 +25,6 @@ public class WeatherChangeEvent extends WeatherEvent implements Cancellable {
         this.cause = cause;
     }
 
-    @ApiStatus.Internal
-    @Deprecated(forRemoval = true)
-    public WeatherChangeEvent(@NotNull final World world, final boolean newWeatherState) {
-        this(world, newWeatherState, Cause.UNKNOWN);
-    }
-
     /**
      * Gets the state of weather that the world is being set to
      *

--- a/paper-api/src/main/java/org/bukkit/event/world/PortalCreateEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/world/PortalCreateEvent.java
@@ -24,12 +24,6 @@ public class PortalCreateEvent extends WorldEvent implements Cancellable {
     private boolean cancelled;
 
     @ApiStatus.Internal
-    @Deprecated(since = "1.14.1", forRemoval = true)
-    public PortalCreateEvent(@NotNull final List<BlockState> blocks, @NotNull final World world, @NotNull CreateReason reason) {
-        this(blocks, world, null, reason);
-    }
-
-    @ApiStatus.Internal
     public PortalCreateEvent(@NotNull final List<BlockState> blocks, @NotNull final World world, @Nullable Entity entity, @NotNull CreateReason reason) {
         super(world);
 


### PR DESCRIPTION
This PR removes a bunch of event constructors.
These constructors were intended for internal use and have been marked for removal since an eternity.