### PR TITLE
Add SulfurCube#swallow

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/SulfurCube.java
+++ b/paper-api/src/main/java/org/bukkit/entity/SulfurCube.java
@@ -7,6 +7,7 @@ import io.papermc.paper.registry.RegistryKey;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
+import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -72,6 +73,30 @@ public interface SulfurCube extends AbstractCubeMob, Shearable, Bucketable, Agea
     default boolean ignite() {
         return this.ignite(false);
     }
+
+    /**
+     * Equips the provided item to this sulfur cube, following any Vanilla logic.
+     * <p>
+     * This method will:
+     * <ul>
+     *     <li>not equip the item to a baby sulfur cube,</li>
+     *     <li>drop an existing body item before, and</li>
+     *     <li>play the absorb-sound.</li>
+     * </ul>
+     * <p>
+     * If you want to circumvent the above-mentioned Vanilla logic, you can instead directly edit
+     * the body equipment slot of the sulfur cube, like this:
+     * <pre>{@code
+     * sulfurCube.getEquipment().setItem(
+     *   EquipmentSlot.BODY,
+     *   itemStack
+     * );
+     * }</pre>
+     *
+     * @param itemStack the item to equip. Use {@link ItemStack#empty()} to unset the item
+     * @return whether the sulfur cube's absorbed item was updated
+     */
+    boolean equipItem(ItemStack itemStack);
 
     /**
      * Represents the archetype of a sulfur cube

--- a/paper-api/src/main/java/org/bukkit/entity/SulfurCube.java
+++ b/paper-api/src/main/java/org/bukkit/entity/SulfurCube.java
@@ -1,9 +1,12 @@
 package org.bukkit.entity;
 
+import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
 import io.papermc.paper.entity.Bucketable;
 import io.papermc.paper.entity.Shearable;
+import io.papermc.paper.event.entity.EntityEquipmentChangedEvent;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.keys.tags.ItemTypeTagKeys;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
@@ -75,28 +78,24 @@ public interface SulfurCube extends AbstractCubeMob, Shearable, Bucketable, Agea
     }
 
     /**
-     * Equips the provided item to this sulfur cube, following any Vanilla logic.
+     * Makes this sulfur cube swallow the provided item, following any Vanilla logic.
      * <p>
      * This method will:
      * <ul>
      *     <li>not equip the item to a baby sulfur cube,</li>
-     *     <li>drop an existing body item before, and</li>
-     *     <li>play the absorb-sound.</li>
+     *     <li>if present, drop a previously swallowed item, and</li>
+     *     <li>play the swallow sound.</li>
      * </ul>
      * <p>
-     * If you want to circumvent the above-mentioned Vanilla logic, you can instead directly edit
-     * the body equipment slot of the sulfur cube, like this:
-     * <pre>{@code
-     * sulfurCube.getEquipment().setItem(
-     *   EquipmentSlot.BODY,
-     *   itemStack
-     * );
-     * }</pre>
+     * If the currently swallowed item is changed, a {@link EntityEquipmentChangedEvent} is called.
+     * May also call a {@link EntityAddToWorldEvent} for the newly dropped {@link Item} entity.
      *
-     * @param itemStack the item to equip. Use {@link ItemStack#empty()} to unset the item
+     * @param itemStack the item to swallow. Use {@link ItemStack#empty()} to unset the item.
+     *                  Items not in the {@link ItemTypeTagKeys#SULFUR_CUBE_SWALLOWABLE} tag
+     *                  will not be properly rendered inside the sulfur cube
      * @return whether the sulfur cube's absorbed item was updated
      */
-    boolean equipItem(ItemStack itemStack);
+    boolean swallow(ItemStack itemStack);
 
     /**
      * Represents the archetype of a sulfur cube

--- a/paper-api/src/main/java/org/bukkit/entity/SulfurCube.java
+++ b/paper-api/src/main/java/org/bukkit/entity/SulfurCube.java
@@ -113,7 +113,7 @@ public interface SulfurCube extends AbstractCubeMob, Shearable, Bucketable, Agea
      * @param itemStack the item stack to be equipped
      * @see #swallow(ItemStack) set the swallowed item, following any Vanilla swallow logic
      */
