### PR TITLE
Implement CraftRegistry#toString

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
@@ -273,4 +273,11 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
 
     final class InvalidHolderOwner implements HolderOwner<M> {
     }
+
+    @Override
+    public String toString() {
+        return "CraftRegistry{" +
+            "minecraftRegistry=" + minecraftRegistry.key() +
+            '}';
+    }
 }


### PR DESCRIPTION
Makes for a better exception message when one of the getOrThrow methods is used