### PR TITLE
Validate lootables refresh-max is not below refresh-min

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -385,6 +385,13 @@ public class WorldConfiguration extends ConfigurationPart {
         public Duration refreshMin = Duration.of("12h");
         public Duration refreshMax = Duration.of("2d");
         public boolean retainUnlootedShulkerBoxLootTableOnNonPlayerBreak = true;
+
+        @PostProcess
+        public void validateRefillRange() throws SerializationException {
+            if (this.refreshMax.seconds() < this.refreshMin.seconds()) {
+                throw new SerializationException("lootables.refresh-max (%s) must be greater than or equal to lootables.refresh-min (%s)".formatted(this.refreshMax.value(), this.refreshMin.value()));
+            }
+        }
     }
 
     public MaxGrowthHeight maxGrowthHeight;


### PR DESCRIPTION
`lootables.refresh-min` and `lootables.refresh-max` were never checked against each other. With `refresh-max` below `refresh-min`, `PaperLootableInventoryData#shouldClearLootTable` computes `RANDOM.nextLong(max - min + 1)` with a non-positive bound, which throws `IllegalArgumentException: bound must be positive` the first time a lootable container is cleared. I verified that throw with a small program (`new Random().nextLong(0)` throws).

Fixes #14165

Added a `@PostProcess` validation on the `Lootables` config part, the same pattern `precomputeDespawnDistances` uses. It rejects `refresh-max < refresh-min` with a clear message at config load, so the mistake fails loudly at startup instead of at the first chest.

Compiles against the full server. I didn't add a unit test because this runs through the world config loading path, which needs the Minecraft registries to be present; happy to add one if there's a pattern for it.