### PR TITLE
Allow a pending entity ID to be applied at configuration end (internal)

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/config/PrepareSpawnTask.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/config/PrepareSpawnTask.java.patch
@@ -156,7 +156,7 @@
                  ChunkPos spawnChunk = ChunkPos.containing(BlockPos.containing(spawnPosition));
                  this.chunkLoadCounter
                      .track(
-@@ -172,14 +_,47 @@
+@@ -172,14 +_,48 @@
          public ServerPlayer spawn(final Connection connection, final CommonListenerCookie cookie) {
              ChunkPos spawnChunk = ChunkPos.containing(BlockPos.containing(this.spawnPosition));
              this.spawnLevel.waitForEntities(spawnChunk, 3);
@@ -174,6 +174,7 @@
 +                player = new ServerPlayer(PrepareSpawnTask.this.server, this.spawnLevel, cookie.gameProfile(), cookie.clientInformation());
 +            }
 +            // Paper end - configuration api - possibly use legacy saved server player instance
++            PrepareSpawnTask.this.listener.paperConnection.applyPendingEntityId(player); // Paper - configuration api - pending entity id
  
              try (ProblemReporter.ScopedCollector reporter = new ProblemReporter.ScopedCollector(player.problemPath(), PrepareSpawnTask.LOGGER)) {
                  Optional<ValueInput> input = PrepareSpawnTask.this.server

--- a/paper-server/patches/sources/net/minecraft/server/network/config/PrepareSpawnTask.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/config/PrepareSpawnTask.java.patch
@@ -174,7 +174,7 @@
 +                player = new ServerPlayer(PrepareSpawnTask.this.server, this.spawnLevel, cookie.gameProfile(), cookie.clientInformation());
 +            }
 +            // Paper end - configuration api - possibly use legacy saved server player instance
-+            PrepareSpawnTask.this.listener.paperConnection.applyPendingEntityId(player); // Paper - configuration api - pending entity id
++            PrepareSpawnTask.this.listener.paperConnection.applyPendingEntityId(player); // Paper - internal entity id api - possibly override player network id if plugins used internal API to configure it.
  
              try (ProblemReporter.ScopedCollector reporter = new ProblemReporter.ScopedCollector(player.problemPath(), PrepareSpawnTask.LOGGER)) {
                  Optional<ValueInput> input = PrepareSpawnTask.this.server

--- a/paper-server/src/main/java/io/papermc/paper/connection/PaperPlayerConfigurationConnection.java
+++ b/paper-server/src/main/java/io/papermc/paper/connection/PaperPlayerConfigurationConnection.java
@@ -31,6 +31,7 @@ import net.minecraft.network.protocol.common.custom.DiscardedPayload;
 import net.minecraft.network.protocol.configuration.ClientboundResetChatPacket;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ClientInformation;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ConfigurationTask;
 import net.minecraft.server.network.ServerConfigurationPacketListenerImpl;
 import org.bukkit.plugin.Plugin;
@@ -40,9 +41,20 @@ import org.jspecify.annotations.Nullable;
 public class PaperPlayerConfigurationConnection extends PaperCommonConnection<ServerConfigurationPacketListenerImpl> implements PlayerConfigurationConnection, Audience, PluginMessageBridgeImpl {
 
     private @Nullable Pointers adventurePointers;
+    private @Nullable Integer pendingEntityId;
 
     public PaperPlayerConfigurationConnection(final ServerConfigurationPacketListenerImpl packetListener) {
         super(packetListener);
+    }
+
+    public void setPendingEntityId(final int entityId) {
+        this.pendingEntityId = entityId;
+    }
+
+    public void applyPendingEntityId(final ServerPlayer player) {
+        if (this.pendingEntityId != null) {
+            player.setId(this.pendingEntityId);
+        }
     }
 
     @Override

--- a/paper-server/src/main/java/io/papermc/paper/connection/PaperPlayerConfigurationConnection.java
+++ b/paper-server/src/main/java/io/papermc/paper/connection/PaperPlayerConfigurationConnection.java
@@ -41,19 +41,30 @@ import org.jspecify.annotations.Nullable;
 public class PaperPlayerConfigurationConnection extends PaperCommonConnection<ServerConfigurationPacketListenerImpl> implements PlayerConfigurationConnection, Audience, PluginMessageBridgeImpl {
 
     private @Nullable Pointers adventurePointers;
-    private @Nullable Integer pendingEntityId;
+    private @Nullable Integer internalPluginDefinedEntityId;
 
     public PaperPlayerConfigurationConnection(final ServerConfigurationPacketListenerImpl packetListener) {
         super(packetListener);
     }
 
-    public void setPendingEntityId(final int entityId) {
-        this.pendingEntityId = entityId;
+    /**
+     * Internal only API that allows plugins to assign a specific entity network id to the player instance once
+     * configuration phase finishes.
+     * <p>
+     * It is fully up to the calling plugin to ensure that no other entity has or will have the passed entity id.
+     * Additionally, as with any other internal API, no backwards compatibility is guaranteed across versions or builds.
+     * Use at own risk.
+     *
+     * @param entityId the network entity id to assign to the player.
+     */
+    public void setInternalPluginDefinedEntityId(final int entityId) {
+        this.internalPluginDefinedEntityId = entityId;
     }
 
+    // Part of the above internal API.
     public void applyPendingEntityId(final ServerPlayer player) {
-        if (this.pendingEntityId != null) {
-            player.setId(this.pendingEntityId);
+        if (this.internalPluginDefinedEntityId != null) {
+            player.setId(this.internalPluginDefinedEntityId);
         }
     }
 


### PR DESCRIPTION
Allow an external service to own the players entity id by exposing an api to set the players entity id during configuration. 