### PR TITLE
Fix connection throttle cleanup wiping the whole tracker

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java.patch
@@ -66,7 +66,7 @@
 +                        ServerHandshakePacketListenerImpl.throttleCounter = 0;
 +
 +                        // Cleanup stale entries
-+                        ServerHandshakePacketListenerImpl.throttleTracker.values().removeIf(time -> time > connectionThrottle);
++                        ServerHandshakePacketListenerImpl.throttleTracker.values().removeIf(time -> currentTime - time > connectionThrottle);
 +                    }
 +                }
 +            }


### PR DESCRIPTION
## Problem

The connection throttle cleanup in `ServerHandshakePacketListenerImpl` wipes the entire `throttleTracker` every ~200 connections. The cleanup predicate compares a stored timestamp against the throttle duration:

```java
throttleTracker.values().removeIf(time -> time > connectionThrottle);
```

`time` is an epoch-millisecond timestamp (~1.7e12); `connectionThrottle` is a duration (default 4000ms). So `time > connectionThrottle` is always true and every entry is removed. The check a few lines above already does it correctly:

```java
currentTime - throttleTracker.get(address) < connectionThrottle
```

Within a cleanup cycle the per-IP throttle works, but every 200th connection clears the map, so a client can time reconnects around the cleanup and slip past the throttle.

## Fix

Compare elapsed time, reusing the `currentTime` already computed in the same block:

```java
throttleTracker.values().removeIf(time -> currentTime - time > connectionThrottle);
```

This is a content-only change to the existing added line in the patch, so it applies cleanly with no rebuildPatches churn.

Fixes #13984.
