### PR TITLE
[ci skip] Fix AreaEffectCloud doc comments

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/AreaEffectCloud.java
+++ b/paper-api/src/main/java/org/bukkit/entity/AreaEffectCloud.java
@@ -115,7 +115,7 @@ public interface AreaEffectCloud extends Entity {
     float getRadiusPerTick();
 
     /**
-     * Gets the amount that the radius of this cloud will decrease by each tick.
+     * Sets the amount that the radius of this cloud will decrease by each tick.
      *
      * @param radius per tick delta
      */
@@ -139,7 +139,7 @@ public interface AreaEffectCloud extends Entity {
     /**
      * Sets the particle which this cloud will be composed of
      *
-     * @param <T> type of particle data (see {@link Particle#getDataType()}
+     * @param <T> type of particle data (see {@link Particle#getDataType()})
      * @param particle the new particle type
      * @param data the data to use for the particle or null,
      *             the type of this depends on {@link Particle#getDataType()}


### PR DESCRIPTION
The javadoc comments for AreaEffectCloud#setRadiusPerTick and AreaEffectCloud#setParticle had some issues