### PR TITLE
Fix incorrect javadoc for LivingEntity.canBreatheUnderwater

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -1063,7 +1063,7 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
 
     /**
      * Returns true if this entity can breathe underwater and will not take
-     * suffocation damage when its air supply reaches zero.
+     * drowning damage when its air supply reaches zero.
      *
      * @return <code>true</code> if the entity can breathe underwater
      */


### PR DESCRIPTION
Noticed this javadoc was incorrect while doing the #13914 PR