### PR TITLE
Deprecate spawnAnimals spawn flag

### DIFF
--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2647,6 +2647,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
     public ChunkSnapshot getEmptyChunkSnapshot(int x, int z, boolean includeBiome, boolean includeBiomeTemp);
 
     /**
+     * Sets if this world can spawn monsters.
+     * <p>Note that setting {@code false} only affects
+     * natural spawning. It doesn't affect spawn eggs, summon command, mobs
+     * spawned from structure generation, spawners, etc.</p>
+     *
+     * @param allowMonsters - if true, monsters are allowed to spawn in this
+     *     world via natural spawning mechanisms.
+     */
+    public void setAllowMonsterSpawning(boolean allowMonsters);
+
+    /**
      * Sets the spawn flags for this.
      * <p>Note that setting {@code false} for either only affects
      * natural spawning. It doesn't affect spawn eggs, summon command, mobs
@@ -2656,6 +2667,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      *     world via natural spawning mechanisms.
      * @param allowAnimals - if true, animals are allowed to spawn in this
      *     world via natural spawning mechanisms.
+     * @deprecated the vanilla server no longer maintains this functionality.
+     * See {@link #setAllowMonsterSpawning(boolean)} if you want to dis/allow monster spawning.
+     * Plugins can control natural spawning of animals via events like {@link org.bukkit.event.entity.EntitySpawnEvent} and the {@link org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason#NATURAL}.
      */
     public void setSpawnFlags(boolean allowMonsters, boolean allowAnimals);
 
@@ -2663,7 +2677,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * Gets whether animals can spawn in this world.
      *
      * @return whether animals can spawn in this world.
+     * @deprecated the vanilla server no longer maintains this functionality. Plugins can control natural spawning via events like {@link org.bukkit.event.entity.EntitySpawnEvent} and the {@link org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason#NATURAL}.
      */
+    @Deprecated(since = "26.2", forRemoval = true)
     public boolean getAllowAnimals();
 
     /**

--- a/paper-api/src/main/java/org/bukkit/World.java
+++ b/paper-api/src/main/java/org/bukkit/World.java
@@ -2671,6 +2671,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      * See {@link #setAllowMonsterSpawning(boolean)} if you want to dis/allow monster spawning.
      * Plugins can control natural spawning of animals via events like {@link org.bukkit.event.entity.EntitySpawnEvent} and the {@link org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason#NATURAL}.
      */
+    @Deprecated(since = "26.2", forRemoval = true)
     public void setSpawnFlags(boolean allowMonsters, boolean allowAnimals);
 
     /**

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -211,7 +211,7 @@
 +            }
 +            // Paper end - PlayerNaturallySpawnCreaturesEvent
 +            boolean spawnPersistent = this.level.ticksPerSpawnCategory.getLong(org.bukkit.entity.SpawnCategory.ANIMAL) != 0L && this.level.getGameTime() % this.level.ticksPerSpawnCategory.getLong(org.bukkit.entity.SpawnCategory.ANIMAL) == 0L; // CraftBukkit
-+            spawningCategories = NaturalSpawner.getFilteredSpawningCategories(spawnCookie, this.spawnFriendlies, this.spawnEnemies, spawnPersistent, this.level); // CraftBukkit // todo snapshot - method lost its spawnFriendlies parameter as mojang is moving away further. We can do what we did prior and reintroduce or re-evaluate. // re-added it for now but let's still re-evaluate later
++            spawningCategories = NaturalSpawner.getFilteredSpawningCategories(spawnCookie, this.spawnFriendlies, this.spawnEnemies, spawnPersistent, this.level); // CraftBukkit
          } else {
              spawningCategories = List.of();
          }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
@@ -1327,6 +1327,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
     }
 
     @Override
+    public void setAllowMonsterSpawning(final boolean allowMonsters) {
+        this.world.getChunkSource().setSpawnSettings(allowMonsters);
+    }
+
+    @Override
     public void setSpawnFlags(boolean allowMonsters, boolean allowAnimals) {
         this.world.getChunkSource().setSpawnSettings(allowMonsters, allowAnimals);
     }


### PR DESCRIPTION
The flag has not been maintained by vanilla for a while and the API
should start phasing it out as well. Appropriate events exist for
plugins to hook into natural spawning of animals.
