### PR TITLE
Add AsyncServerDataFixerRemoveBlockEntityEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/server/AsyncServerDataFixerRemoveBlockEntityEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/server/AsyncServerDataFixerRemoveBlockEntityEvent.java
@@ -7,7 +7,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -19,7 +18,9 @@ import org.jspecify.annotations.NullMarked;
  * <b>WARNING</b>: While this event is prefixed with 'Async' it is executed as part of the chunk loading process.
  * It may hence either execute on the chunk loading worker threads or the servers main thread, if a chunk load
  * is executed there. In either case, heavy or blocking work is <b>strongly</b> discouraged to ensure the
- * server runs smoothly. Schedule large amount of work into separate thread pools.
+ * server runs smoothly. This is also applicable for the chunk loading worker threads, which the server main thread
+ * might be blocking on.
+ * Schedule large amount of work into separate thread pools.
  */
 @NullMarked
 public class AsyncServerDataFixerRemoveBlockEntityEvent extends Event {

--- a/paper-api/src/main/java/io/papermc/paper/event/server/AsyncServerDataFixerRemoveBlockEntityEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/server/AsyncServerDataFixerRemoveBlockEntityEvent.java
@@ -1,0 +1,61 @@
+package io.papermc.paper.event.server;
+
+import io.papermc.paper.math.BlockPosition;
+import io.papermc.paper.persistence.PersistentDataContainerView;
+import net.kyori.adventure.key.Key;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
+
+// TODO javadocs
+@NullMarked
+public class AsyncServerDataFixerRemoveBlockEntityEvent extends Event {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final Key worldKey;
+    private final String blockEntityId;
+    private final BlockPosition blockPosition;
+    private final PersistentDataContainerView persistentDataContainerView;
+
+    public AsyncServerDataFixerRemoveBlockEntityEvent(
+        final Key worldKey,
+        final String blockEntityId,
+        final BlockPosition blockPosition,
+        final PersistentDataContainerView persistentDataContainerView
+    ) {
+        super(!Bukkit.isPrimaryThread());
+        this.worldKey = worldKey;
+        this.blockEntityId = blockEntityId;
+        this.blockPosition = blockPosition;
+        this.persistentDataContainerView = persistentDataContainerView;
+    }
+
+
+    public String getBlockEntityId() {
+        return blockEntityId;
+    }
+
+    public Key getWorldKey() {
+        return worldKey;
+    }
+
+    public BlockPosition getBlockPosition() {
+        return blockPosition;
+    }
+
+    public PersistentDataContainerView getPersistentDataContainerView() {
+        return persistentDataContainerView;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/event/server/AsyncServerDataFixerRemoveBlockEntityEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/server/AsyncServerDataFixerRemoveBlockEntityEvent.java
@@ -6,51 +6,77 @@ import net.kyori.adventure.key.Key;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NullMarked;
 
-// TODO javadocs
+/**
+ * This event is emitted by the server when the data fixer is removing a block entity associated with a block
+ * due to the block entity type no longer existing in this minecraft version.
+ * <p>
+ * Notable examples include the removal of the bed block entity in 26.2.
+ * <p>
+ * <b>WARNING</b>: While this event is prefixed with 'Async' it is executed as part of the chunk loading process.
+ * It may hence either execute on the chunk loading worker threads or the servers main thread, if a chunk load
+ * is executed there. In either case, heavy or blocking work is <b>strongly</b> discouraged to ensure the
+ * server runs smoothly. Schedule large amount of work into separate thread pools.
+ */
 @NullMarked
 public class AsyncServerDataFixerRemoveBlockEntityEvent extends Event {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final Key worldKey;
-    private final Key blockEntityId;
+    private final Key blockEntityType;
     private final BlockPosition blockPosition;
     private final PersistentDataContainerView persistentDataContainerView;
 
+    @ApiStatus.Internal
     public AsyncServerDataFixerRemoveBlockEntityEvent(
         final Key worldKey,
-        final Key blockEntityId,
+        final Key blockEntityType,
         final BlockPosition blockPosition,
         final PersistentDataContainerView persistentDataContainerView
     ) {
         super(!Bukkit.isPrimaryThread());
         this.worldKey = worldKey;
-        this.blockEntityId = blockEntityId;
+        this.blockEntityType = blockEntityType;
         this.blockPosition = blockPosition;
         this.persistentDataContainerView = persistentDataContainerView;
     }
 
-    public Key getBlockEntityId() {
-        return blockEntityId;
+    /**
+     * {@return the key representing the no longer existing block entity type.}
+     */
+    public Key getBlockEntityType() {
+        return blockEntityType;
     }
 
+    /**
+     * {@return the key of the world this block entity was removed from.}
+     *
+     * @see org.bukkit.Server#getWorld(Key)
+     */
     public Key getWorldKey() {
         return worldKey;
     }
 
+    /**
+     * {@return the position of the block entity that was removed.}
+     */
     public BlockPosition getBlockPosition() {
         return blockPosition;
     }
 
+    /**
+     * {@return an immutable view of the persistent data container that was attached to the removed block entity.}
+     */
     public PersistentDataContainerView getPersistentDataContainerView() {
         return persistentDataContainerView;
     }
 
     @Override
-    public @NotNull HandlerList getHandlers() {
+    public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
 

--- a/paper-api/src/main/java/io/papermc/paper/event/server/AsyncServerDataFixerRemoveBlockEntityEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/server/AsyncServerDataFixerRemoveBlockEntityEvent.java
@@ -16,13 +16,13 @@ public class AsyncServerDataFixerRemoveBlockEntityEvent extends Event {
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final Key worldKey;
-    private final String blockEntityId;
+    private final Key blockEntityId;
     private final BlockPosition blockPosition;
     private final PersistentDataContainerView persistentDataContainerView;
 
     public AsyncServerDataFixerRemoveBlockEntityEvent(
         final Key worldKey,
-        final String blockEntityId,
+        final Key blockEntityId,
         final BlockPosition blockPosition,
         final PersistentDataContainerView persistentDataContainerView
     ) {
@@ -33,8 +33,7 @@ public class AsyncServerDataFixerRemoveBlockEntityEvent extends Event {
         this.persistentDataContainerView = persistentDataContainerView;
     }
 
-
-    public String getBlockEntityId() {
+    public Key getBlockEntityId() {
         return blockEntityId;
     }
 

--- a/paper-api/src/main/java/io/papermc/paper/event/server/AsyncServerDataFixerRemoveBlockEntityEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/server/AsyncServerDataFixerRemoveBlockEntityEvent.java
@@ -46,14 +46,14 @@ public class AsyncServerDataFixerRemoveBlockEntityEvent extends Event {
     }
 
     /**
-     * {@return the key representing the no longer existing block entity type.}
+     * {@return the key representing the no longer existing block entity type}
      */
     public Key getBlockEntityType() {
         return blockEntityType;
     }
 
     /**
-     * {@return the key of the world this block entity was removed from.}
+     * {@return the key of the world this block entity was removed from}
      *
      * @see org.bukkit.Server#getWorld(Key)
      */
@@ -62,14 +62,14 @@ public class AsyncServerDataFixerRemoveBlockEntityEvent extends Event {
     }
 
     /**
-     * {@return the position of the block entity that was removed.}
+     * {@return the position of the block entity that was removed}
      */
     public BlockPosition getBlockPosition() {
         return blockPosition;
     }
 
     /**
-     * {@return an immutable view of the persistent data container that was attached to the removed block entity.}
+     * {@return an immutable view of the persistent data container that was attached to the removed block entity}
      */
     public PersistentDataContainerView getPersistentDataContainerView() {
         return persistentDataContainerView;

--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -281,6 +281,7 @@ fun TaskContainer.registerRunTask(
     }
     systemProperty("io.papermc.paper.suppress.sout.nags", true)
     systemProperty("paper.maxChatCommandInputSize", 32767)
+    systemProperty("paper.disableMigrationDelay", true)
 
     val memoryGb = providers.gradleProperty("paper.runMemoryGb").getOrElse("2")
     minHeapSize = "${memoryGb}G"

--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -24087,7 +24087,7 @@ index 23e51ce53e9b1b4f52d49749c13ccaae539c4f0e..afe68487585e5fc2766a10bf69e085f5
      // CraftBukkit start
      public boolean isDebugging() {
 diff --git a/net/minecraft/server/dedicated/DedicatedServer.java b/net/minecraft/server/dedicated/DedicatedServer.java
-index 7264b0d73ddb1d5acadc37d00892288e2b874e9c..0b6d7f99edde802cb464baa5a4b2b4a4dcce684a 100644
+index 602042c367260f7cb2c6c14938285d5df4056158..3b28b39ebf252d8de46f7d0ce27037cdb041f1b5 100644
 --- a/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -530,7 +530,33 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -24589,7 +24589,7 @@ index 5e5aad112058b567214c28ccd719271f12240a35..cd5a325d37f617431ceb568a65570160
  
      @FunctionalInterface
 diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
-index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e04374f149 100644
+index 095617b58c955121e1dcf84246691c20fb3c5b74..513d6ea15d2b3577c649182422f051639d7fea49 100644
 --- a/net/minecraft/server/level/ChunkMap.java
 +++ b/net/minecraft/server/level/ChunkMap.java
 @@ -124,10 +124,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
@@ -25326,7 +25326,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
          return this.upgradeChunkTag(
              tag,
              -1,
-@@ -981,23 +666,66 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -982,23 +667,66 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
          return contextTag;
      }
  
@@ -25402,7 +25402,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
              if (holder != null) {
                  LevelChunk chunk = holder.getTickingChunk();
                  if (chunk != null) {
-@@ -1013,8 +741,8 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1014,8 +742,8 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
      }
  
      boolean anyPlayerCloseEnoughForSpawning(final ChunkPos pos, boolean reducedRange) {
@@ -25413,7 +25413,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
          // Spigot end
      }
  
-@@ -1038,7 +766,20 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1039,7 +767,20 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
      private boolean anyPlayerCloseEnoughForSpawningInternal(final ChunkPos pos, final boolean reducedRange) {
          double blockRange; // Paper - use from event
          // Spigot end
@@ -25435,7 +25435,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
              // Paper start - PlayerNaturallySpawnCreaturesEvent
              com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent event;
              blockRange = 16384.0;
-@@ -1054,26 +795,41 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1055,26 +796,41 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
          }
  
          return false;
@@ -25486,7 +25486,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
          if (player.isSpectator()) {
              return false;
          }
-@@ -1111,18 +867,20 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1112,18 +868,20 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
              this.updatePlayerPos(player);
              if (!ignored) {
                  this.distanceManager.addPlayer(SectionPos.of(player), player);
@@ -25509,7 +25509,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
          }
      }
  
-@@ -1132,13 +890,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1133,13 +891,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
      }
  
      public void move(final ServerPlayer player) {
@@ -25524,7 +25524,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
  
          SectionPos oldSection = player.getLastSectionPos();
          SectionPos newSection = SectionPos.of(player);
-@@ -1147,6 +899,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1148,6 +900,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
          boolean positionChanged = oldSection.asLong() != newSection.asLong();
          if (positionChanged || wasIgnored != ignored) {
              this.updatePlayerPos(player);
@@ -25532,7 +25532,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
              if (!wasIgnored) {
                  this.distanceManager.removePlayer(oldSection, player);
              }
-@@ -1163,47 +916,29 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1164,47 +917,29 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
                  this.playerMap.unIgnorePlayer(player);
              }
  
@@ -25591,7 +25591,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
      }
  
      public boolean hasEntityWithId(final int id) {
-@@ -1232,6 +967,12 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1233,6 +968,12 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
  
                  ChunkMap.TrackedEntity trackedEntity = new ChunkMap.TrackedEntity(entity, range, updateInterval, type.trackDeltas());
                  this.entityMap.put(entity.getId(), trackedEntity);
@@ -25604,7 +25604,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
                  trackedEntity.updatePlayers(this.level.players());
                  if (entity instanceof ServerPlayer player) {
                      this.updatePlayerStatus(player, true);
-@@ -1260,12 +1001,38 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1261,12 +1002,38 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
          if (trackedEntity != null) {
              trackedEntity.broadcastRemoved();
          }
@@ -25645,7 +25645,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
  
          List<ServerPlayer> movedPlayers = Lists.newArrayList();
          List<ServerPlayer> players = this.level.players();
-@@ -1364,17 +1131,11 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1365,17 +1132,11 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
      }
  
      public void waitForLightBeforeSending(final ChunkPos centerChunk, final int chunkRadius) {
@@ -25665,7 +25665,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
              LevelChunk chunk = chunkHolder.getChunkToSend();
              if (chunk != null) {
                  consumer.accept(chunk);
-@@ -1382,14 +1143,21 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1383,14 +1144,21 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
          }
      }
  
@@ -25689,7 +25689,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
          }
  
          @Override
-@@ -1403,13 +1171,96 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1404,13 +1172,96 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
          }
      }
  
@@ -25787,7 +25787,7 @@ index 00caaaddb3858926b1c6ce42dcf25386d7c073ea..e72bdc0311337742c687e318b80f90e0
          public TrackedEntity(final Entity entity, final int range, final int updateInterval, final boolean trackDelta) {
              this.serverEntity = new ServerEntity(ChunkMap.this.level, entity, updateInterval, trackDelta, this, this.seenBy); // Paper
              this.entity = entity;
-@@ -1521,17 +1372,24 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1522,17 +1373,24 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
          }
  
          private int getEffectiveRange() {
@@ -26975,7 +26975,7 @@ index f11c5ea1ee9381e7bf65305b959bd7da67423ece..26822e1211194b411dd8ea75ce523133
          List<Entity> passengers = this.entity.getPassengers();
          if (!passengers.equals(this.lastPassengers)) {
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc5717fde847 100644
+index ce5bd957dbfe52cd81e571359c6de1028dc11cde..5bb8ddc9490ce6c7bc4544ef0ea05484e67ddbe3 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -182,7 +182,7 @@ import net.minecraft.world.waypoints.WaypointTransmitter;
@@ -27370,7 +27370,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
              () -> server.overworld().getDataStorage()
              , savedDataStorage // Paper - initialize SavedDataStorage earlier
          );
-@@ -481,6 +725,20 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -482,6 +726,20 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          this.waypointManager = new ServerWaypointManager(this); // Paper - optimize ServerWaypointManager with locator bar disabled
          this.environmentAttributes = EnvironmentAttributeSystem.builder().addDefaultLayers(this).build();
          this.updateSkyBrightness();
@@ -27391,7 +27391,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
          this.getCraftServer().addWorld(this.getWorld()); // CraftBukkit
      }
  
-@@ -629,8 +887,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -630,8 +888,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                                  profiler.push("checkDespawn");
                                  entity.checkDespawn();
                                  profiler.pop();
@@ -27401,7 +27401,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
                                      Entity vehicle = entity.getVehicle();
                                      if (vehicle != null) {
                                          if (!vehicle.isRemoved() && vehicle.hasPassenger(entity)) {
-@@ -657,7 +914,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -658,7 +915,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          }
  
          profiler.push("entityManagement");
@@ -27410,7 +27410,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
          profiler.pop();
          profiler.push("debugSynchronizers");
          if (this.debugSynchronizers.hasAnySubscriberFor(DebugSubscriptions.NEIGHBOR_UPDATES)) {
-@@ -673,7 +930,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -674,7 +931,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      @Override
      public boolean shouldTickBlocksAt(final long chunkPos) {
@@ -27422,7 +27422,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
      }
  
      protected void tickTime() {
-@@ -697,7 +957,60 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -698,7 +958,60 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          this.players.stream().filter(LivingEntity::isSleeping).collect(Collectors.toList()).forEach(player -> player.stopSleepInBed(false, false));
      }
  
@@ -27483,7 +27483,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
          ChunkPos chunkPos = chunk.getPos();
          int minX = chunkPos.getMinBlockX();
          int minZ = chunkPos.getMinBlockZ();
-@@ -706,7 +1019,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -707,7 +1020,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
          if (!this.paperConfig().environment.disableIceAndSnow) { // Paper - Option to disable ice and snow
          for (int i = 0; i < tickSpeed; i++) {
@@ -27492,7 +27492,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
                  this.tickPrecipitation(this.getBlockRandomPos(minX, 0, minZ, 15));
              }
          }
-@@ -714,31 +1027,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -715,31 +1028,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
          profiler.popPush("tickBlocks");
          if (tickSpeed > 0) {
@@ -27525,7 +27525,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
          }
  
          profiler.pop();
-@@ -1061,6 +1350,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1062,6 +1351,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          if (fluidState.is(type)) {
              fluidState.tick(this, pos, blockState);
          }
@@ -27538,7 +27538,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
      }
  
      private void tickBlock(final BlockPos pos, final Block type) {
-@@ -1068,6 +1363,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1069,6 +1364,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          if (state.is(type)) {
              state.tick(this, pos, this.random);
          }
@@ -27551,7 +27551,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
      }
  
      // Paper start - log detailed entity tick information
-@@ -1152,6 +1453,11 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1153,6 +1454,11 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      }
  
      public void save(final @Nullable ProgressListener progressListener, final boolean flush, final boolean noSave) {
@@ -27563,7 +27563,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
          ServerChunkCache chunkSource = this.getChunkSource();
          if (!noSave) {
              new org.bukkit.event.world.WorldSaveEvent(this.getWorld()).callEvent(); // CraftBukkit
-@@ -1164,13 +1470,18 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1165,13 +1471,18 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                  progressListener.progressStage(Component.translatable("menu.savingChunks"));
              }
  
@@ -27587,7 +27587,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
      }
  
      private void saveLevelData(final boolean sync) {
-@@ -1291,7 +1602,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1292,7 +1603,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              this.removePlayerImmediately((ServerPlayer)existing, Entity.RemovalReason.DISCARDED);
          }
  
@@ -27596,7 +27596,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
      }
  
      // CraftBukkit start
-@@ -1322,7 +1633,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1323,7 +1634,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              }
              // CraftBukkit end
  
@@ -27605,7 +27605,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
          }
      }
  
-@@ -1333,7 +1644,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1334,7 +1645,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      public boolean tryAddFreshEntityWithPassengers(final Entity entity, final org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason) {
          // CraftBukkit end
@@ -27614,7 +27614,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
              return false;
          }
  
-@@ -2122,7 +2433,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2123,7 +2434,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                  }
              }
  
@@ -27623,7 +27623,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
              output.write(String.format(Locale.ROOT, "block_entity_tickers: %d\n", this.blockEntityTickers.size()));
              output.write(String.format(Locale.ROOT, "block_ticks: %d\n", this.getBlockTicks().count()));
              output.write(String.format(Locale.ROOT, "fluid_ticks: %d\n", this.getFluidTicks().count()));
-@@ -2140,13 +2451,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2141,13 +2452,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          Path chunks = rootDir.resolve("chunks.csv");
  
          try (Writer output = Files.newBufferedWriter(chunks)) {
@@ -27639,7 +27639,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
          }
  
          Path entities = rootDir.resolve("entities.csv");
-@@ -2241,8 +2552,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2242,8 +2553,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              Locale.ROOT,
              "players: %s, entities: %s [%s], block_entities: %d [%s], block_ticks: %d, fluid_ticks: %d, chunk_source: %s",
              this.players.size(),
@@ -27650,7 +27650,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
              this.blockEntityTickers.size(),
              getTypeCount(this.blockEntityTickers, TickingBlockEntity::getType),
              this.getBlockTicks().count(),
-@@ -2275,15 +2586,25 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2276,15 +2587,25 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      @Override
      public LevelEntityGetter<Entity> getEntities() {
          org.spigotmc.AsyncCatcher.catchOp("Chunk getEntities call"); // Spigot
@@ -27679,7 +27679,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
      }
  
      public void startTickingChunk(final LevelChunk levelChunk) {
-@@ -2300,8 +2621,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2301,8 +2622,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      public void waitForEntities(final ChunkPos centerChunk, final int radius) {
          List<ChunkPos> chunks = ChunkPos.rangeClosed(centerChunk, radius).toList();
@@ -27690,7 +27690,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
  
              for (ChunkPos chunk : chunks) {
                  if (!this.areEntitiesLoaded(chunk.pack())) {
-@@ -2320,28 +2641,38 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2321,28 +2642,38 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      @Override
      public void close() throws IOException {
          super.close();
@@ -27735,7 +27735,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
      }
  
      public boolean anyPlayerCloseEnoughForSpawning(final BlockPos pos) {
-@@ -2358,7 +2689,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2359,7 +2690,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      }
  
      public boolean canSpawnEntitiesInChunk(final ChunkPos pos) {
@@ -27747,7 +27747,7 @@ index d30f5ed54da9c9518cf61015669e7916cc60e6ca..ac3d8d819bc5042b476f68a2c023cc57
      }
  
      @Override
-@@ -2406,7 +2740,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2407,7 +2741,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      public CrashReportCategory fillReportDetails(final CrashReport report) {
          CrashReportCategory category = super.fillReportDetails(report);
          WeatherData weatherData = this.getWeatherData();
@@ -34601,7 +34601,7 @@ index e7e65ae464aab7e4caf0925a69d658e422203aa4..3f66d1144daf7139a91bfa35e2c288d8
  
      private ChunkAccess doFill(
 diff --git a/net/minecraft/world/level/levelgen/structure/StructureCheck.java b/net/minecraft/world/level/levelgen/structure/StructureCheck.java
-index 332032fa0069ffbe982e087ae9535aab20ab4323..3491dc0b85b462991086613f8004461aa19a585f 100644
+index 2c0e0a2402a76196e74d249308fb5c628741ef0a..54163ba2aa6697055260470e0771ed10f71f23e2 100644
 --- a/net/minecraft/world/level/levelgen/structure/StructureCheck.java
 +++ b/net/minecraft/world/level/levelgen/structure/StructureCheck.java
 @@ -50,8 +50,13 @@ public class StructureCheck {
@@ -34617,10 +34617,10 @@ index 332032fa0069ffbe982e087ae9535aab20ab4323..3491dc0b85b462991086613f8004461a
 +    private final ca.spottedleaf.moonrise.common.map.SynchronisedLong2ObjectMap<it.unimi.dsi.fastutil.objects.Object2IntMap<Structure>> loadedChunksSafe = new ca.spottedleaf.moonrise.common.map.SynchronisedLong2ObjectMap<>(CHUNK_TOTAL_LIMIT);
 +    private final java.util.concurrent.ConcurrentHashMap<Structure, ca.spottedleaf.moonrise.common.map.SynchronisedLong2BooleanMap> featureChecksSafe = new java.util.concurrent.ConcurrentHashMap<>();
 +    // Paper end - rewrite chunk system
+     // Paper start - also store level stem
+     private final ResourceKey<net.minecraft.world.level.dimension.LevelStem> levelStem;
  
-     public StructureCheck(
-         final ChunkScanAccess storageAccess,
-@@ -93,7 +98,7 @@ public class StructureCheck {
+@@ -98,7 +103,7 @@ public class StructureCheck {
  
      public StructureCheckResult checkStart(final ChunkPos pos, final Structure structure, final StructurePlacement placement, final boolean requireUnreferenced) {
          long posKey = pos.pack();
@@ -34629,7 +34629,7 @@ index 332032fa0069ffbe982e087ae9535aab20ab4323..3491dc0b85b462991086613f8004461a
          if (cachedResult != null) {
              return this.checkStructureInfo(cachedResult, structure, requireUnreferenced);
          }
-@@ -107,9 +112,11 @@ public class StructureCheck {
+@@ -112,9 +117,11 @@ public class StructureCheck {
              return StructureCheckResult.START_NOT_PRESENT;
          }
  
@@ -34644,7 +34644,7 @@ index 332032fa0069ffbe982e087ae9535aab20ab4323..3491dc0b85b462991086613f8004461a
          return !isFeatureChunk ? StructureCheckResult.START_NOT_PRESENT : StructureCheckResult.CHUNK_LOAD_NEEDED;
      }
  
-@@ -224,15 +231,25 @@ public class StructureCheck {
+@@ -229,15 +236,25 @@ public class StructureCheck {
      }
  
      private void storeFullResults(final long posKey, final Object2IntMap<Structure> starts) {

--- a/paper-server/patches/features/0002-Rewrite-dataconverter-system.patch
+++ b/paper-server/patches/features/0002-Rewrite-dataconverter-system.patch
@@ -33770,7 +33770,7 @@ index 945fdc4b3958a88342cc881edd6270c2123a8249..212172b6451a073e7c64a336fe4c0650
          return structureTemplate.save(new CompoundTag());
      }
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 0fe6e0470f67709f4112095780924bd765b77b25..0deb69356a5f82c30dff84957e0a471fa76add08 100644
+index afe68487585e5fc2766a10bf69e085f51d498990..1d422607ac31044da2eff88b9f020b8a76c4bd54 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -298,6 +298,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -33816,10 +33816,10 @@ index 4346f3bace176e09d9ffb02e9af29a1281071e2a..df4f03f3a346e0ab0074757b3a077b24
          return this.upgradeChunkTag(chunkTag, defaultVersion, null, SharedConstants.getCurrentVersion().dataVersion().version());
      }
 diff --git a/net/minecraft/world/level/levelgen/structure/StructureCheck.java b/net/minecraft/world/level/levelgen/structure/StructureCheck.java
-index 3491dc0b85b462991086613f8004461aa19a585f..6b5985218bd95edee62e06db40a2b70f989b2910 100644
+index 54163ba2aa6697055260470e0771ed10f71f23e2..2fd8192dd9a041afe97f7776c06551fb087a3f2a 100644
 --- a/net/minecraft/world/level/levelgen/structure/StructureCheck.java
 +++ b/net/minecraft/world/level/levelgen/structure/StructureCheck.java
-@@ -161,7 +161,7 @@ public class StructureCheck {
+@@ -166,7 +166,7 @@ public class StructureCheck {
  
              CompoundTag fixedChunkTag;
              try {

--- a/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
+++ b/paper-server/patches/features/0003-Entity-Activation-Range-2.0.patch
@@ -355,10 +355,10 @@ index 0000000000000000000000000000000000000000..829f7685904fd741e00403647ae76d32
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index ac3d8d819bc5042b476f68a2c023cc5717fde847..bbfe1e0519929ad91d3aecabb510fbf436c203d3 100644
+index 5bb8ddc9490ce6c7bc4544ef0ea05484e67ddbe3..10696186f7776f21a9fbcc49224d05ea2962a93a 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -879,6 +879,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -880,6 +880,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                  profiler.pop();
              }
  
@@ -366,7 +366,7 @@ index ac3d8d819bc5042b476f68a2c023cc5717fde847..bbfe1e0519929ad91d3aecabb510fbf4
              this.entityTickList
                  .forEach(
                      entity -> {
-@@ -1397,12 +1398,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1398,12 +1399,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          entity.totalEntityAge++; // Paper - age-like counter for all entities
          profiler.push(entity.typeHolder()::getRegisteredName);
          profiler.incrementCounter("tickNonPassenger");
@@ -383,7 +383,7 @@ index ac3d8d819bc5042b476f68a2c023cc5717fde847..bbfe1e0519929ad91d3aecabb510fbf4
          }
          // Paper start - log detailed entity tick information
          } finally {
-@@ -1413,7 +1417,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1414,7 +1418,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          // Paper end - log detailed entity tick information
      }
  
@@ -392,7 +392,7 @@ index ac3d8d819bc5042b476f68a2c023cc5717fde847..bbfe1e0519929ad91d3aecabb510fbf4
          if (entity.isRemoved() || entity.getVehicle() != vehicle) {
              entity.stopRiding();
          } else if (entity instanceof Player || this.entityTickList.contains(entity)) {
-@@ -1423,12 +1427,21 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1424,12 +1428,21 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              ProfilerFiller profiler = Profiler.get();
              profiler.push(entity.typeHolder()::getRegisteredName);
              profiler.incrementCounter("tickPassenger");

--- a/paper-server/patches/features/0013-Add-Alternate-Current-redstone-implementation.patch
+++ b/paper-server/patches/features/0013-Add-Alternate-Current-redstone-implementation.patch
@@ -2321,7 +2321,7 @@ index 0000000000000000000000000000000000000000..33cd90c30c22200a4e1ae64f40a0bf78
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index bbfe1e0519929ad91d3aecabb510fbf436c203d3..4eee4a42425bef4f7bcf2fe8115e3cc03064ed5b 100644
+index 10696186f7776f21a9fbcc49224d05ea2962a93a..3112f9d9788b77dca319a05c779972fd073bda61 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -236,6 +236,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
@@ -2332,7 +2332,7 @@ index bbfe1e0519929ad91d3aecabb510fbf436c203d3..4eee4a42425bef4f7bcf2fe8115e3cc0
  
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
-@@ -2783,6 +2784,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2784,6 +2785,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          return this.debugSynchronizers;
      }
  

--- a/paper-server/patches/features/0014-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0014-Incremental-chunk-and-player-saving.patch
@@ -93,10 +93,10 @@ index 1d422607ac31044da2eff88b9f020b8a76c4bd54..b1f5741d5d714f57795c53605db87d86
          ProfilerFiller profiler = Profiler.get();
          this.server.spark.executeMainThreadTasks(); // Paper - spark
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 4eee4a42425bef4f7bcf2fe8115e3cc03064ed5b..586b7de5147dccb9dfa84766c71db9b58bc39abc 100644
+index 3112f9d9788b77dca319a05c779972fd073bda61..6a9bdf0bb711acf2ee0bf20e835aa63759ea9ab2 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1465,6 +1465,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1466,6 +1466,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      public boolean mayInteract(final Entity entity, final BlockPos pos) {
          return !(entity instanceof Player player && (this.server.isUnderSpawnProtection(this, pos, player) || !this.getWorldBorder().isWithinBounds(pos)));
      }

--- a/paper-server/patches/features/0023-Fix-entity-tracker-desync-when-new-players-are-added.patch
+++ b/paper-server/patches/features/0023-Fix-entity-tracker-desync-when-new-players-are-added.patch
@@ -48,10 +48,10 @@ index cff05f64af7f425b77cbbd7680c5cc592faa798c..0ab4080c8e30d5ee14ce5fcbac64b031
              serverEntity.getLastSentYRot(),
              entity.getType(),
 diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
-index e72bdc0311337742c687e318b80f90e04374f149..c8a65d411ccb8a0ef1dad2da8e8f95e8ce4e36a5 100644
+index 513d6ea15d2b3577c649182422f051639d7fea49..e33325f8cae05593a0c28280c3055384d95dd4d1 100644
 --- a/net/minecraft/server/level/ChunkMap.java
 +++ b/net/minecraft/server/level/ChunkMap.java
-@@ -1360,6 +1360,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1361,6 +1361,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
                          ChunkMap.this.level.debugSynchronizers().startTrackingEntity(player, this.entity);
                          }
                          // Paper end - entity tracking events

--- a/paper-server/patches/features/0032-DataConverter-Moonrise-co-fixes.patch
+++ b/paper-server/patches/features/0032-DataConverter-Moonrise-co-fixes.patch
@@ -23,54 +23,6 @@ index 1a6d02df13f3461402fed429f7fbdb5acee877c4..712cca21a6b4736a15d49dceaf7e6d64
  
                  if (attributes == null) {
                      return null;
-diff --git a/ca/spottedleaf/dataconverter/minecraft/converters/tileentity/ConverterAbstractTileEntityRemove.java b/ca/spottedleaf/dataconverter/minecraft/converters/tileentity/ConverterAbstractTileEntityRemove.java
-index a74821562154c99ee3a8571ff8dbf8fe5eacf416..1486f54f7d78e4840309a111ea949acfff4cf90e 100644
---- a/ca/spottedleaf/dataconverter/minecraft/converters/tileentity/ConverterAbstractTileEntityRemove.java
-+++ b/ca/spottedleaf/dataconverter/minecraft/converters/tileentity/ConverterAbstractTileEntityRemove.java
-@@ -61,8 +61,43 @@ public final class ConverterAbstractTileEntityRemove {
-                     return null;
-                 }
- 
-+                // Paper start - call event on block entity removal
-+                final java.util.function.Supplier<net.kyori.adventure.key.Key> worldKeySupplier = com.google.common.base.Suppliers.memoize(() -> {
-+                    final ca.spottedleaf.dataconverter.types.MapType context = data.getMap(net.minecraft.util.datafix.fixes.ChunkHeightAndBiomeFix.DATAFIXER_CONTEXT_TAG);
-+                    if (context == null) return null;
-+
-+                    final @org.intellij.lang.annotations.Subst("minecraft:overworld") String levelIdentifier = context.getString("level_identifier");
-+                    if (levelIdentifier == null) return null;
-+
-+                    return net.kyori.adventure.key.Key.key(levelIdentifier);
-+                });
-+                // Paper end - call event on block entity removal
-+
-                 for (int i = 0; i < blockEntities.size(); ++i) {
-                     if (isType(blockEntities.getMap(i), type)) {
-+                        // Paper start - call event on block entity removal
-+                        final net.kyori.adventure.key.Key worldKey = worldKeySupplier.get();
-+                        if (worldKey != null) {
-+                            final MapType blockEntity = blockEntities.getMap(i);
-+                            final Number x = blockEntity.getNumber("x");
-+                            final Number y = blockEntity.getNumber("y");
-+                            final Number z = blockEntity.getNumber("z");
-+                            if (x != null && y != null && z != null) {
-+                                final org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer container = new org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer(
-+                                    net.minecraft.util.datafix.fixes.RemoveBlockEntityTagFix.DATA_TYPE_REGISTRY
-+                                );
-+                                if (blockEntity.getMap("PublicBukkitValues") instanceof final ca.spottedleaf.dataconverter.types.nbt.NBTMapType nbtMapType) {
-+                                    container.putAll(nbtMapType.getTag());
-+                                }
-+                                new io.papermc.paper.event.server.AsyncServerDataFixerRemoveBlockEntityEvent(
-+                                    worldKey,
-+                                    type,
-+                                    io.papermc.paper.math.Position.block(x.intValue(), y.intValue(), z.intValue()),
-+                                    container
-+                                ).callEvent();
-+                            }
-+                        }
-+                        // Paper end - call event on block entity removal
-                         blockEntities.remove(i--);
-                     }
-                 }
 diff --git a/ca/spottedleaf/dataconverter/minecraft/versions/V4307.java b/ca/spottedleaf/dataconverter/minecraft/versions/V4307.java
 index d2877c20f389d0131e1dd208b464f590671e5d82..27bdc70d861ca39487ad16cb3afb89d604b462c8 100644
 --- a/ca/spottedleaf/dataconverter/minecraft/versions/V4307.java

--- a/paper-server/patches/features/0032-DataConverter-Moonrise-co-fixes.patch
+++ b/paper-server/patches/features/0032-DataConverter-Moonrise-co-fixes.patch
@@ -23,6 +23,54 @@ index 1a6d02df13f3461402fed429f7fbdb5acee877c4..712cca21a6b4736a15d49dceaf7e6d64
  
                  if (attributes == null) {
                      return null;
+diff --git a/ca/spottedleaf/dataconverter/minecraft/converters/tileentity/ConverterAbstractTileEntityRemove.java b/ca/spottedleaf/dataconverter/minecraft/converters/tileentity/ConverterAbstractTileEntityRemove.java
+index a74821562154c99ee3a8571ff8dbf8fe5eacf416..1486f54f7d78e4840309a111ea949acfff4cf90e 100644
+--- a/ca/spottedleaf/dataconverter/minecraft/converters/tileentity/ConverterAbstractTileEntityRemove.java
++++ b/ca/spottedleaf/dataconverter/minecraft/converters/tileentity/ConverterAbstractTileEntityRemove.java
+@@ -61,8 +61,43 @@ public final class ConverterAbstractTileEntityRemove {
+                     return null;
+                 }
+ 
++                // Paper start - call event on block entity removal
++                final java.util.function.Supplier<net.kyori.adventure.key.Key> worldKeySupplier = com.google.common.base.Suppliers.memoize(() -> {
++                    final ca.spottedleaf.dataconverter.types.MapType context = data.getMap(net.minecraft.util.datafix.fixes.ChunkHeightAndBiomeFix.DATAFIXER_CONTEXT_TAG);
++                    if (context == null) return null;
++
++                    final @org.intellij.lang.annotations.Subst("minecraft:overworld") String levelIdentifier = context.getString("level_identifier");
++                    if (levelIdentifier == null) return null;
++
++                    return net.kyori.adventure.key.Key.key(levelIdentifier);
++                });
++                // Paper end - call event on block entity removal
++
+                 for (int i = 0; i < blockEntities.size(); ++i) {
+                     if (isType(blockEntities.getMap(i), type)) {
++                        // Paper start - call event on block entity removal
++                        final net.kyori.adventure.key.Key worldKey = worldKeySupplier.get();
++                        if (worldKey != null) {
++                            final MapType blockEntity = blockEntities.getMap(i);
++                            final Number x = blockEntity.getNumber("x");
++                            final Number y = blockEntity.getNumber("y");
++                            final Number z = blockEntity.getNumber("z");
++                            if (x != null && y != null && z != null) {
++                                final org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer container = new org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer(
++                                    net.minecraft.util.datafix.fixes.RemoveBlockEntityTagFix.DATA_TYPE_REGISTRY
++                                );
++                                if (blockEntity.getMap("PublicBukkitValues") instanceof final ca.spottedleaf.dataconverter.types.nbt.NBTMapType nbtMapType) {
++                                    container.putAll(nbtMapType.getTag());
++                                }
++                                new io.papermc.paper.event.server.AsyncServerDataFixerRemoveBlockEntityEvent(
++                                    worldKey,
++                                    type,
++                                    io.papermc.paper.math.Position.block(x.intValue(), y.intValue(), z.intValue()),
++                                    container
++                                ).callEvent();
++                            }
++                        }
++                        // Paper end - call event on block entity removal
+                         blockEntities.remove(i--);
+                     }
+                 }
 diff --git a/ca/spottedleaf/dataconverter/minecraft/versions/V4307.java b/ca/spottedleaf/dataconverter/minecraft/versions/V4307.java
 index d2877c20f389d0131e1dd208b464f590671e5d82..27bdc70d861ca39487ad16cb3afb89d604b462c8 100644
 --- a/ca/spottedleaf/dataconverter/minecraft/versions/V4307.java

--- a/paper-server/patches/features/0033-Call-AsyncServerDataFixerRemoveBlockEntityEvent-from.patch
+++ b/paper-server/patches/features/0033-Call-AsyncServerDataFixerRemoveBlockEntityEvent-from.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <git@lynxplay.dev>
+Date: Sun, 5 Jul 2026 12:26:53 +0100
+Subject: [PATCH] Call AsyncServerDataFixerRemoveBlockEntityEvent from DC
+
+
+diff --git a/ca/spottedleaf/dataconverter/minecraft/converters/tileentity/ConverterAbstractTileEntityRemove.java b/ca/spottedleaf/dataconverter/minecraft/converters/tileentity/ConverterAbstractTileEntityRemove.java
+index a74821562154c99ee3a8571ff8dbf8fe5eacf416..8d47addc3cf6d0c551809463992da8551c2835f6 100644
+--- a/ca/spottedleaf/dataconverter/minecraft/converters/tileentity/ConverterAbstractTileEntityRemove.java
++++ b/ca/spottedleaf/dataconverter/minecraft/converters/tileentity/ConverterAbstractTileEntityRemove.java
+@@ -61,8 +61,43 @@ public final class ConverterAbstractTileEntityRemove {
+                     return null;
+                 }
+ 
++                // Paper start - call event on block entity removal
++                final java.util.function.Supplier<net.kyori.adventure.key.Key> worldKeySupplier = com.google.common.base.Suppliers.memoize(() -> {
++                    final ca.spottedleaf.dataconverter.types.MapType context = data.getMap(net.minecraft.util.datafix.fixes.ChunkHeightAndBiomeFix.DATAFIXER_CONTEXT_TAG);
++                    if (context == null) return null;
++
++                    final @org.intellij.lang.annotations.Subst("minecraft:overworld") String levelIdentifier = context.getString("level_identifier");
++                    if (levelIdentifier == null) return null;
++
++                    return net.kyori.adventure.key.Key.key(levelIdentifier);
++                });
++                // Paper end - call event on block entity removal
++
+                 for (int i = 0; i < blockEntities.size(); ++i) {
+                     if (isType(blockEntities.getMap(i), type)) {
++                        // Paper start - call event on block entity removal
++                        final net.kyori.adventure.key.Key worldKey = worldKeySupplier.get();
++                        if (worldKey != null) {
++                            final MapType blockEntity = blockEntities.getMap(i);
++                            final Number x = blockEntity.getNumber("x");
++                            final Number y = blockEntity.getNumber("y");
++                            final Number z = blockEntity.getNumber("z");
++                            if (x != null && y != null && z != null) {
++                                final org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer container = new org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer(
++                                    net.minecraft.util.datafix.fixes.RemoveBlockEntityTagFix.DATA_TYPE_REGISTRY
++                                );
++                                if (blockEntity.getMap("PublicBukkitValues") instanceof final ca.spottedleaf.dataconverter.types.nbt.NBTMapType nbtMapType) {
++                                    container.putAll(nbtMapType.getTag());
++                                }
++                                new io.papermc.paper.event.server.AsyncServerDataFixerRemoveBlockEntityEvent(
++                                    worldKey,
++                                    net.kyori.adventure.key.Key.key(type),
++                                    io.papermc.paper.math.Position.block(x.intValue(), y.intValue(), z.intValue()),
++                                    container
++                                ).callEvent();
++                            }
++                        }
++                        // Paper end - call event on block entity removal
+                         blockEntities.remove(i--);
+                     }
+                 }

--- a/paper-server/patches/sources/net/minecraft/server/level/ChunkMap.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ChunkMap.java.patch
@@ -165,21 +165,22 @@
              Optional<ChunkAccess> chunk = Optional.ofNullable(holder.getLatestChunk());
              Optional<LevelChunk> fullChunk = chunk.flatMap(
                  chunkAccess -> chunkAccess instanceof LevelChunk levelChunk ? Optional.of(levelChunk) : Optional.empty()
-@@ -922,14 +_,14 @@
+@@ -922,14 +_,15 @@
          return this.upgradeChunkTag(
              tag,
              -1,
 -            getChunkDataFixContextTag(this.level.dimension(), this.generator().getTypeNameForDataFixer()),
-+            getChunkDataFixContextTag(this.level.getTypeKey(), this.generator().getTypeNameForDataFixer()), // CraftBukkit
++            getChunkDataFixContextTag(this.level.dimension(), this.generator().getTypeNameForDataFixer(), this.level.getTypeKey()), // Paper - pass level stem
              SharedConstants.getCurrentVersion().dataVersion().version()
          );
      }
  
 -    public static CompoundTag getChunkDataFixContextTag(final ResourceKey<Level> dimension, final Optional<Identifier> generatorIdentifier) {
-+    public static CompoundTag getChunkDataFixContextTag(final ResourceKey<net.minecraft.world.level.dimension.LevelStem> stemKey, final Optional<Identifier> generatorIdentifier) { // CraftBukkit
++    public static CompoundTag getChunkDataFixContextTag(final ResourceKey<Level> dimension, final Optional<Identifier> generatorIdentifier, final ResourceKey<net.minecraft.world.level.dimension.LevelStem> stemKey) { // Paper - pass level stem
          CompoundTag contextTag = new CompoundTag();
 -        contextTag.putString("dimension", dimension.identifier().toString());
-+        contextTag.putString("dimension", stemKey.identifier().toString()); // CraftBukkit
++        contextTag.putString("dimension", stemKey.identifier().toString()); // Paper - pass level stem as dimension instead of passed dimension to run datafixers for non minecraft worlds.
++        contextTag.putString("level_identifier", dimension.identifier().toString()); // Paper - store dimension key for later lookup if needed.
          generatorIdentifier.ifPresent(identifier -> contextTag.putString("generator", identifier.toString()));
          return contextTag;
      }

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -234,7 +234,7 @@
          }
  
          this.raids = this.getDataStorage().computeIfAbsent(Raids.TYPE);
-@@ -278,14 +_,13 @@
+@@ -278,10 +_,10 @@
              levelData.setGameType(server.getDefaultGameType());
          }
  
@@ -242,14 +242,10 @@
          WorldOptions options = worldGenSettings.options();
          long seed = options.seed();
          this.structureCheck = new StructureCheck(
++            getTypeKey(), // Paper - pass level stem
              this.chunkSource.chunkScanner(),
              this.registryAccess(),
              server.getStructureManager(),
--            dimension,
-+            getTypeKey(), // Paper - Fix missing CB diff
-             generator,
-             this.chunkSource.randomState(),
-             this,
 @@ -301,10 +_,18 @@
  
          this.sleepStatus = new SleepStatus();

--- a/paper-server/patches/sources/net/minecraft/util/datafix/fixes/RemoveBlockEntityTagFix.java.patch
+++ b/paper-server/patches/sources/net/minecraft/util/datafix/fixes/RemoveBlockEntityTagFix.java.patch
@@ -45,7 +45,7 @@
 +                        }
 +                        new io.papermc.paper.event.server.AsyncServerDataFixerRemoveBlockEntityEvent(
 +                            worldKey,
-+                            blockEntityId,
++                            net.kyori.adventure.key.Key.key(blockEntityId),
 +                            io.papermc.paper.math.Position.block(x.get().intValue(), y.get().intValue(), z.get().intValue()),
 +                            container
 +                        ).callEvent();

--- a/paper-server/patches/sources/net/minecraft/util/datafix/fixes/RemoveBlockEntityTagFix.java.patch
+++ b/paper-server/patches/sources/net/minecraft/util/datafix/fixes/RemoveBlockEntityTagFix.java.patch
@@ -1,0 +1,55 @@
+--- a/net/minecraft/util/datafix/fixes/RemoveBlockEntityTagFix.java
++++ b/net/minecraft/util/datafix/fixes/RemoveBlockEntityTagFix.java
+@@ -17,6 +_,7 @@
+ import net.minecraft.util.datafix.schemas.NamespacedSchema;
+ 
+ public class RemoveBlockEntityTagFix extends DataFix {
++    public static final org.bukkit.craftbukkit.persistence.CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new org.bukkit.craftbukkit.persistence.CraftPersistentDataTypeRegistry(); // Paper - call event on block entity removal
+     private final Set<String> blockEntityIdsToDrop;
+     private final boolean useLegacyDataStructure;
+ 
+@@ -102,6 +_,13 @@
+             chunkTypeOut,
+             input -> input.update(blockEntitiesF, blockEntitiesTypeOut, listTag -> {
+                 ArrayList<Object> keptBlockEntities = new ArrayList<>();
++                // Paper start - extract world for removal event
++                // The context is not part of the schema, so we need to grab it ourselves. Do this lazily and once.
++                final java.util.function.Supplier<net.kyori.adventure.key.@org.jspecify.annotations.Nullable Key> dimensionKey = com.google.common.base.Suppliers.memoize(() -> input.write()
++                    .flatMap(d -> d.get(ChunkHeightAndBiomeFix.DATAFIXER_CONTEXT_TAG).get("level_identifier").asString())
++                    .mapOrElse(net.kyori.adventure.key.Key::key, _ -> null)
++                );
++                // Paper end - extract world for removal event
+ 
+                 for (Object untypedBlockEntity : listTag) {
+                     Typed<?> typedBlockEntity = ExtraDataFixUtils.cast(blockEntityElementsType, untypedBlockEntity, input.getOps());
+@@ -109,6 +_,30 @@
+                     String blockEntityId = typedBlockEntityUnwrapped.getOptional(blockEntityIdF).orElse("");
+                     if (!this.blockEntityIdsToDrop.contains(blockEntityId)) {
+                         keptBlockEntities.add(untypedBlockEntity);
++                    // Paper start - call event on block entity removal
++                    } else {
++                        final net.kyori.adventure.key.Key worldKey = dimensionKey.get();
++                        if (worldKey == null) continue;
++
++                        final java.util.Optional<? extends com.mojang.serialization.Dynamic<?>> blockEntityOpt = typedBlockEntity.write().result();
++                        if (blockEntityOpt.isEmpty()) continue;
++
++                        final java.util.Optional<Number> x = blockEntityOpt.flatMap(e -> e.get("x").asNumber().result());
++                        final java.util.Optional<Number> y = blockEntityOpt.flatMap(e -> e.get("y").asNumber().result());
++                        final java.util.Optional<Number> z = blockEntityOpt.flatMap(e -> e.get("z").asNumber().result());
++                        if (x.isEmpty() || y.isEmpty() || z.isEmpty()) continue;
++
++                        final org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer container = new org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer(DATA_TYPE_REGISTRY);
++                        if (blockEntityOpt.get().get("PublicBukkitValues").orElseEmptyMap().convert(net.minecraft.nbt.NbtOps.INSTANCE).getValue() instanceof final net.minecraft.nbt.CompoundTag compoundTag) {
++                            container.putAll(compoundTag);
++                        }
++                        new io.papermc.paper.event.server.AsyncServerDataFixerRemoveBlockEntityEvent(
++                            worldKey,
++                            blockEntityId,
++                            io.papermc.paper.math.Position.block(x.get().intValue(), y.get().intValue(), z.get().intValue()),
++                            container
++                        ).callEvent();
++                    // Paper end - call event on block entity removal
+                     }
+                 }
+ 

--- a/paper-server/patches/sources/net/minecraft/util/filefix/fixes/LegacyStructureFileFix.java.patch
+++ b/paper-server/patches/sources/net/minecraft/util/filefix/fixes/LegacyStructureFileFix.java.patch
@@ -5,7 +5,7 @@
  
              Optional<Identifier> generatorIdentifier = Optional.ofNullable(Identifier.tryParse(chunkGeneratorType));
 -            CompoundTag dataFixContext = ChunkMap.getChunkDataFixContextTag(dimensionKey, generatorIdentifier);
-+            CompoundTag dataFixContext = ChunkMap.getChunkDataFixContextTag(ResourceKey.create(Registries.LEVEL_STEM, dimensionKey.identifier()), generatorIdentifier); // CraftBukkit
++            CompoundTag dataFixContext = ChunkMap.getChunkDataFixContextTag(dimensionKey, generatorIdentifier, ResourceKey.create(Registries.LEVEL_STEM, dimensionKey.identifier())); // Paper - pass level stem
              storeLegacyStructureDataToChunks(dimensionFixEntry.structures, chunkNbt, dataFixContext, upgradeProgress);
          }
      }

--- a/paper-server/patches/sources/net/minecraft/util/worldupdate/WorldUpgrader.java.patch
+++ b/paper-server/patches/sources/net/minecraft/util/worldupdate/WorldUpgrader.java.patch
@@ -5,7 +5,7 @@
      public static CompoundTag getDataFixContextTag(final Registry<LevelStem> dimensions, final ResourceKey<Level> dimension) {
          ChunkGenerator generator = dimensions.getValueOrThrow(Registries.levelToLevelStem(dimension)).generator();
 -        return ChunkMap.getChunkDataFixContextTag(dimension, generator.getTypeNameForDataFixer());
-+        return ChunkMap.getChunkDataFixContextTag(Registries.levelToLevelStem(dimension), generator.getTypeNameForDataFixer()); // CraftBukkit
++        return ChunkMap.getChunkDataFixContextTag(dimension, generator.getTypeNameForDataFixer(), Registries.levelToLevelStem(dimension)); // Paper - pass level stem
      }
  
      public static boolean verifyChunkPosAndEraseCache(final ChunkPos pos, final CompoundTag upgradedTag) {

--- a/paper-server/patches/sources/net/minecraft/world/level/levelgen/structure/StructureCheck.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/levelgen/structure/StructureCheck.java.patch
@@ -1,27 +1,26 @@
 --- a/net/minecraft/world/level/levelgen/structure/StructureCheck.java
 +++ b/net/minecraft/world/level/levelgen/structure/StructureCheck.java
-@@ -43,7 +_,7 @@
-     private final ChunkScanAccess storageAccess;
-     private final RegistryAccess registryAccess;
-     private final StructureTemplateManager structureTemplateManager;
--    private final ResourceKey<Level> dimension;
-+    private final ResourceKey<net.minecraft.world.level.dimension.LevelStem> dimension; // Paper - fix missing CB diff
-     private final ChunkGenerator chunkGenerator;
-     private final RandomState randomState;
-     private final LevelHeightAccessor heightAccessor;
-@@ -57,7 +_,7 @@
+@@ -52,8 +_,12 @@
+     private final DataFixer fixerUpper;
+     private final Long2ObjectMap<Object2IntMap<Structure>> loadedChunks = new Long2ObjectOpenHashMap<>();
+     private final Map<Structure, Long2BooleanMap> featureChecks = new HashMap<>();
++    // Paper start - also store level stem
++    private final ResourceKey<net.minecraft.world.level.dimension.LevelStem> levelStem;
+ 
+     public StructureCheck(
++        final ResourceKey<net.minecraft.world.level.dimension.LevelStem> levelStem,
++    // Paper end - also store level stem
          final ChunkScanAccess storageAccess,
          final RegistryAccess registryAccess,
          final StructureTemplateManager structureTemplateManager,
--        final ResourceKey<Level> dimension,
-+        final ResourceKey<net.minecraft.world.level.dimension.LevelStem> dimension, // Paper - fix missing CB diff
-         final ChunkGenerator chunkGenerator,
-         final RandomState randomState,
-         final LevelHeightAccessor heightAccessor,
-@@ -77,6 +_,20 @@
+@@ -75,7 +_,22 @@
+         this.biomeSource = biomeSource;
+         this.seed = seed;
          this.fixerUpper = fixerUpper;
-     }
- 
+-    }
++        this.levelStem = levelStem; // Paper - also store level stem
++    }
++
 +    // Paper start - add missing structure salt configs
 +    @Nullable
 +    private Integer getSaltOverride(Structure type) {
@@ -35,10 +34,9 @@
 +        return null;
 +    }
 +    // Paper end - add missing structure seed configs
-+
+ 
      public StructureCheckResult checkStart(final ChunkPos pos, final Structure structure, final StructurePlacement placement, final boolean requireUnreferenced) {
          long posKey = pos.pack();
-         Object2IntMap<Structure> cachedResult = this.loadedChunks.get(posKey);
 @@ -89,7 +_,7 @@
              return storageCheckResult;
          }
@@ -48,3 +46,12 @@
              return StructureCheckResult.START_NOT_PRESENT;
          }
  
+@@ -135,7 +_,7 @@
+         if (collectFields.getResult() instanceof CompoundTag chunkTag) {
+             int version = NbtUtils.getDataVersion(chunkTag);
+             SimpleRegionStorage.injectDatafixingContext(
+-                chunkTag, ChunkMap.getChunkDataFixContextTag(this.dimension, this.chunkGenerator.getTypeNameForDataFixer())
++                chunkTag, ChunkMap.getChunkDataFixContextTag(this.dimension, this.chunkGenerator.getTypeNameForDataFixer(), this.levelStem) // Paper - pass level stem
+             );
+ 
+             CompoundTag fixedChunkTag;


### PR DESCRIPTION
When the servers data converter, either mojangs DFU or papers data converter, drops a block entity, plugins can loose valuable data they previously stored in the block entity via the persistent data container api.

To implement this, pass the level identifier to the data converter context via the __context tag vanilla already maintains. Both DFU and DC have implementations for the event to ensure the event is available even if the DC feature patch is not in.