### PR TITLE
Remove unnecessary 100ms delay on shutdown

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -23832,7 +23832,7 @@ index 9d9fa99ff7694a3356421df711c7b1443047b057..c79206e0eb455081f63cf4de2c974136
      }
  
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 196f47bb89a49e4d053cabad62059836823e6c21..82eb863da02d58b7643cd1ebd6b2f642b3474c5d 100644
+index e95e0a773cf80645d8901646843bc599a2075fd8..90fcdd0b859ea2cbc24938a8fa09c964d5de7114 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -189,7 +189,7 @@ import net.minecraft.world.scores.ScoreboardSaveData;
@@ -23967,7 +23967,7 @@ index 196f47bb89a49e4d053cabad62059836823e6c21..82eb863da02d58b7643cd1ebd6b2f642
              result = true;
          }
  
-@@ -947,7 +1038,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -946,7 +1037,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              }
          }
  
@@ -23976,7 +23976,7 @@ index 196f47bb89a49e4d053cabad62059836823e6c21..82eb863da02d58b7643cd1ebd6b2f642
              this.nextTickTimeNanos = Util.getNanos() + TimeUtil.NANOSECONDS_PER_MILLISECOND;
  
              for (ServerLevel level : this.getAllLevels()) {
-@@ -958,17 +1049,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -957,17 +1048,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.waitUntilNextTick();
          }
  
@@ -24001,7 +24001,7 @@ index 196f47bb89a49e4d053cabad62059836823e6c21..82eb863da02d58b7643cd1ebd6b2f642
  
          this.isSaving = false;
          this.savedDataStorage.close();
-@@ -989,6 +1077,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -988,6 +1076,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.services().nameToIdCache().save(false); // Paper - Perf: Async GameProfileCache saving
          }
          // Spigot end
@@ -24016,7 +24016,7 @@ index 196f47bb89a49e4d053cabad62059836823e6c21..82eb863da02d58b7643cd1ebd6b2f642
          // Paper start - Improved watchdog support - move final shutdown items here
          Util.shutdownExecutors();
          this.onServerExit();
-@@ -1083,16 +1179,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1082,16 +1178,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              // execute small amounts of other tasks just in case the number of tasks we are
              // draining is large - chunk system and packet processing may be latency sensitive
  
@@ -24051,7 +24051,7 @@ index 196f47bb89a49e4d053cabad62059836823e6c21..82eb863da02d58b7643cd1ebd6b2f642
          profiler.pop(); // moonrise:run_all_chunk
          profiler.pop(); // moonrise:run_all_tasks
  
