### PR TITLE
Expose client brand to connection

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/connection/PlayerCommonConnection.java
+++ b/paper-api/src/main/java/io/papermc/paper/connection/PlayerCommonConnection.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import com.destroystokyo.paper.ClientOption;
 import org.bukkit.ServerLinks;
 import org.bukkit.plugin.messaging.PluginMessageRecipient;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a connection that has properties shared between the GAME and CONFIG stage.
@@ -43,4 +44,13 @@ public interface PlayerCommonConnection extends WritablePlayerCookieConnection, 
      * @return the client option value of the player
      */
     <T> T getClientOption(ClientOption<T> type);
+
+    /**
+     * Returns player's client brand name. If the client didn't send this information, the brand name will be null.
+     * <p>
+     * For the Notchian client this name defaults to {@code vanilla}. Some modified clients report other names such as {@code neoforge}.
+     *
+     * @return client brand name
+     */
+    @Nullable String getClientBrandName();
 }

--- a/paper-api/src/main/java/io/papermc/paper/connection/PlayerConfigurationConnection.java
+++ b/paper-api/src/main/java/io/papermc/paper/connection/PlayerConfigurationConnection.java
@@ -1,6 +1,5 @@
 package io.papermc.paper.connection;
 
-import com.destroystokyo.paper.ClientOption;
 import com.destroystokyo.paper.profile.PlayerProfile;
 import net.kyori.adventure.audience.Audience;
 

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -3778,15 +3778,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
         // Paper end
     }
 
-    // Paper start - brand support
     /**
-     * Returns player's client brand name. If the client didn't send this information, the brand name will be null.<br>
-     * For the Notchian client this name defaults to <code>vanilla</code>. Some modified clients report other names such as <code>forge</code>.<br>
+     * Returns player's client brand name. If the client didn't send this information, the brand name will be null.
+     * <p>
+     * For the Notchian client this name defaults to {@code vanilla}. Some modified clients report other names such as {@code neoforge}.
+     *
      * @return client brand name
+     * @see io.papermc.paper.connection.PlayerCommonConnection#getClientBrandName()
      */
