### PR TITLE
Add getPlayer/EntityOrThrow utility methods to CommandSourceStack

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/command/brigadier/CommandSourceStack.java
+++ b/paper-api/src/main/java/io/papermc/paper/command/brigadier/CommandSourceStack.java
@@ -1,10 +1,12 @@
 package io.papermc.paper.command.brigadier;
 
 import com.mojang.brigadier.RedirectModifier;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.CommandNode;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 
@@ -47,6 +49,18 @@ public interface CommandSourceStack {
      * @return entity that executes this command
      */
     @Nullable Entity getExecutor();
+
+    /**
+     * {@return the {@link Player} that is executing this command}
+     * @throws CommandSyntaxException if the {@link #getExecutor() executor} of this command is not a {@link Player}
+     */
+    Player getPlayerOrThrow() throws CommandSyntaxException;
+
+    /**
+     * {@return the {@link Entity} that is executing this command}
+     * @throws CommandSyntaxException if the {@link #getExecutor() executor} of this command is not an {@link Entity}
+     */
+    Entity getEntityOrThrow() throws CommandSyntaxException;
 
     /**
      * Creates a new CommandSourceStack object with a different location for redirecting commands to other nodes.

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommandSourceStack.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommandSourceStack.java
@@ -2,6 +2,7 @@ package io.papermc.paper.command.brigadier;
 
 import com.destroystokyo.paper.brigadier.BukkitBrigadierCommandSource;
 import com.google.common.base.Preconditions;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
@@ -9,6 +10,7 @@ import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -46,6 +48,18 @@ public interface PaperCommandSourceStack extends CommandSourceStack, BukkitBriga
     default CommandSourceStack withExecutor(@NonNull Entity executor) {
         Preconditions.checkNotNull(executor, "Executor cannot be null.");
         return this.getHandle().withEntity(((CraftEntity) executor).getHandle());
+    }
+
+    @Override
+    @NonNull
+    default Player getPlayerOrThrow() throws CommandSyntaxException {
+        return this.getHandle().getPlayerOrException().getBukkitEntity();
+    }
+
+    @Override
+    @NonNull
+    default Entity getEntityOrThrow() throws CommandSyntaxException {
+        return this.getHandle().getEntityOrException().getBukkitEntity();
     }
 
     // OLD METHODS

--- a/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommandSourceStack.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperCommandSourceStack.java
@@ -11,15 +11,16 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public interface PaperCommandSourceStack extends CommandSourceStack, BukkitBrigadierCommandSource {
 
     net.minecraft.commands.CommandSourceStack getHandle();
 
     @Override
-    default @NonNull Location getLocation() {
+    default Location getLocation() {
         Vec2 rot = this.getHandle().getRotation();
         Vec3 pos = this.getHandle().getPosition();
         Level level = this.getHandle().getLevel();
@@ -28,14 +29,12 @@ public interface PaperCommandSourceStack extends CommandSourceStack, BukkitBriga
     }
 
     @Override
-    @NonNull
     default CommandSender getSender() {
         return this.getHandle().getBukkitSender();
     }
 
     @Override
-    @Nullable
-    default Entity getExecutor() {
+    default @Nullable Entity getExecutor() {
         net.minecraft.world.entity.Entity nmsEntity = this.getHandle().getEntity();
         if (nmsEntity == null) {
             return null;
@@ -45,26 +44,24 @@ public interface PaperCommandSourceStack extends CommandSourceStack, BukkitBriga
     }
 
     @Override
-    default CommandSourceStack withExecutor(@NonNull Entity executor) {
+    default CommandSourceStack withExecutor(Entity executor) {
         Preconditions.checkNotNull(executor, "Executor cannot be null.");
         return this.getHandle().withEntity(((CraftEntity) executor).getHandle());
     }
 
     @Override
-    @NonNull
     default Player getPlayerOrThrow() throws CommandSyntaxException {
         return this.getHandle().getPlayerOrException().getBukkitEntity();
     }
 
     @Override
-    @NonNull
     default Entity getEntityOrThrow() throws CommandSyntaxException {
         return this.getHandle().getEntityOrException().getBukkitEntity();
     }
 
     // OLD METHODS
     @Override
-    default org.bukkit.entity.Entity getBukkitEntity() {
+    default @Nullable Entity getBukkitEntity() {
         return this.getExecutor();
     }
 


### PR DESCRIPTION
Adds two useful utility methods to the API's CommandSourceStack to make life easier