### PR TITLE
Add spawned entity to ArmorStandMeta

### DIFF
--- a/paper-api/src/main/java/com/destroystokyo/paper/inventory/meta/ArmorStandMeta.java
+++ b/paper-api/src/main/java/com/destroystokyo/paper/inventory/meta/ArmorStandMeta.java
@@ -1,7 +1,11 @@
 package com.destroystokyo.paper.inventory.meta;
 
+import org.bukkit.entity.EntitySnapshot;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public interface ArmorStandMeta extends ItemMeta {
 
     /**
@@ -75,4 +79,28 @@ public interface ArmorStandMeta extends ItemMeta {
      * @param marker true if a marker
      */
     void setMarker(boolean marker);
+
+    /**
+     * Gets the {@link EntitySnapshot} that will be spawned by this item or null if no entity
+     * has been set.
+     * <p>
+     * All applicable data from the item will be copied, such as pose, custom name,
+     * health, and velocity.
+     *
+     * @return the entity snapshot or null if no entity has been set
+     */
+    @Nullable
+    EntitySnapshot getSpawnedEntity();
+
+    /**
+     * Sets the {@link EntitySnapshot} that will be spawned by this item.
+     * <p>
+     * Must represent an armor stand.
+     * <p>
+     * All applicable data from the entity will be copied, such as pose, custom name,
+     * health, and velocity.
+     *
+     * @param snapshot the snapshot
+     */
+    void setSpawnedEntity(EntitySnapshot snapshot);
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
@@ -1,5 +1,6 @@
 package org.bukkit.craftbukkit.inventory;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap.Builder;
 import java.util.Map;
 import java.util.Objects;
@@ -10,6 +11,9 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.component.TypedEntityData;
 import org.bukkit.Material;
 import org.bukkit.configuration.serialization.DelegateDeserialization;
+import org.bukkit.craftbukkit.entity.CraftEntitySnapshot;
+import org.bukkit.entity.EntitySnapshot;
+import org.jspecify.annotations.Nullable;
 
 @DelegateDeserialization(SerializableMeta.class)
 public class CraftMetaArmorStand extends CraftMetaItem implements com.destroystokyo.paper.inventory.meta.ArmorStandMeta {
@@ -232,5 +236,19 @@ public class CraftMetaArmorStand extends CraftMetaItem implements com.destroysto
     public void setMarker(boolean marker) {
         populateTagIfNull();
         this.entityTag.putBoolean(MARKER.NBT, marker);
+    }
+
+    @Override
+    public @Nullable EntitySnapshot getSpawnedEntity() {
+        if (this.entityTag == null) {
+            return null;
+        }
+        return CraftEntitySnapshot.create(this.entityTag.copy());
+    }
+
+    @Override
+    public void setSpawnedEntity(final EntitySnapshot snapshot) {
+        Preconditions.checkArgument(snapshot.getEntityType() == org.bukkit.entity.EntityType.ARMOR_STAND, "Entity is not an armor stand");
+        this.entityTag = ((CraftEntitySnapshot) snapshot).getData().copy();
     }
 }


### PR DESCRIPTION
Adds `setSpawnedEntity` and `getSpawnedEntity` to `ArmorStandMeta`.

Mostly taken from `SpawnEggMeta`, except:

* Only accepts armor stands because the client always spawns an armor stand.
* Defensively copies the tag to prevent editing the snapshot.
* Adjusted Javadocs.

Supercedes #13777.
