### PR TITLE
Update actions in build.yml to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,13 +38,13 @@ jobs:
       fail-fast: true
     steps:
       - if: ${{ github.event_name == 'push' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # todo remove me again after the update
           ref: ${{ github.ref_name }}
           fetch-depth: 0
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: JDK 25
@@ -54,13 +54,13 @@ jobs:
           distribution: 'zulu'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
           # Allow cache writes on main and dev branches
           cache-read-only: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/dev/') }}
 
       - name: Configure Build
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         id: determine
         env:
           REF_NAME: "${{ github.ref_name }}"
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Test Results
           path: |
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload Paperclip Jar
         if: fromJSON(steps.determine.outputs.result).action == 'paperclip'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: paper-${{ fromJSON(steps.determine.outputs.result).pr }}
           path: paper-server/build/libs/paper-paperclip-*.jar
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Event File
           path: ${{ github.event_path }}


### PR DESCRIPTION
this is to support node 24 - https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

I can update the actions in the other workflows but some of them are no longer being updated, and need a replacement, like https://github.com/marketplace/actions/close-pull-request.

