### PR TITLE
Add commands for managing operators

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/command/PaperBypassPlayerLimitCommand.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/PaperBypassPlayerLimitCommand.java
@@ -1,0 +1,96 @@
+package io.papermc.paper.command;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.Commands;
+import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
+import io.papermc.paper.command.brigadier.argument.resolvers.PlayerProfileListResolver;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.players.NameAndId;
+import net.minecraft.server.players.ServerOpList;
+import net.minecraft.server.players.ServerOpListEntry;
+import org.bukkit.command.CommandSender;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Collection;
+import java.util.UUID;
+
+import static net.kyori.adventure.text.Component.text;
+
+@NullMarked
+public class PaperBypassPlayerLimitCommand {
+    public static final String DESCRIPTION = "Change bypass player limit privilege";
+
+    public static LiteralCommandNode<CommandSourceStack> create() {
+        final PaperBypassPlayerLimitCommand command = new PaperBypassPlayerLimitCommand();
+
+        return Commands.literal("bypassplayerlimit")
+            .requires(source -> source.getSender().hasPermission("bukkit.command.bypassplayerlimit"))
+            .then(Commands.argument("player", ArgumentTypes.playerProfiles())
+                .then(Commands.argument("bypass", BoolArgumentType.bool())
+                    .executes(command::execute)))
+            .build();
+    }
+
+    private int execute(CommandContext<CommandSourceStack> context) {
+        CommandSender sender = context.getSource().getSender();
+        MinecraftServer server = MinecraftServer.getServer();
+        ServerOpList opList = server.getPlayerList().getOps();
+
+        boolean bypass = BoolArgumentType.getBool(context, "bypass");
+
+        try {
+            PlayerProfileListResolver resolver = context.getArgument("player", PlayerProfileListResolver.class);
+            Collection<PlayerProfile> profiles = resolver.resolve(context.getSource());
+
+            if (profiles.isEmpty()) {
+                sender.sendMessage(text("Player not found.", NamedTextColor.RED));
+                return 0;
+            }
+
+            int count = 0;
+            for (PlayerProfile profile : profiles) {
+                UUID uuid = profile.getId();
+                String name = profile.getName();
+
+                if (uuid == null || name == null) {
+                    continue;
+                }
+
+                NameAndId nameAndId = new NameAndId(uuid, name);
+                ServerOpListEntry existingEntry = opList.get(nameAndId);
+
+                if (existingEntry == null) {
+                    sender.sendMessage(text(name + " is not an operator.", NamedTextColor.RED));
+                    continue;
+                }
+
+                ServerOpListEntry newEntry = new ServerOpListEntry(
+                    nameAndId,
+                    existingEntry.permissions(),
+                    bypass
+                );
+
+                opList.add(newEntry);
+
+                sender.sendMessage(text()
+                    .append(text("Set bypass player limit privilege for ", NamedTextColor.WHITE))
+                    .append(text(name, NamedTextColor.AQUA))
+                    .append(text(" to ", NamedTextColor.WHITE))
+                    .append(text(bypass, bypass ? NamedTextColor.GREEN : NamedTextColor.RED))
+                    .append(text(".", NamedTextColor.WHITE))
+                    .build()
+                );
+                count++;
+            }
+            return count;
+        } catch (Exception e) {
+            sender.sendMessage(text("Error executing command.", NamedTextColor.RED));
+            return 0;
+        }
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/command/PaperCommands.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/PaperCommands.java
@@ -34,6 +34,9 @@ public final class PaperCommands {
         registerInternalCommand(PaperMSPTCommand.create(), "paper", PaperMSPTCommand.DESCRIPTION, List.of(), Set.of());
         registerInternalCommand(PaperVersionCommand.create(), "bukkit", PaperVersionCommand.DESCRIPTION, List.of("ver", "about"), Set.of());
         registerInternalCommand(PaperPluginsCommand.create(), "bukkit", PaperPluginsCommand.DESCRIPTION, List.of("pl"), Set.of());
+        registerInternalCommand(PaperOPInfoCommand.create(), "paper", PaperOPInfoCommand.DESCRIPTION, List.of("oplist"), Set.of());
+        registerInternalCommand(PaperOPLevelCommand.create(), "paper", PaperOPLevelCommand.DESCRIPTION, List.of(), Set.of());
+        registerInternalCommand(PaperBypassPlayerLimitCommand.create(), "paper", PaperBypassPlayerLimitCommand.DESCRIPTION, List.of("bpl"), Set.of());
     }
 
     private static void registerInternalCommand(final LiteralCommandNode<CommandSourceStack> node, final String namespace, final String description, final List<String> aliases, final Set<CommandRegistrationFlag> flags) {

--- a/paper-server/src/main/java/io/papermc/paper/command/PaperOPInfoCommand.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/PaperOPInfoCommand.java
@@ -1,0 +1,107 @@
+package io.papermc.paper.command;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.Commands;
+import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
+import io.papermc.paper.command.brigadier.argument.resolvers.selector.PlayerSelectorArgumentResolver;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.permissions.PermissionLevel;
+import net.minecraft.server.players.NameAndId;
+import net.minecraft.server.players.ServerOpList;
+import net.minecraft.server.players.ServerOpListEntry;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Collection;
+
+import static net.kyori.adventure.text.Component.text;
+
+public class PaperOPInfoCommand {
+    public static final String DESCRIPTION = "View information about operators";
+
+    public static LiteralCommandNode<CommandSourceStack> create() {
+        final PaperOPInfoCommand command = new PaperOPInfoCommand();
+
+        return Commands.literal("opinfo")
+            .requires(source -> source.getSender().hasPermission("bukkit.command.opinfo"))
+            .executes(command::executeList)
+            .then(Commands.argument("player", ArgumentTypes.player())
+                .executes(command::executePlayer))
+            .build();
+    }
+
+    private int executeList(CommandContext<CommandSourceStack> context) {
+        CommandSender sender = context.getSource().getSender();
+        MinecraftServer server = MinecraftServer.getServer();
+        ServerOpList opList = server.getPlayerList().getOps();
+
+        Collection<ServerOpListEntry> entries = opList.getEntries();
+        if (entries.isEmpty()) {
+            sender.sendMessage(text("There are no operators on this server.", NamedTextColor.YELLOW));
+            return 0;
+        }
+
+        sender.sendMessage(text("--- Server Operators ---", NamedTextColor.BLUE));
+        for (ServerOpListEntry entry : entries) {
+            formatAndSendEntry(sender, entry);
+        }
+
+        return entries.size();
+    }
+
+    private int executePlayer(CommandContext<CommandSourceStack> context) {
+        CommandSender sender = context.getSource().getSender();
+        MinecraftServer server = MinecraftServer.getServer();
+        ServerOpList opList = server.getPlayerList().getOps();
+
+        try {
+            PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
+            Collection<Player> players = resolver.resolve(context.getSource());
+
+            if (players.isEmpty()) {
+                sender.sendMessage(text("Player not found.", NamedTextColor.RED));
+                return 0;
+            }
+
+            for (Player player : players) {
+                NameAndId nameAndId = new NameAndId(player.getUniqueId(), player.getName());
+                ServerOpListEntry entry = opList.get(nameAndId);
+
+                if (entry == null) {
+                    sender.sendMessage(text(player.getName() + " is not an operator.", NamedTextColor.RED));
+                } else {
+                    formatAndSendEntry(sender, entry);
+                }
+            }
+        } catch (Exception e) {
+            sender.sendMessage(text("Error resolving target player.", NamedTextColor.RED));
+            return 0;
+        }
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private void formatAndSendEntry(CommandSender sender, ServerOpListEntry entry) {
+        NameAndId user = entry.getUser();
+        String name = (user != null) ? user.name() : "Unknown";
+
+        PermissionLevel level = entry.permissions().level();
+        boolean bypassesLimit = entry.getBypassesPlayerLimit();
+
+        Component info = text()
+            .append(text("- ", NamedTextColor.GRAY))
+            .append(text(name, NamedTextColor.AQUA))
+            .append(text(" | Level: ", NamedTextColor.WHITE))
+            .append(text(String.valueOf(level), NamedTextColor.AQUA))
+            .append(text(" | Bypasses Player Limit: ", NamedTextColor.WHITE))
+            .append(text(bypassesLimit, bypassesLimit ? NamedTextColor.GREEN : NamedTextColor.RED))
+            .build();
+
+        sender.sendMessage(info);
+    }
+}

--- a/paper-server/src/main/java/io/papermc/paper/command/PaperOPInfoCommand.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/PaperOPInfoCommand.java
@@ -1,12 +1,13 @@
 package io.papermc.paper.command;
 
+import com.destroystokyo.paper.profile.PlayerProfile;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
-import io.papermc.paper.command.brigadier.argument.resolvers.selector.PlayerSelectorArgumentResolver;
+import io.papermc.paper.command.brigadier.argument.resolvers.PlayerProfileListResolver;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.minecraft.server.MinecraftServer;
@@ -15,9 +16,9 @@ import net.minecraft.server.players.NameAndId;
 import net.minecraft.server.players.ServerOpList;
 import net.minecraft.server.players.ServerOpListEntry;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 
 import java.util.Collection;
+import java.util.UUID;
 
 import static net.kyori.adventure.text.Component.text;
 
@@ -30,7 +31,7 @@ public class PaperOPInfoCommand {
         return Commands.literal("opinfo")
             .requires(source -> source.getSender().hasPermission("bukkit.command.opinfo"))
             .executes(command::executeList)
-            .then(Commands.argument("player", ArgumentTypes.player())
+            .then(Commands.argument("player", ArgumentTypes.playerProfiles())
                 .executes(command::executePlayer))
             .build();
     }
@@ -60,20 +61,27 @@ public class PaperOPInfoCommand {
         ServerOpList opList = server.getPlayerList().getOps();
 
         try {
-            PlayerSelectorArgumentResolver resolver = context.getArgument("player", PlayerSelectorArgumentResolver.class);
-            Collection<Player> players = resolver.resolve(context.getSource());
+            PlayerProfileListResolver resolver = context.getArgument("player", PlayerProfileListResolver.class);
+            Collection<PlayerProfile> profiles = resolver.resolve(context.getSource());
 
-            if (players.isEmpty()) {
+            if (profiles.isEmpty()) {
                 sender.sendMessage(text("Player not found.", NamedTextColor.RED));
                 return 0;
             }
 
-            for (Player player : players) {
-                NameAndId nameAndId = new NameAndId(player.getUniqueId(), player.getName());
+            for (PlayerProfile profile : profiles) {
+                UUID uuid = profile.getId();
+                String name = profile.getName();
+
+                if (uuid == null || name == null) {
+                    continue;
+                }
+
+                NameAndId nameAndId = new NameAndId(uuid, name);
                 ServerOpListEntry entry = opList.get(nameAndId);
 
                 if (entry == null) {
-                    sender.sendMessage(text(player.getName() + " is not an operator.", NamedTextColor.RED));
+                    sender.sendMessage(text(name + " is not an operator.", NamedTextColor.RED));
                 } else {
                     formatAndSendEntry(sender, entry);
                 }

--- a/paper-server/src/main/java/io/papermc/paper/command/PaperOPLevelCommand.java
+++ b/paper-server/src/main/java/io/papermc/paper/command/PaperOPLevelCommand.java
@@ -1,0 +1,101 @@
+package io.papermc.paper.command;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.Commands;
+import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
+import io.papermc.paper.command.brigadier.argument.resolvers.PlayerProfileListResolver;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.permissions.LevelBasedPermissionSet;
+import net.minecraft.server.permissions.PermissionLevel;
+import net.minecraft.server.players.NameAndId;
+import net.minecraft.server.players.ServerOpList;
+import net.minecraft.server.players.ServerOpListEntry;
+import org.bukkit.command.CommandSender;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Collection;
+import java.util.UUID;
+
+import static net.kyori.adventure.text.Component.text;
+
+@NullMarked
+public class PaperOPLevelCommand {
+    public static final String DESCRIPTION = "Change operator permission levels";
+
+    public static LiteralCommandNode<CommandSourceStack> create() {
+        final PaperOPLevelCommand command = new PaperOPLevelCommand();
+
+        return Commands.literal("oplevel")
+            .requires(source -> source.getSender().hasPermission("bukkit.command.oplevel"))
+            .then(Commands.argument("player", ArgumentTypes.playerProfiles())
+                .then(Commands.argument("level", IntegerArgumentType.integer(0, 4))
+                    .executes(command::execute)))
+            .build();
+    }
+
+    private int execute(CommandContext<CommandSourceStack> context) {
+        CommandSender sender = context.getSource().getSender();
+        MinecraftServer server = MinecraftServer.getServer();
+        ServerOpList opList = server.getPlayerList().getOps();
+
+        int newLevel = IntegerArgumentType.getInteger(context, "level");
+
+        try {
+            PlayerProfileListResolver resolver = context.getArgument("player", PlayerProfileListResolver.class);
+            Collection<PlayerProfile> profiles = resolver.resolve(context.getSource());
+
+            if (profiles.isEmpty()) {
+                sender.sendMessage(text("Player not found.", NamedTextColor.RED));
+                return 0;
+            }
+
+            int count = 0;
+            for (PlayerProfile profile : profiles) {
+                UUID uuid = profile.getId();
+                String name = profile.getName();
+
+                if (uuid == null || name == null) {
+                    continue;
+                }
+
+                NameAndId nameAndId = new NameAndId(uuid, name);
+                ServerOpListEntry existingEntry = opList.get(nameAndId);
+
+                boolean bypassesLimit = existingEntry != null && existingEntry.getBypassesPlayerLimit();
+
+                PermissionLevel permLevel = PermissionLevel.byId(newLevel);
+                ServerOpListEntry newEntry = new ServerOpListEntry(
+                    nameAndId,
+                    LevelBasedPermissionSet.forLevel(permLevel),
+                    bypassesLimit
+                );
+
+                opList.add(newEntry);
+
+                var serverPlayer = server.getPlayerList().getPlayer(uuid);
+                if (serverPlayer != null) {
+                    server.getPlayerList().sendPlayerPermissionLevel(serverPlayer);
+                }
+
+                sender.sendMessage(text()
+                    .append(text("Set operator level for ", NamedTextColor.WHITE))
+                    .append(text(name, NamedTextColor.AQUA))
+                    .append(text(" to level ", NamedTextColor.WHITE))
+                    .append(text(newLevel, NamedTextColor.AQUA))
+                    .append(text(".", NamedTextColor.WHITE))
+                    .build()
+                );
+                count++;
+            }
+            return count;
+        } catch (Exception e) {
+            sender.sendMessage(text("Error executing command.", NamedTextColor.RED));
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Hello,

I would like to suggest implementing commands for managing operators.

Currently, there is no way to change a player's operator level without editing the "ops.json" file. Similarly, you cannot change the value of "bypassesPlayerLimit" without editing the file.

This addition would allow server owners to have more control over players they grant operator privileges to. The "/oplevel" command can be used to change the permission level, while "/bypassplayerlimit" changes the value of the "bypassesPlayerLimit" entry.

There is also an "/opinfo" command, which shows a list of operators and allows you to see information for a specific player.