### PR TITLE
Prevent EnderDragon and Wither from receiving effect of vanilla sources

### DIFF
--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -522,10 +522,10 @@ index ba0cdbd064ad3e0cf645c50ab14adcddef48e932..68855c16d2cb3e5b7d7a86f05e7bb2e7
              delta = this.maybeBackOffFromEdge(delta, moverType);
              Vec3 movement = this.collide(delta);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index c471349faf04931668d40faba0f8f45937f1d711..d4fa50aa52a3a6c076d632989e21ff424eec7cf2 100644
+index 9895b1abac28d624bee16750ca146fff7094d0bd..bd5b96c87c140917a420c7e505924687005dae0b 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3404,6 +3404,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3405,6 +3405,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
      protected void playAttackSound() {
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -334,7 +334,7 @@
      }
  
      public Collection<MobEffectInstance> getActiveEffects() {
-@@ -1009,24 +_,69 @@
+@@ -1009,24 +_,70 @@
      }
  
      public final boolean addEffect(final MobEffectInstance newEffect) {
@@ -355,6 +355,7 @@
 +        // Paper start - Don't fire sync event during generation
 +        return this.addEffect(newEffect, source, cause, true);
 +    }
++
 +    public boolean addEffect(final MobEffectInstance newEffect, final @Nullable Entity source, final EntityPotionEffectEvent.Cause cause, final boolean fireEvent) {
 +        // Paper end - Don't fire sync event during generation
 +        // org.spigotmc.AsyncCatcher.catchOp("effect add"); // Spigot // Paper - move to API

--- a/paper-server/patches/sources/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java.patch
@@ -257,6 +257,21 @@
              float dist = Math.max((float)Math.sqrt(egg.distToCenterSqr(this.position())) / 4.0F, 1.0F);
              float yOffset = 6.0F / dist;
              float xRotOld = this.getXRot();
+@@ -846,8 +_,13 @@
+         return this.dragonFight;
+     }
+ 
++    // Paper start - Handle addEffect Override
+     @Override
+-    public boolean addEffect(final MobEffectInstance newEffect, final @Nullable Entity source) {
++    public boolean addEffect(final MobEffectInstance newEffect, final @Nullable Entity source, final org.bukkit.event.entity.EntityPotionEffectEvent.Cause cause, final boolean fireEvent) {
++        if (cause == org.bukkit.event.entity.EntityPotionEffectEvent.Cause.PLUGIN) {
++            super.addEffect(newEffect, source, cause, fireEvent);
++        }
++        // Paper end - Handle addEffect Override
+         return false;
+     }
+ 
 @@ -880,4 +_,23 @@
      protected float sanitizeScale(final float scale) {
          return 1.0F;

--- a/paper-server/patches/sources/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java.patch
@@ -257,18 +257,17 @@
              float dist = Math.max((float)Math.sqrt(egg.distToCenterSqr(this.position())) / 4.0F, 1.0F);
              float yOffset = 6.0F / dist;
              float xRotOld = this.getXRot();
-@@ -846,8 +_,13 @@
-         return this.dragonFight;
+@@ -847,7 +_,12 @@
      }
  
-+    // Paper start - Handle addEffect Override
      @Override
 -    public boolean addEffect(final MobEffectInstance newEffect, final @Nullable Entity source) {
++    // Paper start - Only allow plugins to bypass this requirement
 +    public boolean addEffect(final MobEffectInstance newEffect, final @Nullable Entity source, final org.bukkit.event.entity.EntityPotionEffectEvent.Cause cause, final boolean fireEvent) {
 +        if (cause == org.bukkit.event.entity.EntityPotionEffectEvent.Cause.PLUGIN) {
-+            super.addEffect(newEffect, source, cause, fireEvent);
++            return super.addEffect(newEffect, source, cause, fireEvent);
 +        }
-+        // Paper end - Handle addEffect Override
++        // Paper end - Only allow plugins to bypass this requirement
          return false;
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/boss/wither/WitherBoss.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/boss/wither/WitherBoss.java.patch
@@ -104,14 +104,14 @@
          }
      }
  
-+    // Paper start - Handle addEffect Override
      @Override
 -    public boolean addEffect(final MobEffectInstance newEffect, final @Nullable Entity source) {
++    // Paper start - Only allow plugins to bypass this requirement
 +    public boolean addEffect(final MobEffectInstance newEffect, final @Nullable Entity source, final org.bukkit.event.entity.EntityPotionEffectEvent.Cause cause, final boolean fireEvent) {
 +        if (cause == org.bukkit.event.entity.EntityPotionEffectEvent.Cause.PLUGIN) {
-+            super.addEffect(newEffect, source, cause, fireEvent);
++            return super.addEffect(newEffect, source, cause, fireEvent);
 +        }
-+        // Paper end - Handle addEffect Override
++        // Paper end - Only allow plugins to bypass this requirement
          return false;
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/boss/wither/WitherBoss.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/boss/wither/WitherBoss.java.patch
@@ -81,7 +81,7 @@
              }
  
              this.bossEvent.setProgress(this.getHealth() / this.getMaxHealth());
-@@ -488,16 +_,16 @@
+@@ -488,23 +_,28 @@
      @Override
      protected void dropCustomDeathLoot(final ServerLevel level, final DamageSource source, final boolean killedByPlayer) {
          super.dropCustomDeathLoot(level, source, killedByPlayer);
@@ -102,6 +102,19 @@
          } else {
              this.noActionTime = 0;
          }
+     }
+ 
++    // Paper start - Handle addEffect Override
+     @Override
+-    public boolean addEffect(final MobEffectInstance newEffect, final @Nullable Entity source) {
++    public boolean addEffect(final MobEffectInstance newEffect, final @Nullable Entity source, final org.bukkit.event.entity.EntityPotionEffectEvent.Cause cause, final boolean fireEvent) {
++        if (cause == org.bukkit.event.entity.EntityPotionEffectEvent.Cause.PLUGIN) {
++            super.addEffect(newEffect, source, cause, fireEvent);
++        }
++        // Paper end - Handle addEffect Override
+         return false;
+     }
+ 
 @@ -552,12 +_,18 @@
  
      @Override


### PR DESCRIPTION
Noticed by @Lulu13022002 currently you can give effects to Wither or EnderDragon by using /effects command this is caused by the method used in that command calling the custom method for add the Cause and ignore the override in that entities... this PR add the overload for that method but still allow set the effect using the API (PLUGIN cause)