### PR TITLE
Improvement World Migration for dimension directories

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/world/migration/LegacyCraftBukkitWorldMigration.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/migration/LegacyCraftBukkitWorldMigration.java
@@ -96,8 +96,11 @@ final class LegacyCraftBukkitWorldMigration {
             this.migrateLegacyCraftBukkitPaperData(tempStorage, levelDataResult.dataTag());
             tempStorage.saveAndJoin();
         }
-        deleteMigratedSeparateRoot(this.sourceRoot);
-        LOGGER.info("Completed legacy CraftBukkit import for world '{}' ({})", this.context.worldName(), this.context.dimensionKey().identifier());
+
+        final Path oldSourceRoot = this.sourceRoot.resolveSibling(this.sourceRoot.getFileName() + ".old");
+
+        Files.move(this.sourceRoot, oldSourceRoot);
+        LOGGER.info("Completed legacy CraftBukkit import for world '{}' ({}), the old world was moved into '{}'", this.context.worldName(), this.context.dimensionKey().identifier(), oldSourceRoot);
     }
 
     private void migrateSharedSavedData() throws IOException {
@@ -185,18 +188,6 @@ final class LegacyCraftBukkitWorldMigration {
         final SavedDataType<?> type
     ) throws IOException {
         WorldMigrationSupport.copySavedDataIfPresent(this.sourceDataRoots, this.targetDataRoot, type, true);
-    }
-
-    private static void deleteMigratedSeparateRoot(final Path sourceRoot) throws IOException {
-        if (!Files.exists(sourceRoot)) {
-            return;
-        }
-
-        try (final var paths = Files.walk(sourceRoot)) {
-            for (final Path path : paths.sorted(java.util.Comparator.reverseOrder()).toList()) {
-                Files.deleteIfExists(path);
-            }
-        }
     }
 
     private @Nullable Path findExplicitFile(

--- a/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
@@ -102,7 +102,7 @@ final class WorldMigrationSupport {
             final Path target = targetDimensionPath.resolve(directory);
             if (Files.exists(target)) {
                 pathsWithConflits = true;
-                LOGGER.error("The folder {} already exists for dimension {}", directory, targetDimensionPath);
+                LOGGER.error("The folder '{}' already exists for dimension {}", directory, targetDimensionPath);
                 continue;
             }
             migrationPaths.put(source, target);

--- a/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
@@ -8,7 +8,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.NbtException;
@@ -88,6 +90,9 @@ final class WorldMigrationSupport {
             return;
         }
 
+        boolean pathsWithConflits = false;
+        final HashMap<Path, Path> migrationPaths = new HashMap<>();
+
         for (final String directory : DIMENSION_DIRECTORIES) {
             final Path source = sourceDimensionRoot.resolve(directory);
             if (!Files.exists(source)) {
@@ -95,8 +100,20 @@ final class WorldMigrationSupport {
             }
 
             final Path target = targetDimensionPath.resolve(directory);
-            LOGGER.info("Migrating world directory from {} to {}", source, target);
-            mergeMove(source, target);
+            if (Files.exists(target)) {
+                pathsWithConflits = true;
+                LOGGER.error("The folder {} already exists for world dimension {}", directory, targetDimensionPath);
+                continue;
+            }
+            migrationPaths.put(source, target);
+        }
+
+        if (pathsWithConflits) {
+            throw new IOException("Refusing to overwrite dimension directories in " + targetDimensionPath + " while migrating from " + sourceDimensionRoot);
+        }
+
+        for (Map.Entry<Path, Path> entry : migrationPaths.entrySet()) {
+            mergeMove(entry.getKey(), entry.getValue());
         }
     }
 

--- a/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
@@ -129,10 +129,6 @@ final class WorldMigrationSupport {
             return;
         }
 
-        if (Files.exists(target)) {
-            throw new IOException("Refusing to overwrite existing migrated file " + target + " while moving " + source);
-        }
-
         Files.createDirectories(target.getParent());
         Files.move(source, target);
     }

--- a/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
@@ -117,15 +117,6 @@ final class WorldMigrationSupport {
         }
     }
 
-    private static void tryDeleteIfEmpty(final Path path) throws IOException {
-        try (final var entries = Files.list(path)) {
-            if (entries.findAny().isPresent()) {
-                return;
-            }
-        }
-        Files.deleteIfExists(path);
-    }
-
     record LevelDataResult(@Nullable Dynamic<?> dataTag, boolean fatalError) {}
 
     static LevelDataResult readFixedLevelData(final LevelStorageSource.LevelStorageAccess access) {

--- a/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
@@ -90,7 +90,7 @@ final class WorldMigrationSupport {
             return;
         }
 
-        boolean pathsWithConflits = false;
+        boolean pathsWithConflicts = false;
         final HashMap<Path, Path> migrationPaths = new HashMap<>();
 
         for (final String directory : DIMENSION_DIRECTORIES) {
@@ -101,14 +101,14 @@ final class WorldMigrationSupport {
 
             final Path target = targetDimensionPath.resolve(directory);
             if (Files.exists(target)) {
-                pathsWithConflits = true;
+                pathsWithConflicts = true;
                 LOGGER.error("The folder '{}' already exists for dimension {}", directory, targetDimensionPath);
                 continue;
             }
             migrationPaths.put(source, target);
         }
 
-        if (pathsWithConflits) {
+        if (pathsWithConflicts) {
             throw new IOException("Refusing to overwrite dimension directories in " + targetDimensionPath + " while migrating from " + sourceDimensionRoot);
         }
 

--- a/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
@@ -113,24 +113,8 @@ final class WorldMigrationSupport {
         }
 
         for (Map.Entry<Path, Path> entry : migrationPaths.entrySet()) {
-            mergeMove(entry.getKey(), entry.getValue());
+            Files.move(entry.getKey(), entry.getValue());
         }
-    }
-
-    private static void mergeMove(final Path source, final Path target) throws IOException {
-        if (Files.isDirectory(source)) {
-            Files.createDirectories(target);
-            try (final var entries = Files.list(source)) {
-                for (final Path child : entries.toList()) {
-                    mergeMove(child, target.resolve(child.getFileName().toString()));
-                }
-            }
-            tryDeleteIfEmpty(source);
-            return;
-        }
-
-        Files.createDirectories(target.getParent());
-        Files.move(source, target);
     }
 
     private static void tryDeleteIfEmpty(final Path path) throws IOException {

--- a/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/migration/WorldMigrationSupport.java
@@ -102,7 +102,7 @@ final class WorldMigrationSupport {
             final Path target = targetDimensionPath.resolve(directory);
             if (Files.exists(target)) {
                 pathsWithConflits = true;
-                LOGGER.error("The folder {} already exists for world dimension {}", directory, targetDimensionPath);
+                LOGGER.error("The folder {} already exists for dimension {}", directory, targetDimensionPath);
                 continue;
             }
             migrationPaths.put(source, target);


### PR DESCRIPTION
Based in https://github.com/PaperMC/Paper/issues/13863 and https://github.com/PaperMC/Paper/issues/13867 exists a few edge cases where the main world contains DIM directories related to dimensions used in another world directories for the CraftBukkit structure this cause a issue where throw a issue for try to override region files, this PR just make a check when try to migrate the dimension directories and notify that possible conflict before try to merge.

An example (based in the tickets) for the log if directory in dimension exists: https://mclo.gs/UF5kWET