### PR TITLE
Filter out disallowed control chars

### DIFF
--- a/paper-server/patches/sources/net/minecraft/commands/Commands.java.patch
+++ b/paper-server/patches/sources/net/minecraft/commands/Commands.java.patch
@@ -101,7 +101,7 @@
                  StackTraceElement[] stackTrace = e.getStackTrace();
  
                  for (int i = 0; i < Math.min(stackTrace.length, 3); i++) {
-@@ -366,7 +_,11 @@
+@@ -366,12 +_,16 @@
              return ContextChain.tryFlatten(command.getContext().build(commandString))
                  .orElseThrow(() -> CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand().createWithContext(command.getReader()));
          } catch (CommandSyntaxException e) {
@@ -114,6 +114,12 @@
              if (e.getInput() != null && e.getCursor() >= 0) {
                  int cursor = Math.min(e.getInput().length(), e.getCursor());
                  MutableComponent context = Component.empty()
+                     .withStyle(ChatFormatting.GRAY)
+-                    .withStyle(s -> s.withClickEvent(new ClickEvent.SuggestCommand("/" + commandString)));
++                    .withStyle(s -> s.withClickEvent(new ClickEvent.SuggestCommand("/" + net.minecraft.util.StringUtil.filterText(commandString)))); // Paper - Filter out disallowed control chars
+                 if (cursor > 10) {
+                     context.append(CommonComponents.ELLIPSIS);
+                 }
 @@ -383,7 +_,17 @@
                  }
  


### PR DESCRIPTION
Filtering disallowed chat characters before adding the command to the suggestion click event, prevents component serialization from failing on malformed console input and crashing the server instantly.


## To Reproduce

1. Launch the server
2. Type any unicode control chars or `§` in the console
3. Press enter and server crashed

## Crash report

<details>
<summary>Stacktrace</summary>

```text
Description: Exception in server tick loop

java.lang.RuntimeException: Failed to encode Minecraft Component: empty[style={color=gray,clickEvent=SuggestCommand[command=/§]}, siblings=[literal{§}[style={color=red,underlined}], translation{key='command.context.here', args=[]}[style={color=red,italic}]]]; Disallowed chat character: '§'
	at io.papermc.paper.adventure.WrapperAwareSerializer.lambda$deserialize$0(WrapperAwareSerializer.java:28)
	at com.mojang.serialization.DataResult$Error.getOrThrow(DataResult.java:287)
	at io.papermc.paper.adventure.WrapperAwareSerializer.deserialize(WrapperAwareSerializer.java:28)
	at io.papermc.paper.adventure.WrapperAwareSerializer.deserialize(WrapperAwareSerializer.java:13)
	at io.papermc.paper.adventure.PaperAdventure.asAdventure(PaperAdventure.java:175)
	at net.minecraft.commands.Commands.finishParsing(Commands.java:446)
	at net.minecraft.commands.Commands.performCommand(Commands.java:374)
	at net.minecraft.commands.Commands.performCommand(Commands.java:366)
	at net.minecraft.commands.Commands.performPrefixedCommand(Commands.java:357)
	at net.minecraft.server.dedicated.DedicatedServer.handleConsoleInputs(DedicatedServer.java:574)
	at net.minecraft.server.dedicated.DedicatedServer.tickConnection(DedicatedServer.java:530)
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1838)
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1621)
	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:404)
	at net.minecraft.server.MinecraftServer.processPacketsAndTick(MinecraftServer.java:1679)
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1349)
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:303)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```
</details>