### PR TITLE
Limit max size of subscription codec

### DIFF
--- a/paper-server/patches/sources/net/minecraft/network/protocol/game/ServerboundDebugSubscriptionRequestPacket.java.patch
+++ b/paper-server/patches/sources/net/minecraft/network/protocol/game/ServerboundDebugSubscriptionRequestPacket.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/network/protocol/game/ServerboundDebugSubscriptionRequestPacket.java
++++ b/net/minecraft/network/protocol/game/ServerboundDebugSubscriptionRequestPacket.java
+@@ -11,10 +_,13 @@
+ import net.minecraft.util.debug.DebugSubscription;
+ 
+ public record ServerboundDebugSubscriptionRequestPacket(Set<DebugSubscription<?>> subscriptions) implements Packet<ServerGamePacketListener> {
+-    private static final StreamCodec<RegistryFriendlyByteBuf, Set<DebugSubscription<?>>> SET_STREAM_CODEC = ByteBufCodecs.registry(
+-            Registries.DEBUG_SUBSCRIPTION
+-        )
+-        .apply(ByteBufCodecs.collection(ReferenceOpenHashSet::new));
++    // Paper start - Limit max size of subscription codec
++    private static final StreamCodec<RegistryFriendlyByteBuf, Set<DebugSubscription<?>>> SET_STREAM_CODEC = ByteBufCodecs.collection(
++        ReferenceOpenHashSet::new,
++        ByteBufCodecs.registry(Registries.DEBUG_SUBSCRIPTION),
++        64
++    );
++    // Paper end - Limit max size of subscription codec
+     public static final StreamCodec<RegistryFriendlyByteBuf, ServerboundDebugSubscriptionRequestPacket> STREAM_CODEC = SET_STREAM_CODEC.map(
+         ServerboundDebugSubscriptionRequestPacket::new, ServerboundDebugSubscriptionRequestPacket::subscriptions
+     );

--- a/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -573,7 +573,7 @@
      }
  
      protected GlobalPos selectLevelLoadFocusPos() {
-@@ -639,19 +_,49 @@
+@@ -639,19 +_,50 @@
          this.stopServer();
      }
  
@@ -620,6 +620,7 @@
              this.playerList.saveAll();
 -            this.playerList.removeAll();
 +            this.playerList.removeAll(this.isRestarting); // Paper
++            this.getConnection().handleAllDisconnections(); // Paper
 +            try { Thread.sleep(100); } catch (InterruptedException ex) {} // CraftBukkit - SPIGOT-625 - give server at least a chance to send packets
          }
  

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerConnectionListener.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerConnectionListener.java.patch
@@ -135,3 +135,20 @@
                          iterator.remove();
                          connection.handleDisconnection();
                      }
+@@ -168,6 +_,16 @@
+             }
+         }
+     }
++    // Paper start
++    public void handleAllDisconnections() {
++        synchronized (this.connections) {
++            for (Connection connection : this.connections) {
++                connection.channel.close().awaitUninterruptibly();
++                connection.handleDisconnection();
++            }
++        }
++    }
++    // Paper end
+ 
+     public MinecraftServer getServer() {
+         return this.server;


### PR DESCRIPTION
### Description

This PR adds a maximum size limit to the `ServerboundDebugSubscriptionRequestPacket` codec.

Debug subscription packets are known to be abused by hack clients, in local testing, one client was able to fully occupy at least one Netty IO thread on a high-end system without triggering Paper's packet limiter.

<img width="1400" height="750" alt="image" src="https://github.com/user-attachments/assets/a7982f38-03f6-49c9-994e-0b96d0f63d8c" />

### Fix

Requests containing more than 64 subscriptions are now rejected and disconnect the client with a DecoderException to avoid excessive CPU usage and memory alloc.

The max size should be changed once Mojang adds more subscriptions in DebugSubscriptions. (currently the total count of subscriptions is 16 tho)
