### PR TITLE
Fix three minor ShelfBlock issues

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/level/block/ShelfBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/ShelfBlock.java.patch
@@ -12,3 +12,26 @@
                  BlockState newState = state.setValue(POWERED, signal);
                  if (!signal) {
                      newState = newState.setValue(SIDE_CHAIN_PART, SideChainPart.UNCONNECTED);
+@@ -162,7 +_,7 @@
+         final InteractionHand hand,
+         final BlockHitResult hitResult
+     ) {
+-        if (level.getBlockEntity(pos) instanceof ShelfBlockEntity shelfBlockEntity && !hand.equals(InteractionHand.OFF_HAND)) {
++        if (level.getBlockEntity(pos) instanceof ShelfBlockEntity shelfBlockEntity) {
+             OptionalInt hitSlot = this.getHitSlot(hitResult, state.getValue(FACING));
+             if (hitSlot.isEmpty()) {
+                 return InteractionResult.PASS;
+@@ -227,11 +_,10 @@
+         boolean anySwapped = false;
+ 
+         for (int shelfPartIndex = 0; shelfPartIndex < connectedBlocks.size(); shelfPartIndex++) {
+-            ShelfBlockEntity shelfPart = (ShelfBlockEntity)level.getBlockEntity(connectedBlocks.get(shelfPartIndex));
+-            if (shelfPart != null) {
++            if (level.getBlockEntity(connectedBlocks.get(shelfPartIndex)) instanceof ShelfBlockEntity shelfPart) {
+                 for (int slot = 0; slot < shelfPart.getContainerSize(); slot++) {
+                     int inventorySlot = 9 - (connectedBlocks.size() - shelfPartIndex) * shelfPart.getContainerSize() + slot;
+-                    if (inventorySlot >= 0 && inventorySlot <= inventory.getContainerSize()) {
++                    if (inventorySlot >= 0 && inventorySlot < inventory.getContainerSize()) {
+                         ItemStack placedInventoryItem = inventory.removeItemNoUpdate(inventorySlot);
+                         ItemStack removedShelfItem = shelfPart.swapItemNoUpdate(slot, placedInventoryItem);
+                         if (!placedInventoryItem.isEmpty() || !removedShelfItem.isEmpty()) {


### PR DESCRIPTION
A few small QoL/cleanup ShelfBlock fixes:
- swapHotbar checks the hotbar slot with a bounds check of <= inventory.getContainerSize() which should be < because otherwise it is off by one. ATM it isn't reachable because the slot stays under the container size, but could cause hazards in future if not handled. 
- Replaced the unchecked (ShelfBlockEntity) cast and the null check in the same loop with an instanceof pattern match
- useItemOn ignored the off hand which blocked proper handling of offhand use of the Shelf like in vanilla, so changed to match and have vanilla parity.