### PR TITLE
Fix override of new item for Firework entity

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Firework.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Firework.java
@@ -1,6 +1,6 @@
 package org.bukkit.entity;
 
-import io.papermc.paper.datacomponent.DataComponentType;
+import io.papermc.paper.datacomponent.DataComponentTypes;
 import java.util.UUID;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.FireworkMeta;
@@ -15,7 +15,7 @@ public interface Firework extends Projectile {
      * Get a copy of the fireworks meta
      *
      * @return A copy of the current Firework meta
-     * @apiNote obsolete in favor of {@link #getItem()} with {@link ItemStack#getData(DataComponentType.Valued)} like {@link io.papermc.paper.datacomponent.DataComponentTypes#FIREWORKS}
+     * @apiNote obsolete in favor of {@link #getItem()} / {@link #setItem(ItemStack)} with the equivalent {@link DataComponentTypes#FIREWORKS} component
      */
     @ApiStatus.Obsolete
     FireworkMeta getFireworkMeta();
@@ -26,7 +26,7 @@ public interface Firework extends Projectile {
      * Adjusts detonation ticks automatically.
      *
      * @param meta The FireworkMeta to apply
-     * @apiNote obsolete in favor of {@link #setItem(ItemStack)} with {@link io.papermc.paper.datacomponent.DataComponentTypes#FIREWORKS}
+     * @apiNote obsolete in favor of {@link #getItem()} / {@link #setItem(ItemStack)} with the equivalent {@link DataComponentTypes#FIREWORKS} component
      */
     @ApiStatus.Obsolete
     void setFireworkMeta(FireworkMeta meta);

--- a/paper-api/src/main/java/org/bukkit/entity/Firework.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Firework.java
@@ -1,17 +1,23 @@
 package org.bukkit.entity;
 
+import io.papermc.paper.datacomponent.DataComponentType;
+import java.util.UUID;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.FireworkMeta;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public interface Firework extends Projectile {
 
     /**
      * Get a copy of the fireworks meta
      *
      * @return A copy of the current Firework meta
+     * @apiNote obsolete in favor of {@link #getItem()} with {@link ItemStack#getData(DataComponentType.Valued)} like {@link io.papermc.paper.datacomponent.DataComponentTypes#FIREWORKS}
      */
-    @NotNull
+    @ApiStatus.Obsolete
     FireworkMeta getFireworkMeta();
 
     /**
@@ -20,8 +26,10 @@ public interface Firework extends Projectile {
      * Adjusts detonation ticks automatically.
      *
      * @param meta The FireworkMeta to apply
+     * @apiNote obsolete in favor of {@link #setItem(ItemStack)} with {@link io.papermc.paper.datacomponent.DataComponentTypes#FIREWORKS}
      */
-    void setFireworkMeta(@NotNull FireworkMeta meta);
+    @ApiStatus.Obsolete
+    void setFireworkMeta(FireworkMeta meta);
 
     /**
      * Set the {@link LivingEntity} to which this firework is attached.
@@ -48,8 +56,7 @@ public interface Firework extends Projectile {
      *
      * @return the attached entity, or null if none
      */
-    @Nullable
-    LivingEntity getAttachedTo();
+    @Nullable LivingEntity getAttachedTo();
 
     /**
      * Set the ticks that this firework has been alive. If this value exceeds
@@ -59,7 +66,7 @@ public interface Firework extends Projectile {
      * @deprecated use {@link #setTicksFlown(int)}
      * @return true if the life was set, false if this firework has already detonated
      */
-    @Deprecated(forRemoval = true) // Paper
+    @Deprecated(forRemoval = true, since = "1.18.2")
     boolean setLife(int ticks);
 
     /**
@@ -69,7 +76,7 @@ public interface Firework extends Projectile {
      * @deprecated use {@link #getTicksFlown()}
      * @return the life ticks
      */
-    @Deprecated(forRemoval = true) // Paper
+    @Deprecated(forRemoval = true, since = "1.18.2")
     int getLife();
 
     /**
@@ -79,7 +86,7 @@ public interface Firework extends Projectile {
      * @deprecated use {@link #setTicksToDetonate(int)}
      * @return true if the time was set, false if this firework has already detonated
      */
-    @Deprecated(forRemoval = true) // Paper
+    @Deprecated(forRemoval = true, since = "1.18.2")
     boolean setMaxLife(int ticks);
 
     /**
@@ -88,7 +95,7 @@ public interface Firework extends Projectile {
      * @deprecated use {@link #getTicksToDetonate()}
      * @return the maximum life in ticks
      */
-    @Deprecated(forRemoval = true) // Paper
+    @Deprecated(forRemoval = true, since = "1.18.2")
     int getMaxLife();
 
     /**
@@ -122,30 +129,30 @@ public interface Firework extends Projectile {
      */
     void setShotAtAngle(boolean shotAtAngle);
 
-    // Paper start
-    @org.jetbrains.annotations.Nullable
-    public java.util.UUID getSpawningEntity();
+    /**
+     * Retrieves the UUID of the entity responsible for spawning this firework.
+     *
+     * @return the UUID of the spawning entity, or null if no spawning entity is associated
+     */
+    @Nullable UUID getSpawningEntity();
+
     /**
      * If this firework is boosting an entity, return it
      * @deprecated use {@link #getAttachedTo()}
      * @see #setAttachedTo(LivingEntity)
      * @return The entity being boosted
      */
-    @org.jetbrains.annotations.Nullable
-    @Deprecated
-    default LivingEntity getBoostedEntity() {
-        return getAttachedTo();
+    @Deprecated(since = "1.18.2")
+    default @Nullable LivingEntity getBoostedEntity() {
+        return this.getAttachedTo();
     }
-    // Paper end
 
-    // Paper start - Firework API
     /**
      * Gets the item used in the firework.
      *
      * @return firework item
      */
-    @NotNull
-    public org.bukkit.inventory.ItemStack getItem();
+    ItemStack getItem();
 
     /**
      * Sets the item used in the firework.
@@ -154,7 +161,7 @@ public interface Firework extends Projectile {
      *
      * @param itemStack item to set
      */
-    void setItem(@org.jetbrains.annotations.Nullable org.bukkit.inventory.ItemStack itemStack);
+    void setItem(@Nullable ItemStack itemStack);
 
     /**
      * Gets the number of ticks the firework has flown.
@@ -184,5 +191,4 @@ public interface Firework extends Projectile {
      * @param ticks ticks to detonate on
      */
     void setTicksToDetonate(int ticks);
-    // Paper end
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFirework.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftFirework.java
@@ -1,7 +1,9 @@
 package org.bukkit.craftbukkit.entity;
 
 import com.google.common.base.Preconditions;
+import java.util.OptionalInt;
 import java.util.Random;
+import java.util.UUID;
 import net.minecraft.world.entity.projectile.FireworkRocketEntity;
 import net.minecraft.world.item.ItemStack;
 import org.bukkit.craftbukkit.CraftServer;
@@ -25,17 +27,18 @@ public class CraftFirework extends CraftProjectile implements Firework {
 
     @Override
     public FireworkMeta getFireworkMeta() {
-        return (FireworkMeta) CraftItemStack.getItemMeta(this.getHandle().getEntityData().get(FireworkRocketEntity.DATA_ID_FIREWORKS_ITEM), org.bukkit.inventory.ItemType.FIREWORK_ROCKET); // Paper - Expose firework item directly
+        return (FireworkMeta) CraftItemStack.getItemMeta(this.getHandle().getEntityData().get(FireworkRocketEntity.DATA_ID_FIREWORKS_ITEM), org.bukkit.inventory.ItemType.FIREWORK_ROCKET);
     }
 
     @Override
     public void setFireworkMeta(FireworkMeta meta) {
-        applyFireworkEffect(meta); // Paper - Expose firework item directly
+        final ItemStack item = this.getHandle().getItem();
+        CraftItemStack.applyMetaToItem(item, meta);
+
+        this.getHandle().getEntityData().set(FireworkRocketEntity.DATA_ID_FIREWORKS_ITEM, item);
 
         // Copied from FireworkRocketEntity constructor, update firework lifetime/power
         this.getHandle().lifetime = 10 * (1 + meta.getPower()) + this.random.nextInt(6) + this.random.nextInt(7);
-
-        this.getHandle().getEntityData().markDirty(FireworkRocketEntity.DATA_ID_FIREWORKS_ITEM);
     }
 
     @Override
@@ -45,10 +48,7 @@ public class CraftFirework extends CraftProjectile implements Firework {
         }
 
         this.getHandle().attachedToEntity = (entity != null) ? ((CraftLivingEntity) entity).getHandle() : null;
-        // Paper start - update entity data
-        this.getHandle().getEntityData().set(FireworkRocketEntity.DATA_ATTACHED_TO_TARGET,
-            entity != null ? java.util.OptionalInt.of(entity.getEntityId()) : java.util.OptionalInt.empty());
-        // Paper end - update entity data
+        this.getHandle().getEntityData().set(FireworkRocketEntity.DATA_ATTACHED_TO_TARGET, entity != null ? OptionalInt.of(entity.getEntityId()) : OptionalInt.empty());
         return true;
     }
 
@@ -113,11 +113,10 @@ public class CraftFirework extends CraftProjectile implements Firework {
     }
 
     @Override
-    public java.util.UUID getSpawningEntity() {
-        return getHandle().spawningEntity;
+    public UUID getSpawningEntity() {
+        return this.getHandle().spawningEntity;
     }
 
-    // Paper start - Expose firework item directly + manually setting flight
     @Override
     public org.bukkit.inventory.ItemStack getItem() {
         return CraftItemStack.asBukkitCopy(this.getHandle().getItem());
@@ -125,11 +124,8 @@ public class CraftFirework extends CraftProjectile implements Firework {
 
     @Override
     public void setItem(org.bukkit.inventory.ItemStack itemStack) {
-        FireworkMeta meta = getFireworkMeta();
         ItemStack nmsItem = itemStack == null ? FireworkRocketEntity.getDefaultItem() : CraftItemStack.asNMSCopy(itemStack);
         this.getHandle().getEntityData().set(FireworkRocketEntity.DATA_ID_FIREWORKS_ITEM, nmsItem);
-
-        applyFireworkEffect(meta);
     }
 
     @Override
@@ -151,12 +147,4 @@ public class CraftFirework extends CraftProjectile implements Firework {
     public void setTicksToDetonate(int ticks) {
         this.getHandle().lifetime = ticks;
     }
-
-    void applyFireworkEffect(FireworkMeta meta) {
-        ItemStack item = this.getHandle().getItem();
-        CraftItemStack.applyMetaToItem(item, meta);
-
-        this.getHandle().getEntityData().set(FireworkRocketEntity.DATA_ID_FIREWORKS_ITEM, item);
-    }
-    // Paper end - Expose firework item directly + manually setting flight
 }


### PR DESCRIPTION
This PR closes https://github.com/PaperMC/Paper/issues/13890 and also handle a few things i notice when check the class...

- setItem set the item but also use any previous ItemMeta for set the item again, the PR just remove the use of ItemMeta in setItem because currently its not necesary (thanks Components)
- the helper method `applyFireworkEffect` was removed because that logic its only necesary for `setFireworkMeta`
- a cleanup of comments and imports

I make a few tests for this changes...

The issue reported where the second item was ignored
```java
final Location location = player.getLocation().clone().add(0, 1, 0);
ItemStack first = ItemStack.of(Material.FIREWORK_ROCKET);
first.setData(DataComponentTypes.FIREWORKS, Fireworks.fireworks()
    .addEffect(FireworkEffect.builder()
        .withColor(Color.RED)
        .build()));

ItemStack second = ItemStack.of(Material.FIREWORK_ROCKET);
second.setData(DataComponentTypes.FIREWORKS, Fireworks.fireworks()
    .addEffect(FireworkEffect.builder()
        .withColor(Color.GREEN)
        .build()));

final Firework fireWorkSpawned = location.getWorld().spawn(location, Firework.class, firework -> {
    firework.setItem(first);
    firework.setItem(second); // Won't apply
});
 ```
 
 Just set an ItemMeta
 ```java
 final Location location = player.getLocation().clone().add(0, 1, 0);
ItemStack first = ItemStack.of(Material.FIREWORK_ROCKET);
first.editMeta(FireworkMeta.class, meta -> {
    meta.addEffect(FireworkEffect.builder().withColor(Color.GREEN).build());
});

final Firework fireWorkSpawned = location.getWorld().spawn(location, Firework.class, firework -> {
    firework.setFireworkMeta(((FireworkMeta) first.getItemMeta()));
});
```

Override in spawn (for check if even the markDirty was necesary)
```java
@EventHandler
public void onEntitySpawnEvent(final EntitySpawnEvent event) {
    if (event.getEntity() instanceof Firework firework) {
        ItemStack first = ItemStack.of(Material.FIREWORK_ROCKET);
        first.editMeta(FireworkMeta.class, meta -> {
            meta.addEffect(FireworkEffect.builder().withColor(Color.BLUE).build());
        });
        firework.setFireworkMeta(((FireworkMeta) first.getItemMeta()));
    }
}
```