### PR TITLE
Converting NamespacedKey parameters to lowercase Strings

### DIFF
--- a/paper-api/src/main/java/org/bukkit/NamespacedKey.java
+++ b/paper-api/src/main/java/org/bukkit/NamespacedKey.java
@@ -51,8 +51,8 @@ public final class NamespacedKey implements Key, com.destroystokyo.paper.Namespa
     public NamespacedKey(@NotNull String namespace, @NotNull String key) {
         Preconditions.checkArgument(namespace != null, "Namespace cannot be null");
         Preconditions.checkArgument(key != null, "Key cannot be null");
-        this.namespace = namespace;
-        this.key = key;
+        this.namespace = namespace.toLowerCase(Locale.ROOT);
+        this.key = key.toLowerCase(Locale.ROOT);
 
         this.validate();
     }


### PR DESCRIPTION
It does it in the other constructor where the namespace is derived from a plugin, but not when it is a string.  It just runs `String#toLowerCase` on the `namespace` and `key` parameters, using the Locale.ROOT parameter.