### PR TITLE
[Feature] Add API to query type of PersistentDataContainer value

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/persistence/PersistentDataContainerView.java
+++ b/paper-api/src/main/java/io/papermc/paper/persistence/PersistentDataContainerView.java
@@ -113,9 +113,12 @@ public interface PersistentDataContainerView {
     /**
      * Returns the type of the value that is stored on the
      * {@link PersistentDataHolder} instance.
+     * If no value is present, the value type is unknown or an empty list is
+     * encountered, null will be returned.
      *
      * @param key the key to look up the value type of
-     * @return the data type or null if no value is present for the given key
+     * @return the data type or null if no value is present, the type is unknown
+     * or an empty list is encountered as value.
      */
     @Nullable PersistentDataType<?, ?> getType(NamespacedKey key);
 

--- a/paper-api/src/main/java/io/papermc/paper/persistence/PersistentDataContainerView.java
+++ b/paper-api/src/main/java/io/papermc/paper/persistence/PersistentDataContainerView.java
@@ -1,6 +1,7 @@
 package io.papermc.paper.persistence;
 
 import java.util.Set;
+import net.kyori.adventure.key.Key;
 import org.bukkit.NamespacedKey;
 import org.bukkit.persistence.PersistentDataAdapterContext;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -111,16 +112,20 @@ public interface PersistentDataContainerView {
     <P, C> C getOrDefault(NamespacedKey key, PersistentDataType<P, C> type, C defaultValue);
 
     /**
-     * Returns the type of the value that is stored on the
-     * {@link PersistentDataHolder} instance.
-     * If no value is present, the value type is unknown or an empty list is
-     * encountered, null will be returned.
+     * Estimates the {@link PersistentDataType} of the value.
+     * <br>
+     * <b>WARNING:</b> This method will only return data types
+     * defined in {@link PersistentDataType} which directly map to a specific
+     * nbt tag. The return value will be wrong if the data type is plugin
+     * specific or not represented by a specific nbt tag.
+     * Use {@link #has(NamespacedKey, PersistentDataType)} if you expect a
+     * specific data type.
      *
      * @param key the key to look up the value type of
-     * @return the data type or null if no value is present, the type is unknown
-     * or an empty list is encountered as value.
+     * @return estimated data type or null if no value is present, the type is
+     * unknown or an empty list is encountered as value.
      */
-    @Nullable PersistentDataType<?, ?> getType(NamespacedKey key);
+    @Nullable PersistentDataType<?, ?> estimatePrimitiveDataType(Key key);
 
     /**
      * Get the set of keys present on this {@link PersistentDataContainer}

--- a/paper-api/src/main/java/io/papermc/paper/persistence/PersistentDataContainerView.java
+++ b/paper-api/src/main/java/io/papermc/paper/persistence/PersistentDataContainerView.java
@@ -111,6 +111,15 @@ public interface PersistentDataContainerView {
     <P, C> C getOrDefault(NamespacedKey key, PersistentDataType<P, C> type, C defaultValue);
 
     /**
+     * Returns the type of the value that is stored on the
+     * {@link PersistentDataHolder} instance.
+     *
+     * @param key the key to loop up the value type of
+     * @return the data type or null if no value is present for the given key
+     */
+    @Nullable PersistentDataType<?, ?> getType(NamespacedKey key);
+
+    /**
      * Get the set of keys present on this {@link PersistentDataContainer}
      * instance.
      * <p>

--- a/paper-api/src/main/java/io/papermc/paper/persistence/PersistentDataContainerView.java
+++ b/paper-api/src/main/java/io/papermc/paper/persistence/PersistentDataContainerView.java
@@ -112,7 +112,8 @@ public interface PersistentDataContainerView {
     <P, C> C getOrDefault(NamespacedKey key, PersistentDataType<P, C> type, C defaultValue);
 
     /**
-     * Estimates the {@link PersistentDataType} of the value.
+     * Estimates the {@link PersistentDataType} of the value based on the primitive
+     * type that is stored for the given key.
      * <br>
      * <b>WARNING:</b> This method will only return data types
      * defined in {@link PersistentDataType} which directly map to a specific
@@ -125,7 +126,7 @@ public interface PersistentDataContainerView {
      * @return estimated data type or null if no value is present, the type is
      * unknown or an empty list is encountered as value.
      */
-    @Nullable PersistentDataType<?, ?> estimatePrimitiveDataType(Key key);
+    @Nullable PersistentDataType<?, ?> getPrimitiveStorageType(Key key);
 
     /**
      * Get the set of keys present on this {@link PersistentDataContainer}

--- a/paper-api/src/main/java/io/papermc/paper/persistence/PersistentDataContainerView.java
+++ b/paper-api/src/main/java/io/papermc/paper/persistence/PersistentDataContainerView.java
@@ -114,7 +114,7 @@ public interface PersistentDataContainerView {
      * Returns the type of the value that is stored on the
      * {@link PersistentDataHolder} instance.
      *
-     * @param key the key to loop up the value type of
+     * @param key the key to look up the value type of
      * @return the data type or null if no value is present for the given key
      */
     @Nullable PersistentDataType<?, ?> getType(NamespacedKey key);

--- a/paper-server/src/main/java/io/papermc/paper/persistence/PaperPersistentDataContainerView.java
+++ b/paper-server/src/main/java/io/papermc/paper/persistence/PaperPersistentDataContainerView.java
@@ -179,7 +179,12 @@ public abstract class PaperPersistentDataContainerView implements PersistentData
                     yield null;
                 }
 
-                yield getListTagType(nestedListTag);
+                ListPersistentDataType<?, ?> nestedListType = getListTagType(nestedListTag);
+                if (nestedListType == null) {
+                    yield null;
+                }
+
+                yield PersistentDataType.LIST.listTypeFrom(nestedListType);
             }
             default -> null;
         };

