### PR TITLE
Fix cancelled running scheduled task state

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/threadedregions/scheduler/FoliaAsyncScheduler.java
+++ b/paper-server/src/main/java/io/papermc/paper/threadedregions/scheduler/FoliaAsyncScheduler.java
@@ -233,6 +233,7 @@ public final class FoliaAsyncScheduler implements AsyncScheduler {
                         this.delay = FoliaAsyncScheduler.this.timerThread.schedule(this, delay, TimeUnit.NANOSECONDS);
                     } else {
                         // cancelled repeating task
+                        this.state = STATE_CANCELLED;
                         removeFromTasks = true;
                     }
                 }

--- a/paper-server/src/main/java/io/papermc/paper/threadedregions/scheduler/FoliaEntityScheduler.java
+++ b/paper-server/src/main/java/io/papermc/paper/threadedregions/scheduler/FoliaEntityScheduler.java
@@ -174,13 +174,18 @@ public final class FoliaEntityScheduler implements EntityScheduler {
                 this.plugin.getLogger().log(Level.WARNING, "Entity task for " + this.plugin.getDescription().getFullName() + " generated an exception", throwable);
             } finally {
                 boolean reschedule = false;
-                 if (!repeating && !retired) {
+                if (!repeating && !retired) {
                     this.setStateVolatile(STATE_FINISHED);
                 } else if (retired || !this.plugin.isEnabled()) {
-                     this.setStateVolatile(STATE_CANCELLED);
-                } else if (STATE_EXECUTING == this.compareAndExchangeStateVolatile(STATE_EXECUTING, STATE_IDLE)) {
-                    reschedule = true;
-                } // else: cancelled repeating task
+                    this.setStateVolatile(STATE_CANCELLED);
+                } else {
+                    final int previousState = this.compareAndExchangeStateVolatile(STATE_EXECUTING, STATE_IDLE);
+                    if (previousState == STATE_EXECUTING) {
+                        reschedule = true;
+                    } else if (previousState == STATE_EXECUTING_CANCELLED) {
+                        this.setStateVolatile(STATE_CANCELLED);
+                    }
+                }
 
                 if (!reschedule) {
                     this.run = null;

--- a/paper-server/src/main/java/io/papermc/paper/threadedregions/scheduler/FoliaGlobalRegionScheduler.java
+++ b/paper-server/src/main/java/io/papermc/paper/threadedregions/scheduler/FoliaGlobalRegionScheduler.java
@@ -182,9 +182,14 @@ public class FoliaGlobalRegionScheduler implements GlobalRegionScheduler {
                 boolean reschedule = false;
                 if (!repeating) {
                     this.setStateVolatile(STATE_FINISHED);
-                } else if (STATE_EXECUTING == this.compareAndExchangeStateVolatile(STATE_EXECUTING, STATE_IDLE)) {
-                    reschedule = true;
-                } // else: cancelled repeating task
+                } else {
+                    final int previousState = this.compareAndExchangeStateVolatile(STATE_EXECUTING, STATE_IDLE);
+                    if (previousState == STATE_EXECUTING) {
+                        reschedule = true;
+                    } else if (previousState == STATE_EXECUTING_CANCELLED) {
+                        this.setStateVolatile(STATE_CANCELLED);
+                    }
+                }
 
                 if (!reschedule) {
                     this.run = null;


### PR DESCRIPTION
Fixes #14107

Repeating scheduled tasks cancelled while they are running currently stop being rescheduled, but remain in `CANCELLED_RUNNING` after their callback finishes.

This finalizes the cancellation in all three Folia-friendly schedulers that have a task state machine once the current execution completes. The task then reports `CANCELLED`, and later calls to `cancel()` return `CANCELLED_ALREADY`.

[edit] And one more thing: Folia is also gonna need a minor change in the region scheduler (beyond updating the upstream commit), which I'll probably PR shortly after this one merges (if it merges quickly)