### PR TITLE
Fix Block#applyBoneMeal returning false on success

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
@@ -542,7 +542,7 @@ public class CraftBlock implements Block {
             }
         }
 
-        return result == InteractionResult.SUCCESS && (event == null || !event.isCancelled());
+        return (result == InteractionResult.SUCCESS || result == InteractionResult.SUCCESS_SERVER) && (event == null || !event.isCancelled());
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
@@ -542,7 +542,7 @@ public class CraftBlock implements Block {
             }
         }
 
-        return (result == InteractionResult.SUCCESS || result == InteractionResult.SUCCESS_SERVER) && (event == null || !event.isCancelled());
+        return result instanceof InteractionResult.Success && (event == null || !event.isCancelled());
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/14012 making the server success its consider for the return in the API method.

i keep the other check because the method for sucesss use that two types... for any sucess interaction (like in previous versions)