### PR TITLE
Apply MerchantRecipe ingredient changes to the live offer immediately (#10708)

### DIFF
--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchantRecipe.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchantRecipe.java
@@ -135,9 +135,9 @@ public class CraftMerchantRecipe extends MerchantRecipe {
     }
     // Paper end
 
-    // Paper start - write ingredient changes straight through to the handle,
-    // matching the scalar setters above (they mutate this.handle directly) so
-    // ingredient updates take effect immediately instead of only on trade refresh
+    // Write ingredient changes straight through to the handle, matching the
+    // scalar setters above (they mutate this.handle directly) so ingredient
+    // updates take effect immediately instead of only on trade refresh.
     @Override
     public void addIngredient(ItemStack item) {
         super.addIngredient(item);
@@ -175,7 +175,6 @@ public class CraftMerchantRecipe extends MerchantRecipe {
             this.handle.costB = Optional.empty();
         }
     }
-    // Paper end
 
     public net.minecraft.world.item.trading.MerchantOffer toMinecraft() {
         Preconditions.checkState(!this.getIngredients().isEmpty(), "No offered ingredients");

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchantRecipe.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchantRecipe.java
@@ -135,9 +135,35 @@ public class CraftMerchantRecipe extends MerchantRecipe {
     }
     // Paper end
 
-    public net.minecraft.world.item.trading.MerchantOffer toMinecraft() {
+    // Paper start - write ingredient changes straight through to the handle,
+    // matching the scalar setters above (they mutate this.handle directly) so
+    // ingredient updates take effect immediately instead of only on trade refresh
+    @Override
+    public void addIngredient(ItemStack item) {
+        super.addIngredient(item);
+        this.syncIngredientsToHandle();
+    }
+
+    @Override
+    public void removeIngredient(int index) {
+        super.removeIngredient(index);
+        this.syncIngredientsToHandle();
+    }
+
+    @Override
+    public void setIngredients(List<ItemStack> ingredients) {
+        super.setIngredients(ingredients);
+        this.syncIngredientsToHandle();
+    }
+
+    private void syncIngredientsToHandle() {
         List<ItemStack> ingredients = this.getIngredients();
-        Preconditions.checkState(!ingredients.isEmpty(), "No offered ingredients");
+        if (ingredients.isEmpty()) {
+            // The base ingredient list can be transiently empty (e.g. after removeIngredient
+            // or setIngredients with an empty list); leave the handle's existing costs in
+            // place until a valid ingredient is supplied rather than build an invalid offer.
+            return;
+        }
         net.minecraft.world.item.ItemStack baseCostA = CraftItemStack.asNMSCopy(ingredients.get(0));
         DataComponentExactPredicate baseCostAPredicate = DataComponentExactPredicate.allOf(PatchedDataComponentMap.fromPatch(DataComponentMap.EMPTY, baseCostA.getComponentsPatch()));
         this.handle.baseCostA = new ItemCost(baseCostA.typeHolder(), baseCostA.getCount(), baseCostAPredicate, baseCostA);
@@ -148,6 +174,12 @@ public class CraftMerchantRecipe extends MerchantRecipe {
         } else {
             this.handle.costB = Optional.empty();
         }
+    }
+    // Paper end
+
+    public net.minecraft.world.item.trading.MerchantOffer toMinecraft() {
+        Preconditions.checkState(!this.getIngredients().isEmpty(), "No offered ingredients");
+        this.syncIngredientsToHandle();
         return this.handle;
     }
 


### PR DESCRIPTION
Closes #10708.

`CraftMerchantRecipe`'s scalar setters (`setUses`, `setDemand`, `setExperienceReward`, `setSpecialPrice`, and so on) write straight through to the backing NMS `MerchantOffer`, so they take effect the moment you call them. The ingredient methods did not: `addIngredient`, `removeIngredient`, and `setIngredients` were inherited unchanged from the API's `MerchantRecipe` and only touched the base list. The handle's `baseCostA`/`costB` were rebuilt exclusively inside `toMinecraft()`, which runs on trade refresh, so `setExperienceReward(true)` applied instantly while `setIngredients(...)` only landed once the trade screen rebuilt.

The issue asks to make this consistent one way or another. This picks write-through, since it matches the eight existing scalar setters and the fact that `getRecipe()` hands back a live-backed wrapper. Ingredient changes now sync to the handle immediately; ingredient-agnostic behavior is unchanged.

- Overrides `addIngredient`, `removeIngredient`, `setIngredients` to sync after the base mutation.
- Extracts the cost rebuild into a shared `syncIngredientsToHandle()` helper that `toMinecraft()` reuses (no logic change).
- Guards a transiently or legitimately empty ingredient list so clearing all ingredients does not build an invalid offer; `toMinecraft()` keeps its existing "No offered ingredients" check.

Heads-up for review: I could not compile this locally (Paper's `paper-server` needs a JDK 25 paperweight build with decompiled Mojang sources, which I can't run here), so it is verified by code review rather than a local build. The change is confined to one CraftBukkit class. A CI build and an in-game smoke check on a villager trade would confirm it.
