### PR TITLE
Improvement Interaction Entity for Damage and Projectiles

### DIFF
--- a/paper-api/src/main/java/org/bukkit/entity/Interaction.java
+++ b/paper-api/src/main/java/org/bukkit/entity/Interaction.java
@@ -1,12 +1,14 @@
 package org.bukkit.entity;
 
+import net.kyori.adventure.util.TriState;
 import org.bukkit.OfflinePlayer;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents an entity designed to only record interactions.
  */
+@NullMarked
 public interface Interaction extends Entity {
 
     /**
@@ -14,28 +16,28 @@ public interface Interaction extends Entity {
      *
      * @return width
      */
-    public float getInteractionWidth();
+    float getInteractionWidth();
 
     /**
      * Sets the width of this interaction entity.
      *
      * @param width new width
      */
-    public void setInteractionWidth(float width);
+    void setInteractionWidth(float width);
 
     /**
      * Gets the height of this interaction entity.
      *
      * @return height
      */
-    public float getInteractionHeight();
+    float getInteractionHeight();
 
     /**
      * Sets the height of this interaction entity.
      *
      * @param height new height
      */
-    public void setInteractionHeight(float height);
+    void setInteractionHeight(float height);
 
     /**
      * Gets if this interaction entity should trigger a response when interacted
@@ -43,7 +45,7 @@ public interface Interaction extends Entity {
      *
      * @return response setting
      */
-    public boolean isResponsive();
+    boolean isResponsive();
 
     /**
      * Sets if this interaction entity should trigger a response when interacted
@@ -51,42 +53,58 @@ public interface Interaction extends Entity {
      *
      * @param response new setting
      */
-    public void setResponsive(boolean response);
+    void setResponsive(boolean response);
+
+    /**
+     * Gets if this interaction entity can be hit by projectiles.
+     *
+     * @return A TriState indicating the current state if this entity can be hit by projectiles
+     */
+    TriState canBeHitByProjectile();
+
+    /**
+     * Sets if this interaction entity can be hit by projectiles.
+     * <ul>
+     *     <li>{@link TriState#NOT_SET} – will revert to default</li>
+     *     <li>{@link TriState#TRUE} – will make the entity can be hit by projectiles</li>
+     *     <li>{@link TriState#FALSE} – will make the entity cannot be hit by projectiles</li>
+     * </ul>
+     *
+     * @param canBeHitByProjectile a TriState value representing the state of an interaction can be hit by projectiles
+     */
+    void setCanBeHitByProjectile(final TriState canBeHitByProjectile);
 
     /**
      * Gets the last attack on this interaction entity.
      *
      * @return last attack data, if present
      */
-    @Nullable
-    public PreviousInteraction getLastAttack();
+    @Nullable PreviousInteraction getLastAttack();
 
     /**
      * Gets the last interaction on this entity.
      *
      * @return last interaction data, if present
      */
-    @Nullable
-    public PreviousInteraction getLastInteraction();
+    @Nullable PreviousInteraction getLastInteraction();
 
     /**
      * Represents a previous interaction with this entity.
      */
-    public interface PreviousInteraction {
+    interface PreviousInteraction {
 
         /**
          * Get the previous interacting player.
          *
          * @return interacting player
          */
-        @NotNull
-        public OfflinePlayer getPlayer();
+        OfflinePlayer getPlayer();
 
         /**
          * Gets the Unix timestamp at when this interaction occurred.
          *
          * @return interaction timestamp
          */
-        public long getTimestamp();
+        long getTimestamp();
     }
 }

--- a/paper-server/patches/sources/net/minecraft/world/entity/Interaction.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Interaction.java.patch
@@ -1,5 +1,52 @@
 --- a/net/minecraft/world/entity/Interaction.java
 +++ b/net/minecraft/world/entity/Interaction.java
+@@ -36,6 +_,7 @@
+     private static final boolean DEFAULT_RESPONSE = false;
+     public Interaction.@Nullable PlayerAction attack;
+     public Interaction.@Nullable PlayerAction interaction;
++    public net.kyori.adventure.util.TriState canBeHitByProjectile = net.kyori.adventure.util.TriState.NOT_SET; // Paper - improve interaction API
+ 
+     public Interaction(final EntityType<?> type, final Level level) {
+         super(type, level);
+@@ -57,6 +_,17 @@
+         this.interaction = input.read("interaction", Interaction.PlayerAction.CODEC).orElse(null);
+         this.setResponse(input.getBooleanOr("response", false));
+         this.setBoundingBox(this.makeBoundingBox());
++        // Paper start - improve interaction API
++        input.getString("Paper.CanBeHitByProjectile").ifPresent(
++            override -> {
++                try {
++                    this.canBeHitByProjectile = net.kyori.adventure.util.TriState.valueOf(override);
++                } catch (final Exception ignored) {
++                    com.mojang.logging.LogUtils.getLogger().error("Unknown canBeHitByProjectile override {} for {}", override, this);
++                }
++            }
++        );
++        // Paper end
+     }
+ 
+     @Override
+@@ -66,6 +_,11 @@
+         output.storeNullable("attack", Interaction.PlayerAction.CODEC, this.attack);
+         output.storeNullable("interaction", Interaction.PlayerAction.CODEC, this.interaction);
+         output.putBoolean("response", this.getResponse());
++        // Paper start - improve interaction API
++        if (this.canBeHitByProjectile.equals(net.kyori.adventure.util.TriState.TRUE)) {
++            output.putString("Paper.CanBeHitByProjectile", this.canBeHitByProjectile.name());
++        }
++        // Paper end
+     }
+ 
+     @Override
+@@ -78,7 +_,7 @@
+ 
+     @Override
+     public boolean canBeHitByProjectile() {
+-        return false;
++        return this.canBeHitByProjectile.toBooleanOrElse(false); // Paper - Allow overriding Projectile hit interaction
+     }
+ 
+     @Override
 @@ -99,9 +_,16 @@
      @Override
      public boolean skipAttackInteraction(final Entity source) {
@@ -18,3 +65,15 @@
              }
  
              return !this.getResponse();
