### PR TITLE
Fix summoned trident damage

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
@@ -185,6 +185,15 @@
              }
          }
      }
+@@ -627,7 +_,7 @@
+         this.lastState = input.read("inBlockState", BlockState.CODEC).orElse(null);
+         this.shakeTime = input.getByteOr("shake", (byte)0) & 255;
+         this.setInGround(input.getBooleanOr("inGround", false));
+-        this.baseDamage = input.getDoubleOr("damage", 2.0);
++        this.baseDamage = input.getDoubleOr("damage", this instanceof ThrownTrident ? net.minecraft.world.item.TridentItem.BASE_DAMAGE : 2.0); // Paper - Allow trident custom damage
+         this.pickup = input.read("pickup", AbstractArrow.Pickup.LEGACY_CODEC).orElse(AbstractArrow.Pickup.DISALLOWED);
+         this.setCritArrow(input.getBooleanOr("crit", false));
+         this.setPierceLevel(input.getByteOr("PierceLevel", (byte)0));
 @@ -638,7 +_,14 @@
  
      @Override


### PR DESCRIPTION
Previously summoned trident would only dealt 2 damage points instead of the usual 8 like in vanilla.