### PR TITLE
Expose picked item in PlayerPickItemEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPickBlockEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPickBlockEvent.java
@@ -2,6 +2,7 @@ package io.papermc.paper.event.player;
 
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
@@ -17,8 +18,8 @@ public class PlayerPickBlockEvent extends PlayerPickItemEvent {
     private final Block block;
 
     @ApiStatus.Internal
-    public PlayerPickBlockEvent(final Player player, final Block block, final boolean includeData, final int targetSlot, final int sourceSlot) {
-        super(player, includeData, targetSlot, sourceSlot);
+    public PlayerPickBlockEvent(final Player player, final Block block, final ItemStack item, final boolean includeData, final int targetSlot, final int sourceSlot) {
+        super(player, item, includeData, targetSlot, sourceSlot);
         this.block = block;
     }
 

--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPickEntityEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPickEntityEvent.java
@@ -2,6 +2,7 @@ package io.papermc.paper.event.player;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NullMarked;
 
@@ -17,8 +18,8 @@ public class PlayerPickEntityEvent extends PlayerPickItemEvent {
     private final Entity entity;
 
     @ApiStatus.Internal
-    public PlayerPickEntityEvent(final Player player, final Entity entity, final boolean includeData, final int targetSlot, final int sourceSlot) {
-        super(player, includeData, targetSlot, sourceSlot);
+    public PlayerPickEntityEvent(final Player player, final Entity entity, final ItemStack item, final boolean includeData, final int targetSlot, final int sourceSlot) {
+        super(player, item, includeData, targetSlot, sourceSlot);
         this.entity = entity;
     }
 

--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPickItemEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPickItemEvent.java
@@ -48,7 +48,7 @@ public abstract class PlayerPickItemEvent extends PlayerEvent implements Cancell
      * @return picked item
      */
     public ItemStack getItem() {
-        return this.item;
+        return this.item.clone();
     }
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPickItemEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPickItemEvent.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Range;
 import org.jspecify.annotations.NullMarked;
@@ -24,6 +25,7 @@ public abstract class PlayerPickItemEvent extends PlayerEvent implements Cancell
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
+    private final ItemStack item;
     private final boolean includeData;
 
     private int targetSlot;
@@ -32,11 +34,21 @@ public abstract class PlayerPickItemEvent extends PlayerEvent implements Cancell
     private boolean cancelled;
 
     @ApiStatus.Internal
-    protected PlayerPickItemEvent(final Player player, final boolean includeData, final int targetSlot, final int sourceSlot) {
+    protected PlayerPickItemEvent(final Player player, final ItemStack item, final boolean includeData, final int targetSlot, final int sourceSlot) {
         super(player);
+        this.item = item;
         this.includeData = includeData;
         this.targetSlot = targetSlot;
         this.sourceSlot = sourceSlot;
+    }
+
+    /**
+     * Returns the item that is being picked. The item can be empty.
+     *
+     * @return picked item
+     */
+    public ItemStack getItem() {
+        return this.item;
     }
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPickItemEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPickItemEvent.java
@@ -43,7 +43,7 @@ public abstract class PlayerPickItemEvent extends PlayerEvent implements Cancell
     }
 
     /**
-     * Returns the item that is being picked. The item can be empty.
+     * Returns the item that is being picked.
      *
      * @return picked item
      */

--- a/paper-server/patches/features/0028-Optimise-collision-checking-in-player-move-packet-ha.patch
+++ b/paper-server/patches/features/0028-Optimise-collision-checking-in-player-move-packet-ha.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Optimise collision checking in player move packet handling
 Move collision logic to just the hasNewCollision call instead of getCubes + hasNewCollision
 
 diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 92ce1962e9df66dbda6a3c0e25f6accdafbc4dc7..c6e5e45b1e97bbbfdae6804c313d499aaf3e6e50 100644
+index 4d16b090ceae18e5608250d878f97c418dbfe7fd..a4c25fe41eb45e07447f7ce9d1fb705347d42d0c 100644
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -636,6 +636,7 @@ public class ServerGamePacketListenerImpl
@@ -72,7 +72,7 @@ index 92ce1962e9df66dbda6a3c0e25f6accdafbc4dc7..c6e5e45b1e97bbbfdae6804c313d499a
      }
  
      @Override
-@@ -1544,7 +1578,7 @@ public class ServerGamePacketListenerImpl
+@@ -1545,7 +1579,7 @@ public class ServerGamePacketListenerImpl
                                      }
                                  }
  
@@ -81,7 +81,7 @@ index 92ce1962e9df66dbda6a3c0e25f6accdafbc4dc7..c6e5e45b1e97bbbfdae6804c313d499a
                                  xDist = targetX - this.lastGoodX; // Paper - diff on change, used for checking large move vectors above
                                  yDist = targetY - this.lastGoodY; // Paper - diff on change, used for checking large move vectors above
                                  zDist = targetZ - this.lastGoodZ; // Paper - diff on change, used for checking large move vectors above
-@@ -1570,6 +1604,7 @@ public class ServerGamePacketListenerImpl
+@@ -1571,6 +1605,7 @@ public class ServerGamePacketListenerImpl
                                  boolean playerStandsOnSomething = this.player.verticalCollisionBelow;
                                  this.player.move(MoverType.PLAYER, new Vec3(xDist, yDist, zDist));
                                  this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move
@@ -89,7 +89,7 @@ index 92ce1962e9df66dbda6a3c0e25f6accdafbc4dc7..c6e5e45b1e97bbbfdae6804c313d499a
                                  // Paper start - prevent position desync
                                  if (this.awaitingPositionFromClient != null) {
                                      return; // ... thanks Mojang for letting move calls teleport across dimensions.
-@@ -1603,7 +1638,17 @@ public class ServerGamePacketListenerImpl
+@@ -1604,7 +1639,17 @@ public class ServerGamePacketListenerImpl
                                  }
  
                                  // Paper start - Add fail move event
@@ -108,7 +108,7 @@ index 92ce1962e9df66dbda6a3c0e25f6accdafbc4dc7..c6e5e45b1e97bbbfdae6804c313d499a
                                  if (!allowMovement) {
                                      io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.CLIPPED_INTO_BLOCK,
                                              targetX, targetY, targetZ, targetYRot, targetXRot, false);
-@@ -1730,7 +1775,7 @@ public class ServerGamePacketListenerImpl
+@@ -1731,7 +1776,7 @@ public class ServerGamePacketListenerImpl
  
      private boolean updateAwaitingTeleport() {
          if (this.awaitingPositionFromClient != null) {
@@ -117,7 +117,7 @@ index 92ce1962e9df66dbda6a3c0e25f6accdafbc4dc7..c6e5e45b1e97bbbfdae6804c313d499a
                  this.awaitingTeleportTime = this.tickCount;
                  this.teleport(
                      this.awaitingPositionFromClient.x,
-@@ -1749,6 +1794,34 @@ public class ServerGamePacketListenerImpl
+@@ -1750,6 +1795,34 @@ public class ServerGamePacketListenerImpl
          }
      }
  

--- a/paper-server/patches/features/0032-DataConverter-Moonrise-co-fixes.patch
+++ b/paper-server/patches/features/0032-DataConverter-Moonrise-co-fixes.patch
@@ -58,10 +58,10 @@ index 3b28b39ebf252d8de46f7d0ce27037cdb041f1b5..0b6d7f99edde802cb464baa5a4b2b4a4
          return savedChunks;
      }
 diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a61fb7d1c65b8b940d66f02e64c131b20a3ee610..b4434d534677403c68f1ff657c42736333e2e15e 100644
+index a4c25fe41eb45e07447f7ce9d1fb705347d42d0c..c2aba28916da7f8b0bc8a325cddaa9bb7ecfb251 100644
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1798,9 +1798,14 @@ public class ServerGamePacketListenerImpl
+@@ -1799,9 +1799,14 @@ public class ServerGamePacketListenerImpl
      private boolean hasNewCollision(final ServerLevel level, final Entity entity, final AABB oldBox, final AABB newBox) {
          final List<AABB> collisionsBB = new java.util.ArrayList<>();
          final List<VoxelShape> collisionsVoxel = new java.util.ArrayList<>();

--- a/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -537,7 +537,7 @@
              }
  
              if (packet.includeData() && this.player.canUseGameMasterBlocks() && entity instanceof Avatar avatar) {
-@@ -746,22 +_,35 @@
+@@ -746,22 +_,36 @@
          }
      }
  
