### PR TITLE
Add built-in /ping, /seen, /playtime, /invsee commands

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/command/InvSeeCommand.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/InvSeeCommand.java
@@ -1,0 +1,80 @@
+package io.papermc.paper.command;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.NamedTextColor.GOLD;
+import static net.kyori.adventure.text.format.NamedTextColor.GRAY;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
+
+@DefaultQualifier(NonNull.class)
+public final class InvSeeCommand extends Command {
+
+    public InvSeeCommand(final String name) {
+        super(name);
+        this.description = "Open another player's inventory";
+        this.usageMessage = "/invsee <player>";
+        this.setPermission("bukkit.command.invsee");
+    }
+
+    @Override
+    public boolean execute(final CommandSender sender, final String commandLabel, final String[] args) {
+        if (!testPermission(sender)) return true;
+
+        if (!(sender instanceof final Player viewer)) {
+            sender.sendMessage(text("Only players can use this command.", RED));
+            return true;
+        }
+
+        if (args.length == 0) {
+            sender.sendMessage(text("Usage: " + this.usageMessage, RED));
+            return true;
+        }
+
+        final Player target = Bukkit.getPlayerExact(args[0]);
+        if (target == null) {
+            sender.sendMessage(text("Player not found or not online: " + args[0], RED));
+            return true;
+        }
+
+        if (target.equals(viewer)) {
+            sender.sendMessage(text("You cannot open your own inventory with this command.", RED));
+            return true;
+        }
+
+        viewer.openInventory(target.getInventory());
+        sender.sendMessage(
+            text("Opened ", GRAY)
+                .append(text(target.getName(), GOLD))
+                .append(text("'s inventory.", GRAY))
+        );
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(final CommandSender sender, final String alias, final String[] args, final Location location) {
+        if (args.length == 1) {
+            final List<String> names = new ArrayList<>();
+            for (final Player player : Bukkit.getOnlinePlayers()) {
+                if (sender instanceof final Player p) {
+                    if (p.equals(player)) continue;
+                    if (!p.canSee(player)) continue;
+                }
+                if (player.getName().toLowerCase().startsWith(args[0].toLowerCase())) {
+                    names.add(player.getName());
+                }
+            }
+            return names;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/command/PaperCommands.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/PaperCommands.java
@@ -24,6 +24,10 @@ public final class PaperCommands {
     public static void registerCommands(final MinecraftServer server) {
         COMMANDS.put("paper", new PaperCommand("paper"));
         COMMANDS.put("mspt", new MSPTCommand("mspt"));
+        COMMANDS.put("ping", new PingCommand("ping"));
+        COMMANDS.put("seen", new SeenCommand("seen"));
+        COMMANDS.put("playtime", new PlaytimeCommand("playtime"));
+        COMMANDS.put("invsee", new InvSeeCommand("invsee"));
 
         COMMANDS.forEach((s, command) -> {
             server.server.getCommandMap().register(s, "Paper", command);

--- a/paper-server/src/main/java/io/papermc/paper/command/PingCommand.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/PingCommand.java
@@ -1,0 +1,83 @@
+package io.papermc.paper.command;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.NamedTextColor.GOLD;
+import static net.kyori.adventure.text.format.NamedTextColor.GRAY;
+import static net.kyori.adventure.text.format.NamedTextColor.GREEN;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
+import static net.kyori.adventure.text.format.NamedTextColor.YELLOW;
+
+@DefaultQualifier(NonNull.class)
+public final class PingCommand extends Command {
+
+    public PingCommand(final String name) {
+        super(name);
+        this.description = "View the ping of a player";
+        this.usageMessage = "/ping [player]";
+        this.setPermission("bukkit.command.ping");
+    }
+
+    @Override
+    public boolean execute(final CommandSender sender, final String commandLabel, final String[] args) {
+        if (!testPermission(sender)) return true;
+
+        final Player target;
+        if (args.length == 0) {
+            if (!(sender instanceof final Player self)) {
+                sender.sendMessage(text("Console must specify a player name.", RED));
+                return true;
+            }
+            target = self;
+        } else {
+            if (!sender.hasPermission("bukkit.command.ping.others")) {
+                sender.sendMessage(text("You don't have permission to check other players' ping.", RED));
+                return true;
+            }
+            target = Bukkit.getPlayerExact(args[0]);
+            if (target == null) {
+                sender.sendMessage(text("Player not found: " + args[0], RED));
+                return true;
+            }
+        }
+
+        final int ping = target.getPing();
+        sender.sendMessage(
+            text(target.getName(), GOLD)
+                .append(text("'s ping: ", GRAY))
+                .append(text(ping + "ms", pingColor(ping)))
+        );
+        return true;
+    }
+
+    private static net.kyori.adventure.text.format.TextColor pingColor(final int ping) {
+        if (ping < 100) return GREEN;
+        if (ping < 200) return YELLOW;
+        return RED;
+    }
+
+    @Override
+    public List<String> tabComplete(final CommandSender sender, final String alias, final String[] args, final Location location) {
+        if (args.length == 1 && sender.hasPermission("bukkit.command.ping.others")) {
+            final List<String> names = new ArrayList<>();
+            for (final Player player : Bukkit.getOnlinePlayers()) {
+                if (sender instanceof final Player p && !p.canSee(player)) continue;
+                if (player.getName().toLowerCase().startsWith(args[0].toLowerCase())) {
+                    names.add(player.getName());
+                }
+            }
+            return names;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/command/PlaytimeCommand.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/PlaytimeCommand.java
@@ -1,0 +1,114 @@
+package io.papermc.paper.command;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Statistic;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.NamedTextColor.GOLD;
+import static net.kyori.adventure.text.format.NamedTextColor.GRAY;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
+import static net.kyori.adventure.text.format.NamedTextColor.YELLOW;
+
+@DefaultQualifier(NonNull.class)
+public final class PlaytimeCommand extends Command {
+
+    public PlaytimeCommand(final String name) {
+        super(name);
+        this.description = "View a player's total playtime";
+        this.usageMessage = "/playtime [player]";
+        this.setPermission("bukkit.command.playtime");
+    }
+
+    @Override
+    public boolean execute(final CommandSender sender, final String commandLabel, final String[] args) {
+        if (!testPermission(sender)) return true;
+
+        final OfflinePlayer target;
+        final String targetName;
+
+        if (args.length == 0) {
+            if (!(sender instanceof final Player self)) {
+                sender.sendMessage(text("Console must specify a player name.", RED));
+                return true;
+            }
+            target = self;
+            targetName = self.getName();
+        } else {
+            if (!sender.hasPermission("bukkit.command.playtime.others")) {
+                sender.sendMessage(text("You don't have permission to check other players' playtime.", RED));
+                return true;
+            }
+            final Player online = Bukkit.getPlayerExact(args[0]);
+            if (online != null) {
+                target = online;
+                targetName = online.getName();
+            } else {
+                @SuppressWarnings("deprecation")
+                final OfflinePlayer offline = Bukkit.getOfflinePlayer(args[0]);
+                if (!offline.hasPlayedBefore()) {
+                    sender.sendMessage(text("Player not found: " + args[0], RED));
+                    return true;
+                }
+                target = offline;
+                targetName = offline.getName() != null ? offline.getName() : args[0];
+            }
+        }
+
+        final int ticks;
+        try {
+            ticks = target.getStatistic(Statistic.PLAY_ONE_MINUTE);
+        } catch (final Exception e) {
+            sender.sendMessage(text("Could not retrieve playtime for " + targetName + ".", RED));
+            return true;
+        }
+
+        sender.sendMessage(
+            text(targetName, GOLD)
+                .append(text("'s playtime: ", GRAY))
+                .append(text(formatTicks(ticks), YELLOW))
+        );
+        return true;
+    }
+
+    private static String formatTicks(final int ticks) {
+        long seconds = ticks / 20;
+        long minutes = seconds / 60;
+        long hours = minutes / 60;
+        final long days = hours / 24;
+        minutes %= 60;
+        hours %= 24;
+
+        if (days > 0) {
+            return days + "d " + hours + "h " + minutes + "m";
+        } else if (hours > 0) {
+            return hours + "h " + minutes + "m";
+        } else {
+            return minutes + "m";
+        }
+    }
+
+    @Override
+    public List<String> tabComplete(final CommandSender sender, final String alias, final String[] args, final Location location) {
+        if (args.length == 1 && sender.hasPermission("bukkit.command.playtime.others")) {
+            final List<String> names = new ArrayList<>();
+            for (final Player player : Bukkit.getOnlinePlayers()) {
+                if (sender instanceof final Player p && !p.canSee(player)) continue;
+                if (player.getName().toLowerCase().startsWith(args[0].toLowerCase())) {
+                    names.add(player.getName());
+                }
+            }
+            return names;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/command/SeenCommand.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/SeenCommand.java
@@ -1,0 +1,98 @@
+package io.papermc.paper.command;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.NamedTextColor.GOLD;
+import static net.kyori.adventure.text.format.NamedTextColor.GRAY;
+import static net.kyori.adventure.text.format.NamedTextColor.GREEN;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
+import static net.kyori.adventure.text.format.NamedTextColor.YELLOW;
+
+@DefaultQualifier(NonNull.class)
+public final class SeenCommand extends Command {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter
+        .ofPattern("MMM dd, yyyy 'at' HH:mm:ss z", Locale.ENGLISH)
+        .withZone(ZoneId.systemDefault());
+
+    public SeenCommand(final String name) {
+        super(name);
+        this.description = "Check when a player was last online";
+        this.usageMessage = "/seen <player>";
+        this.setPermission("bukkit.command.seen");
+    }
+
+    @Override
+    public boolean execute(final CommandSender sender, final String commandLabel, final String[] args) {
+        if (!testPermission(sender)) return true;
+        if (args.length == 0) {
+            sender.sendMessage(text("Usage: " + this.usageMessage, RED));
+            return true;
+        }
+
+        final String targetName = args[0];
+        final Player online = Bukkit.getPlayerExact(targetName);
+        if (online != null) {
+            sender.sendMessage(
+                text(online.getName(), GOLD)
+                    .append(text(" is currently ", GRAY))
+                    .append(text("online", GREEN))
+                    .append(text(".", GRAY))
+            );
+            return true;
+        }
+
+        @SuppressWarnings("deprecation")
+        final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(targetName);
+        if (!offlinePlayer.hasPlayedBefore()) {
+            sender.sendMessage(text("Player '" + targetName + "' has never joined this server.", RED));
+            return true;
+        }
+
+        final long lastPlayed = offlinePlayer.getLastPlayed();
+        if (lastPlayed == 0) {
+            sender.sendMessage(text("No last seen data available for '" + targetName + "'.", RED));
+            return true;
+        }
+
+        final String displayName = offlinePlayer.getName() != null ? offlinePlayer.getName() : targetName;
+        final String formatted = FORMATTER.format(Instant.ofEpochMilli(lastPlayed));
+        sender.sendMessage(
+            text(displayName, GOLD)
+                .append(text(" was last seen on ", GRAY))
+                .append(text(formatted, YELLOW))
+                .append(text(".", GRAY))
+        );
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(final CommandSender sender, final String alias, final String[] args, final Location location) {
+        if (args.length == 1) {
+            final List<String> names = new ArrayList<>();
+            for (final Player player : Bukkit.getOnlinePlayers()) {
+                if (sender instanceof final Player p && !p.canSee(player)) continue;
+                if (player.getName().toLowerCase().startsWith(args[0].toLowerCase())) {
+                    names.add(player.getName());
+                }
+            }
+            return names;
+        }
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
I have added some built in commands such as ping, seen, playtime and invsee

I think this is essential for servers that dont want to install a sophisticated plugin for this, and rather have it included into Paper. It is also very lightweight and minimal but effective.