### PR TITLE
Fix TypedKey equals/hashCode symmetry with Key

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/registry/TypedKeyImpl.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/TypedKeyImpl.java
@@ -7,6 +7,27 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 record TypedKeyImpl<T>(Key key, RegistryKey<T> registryKey) implements TypedKey<T> {
     // Wrap key methods to make this easier to use
+    @Override
+    public boolean equals(final Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other instanceof final TypedKey<?> otherTyped) {
+            return this.key.equals(otherTyped.key()) && this.registryKey.equals(otherTyped.registryKey());
+        }
+        // A TypedKey is a Key, so it must compare equal to a plain Key with the same
+        // namespace and value (adventure's Key equality) to keep equals symmetric.
+        return other instanceof final Key otherKey
+            && this.key.namespace().equals(otherKey.namespace())
+            && this.key.value().equals(otherKey.value());
+    }
+
+    @Override
+    public int hashCode() {
+        // Match KeyImpl#hashCode so a TypedKey and an equal plain Key share a hash code.
+        return this.key.hashCode();
+    }
+
     @KeyPattern.Namespace
     @Override
     public String namespace() {

--- a/paper-api/src/test/java/io/papermc/paper/registry/TypedKeyEqualityTest.java
+++ b/paper-api/src/test/java/io/papermc/paper/registry/TypedKeyEqualityTest.java
@@ -1,0 +1,36 @@
+package io.papermc.paper.registry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.kyori.adventure.key.Key;
+import org.bukkit.inventory.ItemType;
+import org.junit.jupiter.api.Test;
+
+class TypedKeyEqualityTest {
+
+    @Test
+    void typedKeyIsSymmetricWithPlainKey() {
+        final Key key = Key.key("minecraft:stone");
+        final TypedKey<ItemType> typedKey = TypedKey.create(RegistryKey.ITEM, key);
+
+        // equals must be symmetric across the Key hierarchy
+        assertTrue(key.equals(typedKey), "plain Key should equal an equal TypedKey");
+        assertTrue(typedKey.equals(key), "TypedKey should equal an equal plain Key");
+        assertEquals(key.equals(typedKey), typedKey.equals(key), "equals must be symmetric");
+
+        // equal keys must share a hash code
+        assertEquals(key.hashCode(), typedKey.hashCode());
+    }
+
+    @Test
+    void typedKeysDifferByRegistry() {
+        final Key key = Key.key("minecraft:stone");
+        final TypedKey<ItemType> itemKey = TypedKey.create(RegistryKey.ITEM, key);
+        final TypedKey<?> blockKey = TypedKey.create(RegistryKey.BLOCK, key);
+
+        // same underlying key but different registries are not equal
+        assertNotEquals(itemKey, blockKey);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #13678.

`TypedKeyImpl` is a record implementing `Key`, but it never overrides `equals`/`hashCode`, so Java generates them from both record components and only matches another `TypedKeyImpl`. Adventure's `KeyImpl.equals` compares any `Key` by namespace + value, so equality is one-directional:

```java
Key key = Key.key("minecraft:stone");
TypedKey<ItemType> typedKey = TypedKey.create(RegistryKey.ITEM, key);
key.equals(typedKey);   // true
typedKey.equals(key);   // false
```

That breaks the symmetry clause of `Object.equals`, and the two hash differently, so a `TypedKey` can go missing in a `HashSet<Key>` built from plain keys, and `contains`/`remove` turn order dependent when both types are mixed.

This overrides `equals`/`hashCode` on `TypedKeyImpl`:

- Against another `TypedKey`, compare underlying key and registry key (same as before, so keys from different registries stay distinct).
- Against a plain `Key`, compare namespace + value to match adventure and stay symmetric.
- `hashCode` returns the underlying key's hash so equal keys share a hash.

One tradeoff: a `TypedKey` now equals its plain `Key`, so two `TypedKey`s with the same key but different registries stay unequal while both equal that plain key, which can break transitivity in that mixed case. That is inherent to `TypedKey extends Key` (Effective Java item 10). This follows the approach suggested in the issue; if you'd rather have strict transitivity, I can make equality key-only instead.

## Changes

- `TypedKeyImpl`: override `equals`/`hashCode`.
- Add `TypedKeyEqualityTest` covering symmetry, hashCode consistency, and registry distinction.
