### PR TITLE
Fix flattening crash from %0$s in translatable components

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+++ b/paper-server/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
@@ -91,7 +91,7 @@ public final class PaperAdventure {
                 if (argIdx != null) {
                     try {
                         final int idx = Integer.parseInt(argIdx) - 1;
-                        if (idx < args.size()) {
+                        if (idx >= 0 && idx < args.size()) {
                             consumer.accept(args.get(idx).asComponent());
                         }
                     } catch (final NumberFormatException ex) {
@@ -99,7 +99,7 @@ public final class PaperAdventure {
                     }
                 } else {
                     final int idx = argPosition++;
-                    if (idx < args.size()) {
+                    if (idx >= 0 && idx < args.size()) {
                         consumer.accept(args.get(idx).asComponent());
                     }
                 }


### PR DESCRIPTION
The translatable component flattener computed the argument index as `Integer.parseInt(argIdx) - 1`, so `%0$s` yields -1. The guard only checked `idx < args.size()`, and -1 passes that whenever the component has arguments, so `args.get(-1)` threw `IndexOutOfBoundsException` instead of dropping the placeholder like out-of-range positive indices are dropped.

Fixes #14163

The guard is now `idx >= 0 && idx < args.size()`, matching the existing "drop out-of-range placeholder" behavior. The sequential-argument branch (`argPosition++`) already only produced non-negative indices, so this only changes the `%0$s` case.

I reproduced the crash with a small harness (parse `%0$s`, `idx = -1`, `args.get(-1)` throws) and confirmed the fix compiles against the full server. I couldn't add a JUnit regression test for the full flattening path because it needs a language entry whose value actually contains `%0$s`, which isn't in the shipped translations. Happy to add one if there's a way to inject test language data.