### PR TITLE
Change default permissions for "/trigger", "/version", and "/plugins".

### DIFF
--- a/paper-api/src/main/java/org/bukkit/util/permissions/CommandPermissions.java
+++ b/paper-api/src/main/java/org/bukkit/util/permissions/CommandPermissions.java
@@ -15,9 +15,9 @@ public final class CommandPermissions {
         Permission commands = DefaultPermissions.registerPermission(ROOT, "Gives the user the ability to use all CraftBukkit commands", parent);
 
         DefaultPermissions.registerPermission(PREFIX + "help", "Allows the user to view the vanilla help menu", PermissionDefault.TRUE, commands);
-        DefaultPermissions.registerPermission(PREFIX + "plugins", "Allows the user to view the list of plugins running on this server", PermissionDefault.TRUE, commands);
+        DefaultPermissions.registerPermission(PREFIX + "plugins", "Allows the user to view the list of plugins running on this server", PermissionDefault.OP, commands);
         DefaultPermissions.registerPermission(PREFIX + "reload", "Allows the user to reload the server settings", PermissionDefault.OP, commands);
-        DefaultPermissions.registerPermission(PREFIX + "version", "Allows the user to view the version of the server", PermissionDefault.TRUE, commands);
+        DefaultPermissions.registerPermission(PREFIX + "version", "Allows the user to view the version of the server", PermissionDefault.OP, commands);
 
         commands.recalculatePermissibles();
         return commands;

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/util/permissions/CommandPermissions.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/util/permissions/CommandPermissions.java
@@ -29,7 +29,7 @@ public final class CommandPermissions {
         DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "seed", "Allows the user to view the seed of the world", PermissionDefault.OP, commands);
         DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "effect", "Allows the user to add/remove effects on players", PermissionDefault.OP, commands);
         DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "selector", "Allows the use of selectors", PermissionDefault.OP, commands);
-        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "trigger", "Allows the use of the trigger command", PermissionDefault.TRUE, commands);
+        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "trigger", "Allows the use of the trigger command", PermissionDefault.OP, commands);
         // Paper start
         DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "advancement", "Allows the user to give, remove, or check player advancements", PermissionDefault.OP, commands);
         DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "attribute", "Allows the user to query, add, remove or set an entity attribute", PermissionDefault.OP, commands);

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/util/permissions/CommandPermissions.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/util/permissions/CommandPermissions.java
@@ -29,7 +29,7 @@ public final class CommandPermissions {
         DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "seed", "Allows the user to view the seed of the world", PermissionDefault.OP, commands);
         DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "effect", "Allows the user to add/remove effects on players", PermissionDefault.OP, commands);
         DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "selector", "Allows the use of selectors", PermissionDefault.OP, commands);
-        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "trigger", "Allows the use of the trigger command", PermissionDefault.OP, commands);
+        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "trigger", "Allows the use of the trigger command", PermissionDefault.TRUE, commands);
         // Paper start
         DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "advancement", "Allows the user to give, remove, or check player advancements", PermissionDefault.OP, commands);
         DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "attribute", "Allows the user to query, add, remove or set an entity attribute", PermissionDefault.OP, commands);


### PR DESCRIPTION
I would like to suggest changing the default permissions for a few commands: "/trigger", "/plugins", and "/version".

Typing "/plugins" allows people to see a list of plugins that are installed on the server. Most server owners don't want regular players to have this information. So, the "/plugins" command should be restricted to operators by default.

Typing "/version" allows people to see what version of Paper is installed. Most server owners don't want regular players to have this information either. So, the "/version" command should also be restricted to operators by default.

As for "/trigger", most players don't even need this command. Thus, based on the principle of least privilege, it would be more secure to restrict the command to operators by default. The "/trigger" command should only be available to regular players if the server owner grants the permission via a permissions plugin (such as LuckPerms).