### PR TITLE
configurable channel limit

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/connection/PluginMessageBridgeImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/connection/PluginMessageBridgeImpl.java
@@ -13,9 +13,10 @@ import org.jspecify.annotations.NullMarked;
 public interface PluginMessageBridgeImpl {
 
     boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
+    int CHANNEL_LIMIT = Integer.getInteger("paper.pluginMessageChannelLimit", 128); // Paper - add a flag to customize the channel limit
 
     default boolean addChannel(String channel) {
-        Preconditions.checkState(DISABLE_CHANNEL_LIMIT || this.channels().size() < 128, "Cannot register channel. Too many channels registered!"); // Paper - flag to disable channel limit
+        Preconditions.checkState(DISABLE_CHANNEL_LIMIT || this.channels().size() < CHANNEL_LIMIT, "Cannot register channel. Too many channels registered!"); // Paper - flag to disable channel limit
         channel = StandardMessenger.validateAndCorrectChannel(channel);
         if (channels().add(channel)) {
             if (this instanceof CraftPlayer player) {


### PR DESCRIPTION
players on my server who use modpacks keep getting kicked because the 128 limit is way too low, im not gonna argue about what limit is suitable but we should at-least be able to change it without disabling the exploit check entirely.