### PR TITLE
Call PlayerBucketEmptyEvent for Sulfur Cube in Bucket

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/item/BucketItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/BucketItem.java.patch
@@ -4,7 +4,7 @@
  import org.jspecify.annotations.Nullable;
  
  public class BucketItem extends Item implements DispensibleContainerItem {
-+    private static @Nullable ItemStack itemLeftInHandAfterPlayerBucketEmptyEvent = null; // Paper - Fix PlayerBucketEmptyEvent result itemstack
++    static @Nullable ItemStack itemLeftInHandAfterPlayerBucketEmptyEvent = null; // Paper - Fix PlayerBucketEmptyEvent result itemstack
      protected final Fluid content;
  
      public BucketItem(final Fluid content, final Item.Properties properties) {
@@ -65,7 +65,7 @@
 +        return this.emptyContents(user, level, pos, hitResult, null, null, null, InteractionHand.MAIN_HAND);
 +    }
 +
-+    public boolean emptyContents(final @Nullable LivingEntity user, final Level level, final BlockPos pos, final @Nullable BlockHitResult hitResult, final Direction direction, final BlockPos clicked, final ItemStack itemStack, final InteractionHand hand) {
++    public boolean emptyContents(final @Nullable LivingEntity user, final Level level, final BlockPos pos, final @Nullable BlockHitResult hitResult, final @Nullable Direction direction, final @Nullable BlockPos clicked, final @Nullable ItemStack itemStack, final InteractionHand hand) {
 +        // CraftBukkit end
          if (!(this.content instanceof FlowingFluid flowingFluid)) {
              return false;

--- a/paper-server/patches/sources/net/minecraft/world/item/MobBucketItem.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/item/MobBucketItem.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/MobBucketItem.java
 +++ b/net/minecraft/world/item/MobBucketItem.java
-@@ -52,18 +_,18 @@
+@@ -52,18 +_,28 @@
          }
  
          if (mob != null) {
@@ -14,6 +14,16 @@
 -    public boolean emptyContents(final @Nullable LivingEntity user, final Level level, final BlockPos pos, final @Nullable BlockHitResult hitResult) {
 +    public boolean emptyContents(final @Nullable LivingEntity user, final Level level, final BlockPos pos, final @Nullable BlockHitResult hitResult, final net.minecraft.core.Direction direction, final BlockPos clicked, final ItemStack itemStack, final net.minecraft.world.InteractionHand hand) { // Paper
          if (this.content == Fluids.EMPTY) {
++            // Paper start - call PlayerBucketEmptyEvent for mobs in buckets with not fluids
++            if (user instanceof net.minecraft.world.entity.player.Player player) {
++                org.bukkit.event.player.PlayerBucketEmptyEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerBucketEmptyEvent(level, player, pos, clicked, direction, itemStack, hand);
++                if (event.isCancelled()) {
++                    player.containerMenu.sendAllDataToRemote(); // SPIGOT-4541
++                    return false;
++                }
++                BucketItem.itemLeftInHandAfterPlayerBucketEmptyEvent = event.getItemStack() != null ? event.getItemStack().equals(org.bukkit.craftbukkit.inventory.CraftItemStack.asNewCraftStack(net.minecraft.world.item.Items.BUCKET)) ? null : org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getItemStack()) : ItemStack.EMPTY; // Paper - Fix PlayerBucketEmptyEvent result itemstack
++            }
++            // Paper end
              this.playEmptySound(user, level, pos);
              return true;
          } else {


### PR DESCRIPTION
This PR include the call of PlayerBucketEmptyEvent for non-liquid buckets with entities, this handle the case of the Sulfur Cube where the bucket not has liquid content.

Close https://github.com/PaperMC/Paper/issues/14149