### PR TITLE
Fix Geyser particle options waterBlocks precondition

### DIFF
--- a/paper-api/src/main/java/org/bukkit/Particle.java
+++ b/paper-api/src/main/java/org/bukkit/Particle.java
@@ -423,7 +423,7 @@ public enum Particle implements Keyed {
         private final int waterBlocks;
 
         protected AbstractGeyser(final int waterBlocks) {
-            Preconditions.checkArgument(waterBlocks > 1, "waterBlocks must be positive");
+            Preconditions.checkArgument(waterBlocks > 0, "waterBlocks must be positive");
             this.waterBlocks = waterBlocks;
         }
 


### PR DESCRIPTION
This PR fixes the waterBlocks argument precondition which required the minimum amount to be 2 instead of 1.