### PR TITLE
Expose resetFlyingTicks for Player

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -2066,6 +2066,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
     public net.kyori.adventure.util.TriState hasFlyingFallDamage();
     // Paper end
 
+    // Paper start - reset flying ticks
+    public void resetFlyingTicks();
+
     /**
      * Hides a player from this player
      *

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -2071,8 +2071,6 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      * Resets the player's flying tick counter used for flight checks.
      * <p>
      * Only valid once the player's connection is initialized.
-     *
-     * @throws IllegalStateException if the connection is not yet initialized
      */
     public void resetFlyingTicks();
 

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -2067,7 +2067,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
     // Paper end
 
     /**
-     * Resets the player's flying tick counter used for flight/floating checks.
+
+     * Resets the player's flying tick counter used for flight checks.
+     * <p>
+     * Only valid once the player's connection is initialized.
+     *
+     * @throws IllegalStateException if the connection is not yet initialized
      */
     public void resetFlyingTicks();
 

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -2066,7 +2066,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
     public net.kyori.adventure.util.TriState hasFlyingFallDamage();
     // Paper end
 
-    // Paper start - reset flying ticks
+    /**
+     * Resets the player's flying tick counter used for flight/floating checks.
+     */
     public void resetFlyingTicks();
 
     /**

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -2463,12 +2463,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     // Paper end - flying fall damage
 
 
-    // Paper start - reset flying ticks
     @Override
     public void resetFlyingTicks() {
         getHandle().connection.resetFlyingTicks();
     }
-    // Paper end - reset flying ticks
 
     @Override
     public void setFlySpeed(float value) {

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -2462,6 +2462,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     }
     // Paper end - flying fall damage
 
+
+    // Paper start - reset flying ticks
+    @Override
+    public void resetFlyingTicks() {
+        getHandle().connection.resetFlyingTicks();
+    }
+    // Paper end - reset flying ticks
+
     @Override
     public void setFlySpeed(float value) {
         this.validateSpeed(value);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -2465,6 +2465,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
 
     @Override
     public void resetFlyingTicks() {
+        if (getHandle().connection == null) {
+            throw new IllegalStateException("Cannot reset flying ticks before player connection is initialized.");
+        }
+
         getHandle().connection.resetFlyingTicks();
     }
 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -2466,7 +2466,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     @Override
     public void resetFlyingTicks() {
         if (getHandle().connection == null) {
-            throw new IllegalStateException("Cannot reset flying ticks before player connection is initialized.");
+            return;
         }
 
         getHandle().connection.resetFlyingTicks();


### PR DESCRIPTION
Simply adds a method to Player which exposes the resetFlyingTicks method from ServerGamePacketListenerImpl.

This is particularly useful for preventing the "flying" kick without having event spam. While you _could_ enable the "allow-flight" option in server.properties, I find that allowing developers to have a method to reset this counter themselves would be useful.

For example, my use case is for my PacketBlocks plugin where players standing on them would be kicked for flying. Currently I require you to enable"allow-flight" however understandbly some server owners may not want to do this.