### PR TITLE
Call EntityDamageByEntityEvent for SulfurCube's contact damage

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
@@ -310,7 +310,7 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
          */
         WORLD_BORDER,
         /**
-         * Damage caused when an entity contacts a block such as a Cactus,
+         * Damage caused when an entity contacts an entity such as Sulfur Cube or block such as a Cactus,
          * Dripstone (Stalagmite) or Berry Bush.
          * <p>
          * Damage: variable

--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
@@ -310,8 +310,7 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
          */
         WORLD_BORDER,
         /**
-         * Damage caused when an entity contacts an entity such as Sulfur Cube or block such as a Cactus,
-         * Dripstone (Stalagmite) or Berry Bush.
+         * Damage caused when an entity contacts another entity (sulfur cube) or block (cactus, dripstone stalagmite, berry bush).
          * <p>
          * Damage: variable
          */

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/cubemob/SulfurCube.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/cubemob/SulfurCube.java.patch
@@ -85,6 +85,15 @@
              }
          }
  
+@@ -525,7 +_,7 @@
+         if (this.level() instanceof ServerLevel serverLevel) {
+             for (SulfurCubeArchetype.ContactDamage damage : this.contactDamages) {
+                 entity.hurtServer(
+-                    serverLevel, new DamageSource(damage.damageType(), damage.attributeToSource() ? this : null), damage.amount().sample(this.getRandom())
++                    serverLevel, new DamageSource(damage.damageType(), damage.attributeToSource() ? this : null).eventEntityDamager(this).knownCause(org.bukkit.event.entity.EntityDamageEvent.DamageCause.CONTACT), damage.amount().sample(this.getRandom()) // Paper - add damager for EntityDamageEvent
+                 );
+             }
+         }
 @@ -605,10 +_,26 @@
  
      @Override


### PR DESCRIPTION
Include Event Damager when Sulfur Cube apply contact damage to entities, this keep the behaviour where DamageSource can not has the source of damage if the definition of contact_damage not include that.