-    @Nullable
-    String getClientBrandName();
-    // Paper end
+    @Nullable String getClientBrandName();
 
     // Paper start - Teleport API
     /**

--- a/paper-server/patches/features/0016-Improve-keepalive-ping-system.patch
+++ b/paper-server/patches/features/0016-Improve-keepalive-ping-system.patch
@@ -102,15 +102,15 @@ index 0000000000000000000000000000000000000000..66d6af2833d76af28fbeb2ce70c194a5
 +    }
 +}
 diff --git a/net/minecraft/server/network/CommonListenerCookie.java b/net/minecraft/server/network/CommonListenerCookie.java
-index d87a00ee3cd04ce25dbe46ae6b386b7f0799102c..ace440c2b82a6368aa27a85ff433ba2cbc8f39a5 100644
+index 021c2b0d4d8b55cb74b16a1210535e97576a83f1..da63706a8199ecfa9cd9de87bef20c8d1898a950 100644
 --- a/net/minecraft/server/network/CommonListenerCookie.java
 +++ b/net/minecraft/server/network/CommonListenerCookie.java
 @@ -3,8 +3,8 @@ package net.minecraft.server.network;
  import com.mojang.authlib.GameProfile;
  import net.minecraft.server.level.ClientInformation;
  
--public record CommonListenerCookie(GameProfile gameProfile, int latency, ClientInformation clientInformation, boolean transferred, @org.jspecify.annotations.Nullable String brandName, java.util.Set<String> channels) { // Paper
-+public record CommonListenerCookie(GameProfile gameProfile, int latency, ClientInformation clientInformation, boolean transferred, @org.jspecify.annotations.Nullable String brandName, java.util.Set<String> channels, io.papermc.paper.util.KeepAlive keepAlive) { // Paper // Paper
+-public record CommonListenerCookie(GameProfile gameProfile, int latency, ClientInformation clientInformation, boolean transferred, @org.jspecify.annotations.Nullable String clientBrand, java.util.Set<String> channels) { // Paper
++public record CommonListenerCookie(GameProfile gameProfile, int latency, ClientInformation clientInformation, boolean transferred, @org.jspecify.annotations.Nullable String clientBrand, java.util.Set<String> channels, io.papermc.paper.util.KeepAlive keepAlive) { // Paper // Paper
      public static CommonListenerCookie createInitial(final GameProfile gameProfile, final boolean transferred) {
 -        return new CommonListenerCookie(gameProfile, 0, ClientInformation.createDefault(), transferred, null, new java.util.HashSet<>()); // Paper
 +        return new CommonListenerCookie(gameProfile, 0, ClientInformation.createDefault(), transferred, null, new java.util.HashSet<>(), new io.papermc.paper.util.KeepAlive()); // Paper // Paper
@@ -147,7 +147,7 @@ index c5490b5b9adbffe9cc80074b1f83158fda267a04..8fb001daa4f87d56ee353cef2d495aa1
          this.latency = cookie.latency();
          this.transferred = cookie.transferred();
          // Paper start
-         this.playerBrand = cookie.brandName();
+         this.clientBrand = cookie.clientBrand();
          this.cserver = server.server;
          this.pluginMessagerChannels = cookie.channels();
 +        this.keepAlive = cookie.keepAlive();
@@ -238,14 +238,14 @@ index c5490b5b9adbffe9cc80074b1f83158fda267a04..8fb001daa4f87d56ee353cef2d495aa1
      }
  
      protected CommonListenerCookie createCookie(final ClientInformation clientInformation) {
--        return new CommonListenerCookie(this.playerProfile(), this.latency, clientInformation, this.transferred, this.playerBrand, this.pluginMessagerChannels); // Paper
+-        return new CommonListenerCookie(this.playerProfile(), this.latency, clientInformation, this.transferred, this.clientBrand, this.pluginMessagerChannels); // Paper
 +        // Paper start - listener handoff should reset pending keepalive expectations
 +        return new CommonListenerCookie(
 +            this.playerProfile(),
 +            this.latency,
 +            clientInformation,
 +            this.transferred,
-+            this.playerBrand,
++            this.clientBrand,
 +            this.pluginMessagerChannels,
 +            this.keepAlive.copyForListenerHandoff()
 +        );

--- a/paper-server/patches/sources/net/minecraft/server/network/CommonListenerCookie.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/CommonListenerCookie.java.patch
@@ -5,7 +5,7 @@
  import net.minecraft.server.level.ClientInformation;
  
 -public record CommonListenerCookie(GameProfile gameProfile, int latency, ClientInformation clientInformation, boolean transferred) {
-+public record CommonListenerCookie(GameProfile gameProfile, int latency, ClientInformation clientInformation, boolean transferred, @org.jspecify.annotations.Nullable String brandName, java.util.Set<String> channels) { // Paper
++public record CommonListenerCookie(GameProfile gameProfile, int latency, ClientInformation clientInformation, boolean transferred, @org.jspecify.annotations.Nullable String clientBrand, java.util.Set<String> channels) { // Paper
      public static CommonListenerCookie createInitial(final GameProfile gameProfile, final boolean transferred) {
 -        return new CommonListenerCookie(gameProfile, 0, ClientInformation.createDefault(), transferred);
 +        return new CommonListenerCookie(gameProfile, 0, ClientInformation.createDefault(), transferred, null, new java.util.HashSet<>()); // Paper

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
@@ -20,7 +20,7 @@
 +    private static final long KEEPALIVE_LIMIT = Long.getLong("paper.playerconnection.keepalive", 30) * 1000; // Paper - provide property to set keepalive limit
 +    protected static final net.minecraft.resources.Identifier MINECRAFT_BRAND = net.minecraft.resources.Identifier.withDefaultNamespace("brand"); // Paper - Brand support
 +    // Paper start - retain certain values
-+    public @Nullable String playerBrand;
++    public @Nullable String clientBrand;
 +    public final java.util.Set<String> pluginMessagerChannels;
 +    // Paper end - retain certain values
  
@@ -31,7 +31,7 @@
          this.latency = cookie.latency();
          this.transferred = cookie.transferred();
 +        // Paper start
-+        this.playerBrand = cookie.brandName();
++        this.clientBrand = cookie.clientBrand();
 +        this.cserver = server.server;
 +        this.pluginMessagerChannels = cookie.channels();
 +        // Paper end
@@ -95,13 +95,13 @@
 +            }
 +
 +            if (identifier.equals(MINECRAFT_BRAND)) {
-+                this.playerBrand = new net.minecraft.network.FriendlyByteBuf(io.netty.buffer.Unpooled.wrappedBuffer(data)).readUtf(256);
++                this.clientBrand = new net.minecraft.network.FriendlyByteBuf(io.netty.buffer.Unpooled.wrappedBuffer(data)).readUtf(256);
 +            }
 +
 +            this.cserver.getMessenger().dispatchIncomingMessage(paperConnection(), identifier.toString(), data);
 +        } catch (final Exception e) {
 +            LOGGER.error("Couldn't handle custom payload on channel {}", identifier, e);
-+            this.disconnect(net.minecraft.network.chat.Component.literal("Invalid custom payload payload!"), io.papermc.paper.connection.DisconnectionReason.INVALID_PAYLOAD); // Paper - kick event cause
++            this.disconnect(Component.literal("Invalid custom payload payload!"), io.papermc.paper.connection.DisconnectionReason.INVALID_PAYLOAD); // Paper - kick event cause
 +        }
 +    }
 +
@@ -335,6 +335,6 @@
  
      protected CommonListenerCookie createCookie(final ClientInformation clientInformation) {
 -        return new CommonListenerCookie(this.playerProfile(), this.latency, clientInformation, this.transferred);
-+        return new CommonListenerCookie(this.playerProfile(), this.latency, clientInformation, this.transferred, this.playerBrand, this.pluginMessagerChannels); // Paper
++        return new CommonListenerCookie(this.playerProfile(), this.latency, clientInformation, this.transferred, this.clientBrand, this.pluginMessagerChannels); // Paper
      }
  }

--- a/paper-server/src/main/java/io/papermc/paper/connection/PaperCommonConnection.java
+++ b/paper-server/src/main/java/io/papermc/paper/connection/PaperCommonConnection.java
@@ -71,6 +71,11 @@ public abstract class PaperCommonConnection<T extends ServerCommonPacketListener
     }
 
     @Override
+    public @Nullable String getClientBrandName() {
+        return this.packetListener.clientBrand;
+    }
+
+    @Override
     public void disconnect(final Component component) {
         this.packetListener.disconnect(PaperAdventure.asVanilla(component), DisconnectionReason.UNKNOWN);
     }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -139,7 +139,6 @@ import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 import org.bukkit.BanEntry;
 import org.bukkit.BanList;
-import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
 import org.bukkit.Effect;
 import org.bukkit.EntityEffect;
@@ -3094,12 +3093,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         // Paper end
     };
 
-    // Paper start - brand support
     @Override
     public String getClientBrandName() {
-        return getHandle().connection.playerBrand;
+        if (this.getHandle().connection == null) {
+            return null;
+        }
+        return this.getHandle().connection.clientBrand;
     }
-    // Paper end
 
     // Paper start
     @Override


### PR DESCRIPTION
Allow to fetch it in the configuration phase after PlayerConnectionInitialConfigureEvent for other events taking only the connection.
This is similar to #13552