### PR TITLE
Use a concurrent cache in CraftRegistry

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
@@ -10,10 +10,10 @@ import io.papermc.paper.registry.tag.Tag;
 import io.papermc.paper.util.Holderable;
 import io.papermc.paper.util.MCUtil;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import net.minecraft.core.Holder;
@@ -148,12 +148,12 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
     }
 
     private final Class<?> bukkitClass; // Paper - relax preload class
-    private final Map<NamespacedKey, B> cache = new HashMap<>();
+    private final Map<NamespacedKey, B> cache = new ConcurrentHashMap<>();
     private final net.minecraft.core.Registry<M> minecraftRegistry;
     private final io.papermc.paper.registry.entry.RegistryTypeMapper<M, B> minecraftToBukkit; // Paper - switch to Holder
     private final BiFunction<NamespacedKey, ApiVersion, NamespacedKey> serializationUpdater; // Paper - rename to make it *clear* what it is *only* for
     private final InvalidHolderOwner invalidHolderOwner = new InvalidHolderOwner();
-    private boolean lockReferenceHolders;
+    private volatile boolean lockReferenceHolders;
 
     public CraftRegistry(Class<?> bukkitClass, net.minecraft.core.Registry<M> minecraftRegistry, BiFunction<? super NamespacedKey, M, B> minecraftToBukkit, BiFunction<NamespacedKey, ApiVersion, NamespacedKey> serializationUpdater) { // Paper - relax preload class
         // Paper start - switch to Holder
@@ -190,11 +190,10 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
 
     @Override
     public B get(NamespacedKey namespacedKey) {
-        B cached = this.cache.get(namespacedKey);
-        if (cached != null) {
-            return cached;
-        }
+        return this.cache.computeIfAbsent(namespacedKey, this::loadBukkit);
+    }
 
+    private B loadBukkit(final NamespacedKey namespacedKey) {
         // Important to use the ResourceKey<?> "get" method below because it will work before registry is frozen
         final Optional<Holder.Reference<M>> holderOptional = this.minecraftRegistry.get(CraftNamespacedKey.toResourceKey(this.minecraftRegistry.key(), namespacedKey));
         final Holder.Reference<M> holder;
@@ -208,11 +207,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
         } else {
             return null;
         }
-        final B bukkit = this.createBukkit(holder);
-
-        this.cache.put(namespacedKey, bukkit);
-
-        return bukkit;
+        return this.createBukkit(holder);
     }
 
     @NotNull


### PR DESCRIPTION
### Problem

`CraftRegistry#get` lazily populates its backing `cache`, reading and then writing a plain `HashMap` with no synchronization.

This cache is reached off the main thread while building `ItemMeta`:

- `CraftItemStack#getItemMeta` resolves the item's `CraftItemType` via `CraftRegistry#get` (to select the meta subclass), and
- `CraftMetaItem` resolves the item's enchantments through `CraftRegistry#get`.

Plugins routinely build `ItemMeta` from other threads, so this map is read and written concurrently, which is unsafe for a `HashMap`.

### Change

- Switch `cache` to a `ConcurrentHashMap`.
- Collapse the `get()`-then-`put()` sequence into a single atomic `computeIfAbsent`.
- Make `lockReferenceHolders` `volatile`, since it is now read from the concurrent `get()` path and flipped once during startup.

### Why this is safe for `computeIfAbsent`

`ConcurrentHashMap#computeIfAbsent` forbids the mapping function from updating the **same** map (recursive update → `IllegalStateException`/bin live-lock). The registry wrapper constructors registered in `PaperRegistries` uniformly just store their `Holder` and defer derived work via `Suppliers.memoize(...)`; the mapping function only touches the NMS registry and `Holder.Reference#createStandAlone`, never this cache. So it never re-enters the map. Any cross-registry resolution a wrapper may perform later targets a different `CraftRegistry` instance (different map) and is lazy regardless.