### PR TITLE
Add maximum time to wait for channels to close

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/network/ServerConnectionListener.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerConnectionListener.java.patch
@@ -163,7 +163,7 @@
                          iterator.remove();
                          connection.handleDisconnection();
                      }
-@@ -219,6 +_,33 @@
+@@ -219,6 +_,28 @@
              }
          }
      }
@@ -183,11 +183,6 @@
 +                    connection.handleDisconnection();
 +                } else {
 +                    LOGGER.error("Timed out whilst waiting for player connection channel to close");
-+                }
-+
-+                // Need to manually throw to match how ChannelFuture#sync throws
-+                if (closeFuture.state() == ChannelFuture.State.FAILED) {
-+                    com.destroystokyo.paper.util.SneakyThrow.sneaky(closeFuture.exceptionNow());
 +                }
 +            }
 +            // Paper end - Add maximum time to wait for channels to close

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerConnectionListener.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerConnectionListener.java.patch
@@ -100,6 +100,34 @@
      public SocketAddress startMemoryChannel() {
          ChannelFuture newChannel;
          synchronized (this.channels) {
+@@ -157,9 +_,26 @@
+     public void stop() {
+         this.running = false;
+ 
++        // Paper start - Add maximum time to wait for channels to close
++        for (final ChannelFuture channel : this.channels) {
++            channel.channel().close();
++        }
++
++        final long startTime = System.currentTimeMillis();
++        // Paper end - Add maximum time to wait for channels to close
+         for (ChannelFuture channel : this.channels) {
+             try {
+-                channel.channel().close().sync();
++                // Paper start - Add maximum time to wait for channels to close
++                final ChannelFuture closeFuture = channel.channel().closeFuture();
++                if (!closeFuture.await(30_000 - (System.currentTimeMillis() - startTime), TimeUnit.MILLISECONDS)) {
++                    LOGGER.error("Timed out whilst waiting for channel to close");
++                }
++
++                // Need to manually throw to match how ChannelFuture#sync throws
++                if (closeFuture.state() == ChannelFuture.State.FAILED) {
++                    com.destroystokyo.paper.util.SneakyThrow.sneaky(closeFuture.exceptionNow());
++                }
++                // Paper end - Add maximum time to wait for channels to close
+             } catch (InterruptedException ignored) {
+                 LOGGER.error("Interrupted whilst closing channel");
+             }
 @@ -187,12 +_,26 @@
  
      public void tick() {
@@ -135,17 +163,34 @@
                          iterator.remove();
                          connection.handleDisconnection();
                      }
-@@ -219,6 +_,16 @@
+@@ -219,6 +_,33 @@
              }
          }
      }
 +    // Paper start
 +    public void handleAllDisconnections() {
 +        synchronized (this.connections) {
++            // Paper start - Add maximum time to wait for channels to close
 +            for (final Connection connection : this.connections) {
-+                connection.channel.close().awaitUninterruptibly();
-+                connection.handleDisconnection();
++                connection.channel.close();
 +            }
++
++            final long startTime = System.currentTimeMillis();
++            for (final Connection connection : this.connections) {
++                final ChannelFuture closeFuture = connection.channel.closeFuture();
++
++                if (closeFuture.awaitUninterruptibly(30_000 - (System.currentTimeMillis() - startTime))) {
++                    connection.handleDisconnection();
++                } else {
++                    LOGGER.error("Timed out whilst waiting for player connection channel to close");
++                }
++
++                // Need to manually throw to match how ChannelFuture#sync throws
++                if (closeFuture.state() == ChannelFuture.State.FAILED) {
++                    com.destroystokyo.paper.util.SneakyThrow.sneaky(closeFuture.exceptionNow());
++                }
++            }
++            // Paper end - Add maximum time to wait for channels to close
 +        }
 +    }
 +    // Paper end


### PR DESCRIPTION
This change intends to allow the server to shutdown somewhat gracefully when one or more of the netty threads becomes deadlocked (typically/always a plugin). What currently happens when you stop the server while it's happening is that it waits indefinitely for the close future to complete before players & chunks have saved, causing data loss when you're forced to kill it