### PR TITLE
NoiseBasedChunkGenerator - fix hardcoded lava level - MC-237017

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java.patch
@@ -1,5 +1,23 @@
 --- a/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
 +++ b/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
+@@ -67,7 +_,7 @@
+     }
+ 
+     private static Aquifer.FluidPicker createFluidPicker(final NoiseGeneratorSettings settings) {
+-        Aquifer.FluidStatus lavaStatus = new Aquifer.FluidStatus(-54, Blocks.LAVA.defaultBlockState());
++        Aquifer.FluidStatus lavaStatus = new Aquifer.FluidStatus(settings.noiseSettings().minY(), Blocks.LAVA.defaultBlockState()); // Fixes MC-237017 (non hardcoded lava level)
+         int seaLevel = settings.seaLevel();
+         Aquifer.FluidStatus seaStatus = new Aquifer.FluidStatus(seaLevel, settings.defaultFluid());
+         Aquifer.FluidStatus emptyStatus = new Aquifer.FluidStatus(DimensionType.MIN_Y * 2, Blocks.AIR.defaultBlockState());
+@@ -75,7 +_,7 @@
+             if (SharedConstants.DEBUG_DISABLE_FLUID_GENERATION) {
+                 return emptyStatus;
+             } else {
+-                return y < Math.min(-54, seaLevel) ? lavaStatus : seaStatus;
++                return y < Math.min(settings.noiseSettings().minY(), seaLevel) ? lavaStatus : seaStatus;  // Fixes MC-237017 (non hardcoded lava level)
+             }
+         };
+     }
 @@ -266,7 +_,7 @@
      @Override
      public void buildSurface(final WorldGenRegion region, final StructureManager structureManager, final RandomState randomState, final ChunkAccess protoChunk) {

--- a/paper-server/patches/sources/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java.patch
@@ -5,7 +5,7 @@
  
      private static Aquifer.FluidPicker createFluidPicker(final NoiseGeneratorSettings settings) {
 -        Aquifer.FluidStatus lavaStatus = new Aquifer.FluidStatus(-54, Blocks.LAVA.defaultBlockState());
-+        Aquifer.FluidStatus lavaStatus = new Aquifer.FluidStatus(settings.noiseSettings().minY(), Blocks.LAVA.defaultBlockState()); // Fixes MC-237017 (non hardcoded lava level)
++        Aquifer.FluidStatus lavaStatus = new Aquifer.FluidStatus(settings.noiseSettings().minY() + 10, Blocks.LAVA.defaultBlockState()); // Fixes MC-237017 (non hardcoded lava level)
          int seaLevel = settings.seaLevel();
          Aquifer.FluidStatus seaStatus = new Aquifer.FluidStatus(seaLevel, settings.defaultFluid());
          Aquifer.FluidStatus emptyStatus = new Aquifer.FluidStatus(DimensionType.MIN_Y * 2, Blocks.AIR.defaultBlockState());
@@ -14,7 +14,7 @@
                  return emptyStatus;
              } else {
 -                return y < Math.min(-54, seaLevel) ? lavaStatus : seaStatus;
-+                return y < Math.min(settings.noiseSettings().minY(), seaLevel) ? lavaStatus : seaStatus;  // Fixes MC-237017 (non hardcoded lava level)
++                return y < Math.min(settings.noiseSettings().minY() + 10, seaLevel) ? lavaStatus : seaStatus;  // Fixes MC-237017 (non hardcoded lava level)
              }
          };
      }


### PR DESCRIPTION
Minecraft gives us the ability in data packs to modify the min Y of a world.
Unfortunately when dropping the Y to a lower value, caves with always be flooded with lava.
This is due to a hardcoded lava level.

I reported it as a bug, and it was closed saying "request a feature, this isn't a bug"
Which I find funny, they give us the control in a datapack to go down to -2032Y, but our caves will be full of lava.
My bug [MC-307994](https://mojira.dev/MC-307994)

Someone commented stating another bug [MC-237017](https://mojira.dev/MC-237017)
This one (same issue as mine) remains open, so that's good news that it's not closed, but bad news is in 5 years it hasn't been fixed. It's also confirmed.

Rather than hardcoding the lava level at a strict -54, this PR aims to take the min Y of the noise settings and add 10.
So min Y being -64, it still results in -54.
If a datapack (such as mine) drops it to -256, the result will be -246.
I have tested this on my own server with said datapack, and works perfectly.

Ref issue #13878 