### PR TITLE
Marking plugins as enabled after onEnable executes

### DIFF
--- a/paper-api/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -270,21 +270,23 @@ public abstract class JavaPlugin extends PluginBase {
      */
     @org.jetbrains.annotations.ApiStatus.Internal
     public final void setEnabled(final boolean enabled) {
-        if (isEnabled != enabled) {
-            isEnabled = enabled;
-
-            if (isEnabled) {
-                this.isBeingEnabled = true;
-                try {
-                    onEnable();
-                } finally {
-                    this.allowsLifecycleRegistration = false;
-                    this.isBeingEnabled = false;
-                }
-            } else {
-                onDisable();
-            }
+        if (isEnabled == enabled) {
+            return;
         }
+
+        if (enabled) {
+            this.isBeingEnabled = true;
+            try {
+                onEnable();
+            } finally {
+                this.allowsLifecycleRegistration = false;
+                this.isBeingEnabled = false;
+            }
+        } else {
+            onDisable();
+        }
+
+        isEnabled = enabled;
     }
 
     private static class DummyPluginLoaderImplHolder {


### PR DESCRIPTION
I was using `this.isEnabled()` to check if my plugin was being enabled twice.  This caused the init to get messed up because all plugins are marked as enabled before onEnable is executed.  I changed it to update `enabled` after the plugin is enabled/disabled so that people can check this flag in their onEnable functions.