### PR TITLE
Soft limit projectile list size

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/item/component/BundleContents.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/component/BundleContents.java.patch
@@ -13,18 +13,15 @@
          .map(BundleContents::new, contents -> contents.items);
      private static final Fraction BUNDLE_IN_BUNDLE_WEIGHT = Fraction.getFraction(1, 16);
      private static final int NO_STACK_INDEX = -1;
-@@ -38,6 +_,11 @@
+@@ -38,7 +_,7 @@
      private final Supplier<DataResult<Fraction>> weight;
  
      private BundleContents(final List<ItemStackTemplate> items, final int selectedItem) {
-+        // Paper start - limit size
-+        if (items.size() > 256) {
-+            throw new IllegalArgumentException("Too many items");
-+        }
-+        // Paper end - limit size
-         this.items = items;
+-        this.items = items;
++        this.items = items.size() > 256 ? items.subList(0, 256) : items; // Paper - limit size
          this.selectedItem = selectedItem;
          this.weight = Suppliers.memoize(() -> computeContentWeight(this.items));
+     }
 @@ -80,6 +_,13 @@
          return !itemToAdd.isEmpty() && itemToAdd.getItem().canFitInsideContainerItems();
      }

--- a/paper-server/patches/sources/net/minecraft/world/item/component/ChargedProjectiles.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/component/ChargedProjectiles.java.patch
@@ -15,7 +15,7 @@
 +    // Paper start - limit size
 +    public ChargedProjectiles {
 +        if (items.size() > 64) {
-+            throw new IllegalArgumentException("Too many items");
++            items = items.subList(0, 64);
 +        }
 +    }
 +    // Paper end - limit size


### PR DESCRIPTION
## Problem
Some plugins, Slimefun, or its addons, for example, provide even higher enchantment levels compared with the vanilla enchantments. And players can craft the crossbow with a higher enchat level. Thus, it can create a long projectile item list in `CrossbowItem#draw` (`EnchantmentHelper#processProjectileCount`).
Unlike the projectile size limit in CODEC, the exception throwing under these constructors will not be caught; it crashes the server instead.

example error:
<img width="2515" height="962" alt="ba1f61b2eaa97c1669851643c2b6aa9f" src="https://github.com/user-attachments/assets/71cc1d5a-b5bc-4089-8153-5961bcf13e01" />

## Fix
So it's better to use a soft limit here to prevent the server crash caused by the hard throw.
Not sure whether we still need to keep the warning message.