### PR TITLE
Fix localized shutdown message

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -804,7 +804,7 @@
 +        // CraftBukkit start - disconnect safely
 +        for (ServerPlayer player : this.players) {
 +            if (isRestarting) player.connection.disconnect(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(org.spigotmc.SpigotConfig.restartMessage), org.bukkit.event.player.PlayerKickEvent.Cause.UNKNOWN); else // Paper - kick event cause (cause is never used here)
-+            player.connection.disconnect(java.util.Objects.requireNonNullElseGet(this.server.server.shutdownMessage(), net.kyori.adventure.text.Component::empty)); // CraftBukkit - add custom shutdown message // Paper - Adventure
++            player.connection.disconnect(java.util.Objects.requireNonNullElseGet(this.server.server.shutdownMessage(), () -> net.kyori.adventure.text.Component.translatable("multiplayer.disconnect.server_shutdown"))); // CraftBukkit - add custom shutdown message // Paper - Adventure
 +        }
 +        // CraftBukkit end
 +

--- a/paper-server/src/main/resources/configurations/bukkit.yml
+++ b/paper-server/src/main/resources/configurations/bukkit.yml
@@ -18,7 +18,7 @@ settings:
     connection-throttle: 4000
     query-plugins: true
     deprecated-verbose: default
-    shutdown-message: Server closed
+    shutdown-message: null
     minimum-api: none
     use-map-color-cache: true
 spawn-limits:


### PR DESCRIPTION
Fixes PaperMC/Paper#11208.

Uses the vanilla translatable shutdown message when no custom shutdown message is configured, while keeping custom shutdown messages configurable via bukkit.yml.
