### PR TITLE
[ci skip] Fix GraalVmProcessor compile time warning

### DIFF
--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -195,6 +195,15 @@ tasks.compileTestJava {
     options.compilerArgs.add("-parameters")
 }
 
+tasks.named<JavaCompile>(log4jPlugins.compileJavaTaskName) {
+    options.compilerArgs.addAll(
+        listOf(
+            "-Alog4j.graalvm.groupId=${project.group}",
+            "-Alog4j.graalvm.artifactId=${project.name}"
+        )
+    )
+}
+
 // Bump compile tasks to 1GB memory to avoid OOMs
 tasks.withType<JavaCompile>().configureEach {
     options.forkOptions.memoryMaximumSize = "1G"


### PR DESCRIPTION
Fixes the following build warning:
```
warning: The `GraalVmProcessor` annotation processor is missing the recommended `log4j.graalvm.groupId` and `log4j.graalvm.artifactId` options.
  To follow the GraalVM recommendations, please add the following options to your build tool:
    -Alog4j.graalvm.groupId=<groupId>
    -Alog4j.graalvm.artifactId=<artifactId>
```