### PR TITLE
update build and publish_pr actions [ci skip]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,6 @@ jobs:
       )
 
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       - if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Test Results
           path: |
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload Paperclip Jar
         if: fromJSON(steps.determine.outputs.result).action == 'paperclip'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: paper-${{ fromJSON(steps.determine.outputs.result).pr }}
           path: paper-server/build/libs/paper-paperclip-*.jar

--- a/.github/workflows/publish_pr.yml
+++ b/.github/workflows/publish_pr.yml
@@ -21,7 +21,7 @@ jobs:
         id: gen_repo_token
         uses: actions/create-github-app-token@v3.2.0
         with:
-          app-id: 1408328
+          client-id: 1408328
           private-key: ${{ secrets.PR_PUBLISHING_GH_APP_KEY }}
           repositories: ${{ github.repository }}
       - name: Publish PR

--- a/.github/workflows/publish_pr.yml
+++ b/.github/workflows/publish_pr.yml
@@ -21,7 +21,7 @@ jobs:
         id: gen_repo_token
         uses: actions/create-github-app-token@v3.2.0
         with:
-          client-id: 1408328
+          client-id: ${{ secrets.PR_PUBLISHING_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.PR_PUBLISHING_GH_APP_KEY }}
           repositories: ${{ github.repository }}
       - name: Publish PR

--- a/.github/workflows/publish_pr.yml
+++ b/.github/workflows/publish_pr.yml
@@ -25,7 +25,7 @@ jobs:
           private-key: ${{ secrets.PR_PUBLISHING_GH_APP_KEY }}
           repositories: ${{ github.repository }}
       - name: Publish PR
-        uses: PaperMC/action-pr-publishing@paper
+        uses: PaperMC/action-pr-publishing@v1.1.0
         env:
           GITHUB_TOKEN: ${{ steps.gen_repo_token.outputs.token }}
         with:


### PR DESCRIPTION
This PR handle a few things related to the build/publish_pr actions.

- Replace the deprecated input in publish_pr for the token action, related to https://github.com/actions/create-github-app-token#client-id-or-app-id
https://github.com/actions/create-github-app-token/pull/353 also use a secret like the other action using that input
- Update the upload-artifact action in build (the missing in https://github.com/PaperMC/Paper/commit/eb44b4bfd0dbcfa7a5c8c099654407ce9aeb344f#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721)
- Remove the strategy in build action because its only necesary for matrix and currently the build not use that
- Set the version for PaperMC/action-pr-publishing based in last releases