### PR TITLE
Fix badge version filter syntax in README.md [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Paper [![Version](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fartifactory.papermc.io%2Fartifactory%2Funiverse%2Fio%2Fpapermc%2Fpaper%2Fpaper-api%2Fmaven-metadata.xml&strategy=highestVersion&filter=26.2*&label=version&color=%23344ceb
+Paper [![Version](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fartifactory.papermc.io%2Fartifactory%2Funiverse%2Fio%2Fpapermc%2Fpaper%2Fpaper-api%2Fmaven-metadata.xml&strategy=highestVersion&filter=26.2.*&label=version&color=%23344ceb
 )](https://papermc.io/downloads/paper)
 [![Paper Build Status](https://img.shields.io/github/actions/workflow/status/PaperMC/Paper/build.yml?branch=main)](https://github.com/PaperMC/Paper/actions)
 [![Discord](https://img.shields.io/discord/289587909051416579.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/papermc)


### PR DESCRIPTION
Mentioned in https://canary.discord.com/channels/289587909051416579/947676006964162611/1534191750820794519
When that badge was introduced i never expect a version like 26.2-rc (from vanilla) takes priority over other formats... this PR just change the filter to only match versions started by `26.2.*` this only breaks early versions but that are for testing and announced in discord so big loss...