### PR TITLE
Update villager prices before opening menu to player

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -442,6 +442,7 @@ public net.minecraft.world.entity.npc.villager.Villager numberOfRestocksToday
 public net.minecraft.world.entity.npc.villager.Villager releaseAllPois()V
 public net.minecraft.world.entity.npc.villager.Villager setUnhappy()V
 public net.minecraft.world.entity.npc.villager.Villager updateDemand()V
+public net.minecraft.world.entity.npc.villager.Villager updateSpecialPrices(Lnet/minecraft/world/entity/player/Player;)V
 public net.minecraft.world.entity.npc.wanderingtrader.WanderingTrader getWanderTarget()Lnet/minecraft/core/BlockPos;
 public net.minecraft.world.entity.player.Abilities flyingSpeed
 public net.minecraft.world.entity.player.Abilities walkingSpeed

--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -385,6 +385,7 @@ public net.minecraft.world.entity.npc.villager.Villager numberOfRestocksToday
 public net.minecraft.world.entity.npc.villager.Villager releaseAllPois()V
 public net.minecraft.world.entity.npc.villager.Villager setUnhappy()V
 public net.minecraft.world.entity.npc.villager.Villager updateDemand()V
+public net.minecraft.world.entity.npc.villager.Villager updateSpecialPrices(Lnet/minecraft/world/entity/player/Player;)V
 public net.minecraft.world.entity.npc.wanderingtrader.WanderingTrader getWanderTarget()Lnet/minecraft/core/BlockPos;
 public net.minecraft.world.entity.player.Inventory equipment
 public net.minecraft.world.entity.player.Player closeContainer()V

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -512,17 +512,18 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         net.minecraft.world.item.trading.Merchant mcMerchant;
         Component name;
         int level = 1; // note: using level 0 with active 'is-regular-villager'-flag allows hiding the name suffix
-        if (merchant instanceof CraftAbstractVillager) {
-            mcMerchant = ((CraftAbstractVillager) merchant).getHandle();
-            name = ((CraftAbstractVillager) merchant).getHandle().getDisplayName();
-            if (merchant instanceof CraftVillager) {
-                level = ((CraftVillager) merchant).getHandle().getVillagerData().level();
+        if (merchant instanceof CraftAbstractVillager craftAbstractVillager) {
+            mcMerchant = craftAbstractVillager.getHandle();
+            name = craftAbstractVillager.getHandle().getDisplayName();
+            if (merchant instanceof CraftVillager craftVillager) {
+                level = craftVillager.getHandle().getVillagerData().level();
+                craftVillager.getHandle().updateSpecialPrices(this.getHandle()); // Update villager prices before to open to player
             }
-        } else if (merchant instanceof CraftMerchantCustom) {
-            mcMerchant = ((CraftMerchantCustom) merchant).getMerchant();
-            name = ((CraftMerchantCustom) merchant).getMerchant().getScoreboardDisplayName();
+        } else if (merchant instanceof CraftMerchantCustom craftMerchantCustom) {
+            mcMerchant = craftMerchantCustom.getMerchant();
+            name = craftMerchantCustom.getMerchant().getScoreboardDisplayName();
         } else {
-            throw new IllegalArgumentException("Can't open merchant " + merchant.toString());
+            throw new IllegalArgumentException("Can't open merchant " + merchant);
         }
 
         mcMerchant.setTradingPlayer(this.getHandle());

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
@@ -512,17 +512,18 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
         net.minecraft.world.item.trading.Merchant mcMerchant;
         Component name;
         int level = 1; // note: using level 0 with active 'is-regular-villager'-flag allows hiding the name suffix
-        if (merchant instanceof CraftAbstractVillager) {
-            mcMerchant = ((CraftAbstractVillager) merchant).getHandle();
-            name = ((CraftAbstractVillager) merchant).getHandle().getDisplayName();
-            if (merchant instanceof CraftVillager) {
-                level = ((CraftVillager) merchant).getHandle().getVillagerData().level();
+        if (merchant instanceof CraftAbstractVillager craftAbstractVillager) {
+            mcMerchant = craftAbstractVillager.getHandle();
+            name = craftAbstractVillager.getHandle().getDisplayName();
+            if (merchant instanceof CraftVillager craftVillager) {
+                level = craftVillager.getHandle().getVillagerData().level();
+                craftVillager.getHandle().updateSpecialPrices(this.getHandle()); // update villager prices before opening menu to player
             }
-        } else if (merchant instanceof CraftMerchantCustom) {
-            mcMerchant = ((CraftMerchantCustom) merchant).getMerchant();
-            name = ((CraftMerchantCustom) merchant).getMerchant().getScoreboardDisplayName();
+        } else if (merchant instanceof CraftMerchantCustom craftMerchantCustom) {
+            mcMerchant = craftMerchantCustom.getMerchant();
+            name = craftMerchantCustom.getMerchant().getScoreboardDisplayName();
         } else {
-            throw new IllegalArgumentException("Can't open merchant " + merchant.toString());
+            throw new IllegalArgumentException("Can't open merchant " + merchant);
         }
 
         mcMerchant.setTradingPlayer(this.getHandle());

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftMenus.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftMenus.java
@@ -54,6 +54,7 @@ public final class CraftMenus {
         int level = 1;
         if (minecraftMerchant instanceof final Villager villager) {
             level = villager.getVillagerData().level();
+            villager.updateSpecialPrices(player); // Update villager prices before to open to player
         }
 
         if (minecraftMerchant.getTradingPlayer() != null) { // merchant's can only have one trader

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftMenus.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftMenus.java
@@ -54,6 +54,7 @@ public final class CraftMenus {
         int level = 1;
         if (minecraftMerchant instanceof final Villager villager) {
             level = villager.getVillagerData().level();
+            villager.updateSpecialPrices(player); // update villager prices before opening menu to player
         }
 
         if (minecraftMerchant.getTradingPlayer() != null) { // merchant's can only have one trader


### PR DESCRIPTION
Talking in discord about the Villager and the inventory this PR handle a behaviour noticed in https://github.com/PaperMC/Paper/issues/13905 where the methods to open inventory related to Villager ignore the update price for reputation or hero of the village, the only "breaking" change here is if user dont expect to get that change of prices, but just need use https://jd.papermc.io/paper/26.1.2/org/bukkit/inventory/MerchantRecipe.html#setIgnoreDiscounts(boolean) for make clear dont wanna updates in the prices.

Thanks @Y2Kwastaken and @masmc05 for the help with the Inventory behaviour.

Can close https://github.com/PaperMC/Paper/issues/13905