### PR TITLE
Do not delay when running minor file fix

### DIFF
--- a/paper-server/patches/sources/net/minecraft/util/filefix/FileFixerUpper.java.patch
+++ b/paper-server/patches/sources/net/minecraft/util/filefix/FileFixerUpper.java.patch
@@ -4,7 +4,7 @@
      ) throws FileFixException {
          int loadedVersion = NbtUtils.getDataVersion(levelDataTag);
          if (this.requiresFileFixing(loadedVersion)) {
-+            if (!io.papermc.paper.world.migration.WorldFolderMigration.didInitialLoad) io.papermc.paper.world.migration.WorldFolderMigration.warnAndDelayStartupMigration(); // Paper
++            if (!io.papermc.paper.world.migration.WorldFolderMigration.didInitialLoad && worldVersionToFileFixerVersion(loadedVersion) == 0) io.papermc.paper.world.migration.WorldFolderMigration.warnAndDelayStartupMigration(); // Paper - warn and delay migration if performing the intial migration from 1.21.11 to >= 26.1
              LOGGER.info("Starting upgrade for world \"{}\"", worldAccess.getLevelId());
              Path worldFolder = worldAccess.getLevelDirectory().path();
              Path fileFixDirectory = worldFolder.resolve("filefix");


### PR DESCRIPTION
Paper halts the server for 30 seconds when performing the large world
import from 1.21.11 to newer versions.

This should not be performed when applying file fixes for 26.1 to 26.2,
which is a single non applicable file fix.

It'll still be performed when importing a spigot or a vanilla world into
the server, however after the applicable file fixes were run (including
the 1.21.11 to 26.1 file fixes).
This should be fixed once we correctly migrate the place where the paper
migration is executed.
