### PR TITLE
feat: skip large block entities

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/player/AsyncBlockEntityUpdateTooLargeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/AsyncBlockEntityUpdateTooLargeEvent.java
@@ -1,0 +1,52 @@
+package io.papermc.paper.event.player;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a block entity update is too large to be sent to a player.
+ * <p>
+ *     This will be fired every time a chunk is re-sent to a player for each
+ *     large block entity, be careful as to not run expensive operations.
+ * </p>
+ * <p>
+ * This event is asynchronous and runs on the network thread.
+ */
+public class AsyncBlockEntityUpdateTooLargeEvent extends PlayerEvent {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final Block block;
+
+    @ApiStatus.Internal
+    public AsyncBlockEntityUpdateTooLargeEvent(@NotNull final Block block, @NotNull final Player player) {
+        super(player, true);
+        this.block = block;
+    }
+
+    /**
+     * Gets the block entity's block.
+     *
+     * @return the block
+     */
+    @NotNull
+    public Block getBlock() {
+        return this.block;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+}

--- a/paper-server/patches/features/0035-Skip-large-block-entities.patch
+++ b/paper-server/patches/features/0035-Skip-large-block-entities.patch
@@ -1,0 +1,171 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: RedVortexDev <58099979+RedVortexDev@users.noreply.github.com>
+Date: Wed, 22 Jul 2026 15:20:47 +0300
+Subject: [PATCH] Skip large block entities
+
+
+diff --git a/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.java b/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.java
+index 2122ff56412a2ad412eb8b2f0e4538aab4257bf2..167cd14d6d4b3e313a94a7213aeb2c29ec04c07b 100644
+--- a/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.java
++++ b/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.java
+@@ -26,12 +26,13 @@ public class ClientboundBlockEntityDataPacket implements Packet<ClientGamePacket
+     private final BlockPos pos;
+     private final BlockEntityType<?> type;
+     private final CompoundTag tag;
++    private final org.bukkit.block.@org.jspecify.annotations.Nullable Block block; // Paper - Provide API block
+ 
+     public static ClientboundBlockEntityDataPacket create(
+         final BlockEntity blockEntity, final BiFunction<BlockEntity, RegistryAccess, CompoundTag> updateTagSaver
+     ) {
+         RegistryAccess registryAccess = blockEntity.getLevel().registryAccess();
+-        return new ClientboundBlockEntityDataPacket(blockEntity.getBlockPos(), blockEntity.getType(), blockEntity.sanitizeSentNbt(updateTagSaver.apply(blockEntity, registryAccess))); // Paper - Sanitize sent data
++        return new ClientboundBlockEntityDataPacket(blockEntity.getBlockPos(), blockEntity.getType(), blockEntity.sanitizeSentNbt(updateTagSaver.apply(blockEntity, registryAccess)), org.bukkit.craftbukkit.block.CraftBlock.at(blockEntity.getLevel(), blockEntity.getBlockPos())); // Paper - Sanitize sent data // Paper - Provide API block
+     }
+ 
+     public static ClientboundBlockEntityDataPacket create(final BlockEntity blockEntity) {
+@@ -39,9 +40,35 @@ public class ClientboundBlockEntityDataPacket implements Packet<ClientGamePacket
+     }
+ 
+     public ClientboundBlockEntityDataPacket(final BlockPos pos, final BlockEntityType<?> type, final CompoundTag tag) {
++        // Paper start - Provide API block
++        this(pos, type, tag, null);
++    }
++
++    // Paper end
++    private ClientboundBlockEntityDataPacket(final BlockPos pos, final BlockEntityType<?> type, final CompoundTag tag, final org.bukkit.block.@org.jspecify.annotations.Nullable Block block) { // Paper - Provide API block
+         this.pos = pos;
+         this.type = type;
+         this.tag = tag;
++        // Paper start - Provide API block
++        this.block = block;
++    }
++
++    // Paper end
++    // Paper start - Skip large block entities
++    @Override
++    public boolean hasLargePacketFallback() {
++        return true;
++    }
++
++    @Override
++    public boolean packetTooLarge(final net.minecraft.network.Connection manager) {
++        net.minecraft.server.level.ServerPlayer player = manager.getPlayer();
++        if (this.block != null && player != null) {
++            org.bukkit.Bukkit.getPluginManager().callEvent(new io.papermc.paper.event.player.AsyncBlockEntityUpdateTooLargeEvent(this.block, player.getBukkitEntity()));
++        }
++
++        return true;
++       // Paper end
+     }
+ 
+     @Override
+diff --git a/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java b/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
+index a52f93d0563f713b1d2b707cdb6ab74e4793a54d..1d6cb89c15da57542c45eb996151e9769a3ed45e 100644
+--- a/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
++++ b/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
+@@ -61,18 +61,28 @@ public class ClientboundLevelChunkPacketData {
+         this.blockEntitiesData = Lists.newArrayList();
+         int totalTileEntities = 0; // Paper - Handle oversized block entities in chunks
+ 
+-        for (Entry<BlockPos, BlockEntity> entry : levelChunk.getBlockEntities().entrySet()) {
+-            // Paper start - Handle oversized block entities in chunks
+-            if (++totalTileEntities > BLOCK_ENTITY_LIMIT) {
+-                net.minecraft.network.protocol.Packet<ClientGamePacketListener> packet = entry.getValue().getUpdatePacket();
+-                if (packet != null) {
+-                    this.extraPackets.add(packet);
+-                    continue;
++        // Paper start - Cache serialized block entity data
++        final ByteBuf blockEntityBuffer = Unpooled.buffer();
++        try {
++            final RegistryFriendlyByteBuf blockEntityFriendlyBuffer = new RegistryFriendlyByteBuf(blockEntityBuffer, levelChunk.getLevel().registryAccess());
++
++            for (Entry<BlockPos, BlockEntity> entry : levelChunk.getBlockEntities().entrySet()) {
++                BlockEntityInfo blockEntityInfo = BlockEntityInfo.create(entry.getValue(), levelChunk.getLevel().registryAccess(), blockEntityFriendlyBuffer); // Paper - Cache serialized block entity data
++                // Paper start - Handle oversized block entities in chunks
++                if (++totalTileEntities > BLOCK_ENTITY_LIMIT || blockEntityInfo.isLarge()) { // Paper - Skip large block entities
++                    net.minecraft.network.protocol.Packet<ClientGamePacketListener> packet = entry.getValue().getUpdatePacket();
++                    if (packet != null) {
++                        this.extraPackets.add(packet);
++                        continue;
++                    }
+                 }
++                // Paper end - Handle oversized block entities in chunks
++                this.blockEntitiesData.add(blockEntityInfo); // Paper - Cache serialized block entity data
+             }
+-            // Paper end - Handle oversized block entities in chunks
+-            this.blockEntitiesData.add(ClientboundLevelChunkPacketData.BlockEntityInfo.create(entry.getValue()));
++        } finally {
++            blockEntityBuffer.release();
+         }
++        // Paper end - Cache serialized block entity data
+     }
+ 
+     public ClientboundLevelChunkPacketData(final RegistryFriendlyByteBuf input, final int x, final int z) {
+@@ -164,12 +174,24 @@ public class ClientboundLevelChunkPacketData {
+         private final int y;
+         private final BlockEntityType<?> type;
+         private final @Nullable CompoundTag tag;
++        private final byte @Nullable [] serializedData; // Paper - Cache serialized block entity data
+ 
+         private BlockEntityInfo(final int packedXZ, final int y, final BlockEntityType<?> type, final @Nullable CompoundTag tag) {
+             this.packedXZ = packedXZ;
+             this.y = y;
+             this.type = type;
+             this.tag = tag;
++            // Paper start - Cache serialized block entity data
++            this.serializedData = null;
++        }
++
++        private BlockEntityInfo(final int packedXZ, final int y, final BlockEntityType<?> type, final @Nullable CompoundTag tag, final byte[] serializedData) {
++            this.packedXZ = packedXZ;
++            this.y = y;
++            this.type = type;
++            this.tag = tag;
++            this.serializedData = serializedData;
++            // Paper end
+         }
+ 
+         private BlockEntityInfo(final RegistryFriendlyByteBuf input) {
+@@ -177,21 +199,39 @@ public class ClientboundLevelChunkPacketData {
+             this.y = input.readShort();
+             this.type = ByteBufCodecs.registry(Registries.BLOCK_ENTITY_TYPE).decode(input);
+             this.tag = input.readNbt();
++            this.serializedData = null; // Paper - Cache serialized block entity data
+         }
+ 
+         private void write(final RegistryFriendlyByteBuf output) {
++            // Paper start - Cache serialized block entity data
++            if (this.serializedData != null) {
++                output.writeBytes(this.serializedData);
++                return;
++            }
++            // Paper end
+             output.writeByte(this.packedXZ);
+             output.writeShort(this.y);
+             ByteBufCodecs.registry(Registries.BLOCK_ENTITY_TYPE).encode(output, this.type);
+             output.writeNbt(this.tag);
+         }
+ 
+-        private static ClientboundLevelChunkPacketData.BlockEntityInfo create(final BlockEntity blockEntity) {
+-            CompoundTag tag = blockEntity.getUpdateTag(blockEntity.getLevel().registryAccess());
++        private static ClientboundLevelChunkPacketData.BlockEntityInfo create(final BlockEntity blockEntity, final net.minecraft.core.RegistryAccess registryAccess, RegistryFriendlyByteBuf buffer) { // Paper - Cache serialized block entity data
++            CompoundTag tag = blockEntity.getUpdateTag(registryAccess); // Paper - Cache serialized block entity data
+             BlockPos pos = blockEntity.getBlockPos();
+             int xz = SectionPos.sectionRelative(pos.getX()) << 4 | SectionPos.sectionRelative(pos.getZ());
+             blockEntity.sanitizeSentNbt(tag); // Paper - Sanitize sent data
+-            return new ClientboundLevelChunkPacketData.BlockEntityInfo(xz, pos.getY(), blockEntity.getType(), tag.isEmpty() ? null : tag);
++            // Paper start - Cache serialized block entity data
++            BlockEntityInfo info = new BlockEntityInfo(xz, pos.getY(), blockEntity.getType(), tag.isEmpty() ? null : tag);
++            buffer.clear();
++            info.write(buffer);
++            return new BlockEntityInfo(xz, pos.getY(), blockEntity.getType(), info.tag, io.netty.buffer.ByteBufUtil.getBytes(buffer));
++        }
++        // Paper end
++        // Paper start - Skip large block entities
++
++        private boolean isLarge() {
++            return this.serializedData != null && this.serializedData.length >= TWO_MEGABYTES - 3;
++            // Paper end
+         }
+     }
+ 

--- a/paper-server/patches/features/0035-Skip-large-block-entities.patch
+++ b/paper-server/patches/features/0035-Skip-large-block-entities.patch
@@ -60,10 +60,22 @@ index 2122ff56412a2ad412eb8b2f0e4538aab4257bf2..167cd14d6d4b3e313a94a7213aeb2c29
  
      @Override
 diff --git a/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java b/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
-index a52f93d0563f713b1d2b707cdb6ab74e4793a54d..1d6cb89c15da57542c45eb996151e9769a3ed45e 100644
+index a52f93d0563f713b1d2b707cdb6ab74e4793a54d..7b2c326897de9ef5622b52bf3a43e67787236a3d 100644
 --- a/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
 +++ b/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
-@@ -61,18 +61,28 @@ public class ClientboundLevelChunkPacketData {
+@@ -35,7 +35,10 @@ public class ClientboundLevelChunkPacketData {
+     // Paper start - Handle oversized block entities in chunks
+     private final java.util.List<net.minecraft.network.protocol.Packet<?>> extraPackets = new java.util.ArrayList<>();
+     private static final int BLOCK_ENTITY_LIMIT = Integer.getInteger("Paper.excessiveTELimit", 750);
+-
++    // Paper start - Skip large block entities
++    private static final boolean SKIP_LARGE_BLOCK_ENTITIES = io.papermc.paper.configuration.GlobalConfiguration.get().chunkUpdates.ignoreLargeBlockEntities;
++    private static final long LARGE_BLOCK_ENTITY_BYTES = io.papermc.paper.configuration.GlobalConfiguration.get().chunkUpdates.largeBlockEntityByteThreshold;
++    // Paper end - Skip large block entities
+     public List<net.minecraft.network.protocol.Packet<?>> getExtraPackets() {
+         return this.extraPackets;
+     }
+@@ -61,18 +64,28 @@ public class ClientboundLevelChunkPacketData {
          this.blockEntitiesData = Lists.newArrayList();
          int totalTileEntities = 0; // Paper - Handle oversized block entities in chunks
  
@@ -82,7 +94,7 @@ index a52f93d0563f713b1d2b707cdb6ab74e4793a54d..1d6cb89c15da57542c45eb996151e976
 +            for (Entry<BlockPos, BlockEntity> entry : levelChunk.getBlockEntities().entrySet()) {
 +                BlockEntityInfo blockEntityInfo = BlockEntityInfo.create(entry.getValue(), levelChunk.getLevel().registryAccess(), blockEntityFriendlyBuffer); // Paper - Cache serialized block entity data
 +                // Paper start - Handle oversized block entities in chunks
-+                if (++totalTileEntities > BLOCK_ENTITY_LIMIT || blockEntityInfo.isLarge()) { // Paper - Skip large block entities
++                if (++totalTileEntities > BLOCK_ENTITY_LIMIT || (SKIP_LARGE_BLOCK_ENTITIES && blockEntityInfo.isLarge())) { // Paper - Skip large block entities
 +                    net.minecraft.network.protocol.Packet<ClientGamePacketListener> packet = entry.getValue().getUpdatePacket();
 +                    if (packet != null) {
 +                        this.extraPackets.add(packet);
@@ -101,7 +113,7 @@ index a52f93d0563f713b1d2b707cdb6ab74e4793a54d..1d6cb89c15da57542c45eb996151e976
      }
  
      public ClientboundLevelChunkPacketData(final RegistryFriendlyByteBuf input, final int x, final int z) {
-@@ -164,12 +174,24 @@ public class ClientboundLevelChunkPacketData {
+@@ -164,12 +177,24 @@ public class ClientboundLevelChunkPacketData {
          private final int y;
          private final BlockEntityType<?> type;
          private final @Nullable CompoundTag tag;
@@ -126,7 +138,7 @@ index a52f93d0563f713b1d2b707cdb6ab74e4793a54d..1d6cb89c15da57542c45eb996151e976
          }
  
          private BlockEntityInfo(final RegistryFriendlyByteBuf input) {
-@@ -177,21 +199,39 @@ public class ClientboundLevelChunkPacketData {
+@@ -177,21 +202,39 @@ public class ClientboundLevelChunkPacketData {
              this.y = input.readShort();
              this.type = ByteBufCodecs.registry(Registries.BLOCK_ENTITY_TYPE).decode(input);
              this.tag = input.readNbt();
@@ -164,7 +176,7 @@ index a52f93d0563f713b1d2b707cdb6ab74e4793a54d..1d6cb89c15da57542c45eb996151e976
 +        // Paper start - Skip large block entities
 +
 +        private boolean isLarge() {
-+            return this.serializedData != null && this.serializedData.length >= TWO_MEGABYTES - 3;
++            return this.serializedData != null && this.serializedData.length >= LARGE_BLOCK_ENTITY_BYTES;
 +            // Paper end
          }
      }

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -13,6 +13,7 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ServerboundPlaceRecipePacket;
 import net.minecraft.resources.Identifier;
+import org.apache.commons.io.FileUtils;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
@@ -164,6 +165,13 @@ public class GlobalConfiguration extends ConfigurationPart {
         public int recipeSpamIncrement = 1;
         public int recipeSpamLimit = 20;
         public IntOr.Disabled incomingPacketThreshold = new IntOr.Disabled(OptionalInt.of(300));
+    }
+
+    public ChunkUpdates chunkUpdates;
+
+    public class ChunkUpdates extends ConfigurationPart {
+        public boolean ignoreLargeBlockEntities = true;
+        public long largeBlockEntityByteThreshold = FileUtils.ONE_MB * 2;
     }
 
     public UnsupportedSettings unsupportedSettings;


### PR DESCRIPTION
This pull request changes how chunk packets are constructed to send separate Block Entity Update packets based on the block entity's size, and not just on how many block entities are in the chunk.

Each block entity is serialized once to not add overhead for checking the data size:
* If it's not too big or hasn't exceeded the block entity limit per chunk, it's added to the regular block entity data list directly.
* If it is, it's re-serialized as a packet to be sent separately alongside the chunk packet

The client-bound block entity data packet now also has a fallback for when it's too large to be sent, to prevent being kicked.
* A new `AsyncBlockEntityUpdateTooLargeEvent` is fired
* The block entity update is ignored

I was not able to perceive any performance loss for normal or large block entities when profiling, however there is a theoretical tradeoff where large block entities would be serialized twice, this should not matter in most cases