### PR TITLE
Fix ItemContainerContents containing null values

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemContainerContents.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperItemContainerContents.java
@@ -19,7 +19,7 @@ public record PaperItemContainerContents(
 
     @Override
     public List<ItemStack> contents() {
-        return MCUtil.transformUnmodifiable(this.impl.items, optional -> optional.map(CraftItemStack::asBukkitCopy).orElse(null));
+        return MCUtil.transformUnmodifiable(this.impl.items, optional -> optional.map(CraftItemStack::asBukkitCopy).orElse(ItemStack.empty()));
     }
 
     static final class BuilderImpl implements ItemContainerContents.Builder {


### PR DESCRIPTION
For some reason PaperItemContainerContents was passing null and not an empty ItemStack in its returned output, even though its marked as nonnull & when creating an ItemContainerContents null is not permitted, this just corrects that.