### PR TITLE
Add end portal creation to PortalCreateEvent

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/world/PortalCreateEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/world/PortalCreateEvent.java
@@ -107,6 +107,11 @@ public class PortalCreateEvent extends WorldEvent implements Cancellable {
          * When the target end platform is created as a result of a player
          * entering an end portal.
          */
-        END_PLATFORM
+        END_PLATFORM,
+        /**
+         * When the blocks inside an end portal are created due to an end portal
+         * frame being completed with all ender eyes.
+         */
+        ENDER_EYE
     }
 }

--- a/paper-server/patches/sources/net/minecraft/world/item/EnderEyeItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/EnderEyeItem.java.patch
@@ -12,6 +12,30 @@
          Block.pushEntitiesUp(targetState, newState, level, pos);
          level.setBlock(pos, newState, Block.UPDATE_CLIENTS);
          level.updateNeighbourForOutputSignal(pos, Blocks.END_PORTAL_FRAME);
+@@ -56,6 +_,23 @@
+         if (match != null) {
+             BlockPos blockPos = match.getFrontTopLeft().offset(-3, 0, -3);
+ 
++            // Paper start - Trigger PortalCreateEvent on end portal creation
++            org.bukkit.craftbukkit.util.BlockStateListPopulator populator = new org.bukkit.craftbukkit.util.BlockStateListPopulator(level.getMinecraftWorld());
++            // Copy below for loop
++            for (int x = 0; x < 3; x++) {
++                for (int z = 0; z < 3; z++) {
++                    BlockPos portalBlockPos = blockPos.offset(x, 0, z);
++                    populator.setBlock(portalBlockPos, Blocks.END_PORTAL.defaultBlockState(), Block.UPDATE_CLIENTS);
++                }
++            }
++            Player portalCreator = context.getPlayer();
++            org.bukkit.World bworld = level.getMinecraftWorld().getWorld();
++            org.bukkit.event.world.PortalCreateEvent event = new org.bukkit.event.world.PortalCreateEvent((java.util.List<org.bukkit.block.BlockState>) (java.util.List) populator.getSnapshotBlocks(), bworld, (portalCreator == null) ? null : portalCreator.getBukkitEntity(), org.bukkit.event.world.PortalCreateEvent.CreateReason.ENDER_EYE);
++            level.getMinecraftWorld().getServer().server.getPluginManager().callEvent(event);
++            if (event.isCancelled()) {
++                return InteractionResult.PASS;
++            }
++            // Paper end - Trigger PortalCreateEvent on end portal creation
+             for (int x = 0; x < 3; x++) {
+                 for (int z = 0; z < 3; z++) {
+                     BlockPos portalBlockPos = blockPos.offset(x, 0, z);
 @@ -64,7 +_,27 @@
                  }
              }

--- a/paper-server/patches/sources/net/minecraft/world/item/EnderEyeItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/EnderEyeItem.java.patch
@@ -28,8 +28,7 @@
 +            Player portalCreator = context.getPlayer();
 +            org.bukkit.World bworld = level.getMinecraftWorld().getWorld();
 +            org.bukkit.event.world.PortalCreateEvent event = new org.bukkit.event.world.PortalCreateEvent((java.util.List<org.bukkit.block.BlockState>) (java.util.List) populator.getSnapshotBlocks(), bworld, (portalCreator == null) ? null : portalCreator.getBukkitEntity(), org.bukkit.event.world.PortalCreateEvent.CreateReason.ENDER_EYE);
-+            level.getMinecraftWorld().getServer().server.getPluginManager().callEvent(event);
-+            if (event.isCancelled()) {
++            if (!event.callEvent()) {
 +                return InteractionResult.PASS;
 +            }
 +            // Paper end - Trigger PortalCreateEvent on end portal creation

--- a/paper-server/patches/sources/net/minecraft/world/item/EnderEyeItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/EnderEyeItem.java.patch
@@ -28,7 +28,7 @@
              }
 +            // Paper start - Trigger PortalCreateEvent on end portal creation
 +            Player portalCreator = context.getPlayer();
-+            org.bukkit.World bworld = level.getMinecraftWorld().getWorld();
++            org.bukkit.World bworld = level.getWorld();
 +            org.bukkit.event.world.PortalCreateEvent event = new org.bukkit.event.world.PortalCreateEvent((java.util.List<org.bukkit.block.BlockState>) (java.util.List) populator.getSnapshotBlocks(), bworld, (portalCreator == null) ? null : portalCreator.getBukkitEntity(), org.bukkit.event.world.PortalCreateEvent.CreateReason.ENDER_EYE);
 +            if (!event.callEvent()) {
 +                return InteractionResult.PASS;

--- a/paper-server/patches/sources/net/minecraft/world/item/EnderEyeItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/EnderEyeItem.java.patch
@@ -12,32 +12,29 @@
          Block.pushEntitiesUp(targetState, newState, level, pos);
          level.setBlock(pos, newState, Block.UPDATE_CLIENTS);
          level.updateNeighbourForOutputSignal(pos, Blocks.END_PORTAL_FRAME);
-@@ -56,6 +_,23 @@
+@@ -56,15 +_,45 @@
          if (match != null) {
              BlockPos blockPos = match.getFrontTopLeft().offset(-3, 0, -3);
  
++            org.bukkit.craftbukkit.util.BlockStateListPopulator populator = new org.bukkit.craftbukkit.util.BlockStateListPopulator(level.getMinecraftWorld()); // Paper
+             for (int x = 0; x < 3; x++) {
+                 for (int z = 0; z < 3; z++) {
+                     BlockPos portalBlockPos = blockPos.offset(x, 0, z);
+-                    level.destroyBlock(portalBlockPos, true, null);
+-                    level.setBlock(portalBlockPos, Blocks.END_PORTAL.defaultBlockState(), Block.UPDATE_CLIENTS);
++                    populator.destroyBlock(portalBlockPos, true, null); // Paper
++                    populator.setBlock(portalBlockPos, Blocks.END_PORTAL.defaultBlockState(), Block.UPDATE_CLIENTS); // Paper
+                 }
+             }
 +            // Paper start - Trigger PortalCreateEvent on end portal creation
-+            org.bukkit.craftbukkit.util.BlockStateListPopulator populator = new org.bukkit.craftbukkit.util.BlockStateListPopulator(level.getMinecraftWorld());
-+            // Copy below for loop
-+            for (int x = 0; x < 3; x++) {
-+                for (int z = 0; z < 3; z++) {
-+                    BlockPos portalBlockPos = blockPos.offset(x, 0, z);
-+                    populator.setBlock(portalBlockPos, Blocks.END_PORTAL.defaultBlockState(), Block.UPDATE_CLIENTS);
-+                }
-+            }
 +            Player portalCreator = context.getPlayer();
 +            org.bukkit.World bworld = level.getMinecraftWorld().getWorld();
 +            org.bukkit.event.world.PortalCreateEvent event = new org.bukkit.event.world.PortalCreateEvent((java.util.List<org.bukkit.block.BlockState>) (java.util.List) populator.getSnapshotBlocks(), bworld, (portalCreator == null) ? null : portalCreator.getBukkitEntity(), org.bukkit.event.world.PortalCreateEvent.CreateReason.ENDER_EYE);
 +            if (!event.callEvent()) {
 +                return InteractionResult.PASS;
 +            }
++            populator.placeBlocks(state -> level.destroyBlock(state.getPosition(), true, null));
 +            // Paper end - Trigger PortalCreateEvent on end portal creation
-             for (int x = 0; x < 3; x++) {
-                 for (int z = 0; z < 3; z++) {
-                     BlockPos portalBlockPos = blockPos.offset(x, 0, z);
-@@ -64,7 +_,27 @@
-                 }
-             }
  
 -            level.globalLevelEvent(LevelEvent.SOUND_END_PORTAL_SPAWN, blockPos.offset(1, 0, 1), 0);
 +            // CraftBukkit start - Use relative location for far away sounds

--- a/paper-server/patches/sources/net/minecraft/world/item/EnderEyeItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/EnderEyeItem.java.patch
@@ -16,7 +16,7 @@
          if (match != null) {
              BlockPos blockPos = match.getFrontTopLeft().offset(-3, 0, -3);
  
-+            org.bukkit.craftbukkit.util.BlockStateListPopulator populator = new org.bukkit.craftbukkit.util.BlockStateListPopulator(level.getMinecraftWorld()); // Paper
++            org.bukkit.craftbukkit.util.BlockStateListPopulator populator = new org.bukkit.craftbukkit.util.BlockStateListPopulator(level); // Paper
              for (int x = 0; x < 3; x++) {
                  for (int z = 0; z < 3; z++) {
                      BlockPos portalBlockPos = blockPos.offset(x, 0, z);


### PR DESCRIPTION
This PR addesses https://github.com/PaperMC/Paper/issues/13832

This does not trigger for world generation (when the end portal generates with all eyes)
It also, at the moment of writing this, does not trigger for the end gateway and exit end portal, as those don't have straightforward access to the Entity that will trigger the portal creation.

See:
1. `net.minecraft.world.level.levelgen.feature.EndGatewayFeature`
2. `net.minecraft.world.level.levelgen.feature.EndPodiumFeature`

Compared to:
1. `net.minecraft.world.level.levelgen.feature.EndPlatformFeature` at L28
2. `net.minecraft.world.level.block.EndPortalBlock` at L100