--- a/paper-server/src/main/java/io/papermc/paper/persistence/PaperPersistentDataContainerView.java
+++ b/paper-server/src/main/java/io/papermc/paper/persistence/PaperPersistentDataContainerView.java
@@ -8,12 +8,14 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.Tag;
 import org.bukkit.NamespacedKey;
 import org.bukkit.craftbukkit.persistence.CraftPersistentDataAdapterContext;
 import org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer;
 import org.bukkit.craftbukkit.persistence.CraftPersistentDataTypeRegistry;
+import org.bukkit.persistence.ListPersistentDataType;
 import org.bukkit.persistence.PersistentDataAdapterContext;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
@@ -74,6 +76,18 @@ public abstract class PaperPersistentDataContainerView implements PersistentData
     }
 
     @Override
+    public @Nullable PersistentDataType<?, ?> getType(final NamespacedKey key) {
+        Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+
+        final Tag value = this.getTag(key.toString());
+        if (value == null) {
+            return null;
+        }
+
+        return getTagType(value);
+    }
+
+    @Override
     public Set<NamespacedKey> getKeys() {
         final Set<String> names = this.toTagCompound().keySet();
         final Set<NamespacedKey> keys = new HashSet<>(names.size());
@@ -116,5 +130,58 @@ public abstract class PaperPersistentDataContainerView implements PersistentData
             NbtIo.write(root, dataOutput);
             return byteArrayOutput.toByteArray();
         }
