### PR TITLE
Clear scoreboard team entries on unregister

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/scores/Scoreboard.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/scores/Scoreboard.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/world/scores/Scoreboard.java
 +++ b/net/minecraft/world/scores/Scoreboard.java
+@@ -267,6 +_,7 @@
+         }
+ 
+         this.onTeamRemoved(team);
++        team.getPlayers().clear(); // Paper - Clear scoreboard team entries on unregister
+     }
+ 
+     public boolean addPlayerToTeam(final String player, final PlayerTeam team) {
 @@ -373,7 +_,7 @@
      }
  


### PR DESCRIPTION
## Description

Unregistering a scoreboard team removes its entries from the scoreboard's internal mappings, but the entries remain stored in the old team instance.

This leaves the unregistered team in an inconsistent state. Calling `hasEntry` on that instance can still return `true`, even though the entry is no longer assigned to that team in the scoreboard.

For example:

```java
Team t1 = scoreboard.registerNewTeam("RED");
t1.addEntry("Notch");

t1.unregister();

Team t2 = scoreboard.registerNewTeam("RED");

if (t1.hasEntry("Notch")) { // <- true
    t1.removeEntry("Notch");
}
```

The call to `removeEntry` fails with:

```text
java.lang.IllegalStateException: Player is either on another team or not on any team. Cannot remove from team 'RED'.
```

This happens because `t1` still contains `"Notch"` in its internal player list, while the scoreboard no longer considers the player to be part of that team.

## Changes

Clear the team's player collection when the team is unregistered.

This ensures that an unregistered team instance accurately reflects its state and prevents stale entries from causing `IllegalStateException`s when the instance is referenced afterwards.
