### PR TITLE
Upgrade upload-artifact for Build Action [ci skip]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Test Results
           path: |
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload Paperclip Jar
         if: fromJSON(steps.determine.outputs.result).action == 'paperclip'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: paper-${{ fromJSON(steps.determine.outputs.result).pr }}
           path: paper-server/build/libs/paper-paperclip-*.jar


### PR DESCRIPTION
Related to https://github.com/PaperMC/Paper/commit/eb44b4bfd0dbcfa7a5c8c099654407ce9aeb344f#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721 not sure why a that action was not updated...