### PR TITLE
Fix PlayerLinksSendEvent not firing when no global links are configured

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
@@ -40,7 +40,7 @@
          LOGGER.info("{} ({}) lost connection: {}", this.gameProfile.name(), this.gameProfile.id(), details.reason().getString());
          if (this.prepareSpawnTask != null) {
              this.prepareSpawnTask.close();
-@@ -81,11 +_,16 @@
+@@ -81,10 +_,15 @@
      }
  
      public void startConfiguration() {
@@ -54,11 +54,10 @@
 +        new org.bukkit.event.player.PlayerLinksSendEvent(this.paperConnection, links).callEvent();
 +        if (!links.getServerLinks().isEmpty()) {
 +            this.send(new ClientboundServerLinksPacket(links.getServerLinks().untrust()));
-         }
 +        // Paper end
+         }
  
          LayeredRegistryAccess<RegistryLayer> registries = this.server.registries();
-         List<KnownPack> knownPacks = this.server
 @@ -97,11 +_,12 @@
          this.synchronizeRegistriesTask = new SynchronizeRegistriesTask(knownPacks, registries);
          this.configurationTasks.add(this.synchronizeRegistriesTask);

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
@@ -40,23 +40,25 @@
          LOGGER.info("{} ({}) lost connection: {}", this.gameProfile.name(), this.gameProfile.id(), details.reason().getString());
          if (this.prepareSpawnTask != null) {
              this.prepareSpawnTask.close();
-@@ -81,10 +_,15 @@
+@@ -81,11 +_,16 @@
      }
  
      public void startConfiguration() {
 +        new io.papermc.paper.event.connection.configuration.PlayerConnectionInitialConfigureEvent(this.paperConnection).callEvent(); // Paper
          this.send(new ClientboundCustomPayloadPacket(new BrandPayload(this.server.getServerModName())));
          ServerLinks serverLinks = this.server.serverLinks();
-         if (!serverLinks.isEmpty()) {
+-        if (!serverLinks.isEmpty()) {
 -            this.send(new ClientboundServerLinksPacket(serverLinks.untrust()));
-+            // Paper start
-+            org.bukkit.craftbukkit.CraftServerLinks links = new org.bukkit.craftbukkit.CraftServerLinks(serverLinks);
-+            new org.bukkit.event.player.PlayerLinksSendEvent(this.paperConnection, links).callEvent();
++        // Paper start
++        org.bukkit.craftbukkit.CraftServerLinks links = new org.bukkit.craftbukkit.CraftServerLinks(serverLinks);
++        new org.bukkit.event.player.PlayerLinksSendEvent(this.paperConnection, links).callEvent();
++        if (!links.getServerLinks().isEmpty()) {
 +            this.send(new ClientboundServerLinksPacket(links.getServerLinks().untrust()));
-+            // Paper end
          }
++        // Paper end
  
          LayeredRegistryAccess<RegistryLayer> registries = this.server.registries();
+         List<KnownPack> knownPacks = this.server
 @@ -97,11 +_,12 @@
          this.synchronizeRegistriesTask = new SynchronizeRegistriesTask(knownPacks, registries);
          this.configurationTasks.add(this.synchronizeRegistriesTask);


### PR DESCRIPTION
## Problem

`PlayerLinksSendEvent` is gated behind an `isEmpty()` check on the server's global `ServerLinks`. This means the event is never fired when no global links are configured, making it impossible for plugins to add per-player links from scratch without a workaround.

Plugins that want to show player-specific links (e.g. localized links based on client language) are currently forced to pre-populate the global `ServerLinks` with dummy entries just to make the event trigger — even though those global entries are irrelevant and must then be cleared inside the event handler.

## Solution

Remove the `isEmpty()` guard before the event, and move it to after the event has been processed. The event now always fires, and the packet is only sent if the resulting `ServerLinks` is non-empty (either from global config or from plugin modifications).