@@ -547,12 +547,13 @@
              Inventory inventory = this.player.getInventory();
              int slotWithExistingItem = inventory.findSlotMatchingItem(itemStack);
 +            // Paper start - Add PlayerPickItemEvent
++            final org.bukkit.inventory.ItemStack bukkitItem = itemStack.asBukkitCopy();
 +            final int sourceSlot = slotWithExistingItem;
 +            final int targetSlot = Inventory.isHotbarSlot(sourceSlot) ? sourceSlot : inventory.getSuitableHotbarSlot();
 +            final org.bukkit.entity.Player bukkitPlayer = this.player.getBukkitEntity();
 +            final io.papermc.paper.event.player.PlayerPickItemEvent event = entity != null
-+                ? new io.papermc.paper.event.player.PlayerPickEntityEvent(bukkitPlayer, entity.getBukkitEntity(), includeData, targetSlot, sourceSlot)
-+                : new io.papermc.paper.event.player.PlayerPickBlockEvent(bukkitPlayer, org.bukkit.craftbukkit.block.CraftBlock.at(this.player.level(), blockPos), includeData, targetSlot, sourceSlot);
++                ? new io.papermc.paper.event.player.PlayerPickEntityEvent(bukkitPlayer, entity.getBukkitEntity(), bukkitItem, includeData, targetSlot, sourceSlot)
++                : new io.papermc.paper.event.player.PlayerPickBlockEvent(bukkitPlayer, org.bukkit.craftbukkit.block.CraftBlock.at(this.player.level(), blockPos), bukkitItem, includeData, targetSlot, sourceSlot);
 +            if (!event.callEvent()) {
 +                return;
 +            }


### PR DESCRIPTION
Adds `PlayerPickItemEvent#getItem`, which returns the item that's being searched for in the inventory, or the item that will be given to a player in creative mode when picking a block or an entity.