### PR TITLE
Fix BlockData merge for cached states

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
@@ -456,6 +456,7 @@ public class CraftBlockData implements BlockData {
         ENCODER_CACHE.clear();
         Block.BLOCK_STATE_REGISTRY.forEach(state -> {
             CraftBlockData data = state.asBlockData();
+            data.parsedStates = state.getValues().toList();
             ENCODER_CACHE.put(data.getAsString(), data);
         });
     }

--- a/paper-server/src/test/java/org/bukkit/BlockDataTest.java
+++ b/paper-server/src/test/java/org/bukkit/BlockDataTest.java
@@ -100,6 +100,22 @@ public class BlockDataTest {
     }
 
     @Test
+    public void testMergeFullySpecifiedBannerData() {
+        BlockData banner = CraftBlockData.fromString(null, "minecraft:light_gray_banner");
+        BlockData rotation = CraftBlockData.fromString(null, "minecraft:light_gray_banner[rotation=1]");
+
+        assertEquals(rotation, banner.merge(rotation));
+    }
+
+    @Test
+    public void testMergeFullySpecifiedLogData() {
+        BlockData log = CraftBlockData.fromString(BlockType.OAK_LOG, null);
+        BlockData axis = CraftBlockData.fromString(BlockType.OAK_LOG, "[axis=y]");
+
+        assertEquals(axis, log.merge(axis));
+    }
+
+    @Test
     public void testMergeAny() {
         Chest trueTarget = (Chest) CraftBlockData.fromString(null, "minecraft:chest[facing=east,waterlogged=true]");
         Chest falseTarget = (Chest) CraftBlockData.fromString(null, "minecraft:chest[facing=east,waterlogged=false]");


### PR DESCRIPTION
Fixes #14064

Retain `parsedStates` for preloaded `BlockData` cache entries. This allows `merge` to correctly handle fully specified string-created `BlockData`
I also added regression tests covering banners and oak logs