### PR TITLE
Fix duplicate dispense events for some items

### DIFF
--- a/paper-server/patches/sources/net/minecraft/core/dispenser/DefaultDispenseItemBehavior.java.patch
+++ b/paper-server/patches/sources/net/minecraft/core/dispenser/DefaultDispenseItemBehavior.java.patch
@@ -66,7 +66,7 @@
 +        itemEntity.setItem(org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getItem()));
 +        itemEntity.setDeltaMovement(org.bukkit.craftbukkit.util.CraftVector.toVec3(event.getVelocity()));
 +
-+        if (source.state().is(net.minecraft.world.level.block.Blocks.DISPENSER) && !event.getItem().getType().equals(craftItem.getType())) {
++        if (source.state().is(net.minecraft.world.level.block.Blocks.DISPENSER) && event.getItem().getType() != craftItem.getType()) {
 +            // Chain to handler for new item
 +            ItemStack eventStack = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getItem());
 +            DispenseItemBehavior dispenseBehavior = DispenserBlock.getDispenseBehavior(source, eventStack);

--- a/paper-server/patches/sources/net/minecraft/core/dispenser/DispenseItemBehavior.java.patch
+++ b/paper-server/patches/sources/net/minecraft/core/dispenser/DispenseItemBehavior.java.patch
@@ -134,14 +134,14 @@
                          return super.execute(source, dispensed);
                      }
  
-                     level.gameEvent(null, GameEvent.FLUID_PICKUP, target);
-                     Item targetType = pickup.getItem();
 +                    // Paper start - Call BlockDispenseEvent
 +                    ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(source, target, dispensed, this);
 +                    if (result != null) {
 +                        return result;
 +                    }
 +                    // Paper end - Call BlockDispenseEvent
+                     level.gameEvent(null, GameEvent.FLUID_PICKUP, target);
+                     Item targetType = pickup.getItem();
 +                    pickup = bucket.pickupBlock(null, level, target, blockState); // CraftBukkit - from above
                      return this.consumeWithRemainder(source, dispensed, new ItemStack(targetType));
                  } else {
@@ -250,20 +250,20 @@
                  this.setSuccess(true);
                  return dispensed;
              }
-@@ -229,6 +_,13 @@
-                     Level level = source.level();
+@@ -230,6 +_,13 @@
                      Direction direction = source.state().getValue(DispenserBlock.FACING);
                      BlockPos target = source.pos().relative(direction);
