### PR TITLE
Use internal block to item conversion for flower pots

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -25,7 +25,7 @@
          ItemStack plant = new ItemStack(this.potted);
 +        // Paper start - Add PlayerFlowerPotManipulateEvent
 +        org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
-+        org.bukkit.inventory.ItemStack pottedStack = new org.bukkit.inventory.ItemStack(org.bukkit.craftbukkit.block.CraftBlockType.minecraftToBukkit(this.potted));
++        org.bukkit.inventory.ItemStack pottedStack = org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(plant);
 +
 +        io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent event = new io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent((org.bukkit.entity.Player) player.getBukkitEntity(), block, pottedStack, false);
 +        if (!event.callEvent()) {


### PR DESCRIPTION
Before this change, the Bukkit ItemStack passed to the event is constructed from a Bukkit Material, which relies on the Bukkit mapping from blocks to items being the same as the Minecraft mapping from blocks to items.

However, it is not the same.
For example, new ItemStack(Material.POTATOES) does not give an ItemStack of type Material.POTATO as this code would expect.
So a flower pot block created as new FlowerPotBlock(Blocks.POTATOES, properties) will crash the server.

After this change, the Bukkit ItemStack passed to the event is constructed from the Minecraft ItemStack, which has already been created based on the Minecraft mapping from blocks to items.