### PR TITLE
Fix build limit message being sent when it shouldn't be

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1235,7 +1235,7 @@
                                      this.player.swing(hand, true);
                                  }
  
-@@ -1394,6 +_,15 @@
+@@ -1394,20 +_,24 @@
                                      && success.swingSource() == InteractionResult.SwingSource.SERVER) {
                                      this.player.swing(hand, true);
                                  }
@@ -1249,9 +1249,10 @@
 +                                }
 +                            // Paper end - Fix inventory desync
                              } else {
-                                 this.player.sendBuildLimitMessage(true, maxY);
+-                                this.player.sendBuildLimitMessage(true, maxY);
++                                // this.player.sendBuildLimitMessage(true, maxY); // Paper - Fix MC-306582: Fix build limit message being sent when it shouldn't be
                              }
-@@ -1401,13 +_,8 @@
+ 
                              this.send(new ClientboundBlockUpdatePacket(level, pos));
                              this.send(new ClientboundBlockUpdatePacket(level, pos.relative(direction)));
                          }


### PR DESCRIPTION
Closes #13941

As far as I can tell this line being there doesn't make a lot of sense and is likely a leftover, see https://github.com/PaperMC/Paper/issues/13941#issuecomment-4642200340 for mcsrc links for comparing.

Before, this line was an else for a statement that checked the height, but after the changes in that snapshot it's now an else for the `this.awaitingPositionFromClient == null && level.mayInteract(this.player, pos)` check, which is wrong since neither of those have anything to do with reaching max height.