-@@ -1393,6 +1504,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1392,6 +1503,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      private boolean pollTaskInternal() {
          if (super.pollTask()) {
@@ -24059,7 +24059,7 @@ index 196f47bb89a49e4d053cabad62059836823e6c21..82eb863da02d58b7643cd1ebd6b2f642
              return true;
          }
  
-@@ -1534,6 +1646,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1533,6 +1645,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // Paper - improve tick loop - moved into runAllTasksAtTickStart
          this.runAllTasksAtTickStart(); // Paper - improve tick loop
          this.tickServer(sprinting ? () -> false : this::haveTime);
@@ -24073,7 +24073,7 @@ index 196f47bb89a49e4d053cabad62059836823e6c21..82eb863da02d58b7643cd1ebd6b2f642
          this.tickFrame.end();
          this.recordEndOfTick(); // Paper - improve tick loop
          profiler.pop();
-@@ -2588,6 +2707,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2587,6 +2706,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
  

--- a/paper-server/patches/features/0014-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0014-Incremental-chunk-and-player-saving.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Incremental chunk and player saving
 
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 1d422607ac31044da2eff88b9f020b8a76c4bd54..b1f5741d5d714f57795c53605db87d86ebb07051 100644
+index bbc8899e2524f39a89525d6f54dc8bd0bded88d9..6de2929fda582cc4ceecd7bfe0b440ac6608669d 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -936,7 +936,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -58,7 +58,7 @@ index 1d422607ac31044da2eff88b9f020b8a76c4bd54..b1f5741d5d714f57795c53605db87d86
              boolean result = this.saveAllChunks(silent, flush, force);
              this.warnOnLowDiskSpace();
              return result;
-@@ -1617,9 +1625,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1616,9 +1624,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
  
          this.ticksUntilAutosave--;
@@ -93,7 +93,7 @@ index 1d422607ac31044da2eff88b9f020b8a76c4bd54..b1f5741d5d714f57795c53605db87d86
          ProfilerFiller profiler = Profiler.get();
          this.server.spark.executeMainThreadTasks(); // Paper - spark
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 3112f9d9788b77dca319a05c779972fd073bda61..6a9bdf0bb711acf2ee0bf20e835aa63759ea9ab2 100644
+index df2c346996204003dbc99c0f33adaeb0e5293d01..762e3b71a8df572234b03dec60d2b6e1e339bb6a 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -1466,6 +1466,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
@@ -113,7 +113,7 @@ index 3112f9d9788b77dca319a05c779972fd073bda61..6a9bdf0bb711acf2ee0bf20e835aa637
      public void save(final @Nullable ProgressListener progressListener, final boolean flush, final boolean noSave) {
          // Paper start - add close param
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 88173a3775734ca271d9ff6a7a253eeb343a82a4..6b6030282ccd7ee3f2d135f7f3278de68214aab6 100644
+index 220409fd6335e17445e1acdbfac8d83ae36a99b4..0099e02d61e26bd6262457f99c6f9f06f90bf9f9 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -208,6 +208,7 @@ import org.slf4j.Logger;

--- a/paper-server/patches/features/0017-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0017-Optimise-EntityScheduler-ticking.patch
@@ -20,10 +20,10 @@ index 2bc436cdf5180a7943c45fabb9fbbedae6f7db56..f312a7f5b1b2a777ab36b94ce7cbf387
  
      @Override
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 0ea7ca24a557ed1fe8d5b043430d7a89ef80bfa2..3f7ea010df940daba07e4739f3498b379a0a6116 100644
+index 6de2929fda582cc4ceecd7bfe0b440ac6608669d..2381f8571f6e614dba1cfb62a1d396be9a065c1c 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1760,32 +1760,22 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1759,32 +1759,22 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          return new ServerStatus.Players(maxPlayers, players.size(), sample);
      }
  

--- a/paper-server/patches/features/0031-Optimize-Hoppers.patch
+++ b/paper-server/patches/features/0031-Optimize-Hoppers.patch
@@ -48,10 +48,10 @@ index 0000000000000000000000000000000000000000..24a2090e068ad3c0d08705050944abdf
 +    }
 +}
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index b71f2e181334ad8646afb48c704c30b6f4a33ffd..68151ce05e7009f28dda0470c744920cbd5f4a27 100644
+index 2381f8571f6e614dba1cfb62a1d396be9a065c1c..879f53a64e3070aca5f6c58a0e200b62c3e51117 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1816,6 +1816,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1815,6 +1815,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              level.hasPhysicsEvent = org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
              level.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - Add EntityMoveEvent
              level.updateLagCompensationTick(); // Paper - lag compensation

--- a/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -548,7 +548,7 @@
      }
  
      protected GlobalPos selectLevelLoadFocusPos() {
-@@ -639,19 +_,50 @@
+@@ -639,19 +_,49 @@
          this.stopServer();
      }
  
@@ -596,7 +596,6 @@
 -            this.playerList.removeAll();
 +            this.playerList.removeAll(this.isRestarting); // Paper
 +            this.getConnection().handleAllDisconnections(); // Paper
-+            try { Thread.sleep(100); } catch (InterruptedException ex) {} // CraftBukkit - SPIGOT-625 - give server at least a chance to send packets
          }
  
          LOGGER.info("Saving worlds");


### PR DESCRIPTION
Inside of handleAllDisconnections we are already waiting for all connections to close, giving the server an extra arbitrary amount of time on top of that to "send packets" doesn't seem necessary since it's all supposed to be closed already by that point