### PR TITLE
feat: skip saving worlds on shutdown when autosave is disabled

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -573,7 +573,7 @@
      }
  
      protected GlobalPos selectLevelLoadFocusPos() {
-@@ -639,19 +_,49 @@
+@@ -639,26 +_,56 @@
          this.stopServer();
      }
  
@@ -623,7 +623,16 @@
 +            try { Thread.sleep(100); } catch (InterruptedException ex) {} // CraftBukkit - SPIGOT-625 - give server at least a chance to send packets
          }
  
-         LOGGER.info("Saving worlds");
+-        LOGGER.info("Saving worlds");
++        LOGGER.info(this.autosavePeriod > 0 ? "Saving worlds" : "Closing worlds (saving disabled)"); // Paper - Skip saving worlds on shutdown when autosave is disabled
+ 
+         for (ServerLevel level : this.getAllLevels()) {
+             if (level != null) {
+-                level.noSave = false;
++                level.noSave = this.autosavePeriod <= 0; // Paper - Skip saving worlds on shutdown when autosave is disabled
+             }
+         }
+ 
 @@ -694,6 +_,20 @@
          } catch (IOException e) {
              LOGGER.error("Failed to unlock level {}", this.storageSource.getLevelId(), e);


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  Respect the `ticks-per.autosave` setting on server shutdown. When autosave is                                                                                                                                                                                                                                     
  disabled (`ticks-per.autosave <= 0`), Paper no longer writes world chunks to                                                                                                                                                                                                                                      
  disk during `stopServer()` it only closes the chunk system cleanly. When                                                                                                                                                                                                                                        
  autosave is enabled (`> 0`), behaviour is unchanged: worlds are saved on stop                                                                                                                                                                                                                                     
  exactly as before.                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                    
  ## Motivation                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                    
  Currently `ticks-per.autosave <= 0` disables periodic autosaving, but the                                                                                                                                                                                                                                         
  server *still* performs a full world save on shutdown, so the setting does not                                                                                                                                                                                                                                    
  actually guarantee a non-persistent world.                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  This is most useful for **minigame / lobby servers** whose main world is meant                                                                                                                                                                                                                                    
  to be ephemeral: the map is reset from a template on every boot, so persisting                                                                                                                                                                                                                                    
  player-made changes on shutdown is undesirable (and a waste of disk I/O on large                                                                                                                                                                                                                                  
  voided worlds). With this change, setting `ticks-per.autosave` to `0`/`-1` makes                                                                                                                                                                                                                                  
  the world truly read-only across restarts, without resorting to plugins that                                                                                                                                                                                                                                      
  force-unload or wipe regions.                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                    
  The boundary (`> 0` saves, `<= 0` skips) matches the existing convention already                                                                                                                                                                                                                                  
  used elsewhere in the server:                                                                                                                                                                                                                                                                                     
  - `MinecraftServer#tickServer` - `fullSave = this.autosavePeriod > 0 && ...`                                                                                                                                                                                                                                      
  - `CraftServer#checkSaveState` - treats `autosavePeriod <= 0` as disabled.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                    
  ## Scope / notes                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                    
  - This only gates **chunk** saving. Global level metadata (`level.dat`,                                                                                                                                                                                                                                           
    scoreboard, saved data via `saveGlobalData`) and player data are still saved                                                                                                                                                                                                                                    
    on stop, as before. Gating those is intentionally out of scope. (Extra option for this in the future?)                                                                                                                                                                                                                                                 
  - Also removes an adjacent dead `while (false && ...)` block left over from the                                                                                                                                                                                                                                   
    chunk-system rewrite, since the surrounding code was already being touched.