### PR TITLE
Mention paper-generator in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,15 @@ initial commits are the decompiled Minecraft source files. The per-file
 patches are applied on top of these files as a single, large commit, which is then followed
 by the individual feature-patch commits.
 
+### Optional paper-generator Project
+
+Paper also includes an optional `paper-generator` project used for generating and updating Minecraft source and mapping data during development.
+
+The project is disabled by default, but can be enabled by uncommenting the following line in `paper-generator.settings.gradle.kts`:
+
+```kotlin
+// include(":paper-generator")
+
 ## Modifying (per-file) Minecraft patches
 
 This is generally what you need to do when editing Minecraft files. Updating our


### PR DESCRIPTION
Adds documentation for the optional paper-generator project in CONTRIBUTING.md.

Changes
Documented the existence and purpose of the optional paper-generator module
Added instructions for enabling the project through paper-generator.settings.gradle.kts

This helps contributors better understand the development setup and optional project configuration available within the Paper repository.