### PR TITLE
Remove experimental annotations from a lot of API

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/ServerBuildInfo.java
+++ b/paper-api/src/main/java/io/papermc/paper/ServerBuildInfo.java
@@ -46,7 +46,6 @@ public interface ServerBuildInfo {
      * @param brandId the brand to check (e.g. "papermc:folia")
      * @return {@code true} if the server supports the specified brand
      */
-    @ApiStatus.Experimental
     boolean isBrandCompatible(final Key brandId);
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/annotation/MinecraftVersionDependent.java
+++ b/paper-api/src/main/java/io/papermc/paper/annotation/MinecraftVersionDependent.java
@@ -1,0 +1,19 @@
+package io.papermc.paper.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that API may change with no or fewer compatibility guarantees across Minecraft versions,
+ * as it is more or less directly representing the underlying Vanilla data.
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({
+    ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE
+})
+public @interface MinecraftVersionDependent {
+}

--- a/paper-api/src/main/java/io/papermc/paper/block/BlockPredicate.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/BlockPredicate.java
@@ -8,7 +8,6 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface BlockPredicate {
 
@@ -38,7 +37,6 @@ public interface BlockPredicate {
 
     @Nullable RegistryKeySet<BlockType> blocks();
 
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder {
 

--- a/paper-api/src/main/java/io/papermc/paper/block/bed/BedEnterAction.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/bed/BedEnterAction.java
@@ -10,7 +10,6 @@ import org.jspecify.annotations.Nullable;
  * happening during {@link io.papermc.paper.event.player.PlayerBedFailEnterEvent}
  */
 @ApiStatus.NonExtendable
-@ApiStatus.Experimental
 public interface BedEnterAction {
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/block/bed/BedEnterProblem.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/bed/BedEnterProblem.java
@@ -10,7 +10,6 @@ import org.jspecify.annotations.Nullable;
  * its spawn point
  */
 @ApiStatus.NonExtendable
-@ApiStatus.Experimental
 public interface BedEnterProblem {
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/block/bed/BedRuleResult.java
+++ b/paper-api/src/main/java/io/papermc/paper/block/bed/BedRuleResult.java
@@ -1,13 +1,11 @@
 package io.papermc.paper.block.bed;
 
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Represents the result of a bed rule during {@link org.bukkit.event.player.PlayerBedEnterEvent}
  * and {@link io.papermc.paper.event.player.PlayerBedFailEnterEvent}. Bed rules are responsible
  * for allowing players to sleep and to set their spawn point
  */
-@ApiStatus.Experimental
 public sealed interface BedRuleResult permits BedRuleResultImpl {
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/command/brigadier/Commands.java
+++ b/paper-api/src/main/java/io/papermc/paper/command/brigadier/Commands.java
@@ -119,7 +119,6 @@ public interface Commands extends Registrar {
      *
      * @return the dispatcher instance
      */
-    @ApiStatus.Experimental
     CommandDispatcher<CommandSourceStack> getDispatcher();
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/connection/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/connection/package-info.java
@@ -1,9 +1,7 @@
 /**
  * This package contains events related to player connections, such as joining and leaving the server.
  */
-@ApiStatus.Experimental
 @NullMarked
 package io.papermc.paper.connection;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/BuildableDataComponent.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/BuildableDataComponent.java
@@ -5,7 +5,6 @@ import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface BuildableDataComponent<C extends BuildableDataComponent<C, B>, B extends DataComponentBuilder<C>> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentBuilder.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentBuilder.java
@@ -10,7 +10,6 @@ import org.jspecify.annotations.NullMarked;
  * @param <C> built component type
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface DataComponentBuilder<C> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentHolder.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentHolder.java
@@ -22,7 +22,6 @@ public interface DataComponentHolder extends DataComponentView {
      * @param <T> value type
      */
     @Utility
-    @ApiStatus.Experimental
     <T> void setData(final DataComponentType.Valued<T> type, final DataComponentBuilder<T> valueBuilder);
 
     /**
@@ -32,7 +31,6 @@ public interface DataComponentHolder extends DataComponentView {
      * @param value value to set
      * @param <T> value type
      */
-    @ApiStatus.Experimental
     <T> void setData(final DataComponentType.Valued<T> type, final T value);
 
     /**
@@ -40,7 +38,6 @@ public interface DataComponentHolder extends DataComponentView {
      *
      * @param type the data component type
      */
-    @ApiStatus.Experimental
     void setData(final DataComponentType.NonValued type);
 
    // TODO: Do we even want to have the concept of overriding here? Not sure what is going on with entity components

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentType.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentType.java
@@ -5,7 +5,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface DataComponentType extends Keyed {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentTypes.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentTypes.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.datacomponent;
 
+import io.papermc.paper.annotation.MinecraftVersionDependent;
 import io.papermc.paper.datacomponent.item.AttackRange;
 import io.papermc.paper.datacomponent.item.BannerPatternLayers;
 import io.papermc.paper.datacomponent.item.BlockItemDataProperties;
@@ -80,7 +81,6 @@ import org.bukkit.inventory.meta.trim.TrimMaterial;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.Positive;
 import org.checkerframework.common.value.qual.IntRange;
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -88,7 +88,7 @@ import org.jspecify.annotations.NullMarked;
  * and {@link org.bukkit.inventory.ItemType ItemTypes} can have.
  */
 @NullMarked
-@ApiStatus.Experimental
+@MinecraftVersionDependent
 public final class DataComponentTypes {
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentView.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/DataComponentView.java
@@ -24,7 +24,6 @@ public interface DataComponentView {
      * @see #hasData(DataComponentType) for DataComponentType.NonValued
      */
     @Contract(pure = true)
-    @ApiStatus.Experimental
     <T> @Nullable T getData(final DataComponentType.Valued<T> type);
 
     /**
@@ -38,7 +37,6 @@ public interface DataComponentView {
      */
     @Utility
     @Contract(value = "_, !null -> !null", pure = true)
-    @ApiStatus.Experimental
     <T> @Nullable T getDataOrDefault(final DataComponentType.Valued<? extends T> type, final @Nullable T fallback);
 
     /**
@@ -48,7 +46,6 @@ public interface DataComponentView {
      * @return {@code true} if set, {@code false} otherwise
      */
     @Contract(pure = true)
-    @ApiStatus.Experimental
     boolean hasData(final DataComponentType type);
 
     // Not applicable to entities
@@ -58,6 +55,5 @@ public interface DataComponentView {
     //  * @return an immutable set of data component types
     //  */
     // @Contract("-> new")
-    // @ApiStatus.Experimental
     // @Unmodifiable Set<DataComponentType> getDataTypes();
 }

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/AttackRange.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/AttackRange.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.Range;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface AttackRange {
 
@@ -42,7 +41,6 @@ public interface AttackRange {
     /**
      * Builder for {@link AttackRange}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<AttackRange> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BannerPatternLayers.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BannerPatternLayers.java
@@ -13,7 +13,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#BANNER_PATTERNS
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface BannerPatternLayers {
 
@@ -38,7 +37,6 @@ public interface BannerPatternLayers {
     /**
      * Builder for {@link BannerPatternLayers}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<BannerPatternLayers> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BlockItemDataProperties.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BlockItemDataProperties.java
@@ -12,7 +12,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#BLOCK_DATA
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface BlockItemDataProperties {
 
@@ -43,7 +42,6 @@ public interface BlockItemDataProperties {
     /**
      * Builder for {@link BlockItemDataProperties}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<BlockItemDataProperties> {
         // building this requires BlockProperty API, so an empty builder for now (essentially read-only)

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BlocksAttacks.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BlocksAttacks.java
@@ -19,7 +19,6 @@ import org.jspecify.annotations.Nullable;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#BLOCKS_ATTACKS
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface BlocksAttacks {
 
@@ -89,7 +88,6 @@ public interface BlocksAttacks {
     /**
      * Builder for {@link BlocksAttacks}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<BlocksAttacks> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BundleContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/BundleContents.java
@@ -13,7 +13,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#BUNDLE_CONTENTS
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface BundleContents {
 
@@ -38,7 +37,6 @@ public interface BundleContents {
     /**
      * Builder for {@link BundleContents}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<BundleContents> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ChargedProjectiles.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ChargedProjectiles.java
@@ -13,7 +13,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#CHARGED_PROJECTILES
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ChargedProjectiles {
 
@@ -38,7 +37,6 @@ public interface ChargedProjectiles {
     /**
      * Builder for {@link ChargedProjectiles}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<ChargedProjectiles> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Consumable.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Consumable.java
@@ -17,7 +17,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#CONSUMABLE
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface Consumable extends BuildableDataComponent<Consumable, Consumable.Builder> {
 
@@ -44,7 +43,6 @@ public interface Consumable extends BuildableDataComponent<Consumable, Consumabl
     /**
      * Builder for {@link Consumable}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<Consumable> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/CustomModelData.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/CustomModelData.java
@@ -14,7 +14,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#CUSTOM_MODEL_DATA
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface CustomModelData {
 
@@ -58,7 +57,6 @@ public interface CustomModelData {
     /**
      * Builder for {@link CustomModelData}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<CustomModelData> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DamageResistant.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DamageResistant.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#DAMAGE_RESISTANT
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface DamageResistant {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DeathProtection.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DeathProtection.java
@@ -13,7 +13,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#DEATH_PROTECTION
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface DeathProtection {
 
@@ -33,7 +32,6 @@ public interface DeathProtection {
     /**
      * Builder for {@link DeathProtection}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<DeathProtection> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DyedItemColor.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/DyedItemColor.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#DYED_COLOR
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface DyedItemColor {
 
@@ -36,7 +35,6 @@ public interface DyedItemColor {
     /**
      * Builder for {@link DyedItemColor}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<DyedItemColor> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Enchantable.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Enchantable.java
@@ -10,7 +10,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#ENCHANTABLE
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface Enchantable {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Equippable.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Equippable.java
@@ -16,7 +16,6 @@ import org.jspecify.annotations.Nullable;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#EQUIPPABLE
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface Equippable extends BuildableDataComponent<Equippable, Equippable.Builder> {
 
@@ -123,7 +122,6 @@ public interface Equippable extends BuildableDataComponent<Equippable, Equippabl
     /**
      * Builder for {@link Equippable}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<Equippable> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Fireworks.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Fireworks.java
@@ -14,7 +14,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#FIREWORKS
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface Fireworks {
 
@@ -47,7 +46,6 @@ public interface Fireworks {
     /**
      * Builder for {@link Fireworks}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<Fireworks> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/FoodProperties.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/FoodProperties.java
@@ -12,7 +12,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#FOOD
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface FoodProperties extends BuildableDataComponent<FoodProperties, FoodProperties.Builder> {
 
@@ -48,7 +47,6 @@ public interface FoodProperties extends BuildableDataComponent<FoodProperties, F
     /**
      * Builder for {@link FoodProperties}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<FoodProperties> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemAdventurePredicate.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemAdventurePredicate.java
@@ -14,7 +14,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#CAN_PLACE_ON
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ItemAdventurePredicate {
 
@@ -39,7 +38,6 @@ public interface ItemAdventurePredicate {
     /**
      * Builder for {@link ItemAdventurePredicate}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<ItemAdventurePredicate> {
         /**

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemArmorTrim.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemArmorTrim.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#TRIM
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ItemArmorTrim  {
 
@@ -31,7 +30,6 @@ public interface ItemArmorTrim  {
     /**
      * Builder for {@link ItemArmorTrim}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<ItemArmorTrim> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemAttributeModifiers.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemAttributeModifiers.java
@@ -16,7 +16,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#ATTRIBUTE_MODIFIERS
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ItemAttributeModifiers {
 
@@ -76,7 +75,6 @@ public interface ItemAttributeModifiers {
     /**
      * Builder for {@link ItemAttributeModifiers}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<ItemAttributeModifiers> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemContainerContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemContainerContents.java
@@ -13,7 +13,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#CONTAINER
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ItemContainerContents {
 
@@ -35,7 +34,6 @@ public interface ItemContainerContents {
     @Contract(value = "-> new", pure = true)
     @Unmodifiable List<ItemStack> contents();
 
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<ItemContainerContents> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemEnchantments.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemEnchantments.java
@@ -15,7 +15,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#STORED_ENCHANTMENTS
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ItemEnchantments {
 
@@ -40,7 +39,6 @@ public interface ItemEnchantments {
     /**
      * Builder for {@link ItemEnchantments}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<ItemEnchantments> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemLore.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ItemLore.java
@@ -14,7 +14,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#LORE
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ItemLore {
 
@@ -47,7 +46,6 @@ public interface ItemLore {
     /**
      * Builder for {@link ItemLore}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<ItemLore> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/JukeboxPlayable.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/JukeboxPlayable.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#JUKEBOX_PLAYABLE
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface JukeboxPlayable  {
 
@@ -26,7 +25,6 @@ public interface JukeboxPlayable  {
     /**
      * Builder for {@link JukeboxPlayable}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<JukeboxPlayable> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/KineticWeapon.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/KineticWeapon.java
@@ -10,7 +10,6 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface KineticWeapon {
 
@@ -72,7 +71,6 @@ public interface KineticWeapon {
     /**
      * Builder for {@link KineticWeapon}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<KineticWeapon> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/LodestoneTracker.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/LodestoneTracker.java
@@ -12,7 +12,6 @@ import org.jspecify.annotations.Nullable;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#LODESTONE_TRACKER
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface LodestoneTracker {
 
@@ -45,7 +44,6 @@ public interface LodestoneTracker {
     /**
      * Builder for {@link LodestoneTracker}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<LodestoneTracker> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/MapDecorations.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/MapDecorations.java
@@ -14,7 +14,6 @@ import org.jspecify.annotations.Nullable;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#MAP_DECORATIONS
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface MapDecorations {
 
@@ -53,7 +52,6 @@ public interface MapDecorations {
     /**
      * Decoration present on the map.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface DecorationEntry {
 
@@ -94,7 +92,6 @@ public interface MapDecorations {
      * Builder for {@link MapDecorations}.
      */
     @ApiStatus.NonExtendable
-    @ApiStatus.Experimental
     interface Builder extends DataComponentBuilder<MapDecorations> {
 
         /**

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/MapId.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/MapId.java
@@ -10,7 +10,6 @@ import org.jspecify.annotations.NullMarked;
  */
 @NullMarked
 @ApiStatus.NonExtendable
-@ApiStatus.Experimental
 public interface MapId {
 
     @Contract(value = "_ -> new", pure = true)

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/MapItemColor.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/MapItemColor.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#MAP_COLOR
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface MapItemColor {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/OminousBottleAmplifier.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/OminousBottleAmplifier.java
@@ -10,7 +10,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#OMINOUS_BOTTLE_AMPLIFIER
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface OminousBottleAmplifier {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PiercingWeapon.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PiercingWeapon.java
@@ -9,7 +9,6 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface PiercingWeapon {
 
@@ -33,7 +32,6 @@ public interface PiercingWeapon {
     /**
      * Builder for {@link PiercingWeapon}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<PiercingWeapon> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotDecorations.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotDecorations.java
@@ -12,7 +12,6 @@ import org.jspecify.annotations.Nullable;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#POT_DECORATIONS
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface PotDecorations {
 
@@ -61,7 +60,6 @@ public interface PotDecorations {
     /**
      * Builder for {@link PotDecorations}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<PotDecorations> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotionContents.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/PotionContents.java
@@ -16,7 +16,6 @@ import org.jspecify.annotations.Nullable;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#POTION_CONTENTS
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface PotionContents {
 
@@ -81,7 +80,6 @@ public interface PotionContents {
     @Contract(pure = true)
     Color computeEffectiveColor();
 
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<PotionContents> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Repairable.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Repairable.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#REPAIRABLE
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface Repairable {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ResolvableProfile.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/ResolvableProfile.java
@@ -23,7 +23,6 @@ import org.jspecify.annotations.Nullable;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#PROFILE
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ResolvableProfile extends PlayerHeadObjectContents.SkinSource {
 
@@ -115,7 +114,6 @@ public interface ResolvableProfile extends PlayerHeadObjectContents.SkinSource {
     /**
      * Override rendering options for a {@link ResolvableProfile}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface SkinPatch {
 
@@ -182,7 +180,6 @@ public interface ResolvableProfile extends PlayerHeadObjectContents.SkinSource {
     /**
      * Builder for {@link SkinPatch}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface SkinPatchBuilder extends DataComponentBuilder<SkinPatch> {
         /**
@@ -225,7 +222,6 @@ public interface ResolvableProfile extends PlayerHeadObjectContents.SkinSource {
     /**
      * Builder for {@link ResolvableProfile}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<ResolvableProfile> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SeededContainerLoot.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SeededContainerLoot.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#CONTAINER_LOOT
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface SeededContainerLoot {
 
@@ -44,7 +43,6 @@ public interface SeededContainerLoot {
     /**
      * Builder for {@link SeededContainerLoot}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<SeededContainerLoot> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SulfurCubeContent.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SulfurCubeContent.java
@@ -10,7 +10,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#SULFUR_CUBE_CONTENT
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface SulfurCubeContent {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SuspiciousStewEffects.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SuspiciousStewEffects.java
@@ -14,7 +14,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#SUSPICIOUS_STEW_EFFECTS
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface SuspiciousStewEffects {
 
@@ -39,7 +38,6 @@ public interface SuspiciousStewEffects {
     /**
      * Builder for {@link SuspiciousStewEffects}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<SuspiciousStewEffects> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SwingAnimation.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/SwingAnimation.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface SwingAnimation {
 
@@ -33,7 +32,6 @@ public interface SwingAnimation {
     /**
      * Builder for {@link SwingAnimation}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<SwingAnimation> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Tool.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Tool.java
@@ -19,7 +19,6 @@ import org.jspecify.annotations.Nullable;
  * @see DataComponentTypes#TOOL
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface Tool {
 
@@ -80,7 +79,6 @@ public interface Tool {
     @Contract(pure = true)
     boolean canDestroyBlocksInCreative();
 
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Rule {
 
@@ -111,7 +109,6 @@ public interface Tool {
     /**
      * Builder for {@link Tool}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<Tool> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/TooltipDisplay.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/TooltipDisplay.java
@@ -8,7 +8,6 @@ import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface TooltipDisplay {
 
@@ -29,7 +28,6 @@ public interface TooltipDisplay {
     /**
      * Builder for {@link TooltipDisplay}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<TooltipDisplay> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/UseCooldown.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/UseCooldown.java
@@ -13,7 +13,6 @@ import org.jspecify.annotations.Nullable;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#USE_COOLDOWN
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface UseCooldown {
 
@@ -46,7 +45,6 @@ public interface UseCooldown {
     @Contract(pure = true)
     @Nullable Key cooldownGroup();
 
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<UseCooldown> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/UseEffects.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/UseEffects.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface UseEffects {
 
@@ -31,7 +30,6 @@ public interface UseEffects {
     /**
      * Builder for {@link UseEffects}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<UseEffects> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/UseRemainder.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/UseRemainder.java
@@ -10,7 +10,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#USE_REMAINDER
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface UseRemainder {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Weapon.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Weapon.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface Weapon {
 
@@ -36,7 +35,6 @@ public interface Weapon {
     /**
      * Builder for {@link Weapon}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<Weapon> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WritableBookContent.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WritableBookContent.java
@@ -14,7 +14,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#WRITABLE_BOOK_CONTENT
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface WritableBookContent extends BookLike {
 
@@ -34,7 +33,6 @@ public interface WritableBookContent extends BookLike {
     /**
      * Builder for {@link WritableBookContent}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<WritableBookContent> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WrittenBookContent.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/WrittenBookContent.java
@@ -17,7 +17,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.DataComponentTypes#WRITTEN_BOOK_CONTENT
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface WrittenBookContent extends BookLike {
 
@@ -75,7 +74,6 @@ public interface WrittenBookContent extends BookLike {
     /**
      * Builder for {@link WrittenBookContent}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<WrittenBookContent> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/attribute/AttributeModifierDisplay.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/attribute/AttributeModifierDisplay.java
@@ -13,7 +13,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.item.ItemAttributeModifiers#itemAttributes()
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface AttributeModifierDisplay {
 
@@ -53,7 +52,6 @@ public interface AttributeModifierDisplay {
     /**
      * Hidden statistics display for the attribute modifier.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Hidden extends AttributeModifierDisplay {
     }
@@ -62,7 +60,6 @@ public interface AttributeModifierDisplay {
      * Default display for the attribute modifier, showing
      * the statistic of its effect.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Default extends AttributeModifierDisplay {
     }
@@ -71,7 +68,6 @@ public interface AttributeModifierDisplay {
      * Specifies an overridden text to show instead of
      * the default behavior for the attribute modifier.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface OverrideText extends AttributeModifierDisplay {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/attribute/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/attribute/package-info.java
@@ -1,9 +1,6 @@
-/**
- * This package contains classes related to dialog actions in the Paper API.
- */
 @NullMarked
 @MinecraftVersionDependent
-package io.papermc.paper.registry.data.dialog.action;
+package io.papermc.paper.datacomponent.item.attribute;
 
 import io.papermc.paper.annotation.MinecraftVersionDependent;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/DamageReduction.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/DamageReduction.java
@@ -16,7 +16,6 @@ import org.jspecify.annotations.Nullable;
  * @see io.papermc.paper.datacomponent.item.BlocksAttacks#damageReductions()
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface DamageReduction {
 
@@ -56,7 +55,6 @@ public interface DamageReduction {
     /**
      * Builder for {@link DamageReduction}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<DamageReduction> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/ItemDamageFunction.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/ItemDamageFunction.java
@@ -13,7 +13,6 @@ import org.jspecify.annotations.NullMarked;
  * @see io.papermc.paper.datacomponent.item.BlocksAttacks#itemDamage()
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ItemDamageFunction {
 
@@ -54,7 +53,6 @@ public interface ItemDamageFunction {
     /**
      * Builder for {@link ItemDamageFunction}.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DataComponentBuilder<ItemDamageFunction> {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/blocksattacks/package-info.java
@@ -1,9 +1,6 @@
-/**
- * This package contains classes related to dialog actions in the Paper API.
- */
 @NullMarked
 @MinecraftVersionDependent
-package io.papermc.paper.registry.data.dialog.action;
+package io.papermc.paper.datacomponent.item.blocksattacks;
 
 import io.papermc.paper.annotation.MinecraftVersionDependent;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumeEffect.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/consumable/ConsumeEffect.java
@@ -13,7 +13,6 @@ import org.jspecify.annotations.NullMarked;
  * Effect that occurs when consuming an item.
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ConsumeEffect {
 
@@ -75,7 +74,6 @@ public interface ConsumeEffect {
     /**
      * Represents a consumable effect that randomly teleports the entity on consumption.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface TeleportRandomly extends ConsumeEffect {
 
@@ -90,7 +88,6 @@ public interface ConsumeEffect {
     /**
      * Represents a consumable effect that removes status effects on consumption.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface RemoveStatusEffects extends ConsumeEffect {
 
@@ -105,7 +102,6 @@ public interface ConsumeEffect {
     /**
      * Represents a consumable effect that plays a sound on consumption.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface PlaySound extends ConsumeEffect {
 
@@ -120,7 +116,6 @@ public interface ConsumeEffect {
     /**
      * Represents a consumable effect that clears all effects on consumption.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface ClearAllStatusEffects extends ConsumeEffect {
 
@@ -129,7 +124,6 @@ public interface ConsumeEffect {
     /**
      * Represents a consumable effect that applies potion effects based on a probability on consumption.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface ApplyStatusEffects extends ConsumeEffect {
 

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/consumable/ItemUseAnimation.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/consumable/ItemUseAnimation.java
@@ -1,11 +1,8 @@
 package io.papermc.paper.datacomponent.item.consumable;
 
-import org.jetbrains.annotations.ApiStatus;
-
 /**
  * Represents the hand animation that is used when a player is consuming this item.
  */
-@ApiStatus.Experimental
 public enum ItemUseAnimation {
     // Start generate - ItemUseAnimation
     NONE,

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/consumable/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/consumable/package-info.java
@@ -1,9 +1,6 @@
-/**
- * This package contains classes related to dialog actions in the Paper API.
- */
 @NullMarked
 @MinecraftVersionDependent
-package io.papermc.paper.registry.data.dialog.action;
+package io.papermc.paper.datacomponent.item.consumable;
 
 import io.papermc.paper.annotation.MinecraftVersionDependent;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Item data components, representing its runtime counterpart as a version-specific data-focused type.
+ * <p>
+ * Interfaces in this package may change without a proper deprecation cycle given it is meant to
+ * directly represent Vanilla data.
+ */
+@NullMarked
+@MinecraftVersionDependent
+package io.papermc.paper.datacomponent.item;
+
+import io.papermc.paper.annotation.MinecraftVersionDependent;
+import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/datapack/DatapackRegistrar.java
+++ b/paper-api/src/main/java/io/papermc/paper/datapack/DatapackRegistrar.java
@@ -168,7 +168,6 @@ public interface DatapackRegistrar extends Registrar {
      * Configures additional, optional, details about a datapack.
      */
     @ApiStatus.NonExtendable
-    @ApiStatus.Experimental
     interface Configurer {
 
         /**

--- a/paper-api/src/main/java/io/papermc/paper/dialog/Dialog.java
+++ b/paper-api/src/main/java/io/papermc/paper/dialog/Dialog.java
@@ -27,7 +27,6 @@ public interface Dialog extends Keyed, DialogLike {
      * @param value the builder to use for creating the dialog
      * @return a new dialog instance
      */
-    @ApiStatus.Experimental
     static Dialog create(final Consumer<RegistryBuilderFactory<Dialog, ? extends DialogRegistryEntry.Builder>> value) {
         return InlinedRegistryBuilderProvider.instance().createDialog(value);
     }

--- a/paper-api/src/main/java/io/papermc/paper/dialog/DialogResponseView.java
+++ b/paper-api/src/main/java/io/papermc/paper/dialog/DialogResponseView.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.Nullable;
  * dialog form. It is on the plugin to validate that the response
  * is valid.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface DialogResponseView {
 

--- a/paper-api/src/main/java/io/papermc/paper/event/connection/configuration/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/connection/configuration/package-info.java
@@ -1,9 +1,7 @@
 /**
  * Configuration connection events.
  */
-@ApiStatus.Experimental
 @NullMarked
 package io.papermc.paper.event.connection.configuration;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/event/connection/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/connection/package-info.java
@@ -2,8 +2,6 @@
  * Common connection events.
  */
 @NullMarked
-@ApiStatus.Experimental
 package io.papermc.paper.event.connection;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/event/packet/UncheckedSignChangeEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/packet/UncheckedSignChangeEvent.java
@@ -24,7 +24,6 @@ import org.jspecify.annotations.NullMarked;
  * @see Player#openVirtualSign(Position, Side)
  */
 @NullMarked
-@ApiStatus.Experimental
 public class UncheckedSignChangeEvent extends PlayerEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();

--- a/paper-api/src/main/java/io/papermc/paper/event/player/AsyncPlayerSpawnLocationEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/AsyncPlayerSpawnLocationEvent.java
@@ -16,7 +16,6 @@ import org.jspecify.annotations.NullMarked;
  * <p>The player will be kept in the configuration phase until all event handlers return and
  * the spawn location is loaded.</p>
  */
-@ApiStatus.Experimental
 @NullMarked
 public class AsyncPlayerSpawnLocationEvent extends Event {
 

--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerBedFailEnterEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerBedFailEnterEvent.java
@@ -48,7 +48,6 @@ public class PlayerBedFailEnterEvent extends PlayerEvent implements Cancellable 
      *
      * @return the action representing the default outcome of this event
      */
-    @ApiStatus.Experimental
     public BedEnterAction enterAction() {
         return this.enterAction;
     }

--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerCustomClickEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerCustomClickEvent.java
@@ -19,7 +19,6 @@ import org.jspecify.annotations.Nullable;
  * @see net.kyori.adventure.text.event.ClickEvent#custom(Key, BinaryTagHolder)
  * @see io.papermc.paper.registry.data.dialog.action.DialogAction#customClick(DialogActionCallback, ClickCallback.Options)
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 @NullMarked
 public abstract class PlayerCustomClickEvent extends Event {

--- a/paper-api/src/main/java/io/papermc/paper/plugin/loader/PluginClasspathBuilder.java
+++ b/paper-api/src/main/java/io/papermc/paper/plugin/loader/PluginClasspathBuilder.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.NullMarked;
  * A mutable builder that may be used to collect and register all {@link ClassPathLibrary} instances a
  * {@link PluginLoader} aims to provide to its plugin at runtime.
  */
-@ApiStatus.Experimental
 @NullMarked
 @ApiStatus.NonExtendable
 public interface PluginClasspathBuilder {

--- a/paper-api/src/main/java/io/papermc/paper/registry/RegistryBuilder.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/RegistryBuilder.java
@@ -8,7 +8,6 @@ import org.jspecify.annotations.NullMarked;
  *
  * @param <T> registry value type
  */
-@ApiStatus.Experimental
 @NullMarked
 @ApiStatus.NonExtendable
 public interface RegistryBuilder<T> {

--- a/paper-api/src/main/java/io/papermc/paper/registry/RegistryBuilderFactory.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/RegistryBuilderFactory.java
@@ -13,7 +13,6 @@ import org.jspecify.annotations.NullMarked;
  * @param <B> The type of the registry builder
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface RegistryBuilderFactory<T, B extends RegistryBuilder<T>> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/BannerPatternRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/BannerPatternRegistryEntry.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Contract;
 /**
  * A data-centric version-specific registry entry for the {@link PatternType} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface BannerPatternRegistryEntry {
 
@@ -36,7 +35,6 @@ public interface BannerPatternRegistryEntry {
      *     <li>{@link #translationKey(String)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends BannerPatternRegistryEntry, RegistryBuilder<PatternType> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/CatTypeRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/CatTypeRegistryEntry.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Contract;
 /**
  * A data-centric version-specific registry entry for the {@link Cat.Type} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface CatTypeRegistryEntry {
 
@@ -36,7 +35,6 @@ public interface CatTypeRegistryEntry {
      *     <li>{@link #babyClientTextureAsset(ClientTextureAsset)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends CatTypeRegistryEntry, RegistryBuilder<Cat.Type> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/ChickenVariantRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/ChickenVariantRegistryEntry.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Contract;
 /**
  * A data-centric version-specific registry entry for the {@link Chicken.Variant} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ChickenVariantRegistryEntry {
 
@@ -59,7 +58,6 @@ public interface ChickenVariantRegistryEntry {
      *     <li>{@link #model(Model)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends ChickenVariantRegistryEntry, RegistryBuilder<Chicken.Variant> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/CowVariantRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/CowVariantRegistryEntry.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Contract;
 /**
  * A data-centric version-specific registry entry for the {@link Cow.Variant} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface CowVariantRegistryEntry {
 
@@ -64,7 +63,6 @@ public interface CowVariantRegistryEntry {
      *     <li>{@link #model(Model)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends CowVariantRegistryEntry, RegistryBuilder<Cow.Variant> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/DamageTypeRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/DamageTypeRegistryEntry.java
@@ -11,7 +11,6 @@ import org.jetbrains.annotations.Contract;
 /**
  * A data-centric version-specific registry entry for the {@link DamageType} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface DamageTypeRegistryEntry {
 
@@ -63,7 +62,6 @@ public interface DamageTypeRegistryEntry {
      *     <li>{@link #damageScaling(DamageScaling)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends DamageTypeRegistryEntry, RegistryBuilder<DamageType> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/EnchantmentRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/EnchantmentRegistryEntry.java
@@ -22,7 +22,6 @@ import org.jspecify.annotations.Nullable;
 /**
  * A data-centric version-specific registry entry for the {@link Enchantment} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface EnchantmentRegistryEntry {
 
@@ -138,7 +137,6 @@ public interface EnchantmentRegistryEntry {
      *     <li>{@link #activeSlots(Iterable)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends EnchantmentRegistryEntry, RegistryBuilder<Enchantment> {
 
@@ -296,7 +294,6 @@ public interface EnchantmentRegistryEntry {
     /**
      * The enchantment cost interface represents the cost of applying an enchantment, split up into its different components.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface EnchantmentCost {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/FrogVariantRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/FrogVariantRegistryEntry.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Contract;
 /**
  * A data-centric version-specific registry entry for the {@link Frog.Variant} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface FrogVariantRegistryEntry {
 
@@ -28,7 +27,6 @@ public interface FrogVariantRegistryEntry {
      *     <li>{@link #clientTextureAsset(ClientTextureAsset)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends FrogVariantRegistryEntry, RegistryBuilder<Frog.Variant> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/GameEventRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/GameEventRegistryEntry.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Contract;
 /**
  * A data-centric version-specific registry entry for the {@link GameEvent} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface GameEventRegistryEntry {
 
@@ -29,7 +28,6 @@ public interface GameEventRegistryEntry {
      *     <li>{@link #range(int)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends GameEventRegistryEntry, RegistryBuilder<GameEvent> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/InstrumentRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/InstrumentRegistryEntry.java
@@ -15,7 +15,6 @@ import java.util.function.Consumer;
 /**
  * A data-centric version-specific registry entry for the {@link org.bukkit.MusicInstrument} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface InstrumentRegistryEntry {
 
@@ -68,7 +67,6 @@ public interface InstrumentRegistryEntry {
      *     <li>{@link #description(Component)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends InstrumentRegistryEntry, RegistryBuilder<MusicInstrument> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/JukeboxSongRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/JukeboxSongRegistryEntry.java
@@ -16,7 +16,6 @@ import org.jetbrains.annotations.Range;
 /**
  * A data-centric version-specific registry entry for the {@link JukeboxSong} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface JukeboxSongRegistryEntry {
 
@@ -65,7 +64,6 @@ public interface JukeboxSongRegistryEntry {
      *     <li>{@link #comparatorOutput(int)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends JukeboxSongRegistryEntry, RegistryBuilder<JukeboxSong> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/PaintingVariantRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/PaintingVariantRegistryEntry.java
@@ -12,7 +12,6 @@ import org.jspecify.annotations.Nullable;
 /**
  * A data-centric version-specific registry entry for the {@link Art} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface PaintingVariantRegistryEntry {
 
@@ -66,7 +65,6 @@ public interface PaintingVariantRegistryEntry {
      *     <li>{@link #assetId(Key)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends PaintingVariantRegistryEntry, RegistryBuilder<Art> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/PigVariantRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/PigVariantRegistryEntry.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Contract;
 /**
  * A data-centric version-specific registry entry for the {@link Pig.Variant} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface PigVariantRegistryEntry {
 
@@ -59,7 +58,6 @@ public interface PigVariantRegistryEntry {
      *     <li>{@link #model(Model)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends PigVariantRegistryEntry, RegistryBuilder<Pig.Variant> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/SoundEventRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/SoundEventRegistryEntry.java
@@ -10,7 +10,6 @@ import org.jspecify.annotations.Nullable;
 /**
  * A data-centric version-specific registry entry for the {@link Sound} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface SoundEventRegistryEntry {
 
@@ -38,7 +37,6 @@ public interface SoundEventRegistryEntry {
      *     <li>{@link #location(Key)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends SoundEventRegistryEntry, RegistryBuilder<Sound> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/SulfurCubeArchetypeRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/SulfurCubeArchetypeRegistryEntry.java
@@ -74,6 +74,7 @@ public interface SulfurCubeArchetypeRegistryEntry {
          * @apiNote for non-constant damage this will return one possible sample
          * instead of the exact amount
          */
+        @ApiStatus.Experimental
         @NonNegative float amount(); // todo expose FloatProvider/IntProvider in a consistent way (should match Machine's PR for dimension type)
 
         /**
@@ -91,6 +92,7 @@ public interface SulfurCubeArchetypeRegistryEntry {
          * @return the created instance
          */
         @Contract(value = "_, _, _ -> new", pure = true)
+        @ApiStatus.Experimental
         static ContactDamage of(final TypedKey<DamageType> damageType, final @NonNegative float amount, final boolean attributeToSource) {
             record Impl(TypedKey<DamageType> damageType, @NonNegative float amount, boolean attributeToSource) implements ContactDamage {
             }
@@ -181,6 +183,7 @@ public interface SulfurCubeArchetypeRegistryEntry {
         /**
          * {@return the sound played once the sulfur cube is knocked}
          */
+        @ApiStatus.Experimental
         TypedKey<Sound> hitSound(); // todo should take a RegistryHolder but need more thoughts on the create method
 
         /**
@@ -208,6 +211,7 @@ public interface SulfurCubeArchetypeRegistryEntry {
          * @return the created instance
          */
         @Contract(value = "_, _, _, _ -> new", pure = true)
+        @ApiStatus.Experimental
         static SoundSettings of(final TypedKey<Sound> hitSound, final TypedKey<Sound> pushSound, final float pushSoundImpulseThreshold, final float pushSoundCooldown) {
             record Impl(TypedKey<Sound> hitSound, TypedKey<Sound> pushSound, float pushSoundImpulseThreshold, float pushSoundCooldown) implements SoundSettings {
             }

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/SulfurCubeArchetypeRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/SulfurCubeArchetypeRegistryEntry.java
@@ -180,15 +180,17 @@ public interface SulfurCubeArchetypeRegistryEntry {
     @ApiStatus.NonExtendable
     interface SoundSettings {
 
+        // todo The sounds should take a RegistryHolder but need more thoughts on the create method
         /**
          * {@return the sound played once the sulfur cube is knocked}
          */
         @ApiStatus.Experimental
-        TypedKey<Sound> hitSound(); // todo should take a RegistryHolder but need more thoughts on the create method
+        TypedKey<Sound> hitSound();
 
         /**
          * {@return the sound played once the sulfur cube is pushed}
          */
+        @ApiStatus.Experimental
         TypedKey<Sound> pushSound();
 
         /**

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/SulfurCubeArchetypeRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/SulfurCubeArchetypeRegistryEntry.java
@@ -22,14 +22,12 @@ import static io.papermc.paper.util.BoundChecker.requirePositive;
 /**
  * A data-centric version-specific registry entry for the {@link SulfurCube.Archetype} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface SulfurCubeArchetypeRegistryEntry {
 
     /**
      * An attribute entry to apply to a sulfur cube of this archetype.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface AttributeEntry {
 
@@ -63,7 +61,6 @@ public interface SulfurCubeArchetypeRegistryEntry {
      * The contact damage a sulfur cube of this archetype will deal when pushed
      * by another entity.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface ContactDamage {
 
@@ -105,7 +102,6 @@ public interface SulfurCubeArchetypeRegistryEntry {
     /**
      * The explosion settings of a sulfur cube of this archetype.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface ExplosionSettings {
 
@@ -147,7 +143,6 @@ public interface SulfurCubeArchetypeRegistryEntry {
      * The knockback modifiers a sulfur cube of this archetype will receive
      * when knocked by another entity.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface KnockbackModifiers {
 
@@ -180,7 +175,6 @@ public interface SulfurCubeArchetypeRegistryEntry {
     /**
      * The sound settings of a sulfur cube of this archetype.
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface SoundSettings {
 
@@ -284,7 +278,6 @@ public interface SulfurCubeArchetypeRegistryEntry {
      *     <li>{@link #soundSettings(SoundSettings)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends SulfurCubeArchetypeRegistryEntry, RegistryBuilder<SulfurCube.Archetype> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/TrimMaterialRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/TrimMaterialRegistryEntry.java
@@ -14,7 +14,6 @@ import org.jetbrains.annotations.Unmodifiable;
 /**
  * A data-centric version-specific registry entry for the {@link org.bukkit.inventory.meta.trim.TrimMaterial} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface TrimMaterialRegistryEntry {
 
@@ -54,7 +53,6 @@ public interface TrimMaterialRegistryEntry {
      *     <li>{@link #description(Component)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends TrimMaterialRegistryEntry, RegistryBuilder<TrimMaterial> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/TrimPatternRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/TrimPatternRegistryEntry.java
@@ -10,7 +10,6 @@ import org.jetbrains.annotations.Contract;
 /**
  * A data-centric version-specific registry entry for the {@link org.bukkit.inventory.meta.trim.TrimPattern} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface TrimPatternRegistryEntry {
 
@@ -47,7 +46,6 @@ public interface TrimPatternRegistryEntry {
      *     <li>{@link #description(Component)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends TrimPatternRegistryEntry, RegistryBuilder<TrimPattern> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/WolfVariantRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/WolfVariantRegistryEntry.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Contract;
 /**
  * A data-centric version-specific registry entry for the {@link Wolf.Variant} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface WolfVariantRegistryEntry {
 
@@ -68,7 +67,6 @@ public interface WolfVariantRegistryEntry {
      *     <li>{@link #babyTameClientTextureAsset(ClientTextureAsset)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends WolfVariantRegistryEntry, RegistryBuilder<Wolf.Variant> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/ZombieNautilusVariantRegistryEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/ZombieNautilusVariantRegistryEntry.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Contract;
 /**
  * A data-centric version-specific registry entry for the {@link org.bukkit.entity.ZombieNautilus.Variant} type.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ZombieNautilusVariantRegistryEntry {
 
@@ -51,7 +50,6 @@ public interface ZombieNautilusVariantRegistryEntry {
      *     <li>{@link #model(Model)}</li>
      * </ul>
      */
-    @ApiStatus.Experimental
     @ApiStatus.NonExtendable
     interface Builder extends ZombieNautilusVariantRegistryEntry, RegistryBuilder<ZombieNautilus.Variant> {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/client/ClientTextureAsset.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/client/ClientTextureAsset.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Contract;
  * A data-centric version-specific representation of a client texture asset, composed of an identifier and a path.
  * Follows the same, version-specific, compatibility guarantees as the RegistryEntry types it is used in.
  */
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface ClientTextureAsset {
 

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/client/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/client/package-info.java
@@ -1,9 +1,6 @@
-/**
- * This package contains classes related to dialog actions in the Paper API.
- */
 @NullMarked
 @MinecraftVersionDependent
-package io.papermc.paper.registry.data.dialog.action;
+package io.papermc.paper.registry.data.client;
 
 import io.papermc.paper.annotation.MinecraftVersionDependent;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/body/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/body/package-info.java
@@ -2,8 +2,8 @@
  * This package contains classes related to dialog bodies in the Paper API.
  */
 @NullMarked
-@ApiStatus.Experimental
+@MinecraftVersionDependent
 package io.papermc.paper.registry.data.dialog.body;
 
-import org.jetbrains.annotations.ApiStatus;
+import io.papermc.paper.annotation.MinecraftVersionDependent;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/input/package-info.java
@@ -2,8 +2,8 @@
  * Dialog inputs for Paper API.
  */
 @NullMarked
-@ApiStatus.Experimental
+@MinecraftVersionDependent
 package io.papermc.paper.registry.data.dialog.input;
 
-import org.jetbrains.annotations.ApiStatus;
+import io.papermc.paper.annotation.MinecraftVersionDependent;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/package-info.java
@@ -1,6 +1,6 @@
 @NullMarked
-@ApiStatus.Experimental
+@MinecraftVersionDependent
 package io.papermc.paper.registry.data.dialog;
 
-import org.jetbrains.annotations.ApiStatus;
+import io.papermc.paper.annotation.MinecraftVersionDependent;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/type/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/dialog/type/package-info.java
@@ -2,8 +2,8 @@
  * Dialog types for the Paper API.
  */
 @NullMarked
-@ApiStatus.Experimental
+@MinecraftVersionDependent
 package io.papermc.paper.registry.data.dialog.type;
 
-import org.jetbrains.annotations.ApiStatus;
+import io.papermc.paper.annotation.MinecraftVersionDependent;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/registry/data/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/data/package-info.java
@@ -7,6 +7,8 @@
  * exposed during registry creation/modification.
  */
 @NullMarked
+@MinecraftVersionDependent
 package io.papermc.paper.registry.data;
 
+import io.papermc.paper.annotation.MinecraftVersionDependent;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/registry/event/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/event/package-info.java
@@ -1,9 +1,7 @@
 /**
  * This package contains events related to the Paper registry system.
  */
-@ApiStatus.Experimental
 @NullMarked
 package io.papermc.paper.registry.event;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/registry/event/type/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/event/type/package-info.java
@@ -1,9 +1,7 @@
 /**
  * This package contains events related to the Paper registry system.
  */
-@ApiStatus.Experimental
 @NullMarked
 package io.papermc.paper.registry.event.type;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/registry/holder/RegistryHolder.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/holder/RegistryHolder.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @param <API> the registry's type
  * @param <ENTRY> the type of the registry entry (for inlined values)
  */
+@ApiStatus.Experimental
 public sealed interface RegistryHolder<API, ENTRY> permits RegistryHolder.Reference, RegistryHolder.Inlined {
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/registry/holder/RegistryHolder.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/holder/RegistryHolder.java
@@ -11,7 +11,6 @@ import org.jetbrains.annotations.ApiStatus;
  * @param <API> the registry's type
  * @param <ENTRY> the type of the registry entry (for inlined values)
  */
-@ApiStatus.Experimental
 public sealed interface RegistryHolder<API, ENTRY> permits RegistryHolder.Reference, RegistryHolder.Inlined {
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/registry/holder/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/holder/package-info.java
@@ -1,9 +1,7 @@
 /**
  * Registry holders.
  */
-@ApiStatus.Experimental
 @NullMarked
 package io.papermc.paper.registry.holder;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/registry/holder/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/holder/package-info.java
@@ -1,7 +1,9 @@
 /**
  * Registry holders.
  */
+@ApiStatus.Experimental
 @NullMarked
 package io.papermc.paper.registry.holder;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/registry/set/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/set/package-info.java
@@ -3,7 +3,9 @@
  * <p>
  * Registry sets are collections of keys or inlined values of a type that has a registry.
  */
+@ApiStatus.Experimental
 @NullMarked
 package io.papermc.paper.registry.set;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/registry/set/package-info.java
+++ b/paper-api/src/main/java/io/papermc/paper/registry/set/package-info.java
@@ -3,9 +3,7 @@
  * <p>
  * Registry sets are collections of keys or inlined values of a type that has a registry.
  */
-@ApiStatus.Experimental
 @NullMarked
 package io.papermc.paper.registry.set;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/io/papermc/paper/text/Filtered.java
+++ b/paper-api/src/main/java/io/papermc/paper/text/Filtered.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.Nullable;
  *
  * @param <T> type of value
  */
-@ApiStatus.Experimental
 @NullMarked
 public interface Filtered<T> {
 

--- a/paper-api/src/main/java/io/papermc/paper/world/damagesource/CombatEntry.java
+++ b/paper-api/src/main/java/io/papermc/paper/world/damagesource/CombatEntry.java
@@ -12,7 +12,6 @@ import org.jspecify.annotations.Nullable;
  * Represents a combat entry
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface CombatEntry {
 

--- a/paper-api/src/main/java/io/papermc/paper/world/damagesource/CombatTracker.java
+++ b/paper-api/src/main/java/io/papermc/paper/world/damagesource/CombatTracker.java
@@ -12,7 +12,6 @@ import java.util.List;
  * Represents entity's combat tracker
  */
 @NullMarked
-@ApiStatus.Experimental
 @ApiStatus.NonExtendable
 public interface CombatTracker {
 

--- a/paper-api/src/main/java/io/papermc/paper/world/damagesource/FallLocationType.java
+++ b/paper-api/src/main/java/io/papermc/paper/world/damagesource/FallLocationType.java
@@ -1,14 +1,12 @@
 package io.papermc.paper.world.damagesource;
 
 import net.kyori.adventure.translation.Translatable;
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 /**
  * Represents a type of location from which the entity fell.
  */
 @NullMarked
-@ApiStatus.Experimental
 public sealed interface FallLocationType extends Translatable permits FallLocationTypeImpl {
 
     /**

--- a/paper-api/src/main/java/org/bukkit/Bukkit.java
+++ b/paper-api/src/main/java/org/bukkit/Bukkit.java
@@ -2148,7 +2148,6 @@ public final class Bukkit {
      * @return the server's links
      */
     @NotNull
-    @ApiStatus.Experimental
     public static ServerLinks getServerLinks() {
         return server.getServerLinks();
     }

--- a/paper-api/src/main/java/org/bukkit/ExplosionResult.java
+++ b/paper-api/src/main/java/org/bukkit/ExplosionResult.java
@@ -1,11 +1,8 @@
 package org.bukkit;
 
-import org.jetbrains.annotations.ApiStatus;
-
 /**
  * Represents the outcome of an explosion.
  */
-@ApiStatus.Experimental
 public enum ExplosionResult {
 
     /**

--- a/paper-api/src/main/java/org/bukkit/MusicInstrument.java
+++ b/paper-api/src/main/java/org/bukkit/MusicInstrument.java
@@ -10,7 +10,6 @@ import java.util.function.Consumer;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -23,7 +22,6 @@ public abstract class MusicInstrument implements Keyed, net.kyori.adventure.tran
      * @param value a consumer for the builder factory
      * @return the created music instrument
      */
-    @ApiStatus.Experimental
     public static MusicInstrument create(final Consumer<RegistryBuilderFactory<MusicInstrument, ? extends InstrumentRegistryEntry.Builder>> value) {
         return InlinedRegistryBuilderProvider.instance().createInstrument(value);
     }

--- a/paper-api/src/main/java/org/bukkit/Registry.java
+++ b/paper-api/src/main/java/org/bukkit/Registry.java
@@ -197,7 +197,6 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      *
      * @see MenuType
      */
-    @ApiStatus.Experimental
     Registry<MenuType> MENU = registryFor(RegistryKey.MENU);
     /**
      * Server mob effects.
@@ -503,7 +502,6 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      * @see #hasTag(TagKey)
      * @see #getTagValues(TagKey)
      */
-    @ApiStatus.Experimental
     Tag<T> getTag(TagKey<T> key);
 
     /**
@@ -516,7 +514,6 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      * @see #getTag(TagKey)
      * @see Tag#resolve(Registry)
      */
-    @ApiStatus.Experimental
     default Collection<T> getTagValues(final TagKey<T> key) {
         Tag<T> tag = this.getTag(key);
         return tag.resolve(this);
@@ -528,7 +525,6 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
      * @return a stream of all tags in this registry
      * @throws UnsupportedOperationException if this registry doesn't have or support tags
      */
-    @ApiStatus.Experimental
     Collection<Tag<T>> getTags();
     // Paper end - RegistrySet API
 

--- a/paper-api/src/main/java/org/bukkit/Server.java
+++ b/paper-api/src/main/java/org/bukkit/Server.java
@@ -1599,7 +1599,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      *
      * @return the level directory
      */
-    @ApiStatus.Experimental
     @NotNull
     Path getLevelDirectory();
 
@@ -1941,7 +1940,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      * @return the server's links
      */
     @NotNull
-    @ApiStatus.Experimental
     ServerLinks getServerLinks();
 
     /**

--- a/paper-api/src/main/java/org/bukkit/ServerLinks.java
+++ b/paper-api/src/main/java/org/bukkit/ServerLinks.java
@@ -2,14 +2,12 @@ package org.bukkit;
 
 import java.net.URI;
 import java.util.List;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a collections of links which may be sent to a client.
  */
-@ApiStatus.Experimental
 public interface ServerLinks {
 
     /**

--- a/paper-api/src/main/java/org/bukkit/block/BrewingStand.java
+++ b/paper-api/src/main/java/org/bukkit/block/BrewingStand.java
@@ -31,7 +31,6 @@ public interface BrewingStand extends Container {
      * @param recipeBrewTime recipe brew time (in ticks)
      * @throws IllegalArgumentException if the recipe brew time is non-positive
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     void setRecipeBrewTime(@org.jetbrains.annotations.Range(from = 1, to = Integer.MAX_VALUE) int recipeBrewTime);
 
     /**
@@ -41,7 +40,6 @@ public interface BrewingStand extends Container {
      *
      * @return recipe brew time (in ticks)
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     @org.jetbrains.annotations.Range(from = 1, to = Integer.MAX_VALUE) int getRecipeBrewTime();
     // Paper end - Add recipeBrewTime
 

--- a/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
+++ b/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.spawner.TrialSpawnerConfiguration;
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -186,7 +185,6 @@ public interface TrialSpawner extends TileState {
      *
      * @return the TrialSpawnerConfiguration
      */
-    @ApiStatus.Experimental
     TrialSpawnerConfiguration getNormalConfiguration();
 
     /**
@@ -195,6 +193,5 @@ public interface TrialSpawner extends TileState {
      *
      * @return the TrialSpawnerConfiguration
      */
-    @ApiStatus.Experimental
     TrialSpawnerConfiguration getOminousConfiguration();
 }

--- a/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
+++ b/paper-api/src/main/java/org/bukkit/block/TrialSpawner.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.spawner.TrialSpawnerConfiguration;
+import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -185,6 +186,7 @@ public interface TrialSpawner extends TileState {
      *
      * @return the TrialSpawnerConfiguration
      */
+    @ApiStatus.Experimental
     TrialSpawnerConfiguration getNormalConfiguration();
 
     /**
@@ -193,5 +195,6 @@ public interface TrialSpawner extends TileState {
      *
      * @return the TrialSpawnerConfiguration
      */
+    @ApiStatus.Experimental
     TrialSpawnerConfiguration getOminousConfiguration();
 }

--- a/paper-api/src/main/java/org/bukkit/enchantments/Enchantment.java
+++ b/paper-api/src/main/java/org/bukkit/enchantments/Enchantment.java
@@ -10,6 +10,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.Translatable;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -486,6 +487,7 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
      *
      * @return a registry set of enchantments exclusive to this one.
      */
+    @ApiStatus.Experimental
     public abstract io.papermc.paper.registry.set.@NotNull RegistryKeySet<Enchantment> getExclusiveWith();
     // Paper end - even more Enchantment API
 

--- a/paper-api/src/main/java/org/bukkit/enchantments/Enchantment.java
+++ b/paper-api/src/main/java/org/bukkit/enchantments/Enchantment.java
@@ -486,7 +486,6 @@ public abstract class Enchantment implements Keyed, Translatable, net.kyori.adve
      *
      * @return a registry set of enchantments exclusive to this one.
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public abstract io.papermc.paper.registry.set.@NotNull RegistryKeySet<Enchantment> getExclusiveWith();
     // Paper end - even more Enchantment API
 

--- a/paper-api/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/paper-api/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -1223,7 +1223,6 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      *
      * @param hand the hand that contains the item to be used
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     void startUsingItem(@NotNull org.bukkit.inventory.EquipmentSlot hand);
 
     /**
@@ -1234,7 +1233,6 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      * This method does not make any guarantees about the effect of this method
      * as such depends on the entity and its state.
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     void completeUsingActiveItem();
 
     /**
@@ -1520,7 +1518,6 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      *
      * @return the entity's combat tracker
      */
-    @ApiStatus.Experimental
     @NotNull CombatTracker getCombatTracker();
 
     /**

--- a/paper-api/src/main/java/org/bukkit/entity/Player.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Player.java
@@ -632,7 +632,6 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      *
      * @return collection of entities corresponding to current pearls.
      */
-    @ApiStatus.Experimental
     public Collection<EnderPearl> getEnderPearls();
 
     /**
@@ -3550,7 +3549,6 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      * @param side The side to edit
      * @see io.papermc.paper.event.packet.UncheckedSignChangeEvent
      */
-    @ApiStatus.Experimental
     void openVirtualSign(Position block, Side side);
 
     /**
@@ -3932,20 +3930,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      * Gets the set of chunk keys for all chunks that have been sent to the player.
      *
      * @return an immutable set of chunk keys
-     * @apiNote currently marked as experimental to gather feedback regarding the returned set being an immutable copy
-     * vs it potentially being an unmodifiable view of the set chunks.
      */
-    @ApiStatus.Experimental
     java.util.@org.jetbrains.annotations.Unmodifiable Set<Long> getSentChunkKeys();
 
     /**
      * Gets the set of chunks that have been sent to the player.
      *
      * @return an immutable set of chunks
-     * @apiNote currently marked as experimental to gather feedback regarding the returned set being an immutable copy
-      * vs it potentially being an unmodifiable view of the set chunks.
      */
-    @ApiStatus.Experimental
     java.util.@org.jetbrains.annotations.Unmodifiable Set<org.bukkit.Chunk> getSentChunks();
 
     /**
@@ -4039,7 +4031,6 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      *
      * @return the game connection
      */
-    @ApiStatus.Experimental
     PlayerGameConnection getConnection();
 
     @Override

--- a/paper-api/src/main/java/org/bukkit/event/block/BrewingStartEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/BrewingStartEvent.java
@@ -10,7 +10,6 @@ import org.jetbrains.annotations.Range;
 /**
  * Called when a brewing stand starts to brew.
  */
-@ApiStatus.Experimental // Paper
 public class BrewingStartEvent extends InventoryBlockStartEvent {
 
     private int brewingTime;
@@ -51,7 +50,6 @@ public class BrewingStartEvent extends InventoryBlockStartEvent {
      *
      * @return recipe brew time (in ticks)
      */
-    @ApiStatus.Experimental
     public @Range(from = 1, to = Integer.MAX_VALUE) int getRecipeBrewTime() {
         return this.recipeBrewTime;
     }
@@ -64,7 +62,6 @@ public class BrewingStartEvent extends InventoryBlockStartEvent {
      * @param recipeBrewTime recipe brew time (in ticks)
      * @throws IllegalArgumentException if the recipe brew time is non-positive
      */
-    @ApiStatus.Experimental
     public void setRecipeBrewTime(@Range(from = 1, to = Integer.MAX_VALUE) int recipeBrewTime) {
         Preconditions.checkArgument(recipeBrewTime > 0, "recipeBrewTime must be positive");
         this.recipeBrewTime = recipeBrewTime;

--- a/paper-api/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/CampfireStartEvent.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when a Campfire starts to cook.
  */
-@ApiStatus.Experimental // Paper
 public class CampfireStartEvent extends InventoryBlockStartEvent {
 
     private final CampfireRecipe campfireRecipe;

--- a/paper-api/src/main/java/org/bukkit/event/entity/TrialSpawnerSpawnEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/TrialSpawnerSpawnEvent.java
@@ -10,7 +10,6 @@ import org.jetbrains.annotations.NotNull;
  * <p>
  * If this event is cancelled, the entity will not spawn.
  */
-@ApiStatus.Experimental
 public class TrialSpawnerSpawnEvent extends EntitySpawnEvent {
 
     private final TrialSpawner spawner;

--- a/paper-api/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
@@ -311,7 +311,6 @@ public class AsyncPlayerPreLoginEvent extends Event {
      * Gets the connection for the player logging in.
      * @return connection
      */
-    @ApiStatus.Experimental
     @NotNull
     public PlayerLoginConnection getConnection() {
         return playerLoginConnection;

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerBedEnterEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerBedEnterEvent.java
@@ -57,7 +57,6 @@ public class PlayerBedEnterEvent extends PlayerEvent implements Cancellable {
      *
      * @return the action representing the default outcome of this event
      */
-    @ApiStatus.Experimental
     public @NotNull BedEnterAction enterAction() {
         return this.enterAction;
     }

--- a/paper-api/src/main/java/org/bukkit/event/player/PlayerLinksSendEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/player/PlayerLinksSendEvent.java
@@ -11,7 +11,6 @@ import org.jetbrains.annotations.NotNull;
 /**
  * This event is called when the list of links is sent to the player.
  */
-@ApiStatus.Experimental
 public class PlayerLinksSendEvent extends Event {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();

--- a/paper-api/src/main/java/org/bukkit/event/world/AsyncStructureGenerateEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/world/AsyncStructureGenerateEvent.java
@@ -35,7 +35,6 @@ import org.jetbrains.annotations.Unmodifiable;
  * appropriately.
  * <p>
  */
-@ApiStatus.Experimental
 public class AsyncStructureGenerateEvent extends WorldEvent {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();

--- a/paper-api/src/main/java/org/bukkit/event/world/AsyncStructureGenerateEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/world/AsyncStructureGenerateEvent.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.Unmodifiable;
  * appropriately.
  * <p>
  */
+@ApiStatus.Experimental
 public class AsyncStructureGenerateEvent extends WorldEvent {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();

--- a/paper-api/src/main/java/org/bukkit/inventory/InventoryView.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/InventoryView.java
@@ -332,6 +332,5 @@ public interface InventoryView {
      *
      * @return the menu type of the inventory view or null if not applicable
      */
-    @ApiStatus.Experimental
     @Nullable MenuType getMenuType();
 }

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -1179,7 +1179,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      * @see #hasData(io.papermc.paper.datacomponent.DataComponentType) for DataComponentType.NonValued
      */
     @org.jetbrains.annotations.Contract(pure = true)
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public <T> @Nullable T getData(final io.papermc.paper.datacomponent.DataComponentType.@NotNull Valued<T> type) {
         return this.craftDelegate.getData(type);
     }
@@ -1195,7 +1194,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      */
     @Utility
     @org.jetbrains.annotations.Contract(value = "_, !null -> !null", pure = true)
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public <T> @Nullable T getDataOrDefault(final io.papermc.paper.datacomponent.DataComponentType.@NotNull Valued<? extends T> type, final @Nullable T fallback) {
         final T object = this.getData(type);
         return object != null ? object : fallback;
@@ -1208,7 +1206,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      * @return {@code true} if set, {@code false} otherwise
      */
     @org.jetbrains.annotations.Contract(pure = true)
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public boolean hasData(final io.papermc.paper.datacomponent.@NotNull DataComponentType type) {
         return this.craftDelegate.hasData(type);
     }
@@ -1219,7 +1216,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      * @return an immutable set of data component types
      */
     @org.jetbrains.annotations.Contract("-> new")
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public java.util.@org.jetbrains.annotations.Unmodifiable Set<io.papermc.paper.datacomponent.@NotNull DataComponentType> getDataTypes() {
         return this.craftDelegate.getDataTypes();
     }
@@ -1235,7 +1231,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      * @param <T> value type
      */
     @Utility
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public <T> void setData(final io.papermc.paper.datacomponent.DataComponentType.@NotNull Valued<T> type, final @NotNull io.papermc.paper.datacomponent.DataComponentBuilder<T> valueBuilder) {
         this.setData(type, valueBuilder.build());
     }
@@ -1274,7 +1269,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      * @param value value to set
      * @param <T> value type
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public <T> void setData(final io.papermc.paper.datacomponent.DataComponentType.@NotNull Valued<T> type, final @NotNull T value) {
         this.craftDelegate.setData(type, value);
     }
@@ -1284,7 +1278,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      *
      * @param type the data component type
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public void setData(final io.papermc.paper.datacomponent.DataComponentType.@NotNull NonValued type) {
         this.craftDelegate.setData(type);
     }
@@ -1294,7 +1287,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      *
      * @param type the data component type
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public void unsetData(final io.papermc.paper.datacomponent.@NotNull DataComponentType type) {
         this.craftDelegate.unsetData(type);
     }
@@ -1305,7 +1297,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      *
      * @param type the data component type
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public void resetData(final io.papermc.paper.datacomponent.@NotNull DataComponentType type) {
         this.craftDelegate.resetData(type);
     }
@@ -1330,7 +1321,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      * @param source the item stack to copy from
      * @param filter predicate for which components to copy
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public void copyDataFrom(final @NotNull ItemStack source, final @NotNull Predicate<io.papermc.paper.datacomponent.@NotNull DataComponentType> filter) {
         this.craftDelegate.copyDataFrom(source, filter);
     }
@@ -1342,7 +1332,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      * @param type the data component type
      * @return {@code true} if the data type is overridden
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public boolean isDataOverridden(final io.papermc.paper.datacomponent.@NotNull DataComponentType type) {
         return this.craftDelegate.isDataOverridden(type);
     }
@@ -1355,7 +1344,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      * @param excludeTypes the data component types to ignore
      * @return {@code true} if the provided item is equal, ignoring the provided components
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public boolean matchesWithoutData(final @NotNull ItemStack item, final @NotNull java.util.Set<io.papermc.paper.datacomponent.@NotNull DataComponentType> excludeTypes) {
         return this.matchesWithoutData(item, excludeTypes, false);
     }
@@ -1369,7 +1357,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      * @param ignoreCount ignore the count of the item
      * @return {@code true} if the provided item is equal, ignoring the provided components
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     public boolean matchesWithoutData(final @NotNull ItemStack item, final @NotNull java.util.Set<io.papermc.paper.datacomponent.@NotNull DataComponentType> excludeTypes, final boolean ignoreCount) {
         return this.craftDelegate.matchesWithoutData(item, excludeTypes, ignoreCount);
     }

--- a/paper-api/src/main/java/org/bukkit/inventory/ItemType.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/ItemType.java
@@ -3401,7 +3401,6 @@ public interface ItemType extends Keyed, Translatable, net.kyori.adventure.trans
      * @param type the data component type
      * @return {@code true} if there is a default value
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     boolean hasDefaultData(DataComponentType type);
 
     /**

--- a/paper-api/src/main/java/org/bukkit/inventory/MenuType.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/MenuType.java
@@ -19,7 +19,6 @@ import org.bukkit.inventory.view.StonecutterView;
 import org.bukkit.inventory.view.builder.InventoryViewBuilder;
 import org.bukkit.inventory.view.builder.LocationInventoryViewBuilder;
 import org.bukkit.inventory.view.builder.MerchantInventoryViewBuilder;
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -28,7 +27,6 @@ import org.jspecify.annotations.Nullable;
  * created and viewed by the player.
  */
 @NullMarked
-@ApiStatus.Experimental
 public interface MenuType extends Keyed, io.papermc.paper.world.flag.FeatureDependant { // Paper - make FeatureDependant
 
     /**

--- a/paper-api/src/main/java/org/bukkit/inventory/meta/trim/TrimMaterial.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/meta/trim/TrimMaterial.java
@@ -13,7 +13,6 @@ import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.Translatable;
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -28,7 +27,6 @@ public interface TrimMaterial extends Keyed, Translatable {
      * @param value a consumer for the builder factory
      * @return the created trim material
      */
-    @ApiStatus.Experimental
     static TrimMaterial create(final Consumer<RegistryBuilderFactory<TrimMaterial, ? extends TrimMaterialRegistryEntry.Builder>> value) {
         return InlinedRegistryBuilderProvider.instance().createTrimMaterial(value);
     }

--- a/paper-api/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
@@ -13,7 +13,6 @@ import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.Translatable;
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -28,7 +27,6 @@ public interface TrimPattern extends Keyed, Translatable {
      * @param value a consumer for the builder factory
      * @return the created trim pattern
      */
-    @ApiStatus.Experimental
     static TrimPattern create(final Consumer<RegistryBuilderFactory<TrimPattern, ? extends TrimPatternRegistryEntry.Builder>> value) {
         return InlinedRegistryBuilderProvider.instance().createTrimPattern(value);
     }

--- a/paper-api/src/main/java/org/bukkit/inventory/view/BrewingStandView.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/view/BrewingStandView.java
@@ -55,7 +55,6 @@ public interface BrewingStandView extends InventoryView {
      * @param recipeBrewTime recipe brew time (in ticks)
      * @throws IllegalArgumentException if the recipe brew time is non-positive
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     void setRecipeBrewTime(@org.jetbrains.annotations.Range(from = 1, to = Integer.MAX_VALUE) int recipeBrewTime);
 
     /**
@@ -65,7 +64,6 @@ public interface BrewingStandView extends InventoryView {
      *
      * @return recipe brew time (in ticks)
      */
-    @org.jetbrains.annotations.ApiStatus.Experimental
     @org.jetbrains.annotations.Range(from = 1, to = Integer.MAX_VALUE) int getRecipeBrewTime();
     // Paper end - Add recipeBrewTime
 }

--- a/paper-api/src/main/java/org/bukkit/inventory/view/builder/InventoryViewBuilder.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/view/builder/InventoryViewBuilder.java
@@ -3,7 +3,6 @@ package org.bukkit.inventory.view.builder;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.inventory.InventoryView;
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -11,7 +10,6 @@ import org.jspecify.annotations.Nullable;
  *
  * @param <V> the type of InventoryView created from this builder
  */
-@ApiStatus.Experimental
 public interface InventoryViewBuilder<V extends InventoryView> {
 
     /**

--- a/paper-api/src/main/java/org/bukkit/inventory/view/builder/LocationInventoryViewBuilder.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/view/builder/LocationInventoryViewBuilder.java
@@ -3,6 +3,7 @@ package org.bukkit.inventory.view.builder;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Location;
 import org.bukkit.inventory.InventoryView;
+import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -10,6 +11,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @param <V> the type of InventoryView created from this builder
  */
+@ApiStatus.Experimental
 public interface LocationInventoryViewBuilder<V extends InventoryView> extends InventoryViewBuilder<V> {
 
     @Override

--- a/paper-api/src/main/java/org/bukkit/inventory/view/builder/LocationInventoryViewBuilder.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/view/builder/LocationInventoryViewBuilder.java
@@ -3,7 +3,6 @@ package org.bukkit.inventory.view.builder;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Location;
 import org.bukkit.inventory.InventoryView;
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -11,7 +10,6 @@ import org.jspecify.annotations.Nullable;
  *
  * @param <V> the type of InventoryView created from this builder
  */
-@ApiStatus.Experimental
 public interface LocationInventoryViewBuilder<V extends InventoryView> extends InventoryViewBuilder<V> {
 
     @Override

--- a/paper-api/src/main/java/org/bukkit/inventory/view/builder/MerchantInventoryViewBuilder.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/view/builder/MerchantInventoryViewBuilder.java
@@ -4,7 +4,6 @@ import net.kyori.adventure.text.Component;
 import org.bukkit.Server;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.Merchant;
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -12,7 +11,6 @@ import org.jspecify.annotations.Nullable;
  *
  * @param <V> the type of InventoryView created by this builder
  */
-@ApiStatus.Experimental
 public interface MerchantInventoryViewBuilder<V extends InventoryView> extends InventoryViewBuilder<V> {
 
     @Override

--- a/paper-api/src/main/java/org/bukkit/inventory/view/builder/package-info.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/view/builder/package-info.java
@@ -2,8 +2,6 @@
  * A Package that contains builders for building InventoryViews.
  */
 @NullMarked
-@ApiStatus.Experimental
 package org.bukkit.inventory.view.builder;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;

--- a/paper-api/src/main/java/org/bukkit/inventory/view/package-info.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/view/package-info.java
@@ -2,5 +2,4 @@
  * Package for {@link org.bukkit.inventory.InventoryView} child interfaces that
  * house further usability for {@link org.bukkit.inventory.InventoryView}.
  */
-@org.jetbrains.annotations.ApiStatus.Experimental
 package org.bukkit.inventory.view;

--- a/paper-api/src/main/java/org/bukkit/plugin/messaging/Messenger.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/messaging/Messenger.java
@@ -5,7 +5,6 @@ import io.papermc.paper.connection.PlayerConnection;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -242,6 +241,5 @@ public interface Messenger {
      * @param channel Channel that the message was sent by.
      * @param message Raw payload of the message.
      */
-    @ApiStatus.Experimental
     public void dispatchIncomingMessage(@NotNull PlayerConnection source, @NotNull String channel, byte @NotNull [] message);
 }

--- a/paper-api/src/main/java/org/bukkit/plugin/messaging/PluginMessageListener.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/messaging/PluginMessageListener.java
@@ -2,7 +2,6 @@ package org.bukkit.plugin.messaging;
 
 import io.papermc.paper.connection.PlayerConnection;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -35,7 +34,6 @@ public interface PluginMessageListener {
      * @param connection Source of the message.
      * @param message The raw message that was sent.
      */
-    @ApiStatus.Experimental
     default void onPluginMessageReceived(@NotNull String channel, @NotNull PlayerConnection connection, byte @NotNull [] message) {
     }
 }

--- a/paper-api/src/main/java/org/bukkit/spawner/TrialSpawnerConfiguration.java
+++ b/paper-api/src/main/java/org/bukkit/spawner/TrialSpawnerConfiguration.java
@@ -2,12 +2,14 @@ package org.bukkit.spawner;
 
 import java.util.Map;
 import org.bukkit.loot.LootTable;
+import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 /**
  * Represents one of the configurations of a trial spawner.
  */
 @NullMarked
+@ApiStatus.Experimental
 public interface TrialSpawnerConfiguration extends BaseSpawner {
 
     /**

--- a/paper-api/src/main/java/org/bukkit/spawner/TrialSpawnerConfiguration.java
+++ b/paper-api/src/main/java/org/bukkit/spawner/TrialSpawnerConfiguration.java
@@ -2,14 +2,12 @@ package org.bukkit.spawner;
 
 import java.util.Map;
 import org.bukkit.loot.LootTable;
-import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
 /**
  * Represents one of the configurations of a trial spawner.
  */
 @NullMarked
-@ApiStatus.Experimental
 public interface TrialSpawnerConfiguration extends BaseSpawner {
 
     /**

--- a/paper-api/src/main/java/org/bukkit/structure/Structure.java
+++ b/paper-api/src/main/java/org/bukkit/structure/Structure.java
@@ -12,7 +12,6 @@ import org.bukkit.persistence.PersistentDataHolder;
 import org.bukkit.util.BlockTransformer;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.EntityTransformer;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -111,7 +110,6 @@ public interface Structure extends PersistentDataHolder {
      * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
      * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
      */
-    @ApiStatus.Experimental
     void place(@NotNull Location location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
 
     /**
@@ -152,7 +150,6 @@ public interface Structure extends PersistentDataHolder {
      * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
      * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
      */
-    @ApiStatus.Experimental
     void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
 
     /**

--- a/paper-api/src/main/java/org/bukkit/structure/Structure.java
+++ b/paper-api/src/main/java/org/bukkit/structure/Structure.java
@@ -12,6 +12,7 @@ import org.bukkit.persistence.PersistentDataHolder;
 import org.bukkit.util.BlockTransformer;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.EntityTransformer;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -110,6 +111,7 @@ public interface Structure extends PersistentDataHolder {
      * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
      * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
      */
+    @ApiStatus.Experimental
     void place(@NotNull Location location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
 
     /**
@@ -150,6 +152,7 @@ public interface Structure extends PersistentDataHolder {
      * @param blockTransformers A collection of {@link BlockTransformer}s to apply to the structure.
      * @param entityTransformers A collection of {@link EntityTransformer}s to apply to the structure.
      */
+    @ApiStatus.Experimental
     void place(@NotNull RegionAccessor regionAccessor, @NotNull BlockVector location, boolean includeEntities, @NotNull StructureRotation structureRotation, @NotNull Mirror mirror, int palette, float integrity, @NotNull Random random, @NotNull Collection<BlockTransformer> blockTransformers, @NotNull Collection<EntityTransformer> entityTransformers);
 
     /**

--- a/paper-api/src/main/java/org/bukkit/tag/DamageTypeTags.java
+++ b/paper-api/src/main/java/org/bukkit/tag/DamageTypeTags.java
@@ -1,5 +1,6 @@
 package org.bukkit.tag;
 
+import io.papermc.paper.annotation.MinecraftVersionDependent;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
@@ -10,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Vanilla {@link DamageType} {@link Tag tags}.
  */
-@ApiStatus.Experimental
+@MinecraftVersionDependent
 public final class DamageTypeTags {
 
     // Start generate - DamageTypeTags

--- a/paper-api/src/main/java/org/bukkit/tag/package-info.java
+++ b/paper-api/src/main/java/org/bukkit/tag/package-info.java
@@ -1,7 +1,0 @@
-/**
- * {@link org.bukkit.Tag Tag}-related API.
- */
-@ApiStatus.Experimental
-package org.bukkit.tag;
-
-import org.jetbrains.annotations.ApiStatus;

--- a/paper-api/src/main/java/org/bukkit/util/BlockTransformer.java
+++ b/paper-api/src/main/java/org/bukkit/util/BlockTransformer.java
@@ -3,12 +3,14 @@ package org.bukkit.util;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.generator.LimitedRegion;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * A BlockTransformer is used to modify blocks that are placed by structure.
  */
 @FunctionalInterface
+@ApiStatus.Experimental
 public interface BlockTransformer {
 
     /**

--- a/paper-api/src/main/java/org/bukkit/util/BlockTransformer.java
+++ b/paper-api/src/main/java/org/bukkit/util/BlockTransformer.java
@@ -3,14 +3,12 @@ package org.bukkit.util;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.generator.LimitedRegion;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * A BlockTransformer is used to modify blocks that are placed by structure.
  */
 @FunctionalInterface
-@ApiStatus.Experimental
 public interface BlockTransformer {
 
     /**

--- a/paper-api/src/main/java/org/bukkit/util/EntityTransformer.java
+++ b/paper-api/src/main/java/org/bukkit/util/EntityTransformer.java
@@ -2,14 +2,12 @@ package org.bukkit.util;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.generator.LimitedRegion;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * A EntityTransformer is used to modify entities that are spawned by structure.
  */
 @FunctionalInterface
-@ApiStatus.Experimental
 public interface EntityTransformer {
 
     /**

--- a/paper-api/src/main/java/org/bukkit/util/EntityTransformer.java
+++ b/paper-api/src/main/java/org/bukkit/util/EntityTransformer.java
@@ -2,12 +2,14 @@ package org.bukkit.util;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.generator.LimitedRegion;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * A EntityTransformer is used to modify entities that are spawned by structure.
  */
 @FunctionalInterface
+@ApiStatus.Experimental
 public interface EntityTransformer {
 
     /**


### PR DESCRIPTION
Mainly:
- Data components
- Bed enter actions
- Connection
- Inventory view and menu builders (except for the location subtype given block entity behavior has issues)
- Combat tracker
- Server links
- Dialogs

It's not a goal to add the new annotation everywhere that it would realistically fit here, just to where it replaces existing experimental annotations.