### PR TITLE
Lazy initialization of formattedDisplayName

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/scores/Objective.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/scores/Objective.java.patch
@@ -1,0 +1,38 @@
+--- a/net/minecraft/world/scores/Objective.java
++++ b/net/minecraft/world/scores/Objective.java
+@@ -18,7 +_,7 @@
+     private final String name;
+     private final ObjectiveCriteria criteria;
+     private Component displayName;
+-    private Component formattedDisplayName;
++    private @Nullable Component formattedDisplayName; // Paper - Lazy initialization because only used internally by Commands
+     private ObjectiveCriteria.RenderType renderType;
+     private boolean displayAutoUpdate;
+     private @Nullable NumberFormat numberFormat;
+@@ -36,7 +_,6 @@
+         this.name = name;
+         this.criteria = criteria;
+         this.displayName = displayName;
+-        this.formattedDisplayName = this.createFormattedDisplayName();
+         this.renderType = renderType;
+         this.displayAutoUpdate = displayAutoUpdate;
+         this.numberFormat = numberFormat;
+@@ -81,12 +_,17 @@
+     }
+ 
+     public Component getFormattedDisplayName() {
++        // Paper start - Lazy initialization because only used internally by Commands
++        if (this.formattedDisplayName == null) {
++            this.formattedDisplayName = this.createFormattedDisplayName();
++        }
++        // Paper start - Lazy initialization because only used internally by Commands
+         return this.formattedDisplayName;
+     }
+ 
+     public void setDisplayName(final Component name) {
+         this.displayName = name;
+-        this.formattedDisplayName = this.createFormattedDisplayName();
++        this.formattedDisplayName = null; // Paper - Lazy initialization because only used internally by Commands
+         this.scoreboard.onObjectiveChanged(this);
+     }
+ 


### PR DESCRIPTION
`Objective#getFormattedDisplayName()` is only used internally by vanilla commands ScoreboardCommand and TriggerCommand.
So its unnecessary to initialize with objective it if its if only a small part of Objective will ever use it.