### PR TITLE
Fix guardian fish smelting loot warning

### DIFF
--- a/paper-server/patches/resources/data/minecraft/loot_table/entities/elder_guardian.json.patch
+++ b/paper-server/patches/resources/data/minecraft/loot_table/entities/elder_guardian.json.patch
@@ -1,0 +1,143 @@
+--- a/data/minecraft/loot_table/entities/elder_guardian.json
++++ b/data/minecraft/loot_table/entities/elder_guardian.json
+@@ -142,46 +_,100 @@
+       ],
+       "entries": [
+         {
+-          "type": "minecraft:loot_table",
+-          "functions": [
+-            {
+-              "conditions": [
+-                {
+-                  "condition": "minecraft:any_of",
+-                  "terms": [
+-                    {
+-                      "condition": "minecraft:entity_properties",
+-                      "entity": "this",
+-                      "predicate": {
+-                        "flags": {
+-                          "is_on_fire": true
+-                        }
+-                      }
+-                    },
+-                    {
+-                      "condition": "minecraft:entity_properties",
+-                      "entity": "direct_attacker",
+-                      "predicate": {
+-                        "equipment": {
+-                          "mainhand": {
+-                            "predicates": {
+-                              "minecraft:enchantments": [
+-                                {
+-                                  "enchantments": "#minecraft:smelts_loot"
+-                                }
+-                              ]
+-                            }
+-                          }
+-                        }
+-                      }
+-                    }
+-                  ]
+-                }
+-              ],
+-              "function": "minecraft:furnace_smelt"
+-            }
+-          ],
+-          "value": "minecraft:gameplay/fishing/fish"
++          "type": "minecraft:item",
++          "functions": [
++            {
++              "conditions": [
++                {
++                  "condition": "minecraft:any_of",
++                  "terms": [
++                    {
++                      "condition": "minecraft:entity_properties",
++                      "entity": "this",
++                      "predicate": {
++                        "flags": {
++                          "is_on_fire": true
++                        }
++                      }
++                    },
++                    {
++                      "condition": "minecraft:entity_properties",
++                      "entity": "direct_attacker",
++                      "predicate": {
++                        "equipment": {
++                          "mainhand": {
++                            "predicates": {
++                              "minecraft:enchantments": [
++                                {
++                                  "enchantments": "#minecraft:smelts_loot"
++                                }
++                              ]
++                            }
++                          }
++                        }
++                      }
++                    }
++                  ]
++                }
++              ],
++              "function": "minecraft:furnace_smelt"
++            }
++          ],
++          "name": "minecraft:cod",
++          "weight": 60
++        },
++        {
++          "type": "minecraft:item",
++          "functions": [
++            {
++              "conditions": [
++                {
++                  "condition": "minecraft:any_of",
++                  "terms": [
++                    {
++                      "condition": "minecraft:entity_properties",
++                      "entity": "this",
++                      "predicate": {
++                        "flags": {
++                          "is_on_fire": true
++                        }
++                      }
++                    },
++                    {
++                      "condition": "minecraft:entity_properties",
++                      "entity": "direct_attacker",
++                      "predicate": {
++                        "equipment": {
++                          "mainhand": {
++                            "predicates": {
++                              "minecraft:enchantments": [
++                                {
++                                  "enchantments": "#minecraft:smelts_loot"
++                                }
++                              ]
++                            }
++                          }
++                        }
++                      }
++                    }
++                  ]
++                }
++              ],
++              "function": "minecraft:furnace_smelt"
++            }
++          ],
++          "name": "minecraft:salmon",
++          "weight": 25
++        },
++        {
++          "type": "minecraft:item",
++          "name": "minecraft:tropical_fish",
++          "weight": 2
++        },
++        {
++          "type": "minecraft:item",
++          "name": "minecraft:pufferfish",
++          "weight": 13
+         }
+       ],
+       "rolls": 1.0

