### PR TITLE
Configurable TPS catchup

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -824,7 +824,7 @@
 +                    final long ticksBehind = Math.max(1L, this.tickSchedule.getPeriodsAhead(thisTickNanos, tickStart));
 +                    final long catchup = (long)Math.max(
 +                        1,
-+                        5 //ConfigHolder.getConfig().tickLoop.catchupTicks.getOrDefault(MoonriseConfig.TickLoop.DEFAULT_CATCHUP_TICKS).intValue()
++                        io.papermc.paper.configuration.GlobalConfiguration.get().misc.catchupTicks
 +                    );
 +
 +                    // adjust ticksBehind so that it is not greater-than catchup

--- a/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -824,7 +824,7 @@
 +                    final long ticksBehind = Math.max(1L, this.tickSchedule.getPeriodsAhead(thisTickNanos, tickStart));
 +                    final long catchup = (long)Math.max(
 +                        1,
-+                        io.papermc.paper.configuration.GlobalConfiguration.get().misc.catchupTicks
++                        io.papermc.paper.configuration.GlobalConfiguration.get().misc.catchupTicks.or(5)
 +                    );
 +
 +                    // adjust ticksBehind so that it is not greater-than catchup

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -319,6 +319,7 @@ public class GlobalConfiguration extends ConfigurationPart {
             }
         }
         public int maxJoinsPerTick = 5;
+        public int catchupTicks = 5;
         public boolean sendFullPosForItemEntities = false;
         public boolean loadPermissionsYmlBeforePlugins = true;
         @Constraints.Min(4)

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -319,6 +319,7 @@ public class GlobalConfiguration extends ConfigurationPart {
             }
         }
         public int maxJoinsPerTick = 5;
+        @Constraints.Min(0)
         public IntOr.Default catchupTicks = IntOr.Default.USE_DEFAULT;
         public boolean sendFullPosForItemEntities = false;
         public boolean loadPermissionsYmlBeforePlugins = true;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -319,7 +319,7 @@ public class GlobalConfiguration extends ConfigurationPart {
             }
         }
         public int maxJoinsPerTick = 5;
-        public int catchupTicks = 5;
+        public IntOr.Default catchupTicks = IntOr.Default.USE_DEFAULT;
         public boolean sendFullPosForItemEntities = false;
         public boolean loadPermissionsYmlBeforePlugins = true;
         @Constraints.Min(4)


### PR DESCRIPTION
Moonrise has a configuration, currently commented, for TPS catchup.
This basically makes this configuration accessible so people that don't want TPS catchup can disable it in their servers.

This addresses the discussion at https://github.com/PaperMC/Paper/discussions/10488.
Some plugins probably still rely on the catchup, although documentation on proper practices has been around for years to not rely on that, plus this is an opt-in feature, since I kept the default value as 5 ticks.