### PR TITLE
Bring back API to get world type information other than flat vs not flat

### DIFF
--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2949,8 +2949,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * Gets the type of this world.
      *
      * @return Type of this world.
+     * @deprecated Deprecated in favor of {@link #getWorldTypeKey()}, world types are now data driven and the old world type system may eventually get replaced entirely
      */
     @Nullable
+    @Deprecated(since = "1.16.1")
     public WorldType getWorldType();
 
     /**

--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2954,6 +2954,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
     public WorldType getWorldType();
 
     /**
+     * Gets the key of the world type of this world.
+     *
+     * @return Key of this world's world type.
+     */
+    @NotNull
+    public NamespacedKey getWorldTypeKey();
+
+    /**
      * Gets whether or not structures are being generated.
      *
      * @return True if structures are being generated.

--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2949,12 +2949,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * Gets the type of this world.
      *
      * @return Type of this world.
-     * @deprecated world type is only used to select the default word generation
-     * settings and is not stored in Vanilla worlds, making it impossible for
-     * this method to always return the correct value.
      */
     @Nullable
-    @Deprecated(since = "1.16.1")
     public WorldType getWorldType();
 
     /**

--- a/paper-api/src/main/java/org/bukkit/WorldType.java
+++ b/paper-api/src/main/java/org/bukkit/WorldType.java
@@ -13,7 +13,9 @@ public enum WorldType {
     NORMAL("DEFAULT"),
     FLAT("FLAT"),
     LARGE_BIOMES("LARGEBIOMES"),
-    AMPLIFIED("AMPLIFIED");
+    AMPLIFIED("AMPLIFIED"),
+    CAVES("CAVES"),
+    FLOATING_ISLANDS("FLOATING_ISLANDS");
 
     private static final Map<String, WorldType> BY_NAME = Maps.newHashMap();
     private final String name;

--- a/paper-api/src/main/java/org/bukkit/WorldType.java
+++ b/paper-api/src/main/java/org/bukkit/WorldType.java
@@ -15,7 +15,8 @@ public enum WorldType {
     LARGE_BIOMES("LARGEBIOMES"),
     AMPLIFIED("AMPLIFIED"),
     CAVES("CAVES"),
-    FLOATING_ISLANDS("FLOATING_ISLANDS");
+    FLOATING_ISLANDS("FLOATING_ISLANDS"),
+    DEBUG("DEBUG");
 
     private static final Map<String, WorldType> BY_NAME = Maps.newHashMap();
     private final String name;

--- a/paper-server/patches/sources/net/minecraft/world/level/chunk/ChunkGenerator.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/chunk/ChunkGenerator.java.patch
@@ -1,7 +1,11 @@
 --- a/net/minecraft/world/level/chunk/ChunkGenerator.java
 +++ b/net/minecraft/world/level/chunk/ChunkGenerator.java
-@@ -105,8 +_,8 @@
+@@ -103,10 +_,12 @@
+         this.featuresPerStep.get();
+     }
  
++    public abstract org.bukkit.NamespacedKey getKey(); // Paper - Add way to get world type key
++
      protected abstract MapCodec<? extends ChunkGenerator> codec();
  
 -    public ChunkGeneratorStructureState createState(final HolderLookup<StructureSet> structureSets, final RandomState randomState, final long legacyLevelSeed) {

--- a/paper-server/patches/sources/net/minecraft/world/level/levelgen/DebugLevelSource.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/levelgen/DebugLevelSource.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/world/level/levelgen/DebugLevelSource.java
++++ b/net/minecraft/world/level/levelgen/DebugLevelSource.java
+@@ -48,6 +_,13 @@
+         super(new FixedBiomeSource(plains));
+     }
+ 
++    // Paper start - Add way to get world type key
++    @Override
++    public org.bukkit.NamespacedKey getKey() {
++        return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromResourceKey(net.minecraft.world.level.levelgen.presets.WorldPresets.DEBUG);
++    }
++    // Paper end - Add way to get world type key
++
+     @Override
+     protected MapCodec<? extends ChunkGenerator> codec() {
+         return CODEC;

--- a/paper-server/patches/sources/net/minecraft/world/level/levelgen/FlatLevelSource.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/levelgen/FlatLevelSource.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/levelgen/FlatLevelSource.java
 +++ b/net/minecraft/world/level/levelgen/FlatLevelSource.java
-@@ -32,17 +_,22 @@
+@@ -32,23 +_,35 @@
      private final FlatLevelGeneratorSettings settings;
  
      public FlatLevelSource(final FlatLevelGeneratorSettings generatorSettings) {
@@ -26,3 +26,16 @@
      }
  
      @Override
+     protected MapCodec<? extends ChunkGenerator> codec() {
+         return CODEC;
+     }
++
++    // Paper start - Add way to get world type key
++    @Override
++    public org.bukkit.NamespacedKey getKey() {
++        return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromResourceKey(net.minecraft.world.level.levelgen.presets.WorldPresets.FLAT);
++    }
++    // Paper end - Add way to get world type key
+ 
+     public FlatLevelGeneratorSettings settings() {
+         return this.settings;

--- a/paper-server/patches/sources/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java.patch
@@ -1,5 +1,19 @@
 --- a/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
 +++ b/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
+@@ -102,6 +_,13 @@
+         );
+     }
+ 
++    // Paper start - Add way to get world type key
++    @Override
++    public org.bukkit.NamespacedKey getKey() {
++        return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromResourceKey(this.generatorSettings().unwrapKey().orElse(net.minecraft.world.level.levelgen.NoiseGeneratorSettings.OVERWORLD));
++    }
++    // Paper end - Add way to get world type key
++
+     @Override
+     protected MapCodec<? extends ChunkGenerator> codec() {
+         return CODEC;
 @@ -266,7 +_,7 @@
      @Override
      public void buildSurface(final WorldGenRegion region, final StructureManager structureManager, final RandomState randomState, final ChunkAccess protoChunk) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1467,6 +1467,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
             if (noiseGen.generatorSettings().is(net.minecraft.world.level.levelgen.NoiseGeneratorSettings.LARGE_BIOMES)) {
                 return org.bukkit.WorldType.LARGE_BIOMES;
             }
+
+            if (noiseGen.generatorSettings().is(net.minecraft.world.level.levelgen.NoiseGeneratorSettings.CAVES)) {
+                return org.bukkit.WorldType.CAVES;
+            }
+
+            if (noiseGen.generatorSettings().is(net.minecraft.world.level.levelgen.NoiseGeneratorSettings.FLOATING_ISLANDS)) {
+                return org.bukkit.WorldType.FLOATING_ISLANDS;
+            }
         }
 
         return this.world.isFlat() ? org.bukkit.WorldType.FLAT : org.bukkit.WorldType.NORMAL;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1492,29 +1492,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
 
     @Override
     public NamespacedKey getWorldTypeKey() {
-        net.minecraft.world.level.chunk.ChunkGenerator generator = this.world.getChunkSource().getGenerator();
-
-        if (generator instanceof org.bukkit.craftbukkit.generator.CustomChunkGenerator customGen) {
-            generator = customGen.getDelegate();
-        }
-
-        if (generator instanceof net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator noiseGen) {
-            java.util.Optional<net.minecraft.resources.ResourceKey<net.minecraft.world.level.levelgen.NoiseGeneratorSettings>> key = noiseGen.generatorSettings().unwrapKey();
-
-            if (key.isPresent()) {
-                return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromResourceKey(key.get());
-            }
-        }
-
-        if (generator instanceof net.minecraft.world.level.levelgen.DebugLevelSource) {
-            return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromResourceKey(net.minecraft.world.level.levelgen.presets.WorldPresets.DEBUG);
-        }
-
-        if (this.world.isFlat()) {
-            return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromResourceKey(net.minecraft.world.level.levelgen.presets.WorldPresets.FLAT);
-        }
-
-        return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromResourceKey(net.minecraft.world.level.levelgen.presets.WorldPresets.NORMAL);
+        return this.world.getChunkSource().getGenerator().getKey();
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1459,7 +1459,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
 
     @Override
     public org.bukkit.WorldType getWorldType() {
-        if (this.world.getChunkSource().getGenerator() instanceof net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator noiseGen) {
+        net.minecraft.world.level.chunk.ChunkGenerator generator = this.world.getChunkSource().getGenerator();
+
+        if (generator instanceof org.bukkit.craftbukkit.generator.CustomChunkGenerator customGen) {
+            generator = customGen.getDelegate();
+        }
+
+        if (generator instanceof net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator noiseGen) {
             if (noiseGen.generatorSettings().is(net.minecraft.world.level.levelgen.NoiseGeneratorSettings.AMPLIFIED)) {
                 return org.bukkit.WorldType.AMPLIFIED;
             }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1491,6 +1491,33 @@ public class CraftWorld extends CraftRegionAccessor implements World {
     }
 
     @Override
+    public NamespacedKey getWorldTypeKey() {
+        net.minecraft.world.level.chunk.ChunkGenerator generator = this.world.getChunkSource().getGenerator();
+
+        if (generator instanceof org.bukkit.craftbukkit.generator.CustomChunkGenerator customGen) {
+            generator = customGen.getDelegate();
+        }
+
+        if (generator instanceof net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator noiseGen) {
+            java.util.Optional<net.minecraft.resources.ResourceKey<net.minecraft.world.level.levelgen.NoiseGeneratorSettings>> key = noiseGen.generatorSettings().unwrapKey();
+
+            if (key.isPresent()) {
+                return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromResourceKey(key.get());
+            }
+        }
+
+        if (generator instanceof net.minecraft.world.level.levelgen.DebugLevelSource) {
+            return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromResourceKey(net.minecraft.world.level.levelgen.presets.WorldPresets.DEBUG);
+        }
+
+        if (this.world.isFlat()) {
+            return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromResourceKey(net.minecraft.world.level.levelgen.presets.WorldPresets.FLAT);
+        }
+
+        return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromResourceKey(net.minecraft.world.level.levelgen.presets.WorldPresets.NORMAL);
+    }
+
+    @Override
     public boolean canGenerateStructures() {
         return this.world.worldGenSettings.options().generateStructures();
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1459,6 +1459,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
 
     @Override
     public org.bukkit.WorldType getWorldType() {
+        if (this.world.getChunkSource().getGenerator() instanceof net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator noiseGen) {
+            if (noiseGen.generatorSettings().is(net.minecraft.world.level.levelgen.NoiseGeneratorSettings.AMPLIFIED)) {
+                return org.bukkit.WorldType.AMPLIFIED;
+            }
+
+            if (noiseGen.generatorSettings().is(net.minecraft.world.level.levelgen.NoiseGeneratorSettings.LARGE_BIOMES)) {
+                return org.bukkit.WorldType.LARGE_BIOMES;
+            }
+        }
+
         return this.world.isFlat() ? org.bukkit.WorldType.FLAT : org.bukkit.WorldType.NORMAL;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1483,6 +1483,10 @@ public class CraftWorld extends CraftRegionAccessor implements World {
             }
         }
 
+        if (generator instanceof net.minecraft.world.level.levelgen.DebugLevelSource) {
+            return org.bukkit.WorldType.DEBUG;
+        }
+
         return this.world.isFlat() ? org.bukkit.WorldType.FLAT : org.bukkit.WorldType.NORMAL;
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
@@ -339,6 +339,11 @@ public class CustomChunkGenerator extends InternalChunkGenerator {
     }
 
     @Override
+    public org.bukkit.NamespacedKey getKey() {
+        return this.delegate.getKey();
+    }
+
+    @Override
     protected MapCodec<? extends net.minecraft.world.level.chunk.ChunkGenerator> codec() {
         return MapCodec.unit(null);
     }


### PR DESCRIPTION
I originally did this before the hard-fork in PR #10314

Completely forgot about it until now, figured I would redo it with the requested changes