### PR TITLE
Add getLastDamageTime method to Combat Tracker API

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -135,6 +135,7 @@ public net.minecraft.world.SimpleContainer items
 public net.minecraft.world.damagesource.CombatTracker entries
 public net.minecraft.world.damagesource.CombatTracker getMostSignificantFall()Lnet/minecraft/world/damagesource/CombatEntry;
 public net.minecraft.world.damagesource.CombatTracker inCombat
+public net.minecraft.world.damagesource.CombatTracker lastDamageTime
 public net.minecraft.world.damagesource.CombatTracker mob
 public net.minecraft.world.damagesource.CombatTracker takingDamage
 public net.minecraft.world.damagesource.DamageSource <init>(Lnet/minecraft/core/Holder;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/Vec3;)V

--- a/paper-api/src/main/java/io/papermc/paper/world/damagesource/CombatTracker.java
+++ b/paper-api/src/main/java/io/papermc/paper/world/damagesource/CombatTracker.java
@@ -107,4 +107,11 @@ public interface CombatTracker {
      * @return the fall location type
      */
     @Nullable FallLocationType calculateFallLocationType();
+
+    /**
+     * Returns time since last damage in ticks
+     *
+     * @return ticks since last damage
+     */
+    int getLastDamageTime();
 }

--- a/paper-api/src/main/java/io/papermc/paper/world/damagesource/CombatTracker.java
+++ b/paper-api/src/main/java/io/papermc/paper/world/damagesource/CombatTracker.java
@@ -109,7 +109,7 @@ public interface CombatTracker {
     @Nullable FallLocationType calculateFallLocationType();
 
     /**
-     * Returns time since last damage in ticks
+     * Returns time since last damage in ticks.
      *
      * @return ticks since last damage
      */

--- a/paper-server/src/main/java/io/papermc/paper/world/damagesource/PaperCombatTrackerWrapper.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/damagesource/PaperCombatTrackerWrapper.java
@@ -79,6 +79,11 @@ public record PaperCombatTrackerWrapper(
         return Optionull.map(fallLocation, PaperCombatTrackerWrapper::minecraftToPaper);
     }
 
+    @Override
+    public int getLastDamageTime() {
+        return this.handle.mob.tickCount - this.handle.lastDamageTime;
+    }
+
     private static final BiMap<FallLocation, FallLocationType> FALL_LOCATION_MAPPING = Util.make(() -> {
         final BiMap<FallLocation, FallLocationType> map = HashBiMap.create(8);
         map.put(FallLocation.GENERIC, FallLocationType.GENERIC);


### PR DESCRIPTION
This PR adds a method to get the time since damage was last taken as an extension to the Combat Tracker API.

I decided to calculate the time relative to the entity's tickCount, since the tickCount currently isn't exposed in the API, which would have made the value returned from this new method unfit for further calculations. In most cases, the user would want to calculate the ticks from the current time anyway.

The last damage time could obviously also be calculated using a damage listener, but that would add unnecessary overhead for calculating a value that is already tracked by the server, in my opinion