### PR TITLE
Add Builder class for MerchantRecipe

### DIFF
--- a/paper-api/src/main/java/org/bukkit/inventory/MerchantRecipe.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/MerchantRecipe.java
@@ -99,7 +99,7 @@ public class MerchantRecipe implements Recipe {
         this.setIngredients(recipe.ingredients);
     }
     // Paper end
-    
+
     @Override
     public ItemStack getResult() {
         return result.clone(); // Paper
@@ -123,7 +123,7 @@ public class MerchantRecipe implements Recipe {
             this.ingredients.add(item.clone());
         }
     }
-    
+
     public List<ItemStack> getIngredients() {
         List<ItemStack> copy = new ArrayList<ItemStack>();
         for (ItemStack item : ingredients) {
@@ -318,7 +318,7 @@ public class MerchantRecipe implements Recipe {
         this.ignoreDiscounts = ignoreDiscounts;
     }
     // Paper end
-    
+
     /**
      * Creates a {@link Builder} instance to use for modifying values such as the result
      * item.<br>
@@ -329,7 +329,7 @@ public class MerchantRecipe implements Recipe {
     public Builder builder() {
         return new Builder(this);
     }
-    
+
     /**
      * Builder class for creating a new {@link MerchantRecipe}.
      * This class allows the result ItemStack to be modified until the
@@ -350,7 +350,7 @@ public class MerchantRecipe implements Recipe {
         private int villagerExperience = 0;
         private float priceMultiplier = 0.0F;
         private boolean ignoreDiscounts = false;
-        
+
         /**
          * Basic constructor to create a new Builder class from a provided result
          * ItemStack and maxUses integer.<br>
@@ -365,7 +365,7 @@ public class MerchantRecipe implements Recipe {
             this.result = result;
             this.maxUses = maxUses;
         }
-        
+
         /**
          * Constructor for creating a Builder instance from an existing
          * {@link MerchantRecipe} instance.<br>
@@ -386,7 +386,7 @@ public class MerchantRecipe implements Recipe {
             this.priceMultiplier = merchantRecipe.getPriceMultiplier();
             this.ignoreDiscounts = merchantRecipe.shouldIgnoreDiscounts();
         }
-        
+
         /**
          * Sets the {@link ItemStack} to use as the result for this MerchantRecipe.
          *
@@ -398,7 +398,7 @@ public class MerchantRecipe implements Recipe {
             this.result = result.clone();
             return this;
         }
-        
+
         /**
          * Adds an {@link ItemStack} as a new Ingredient for this MerchantRecipe.<br>
          * The position of the ItemStack in the list determines which ingredient
@@ -413,7 +413,7 @@ public class MerchantRecipe implements Recipe {
             ingredients.add(item.clone());
             return this;
         }
-        
+
         /**
          * Removes an ingredient from the provided index in the ingredients list.
          *
@@ -424,7 +424,7 @@ public class MerchantRecipe implements Recipe {
             ingredients.remove(index);
             return this;
         }
-        
+
         /**
          * Sets the {@link ItemStack List of ItemStacks} to use for this MerchantRecipe.
          *
@@ -441,7 +441,7 @@ public class MerchantRecipe implements Recipe {
             this.ingredients = copy;
             return this;
         }
-        
+
         /**
          * Resets the demand for this MerchantRecipe to 0.<br>
          * This is a convenience method for {@code setDemand(0)}.
@@ -451,7 +451,7 @@ public class MerchantRecipe implements Recipe {
         public Builder resetDemand() {
             return setDemand(0);
         }
-        
+
         /**
          * Sets the demand for this MerchantRecipe.
          * @param demand Demant for this MerchantRecipe.
@@ -461,7 +461,7 @@ public class MerchantRecipe implements Recipe {
             this.demand = demand;
             return this;
         }
-        
+
         /**
          * Resets the special price for this MerchantRecipe to 0.<br>
          * This is a convenience method for {@code setSpecialPrice(0)}.
@@ -471,7 +471,7 @@ public class MerchantRecipe implements Recipe {
         public Builder resetSpecialPrice() {
             return setSpecialPrice(0);
         }
-        
+
         /**
          * Sets the special price for this MerchantRecipe.
          * @param specialPrice Special Price for this MerchantRecipe.
@@ -481,7 +481,7 @@ public class MerchantRecipe implements Recipe {
             this.specialPrice = specialPrice;
             return this;
         }
-        
+
         /**
          * Resets the Use count for this MerchantRecipe to 0.<br>
          * This is a convenience method for {@code setUses(0)}.
@@ -491,7 +491,7 @@ public class MerchantRecipe implements Recipe {
         public Builder resetUses() {
             return setUses(0);
         }
-        
+
         /**
          * Sets the uses for this MerchantRecipe.
          *
@@ -502,7 +502,7 @@ public class MerchantRecipe implements Recipe {
             this.uses = uses;
             return this;
         }
-        
+
         /**
          * Sets the max uses for this MerchantRecipe.
          *
@@ -513,7 +513,7 @@ public class MerchantRecipe implements Recipe {
             this.maxUses = maxUses;
             return this;
         }
-        
+
         /**
          * Enables the MerchantRecipe to give experience to the player on
          * completing the trade.<br>
@@ -524,7 +524,7 @@ public class MerchantRecipe implements Recipe {
         public Builder experienceReward() {
             return setExperienceReward(true);
         }
-        
+
         /**
          * Sets whether this MerchantRecipe should give experience to a player
          * on completing the trade.
@@ -536,7 +536,7 @@ public class MerchantRecipe implements Recipe {
             this.experienceReward = experienceReward;
             return this;
         }
-        
+
         /**
          * Sets amount of experience the Villager gains when completing a trade.
          *
@@ -547,7 +547,7 @@ public class MerchantRecipe implements Recipe {
             this.villagerExperience = villagerExperience;
             return this;
         }
-        
+
         /**
          * Sets the multiplier to apply on prices for this MerchantRecipe.
          *
@@ -558,7 +558,7 @@ public class MerchantRecipe implements Recipe {
             this.priceMultiplier = priceMultiplier;
             return this;
         }
-        
+
         /**
          * Enables this MerchantRecipe to ignore any discounts from cases like a
          * Player having the {@link PotionEffectType#HERO_OF_THE_VILLAGE Hero of the Village}
@@ -570,7 +570,7 @@ public class MerchantRecipe implements Recipe {
         public Builder ignoreDiscounts() {
             return setIgnoreDiscounts(true);
         }
-        
+
         /**
          * Sets whether this MerchantRecipe should ignore discounts applued from
          * cases like a Player having the {@link PotionEffectType#HERO_OF_THE_VILLAGE Hero of the Village}
@@ -583,7 +583,7 @@ public class MerchantRecipe implements Recipe {
             this.ignoreDiscounts = ignoreDiscounts;
             return this;
         }
-        
+
         /**
          * Creates a new {@link MerchantRecipe} instance with the values of this class
          * applies.

--- a/paper-api/src/main/java/org/bukkit/inventory/MerchantRecipe.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/MerchantRecipe.java
@@ -7,9 +7,8 @@ import org.bukkit.Material;
 import org.bukkit.entity.Villager;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.NumberConversions;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a merchant's trade.
@@ -47,9 +46,10 @@ import org.jspecify.annotations.NullMarked;
  * constraining the resulting value between <code>1</code> and the item stack's
  * {@link ItemStack#getMaxStackSize() maximum stack size}.
  */
+@NullMarked
 public class MerchantRecipe implements Recipe {
 
-    private ItemStack result;
+    private final ItemStack result;
     private List<ItemStack> ingredients = new ArrayList<ItemStack>();
     private int uses;
     private int maxUses;
@@ -60,26 +60,26 @@ public class MerchantRecipe implements Recipe {
     private float priceMultiplier;
     private boolean ignoreDiscounts; // Paper
 
-    public MerchantRecipe(@NotNull ItemStack result, int maxUses) {
+    public MerchantRecipe(ItemStack result, int maxUses) {
         this(result, 0, maxUses, false);
     }
 
-    public MerchantRecipe(@NotNull ItemStack result, int uses, int maxUses, boolean experienceReward) {
+    public MerchantRecipe(ItemStack result, int uses, int maxUses, boolean experienceReward) {
         this(result, uses, maxUses, experienceReward, 0, 0.0F, 0, 0);
     }
 
-    public MerchantRecipe(@NotNull ItemStack result, int uses, int maxUses, boolean experienceReward, int villagerExperience, float priceMultiplier) {
+    public MerchantRecipe(ItemStack result, int uses, int maxUses, boolean experienceReward, int villagerExperience, float priceMultiplier) {
         this(result, uses, maxUses, experienceReward, villagerExperience, priceMultiplier, 0, 0);
     }
 
-    public MerchantRecipe(@NotNull ItemStack result, int uses, int maxUses, boolean experienceReward, int villagerExperience, float priceMultiplier, int demand, int specialPrice) {
+    public MerchantRecipe(ItemStack result, int uses, int maxUses, boolean experienceReward, int villagerExperience, float priceMultiplier, int demand, int specialPrice) {
         // Paper start - add ignoreDiscounts param
         this(result, uses, maxUses, experienceReward, villagerExperience, priceMultiplier, demand, specialPrice, false);
     }
-    public MerchantRecipe(@NotNull ItemStack result, int uses, int maxUses, boolean experienceReward, int villagerExperience, float priceMultiplier, boolean ignoreDiscounts) {
+    public MerchantRecipe(ItemStack result, int uses, int maxUses, boolean experienceReward, int villagerExperience, float priceMultiplier, boolean ignoreDiscounts) {
         this(result, uses, maxUses, experienceReward, villagerExperience, priceMultiplier, 0, 0, ignoreDiscounts);
     }
-    public MerchantRecipe(@NotNull ItemStack result, int uses, int maxUses, boolean experienceReward, int villagerExperience, float priceMultiplier, int demand, int specialPrice, boolean ignoreDiscounts) {
+    public MerchantRecipe(ItemStack result, int uses, int maxUses, boolean experienceReward, int villagerExperience, float priceMultiplier, int demand, int specialPrice, boolean ignoreDiscounts) {
         Preconditions.checkArgument(!result.isEmpty(), "Recipe cannot have an empty result."); // Paper
         this.ignoreDiscounts = ignoreDiscounts;
         // Paper end
@@ -94,19 +94,18 @@ public class MerchantRecipe implements Recipe {
     }
 
     // Paper start - add copy ctor
-    public MerchantRecipe(@NotNull MerchantRecipe recipe) {
+    public MerchantRecipe(MerchantRecipe recipe) {
         this(recipe.result.clone(), recipe.uses, recipe.maxUses, recipe.experienceReward, recipe.villagerExperience, recipe.priceMultiplier, recipe.demand, recipe.specialPrice, recipe.ignoreDiscounts);
         this.setIngredients(recipe.ingredients);
     }
     // Paper end
-
-    @NotNull
+    
     @Override
     public ItemStack getResult() {
         return result.clone(); // Paper
     }
 
-    public void addIngredient(@NotNull ItemStack item) {
+    public void addIngredient(ItemStack item) {
         Preconditions.checkState(ingredients.size() < 2, "MerchantRecipe can only have maximum 2 ingredients");
         Preconditions.checkArgument(!item.isEmpty(), "Recipe cannot have an empty itemstack ingredient."); // Paper
         ingredients.add(item.clone());
@@ -116,7 +115,7 @@ public class MerchantRecipe implements Recipe {
         ingredients.remove(index);
     }
 
-    public void setIngredients(@NotNull List<ItemStack> ingredients) {
+    public void setIngredients(List<ItemStack> ingredients) {
         Preconditions.checkState(ingredients.size() <= 2, "MerchantRecipe can only have maximum 2 ingredients");
         this.ingredients = new ArrayList<ItemStack>();
         for (ItemStack item : ingredients) {
@@ -124,8 +123,7 @@ public class MerchantRecipe implements Recipe {
             this.ingredients.add(item.clone());
         }
     }
-
-    @NotNull
+    
     public List<ItemStack> getIngredients() {
         List<ItemStack> copy = new ArrayList<ItemStack>();
         for (ItemStack item : ingredients) {
@@ -435,11 +433,12 @@ public class MerchantRecipe implements Recipe {
          */
         public Builder setIngredients(List<ItemStack> ingredients) {
             Preconditions.checkState(ingredients.size() <= 2, "Recipe can only have maximum 2 ingredients");
-            this.ingredients = new ArrayList<>();
+            List<ItemStack> copy = new ArrayList<>();
             for (ItemStack item : ingredients) {
                 Preconditions.checkArgument(!item.isEmpty(), "Recipe cannot have an empty itemstack ingredient.");
-                this.ingredients.add(item.clone());
+                copy.add(item);
             }
+            this.ingredients = copy;
             return this;
         }
         

--- a/paper-api/src/main/java/org/bukkit/inventory/MerchantRecipe.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/MerchantRecipe.java
@@ -9,6 +9,7 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.NumberConversions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Represents a merchant's trade.
@@ -319,4 +320,280 @@ public class MerchantRecipe implements Recipe {
         this.ignoreDiscounts = ignoreDiscounts;
     }
     // Paper end
+    
+    /**
+     * Creates a {@link Builder} instance to use for modifying values such as the result
+     * item.<br>
+     * This Builder class will contain all the values from this MerchantRecipe instance.
+     *
+     * @return New Builder class with values from this MerchantRecipe applied.
+     */
+    public Builder builder() {
+        return new Builder(this);
+    }
+    
+    /**
+     * Builder class for creating a new {@link MerchantRecipe}.
+     * This class allows the result ItemStack to be modified until the
+     * {@link #build() the MerchantRecipe is build}.
+     *
+     * <p>A Builder copy of an existing MerchantRecipe can be obtained through
+     * its {@link MerchantRecipe#builder() builder method}.
+     */
+    @NullMarked
+    public static class Builder {
+        private ItemStack result;
+        private List<ItemStack> ingredients = new ArrayList<>();
+        private int uses = 0;
+        private int maxUses;
+        private boolean experienceReward = false;
+        private int specialPrice = 0;
+        private int demand = 0;
+        private int villagerExperience = 0;
+        private float priceMultiplier = 0.0F;
+        private boolean ignoreDiscounts = false;
+        
+        /**
+         * Basic constructor to create a new Builder class from a provided result
+         * ItemStack and maxUses integer.<br>
+         * The created Builder will have all its other values be empty, zero or
+         * false, depending on the type.
+         *
+         * @param result The ItemStack to use as the result for the MerchantRecipe.
+         * @param maxUses Number of max uses for this MerchantRecipe
+         */
+        public Builder(ItemStack result, int maxUses) {
+            Preconditions.checkArgument(!result.isEmpty(), "Result cannot be empty");
+            this.result = result;
+            this.maxUses = maxUses;
+        }
+        
+        /**
+         * Constructor for creating a Builder instance from an existing
+         * {@link MerchantRecipe} instance.<br>
+         * This Builder instance will have all its values set to what the provided
+         * MerchantRecipe had set.
+         *
+         * @param merchantRecipe The MerchantRecipe instance to create a Builder instance from.
+         */
+        public Builder(MerchantRecipe merchantRecipe) {
+            this.result = merchantRecipe.getResult();
+            this.ingredients = merchantRecipe.getIngredients();
+            this.uses = merchantRecipe.getUses();
+            this.maxUses = merchantRecipe.getMaxUses();
+            this.experienceReward = merchantRecipe.hasExperienceReward();
+            this.specialPrice = merchantRecipe.getSpecialPrice();
+            this.demand = merchantRecipe.getDemand();
+            this.villagerExperience = merchantRecipe.getVillagerExperience();
+            this.priceMultiplier = merchantRecipe.getPriceMultiplier();
+            this.ignoreDiscounts = merchantRecipe.shouldIgnoreDiscounts();
+        }
+        
+        /**
+         * Sets the {@link ItemStack} to use as the result for this MerchantRecipe.
+         *
+         * @param result Result ItemStack for this MerchantRecipe.
+         * @return This Builder for chaining purposes.
+         */
+        public Builder setResult(ItemStack result) {
+            Preconditions.checkArgument(!result.isEmpty(), "Result cannot be empty.");
+            this.result = result.clone();
+            return this;
+        }
+        
+        /**
+         * Adds an {@link ItemStack} as a new Ingredient for this MerchantRecipe.<br>
+         * The position of the ItemStack in the list determines which ingredient
+         * it is and there can't be more than 2 in total.
+         *
+         * @param item The ItemStack to add.
+         * @return This Builder for chaining purposes.
+         */
+        public Builder addIngredient(ItemStack item) {
+            Preconditions.checkState(ingredients.size() < 2, "Recipe can only have maximum 2 ingredients");
+            Preconditions.checkArgument(!item.isEmpty(), "Recipe cannot have an empty itemstack ingredient.");
+            ingredients.add(item.clone());
+            return this;
+        }
+        
+        /**
+         * Removes an ingredient from the provided index in the ingredients list.
+         *
+         * @param index position in the list to remove the ItemStack from.
+         * @return This Builder for chaining purposes.
+         */
+        public Builder removeIngredient(int index) {
+            ingredients.remove(index);
+            return this;
+        }
+        
+        /**
+         * Sets the {@link ItemStack List of ItemStacks} to use for this MerchantRecipe.
+         *
+         * @param ingredients List of ItemStacks to use as the ingredients.
+         * @return This Builder for chaining purposes.
+         */
+        public Builder setIngredients(List<ItemStack> ingredients) {
+            Preconditions.checkState(ingredients.size() <= 2, "Recipe can only have maximum 2 ingredients");
+            this.ingredients = new ArrayList<>();
+            for (ItemStack item : ingredients) {
+                Preconditions.checkArgument(!item.isEmpty(), "Recipe cannot have an empty itemstack ingredient.");
+                this.ingredients.add(item.clone());
+            }
+            return this;
+        }
+        
+        /**
+         * Resets the demand for this MerchantRecipe to 0.<br>
+         * This is a convenience method for {@code setDemand(0)}.
+         *
+         * @return This Builder for chaining purposes.
+         */
+        public Builder resetDemand() {
+            return setDemand(0);
+        }
+        
+        /**
+         * Sets the demand for this MerchantRecipe.
+         * @param demand Demant for this MerchantRecipe.
+         * @return This Builder for chaining purposes.
+         */
+        public Builder setDemand(int demand) {
+            this.demand = demand;
+            return this;
+        }
+        
+        /**
+         * Resets the special price for this MerchantRecipe to 0.<br>
+         * This is a convenience method for {@code setSpecialPrice(0)}.
+         *
+         * @return This Builder for chaining purposes.
+         */
+        public Builder resetSpecialPrice() {
+            return setSpecialPrice(0);
+        }
+        
+        /**
+         * Sets the special price for this MerchantRecipe.
+         * @param specialPrice Special Price for this MerchantRecipe.
+         * @return This Builder for chaining purposes.
+         */
+        public Builder setSpecialPrice(int specialPrice) {
+            this.specialPrice = specialPrice;
+            return this;
+        }
+        
+        /**
+         * Resets the Use count for this MerchantRecipe to 0.<br>
+         * This is a convenience method for {@code setUses(0)}.
+         *
+         * @return This Builder for chaining purposes.
+         */
+        public Builder resetUses() {
+            return setUses(0);
+        }
+        
+        /**
+         * Sets the uses for this MerchantRecipe.
+         *
+         * @param uses Use count for this MerchantRecipe.
+         * @return This Builder for chaining purposes.
+         */
+        public Builder setUses(int uses) {
+            this.uses = uses;
+            return this;
+        }
+        
+        /**
+         * Sets the max uses for this MerchantRecipe.
+         *
+         * @param maxUses Max use count for this MerchantRecipe.
+         * @return This Builder for chaining purposes.
+         */
+        public Builder setMaxUses(int maxUses) {
+            this.maxUses = maxUses;
+            return this;
+        }
+        
+        /**
+         * Enables the MerchantRecipe to give experience to the player on
+         * completing the trade.<br>
+         * This is a convenience method for {@code setExperienceReward(true)}.
+         *
+         * @return This Builder for chaining purposes.
+         */
+        public Builder experienceReward() {
+            return setExperienceReward(true);
+        }
+        
+        /**
+         * Sets whether this MerchantRecipe should give experience to a player
+         * on completing the trade.
+         *
+         * @param experienceReward Setting whether the MerchantRecipe should give experience.
+         * @return This Builder for chaining purposes.
+         */
+        public Builder setExperienceReward(boolean experienceReward) {
+            this.experienceReward = experienceReward;
+            return this;
+        }
+        
+        /**
+         * Sets amount of experience the Villager gains when completing a trade.
+         *
+         * @param villagerExperience Amount of experience the villager should gain.
+         * @return This Builder for chaining purposes.
+         */
+        public Builder setVillageExperience(int villagerExperience) {
+            this.villagerExperience = villagerExperience;
+            return this;
+        }
+        
+        /**
+         * Sets the multiplier to apply on prices for this MerchantRecipe.
+         *
+         * @param priceMultiplier Multiplier to apply to this MerchantRecipe.
+         * @return This Builder for chaining purposes.
+         */
+        public Builder setPriceMultiplier(float priceMultiplier) {
+            this.priceMultiplier = priceMultiplier;
+            return this;
+        }
+        
+        /**
+         * Enables this MerchantRecipe to ignore any discounts from cases like a
+         * Player having the {@link PotionEffectType#HERO_OF_THE_VILLAGE Hero of the Village}
+         * effect.<br>
+         * This is a convenience method for {@code setIgnoreDiscounts(true)}.
+         *
+         * @return This Builder for chaining purposes.
+         */
+        public Builder ignoreDiscounts() {
+            return setIgnoreDiscounts(true);
+        }
+        
+        /**
+         * Sets whether this MerchantRecipe should ignore discounts applued from
+         * cases like a Player having the {@link PotionEffectType#HERO_OF_THE_VILLAGE Hero of the Village}
+         * effect.
+         *
+         * @param ignoreDiscounts Whether this MerchantRecipe should ignore discounts.
+         * @return This Builder for chaining purposes.
+         */
+        public Builder setIgnoreDiscounts(boolean ignoreDiscounts) {
+            this.ignoreDiscounts = ignoreDiscounts;
+            return this;
+        }
+        
+        /**
+         * Creates a new {@link MerchantRecipe} instance with the values of this class
+         * applies.
+         *
+         * @return New MerchantRecipe class.
+         */
+        public MerchantRecipe build() {
+            return new MerchantRecipe(result, uses, maxUses, experienceReward,
+                villagerExperience, priceMultiplier, demand, specialPrice, ignoreDiscounts);
+        }
+    }
 }

--- a/paper-api/src/main/java/org/bukkit/inventory/MerchantRecipe.java
+++ b/paper-api/src/main/java/org/bukkit/inventory/MerchantRecipe.java
@@ -145,7 +145,7 @@ public class MerchantRecipe implements Recipe {
             return null;
         }
 
-        ItemStack firstIngredient = this.ingredients.get(0).clone();
+        ItemStack firstIngredient = this.ingredients.getFirst().clone();
         adjust(firstIngredient);
         return firstIngredient;
     }


### PR DESCRIPTION
This Pull request adds a Builder class to the `MerchantRecipe` class.

## Motivation

The result item in the MerchantRecipe class is unmodifiable and the only way to change it, is by creating a new instance of the class.
This is okay for situations where you want to modify the values like experience gain, multiplier, etc. but for situations where you just want to change the result item of an existing MerchantRecipe, this situation becomes tedious, as you now need to apply every single value from the original MerchantRecipe, to the new one through the constructor.

This Builder class should help, as there is now a method in MerchantRecipe called `builder()` that returns a new Builder class using the MerchantRecipe's settings and allowing you to modify them.

## Notes

I'm currently debugging an issue where the MerchantRecipe modification in a VillagerAcquireTradeEvent results in a villager not getting any trades to share.
The event is fired regularely, but interacting with the villager ends up in them shaking the head as if they have no trades.

I'm unsure of the cause here, but it may be an oversight on my end.

Here's the code used to test through the test-plugin:
```java
    @EventHandler
    public void onVillager(VillagerAcquireTradeEvent event) {
        getLogger().info("Event fired!");
        MerchantRecipe.Builder builder = event.getRecipe().builder();
        
        builder.setIngredients(List.of(ItemStack.of(Material.DIRT, 64)))
            .setResult(ItemStack.of(Material.DIAMOND));
        
        event.setRecipe(builder.build());
    }
```