### PR TITLE
feat: add EntityType#getSpawnCategory()

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/InternalAPIBridge.java
+++ b/paper-api/src/main/java/io/papermc/paper/InternalAPIBridge.java
@@ -29,6 +29,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Pose;
+import org.bukkit.entity.SpawnCategory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -96,6 +97,8 @@ public interface InternalAPIBridge {
     DamageEffect getDamageEffect(String key);
 
     String getTranslationKey(EntityType entityType);
+
+    SpawnCategory getSpawnCategory(EntityType entityType);
 
     /*
      * Called once by the version command on first use, then cached.

--- a/paper-api/src/main/java/org/bukkit/entity/EntityType.java
+++ b/paper-api/src/main/java/org/bukkit/entity/EntityType.java
@@ -344,6 +344,17 @@ public enum EntityType implements Keyed, Translatable, net.kyori.adventure.trans
     }
 
     /**
+     * Gets the spawn category of this entity type.
+     *
+     * @return the spawn category
+     * @throws IllegalArgumentException if the entity does not have a spawn category (is probably a custom entity)
+     */
+    public @NotNull SpawnCategory getSpawnCategory() {
+        Preconditions.checkArgument(this != UNKNOWN, "UNKNOWN entities do not have a spawn category");
+        return InternalAPIBridge.get().getSpawnCategory(this);
+    }
+
+    /**
      * Checks if the entity has default attributes.
      *
      * @return true if it has default attributes

--- a/paper-server/src/main/java/io/papermc/paper/PaperServerInternalAPIBridge.java
+++ b/paper-server/src/main/java/io/papermc/paper/PaperServerInternalAPIBridge.java
@@ -59,6 +59,7 @@ import org.bukkit.craftbukkit.entity.CraftMannequin;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.util.CraftMagicNumbers;
 import org.bukkit.craftbukkit.util.CraftNamespacedKey;
+import org.bukkit.craftbukkit.util.CraftSpawnCategory;
 import org.bukkit.damage.DamageEffect;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.damage.DamageType;
@@ -66,6 +67,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Pose;
+import org.bukkit.entity.SpawnCategory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -109,6 +111,11 @@ public class PaperServerInternalAPIBridge implements InternalAPIBridge {
             Optionull.map(fallLocationType, PaperCombatTrackerWrapper::paperToMinecraft),
             fallDistance
         );
+    }
+
+    @Override
+    public SpawnCategory getSpawnCategory(EntityType entityType) {
+        return CraftSpawnCategory.toBukkit(CraftEntityType.bukkitToMinecraft(entityType).getCategory());
     }
 
     private CombatEntry createCombatEntry(

--- a/paper-server/src/test/java/org/bukkit/entity/EntityTypesTest.java
+++ b/paper-server/src/test/java/org/bukkit/entity/EntityTypesTest.java
@@ -17,4 +17,12 @@ public class EntityTypesTest {
             }
         }
     }
+
+    @Test
+    void testGetSpawnCategory() {
+        for (EntityType type : EntityType.values()) {
+            if (type == EntityType.UNKNOWN) continue;
+            assertNotNull(type.getSpawnCategory(), "SpawnCategory should not be null for " + type);
+        }
+    }
 }


### PR DESCRIPTION
Allows retrieving the spawn category of an entity type without needing to spawn an instance of it first.

closes #13930 