+@@ -112,6 +_,11 @@
+ 
+     @Override
+     public final boolean hurtServer(final ServerLevel level, final DamageSource source, final float damage) {
++        // Paper start
++        if (!(source.getDirectEntity() instanceof Player)) { // Avoid trigger for player because it's already managed in skipAttackInteraction
++            org.bukkit.craftbukkit.event.CraftEventFactory.callNonLivingEntityDamageEvent(this, source, damage, true);
++        }
++        // Paper end
+         return false;
+     }
+ 

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftInteraction.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftInteraction.java
@@ -1,6 +1,7 @@
 package org.bukkit.craftbukkit.entity;
 
 import java.util.UUID;
+import net.kyori.adventure.util.TriState;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.craftbukkit.CraftServer;
@@ -45,6 +46,16 @@ public class CraftInteraction extends CraftEntity implements Interaction {
     @Override
     public void setResponsive(boolean response) {
         this.getHandle().setResponse(response);
+    }
+
+    @Override
+    public TriState canBeHitByProjectile() {
+        return this.getHandle().canBeHitByProjectile;
+    }
+
+    @Override
+    public void setCanBeHitByProjectile(final TriState canBeHitByProjectile) {
+        this.getHandle().canBeHitByProjectile = canBeHitByProjectile;
     }
 
     @Override


### PR DESCRIPTION
I talk about this in [discord](https://canary.discord.com/channels/289587909051416579/925530366192779286/1530592331261153497) this PR make a few improvements to allow more uses for the Interaction Entity

- Allow modify behaviour for projectiles, currently the projectile just ignore the entity, this PR allow change that and then you can listen the ProjectileHitEvent, this can help for cases where wanna use a Display and also an Interaction
- Call Damage Events for damages not related to Player, currently only the direct damage by Player are called, other damages are ignored... the PR now call for the others damages in cancel state because the final damage its ignored, i follow the same logic than ArmorStand where the damage events are called even if the entity cannot be damaged (Invulnerable tag)