### PR TITLE
Fix incorrect InventoryClickEvent slots when clicking your own inventory during invsee

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftAbstractInventoryView.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftAbstractInventoryView.java
@@ -56,16 +56,23 @@ public abstract class CraftAbstractInventoryView implements InventoryView {
     }
 
     public Inventory mapValidSlotToInventory(final int rawSlot) {
-        if (rawSlot < this.getTopInventory().getSize()) {
+        if (rawSlot < this.getTopSlots()) {
             return this.getTopInventory();
         } else {
             return this.getBottomInventory();
         }
     }
 
+    // The number of raw slots the top inventory occupies in the open menu. This is
+    // usually just its size, but a view can override it when the menu renders fewer
+    // slots than the inventory reports (e.g. a player inventory shown as a chest).
+    public int getTopSlots() {
+        return this.getTopInventory().getSize();
+    }
+
     @Override
     public int convertSlot(final int rawSlot) {
-        int numInTop = this.getTopInventory().getSize();
+        int numInTop = this.getTopSlots();
         // Index from the top inventory as having slots from [0,size]
         if (rawSlot < numInTop) {
             return rawSlot;
@@ -132,7 +139,7 @@ public abstract class CraftAbstractInventoryView implements InventoryView {
     @Override
     public InventoryType.SlotType getSlotType(final int slot) {
         InventoryType.SlotType type = InventoryType.SlotType.CONTAINER;
-        if (slot >= 0 && slot < this.getTopInventory().getSize()) {
+        if (slot >= 0 && slot < this.getTopSlots()) {
             switch (this.getType()) {
                 case BLAST_FURNACE:
                 case FURNACE:
@@ -229,7 +236,7 @@ public abstract class CraftAbstractInventoryView implements InventoryView {
 
     @Override
     public int countSlots() {
-        return this.getTopInventory().getSize() + this.getBottomInventory().getSize();
+        return this.getTopSlots() + this.getBottomInventory().getSize();
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
@@ -72,6 +72,18 @@ public class CraftContainer extends AbstractContainerMenu {
                 return inventory.getType();
             }
 
+            @Override
+            public int getTopSlots() {
+                // A player inventory shown inside a container is laid out as a generic
+                // chest (whole rows of 9), so the armour and off-hand slots that
+                // getSize() counts are not rendered. Use the number of slots actually
+                // laid out so the raw-slot mapping matches the open menu.
+                if (inventory.getType() == InventoryType.PLAYER) {
+                    return (inventory.getSize() / 9) * 9;
+                }
+                return inventory.getSize();
+            }
+
             // Paper start
             @Override
             public net.kyori.adventure.text.Component title() {


### PR DESCRIPTION
Fixes #11245

When you open another player's inventory (invsee-style, via `player.openInventory(target.getInventory())`) and then click an item in your own inventory at the bottom, `InventoryClickEvent` reports a completely unrelated slot and item. It has been broken since around 1.14.

The top inventory in that case is drawn as a generic 9x4 chest, so it only shows 36 slots. A player inventory, though, reports a size of 41 because it also counts the four armour slots and the off-hand. The slot conversion in `CraftAbstractInventoryView` keyed off that reported size, so every raw slot in the bottom inventory ended up five out. The first few slots of your own inventory were even treated as part of the top.

This adds a small `getTopSlots()` hook (it defaults to the current behaviour, so nothing else changes) and, for a player inventory opened in a container, returns the slot count that is actually laid out. With that, `convertSlot`, `getSlotType`, and `countSlots` line up with the real container again.

I worked the mapping through by hand (raw slot 36 maps to main inventory slot 9, raw 71 to hotbar 8, and so on) and it checks out, but I have not been able to run it against a live server build yet, so a second look there would be welcome.
