### PR TITLE
Fix username duplication in chat when defaultRenderer is explicitly set

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
@@ -186,7 +186,7 @@ public final class ChatProcessor {
         final ChatRenderer renderer = event.renderer();
 
         final Set<Audience> viewers = event.viewers();
-        final ResourceKey<ChatType> chatTypeKey = renderer instanceof ChatRenderer.Default ? ChatType.CHAT : PAPER_RAW;
+        final ResourceKey<ChatType> chatTypeKey = renderer instanceof ChatRenderer.Default && !this.flags.get(FORMAT_CHANGED) ? ChatType.CHAT : PAPER_RAW;
         final ChatType.Bound chatType = ChatType.bind(chatTypeKey, this.player.level().registryAccess(), PaperAdventure.asVanilla(displayName(player)));
 
         OutgoingChat outgoingChat = viewers instanceof LazyChatAudienceSet lazyAudienceSet && lazyAudienceSet.isLazy() ? new ServerOutgoingChat() : new ViewersOutgoingChat();

--- a/paper-server/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
@@ -171,7 +171,7 @@ public final class ChatProcessor {
     private void readModernModifications(final AbstractChatEvent chatEvent, final ChatRenderer originalRenderer) {
         this.flags.set(MESSAGE_CHANGED, !chatEvent.message().equals(this.paper$originalMessage));
         boolean isBothDefaultRenderers = chatEvent.renderer() instanceof ChatRenderer.Default && originalRenderer instanceof ChatRenderer.Default; // Avoids default renderer format duplication
-        if (originalRenderer != chatEvent.renderer() && !isBothDefaultRenderers) { // don't set to false if it hasn't changed
+        if (originalRenderer != chatEvent.renderer() && !isBothDefaultRenderers) { // don't set to true if it hasn't changed
             this.flags.set(FORMAT_CHANGED, true);
         }
     }

--- a/paper-server/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
@@ -170,8 +170,8 @@ public final class ChatProcessor {
 
     private void readModernModifications(final AbstractChatEvent chatEvent, final ChatRenderer originalRenderer) {
         this.flags.set(MESSAGE_CHANGED, !chatEvent.message().equals(this.paper$originalMessage));
-        boolean isBothDefaultRenderers = !(chatEvent.renderer() instanceof ChatRenderer.Default && originalRenderer instanceof ChatRenderer.Default); // Avoids default renderer format duplication
-        if (originalRenderer != chatEvent.renderer() && isBothDefaultRenderers) { // don't set to false if it hasn't changed
+        boolean isBothDefaultRenderers = chatEvent.renderer() instanceof ChatRenderer.Default && originalRenderer instanceof ChatRenderer.Default; // Avoids default renderer format duplication
+        if (originalRenderer != chatEvent.renderer() && !isBothDefaultRenderers) { // don't set to false if it hasn't changed
             this.flags.set(FORMAT_CHANGED, true);
         }
     }

--- a/paper-server/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
@@ -170,7 +170,8 @@ public final class ChatProcessor {
 
     private void readModernModifications(final AbstractChatEvent chatEvent, final ChatRenderer originalRenderer) {
         this.flags.set(MESSAGE_CHANGED, !chatEvent.message().equals(this.paper$originalMessage));
-        if (originalRenderer != chatEvent.renderer()) { // don't set to false if it hasn't changed
+        boolean isBothDefaultRenderers = !(chatEvent.renderer() instanceof ChatRenderer.Default && originalRenderer instanceof ChatRenderer.Default); // Avoids default renderer format duplication
+        if (originalRenderer != chatEvent.renderer() && isBothDefaultRenderers) { // don't set to false if it hasn't changed
             this.flags.set(FORMAT_CHANGED, true);
         }
     }
@@ -186,7 +187,7 @@ public final class ChatProcessor {
         final ChatRenderer renderer = event.renderer();
 
         final Set<Audience> viewers = event.viewers();
-        final ResourceKey<ChatType> chatTypeKey = renderer instanceof ChatRenderer.Default && !this.flags.get(FORMAT_CHANGED) ? ChatType.CHAT : PAPER_RAW;
+        final ResourceKey<ChatType> chatTypeKey = renderer instanceof ChatRenderer.Default ? ChatType.CHAT : PAPER_RAW;
         final ChatType.Bound chatType = ChatType.bind(chatTypeKey, this.player.level().registryAccess(), PaperAdventure.asVanilla(displayName(player)));
 
         OutgoingChat outgoingChat = viewers instanceof LazyChatAudienceSet lazyAudienceSet && lazyAudienceSet.isLazy() ? new ServerOutgoingChat() : new ViewersOutgoingChat();


### PR DESCRIPTION
Resolves #13574

Explicitly setting the default renderer caused chatTypeKey to be `ChatType.CHAT`, which rendered the username again on the client.