### PR TITLE
Fix PlayerInteractAtEntityEvent cancellation/mutation desync

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1855,7 +1855,7 @@
 +                        final boolean resendData = event.isCancelled() || !ServerGamePacketListenerImpl.this.player.getItemInHand(hand).is(itemType);
 +
 +                        // Entity in bucket - SPIGOT-4048 and SPIGOT-6859
-+                        if (itemType == Items.WATER_BUCKET && target instanceof net.minecraft.world.entity.Bucketable && target instanceof LivingEntity && resendData) {
++                        if (resendData && target instanceof net.minecraft.world.entity.Bucketable bucketable && target.isAlive() && bucketable.canBePickedUpWithBucket(usedItemStack)) {
 +                            target.resendPossiblyDesyncedEntityData(ServerGamePacketListenerImpl.this.player); // Paper - The entire mob gets deleted, so resend it
 +                        }
 +
@@ -1878,7 +1878,7 @@
 +                            // Refresh the current entity metadata
 +                            target.refreshEntityData(ServerGamePacketListenerImpl.this.player);
 +                            // SPIGOT-7136 - Allays
-+                            if (target instanceof net.minecraft.world.entity.animal.allay.Allay || target instanceof net.minecraft.world.entity.animal.equine.AbstractHorse) { // Paper - Fix horse armor desync
++                            if (target instanceof net.minecraft.world.entity.animal.allay.Allay || target instanceof net.minecraft.world.entity.animal.equine.AbstractHorse || target instanceof net.minecraft.world.entity.animal.golem.CopperGolem) { // Paper - Fix equipment desync
 +                                ServerGamePacketListenerImpl.this.send(new net.minecraft.network.protocol.game.ClientboundSetEquipmentPacket(
 +                                    target.getId(), java.util.Arrays.stream(net.minecraft.world.entity.EquipmentSlot.values())
 +                                    .map((slot) -> com.mojang.datafixers.util.Pair.of(slot, ((LivingEntity) target).getItemBySlot(slot).copy()))

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1806,7 +1806,7 @@
                              LOGGER.warn("Player {} tried to attack an invalid entity", this.player.getPlainTextName());
                          } else if (mainHandItem.isItemEnabled(level.enabledFeatures())) {
                              if (!this.player.cannotAttackWithItem(mainHandItem, 5)) {
-@@ -1836,25 +_,88 @@
+@@ -1836,25 +_,52 @@
                      }
                  }
              }
@@ -1844,49 +1844,13 @@
                      if (tool.isItemEnabled(level.enabledFeatures())) {
                          ItemStack usedItemStack = tool.copy();
 +                        // CraftBukkit start
-+                        final Item itemType = tool.getItem();
-+                        boolean triggerLeashUpdate = usedItemStack.is(Items.LEAD) && target instanceof net.minecraft.world.entity.Leashable;
-+
 +                        final PlayerInteractAtEntityEvent event = new PlayerInteractAtEntityEvent(
 +                            ServerGamePacketListenerImpl.this.getCraftPlayer(), target.getBukkitEntity(),
 +                            org.bukkit.craftbukkit.util.CraftVector.toBukkit(location), org.bukkit.craftbukkit.CraftEquipmentSlot.getHand(hand)
 +                        );
 +                        ServerGamePacketListenerImpl.this.cserver.getPluginManager().callEvent(event);
-+                        final boolean resendData = event.isCancelled() || !ServerGamePacketListenerImpl.this.player.getItemInHand(hand).is(itemType);
-+
-+                        // Entity in bucket - SPIGOT-4048 and SPIGOT-6859
-+                        if (resendData && target instanceof net.minecraft.world.entity.Bucketable bucketable && target.isAlive() && bucketable.canBePickedUpWithBucket(usedItemStack)) {
-+                            target.resendPossiblyDesyncedEntityData(ServerGamePacketListenerImpl.this.player); // Paper - The entire mob gets deleted, so resend it
-+                        }
-+
-+                        // Paper start - Fix inventory desync
-+                        if (resendData) {
-+                            if (io.papermc.paper.util.MCUtil.clientPredictsInteraction(ServerGamePacketListenerImpl.this.player, target, tool)) {
-+                                ServerGamePacketListenerImpl.this.player.containerMenu.sendAllDataToRemote();
-+                            } else {
-+                                ServerGamePacketListenerImpl.this.player.containerMenu.forceHeldSlot(hand);
-+                            }
-+                        }
-+                        // Paper end - Fix inventory desync
-+
-+                        if (triggerLeashUpdate && resendData) {
-+                            // Refresh the current leash state
-+                            ServerGamePacketListenerImpl.this.send(new net.minecraft.network.protocol.game.ClientboundSetEntityLinkPacket(target, ((net.minecraft.world.entity.Leashable) target).getLeashHolder()));
-+                        }
-+
-+                        if (resendData) {
-+                            // Refresh the current entity metadata
-+                            target.refreshEntityData(ServerGamePacketListenerImpl.this.player);
-+                            // SPIGOT-7136 - Allays
-+                            if (target instanceof net.minecraft.world.entity.animal.allay.Allay || target instanceof net.minecraft.world.entity.animal.equine.AbstractHorse || target instanceof net.minecraft.world.entity.animal.golem.CopperGolem) { // Paper - Fix equipment desync
-+                                ServerGamePacketListenerImpl.this.send(new net.minecraft.network.protocol.game.ClientboundSetEquipmentPacket(
-+                                    target.getId(), java.util.Arrays.stream(net.minecraft.world.entity.EquipmentSlot.values())
-+                                    .map((slot) -> com.mojang.datafixers.util.Pair.of(slot, ((LivingEntity) target).getItemBySlot(slot).copy()))
-+                                    .collect(Collectors.toList()), true)); // Paper - sanitize
-+                                player.containerMenu.sendAllDataToRemote();
-+                            } else {
-+                                ServerGamePacketListenerImpl.this.player.containerMenu.forceHeldSlot(hand); // Paper - fix slot desync (is this needed?)
-+                            }
++                        if (event.isCancelled() || !ItemStack.matches(usedItemStack, this.player.getItemInHand(hand))) {
++                            io.papermc.paper.util.MCUtil.resyncEntityInteraction(ServerGamePacketListenerImpl.this.player, target, hand, usedItemStack);
 +                        }
 +
 +                        if (event.isCancelled()) {

--- a/paper-server/src/main/java/io/papermc/paper/util/MCUtil.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/MCUtil.java
@@ -4,6 +4,7 @@ import ca.spottedleaf.moonrise.common.PlatformHooks;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.mojang.datafixers.util.Pair;
 import io.papermc.paper.adventure.PaperAdventure;
 import io.papermc.paper.math.BlockPosition;
 import io.papermc.paper.math.FinePosition;
@@ -32,14 +33,31 @@ import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.NbtUtils;
+import net.minecraft.network.protocol.game.ClientboundSetEntityLinkPacket;
+import net.minecraft.network.protocol.game.ClientboundSetEquipmentPacket;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.util.datafix.DataFixers;
 import net.minecraft.util.datafix.fixes.References;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.AgeableMob;
 import net.minecraft.world.entity.Bucketable;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EquipmentSlotGroup;
+import net.minecraft.world.entity.Leashable;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.animal.allay.Allay;
+import net.minecraft.world.entity.animal.axolotl.Axolotl;
 import net.minecraft.world.entity.animal.cow.AbstractCow;
 import net.minecraft.world.entity.animal.cow.MushroomCow;
+import net.minecraft.world.entity.animal.equine.AbstractHorse;
+import net.minecraft.world.entity.animal.goat.Goat;
+import net.minecraft.world.entity.animal.golem.CopperGolem;
+import net.minecraft.world.entity.animal.nautilus.AbstractNautilus;
+import net.minecraft.world.entity.animal.wolf.Wolf;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.ItemStack;
@@ -255,15 +273,82 @@ public final class MCUtil {
             || (stack.is(Items.GLASS_BOTTLE)); // taking honey from bee nests/hives
     }
 
-    public static boolean clientPredictsInteraction(final Player player, final Entity entity, final ItemStack stack) {
-        // the remaining cases need either count > 1 or infinite materials
-        if (stack.getCount() <= 1 && !player.hasInfiniteMaterials()) {
-            return false;
+    public static void resyncEntityInteraction(final ServerPlayer player, final Entity target, final InteractionHand hand, final ItemStack usedItemStack) {
+        final boolean baby = target instanceof AgeableMob ageableMob && ageableMob.isBaby();
+
+        final boolean refill = !baby
+            && (target instanceof AbstractCow && usedItemStack.is(Items.BUCKET)
+                || target instanceof Goat && usedItemStack.is(Items.BUCKET)
+                || target instanceof MushroomCow && usedItemStack.is(Items.BOWL))
+            || target instanceof Axolotl && usedItemStack.is(Items.TROPICAL_FISH_BUCKET)
+            || target instanceof AbstractNautilus && usedItemStack.is(ItemTags.NAUTILUS_BUCKET_FOOD);
+
+        final boolean bucketable = target instanceof Bucketable b
+            && target.isAlive()
+            && b.canBePickedUpWithBucket(usedItemStack);
+        // Taking an Allay's item can update any slot
+        final boolean allayTake = target instanceof Allay allay
+            && hand == InteractionHand.MAIN_HAND
+            && usedItemStack.isEmpty()
+            && !allay.getMainHandItem().isEmpty();
+        // A filled result is added to another slot when the input is not replaced. See ItemUtils#createFilledResult
+        final boolean filledResult = (usedItemStack.getCount() > 1 || player.hasInfiniteMaterials())
+            && (refill || bucketable);
+
+        if (allayTake || filledResult) {
+            player.containerMenu.sendAllDataToRemote();
+        } else {
+            player.containerMenu.forceHeldSlot(hand);
         }
 
-        return (entity instanceof AbstractCow && stack.is(Items.BUCKET))
-            || (entity instanceof MushroomCow && stack.is(Items.BOWL))
-            || (entity instanceof Bucketable bucketable && bucketable.canBePickedUpWithBucket(stack));
+        if (bucketable) {
+            target.resendPossiblyDesyncedEntityData(player);
+            return;
+        }
+
+        // Conservative entity metadata refresh
+        target.refreshEntityData(player);
+
+        final boolean shearing = usedItemStack.is(Items.SHEARS);
+
+        final EquipmentSlotGroup group = switch (target) {
+            // Giving or taking an item from an Allay changes main-hand
+            case Allay _ -> EquipmentSlotGroup.MAINHAND;
+            // Equipping horse armor changes the horse's body
+            case AbstractHorse _ -> EquipmentSlotGroup.BODY;
+            // Taking a copper golem's held item changes main-hand
+            case CopperGolem _ -> EquipmentSlotGroup.MAINHAND;
+            // Equipping or repairing wolf armor changes the wolf's body
+            case Wolf _ -> EquipmentSlotGroup.BODY;
+            // Shearing equipment from mobs can change any equipment slot
+            case Mob _ when shearing -> EquipmentSlotGroup.ANY;
+            default -> null;
+        };
+
+        if (group != null) {
+            player.connection.send(new ClientboundSetEquipmentPacket(
+                target.getId(),
+                group.slots()
+                    .stream()
+                    .map(slot -> Pair.of(slot, ((LivingEntity) target).getItemBySlot(slot).copy()))
+                    .toList(),
+                true
+            ));
+        }
+
+        // Shearing predicts removing both the target's leash and any entities leashed to the target
+        if (shearing) {
+            if (target instanceof Leashable leashable) {
+                player.connection.send(new ClientboundSetEntityLinkPacket(target, leashable.getLeashHolder()));
+            }
+
+            for (final Leashable leashable : Leashable.leashableLeashedTo(target)) {
+                final Entity entity = (Entity) leashable;
+                if (player.getBukkitEntity().canSee(entity.getBukkitEntity())) {
+                    player.connection.send(new ClientboundSetEntityLinkPacket(entity, leashable.getLeashHolder()));
+                }
+            }
+        }
     }
 
     public static String getLevelName(Level level) {

--- a/paper-server/src/main/java/io/papermc/paper/util/MCUtil.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/MCUtil.java
@@ -46,6 +46,7 @@ import net.minecraft.world.entity.AgeableMob;
 import net.minecraft.world.entity.Bucketable;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlotGroup;
+import net.minecraft.world.entity.Interaction;
 import net.minecraft.world.entity.Leashable;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
@@ -306,8 +307,11 @@ public final class MCUtil {
             return;
         }
 
-        // Conservative entity metadata refresh
-        target.refreshEntityData(player);
+        /* Interaction entities do not predict anything, and resending their
+        default width and height causes Paper#11496 .*/
+        if (!(target instanceof Interaction)) {
+            target.refreshEntityData(player);
+        }
 
         final boolean shearing = usedItemStack.is(Items.SHEARS);
 

--- a/paper-server/src/main/java/io/papermc/paper/util/MCUtil.java
+++ b/paper-server/src/main/java/io/papermc/paper/util/MCUtil.java
@@ -263,7 +263,7 @@ public final class MCUtil {
 
         return (entity instanceof AbstractCow && stack.is(Items.BUCKET))
             || (entity instanceof MushroomCow && stack.is(Items.BOWL))
-            || (entity instanceof Bucketable && stack.is(Items.WATER_BUCKET));
+            || (entity instanceof Bucketable bucketable && bucketable.canBePickedUpWithBucket(stack));
     }
 
     public static String getLevelName(Level level) {


### PR DESCRIPTION
I started this PR just trying to fix #14113, but after attempting to clean up the logic, I found that it missed quite a bit of client prediction, so I decided to do a bit of a bigger refactor. More notes on the commit messages.

I also figured it'd be safe to tackle #11496 while I was modifying this part of the code, noting that right now it is safe to not resend tracked entity data for interaction entities as they don't do any client-side prediction.

Opening as a draft as I have yet to test all the cases that have been fixed, I'll try to edit the PR with a video showing the parts that were missed in the previous logic. If someone suffering from #14113 or #11496 wants to test the PR, you can hit me up in the Paper discord if you do find issues