--- a/paper-server/patches/resources/data/minecraft/loot_table/entities/guardian.json.patch
+++ b/paper-server/patches/resources/data/minecraft/loot_table/entities/guardian.json.patch
@@ -1,0 +1,143 @@
+--- a/data/minecraft/loot_table/entities/guardian.json
++++ b/data/minecraft/loot_table/entities/guardian.json
+@@ -127,46 +_,100 @@
+       ],
+       "entries": [
+         {
+-          "type": "minecraft:loot_table",
+-          "functions": [
+-            {
+-              "conditions": [
+-                {
+-                  "condition": "minecraft:any_of",
+-                  "terms": [
+-                    {
+-                      "condition": "minecraft:entity_properties",
+-                      "entity": "this",
+-                      "predicate": {
+-                        "flags": {
+-                          "is_on_fire": true
+-                        }
+-                      }
+-                    },
+-                    {
+-                      "condition": "minecraft:entity_properties",
+-                      "entity": "direct_attacker",
+-                      "predicate": {
+-                        "equipment": {
+-                          "mainhand": {
+-                            "predicates": {
+-                              "minecraft:enchantments": [
+-                                {
+-                                  "enchantments": "#minecraft:smelts_loot"
+-                                }
+-                              ]
+-                            }
+-                          }
+-                        }
+-                      }
+-                    }
+-                  ]
+-                }
+-              ],
+-              "function": "minecraft:furnace_smelt"
+-            }
+-          ],
+-          "value": "minecraft:gameplay/fishing/fish"
++          "type": "minecraft:item",
++          "functions": [
++            {
++              "conditions": [
++                {
++                  "condition": "minecraft:any_of",
++                  "terms": [
++                    {
++                      "condition": "minecraft:entity_properties",
++                      "entity": "this",
++                      "predicate": {
++                        "flags": {
++                          "is_on_fire": true
++                        }
++                      }
++                    },
++                    {
++                      "condition": "minecraft:entity_properties",
++                      "entity": "direct_attacker",
++                      "predicate": {
++                        "equipment": {
++                          "mainhand": {
++                            "predicates": {
++                              "minecraft:enchantments": [
++                                {
++                                  "enchantments": "#minecraft:smelts_loot"
++                                }
++                              ]
++                            }
++                          }
++                        }
++                      }
++                    }
++                  ]
++                }
++              ],
++              "function": "minecraft:furnace_smelt"
++            }
++          ],
++          "name": "minecraft:cod",
++          "weight": 60
++        },
++        {
++          "type": "minecraft:item",
++          "functions": [
++            {
++              "conditions": [
++                {
++                  "condition": "minecraft:any_of",
++                  "terms": [
++                    {
++                      "condition": "minecraft:entity_properties",
++                      "entity": "this",
++                      "predicate": {
++                        "flags": {
++                          "is_on_fire": true
++                        }
++                      }
++                    },
++                    {
++                      "condition": "minecraft:entity_properties",
++                      "entity": "direct_attacker",
++                      "predicate": {
++                        "equipment": {
++                          "mainhand": {
++                            "predicates": {
++                              "minecraft:enchantments": [
++                                {
++                                  "enchantments": "#minecraft:smelts_loot"
++                                }
++                              ]
++                            }
++                          }
++                        }
++                      }
++                    }
++                  ]
++                }
++              ],
++              "function": "minecraft:furnace_smelt"
++            }
++          ],
++          "name": "minecraft:salmon",
++          "weight": 25
++        },
++        {
++          "type": "minecraft:item",
++          "name": "minecraft:tropical_fish",
++          "weight": 2
++        },
++        {
++          "type": "minecraft:item",
++          "name": "minecraft:pufferfish",
++          "weight": 13
+         }
+       ],
+       "rolls": 1.0


### PR DESCRIPTION
## Description

This fixes a warning caused by Guardian and Elder Guardian bonus fish loot applying `minecraft:furnace_smelt` to the entire `minecraft:gameplay/fishing/fish` loot table.

That nested fish loot table can roll `pufferfish` and `tropical_fish`, which do not have smelting recipes. When a Guardian is on fire or killed with an enchantment in `#minecraft:smelts_loot`, the server attempts to smelt those items and logs a warning.

This change applies `minecraft:furnace_smelt` only to `cod` and `salmon`.