### PR TITLE
Reapply Patch Optimize hasItemMeta (remove getItemMeta call)

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
@@ -464,7 +464,7 @@ public final class CraftItemStack extends ItemStack {
 
     @Override
     public boolean hasItemMeta() {
-        return CraftItemStack.hasItemMeta(this.handle) && !CraftItemFactory.instance().equals(this.getItemMeta(), null);
+        return CraftItemStack.hasItemMeta(this.handle) && (this.handle.getDamageValue() != 0 || this.handle.getComponentsPatch().size() >= (this.handle.getComponentsPatch().get(DataComponentMap.EMPTY, CraftMetaItem.DAMAGE.TYPE) != null ? 2 : 1)); // Paper - keep 1.12 CraftBukkit behavior without calling getItemMeta
     }
 
     static boolean hasItemMeta(net.minecraft.world.item.ItemStack item) {

--- a/paper-server/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
+++ b/paper-server/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
@@ -1,6 +1,7 @@
 package org.bukkit.craftbukkit.inventory;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -175,6 +176,32 @@ public class ItemMetaTest {
         }
     }
     // Paper end
+
+    private void testHasItemMeta(ItemStack stack) {
+        assertThat(stack.hasItemMeta(), is(false), "Should not have ItemMeta");
+
+        stack.setDurability((short) 0);
+        assertThat(stack.hasItemMeta(), is(false), "ItemStack with zero durability should not have ItemMeta");
+
+        stack.setDurability((short) 2);
+        assertThat(stack.hasItemMeta(), is(true), "ItemStack with non-zero durability should have ItemMeta");
+
+        stack.setLore(Collections.singletonList("Lore"));
+        assertThat(stack.hasItemMeta(), is(true), "ItemStack with lore and durability should have ItemMeta");
+
+        stack.setDurability((short) 0);
+        assertThat(stack.hasItemMeta(), is(true), "ItemStack with lore should have ItemMeta");
+
+        stack.setLore(null);
+    }
+
+    @Test
+    public void testHasItemMeta() {
+        ItemStack itemStack = new ItemStack(Material.SHEARS);
+
+        testHasItemMeta(itemStack);
+        testHasItemMeta(CraftItemStack.asCraftCopy(itemStack));
+    }
 
     @Test
     public void testEachExtraData() {


### PR DESCRIPTION
Reapply Patch #1279

> Spigot 1.13 checks if any field (which are manually copied from the ItemStack's "tag" NBT tag) on the ItemMeta class of an ItemStack is set.
> 
> We could just check if the "tag" NBT tag is empty, albeit that would break some plugins. The only general tag added on 1.13 is "Damage", and we can just check if the "tag" NBT tag contains any other tag that's not "Damage" (https://minecraft.gamepedia.com/Player.dat_format#Item_structure) making the `hasItemStack` method behave as before.
> 
> Returns true if getDamage() != 0 or has damage tag or other tag is set.

Lastly, in Paper 1.20.4 there was still this patch: https://github.com/PaperMC/Paper-archive/blob/ver/1.20.4/patches/server/0221-Don-t-call-getItemMeta-on-hasItemMeta.patch, probably just did not survive the component rewrite