+    }
+
+    private static @Nullable PersistentDataType<?, ?> getTagType(final Tag value) {
+        return switch (value.getId()) {
+            case Tag.TAG_BYTE -> PersistentDataType.BYTE;
+            case Tag.TAG_SHORT -> PersistentDataType.SHORT;
+            case Tag.TAG_INT -> PersistentDataType.INTEGER;
+            case Tag.TAG_LONG -> PersistentDataType.LONG;
+            case Tag.TAG_FLOAT -> PersistentDataType.FLOAT;
+            case Tag.TAG_DOUBLE -> PersistentDataType.DOUBLE;
+            case Tag.TAG_BYTE_ARRAY -> PersistentDataType.BYTE_ARRAY;
+            case Tag.TAG_STRING -> PersistentDataType.STRING;
+            case Tag.TAG_COMPOUND -> PersistentDataType.TAG_CONTAINER;
+            case Tag.TAG_INT_ARRAY -> PersistentDataType.INTEGER_ARRAY;
+            case Tag.TAG_LONG_ARRAY -> PersistentDataType.LONG_ARRAY;
+            case Tag.TAG_LIST -> {
+                if (!(value instanceof ListTag listTag)) {
+                    yield null;
+                }
+
+                yield getListTagType(listTag);
+            }
+            default -> null;
+        };
+    }
+
+    private static @Nullable ListPersistentDataType<?, ?> getListTagType(final ListTag value) {
+        return switch (value.identifyRawElementType()) {
+            case Tag.TAG_BYTE -> PersistentDataType.LIST.bytes();
+            case Tag.TAG_SHORT -> PersistentDataType.LIST.shorts();
+            case Tag.TAG_INT -> PersistentDataType.LIST.integers();
+            case Tag.TAG_LONG -> PersistentDataType.LIST.longs();
+            case Tag.TAG_FLOAT -> PersistentDataType.LIST.floats();
+            case Tag.TAG_DOUBLE -> PersistentDataType.LIST.doubles();
+            case Tag.TAG_BYTE_ARRAY -> PersistentDataType.LIST.byteArrays();
+            case Tag.TAG_STRING -> PersistentDataType.LIST.strings();
+            case Tag.TAG_COMPOUND -> PersistentDataType.LIST.dataContainers();
+            case Tag.TAG_INT_ARRAY -> PersistentDataType.LIST.integerArrays();
+            case Tag.TAG_LONG_ARRAY -> PersistentDataType.LIST.longArrays();
+            case Tag.TAG_LIST -> {
+                if (value.isEmpty()) {
+                    yield null;
+                }
+
+                final Tag nestedTag = value.getFirst();
+                if (!(nestedTag instanceof ListTag nestedListTag)) {
+                    yield null;
+                }
+
+                yield getListTagType(nestedListTag);
+            }
+            default -> null;
+        };
     }
 }

--- a/paper-server/src/main/java/io/papermc/paper/persistence/PaperPersistentDataContainerView.java
+++ b/paper-server/src/main/java/io/papermc/paper/persistence/PaperPersistentDataContainerView.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import net.kyori.adventure.key.Key;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtIo;
@@ -76,10 +77,10 @@ public abstract class PaperPersistentDataContainerView implements PersistentData
     }
 
     @Override
-    public @Nullable PersistentDataType<?, ?> getType(final NamespacedKey key) {
+    public @Nullable PersistentDataType<?, ?> estimatePrimitiveDataType(final Key key) {
         Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
 
-        final Tag value = this.getTag(key.toString());
+        final Tag value = this.getTag(key.asString());
         if (value == null) {
             return null;
         }

--- a/paper-server/src/main/java/io/papermc/paper/persistence/PaperPersistentDataContainerView.java
+++ b/paper-server/src/main/java/io/papermc/paper/persistence/PaperPersistentDataContainerView.java
@@ -77,7 +77,7 @@ public abstract class PaperPersistentDataContainerView implements PersistentData
     }
 
     @Override
-    public @Nullable PersistentDataType<?, ?> estimatePrimitiveDataType(final Key key) {
+    public @Nullable PersistentDataType<?, ?> getPrimitiveStorageType(final Key key) {
         Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
 
         final Tag value = this.getTag(key.asString());


### PR DESCRIPTION
Hi,
this PR adds a method that makes it possible to query the data type of a specific value inside a persistent data container.
With this method it will be possible to read a value without knowing the exact type of the value you are trying to read.
This is useful for migrating the data type of a value to another one or for a library that sits on top of Paper and does not know the type by design.
It enables further tools like editors for the persistent data container to be developed without the need to check every available data type or using a nbt API.

I have tested the method using the test-plugin and can provide my testing code if necessary.

~This API in its current form is not able to correctly determine the data type of nested lists but I'm already trying to fix this issue.~ Already fixed.

Any question or feedback is welcome. 🙂 