### PR TITLE
Fix Adventure Codec for ClickEvent#custom when BinaryTagHolder is null

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/adventure/AdventureCodecs.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/AdventureCodecs.java
@@ -149,8 +149,10 @@ public final class AdventureCodecs {
     ).apply(instance, ClickEvent::showDialog)));
     static final MapCodec<ClickEvent> CUSTOM_CODEC = mapCodec((instance) -> instance.group(
         KEY_CODEC.fieldOf("id").forGetter(a -> ((ClickEvent.Payload.Custom) a.payload()).key()),
-        BINARY_TAG_HOLDER_CODEC.fieldOf("payload").forGetter(a -> ((ClickEvent.Payload.Custom) a.payload()).nbt())
-    ).apply(instance, ClickEvent::custom));
+        BINARY_TAG_HOLDER_CODEC.optionalFieldOf("payload").forGetter(a -> Optional.ofNullable(((ClickEvent.Payload.Custom) a.payload()).nbt()))
+    ).apply(instance, (key, binaryTagHolder) -> {
+        return ClickEvent.custom(key, binaryTagHolder.orElse(null));
+    }));
 
     static final ClickEventType OPEN_URL_CLICK_EVENT_TYPE = new ClickEventType(OPEN_URL_CODEC, "open_url");
     static final ClickEventType OPEN_FILE_CLICK_EVENT_TYPE = new ClickEventType(OPEN_FILE_CODEC, "open_file");


### PR DESCRIPTION
Fix https://github.com/PaperMC/Paper/issues/14072

Looks like [since](https://github.com/PaperMC/adventure/commit/f4ea9042b9a7e1124dbccc9c8989752c9ad0e640) Adventure 5 the BinaryTagHolder for ClickEvent#custom can be null causing issues in the Adventure Codec because mark that field like NonNull, this PR just handle that case for use the correct behaviour.