### PR TITLE
Add io_uring support

### DIFF
--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -131,6 +131,9 @@ dependencies {
         isTransitive = false
     }
     implementation("io.netty:netty-codec-haproxy:4.2.7.Final") // Add support for proxy protocol
+    implementation("io.netty:netty-transport-classes-io_uring:4.2.7.Final") // Add support for io_uring
+    implementation("io.netty:netty-transport-native-io_uring:4.2.7.Final:linux-x86_64")
+    implementation("io.netty:netty-transport-native-io_uring:4.2.7.Final:linux-aarch_64")
     implementation("org.apache.logging.log4j:log4j-iostreams:2.25.2")
     implementation("org.ow2.asm:asm-commons:9.9.1")
     implementation("org.spongepowered:configurate-yaml:4.2.0")

--- a/paper-server/patches/sources/net/minecraft/network/Connection.java.patch
+++ b/paper-server/patches/sources/net/minecraft/network/Connection.java.patch
@@ -222,7 +222,7 @@
          }
  
          if (this.tickCount++ % 20 == 0) {
-@@ -390,6 +_,7 @@
+@@ -390,12 +_,13 @@
      }
  
      public void disconnect(final DisconnectionDetails details) {
@@ -230,6 +230,13 @@
          if (this.channel == null) {
              this.delayedDisconnect = details;
          }
+ 
+         if (this.isConnected()) {
+-            this.channel.close().awaitUninterruptibly();
++            this.channel.close(); // We can't wait as this may be called from an event loop.
+             this.disconnectionDetails = details;
+         }
+     }
 @@ -534,6 +_,14 @@
          }
      }

--- a/paper-server/patches/sources/net/minecraft/server/network/EventLoopGroupHolder.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/EventLoopGroupHolder.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/network/EventLoopGroupHolder.java
 +++ b/net/minecraft/server/network/EventLoopGroupHolder.java
-@@ -48,19 +_,39 @@
+@@ -48,19 +_,63 @@
              return LocalIoHandler.newFactory();
          }
      };
@@ -12,6 +12,20 @@
 +        }
 +    };
 +    // Paper end - Unix domain socket support
++    // Paper start - io_uring transport support
++    private static final EventLoopGroupHolder IO_URING = new EventLoopGroupHolder("IO Uring", io.netty.channel.uring.IoUringSocketChannel.class, io.netty.channel.uring.IoUringServerSocketChannel.class) {
++        @Override
++        protected IoHandlerFactory ioHandlerFactory() {
++            return io.netty.channel.uring.IoUringIoHandler.newFactory();
++        }
++    };
++    private static final EventLoopGroupHolder IO_URING_UNIX_DOMAIN = new EventLoopGroupHolder("Unix Domain Socket", io.netty.channel.uring.IoUringDomainSocketChannel.class, io.netty.channel.uring.IoUringServerDomainSocketChannel.class) {
++        @Override
++        protected IoHandlerFactory ioHandlerFactory() {
++            return io.netty.channel.uring.IoUringIoHandler.newFactory();
++        }
++    };
++    // Paper end - io_uring transport support
      private final String type;
      private final Class<? extends Channel> channelCls;
      private final Class<? extends ServerChannel> serverChannelCls;
@@ -29,6 +43,16 @@
                  return KQUEUE;
              }
  
++            // Paper start - io_uring transport support
++            if (io.papermc.paper.configuration.GlobalConfiguration.get().network.useIoUringTransport) {
++                if (address instanceof io.netty.channel.unix.DomainSocketAddress) {
++                    return IO_URING_UNIX_DOMAIN;
++                } else {
++                    return IO_URING;
++                }
++            }
++            // Paper end - io_uring transport support
++
              if (Epoll.isAvailable()) {
 -                return EPOLL;
 +                // Paper start - Unix domain socket support

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -141,6 +141,28 @@ public class GlobalConfiguration extends ConfigurationPart {
         }
     }
 
+    public Network network;
+
+    public class Network extends ConfigurationPart {
+        public boolean useIoUringTransport = false;
+
+        @PostProcess
+        private void postProcess() {
+            if (!this.useIoUringTransport) return;
+
+            if (!io.netty.channel.uring.IoUring.isAvailable()) {
+                LOGGER.error("Linux io_uring transport is enabled but is not supported on this system. Disabling io_uring...");
+                this.useIoUringTransport = false;
+            }
+
+            if (!net.minecraft.server.MinecraftServer.getServer().useNativeTransport()) {
+                LOGGER.error("Linux io_uring transport is enabled but native transports are disabled in server.properties. Disabling io_uring...");
+                this.useIoUringTransport = false;
+            }
+        }
+
+    }
+
     public Console console;
 
     public class Console extends ConfigurationPart {


### PR DESCRIPTION
To complement the work done by Beanes in https://github.com/PaperMC/Paper/pull/13929, this PR implements io_uring transport to Paper, including its version of Unix Domain socket support.
As such, this PR depends on https://github.com/PaperMC/Paper/pull/13929 being merged first, as currently Minecraft seems to rely on a hacky workaround to hide a race condition while setting up compression.

I do agree that Paper might not get a huge boost from io_uring, since it won't handle as many active connections as Velocity, but Folia will most definitely get a significant improvement from this. And with this not being a region-related feature, it is more suitable have it on Paper and let Folia get it downstream.

This also relies on removing the synchronization in `Connection#disconnect` from the netty threads, as it will trigger Netty's deadlock prevention in the form of `io.netty.util.concurrent.BlockingOperationException`.
This used to be part of Paper, but was removed in https://github.com/PaperMC/Paper/commit/8021488ef48a4aae5246cd3d2f97b8573bffdad9, currently unsure if was intentional or not as it doesn't seem to affect the disconnection state fixes.
I'm open to discussion whether synchronizing on the netty threads is appropriate or not in this scenario, or if this should be handled differently for io_uring.

This has also been made opt-in configurable, following Velocity's:
https://github.com/PaperMC/Velocity/commit/ae312339a36d9c60232a275378cf264d41d4f7c9