### PR TITLE
Fix missed chest open callbacks for max-range opens

### DIFF
--- a/paper-server/patches/features/0019-Delay-open-close-callbacks-for-chests.patch
+++ b/paper-server/patches/features/0019-Delay-open-close-callbacks-for-chests.patch
@@ -49,7 +49,7 @@ diff --git a/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
 index baa8b5aba0500981a191626553d66650c7304b88..52737172ccfa0c7c977e4f2fe1db242e0bb92d25 100644
 --- a/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
 +++ b/net/minecraft/world/level/block/entity/ContainerOpenersCounter.java
-@@ -37,11 +37,23 @@ public abstract class ContainerOpenersCounter {
+@@ -37,11 +37,24 @@ public abstract class ContainerOpenersCounter {
  
      protected abstract void openerCountChanged(final Level level, final BlockPos pos, final BlockState blockState, int previous, int current);
  
@@ -66,6 +66,7 @@ index baa8b5aba0500981a191626553d66650c7304b88..52737172ccfa0c7c977e4f2fe1db242e
      ) {
 +        // Paper start - delay open/close callbacks
 +        if (this.delayCallbacks()) {
++            this.maxInteractionRange = Math.max(maxInteractionRange, this.maxInteractionRange);
 +            scheduleRecheck(level, pos, blockState, 1);
 +            return;
 +        }


### PR DESCRIPTION
Simple summary:

Delayed open/close path (introduced by "Delay open/close callbacks for chests") never adopts the opener's interaction range so the first scan is too small and can miss the player who opened the container.

This allows a player from ~4.8-5.5 blocks to open chests and other containers without activating redstone.

Simple explanation: 

The code only schedules a recheck, but never does it properly; unlike the immediate path it does not do maxInteractionRange = max(arg, this.maxInteractionRange). The recheck's viewer scan uses AABB(pos).inflate(this.maxInteractionRange + 4.0), which for a fresh counter is only a 4-block box - while the server accepts block interactions from up to blockInteractionRange + 1.0 (5.5 blocks by default).

- openCount stays at 0, so onOpen never runs which means the lid doesn't open, and GameEvent.CONTAINER_OPEN never fires which means redstone does not trigger.

- recheckOpeners only reschedules itself while openCount > 0, so no further recheck happens - the container stays in this silent state for the entire session, and closing it fires nothing either.

Fix explanation:

The fix was pretty simple, basically a 1 liner. We adopt the passed interaction range in the delayed path matching what the code  already does at the end of `incrementOpeners`. The first recheck then scans an ~8.5-block box and once it finds the opener it sets `openCount = 1` and keeps rescheduling while open. Behavior for normal-range opens is unchanged (the scan predicate still requires `hasContainerOpen`, and the count is recomputed from live viewers).