-    default void setEquipped(ItemStack itemStack) {
+    default void setEquipped(final ItemStack itemStack) {
         this.getEquipment().setItem(EquipmentSlot.BODY, itemStack);
     }
 

--- a/paper-api/src/main/java/org/bukkit/entity/SulfurCube.java
+++ b/paper-api/src/main/java/org/bukkit/entity/SulfurCube.java
@@ -110,7 +110,7 @@ public interface SulfurCube extends AbstractCubeMob, Shearable, Bucketable, Agea
      * <p>
      * This method will call a {@link EntityEquipmentChangedEvent}.
      *
-     * @param itemStack the item stack to be equipped
+     * @param itemStack the item stack to be equipped, use {@link ItemStack#empty()} to unset the item
      * @see #swallow(ItemStack) set the swallowed item, following any Vanilla swallow logic
      */
     default void setEquipped(final ItemStack itemStack) {
@@ -123,7 +123,8 @@ public interface SulfurCube extends AbstractCubeMob, Shearable, Bucketable, Agea
      * This method acts as a simple utility method to get the {@link EquipmentSlot#BODY}
      * equipment slot of this sulfur cube, which holds the sulfur cube's swallowed item.
      *
-     * @return the item stack in the {@link EquipmentSlot#BODY} equipment slot
+     * @return the item stack in the {@link EquipmentSlot#BODY} equipment slot, returns {@link ItemStack#empty()}
+     * if no item is present
      */
     default ItemStack getEquipped() {
         return this.getEquipment().getItem(EquipmentSlot.BODY);

--- a/paper-api/src/main/java/org/bukkit/entity/SulfurCube.java
+++ b/paper-api/src/main/java/org/bukkit/entity/SulfurCube.java
@@ -10,6 +10,7 @@ import io.papermc.paper.registry.keys.tags.ItemTypeTagKeys;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
 import org.bukkit.Keyed;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
 
@@ -94,8 +95,39 @@ public interface SulfurCube extends AbstractCubeMob, Shearable, Bucketable, Agea
      *                  Items not in the {@link ItemTypeTagKeys#SULFUR_CUBE_SWALLOWABLE} tag
      *                  will not be properly rendered inside the sulfur cube
      * @return whether the sulfur cube's absorbed item was updated
+     * @see #setEquipped(ItemStack) set the swallowed item, skipping any Vanilla swallow logic
      */
     boolean swallow(ItemStack itemStack);
+
+    /**
+     * Sets the swallowed item stack for this sulfur cube.
+     * <p>
+     * This method acts as a simple utility method to set the {@link EquipmentSlot#BODY}
+     * equipment slot of this sulfur cube, which holds the sulfur cube's swallowed item.
+     * <p>
+     * Different to {@link #swallow(ItemStack)}, this method does not play a sound or
+     * drop the previously equipped item on the ground.
+     * <p>
+     * This method will call a {@link EntityEquipmentChangedEvent}.
+     *
+     * @param itemStack the item stack to be equipped
+     * @see #swallow(ItemStack) set the swallowed item, following any Vanilla swallow logic
+     */
+    default void setEquipped(ItemStack itemStack) {
+        this.getEquipment().setItem(EquipmentSlot.BODY, itemStack);
+    }
+
+    /**
+     * Retrieves the item stack currently swallowed by this sulfur cube.
+     * <p>
+     * This method acts as a simple utility method to get the {@link EquipmentSlot#BODY}
+     * equipment slot of this sulfur cube, which holds the sulfur cube's swallowed item.
+     *
+     * @return the item stack in the {@link EquipmentSlot#BODY} equipment slot
+     */
+    default ItemStack getEquipped() {
+        return this.getEquipment().getItem(EquipmentSlot.BODY);
+    }
 
     /**
      * Represents the archetype of a sulfur cube

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSulfurCube.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSulfurCube.java
@@ -10,7 +10,9 @@ import net.minecraft.world.entity.SulfurCubeArchetype;
 import net.minecraft.world.entity.item.PrimedTnt;
 import org.bukkit.craftbukkit.CraftRegistry;
 import org.bukkit.craftbukkit.CraftServer;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.SulfurCube;
+import org.bukkit.inventory.ItemStack;
 
 public class CraftSulfurCube extends CraftAbstractCubeMob implements SulfurCube, PaperShearable, PaperBucketable {
     public CraftSulfurCube(final CraftServer server, final net.minecraft.world.entity.monster.cubemob.SulfurCube entity) {
@@ -42,6 +44,11 @@ public class CraftSulfurCube extends CraftAbstractCubeMob implements SulfurCube,
     @Override
     public boolean ignite(final boolean imminent) {
         return this.getHandle().primeTime(imminent);
+    }
+
+    @Override
+    public boolean equipItem(final ItemStack itemStack) {
+        return this.getHandle().equipItem(CraftItemStack.asNMSCopy(itemStack));
     }
 
     @Override

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSulfurCube.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftSulfurCube.java
@@ -47,7 +47,7 @@ public class CraftSulfurCube extends CraftAbstractCubeMob implements SulfurCube,
     }
 
     @Override
-    public boolean equipItem(final ItemStack itemStack) {
+    public boolean swallow(final ItemStack itemStack) {
         return this.getHandle().equipItem(CraftItemStack.asNMSCopy(itemStack));
     }
 


### PR DESCRIPTION
This PR exposes the NMS-internal `SulfurCube#equipItem` method as an API-method.

Currently, if you want to set the item swallowed by a SulfurCube, you have to call the following code: 
```java
cube.getEquipment().setItem(
  EquipmentSlot.BODY,
  ItemType.BIRCH_LOG.createItemStack()
);
```

This is *fine* if you know about it. However that skips a little bit of logic that's inside the NMS `SulfurfCube#equipItem` method. Additionally, it's not intuitive for anyone simply scrolling through the SulfurCube API methods.

(Discussion: https://discord.com/channels/289587909051416579/925530366192779286/1526310872450994318)