### PR TITLE
Improvement PlayerItemConsumeEvent call for instant consumption

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerItemConsumeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerItemConsumeEvent.java
@@ -1,14 +1,14 @@
 package org.bukkit.event.player;
 
-import org.bukkit.Material;
+import java.util.Objects;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This event will fire when a player is finishing consuming an item (food,
@@ -20,27 +20,27 @@ import org.jetbrains.annotations.Nullable;
  * If the event is cancelled the effect will not be applied and the item will
  * not be removed from the player's inventory.
  */
+@NullMarked
 public class PlayerItemConsumeEvent extends PlayerEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final EquipmentSlot hand;
     private ItemStack item;
-    @Nullable private ItemStack replacement;
+    private @Nullable ItemStack replacement;
 
     private boolean cancelled;
 
     @ApiStatus.Internal
-    public PlayerItemConsumeEvent(@NotNull final Player player, @NotNull final ItemStack item, @NotNull final EquipmentSlot hand) {
+    public PlayerItemConsumeEvent(final Player player, final ItemStack item, final EquipmentSlot hand) {
         super(player);
-
         this.item = item;
         this.hand = hand;
     }
 
     @ApiStatus.Internal
     @Deprecated(since = "1.19.2", forRemoval = true)
-    public PlayerItemConsumeEvent(@NotNull final Player player, @NotNull final ItemStack item) {
+    public PlayerItemConsumeEvent(final Player player, final ItemStack item) {
         this(player, item, EquipmentSlot.HAND);
     }
 
@@ -51,7 +51,6 @@ public class PlayerItemConsumeEvent extends PlayerEvent implements Cancellable {
      *
      * @return an ItemStack for the item being consumed
      */
-    @NotNull
     public ItemStack getItem() {
         return this.item.clone();
     }
@@ -62,11 +61,7 @@ public class PlayerItemConsumeEvent extends PlayerEvent implements Cancellable {
      * @param item the item being consumed
      */
     public void setItem(@Nullable ItemStack item) {
-        if (item == null) {
-            this.item = new ItemStack(Material.AIR);
-        } else {
-            this.item = item;
-        }
+        this.item = Objects.requireNonNullElseGet(item, ItemStack::empty);
     }
 
     /**
@@ -74,7 +69,6 @@ public class PlayerItemConsumeEvent extends PlayerEvent implements Cancellable {
      *
      * @return the hand
      */
-    @NotNull
     public EquipmentSlot getHand() {
         return this.hand;
     }
@@ -85,8 +79,7 @@ public class PlayerItemConsumeEvent extends PlayerEvent implements Cancellable {
      *
      * @return The custom item stack that will replace the consumed item or {@code null}
      */
-    @Nullable
-    public ItemStack getReplacement() {
+    public @Nullable ItemStack getReplacement() {
         return this.replacement;
     }
 
@@ -110,13 +103,11 @@ public class PlayerItemConsumeEvent extends PlayerEvent implements Cancellable {
         this.cancelled = cancel;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
 
-    @NotNull
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -1670,21 +1670,16 @@
              }
          }
      }
-@@ -3573,9 +_,41 @@
+@@ -3573,7 +_,30 @@
                  this.releaseUsingItem();
              } else {
                  if (!this.useItem.isEmpty() && this.isUsingItem()) {
 -                    ItemStack result = this.useItem.finishUsingItem(this.level(), this);
-+                    this.startUsingItem(this.getUsedItemHand(), true); // Paper - Prevent consuming the wrong itemstack
-+                    // CraftBukkit start - fire PlayerItemConsumeEvent
++                    this.startUsingItem(this.getUsedItemHand(), true); // Paper - Prevent consuming the wrong ItemStack
++                    // Paper start - PlayerItemConsumeEvent event
 +                    ItemStack result;
-+                    org.bukkit.event.player.PlayerItemConsumeEvent event = null; // Paper
 +                    if (this instanceof ServerPlayer serverPlayer) {
-+                        org.bukkit.inventory.ItemStack craftItem = CraftItemStack.asBukkitCopy(this.useItem);
-+                        org.bukkit.inventory.EquipmentSlot handSlot = org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(hand);
-+                        event = new org.bukkit.event.player.PlayerItemConsumeEvent((org.bukkit.entity.Player)this.getBukkitEntity(), craftItem, handSlot); // Paper
-+                        this.level().getCraftServer().getPluginManager().callEvent(event);
-+
++                        final org.bukkit.event.player.PlayerItemConsumeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerItemConsumeEvent(serverPlayer, hand, this.useItem);
 +                        if (event.isCancelled()) {
 +                            net.minecraft.world.item.component.Consumable consumable = this.useItem.get(DataComponents.CONSUMABLE);
 +                            if (consumable != null) {
@@ -1695,24 +1690,18 @@
 +                            this.stopUsingItem(); // Paper - event is using an item, clear active item to reset its use
 +                            return;
 +                        }
-+
-+                        result = (craftItem.equals(event.getItem())) ? this.useItem.finishUsingItem(this.level(), this) : CraftItemStack.asNMSCopy(event.getItem()).finishUsingItem(this.level(), this);
++                        final net.minecraft.world.item.ItemStack eventItemNmsCopy = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getItem());
++                        result = (this.useItem.equals(eventItemNmsCopy)) ? this.useItem.finishUsingItem(this.level(), this) : eventItemNmsCopy.finishUsingItem(this.level(), this);
++                        if (event.getReplacement() != null) {
++                            result = CraftItemStack.asNMSCopy(event.getReplacement());
++                        }
 +                    } else {
 +                        result = this.useItem.finishUsingItem(this.level(), this);
 +                    }
-+                    // Paper start - save the default replacement item and change it if necessary
-+                    final ItemStack defaultReplacement = result;
-+                    if (event != null && event.getReplacement() != null) {
-+                        result = CraftItemStack.asNMSCopy(event.getReplacement());
-+                    }
 +                    // Paper end
-+                    // CraftBukkit end
                      if (result != this.useItem) {
                          this.setItemInHand(hand, result);
-+                        if (event != null && event.getReplacement() != null && this instanceof final ServerPlayer player) player.containerMenu.forceHeldSlot(hand); // Paper - Fix inventory desync; Paper#13253
                      }
- 
-                     this.stopUsingItem();
 @@ -3607,6 +_,7 @@
          ItemStack itemInUsedHand = this.getItemInHand(this.getUsedItemHand());
          if (!this.useItem.isEmpty() && ItemStack.isSameItem(itemInUsedHand, this.useItem)) {

--- a/paper-server/patches/sources/net/minecraft/world/item/component/Consumable.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/component/Consumable.java.patch
@@ -1,5 +1,33 @@
 --- a/net/minecraft/world/item/component/Consumable.java
 +++ b/net/minecraft/world/item/component/Consumable.java
+@@ -68,7 +_,26 @@
+                 user.startUsingItem(hand);
+                 return InteractionResult.CONSUME;
+             } else {
+-                ItemStack result = this.onConsume(user.level(), user, stack);
++                // Paper start - PlayerItemConsumeEvent event for instant consumption
++                ItemStack result;
++                if (user instanceof ServerPlayer serverPlayer) {
++                    final org.bukkit.event.player.PlayerItemConsumeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerItemConsumeEvent(serverPlayer, hand, stack);
++                    if (event.isCancelled()) {
++                        serverPlayer.containerMenu.forceHeldSlot(hand);
++                        serverPlayer.getBukkitEntity().updateScaledHealth();
++                        return InteractionResult.FAIL;
++                    }
++                    final net.minecraft.world.item.ItemStack eventItemNmsCopy = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getItem());
++                    result = this.onConsume(user.level(), user, (stack.equals(eventItemNmsCopy)) ? stack : eventItemNmsCopy);
++                    if (event.getReplacement() != null) {
++                        result = org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getReplacement());
++                        serverPlayer.setItemInHand(hand, result);
++                        serverPlayer.containerMenu.forceHeldSlot(hand);
++                    }
++                } else {
++                    result = this.onConsume(user.level(), user, stack);
++                }
++                // Paper end
+                 return InteractionResult.CONSUME.heldItemTransformedTo(result);
+             }
+         }
 @@ -84,13 +_,35 @@
  
          stack.getAllOfType(ConsumableListener.class).forEach(component -> component.onConsume(level, user, stack, this));

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -247,6 +247,7 @@ import org.bukkit.event.player.PlayerExpCooldownChangeEvent;
 import org.bukkit.event.player.PlayerHarvestBlockEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerItemMendEvent;
 import org.bukkit.event.player.PlayerLevelChangeEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
@@ -2424,5 +2425,14 @@ public class CraftEventFactory {
             return PrimedTnt.NO_FUSE;
         }
         return event.getFuseTime();
+    }
+
+    public static PlayerItemConsumeEvent callPlayerItemConsumeEvent(final ServerPlayer serverPlayer, final InteractionHand hand, final ItemStack stack) {
+        final org.bukkit.inventory.ItemStack craftItem = org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(stack);
+        final org.bukkit.inventory.EquipmentSlot handSlot = org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(hand);
+        final org.bukkit.event.player.PlayerItemConsumeEvent event = new org.bukkit.event.player.PlayerItemConsumeEvent(serverPlayer.getBukkitEntity(), craftItem, handSlot);
+        event.callEvent();
+
+        return event;
     }
 }


### PR DESCRIPTION
This PR improvement the logic for PlayerItemConsumeEvent, currently only its called when the use of item reach 0 (consume) this logic works when the consume time is set and its not 0, when its 0 this logic is skipped and the event its not called, for fix this i call this event for that case too and handle the most of logic like happen with the item in use...

This can close https://github.com/PaperMC/Paper/issues/13138