### PR TITLE
Expose Entity Source for EntityPotionEffectEvent

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -623,9 +623,7 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      * @param effect PotionEffect to be added
      * @return whether the effect could be added
      */
-    default boolean addPotionEffect(@NotNull PotionEffect effect) {
-        return this.addPotionEffect(effect, false);
-    }
+    boolean addPotionEffect(@NotNull PotionEffect effect);
 
     /**
      * Adds the given {@link PotionEffect} to the living entity.
@@ -639,7 +637,9 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      * now supported.
      */
     @Deprecated(since = "1.15.2")
-    public boolean addPotionEffect(@NotNull PotionEffect effect, boolean force);
+    default boolean addPotionEffect(@NotNull PotionEffect effect, boolean force) {
+        return this.addPotionEffect(effect);
+    }
 
     /**
      * Attempts to add all of the given {@link PotionEffect} to the living

--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityPotionEffectEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityPotionEffectEvent.java
@@ -40,8 +40,14 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
         this.entitySource = entitySource;
     }
 
+    @Override
+    public LivingEntity getEntity() {
+        return (LivingEntity) super.getEntity();
+    }
+
     /**
-     * Gets the entity which caused the effect change.
+     * Gets the entity which caused the effect change
+     * (Not applicable for {@link Action#REMOVED}).
      *
      * @return The entity which caused the effect change or {@code null}
      */
@@ -93,15 +99,12 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
      * @return The effect type which will be modified on the entity.
      */
     public PotionEffectType getModifiedType() {
-        if (this.oldEffect == null && this.newEffect == null) {
-            throw new IllegalStateException("The event not has any effect, this can be caused by a plugin");
-        }
         return this.oldEffect == null ? this.newEffect.getType() : this.oldEffect.getType();
     }
 
     /**
      * Returns if the new potion effect will override the old potion effect
-     * (Only applicable for the CHANGED Action).
+     * (Only applicable for {@link Action#CHANGED}).
      *
      * @return If the new effect will override the old one.
      */
@@ -110,8 +113,8 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
     }
 
     /**
-     * Sets if the new potion effect will override the old potion effect (Only
-     * applicable for the CHANGED action).
+     * Sets if the new potion effect will override the old potion effect
+     * (Only applicable for {@link Action#CHANGED}).
      *
      * @param override If the new effect will override the old one.
      */

--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityPotionEffectEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityPotionEffectEvent.java
@@ -1,25 +1,28 @@
 package org.bukkit.event.entity;
 
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Called when a potion effect is modified on an entity.
  * <p>
  * If the event is cancelled, no change will be made on the entity.
  */
+@NullMarked
 public class EntityPotionEffectEvent extends EntityEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
-    private final PotionEffect oldEffect;
-    private final PotionEffect newEffect;
+    private final @Nullable PotionEffect oldEffect;
+    private final @Nullable PotionEffect newEffect;
+    private final @Nullable Entity entitySource;
     private final Cause cause;
     private final Action action;
     private boolean override;
@@ -27,13 +30,23 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
     private boolean cancelled;
 
     @ApiStatus.Internal
