### PR TITLE
Only scan world if Villager profession has secondary POI

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/sensing/SecondaryPoiSensor.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/sensing/SecondaryPoiSensor.java.patch
@@ -4,7 +4,7 @@
          List<GlobalPos> jobSites = Lists.newArrayList();
          int horizontalSearch = 4;
  
-+        if (!body.getVillagerData().profession().value().secondaryPoi().isEmpty()) // Paper - Only scan world if Villager profession has secondary POI
++        if (!body.getVillagerData().profession().value().secondaryPoi().isEmpty()) // Paper - Perf: Only scan world if Villager profession has secondary POI
          for (int x = -4; x <= 4; x++) {
              for (int y = -2; y <= 2; y++) {
                  for (int z = -4; z <= 4; z++) {

--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/sensing/SecondaryPoiSensor.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/sensing/SecondaryPoiSensor.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/entity/ai/sensing/SecondaryPoiSensor.java
++++ b/net/minecraft/world/entity/ai/sensing/SecondaryPoiSensor.java
+@@ -27,6 +_,7 @@
+         List<GlobalPos> jobSites = Lists.newArrayList();
+         int horizontalSearch = 4;
+ 
++        if (!body.getVillagerData().profession().value().secondaryPoi().isEmpty()) // Paper - Only scan world if Villager profession has secondary POI
+         for (int x = -4; x <= 4; x++) {
+             for (int y = -2; y <= 2; y++) {
+                 for (int z = -4; z <= 4; z++) {


### PR DESCRIPTION
In Vanilla all Villagers query (and potentially even load) all blocks in a 9x5x9 area around them via the `SecondaryPoiSensor` to search for valid secondary POIs even though most Villagers don't actually search for any. Only the profession "farmer" searches for a secondary POI (the farmland) in Vanilla making these.

As not the full logic can be seen in the patch, here is the unnecessary loop which is disabled unless the Villager's profession has secondary POI set:

```java
        for (int x = -4; x <= 4; x++) {
            for (int y = -2; y <= 2; y++) {
                for (int z = -4; z <= 4; z++) {
                    BlockPos testPos = center.offset(x, y, z);
                    if (body.getVillagerData().profession().value().secondaryPoi().contains(level.getBlockState(testPos).getBlock())) {
                        jobSites.add(GlobalPos.of(dimensionType, testPos));
                    }
                }
            }
        }

        Brain<?> brain = body.getBrain();
        if (!jobSites.isEmpty()) {
            brain.setMemory(MemoryModuleType.SECONDARY_JOB_SITE, jobSites);
        } else {
            brain.eraseMemory(MemoryModuleType.SECONDARY_JOB_SITE);
        }
```

In order to keep the rest of the logic with the memory intact only this loop is disabled, not the whole sensor.