-+                    // Paper start - Call BlockDispenseEvent
-+                    ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(source, target, dispensed, this);
-+                    if (result != null) {
-+                        this.setSuccess(false);
-+                        return result;
-+                    }
-+                    // Paper end - Call BlockDispenseEvent
                      if (level.isEmptyBlock(target) && WitherSkullBlock.canSpawnMob(level, target, dispensed)) {
++                        // Paper start - Call BlockDispenseEvent
++                        ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(source, target, dispensed, this);
++                        if (result != null) {
++                            this.setSuccess(false);
++                            return result;
++                        }
++                        // Paper end - Call BlockDispenseEvent
                          level.setBlock(
                              target,
+                             Blocks.WITHER_SKELETON_SKULL.defaultBlockState().setValue(SkullBlock.ROTATION, RotationSegment.convertToSegment(direction)),
 @@ -243,7 +_,7 @@
                          dispensed.shrink(1);
                          this.setSuccess(true);
@@ -273,20 +273,20 @@
                      }
  
                      return dispensed;
-@@ -256,6 +_,13 @@
-                 Level level = source.level();
+@@ -257,6 +_,13 @@
                  BlockPos target = source.pos().relative(source.state().getValue(DispenserBlock.FACING));
                  CarvedPumpkinBlock pumpkinBlock = (CarvedPumpkinBlock)Blocks.CARVED_PUMPKIN;
-+                // Paper start - Call BlockDispenseEvent
-+                ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(source, target, dispensed, this);
-+                if (result != null) {
-+                    this.setSuccess(false);
-+                    return result;
-+                }
-+                // Paper end - Call BlockDispenseEvent
                  if (level.isEmptyBlock(target) && pumpkinBlock.canSpawnGolem(level, target)) {
++                    // Paper start - Call BlockDispenseEvent
++                    ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(source, target, dispensed, this);
++                    if (result != null) {
++                        this.setSuccess(false);
++                        return result;
++                    }
++                    // Paper end - Call BlockDispenseEvent
                      if (!level.isClientSide()) {
                          level.setBlock(target, pumpkinBlock.defaultBlockState(), Block.UPDATE_ALL);
+                         level.gameEvent(null, GameEvent.BLOCK_PLACE, target);
 @@ -265,7 +_,7 @@
                      dispensed.shrink(1);
                      this.setSuccess(true);
@@ -296,19 +296,30 @@
                  }
  
                  return dispensed;
-@@ -288,6 +_,12 @@
-                     ServerLevel level = source.level();
-                     BlockPos target = source.pos().relative(source.state().getValue(DispenserBlock.FACING));
+@@ -290,11 +_,23 @@
                      BlockState state = level.getBlockState(target);
-+                    // Paper start - Call BlockDispenseEvent
-+                    ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(source, target, dispensed, this);
-+                    if (result != null) {
-+                        return result;
-+                    }
-+                    // Paper end - Call BlockDispenseEvent
                      if (state.is(BlockTags.BEEHIVES, s -> s.hasProperty(BeehiveBlock.HONEY_LEVEL) && s.getBlock() instanceof BeehiveBlock)
                          && state.getValue(BeehiveBlock.HONEY_LEVEL) >= 5) {
++                        // Paper start - Call BlockDispenseEvent
++                        ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(source, target, dispensed, this);
++                        if (result != null) {
++                            return result;
++                        }
++                        // Paper end - Call BlockDispenseEvent
                          ((BeehiveBlock)state.getBlock())
+                             .releaseBeesAndResetHoneyLevel(level, state, target, null, BeehiveBlockEntity.BeeReleaseStatus.BEE_RELEASED);
+                         this.setSuccess(true);
+                         return this.takeLiquid(source, dispensed, new ItemStack(Items.HONEY_BOTTLE));
+                     } else if (level.getFluidState(target).is(FluidTags.WATER)) {
++                        // Paper start - Call BlockDispenseEvent
++                        ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(source, target, dispensed, this);
++                        if (result != null) {
++                            return result;
++                        }
++                        // Paper end - Call BlockDispenseEvent
+                         this.setSuccess(true);
+                         return this.takeLiquid(source, dispensed, PotionContents.createItemStack(Items.POTION, Potions.WATER));
+                     } else {
 @@ -313,6 +_,13 @@
                  this.setSuccess(true);
                  if (blockState.is(Blocks.RESPAWN_ANCHOR)) {

--- a/paper-server/patches/sources/net/minecraft/core/dispenser/FlintAndSteelDispenseItemBehavior.java.patch
+++ b/paper-server/patches/sources/net/minecraft/core/dispenser/FlintAndSteelDispenseItemBehavior.java.patch
@@ -1,19 +1,16 @@
 --- a/net/minecraft/core/dispenser/FlintAndSteelDispenseItemBehavior.java
 +++ b/net/minecraft/core/dispenser/FlintAndSteelDispenseItemBehavior.java
-@@ -24,16 +_,27 @@
-         this.setSuccess(true);
-         Direction facing = source.state().getValue(DispenserBlock.FACING);
-         BlockPos targetPos = source.pos().relative(facing);
-+        // Paper start - Call BlockDispenseEvent
-+        ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(source, targetPos, dispensed, this);
-+        if (result != null) {
-+            this.setSuccess(false);
-+            return result;
-+        }
-+        // Paper end - Call BlockDispenseEvent
+@@ -27,13 +_,39 @@
          BlockState target = level.getBlockState(targetPos);
          if (!tryIgniteExplosiveEntities(level, targetPos)) {
              if (BaseFireBlock.canBePlacedAt(level, targetPos, facing)) {
++                // Paper start - Call BlockDispenseEvent
++                ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(source, targetPos, dispensed, this);
++                if (result != null) {
++                    this.setSuccess(false);
++                    return result;
++                }
++                // Paper end - Call BlockDispenseEvent
 +                // CraftBukkit start - Ignition by dispensing flint and steel
 +                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBlockIgniteEvent(level, targetPos, source.pos()).isCancelled()) {
                  level.setBlockAndUpdate(targetPos, BaseFireBlock.getState(level, targetPos));
@@ -21,11 +18,34 @@
 +                }
 +                // CraftBukkit end
              } else if (CampfireBlock.canLight(target) || CandleBlock.canLight(target) || CandleCakeBlock.canLight(target)) {
++                // Paper start - Call BlockDispenseEvent
++                ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(source, targetPos, dispensed, this);
++                if (result != null) {
++                    this.setSuccess(false);
++                    return result;
++                }
++                // Paper end - Call BlockDispenseEvent
                  level.setBlockAndUpdate(targetPos, target.setValue(BlockStateProperties.LIT, true));
                  level.gameEvent(null, GameEvent.BLOCK_CHANGE, targetPos);
              } else if (target.getBlock() instanceof TntBlock) {
 -                if (TntBlock.prime(level, targetPos)) {
++                // Paper start - Call BlockDispenseEvent
++                // TODO ideally in the prime supplier otherwise it's a fail
++                ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(source, targetPos, dispensed, this);
++                if (result != null) {
++                    this.setSuccess(false);
++                    return result;
++                }
++                // Paper end - Call BlockDispenseEvent
 +                if (TntBlock.prime(level, targetPos, () -> org.bukkit.craftbukkit.event.CraftEventFactory.callTNTPrimeEvent(level, targetPos, org.bukkit.event.block.TNTPrimeEvent.PrimeCause.DISPENSER, null, source.pos()))) { // CraftBukkit - TNTPrimeEvent
                      level.removeBlock(targetPos, false);
                  } else {
                      this.setSuccess(false);
+@@ -54,6 +_,7 @@
+             return false;
+         }
+ 
++        // TODO - call dispense event
+         entities.getFirst().primeTime(false);
+         return true;
+     }


### PR DESCRIPTION
Replaces https://github.com/PaperMC/Paper/pull/8525

> Both wither skulls and carved pumpkins fired a BlockDispenseEvent twice if they didn't spawn a mob.
This is possibly a behavior change, but as usual, it's actually a bug fix so the behavior before was wrong.

In general if the dispense action fails completely no event occur (i.e the item is not dispensed nor consumed), the event is only triggered for the action that will succeed (that is partially true currently but should be better now).
Also moved fluid pickup game event after the event for taking liquid in bucket since the event is cancellable.