### PR TITLE
Add Allies and additional rule API

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -5,6 +5,8 @@ import java.util.Set;
 import java.util.UUID;
 import io.papermc.paper.datacomponent.DataComponentView;
 import io.papermc.paper.entity.LookAnchor;
+import java.util.function.Predicate;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.util.TriState;
@@ -1332,4 +1334,39 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      */
     void broadcastHurtAnimation(@NotNull java.util.Collection<Player> players);
     // Paper end - broadcast hurt animation
+
+    /**
+     * Gets if the entity is allied to the given entity.
+     *
+     * @param other the other entity
+     * @return true if the entity is allied to the given entity
+     */
+    boolean isAlliedTo(@NotNull Entity other);
+
+    /**
+     * Gets the current additional rule of alliance with any entity.
+     * <br>
+     * This is an additional rule from the vanilla behaviour for any entity, like share a team.
+     * <br>
+     * This rule is not (currently) persistent.
+     *
+     * @return additional rule of alliance
+     * @see #addAdditionalAlliedRule(Key, Predicate)
+     */
+    @Nullable Predicate<Entity> getAdditionalAlliedRule(@NotNull Key key);
+
+    /**
+     * Sets the current additional rule of alliance with any entity.
+     *
+     * @param key the key of the additional rule
+     * @param predicate the additional rule of alliance with any entity
+     */
+    void addAdditionalAlliedRule(@NotNull Key key, @NotNull Predicate<Entity> predicate);
+
+    /**
+     * Remove the additional rule of alliance with any entity.
+     *
+     * @param key the key of the additional rule
+     */
+    void removeAdditionalAlliedRule(@NotNull Key key);
 }

--- a/paper-api/src/main/java/org/bukkit/entity/Entity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Entity.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 import io.papermc.paper.datacomponent.DataComponentView;
 import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.math.Angle;
+import java.util.function.Predicate;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.util.TriState;
@@ -1345,4 +1347,39 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      */
     void broadcastHurtAnimation(@NotNull java.util.Collection<Player> players);
     // Paper end - broadcast hurt animation
+
+    /**
+     * Gets if the entity is allied to the given entity.
+     *
+     * @param other the other entity
+     * @return true if the entity is allied to the given entity
+     */
+    boolean isAlliedTo(@NotNull Entity other);
+
+    /**
+     * Gets the current additional rule of alliance with any entity.
+     * <br>
+     * This is an additional rule from the vanilla behaviour for any entity, like share a team.
+     * <br>
+     * This rule is not (currently) persistent.
+     *
+     * @return additional rule of alliance
+     * @see #addAdditionalAlliedRule(Key, Predicate)
+     */
+    @Nullable Predicate<Entity> getAdditionalAlliedRule(@NotNull Key key);
+
+    /**
+     * Sets the current additional rule of alliance with any entity.
+     *
+     * @param key the key of the additional rule
+     * @param predicate the additional rule of alliance with any entity
+     */
+    void addAdditionalAlliedRule(@NotNull Key key, @NotNull Predicate<Entity> predicate);
+
+    /**
+     * Remove the additional rule of alliance with any entity.
+     *
+     * @param key the key of the additional rule
+     */
+    void removeAdditionalAlliedRule(@NotNull Key key);
 }

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1299,6 +1299,15 @@
          return this.level().getScoreboard().getPlayersTeam(this.getScoreboardName());
      }
  
+@@ -2773,7 +_,7 @@
+     }
+ 
+     protected boolean considersEntityAsAlly(final Entity other) {
+-        return this.isAlliedTo(other.getTeam());
++        return this.isAlliedTo(other.getTeam()) || this.getBukkitEntity().considersEntityAsAlly0(other.getBukkitEntity()); // Paper - Allies API
+     }
+ 
+     public boolean isAlliedTo(final @Nullable Team other) {
 @@ -2781,7 +_,11 @@
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1295,6 +1295,15 @@
          return this.level().getScoreboard().getPlayersTeam(this.getScoreboardName());
      }
  
+@@ -2773,7 +_,7 @@
+     }
+ 
+     protected boolean considersEntityAsAlly(final Entity other) {
+-        return this.isAlliedTo(other.getTeam());
++        return this.isAlliedTo(other.getTeam()) || this.getBukkitEntity().considersEntityAsAlly0(other.getBukkitEntity()); // Paper - Allies API
+     }
+ 
+     public boolean isAlliedTo(final @Nullable Team other) {
 @@ -2781,7 +_,11 @@
      }
  

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -10,10 +10,14 @@ import io.papermc.paper.datacomponent.DataComponentType;
 import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.entity.TeleportFlag;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.pointer.PointersSupplier;
 import net.kyori.adventure.util.TriState;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -98,6 +102,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     protected Entity entity;
     private final EntityType entityType;
     private EntityDamageEvent lastDamageEvent;