-    public EntityPotionEffectEvent(@NotNull LivingEntity livingEntity, @Nullable PotionEffect oldEffect, @Nullable PotionEffect newEffect, @NotNull Cause cause, @NotNull Action action, boolean override) {
+    public EntityPotionEffectEvent(final LivingEntity livingEntity, final @Nullable PotionEffect oldEffect, final @Nullable PotionEffect newEffect, final @Nullable Entity entitySource, final Cause cause, final Action action, final boolean override) {
         super(livingEntity);
         this.oldEffect = oldEffect;
         this.newEffect = newEffect;
         this.cause = cause;
         this.action = action;
         this.override = override;
+        this.entitySource = entitySource;
+    }
+
+    /**
+     * Gets the entity which caused the effect change.
+     *
+     * @return The entity which caused the effect change or {@code null}
+     */
+    public @Nullable Entity getSource() {
+        return this.entitySource;
     }
 
     /**
@@ -42,8 +55,7 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
      * @return The old potion effect or {@code null} if the entity did not have the
      * changed effect type.
      */
-    @Nullable
-    public PotionEffect getOldEffect() {
+    public @Nullable PotionEffect getOldEffect() {
         return this.oldEffect;
     }
 
@@ -53,8 +65,7 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
      * @return The new potion effect or {@code null} if the effect of the changed type
      * will be removed.
      */
-    @Nullable
-    public PotionEffect getNewEffect() {
+    public @Nullable PotionEffect getNewEffect() {
         return this.newEffect;
     }
 
@@ -63,7 +74,6 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
      *
      * @return A Cause value why the effect has changed.
      */
-    @NotNull
     public Cause getCause() {
         return this.cause;
     }
@@ -73,7 +83,6 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
      *
      * @return An action to be performed on the potion effect type.
      */
-    @NotNull
     public Action getAction() {
         return this.action;
     }
@@ -83,9 +92,11 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
      *
      * @return The effect type which will be modified on the entity.
      */
-    @NotNull
     public PotionEffectType getModifiedType() {
-        return (this.oldEffect == null) ? ((this.newEffect == null) ? null : this.newEffect.getType()) : this.oldEffect.getType(); // todo not null?
+        if (this.oldEffect == null && this.newEffect == null) {
+            throw new IllegalStateException("The event not has any effect, this can be caused by a plugin");
+        }
+        return this.oldEffect == null ? this.newEffect.getType() : this.oldEffect.getType();
     }
 
     /**
@@ -118,13 +129,11 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
         this.cancelled = cancel;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
 
-    @NotNull
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityPotionEffectEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityPotionEffectEvent.java
@@ -34,10 +34,10 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
         super(livingEntity);
         this.oldEffect = oldEffect;
         this.newEffect = newEffect;
+        this.entitySource = entitySource;
         this.cause = cause;
         this.action = action;
         this.override = override;
-        this.entitySource = entitySource;
     }
 
     @Override
@@ -46,10 +46,10 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
     }
 
     /**
-     * Gets the entity which caused the effect change
+     * Gets the entity which caused the effect to change
      * (Not applicable for {@link Action#REMOVED}).
      *
-     * @return The entity which caused the effect change or {@code null}
+     * @return The entity which caused the effect to change or {@code null}
      */
     public @Nullable Entity getSource() {
         return this.entitySource;

--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityPotionEffectEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityPotionEffectEvent.java
@@ -46,16 +46,6 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
     }
 
     /**
-     * Gets the entity which caused the effect to change
-     * (Not applicable for {@link Action#REMOVED}).
-     *
-     * @return The entity which caused the effect to change or {@code null}
-     */
-    public @Nullable Entity getSource() {
-        return this.entitySource;
-    }
-
-    /**
      * Gets the old potion effect of the changed type, which will be removed.
      *
      * @return The old potion effect or {@code null} if the entity did not have the
@@ -73,6 +63,16 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable 
      */
     public @Nullable PotionEffect getNewEffect() {
         return this.newEffect;
+    }
+
+    /**
+     * Gets the entity which caused the effect to change
+     * (Not applicable for {@link Action#REMOVED}).
+     *
+     * @return The entity which caused the effect to change or {@code null}
+     */
+    public @Nullable Entity getSource() {
+        return this.entitySource;
     }
 
     /**

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -522,10 +522,10 @@ index ba0cdbd064ad3e0cf645c50ab14adcddef48e932..68855c16d2cb3e5b7d7a86f05e7bb2e7
              delta = this.maybeBackOffFromEdge(delta, moverType);
              Vec3 movement = this.collide(delta);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index c7466b4bc4169d43d8fda6d4c143c9f7e7ad07c2..11cbf9b301c1e03925f635f7ae7b3b5e97aa1657 100644
+index b94efe5ec36c2203b10645994066058578cd308b..9b0b1b56768d6209abc5dfd582fb43fb7f552126 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3409,6 +3409,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3386,6 +3386,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
      protected void playAttackSound() {
      }
  

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -522,10 +522,10 @@ index ba0cdbd064ad3e0cf645c50ab14adcddef48e932..68855c16d2cb3e5b7d7a86f05e7bb2e7
              delta = this.maybeBackOffFromEdge(delta, moverType);
              Vec3 movement = this.collide(delta);
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 9895b1abac28d624bee16750ca146fff7094d0bd..bd5b96c87c140917a420c7e505924687005dae0b 100644
+index c7466b4bc4169d43d8fda6d4c143c9f7e7ad07c2..11cbf9b301c1e03925f635f7ae7b3b5e97aa1657 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3405,6 +3405,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3409,6 +3409,14 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
      protected void playAttackSound() {
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -230,7 +230,7 @@
          }, this::clearSleepingPos);
          input.read("Brain", Brain.Packed.CODEC).ifPresent(packedBrain -> this.brain = this.makeBrain(packedBrain));
          this.lastHurtByPlayer = EntityReference.read(input, "last_hurt_by_player");
-@@ -846,15 +_,44 @@
+@@ -846,15 +_,46 @@
          this.updateDirtyEffects();
      }
  
@@ -240,13 +240,15 @@
 +
 +    private static class ProcessableEffect {
 +
-+        private Holder<MobEffect> type;
-+        private MobEffectInstance effect;
++        private @Nullable Holder<MobEffect> type;
++        private @Nullable MobEffectInstance effect;
++        private @Nullable Entity source;
 +        private final EntityPotionEffectEvent.Cause cause;
 +
-+        private ProcessableEffect(MobEffectInstance effect, EntityPotionEffectEvent.Cause cause) {
++        private ProcessableEffect(MobEffectInstance effect, @Nullable Entity source, EntityPotionEffectEvent.Cause cause) {
 +            this.effect = effect;
 +            this.cause = cause;
++            this.source = source;
 +        }
 +
 +        private ProcessableEffect(Holder<MobEffect> type, EntityPotionEffectEvent.Cause cause) {
@@ -275,18 +277,20 @@
                          iterator.remove();
                          this.onEffectsRemoved(List.of(effect));
                      } else if (effect.getDuration() % 600 == 0) {
-@@ -863,6 +_,18 @@
+@@ -863,6 +_,20 @@
                  }
              } catch (ConcurrentModificationException var6) {
              }
 +
 +            // CraftBukkit start
 +            this.isTickingEffects = false;
-+            for (ProcessableEffect effect : this.effectsToProcess) {
++            for (final ProcessableEffect effect : this.effectsToProcess) {
 +                if (effect.effect != null) {
-+                    this.addEffect(effect.effect, effect.cause);
++                    this.addEffect(effect.effect, effect.source, effect.cause);
 +                } else {
-+                    this.removeEffect(effect.type, effect.cause);
++                    if (effect.type != null) {
++                        this.removeEffect(effect.type, effect.cause);
++                    }
 +                }
 +            }
 +            this.effectsToProcess.clear();
@@ -360,7 +364,7 @@
 +        // Paper end - Don't fire sync event during generation
 +        // org.spigotmc.AsyncCatcher.catchOp("effect add"); // Spigot // Paper - move to API
 +        if (this.isTickingEffects) {
-+            this.effectsToProcess.add(new ProcessableEffect(newEffect, cause));
++            this.effectsToProcess.add(new ProcessableEffect(newEffect, source, cause));
 +            return true;
 +        }
 +        // CraftBukkit end
@@ -379,7 +383,7 @@
 +        }
 +
 +        if (fireEvent) {
-+            EntityPotionEffectEvent event = CraftEventFactory.callEntityPotionEffectChangeEvent(this, effect, newEffect, cause, override);
++            EntityPotionEffectEvent event = CraftEventFactory.callEntityPotionEffectChangeEvent(this, effect, newEffect, source, cause, override);
 +            override = event.isOverride();
 +            if (event.isCancelled()) {
 +                return false;

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -230,39 +230,18 @@
          }, this::clearSleepingPos);
          input.read("Brain", Brain.Packed.CODEC).ifPresent(packedBrain -> this.brain = this.makeBrain(packedBrain));
          this.lastHurtByPlayer = EntityReference.read(input, "last_hurt_by_player");
-@@ -846,15 +_,46 @@
+@@ -846,15 +_,25 @@
          this.updateDirtyEffects();
      }
  
-+    // CraftBukkit start
-+    private boolean isTickingEffects = false;
-+    private final List<ProcessableEffect> effectsToProcess = Lists.newArrayList();
-+
-+    private static class ProcessableEffect {
-+
-+        private @Nullable Holder<MobEffect> type;
-+        private @Nullable MobEffectInstance effect;
-+        private @Nullable Entity source;
-+        private final EntityPotionEffectEvent.Cause cause;
-+
-+        private ProcessableEffect(MobEffectInstance effect, @Nullable Entity source, EntityPotionEffectEvent.Cause cause) {
-+            this.effect = effect;
-+            this.cause = cause;
-+            this.source = source;
-+        }
-+
-+        private ProcessableEffect(Holder<MobEffect> type, EntityPotionEffectEvent.Cause cause) {
-+            this.type = type;
-+            this.cause = cause;
-+        }
-+    }
-+    // CraftBukkit end
++    private boolean tickingEffects = false; // CraftBukkit
++    private final java.util.Queue<Runnable> deferredEffectUpdates = new java.util.concurrent.ConcurrentLinkedQueue<>(); // CraftBukkit
 +
      protected void tickEffects() {
          if (this.level() instanceof ServerLevel serverLevel) {
              Iterator<Holder<MobEffect>> iterator = this.activeEffects.keySet().iterator();
  
-+            this.isTickingEffects = true; // CraftBukkit
++            this.tickingEffects = true; // CraftBukkit
              try {
                  while (iterator.hasNext()) {
                      Holder<MobEffect> mobEffect = iterator.next();
@@ -277,23 +256,16 @@
                          iterator.remove();
                          this.onEffectsRemoved(List.of(effect));
                      } else if (effect.getDuration() % 600 == 0) {
-@@ -863,6 +_,20 @@
+@@ -863,6 +_,13 @@
                  }
              } catch (ConcurrentModificationException var6) {
              }
-+
 +            // CraftBukkit start
-+            this.isTickingEffects = false;
-+            for (final ProcessableEffect effect : this.effectsToProcess) {
-+                if (effect.effect != null) {
-+                    this.addEffect(effect.effect, effect.source, effect.cause);
-+                } else {
-+                    if (effect.type != null) {
-+                        this.removeEffect(effect.type, effect.cause);
-+                    }
-+                }
++            this.tickingEffects = false;
++            Runnable task;
++            while ((task = this.deferredEffectUpdates.poll()) != null) {
++                task.run();
 +            }
-+            this.effectsToProcess.clear();
 +            // CraftBukkit end
          } else {
              for (MobEffectInstance effect : this.activeEffects.values()) {
@@ -338,7 +310,7 @@
      }
  
      public Collection<MobEffectInstance> getActiveEffects() {
-@@ -1009,24 +_,70 @@
+@@ -1009,24 +_,69 @@
      }
  
      public final boolean addEffect(final MobEffectInstance newEffect) {
@@ -362,9 +334,8 @@
 +
 +    public boolean addEffect(final MobEffectInstance newEffect, final @Nullable Entity source, final EntityPotionEffectEvent.Cause cause, final boolean fireEvent) {
 +        // Paper end - Don't fire sync event during generation
-+        // org.spigotmc.AsyncCatcher.catchOp("effect add"); // Spigot // Paper - move to API
-+        if (this.isTickingEffects) {
-+            this.effectsToProcess.add(new ProcessableEffect(newEffect, source, cause));
++        if (this.tickingEffects) {
++            this.deferredEffectUpdates.offer(() -> this.addEffect(newEffect, source, cause, fireEvent));
 +            return true;
 +        }
 +        // CraftBukkit end
@@ -383,7 +354,7 @@
 +        }
 +
 +        if (fireEvent) {
-+            EntityPotionEffectEvent event = CraftEventFactory.callEntityPotionEffectChangeEvent(this, effect, newEffect, source, cause, override);
++            EntityPotionEffectEvent event = CraftEventFactory.callEntityPotionEffectChangeEvent(this, effect, newEffect, source, cause, null, override);
 +            override = event.isOverride();
 +            if (event.isCancelled()) {
 +                return false;
@@ -411,16 +382,17 @@
          }
  
          newEffect.onEffectStarted(this);
-@@ -1060,11 +_,35 @@
+@@ -1060,11 +_,41 @@
      }
  
      public final @Nullable MobEffectInstance removeEffectNoUpdate(final Holder<MobEffect> effect) {
 +        // CraftBukkit start
 +        return this.removeEffectNoUpdate(effect, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.UNKNOWN);
 +    }
-+    public @Nullable MobEffectInstance removeEffectNoUpdate(final Holder<MobEffect> effect, final EntityPotionEffectEvent.Cause cause) {
-+        if (this.isTickingEffects) {
-+            this.effectsToProcess.add(new ProcessableEffect(effect, cause));
++
++    public final @Nullable MobEffectInstance removeEffectNoUpdate(final Holder<MobEffect> effect, final EntityPotionEffectEvent.Cause cause) {
++        if (this.tickingEffects) {
++            this.deferredEffectUpdates.offer(() -> this.removeEffectNoUpdate(effect, cause));
 +            return null;
 +        }
 +
@@ -443,6 +415,11 @@
 +    }
 +
 +    public boolean removeEffect(final Holder<MobEffect> effect, final EntityPotionEffectEvent.Cause cause) {
++        if (this.tickingEffects) {
++            this.deferredEffectUpdates.offer(() -> this.removeEffect(effect, cause));
++            return true;
++        }
++
 +        MobEffectInstance effectInstance = this.removeEffectNoUpdate(effect, cause);
 +        // CraftBukkit end
          if (effectInstance != null) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
@@ -504,10 +504,9 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
     }
 
     @Override
-    public boolean addPotionEffect(PotionEffect effect, boolean force) {
+    public boolean addPotionEffect(PotionEffect effect) {
         org.spigotmc.AsyncCatcher.catchOp("effect add"); // Paper
-        this.getHandle().addEffect(org.bukkit.craftbukkit.potion.CraftPotionUtil.fromBukkit(effect), EntityPotionEffectEvent.Cause.PLUGIN); // Paper - Don't ignore icon
-        return true;
+        return this.getHandle().addEffect(org.bukkit.craftbukkit.potion.CraftPotionUtil.fromBukkit(effect), EntityPotionEffectEvent.Cause.PLUGIN); // Paper - Don't ignore icon
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import net.minecraft.Optionull;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -1885,14 +1886,14 @@ public class CraftEventFactory {
     }
 
     public static EntityPotionEffectEvent callEntityPotionEffectChangeEvent(net.minecraft.world.entity.LivingEntity entity, @Nullable MobEffectInstance oldEffect, @Nullable MobEffectInstance newEffect, EntityPotionEffectEvent.Cause cause) {
-        return CraftEventFactory.callEntityPotionEffectChangeEvent(entity, oldEffect, newEffect, cause, true);
+        return CraftEventFactory.callEntityPotionEffectChangeEvent(entity, oldEffect, newEffect, null, cause, true);
     }
 
     public static EntityPotionEffectEvent callEntityPotionEffectChangeEvent(net.minecraft.world.entity.LivingEntity entity, @Nullable MobEffectInstance oldEffect, @Nullable MobEffectInstance newEffect, EntityPotionEffectEvent.Cause cause, EntityPotionEffectEvent.Action action) {
-        return CraftEventFactory.callEntityPotionEffectChangeEvent(entity, oldEffect, newEffect, cause, action, true);
+        return CraftEventFactory.callEntityPotionEffectChangeEvent(entity, oldEffect, newEffect, null, cause, action, true);
     }
 
-    public static EntityPotionEffectEvent callEntityPotionEffectChangeEvent(net.minecraft.world.entity.LivingEntity entity, @Nullable MobEffectInstance oldEffect, @Nullable MobEffectInstance newEffect, EntityPotionEffectEvent.Cause cause, boolean willOverride) {
+    public static EntityPotionEffectEvent callEntityPotionEffectChangeEvent(net.minecraft.world.entity.LivingEntity entity, @Nullable MobEffectInstance oldEffect, @Nullable MobEffectInstance newEffect, @Nullable net.minecraft.world.entity.Entity source, EntityPotionEffectEvent.Cause cause, boolean willOverride) {
         EntityPotionEffectEvent.Action action = EntityPotionEffectEvent.Action.CHANGED;
         if (oldEffect == null) {
             action = EntityPotionEffectEvent.Action.ADDED;
@@ -1900,16 +1901,16 @@ public class CraftEventFactory {
             action = EntityPotionEffectEvent.Action.REMOVED;
         }
 
-        return CraftEventFactory.callEntityPotionEffectChangeEvent(entity, oldEffect, newEffect, cause, action, willOverride);
+        return CraftEventFactory.callEntityPotionEffectChangeEvent(entity, oldEffect, newEffect, source, cause, action, willOverride);
     }
 
-    public static EntityPotionEffectEvent callEntityPotionEffectChangeEvent(net.minecraft.world.entity.LivingEntity entity, @Nullable MobEffectInstance oldEffect, @Nullable MobEffectInstance newEffect, EntityPotionEffectEvent.Cause cause, EntityPotionEffectEvent.Action action, boolean willOverride) {
+    public static EntityPotionEffectEvent callEntityPotionEffectChangeEvent(net.minecraft.world.entity.LivingEntity entity, @Nullable MobEffectInstance oldEffect, @Nullable MobEffectInstance newEffect, @Nullable net.minecraft.world.entity.Entity source, EntityPotionEffectEvent.Cause cause, EntityPotionEffectEvent.Action action, boolean willOverride) {
         PotionEffect bukkitOldEffect = (oldEffect == null) ? null : CraftPotionUtil.toBukkit(oldEffect);
         PotionEffect bukkitNewEffect = (newEffect == null) ? null : CraftPotionUtil.toBukkit(newEffect);
 
         Preconditions.checkState(bukkitOldEffect != null || bukkitNewEffect != null, "Old and new potion effect are both null");
 
-        EntityPotionEffectEvent event = new EntityPotionEffectEvent((LivingEntity) entity.getBukkitEntity(), bukkitOldEffect, bukkitNewEffect, cause, action, willOverride);
+        EntityPotionEffectEvent event = new EntityPotionEffectEvent((LivingEntity) entity.getBukkitEntity(), bukkitOldEffect, bukkitNewEffect, Optionull.map(source, Entity::getBukkitEntity), cause, action, willOverride);
         Bukkit.getPluginManager().callEvent(event);
 
         return event;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -2,7 +2,6 @@ package org.bukkit.craftbukkit.event;
 
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.mojang.authlib.GameProfile;
 import com.mojang.datafixers.util.Either;
@@ -1886,31 +1885,30 @@ public class CraftEventFactory {
     }
 
     public static EntityPotionEffectEvent callEntityPotionEffectChangeEvent(net.minecraft.world.entity.LivingEntity entity, @Nullable MobEffectInstance oldEffect, @Nullable MobEffectInstance newEffect, EntityPotionEffectEvent.Cause cause) {
-        return CraftEventFactory.callEntityPotionEffectChangeEvent(entity, oldEffect, newEffect, null, cause, true);
+        return CraftEventFactory.callEntityPotionEffectChangeEvent(entity, oldEffect, newEffect, null, cause, null, true);
     }
 
     public static EntityPotionEffectEvent callEntityPotionEffectChangeEvent(net.minecraft.world.entity.LivingEntity entity, @Nullable MobEffectInstance oldEffect, @Nullable MobEffectInstance newEffect, EntityPotionEffectEvent.Cause cause, EntityPotionEffectEvent.Action action) {
         return CraftEventFactory.callEntityPotionEffectChangeEvent(entity, oldEffect, newEffect, null, cause, action, true);
     }
 
-    public static EntityPotionEffectEvent callEntityPotionEffectChangeEvent(net.minecraft.world.entity.LivingEntity entity, @Nullable MobEffectInstance oldEffect, @Nullable MobEffectInstance newEffect, @Nullable net.minecraft.world.entity.Entity source, EntityPotionEffectEvent.Cause cause, boolean willOverride) {
-        EntityPotionEffectEvent.Action action = EntityPotionEffectEvent.Action.CHANGED;
+    private static EntityPotionEffectEvent.Action computeEffectAction(@Nullable MobEffectInstance oldEffect, @Nullable MobEffectInstance newEffect) {
         if (oldEffect == null) {
-            action = EntityPotionEffectEvent.Action.ADDED;
-        } else if (newEffect == null) {
-            action = EntityPotionEffectEvent.Action.REMOVED;
+            return EntityPotionEffectEvent.Action.ADDED;
         }
-
-        return CraftEventFactory.callEntityPotionEffectChangeEvent(entity, oldEffect, newEffect, source, cause, action, willOverride);
+        if (newEffect == null) {
+            return EntityPotionEffectEvent.Action.REMOVED;
+        }
+        return EntityPotionEffectEvent.Action.CHANGED;
     }
 
-    public static EntityPotionEffectEvent callEntityPotionEffectChangeEvent(net.minecraft.world.entity.LivingEntity entity, @Nullable MobEffectInstance oldEffect, @Nullable MobEffectInstance newEffect, @Nullable net.minecraft.world.entity.Entity source, EntityPotionEffectEvent.Cause cause, EntityPotionEffectEvent.Action action, boolean willOverride) {
+    public static EntityPotionEffectEvent callEntityPotionEffectChangeEvent(net.minecraft.world.entity.LivingEntity entity, @Nullable MobEffectInstance oldEffect, @Nullable MobEffectInstance newEffect, @Nullable net.minecraft.world.entity.Entity source, EntityPotionEffectEvent.Cause cause, @Nullable EntityPotionEffectEvent.Action knownAction, boolean willOverride) {
+        assert oldEffect != null || newEffect != null;
+
         PotionEffect bukkitOldEffect = (oldEffect == null) ? null : CraftPotionUtil.toBukkit(oldEffect);
         PotionEffect bukkitNewEffect = (newEffect == null) ? null : CraftPotionUtil.toBukkit(newEffect);
 
-        Preconditions.checkState(bukkitOldEffect != null || bukkitNewEffect != null, "Old and new potion effect are both null");
-
-        EntityPotionEffectEvent event = new EntityPotionEffectEvent((LivingEntity) entity.getBukkitEntity(), bukkitOldEffect, bukkitNewEffect, Optionull.map(source, Entity::getBukkitEntity), cause, action, willOverride);
+        EntityPotionEffectEvent event = new EntityPotionEffectEvent((LivingEntity) entity.getBukkitEntity(), bukkitOldEffect, bukkitNewEffect, Optionull.map(source, Entity::getBukkitEntity), cause, knownAction != null ? knownAction : computeEffectAction(oldEffect, newEffect), willOverride);
         Bukkit.getPluginManager().callEvent(event);
 
         return event;


### PR DESCRIPTION
This PR its related to https://github.com/PaperMC/Paper/pull/13955 with a suggestion from lulu, where can be good expose the source entity related to a effect.