### PR TITLE
Skip migration for deleted dimensions post first migration in server

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -98,6 +98,7 @@ public net.minecraft.util.Util onThreadException(Ljava/lang/Thread;Ljava/lang/Th
 public net.minecraft.util.datafix.fixes.BlockStateData register(ILcom/mojang/serialization/Dynamic;[Lcom/mojang/serialization/Dynamic;)V
 public net.minecraft.util.datafix.fixes.ItemIdFix ITEM_NAMES
 public net.minecraft.util.datafix.fixes.ItemSpawnEggFix ID_TO_ENTITY
+public net.minecraft.util.filefix.FileFixerUpper FILE_FIXER_INTRODUCTION_VERSION
 public net.minecraft.world.BossEvent color
 public net.minecraft.world.BossEvent name
 public net.minecraft.world.BossEvent overlay

--- a/paper-server/patches/sources/net/minecraft/util/filefix/FileFixerUpper.java.patch
+++ b/paper-server/patches/sources/net/minecraft/util/filefix/FileFixerUpper.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/util/filefix/FileFixerUpper.java
 +++ b/net/minecraft/util/filefix/FileFixerUpper.java
+@@ -48,7 +_,7 @@
+ import org.slf4j.Logger;
+ 
+ public class FileFixerUpper {
+-    private static final int FILE_FIXER_INTRODUCTION_VERSION = 4772;
++    public static final int FILE_FIXER_INTRODUCTION_VERSION = 4772; // Paper - public for world migration checks
+     private static final Gson GSON = new Gson().newBuilder().setPrettyPrinting().create();
+     private static final String FILE_FIX_DIRECTORY_NAME = "filefix";
+     private static final String NEW_WORLD_TEMP_NAME = "new_world";
 @@ -82,6 +_,7 @@
      ) throws FileFixException {
          int loadedVersion = NbtUtils.getDataVersion(levelDataTag);

--- a/paper-server/patches/sources/net/minecraft/util/filefix/FileFixerUpper.java.patch
+++ b/paper-server/patches/sources/net/minecraft/util/filefix/FileFixerUpper.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/util/filefix/FileFixerUpper.java
 +++ b/net/minecraft/util/filefix/FileFixerUpper.java
-@@ -48,7 +_,7 @@
- import org.slf4j.Logger;
- 
- public class FileFixerUpper {
--    private static final int FILE_FIXER_INTRODUCTION_VERSION = 4772;
-+    public static final int FILE_FIXER_INTRODUCTION_VERSION = 4772; // Paper - public for world migration checks
-     private static final Gson GSON = new Gson().newBuilder().setPrettyPrinting().create();
-     private static final String FILE_FIX_DIRECTORY_NAME = "filefix";
-     private static final String NEW_WORLD_TEMP_NAME = "new_world";
 @@ -82,6 +_,7 @@
      ) throws FileFixException {
          int loadedVersion = NbtUtils.getDataVersion(levelDataTag);

--- a/paper-server/src/main/java/io/papermc/paper/world/PaperWorldLoader.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/PaperWorldLoader.java
@@ -5,8 +5,10 @@ import io.papermc.paper.world.saveddata.PaperLevelOverrides;
 import io.papermc.paper.world.saveddata.PaperWorldMetadata;
 import io.papermc.paper.world.saveddata.PaperWorldPDC;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Locale;
 import java.util.UUID;
+import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.Main;
@@ -118,15 +120,15 @@ public record PaperWorldLoader(MinecraftServer server, String levelId) {
     }
 
     public void loadInitialWorlds() {
-        final var levelStemRegistry = this.server.registryAccess().lookupOrThrow(Registries.LEVEL_STEM);
-        final boolean hasWorldData = this.server.storageSource.hasWorldData();
+        final Registry<LevelStem> levelStemRegistry = this.server.registryAccess().lookupOrThrow(Registries.LEVEL_STEM);
         final LevelStem overworldStem = requireNonNull(levelStemRegistry.getValue(LevelStem.OVERWORLD), "Overworld stem missing");
+        final boolean hasWorldData = this.hasDimensionData(overworldStem);
         this.loadInitialWorld(overworldStem, hasWorldData);
         for (final LevelStem stem : levelStemRegistry) {
             if (stem == overworldStem) {
                 continue;
             }
-            this.loadInitialWorld(stem, hasWorldData);
+            this.loadInitialWorld(stem, this.hasDimensionData(stem));
         }
 
         // ((DedicatedServer) this.server).forceDifficulty();
@@ -162,6 +164,12 @@ public record PaperWorldLoader(MinecraftServer server, String levelId) {
         }
 
         this.server.createLevel(stem, loading, worldDataAndGenSettings);
+    }
+
+    private boolean hasDimensionData(final LevelStem stem) {
+        final ResourceKey<LevelStem> stemKey = this.server.registryAccess().lookupOrThrow(Registries.LEVEL_STEM).getResourceKey(stem).orElseThrow();
+        final ResourceKey<Level> dimensionKey = Registries.levelStemToLevel(stemKey);
+        return Files.isDirectory(this.server.storageSource.getDimensionPath(dimensionKey));
     }
 
     public static WorldGenSettings loadWorldGenSettings(

--- a/paper-server/src/main/java/io/papermc/paper/world/migration/WorldFolderMigration.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/migration/WorldFolderMigration.java
@@ -7,7 +7,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.NbtUtils;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.filefix.FileFixerUpper;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.dimension.LevelStem;
 import net.minecraft.world.level.levelgen.WorldGenSettings;
@@ -91,7 +96,24 @@ public final class WorldFolderMigration {
         if (!context.rootAccess().getLevelId().equals(context.worldName()) && Files.isDirectory(context.rootAccess().parent().getLevelPath(context.worldName()))) {
             return MigrationMode.LEGACY_CRAFTBUKKIT_MIGRATION;
         }
-        return hasCurrentPaperData(context.rootAccess(), context.dimensionKey()) ? MigrationMode.NO_OP : MigrationMode.VANILLA_MIGRATION;
+        if (hasCurrentPaperData(context.rootAccess(), context.dimensionKey())) {
+            return MigrationMode.NO_OP;
+        }
+        // the dimension was deleted
+        if (!Files.isDirectory(context.rootAccess().getDimensionPath(context.dimensionKey()))) {
+            try {
+                final CompoundTag rawLevelData = NbtIo.readCompressed(
+                    context.rootAccess().getLevelDirectory().dataFile(), NbtAccounter.uncompressedQuota()
+                );
+                final int dataVersion = NbtUtils.getDataVersion(rawLevelData.getCompoundOrEmpty("Data"));
+                if (dataVersion >= FileFixerUpper.FILE_FIXER_INTRODUCTION_VERSION) {
+                    return MigrationMode.NO_OP;
+                }
+            } catch (final IOException ex) {
+                throw new RuntimeException("Failed to read level data for world migration classification", ex);
+            }
+        }
+        return MigrationMode.VANILLA_MIGRATION;
     }
 
     static boolean hasCurrentPaperData(final LevelStorageSource.LevelStorageAccess rootAccess, final ResourceKey<Level> dimensionKey) {


### PR DESCRIPTION
Related to https://github.com/PaperMC/Paper/issues/13873 this PR with the help of @jpenilla try to manage the case where dimensions can be deleted of the server (post-migration to paper world structure).

Currently if you delete a dimension the server try to run a migration based in the changes what its not necesary, so we skip that logic and modify the later call to load worlds for manage to correctly regen that dimensions.

Know Issues.
- If you delete the overworld dimension you get a crash for the missing `world_gen_settings.dat` (in paper that file is in the dimension directories), in vanilla you can get the same crash but need delete the file from the global data directory in the world

Closes #13873