+    private final Map<Key, Predicate<org.bukkit.entity.Entity>> additionalAlliedRules = new HashMap<>();
     private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftEntity.DATA_TYPE_REGISTRY);
     // Paper start - Folia shedulers
     public final io.papermc.paper.threadedregions.EntityScheduler taskScheduler = new io.papermc.paper.threadedregions.EntityScheduler(this);
@@ -1337,6 +1342,31 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     @Override
     public boolean hasData(final @NotNull DataComponentType type) {
         return this.entity.get(io.papermc.paper.datacomponent.PaperDataComponentType.bukkitToMinecraft(type)) != null;
+    }
+
+    public boolean considersEntityAsAlly0(org.bukkit.entity.Entity entity) {
+        return this.additionalAlliedRules.values().stream().anyMatch(entityPredicate -> entityPredicate.test(entity));
+    }
+
+    @Override
+    public boolean isAlliedTo(@NotNull org.bukkit.entity.Entity other) {
+        Preconditions.checkArgument(other != null, "other cannot be null");
+        return this.getHandle().isAlliedTo(((CraftEntity)other).getHandle());
+    }
+
+    @Override
+    public Predicate<org.bukkit.entity.Entity> getAdditionalAlliedRule(@NotNull Key key) {
+        return this.additionalAlliedRules.get(key);
+    }
+
+    @Override
+    public void addAdditionalAlliedRule(@NotNull Key key, @NotNull Predicate<org.bukkit.entity.Entity> predicate) {
+        this.additionalAlliedRules.put(key, predicate);
+    }
+
+    @Override
+    public void removeAdditionalAlliedRule(@NotNull Key key) {
+        this.additionalAlliedRules.remove(key);
     }
 
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -1363,6 +1363,9 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     }
 
     public boolean considersEntityAsAlly0(org.bukkit.entity.Entity entity) {
+        if (this.additionalAlliedRules.isEmpty()) {
+            return false;
+        }
         return this.additionalAlliedRules.values().stream().anyMatch(entityPredicate -> entityPredicate.test(entity));
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
@@ -11,12 +11,16 @@ import io.papermc.paper.datacomponent.PaperDataComponentType;
 import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.entity.TeleportFlag;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import io.papermc.paper.math.Angle;
+import java.util.function.Predicate;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.pointer.PointersSupplier;
 import net.kyori.adventure.util.TriState;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -101,6 +105,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     protected Entity entity;
     private final EntityType entityType;
     private EntityDamageEvent lastDamageEvent;
+    private final Map<Key, Predicate<org.bukkit.entity.Entity>> additionalAlliedRules = new HashMap<>();
     private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftEntity.DATA_TYPE_REGISTRY);
     // Paper start - Folia shedulers
     public final io.papermc.paper.threadedregions.EntityScheduler taskScheduler = new io.papermc.paper.threadedregions.EntityScheduler(this);
@@ -1355,6 +1360,31 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
     @Override
     public boolean hasData(final @NotNull DataComponentType type) {
         return this.getHandleRaw().get(PaperDataComponentType.bukkitToMinecraft(type)) != null;
+    }
+
+    public boolean considersEntityAsAlly0(org.bukkit.entity.Entity entity) {
+        return this.additionalAlliedRules.values().stream().anyMatch(entityPredicate -> entityPredicate.test(entity));
+    }
+
+    @Override
+    public boolean isAlliedTo(@NotNull org.bukkit.entity.Entity other) {
+        Preconditions.checkArgument(other != null, "other cannot be null");
+        return this.getHandle().isAlliedTo(((CraftEntity)other).getHandle());
+    }
+
+    @Override
+    public Predicate<org.bukkit.entity.Entity> getAdditionalAlliedRule(@NotNull Key key) {
+        return this.additionalAlliedRules.get(key);
+    }
+
+    @Override
+    public void addAdditionalAlliedRule(@NotNull Key key, @NotNull Predicate<org.bukkit.entity.Entity> predicate) {
+        this.additionalAlliedRules.put(key, predicate);
+    }
+
+    @Override
+    public void removeAdditionalAlliedRule(@NotNull Key key) {
+        this.additionalAlliedRules.remove(key);
     }
 
 }


### PR DESCRIPTION
Currently exists a "isAllies" method in NMS used for things like target/considerations in Entities, one rule of that is if two entities share a team then are allies, this API allow pass additional rules by Key, this its a good alternative for listen every time the Target Event or track Memory for entities who not use that event.

This allow things like.
```java
player.getWorld().spawn(player.getLocation(), Warden.class, entity -> {
                        entity.addAdditionalAlliedRule(Key.key(TestPlugin.this, "rule_1"),target -> {
                            return target instanceof Player playerTarget && playerTarget.getInventory().getItemInMainHand().getType().name().contains("SWORD");
                        });
                        entity.addAdditionalAlliedRule(Key.key(TestPlugin.this, "rule_2"),target -> {
                            return target instanceof Player playerTarget && playerTarget.getInventory().getItemInMainHand().getType().name().contains("PICKAXE");
                        });
                    });
```

for

https://github.com/user-attachments/assets/34846cef-9bb1-4905-9e10-ca092ac6f689

