### PR TITLE
Bump jline

### DIFF
--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -111,8 +111,8 @@ abstract class MockitoAgentProvider : CommandLineArgumentProvider {
 dependencies {
     implementation(project(":paper-api"))
     implementation("ca.spottedleaf:leafpile:1.0.0")
-    implementation("org.jline:jline-terminal-ffm:3.27.1") // use ffm on java 22+
-    implementation("org.jline:jline-terminal-jni:3.27.1") // fall back to jni on java 21
+    implementation("org.jline:jline-terminal-ffm:4.3.1")
+    implementation("org.jline:jline-terminal-jni:4.3.1") // This can probably be dropped
     implementation("net.minecrell:terminalconsoleappender:1.3.0")
     implementation("net.kyori:adventure-text-serializer-ansi")
 


### PR DESCRIPTION
The bug I was holding back on for this has been resolved, updates jline
to 4.3.1, noting that now we're targetting Java 25 as the base, we no
longer need the JNI terminal; This has been kept for now as jline can use
it for a fallback, but will likely be removed in the future.
