### PR TITLE
Call EntityCollideWithEntityEvent for Sulfur Cube pushed by Player

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/entity/EntityCollideWithEntityEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/entity/EntityCollideWithEntityEvent.java
@@ -1,12 +1,12 @@
 package io.papermc.paper.event.entity;
 
+import java.util.List;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import java.util.List;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Fired when two entities collide with each other.
@@ -15,6 +15,7 @@ import java.util.List;
  * Note that even if cancelled, the client may still run its own collision unless
  * disabled via player teams.
  */
+@NullMarked
 public class EntityCollideWithEntityEvent extends Event implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
@@ -22,8 +23,8 @@ public class EntityCollideWithEntityEvent extends Event implements Cancellable {
     private final List<Entity> entities;
 
     @ApiStatus.Internal
-    public EntityCollideWithEntityEvent(@NotNull Entity entity1, @NotNull Entity entity2) {
-        entities = List.of(entity1, entity2);
+    public EntityCollideWithEntityEvent(final Entity entity1, final Entity entity2) {
+        this.entities = List.of(entity1, entity2);
     }
 
     /**
@@ -31,23 +32,22 @@ public class EntityCollideWithEntityEvent extends Event implements Cancellable {
      *
      * @return entities that are involved in this event
      */
-    public @NotNull List<Entity> getEntities() {
-        return entities;
+    public List<Entity> getEntities() {
+        return this.entities;
     }
 
     @Override
-    public @NotNull HandlerList getHandlers() {
+    public HandlerList getHandlers() {
         return HANDLER_LIST;
     }
 
-    @NotNull
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }
 
     @Override
     public boolean isCancelled() {
-        return cancelled;
+        return this.cancelled;
     }
 
     @Override

--- a/paper-server/patches/sources/net/minecraft/world/entity/monster/cubemob/SulfurCube.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/monster/cubemob/SulfurCube.java.patch
@@ -156,6 +156,17 @@
          this.playSound(this.getEjectSound());
          this.pickupTimer = 100;
      }
+@@ -748,6 +_,10 @@
+             double sulfurCubeTopPosition = sulfurCubeBottomPosition + this.getBbHeight();
+             double pusherTopPosition = pusherFeetPosition + pusher.getBbHeight();
+             if (cubeToPusher.horizontalDistance() < 1.3F && pusherFeetPosition <= sulfurCubeTopPosition && pusherTopPosition > sulfurCubeBottomPosition) {
++                // Paper start - Add EntityCollideWithEntity Event
++                if (io.papermc.paper.event.entity.EntityCollideWithEntityEvent.getHandlerList().getRegisteredListeners().length != 0 &&
++                    !new io.papermc.paper.event.entity.EntityCollideWithEntityEvent(this.getBukkitEntity(), pusher.getBukkitEntity()).callEvent()) return;
++                // Paper end - Add EntityCollideWithEntity Event
+                 double knockback = Math.max(0.0, 1.0 - this.getAttributeValue(Attributes.KNOCKBACK_RESISTANCE));
+                 Vec3 pushDirection = cubeToPusher.horizontal().normalize().scale(knockback);
+                 float pushSpeedScale = player.isPassenger() ? 0.16F : 0.3F;
 @@ -827,7 +_,7 @@
      }
  


### PR DESCRIPTION
With the addition of https://github.com/PaperMC/Paper/commit/9119d1d121f64f564da245177ee05ba47d226c2d
This PR include the case for Sulfur Cube with item, this follow another logic for "playerTouch" rather than push.

also apply the JSpecify changes.