### PR TITLE
Add EntityLootGenerateEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityLootGenerateEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityLootGenerateEvent.java
@@ -1,0 +1,104 @@
+package io.papermc.paper.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.loot.LootContext;
+import org.bukkit.loot.LootTable;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Called when a {@link LootTable} is generated for an {@link Entity}.
+ * <br>
+ * For example: When an entity dies, an armadillo sheds, etc.
+ */
+@NullMarked
+public class EntityLootGenerateEvent extends EntityEvent implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final LootTable lootTable;
+    private final LootContext lootContext;
+    private final List<ItemStack> loot;
+
+    private boolean cancelled;
+
+    @ApiStatus.Internal
+    public EntityLootGenerateEvent(Entity entity, LootTable lootTable, LootContext lootContext, List<ItemStack> loot) {
+        super(entity);
+        this.lootTable = lootTable;
+        this.lootContext = lootContext;
+        this.loot = loot;
+    }
+
+    /**
+     * Get the loot table used to generate loot.
+     *
+     * @return the loot table
+     */
+    public LootTable getLootTable() {
+        return this.lootTable;
+    }
+
+    /**
+     * Get the loot context used to provide context to the loot table's loot
+     * generation.
+     *
+     * @return the loot context
+     */
+    public LootContext getLootContext() {
+        return this.lootContext;
+    }
+
+    /**
+     * Set the loot to be generated. {@code null} items will be treated as air.
+     * <br>
+     * Note: the set collection is not the one which will be returned by
+     * {@link #getLoot()}.
+     *
+     * @param loot the loot to generate, {@code null} to clear all loot
+     */
+    public void setLoot(@Nullable Collection<ItemStack> loot) {
+        this.loot.clear();
+        if (loot != null) {
+            this.loot.addAll(loot);
+        }
+    }
+
+    /**
+     * Get a mutable list of all loot to be generated.
+     * <p>
+     * Any items added or removed from the returned list will be reflected in
+     * the loot generation. {@code null} items will be treated as air.
+     *
+     * @return the loot to generate
+     */
+    public List<ItemStack> getLoot() {
+        return this.loot;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/paper-api/src/main/java/org/bukkit/event/world/LootGenerateEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/world/LootGenerateEvent.java
@@ -2,6 +2,7 @@ package org.bukkit.event.world;
 
 import java.util.Collection;
 import java.util.List;
+import io.papermc.paper.event.entity.EntityLootGenerateEvent;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Cancellable;
@@ -19,8 +20,8 @@ import org.jetbrains.annotations.Nullable;
  * Called when a {@link LootTable} is generated in the world for an
  * {@link InventoryHolder}.
  * <p>
- * This event is NOT currently called when an entity's loot table has been
- * generated (use {@link EntityDeathEvent#getDrops()}), but WILL be called by
+ * This event is NOT called when an entity's loot table has been
+ * generated (use {@link EntityLootGenerateEvent} or {@link EntityDeathEvent#getDrops()}), but WILL be called by
  * plugins invoking
  * {@link LootTable#fillInventory(org.bukkit.inventory.Inventory, java.util.Random, LootContext)}.
  */

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -355,7 +355,7 @@ index 0000000000000000000000000000000000000000..829f7685904fd741e00403647ae76d32
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 5bb8ddc9490ce6c7bc4544ef0ea05484e67ddbe3..10696186f7776f21a9fbcc49224d05ea2962a93a 100644
+index e5328f08d6a323aa1307ed791a88916b4588939c..1afbe7a877f8055702809bc33b110bdf2933f999 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -880,6 +880,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
@@ -463,7 +463,7 @@ index 271ed1128959287f6c1b6ca59ded377b88f5afff..f03fa06c0ba56f7f5e1e45bc1568a490
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index ba0cdbd064ad3e0cf645c50ab14adcddef48e932..68855c16d2cb3e5b7d7a86f05e7bb2e7922a5ba0 100644
+index 00d1ba3e42076f0de52455d66c4e056fdc48cd7a..700b5740229b5a97b8755c7d4205e8a99f229f9e 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -382,6 +382,15 @@ public abstract class Entity
@@ -522,10 +522,10 @@ index ba0cdbd064ad3e0cf645c50ab14adcddef48e932..68855c16d2cb3e5b7d7a86f05e7bb2e7
              delta = this.maybeBackOffFromEdge(delta, moverType);
              Vec3 movement = this.collide(delta);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 2837e630ae414bd37c4afc72c83a78e4d38a945a..3a4da514c163e7565fc241835db52c464a5c4734 100644
+index f77fa29184cc5e6bd392f7a205bd03d1b471cb28..dd87ad6038ab4f03348dfc794c6abc618d6393e6 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3385,6 +3385,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3403,6 +3403,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
      protected void playAttackSound() {
      }
  
@@ -675,7 +675,7 @@ index fd25032b8a68bec2951fdc626fd95946fea5deb4..c800c894a921ae77ed1757794ddf8d73
      public void tick() {
          if (this.getItem().isEmpty()) {
 diff --git a/net/minecraft/world/entity/npc/villager/Villager.java b/net/minecraft/world/entity/npc/villager/Villager.java
-index e1cac3972e8ec33ee269061e2f4dee83c04dbeb7..4f8439afa4ea602b662e68e6b86e9d927fb6a481 100644
+index 48bf5f612b91c457dd8e99955429832daeaab9e2..0a02aef2ff159a1d94870bf3cede0ed29ae192af 100644
 --- a/net/minecraft/world/entity/npc/villager/Villager.java
 +++ b/net/minecraft/world/entity/npc/villager/Villager.java
 @@ -235,11 +235,35 @@ public class Villager extends AbstractVillager implements VillagerDataHolder, Re

--- a/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0005-Entity-Activation-Range-2.0.patch
@@ -354,7 +354,7 @@ index 0000000000000000000000000000000000000000..ce6b57eeeeb1bd652f4bb53c19dcfbc0
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 89da20b0682708ba8bfc0d10381eb9784d80c395..b5d63d7b848c11ed322d512adeee102886cbb6fd 100644
+index 0fabe7fe4d302695505bed2cef4ce580358b8b82..9fc39230f52f4cf6b44edd34aa9542b9d500538e 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -864,6 +864,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
@@ -462,7 +462,7 @@ index 0df8332933203a904bd9ef9efb3c9bce21e65441..1a502cbd8acea9420fa6dd8d716018b5
      public void tick() {
          super.tick();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 593265d78564b60bacbb4899f18a6e74bf56601d..84c664711658eb83b5ff9d4c8470fd8ec54a5473 100644
+index e5d56fdb5cfd4aa291dbdb879e478134a85c9beb..196a15d3761eab416cb519fd52c86cc100b8080a 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -382,6 +382,15 @@ public abstract class Entity
@@ -521,10 +521,10 @@ index 593265d78564b60bacbb4899f18a6e74bf56601d..84c664711658eb83b5ff9d4c8470fd8e
              delta = this.maybeBackOffFromEdge(delta, moverType);
              Vec3 movement = this.collide(delta);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index f62e535b62d249dd3be19d7c1b02fae8dad31c10..6eb95b979ffe37d78fd68eb57ebe71891beb0d28 100644
+index e90339ef63c535c7a376747fcedcd49275612ae3..fdd9ed362c68932a5c3dd7856108243004636d05 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3380,6 +3380,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3398,6 +3398,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
      protected void playAttackSound() {
      }
  
@@ -818,7 +818,7 @@ index f46cca0467bb4da5511bc953ce5b43fa606bf978..445c5cafad71028171c1f26193966177
 +
  }
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index cc492445307ddc08446484d272866f01646cf7b3..a5d46832d4f8a13b0bf67b523c21d5c3b44209a9 100644
+index 46ca14a186f23a05bd0e6437adcb67dc09d94d8b..00bfadc908cfa9f1600c4bcc3cd21cca579cdc4f 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
 @@ -155,6 +155,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -966,6 +966,41 @@
      }
  
      protected void dropCustomDeathLoot(final ServerLevel level, final DamageSource source, final boolean killedByPlayer) {
+@@ -1546,8 +_,18 @@
+             builder = builder.withParameter(LootContextParams.LAST_DAMAGE_PLAYER, killerPlayer).withLuck(killerPlayer.getLuck());
+         }
+ 
++        // Paper start - EntityLootGenerateEvent
++        List<ItemStack> drops = new it.unimi.dsi.fastutil.objects.ObjectArrayList<>();
+         LootParams params = builder.create(LootContextParamSets.ENTITY);
+-        table.getRandomItems(params, this.getLootTableSeed(), itemStackConsumer);
++        table.getRandomItems(params, this.getLootTableSeed(), drops::add);
++
++        List<org.bukkit.inventory.ItemStack> bukkitLoot = drops.stream().map(CraftItemStack::asCraftMirror).collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
++        io.papermc.paper.event.entity.EntityLootGenerateEvent event = new io.papermc.paper.event.entity.EntityLootGenerateEvent(this.getBukkitEntity(), table.craftLootTable, org.bukkit.craftbukkit.CraftLootTable.convertParams(params), bukkitLoot);
++        if (!event.callEvent()) {
++            return;
++        }
++        event.getLoot().stream().map(org.bukkit.craftbukkit.inventory.CraftItemStack::asNMSCopy).forEach(itemStackConsumer);
++        // Paper end
+     }
+ 
+     public boolean dropFromEntityInteractLootTable(
+@@ -1602,6 +_,14 @@
+         LootTable lootTable = level.getServer().reloadableRegistries().getLootTable(key);
+         LootParams params = paramsBuilder.apply(new LootParams.Builder(level));
+         List<ItemStack> drops = lootTable.getRandomItems(params);
++        // Paper start - EntityLootGenerateEvent
++        List<org.bukkit.inventory.ItemStack> bukkitLoot = drops.stream().map(CraftItemStack::asCraftMirror).collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
++        io.papermc.paper.event.entity.EntityLootGenerateEvent event = new io.papermc.paper.event.entity.EntityLootGenerateEvent(this.getBukkitEntity(), lootTable.craftLootTable, org.bukkit.craftbukkit.CraftLootTable.convertParams(params), bukkitLoot);
++        if (!event.callEvent()) {
++            return false;
++        }
++        drops = event.getLoot().stream().map(org.bukkit.craftbukkit.inventory.CraftItemStack::asNMSCopy).collect(it.unimi.dsi.fastutil.objects.ObjectArrayList.toList());
++        // Paper end
+         if (!drops.isEmpty()) {
+             drops.forEach(stack -> consumer.accept(level, stack));
+             return true;
 @@ -1611,9 +_,14 @@
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -885,6 +885,41 @@
      }
  
      protected void dropCustomDeathLoot(final ServerLevel level, final DamageSource source, final boolean killedByPlayer) {
+@@ -1575,8 +_,18 @@
+             builder = builder.withParameter(LootContextParams.LAST_DAMAGE_PLAYER, killerPlayer).withLuck(killerPlayer.getLuck());
+         }
+ 
++        // Paper start - EntityLootGenerateEvent
++        List<ItemStack> drops = new it.unimi.dsi.fastutil.objects.ObjectArrayList<>();
+         LootParams params = builder.create(LootContextParamSets.ENTITY);
+-        table.getRandomItems(params, this.getLootTableSeed(), itemStackConsumer);
++        table.getRandomItems(params, this.getLootTableSeed(), drops::add);
++
++        List<org.bukkit.inventory.ItemStack> bukkitLoot = drops.stream().map(CraftItemStack::asCraftMirror).collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
++        io.papermc.paper.event.entity.EntityLootGenerateEvent event = new io.papermc.paper.event.entity.EntityLootGenerateEvent(this.getBukkitEntity(), table.craftLootTable, org.bukkit.craftbukkit.CraftLootTable.convertParams(params), bukkitLoot);
++        if (!event.callEvent()) {
++            return;
++        }
++        event.getLoot().stream().map(org.bukkit.craftbukkit.inventory.CraftItemStack::asNMSCopy).forEach(itemStackConsumer);
++        // Paper end
+     }
+ 
+     public boolean dropFromEntityInteractLootTable(
+@@ -1631,6 +_,14 @@
+         LootTable lootTable = level.getServer().reloadableRegistries().getLootTable(key);
+         LootParams params = paramsBuilder.apply(new LootParams.Builder(level));
+         List<ItemStack> drops = lootTable.getRandomItems(params);
++        // Paper start - EntityLootGenerateEvent
++        List<org.bukkit.inventory.ItemStack> bukkitLoot = drops.stream().map(CraftItemStack::asCraftMirror).collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
++        io.papermc.paper.event.entity.EntityLootGenerateEvent event = new io.papermc.paper.event.entity.EntityLootGenerateEvent(this.getBukkitEntity(), lootTable.craftLootTable, org.bukkit.craftbukkit.CraftLootTable.convertParams(params), bukkitLoot);
++        if (!event.callEvent()) {
++            return false;
++        }
++        drops = event.getLoot().stream().map(org.bukkit.craftbukkit.inventory.CraftItemStack::asNMSCopy).collect(it.unimi.dsi.fastutil.objects.ObjectArrayList.toList());
++        // Paper end
+         if (!drops.isEmpty()) {
+             drops.forEach(stack -> consumer.accept(level, stack));
+             return true;
 @@ -1640,9 +_,14 @@
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/level/storage/loot/LootContext.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/storage/loot/LootContext.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/level/storage/loot/LootContext.java
++++ b/net/minecraft/world/level/storage/loot/LootContext.java
+@@ -60,6 +_,10 @@
+         this.visitedElements.remove(element);
+     }
+ 
++    public LootParams getParams() {
++        return this.params;
++    }
++
+     public HolderGetter.Provider getResolver() {
+         return this.lootDataResolver;
+     }

--- a/paper-server/patches/sources/net/minecraft/world/level/storage/loot/LootContext.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/storage/loot/LootContext.java.patch
@@ -1,12 +1,14 @@
 --- a/net/minecraft/world/level/storage/loot/LootContext.java
 +++ b/net/minecraft/world/level/storage/loot/LootContext.java
-@@ -60,6 +_,10 @@
+@@ -60,6 +_,12 @@
          this.visitedElements.remove(element);
      }
  
++    // Paper start - expose LootContext params
 +    public LootParams getParams() {
 +        return this.params;
 +    }
++    // Paper end
 +
      public HolderGetter.Provider getResolver() {
          return this.lootDataResolver;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
@@ -148,6 +148,29 @@ public class CraftLootTable implements org.bukkit.loot.LootTable {
         }
     }
 
+    public static LootContext convertParams(net.minecraft.world.level.storage.loot.LootParams info) {
+        Vec3 position = info.contextMap().getOptional(LootContextParams.ORIGIN);
+        if (position == null) {
+            position = info.contextMap().getOptional(LootContextParams.THIS_ENTITY).position(); // Every vanilla context has origin or this_entity, see LootContextParamSets
+        }
+        Location location = CraftLocation.toBukkit(position, info.getLevel());
+        LootContext.Builder contextBuilder = new LootContext.Builder(location);
+
+        if (info.contextMap().has(LootContextParams.ATTACKING_ENTITY)) {
+            CraftEntity killer = info.contextMap().getOptional(LootContextParams.ATTACKING_ENTITY).getBukkitEntity();
+            if (killer instanceof CraftHumanEntity) {
+                contextBuilder.killer((CraftHumanEntity) killer);
+            }
+        }
+
+        if (info.contextMap().has(LootContextParams.THIS_ENTITY)) {
+            contextBuilder.lootedEntity(info.contextMap().getOptional(LootContextParams.THIS_ENTITY).getBukkitEntity());
+        }
+
+        contextBuilder.luck(info.getLuck());
+        return contextBuilder.build();
+    }
+
     public static LootContext convertContext(net.minecraft.world.level.storage.loot.LootContext info) {
         Vec3 position = info.getOptionalParameter(LootContextParams.ORIGIN);
         if (position == null) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
@@ -148,11 +149,23 @@ public class CraftLootTable implements org.bukkit.loot.LootTable {
         }
     }
 
-    public static LootContext convertParams(net.minecraft.world.level.storage.loot.LootParams info) {
-        Vec3 position = info.contextMap().getOptional(LootContextParams.ORIGIN);
-        if (position == null) {
-            position = info.contextMap().getOptional(LootContextParams.THIS_ENTITY).position(); // Every vanilla context has origin or this_entity, see LootContextParamSets
+    public static LootContext convertContext(net.minecraft.world.level.storage.loot.LootContext info) {
+        return convertParams(info.getParams());
+    }
+
+    public static LootContext convertParams(LootParams info) {
+        // Every vanilla context (excluding empty) has at least one of these, see LootContextParamSets
+        Vec3 position;
+        if (info.contextMap().has(LootContextParams.ORIGIN)) {
+            position = info.contextMap().getOrThrow(LootContextParams.ORIGIN);
+        } else if (info.contextMap().has(LootContextParams.THIS_ENTITY)) {
+            position = info.contextMap().getOrThrow(LootContextParams.THIS_ENTITY).position();
+        } else if (info.contextMap().has(LootContextParams.TARGET_ENTITY)) {
+            position = info.contextMap().getOrThrow(LootContextParams.TARGET_ENTITY).position();
+        } else {
+            position = info.contextMap().getOrThrow(LootContextParams.INTERACTING_ENTITY).position();
         }
+
         Location location = CraftLocation.toBukkit(position, info.getLevel());
         LootContext.Builder contextBuilder = new LootContext.Builder(location);
 
@@ -165,29 +178,6 @@ public class CraftLootTable implements org.bukkit.loot.LootTable {
 
         if (info.contextMap().has(LootContextParams.THIS_ENTITY)) {
             contextBuilder.lootedEntity(info.contextMap().getOptional(LootContextParams.THIS_ENTITY).getBukkitEntity());
-        }
-
-        contextBuilder.luck(info.getLuck());
-        return contextBuilder.build();
-    }
-
-    public static LootContext convertContext(net.minecraft.world.level.storage.loot.LootContext info) {
-        Vec3 position = info.getOptionalParameter(LootContextParams.ORIGIN);
-        if (position == null) {
-            position = info.getOptionalParameter(LootContextParams.THIS_ENTITY).position(); // Every vanilla context has origin or this_entity, see LootContextParamSets
-        }
-        Location location = CraftLocation.toBukkit(position, info.getLevel());
-        LootContext.Builder contextBuilder = new LootContext.Builder(location);
-
-        if (info.hasParameter(LootContextParams.ATTACKING_ENTITY)) {
-            CraftEntity killer = info.getOptionalParameter(LootContextParams.ATTACKING_ENTITY).getBukkitEntity();
-            if (killer instanceof CraftHumanEntity) {
-                contextBuilder.killer((CraftHumanEntity) killer);
-            }
-        }
-
-        if (info.hasParameter(LootContextParams.THIS_ENTITY)) {
-            contextBuilder.lootedEntity(info.getOptionalParameter(LootContextParams.THIS_ENTITY).getBukkitEntity());
         }
 
         contextBuilder.luck(info.getLuck());


### PR DESCRIPTION
Currently the only way to get the entities loot on death is using EntityDeathEvent#getDrops, but that also includes drops from things like chest horses, boat chests, blocks held by enderman, etc.

If you only want to mutate that entities loot table you have to manually handle every edge case which is painful to say the least.

EntityLootGenerateEvent is intended to solve the gap.