### PR TITLE
Optimize event dispatch when no listeners are registered

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -29291,7 +29291,7 @@ index 09b6da207530987b483444cebeadc2f1c9a15247..3666c3efd188508153b6482db425648e
 +    // Paper end - block counting
  }
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index ec8b47eebc30a73adb3195aa91fd5b82518cac2d..4b74c91b47318d048abc53952ebeae7615f50524 100644
+index 2fd4add6c2865d20cb5afb324b5f85ff5eac2ef2..32b5b1d5a9ab6ec3880e142cb263d8d47d680000 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -164,7 +164,7 @@ public abstract class Entity
@@ -29542,7 +29542,7 @@ index ec8b47eebc30a73adb3195aa91fd5b82518cac2d..4b74c91b47318d048abc53952ebeae76
  
      public Entity(final EntityType<?> type, final Level level) {
          this.type = type;
-@@ -1484,34 +1590,76 @@ public abstract class Entity
+@@ -1488,34 +1594,76 @@ public abstract class Entity
      }
  
      private Vec3 collide(final Vec3 movement) {
@@ -29642,7 +29642,7 @@ index ec8b47eebc30a73adb3195aa91fd5b82518cac2d..4b74c91b47318d048abc53952ebeae76
      }
  
      private static float[] collectCandidateStepUpHeights(
-@@ -2832,17 +2980,106 @@ public abstract class Entity
+@@ -2836,17 +2984,106 @@ public abstract class Entity
              return false;
          }
  
@@ -29759,7 +29759,7 @@ index ec8b47eebc30a73adb3195aa91fd5b82518cac2d..4b74c91b47318d048abc53952ebeae76
      }
  
      public InteractionResult interact(final Player player, final InteractionHand hand, final Vec3 location) {
-@@ -4449,15 +4686,17 @@ public abstract class Entity
+@@ -4453,15 +4690,17 @@ public abstract class Entity
      }
  
      public Iterable<Entity> getIndirectPassengers() {
@@ -29785,7 +29785,7 @@ index ec8b47eebc30a73adb3195aa91fd5b82518cac2d..4b74c91b47318d048abc53952ebeae76
      }
  
      public int countPlayerPassengers() {
-@@ -4768,6 +5007,15 @@ public abstract class Entity
+@@ -4772,6 +5011,15 @@ public abstract class Entity
      }
  
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
@@ -29801,7 +29801,7 @@ index ec8b47eebc30a73adb3195aa91fd5b82518cac2d..4b74c91b47318d048abc53952ebeae76
          if (!checkPosition(this, x, y, z)) {
              return;
          }
-@@ -4917,6 +5165,12 @@ public abstract class Entity
+@@ -4921,6 +5169,12 @@ public abstract class Entity
  
      @Override
      public final void setRemoved(final Entity.RemovalReason reason, org.bukkit.event.entity.EntityRemoveEvent.@Nullable Cause cause) { // CraftBukkit - add Bukkit remove cause
@@ -29814,7 +29814,7 @@ index ec8b47eebc30a73adb3195aa91fd5b82518cac2d..4b74c91b47318d048abc53952ebeae76
          org.bukkit.craftbukkit.event.CraftEventFactory.callEntityRemoveEvent(this, cause); // CraftBukkit
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
          if (this.removalReason == null) {
-@@ -4928,7 +5182,7 @@ public abstract class Entity
+@@ -4932,7 +5186,7 @@ public abstract class Entity
              this.stopRiding();
          }
  
@@ -29823,7 +29823,7 @@ index ec8b47eebc30a73adb3195aa91fd5b82518cac2d..4b74c91b47318d048abc53952ebeae76
          this.levelCallback.onRemove(reason);
          this.onRemoval(reason);
          // Paper start - Folia schedulers
-@@ -4966,7 +5220,7 @@ public abstract class Entity
+@@ -4970,7 +5224,7 @@ public abstract class Entity
      public boolean shouldBeSaved() {
          return (this.removalReason == null || this.removalReason.shouldSave())
              && !this.isPassenger()
@@ -35308,7 +35308,7 @@ index 64194984fa30038b5bd53140511faf2b5784ead5..c6825283ad1787fcf4bfb93b32ca8396
  
      public int getLightSectionCount() {
 diff --git a/net/minecraft/world/level/material/FlowingFluid.java b/net/minecraft/world/level/material/FlowingFluid.java
-index ee960c0b1e7f510b77949db2a57a53357a00f62d..e93c900385994d391242def7d022d06e6ef23861 100644
+index e825c5587b6a8f8545594aa0a65bf1bf84b8f5c7..80b444cb7c4df5605c9f7904739843dfef3ff16d 100644
 --- a/net/minecraft/world/level/material/FlowingFluid.java
 +++ b/net/minecraft/world/level/material/FlowingFluid.java
 @@ -46,6 +46,48 @@ public abstract class FlowingFluid extends Fluid {
@@ -35360,7 +35360,7 @@ index ee960c0b1e7f510b77949db2a57a53357a00f62d..e93c900385994d391242def7d022d06e
      @Override
      protected void createFluidStateDefinition(final StateDefinition.Builder<Fluid, FluidState> builder) {
          builder.add(FALLING);
-@@ -211,72 +253,70 @@ public abstract class FlowingFluid extends Fluid {
+@@ -215,72 +257,70 @@ public abstract class FlowingFluid extends Fluid {
          return amount <= 0 ? Fluids.EMPTY.defaultFluidState() : this.getFlowing(amount, false);
      }
  

--- a/paper-server/patches/features/0017-Optimise-EntityScheduler-ticking.patch
+++ b/paper-server/patches/features/0017-Optimise-EntityScheduler-ticking.patch
@@ -66,10 +66,10 @@ index 6de2929fda582cc4ceecd7bfe0b440ac6608669d..2381f8571f6e614dba1cfb62a1d396be
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.ADVENTURE_CLICK_MANAGER.handleQueue(this.tickCount); // Paper
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.DIALOG_CLICK_MANAGER.handleQueue(this.tickCount); // Paper
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index f8f479bd0ce2498c0cf4beab07d961247735e23c..d958c4717739e588c5f8985dec5d215c745f49fc 100644
+index 9c4139f8739a88c8a62e907f8bc2297761b4bce7..22c71672e96f7121bd2bfd6c40163e8b1d809817 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -5237,6 +5237,11 @@ public abstract class Entity
+@@ -5241,6 +5241,11 @@ public abstract class Entity
          this.getBukkitEntity().taskScheduler.retire();
      }
      // Paper end - Folia schedulers

--- a/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -521,7 +521,7 @@
          if (this.noPhysics) {
              this.setPos(this.getX() + delta.x, this.getY() + delta.y, this.getZ() + delta.z);
              this.horizontalCollision = false;
-@@ -785,6 +_,27 @@
+@@ -785,6 +_,31 @@
                  if (this.canSimulateMovement() && (movedVertically && this.verticalCollision || this.horizontalCollision)) {
                      this.restituteMovementAfterCollisions(effectState, xCollision, zCollision, movement);
                  }
@@ -541,8 +541,12 @@
 +                    }
 +
 +                    if (!block.getType().isAir()) {
-+                        org.bukkit.event.vehicle.VehicleBlockCollisionEvent event = new org.bukkit.event.vehicle.VehicleBlockCollisionEvent(vehicle, block, org.bukkit.craftbukkit.util.CraftVector.toBukkit(originalMovement)); // Paper - Expose pre-collision velocity
-+                        event.callEvent();
++                        // Paper start - Guard VehicleBlockCollisionEvent when no plugins listen
++                        if (org.bukkit.event.vehicle.VehicleBlockCollisionEvent.getHandlerList().getRegisteredListeners().length != 0) {
++                            org.bukkit.event.vehicle.VehicleBlockCollisionEvent event = new org.bukkit.event.vehicle.VehicleBlockCollisionEvent(vehicle, block, org.bukkit.craftbukkit.util.CraftVector.toBukkit(originalMovement)); // Paper - Expose pre-collision velocity
++                            event.callEvent();
++                        }
++                        // Paper end - Guard VehicleBlockCollisionEvent when no plugins listen
 +                    }
 +                }
 +                // CraftBukkit end

--- a/paper-server/patches/sources/net/minecraft/world/entity/vehicle/boat/AbstractBoat.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/vehicle/boat/AbstractBoat.java.patch
@@ -25,7 +25,7 @@
          return true;
      }
  
-@@ -175,11 +_,30 @@
+@@ -175,11 +_,38 @@
  
      @Override
      public void push(final Entity entity) {
@@ -34,11 +34,15 @@
              if (entity.getBoundingBox().minY < this.getBoundingBox().maxY) {
 +                // CraftBukkit start
 +                if (!this.isPassengerOfSameVehicle(entity)) {
-+                    org.bukkit.event.vehicle.VehicleEntityCollisionEvent event = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
-+                        (org.bukkit.entity.Vehicle) this.getBukkitEntity(),
-+                        entity.getBukkitEntity()
-+                    );
-+                    if (!event.callEvent()) return;
++                    // Paper start - Guard VehicleEntityCollisionEvent when no plugins listen
++                    if (org.bukkit.event.vehicle.VehicleEntityCollisionEvent.getHandlerList().getRegisteredListeners().length != 0) {
++                        org.bukkit.event.vehicle.VehicleEntityCollisionEvent event = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
++                            (org.bukkit.entity.Vehicle) this.getBukkitEntity(),
++                            entity.getBukkitEntity()
++                        );
++                        if (!event.callEvent()) return;
++                    }
++                    // Paper end - Guard VehicleEntityCollisionEvent when no plugins listen
 +                }
 +                // CraftBukkit end
                  super.push(entity);
@@ -46,17 +50,21 @@
          } else if (entity.getBoundingBox().minY <= this.getBoundingBox().minY) {
 +            // CraftBukkit start
 +            if (!this.isPassengerOfSameVehicle(entity)) {
-+                org.bukkit.event.vehicle.VehicleEntityCollisionEvent event = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
-+                    (org.bukkit.entity.Vehicle) this.getBukkitEntity(),
-+                    entity.getBukkitEntity()
-+                );
-+                if (!event.callEvent()) return;
++                // Paper start - Guard VehicleEntityCollisionEvent when no plugins listen
++                if (org.bukkit.event.vehicle.VehicleEntityCollisionEvent.getHandlerList().getRegisteredListeners().length != 0) {
++                    org.bukkit.event.vehicle.VehicleEntityCollisionEvent event = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
++                        (org.bukkit.entity.Vehicle) this.getBukkitEntity(),
++                        entity.getBukkitEntity()
++                    );
++                    if (!event.callEvent()) return;
++                }
++                // Paper end - Guard VehicleEntityCollisionEvent when no plugins listen
 +            }
 +            // CraftBukkit end
              super.push(entity);
          }
      }
-@@ -246,6 +_,18 @@
+@@ -246,6 +_,20 @@
              this.setDeltaMovement(Vec3.ZERO);
          }
  
@@ -64,9 +72,11 @@
 +        org.bukkit.Location to = org.bukkit.craftbukkit.util.CraftLocation.toBukkit(this.position(), this.level(), this.getYRot(), this.getXRot());
 +        org.bukkit.entity.Vehicle vehicle = (org.bukkit.entity.Vehicle) this.getBukkitEntity();
 +
-+        new org.bukkit.event.vehicle.VehicleUpdateEvent(vehicle).callEvent();
++        if (org.bukkit.event.vehicle.VehicleUpdateEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard VehicleUpdateEvent when no plugins listen
++            new org.bukkit.event.vehicle.VehicleUpdateEvent(vehicle).callEvent();
++        }
 +
-+        if (this.lastLocation != null && !this.lastLocation.equals(to)) {
++        if (this.lastLocation != null && !this.lastLocation.equals(to) && org.bukkit.event.vehicle.VehicleMoveEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard VehicleMoveEvent when no plugins listen
 +            org.bukkit.event.vehicle.VehicleMoveEvent event = new org.bukkit.event.vehicle.VehicleMoveEvent(vehicle, this.lastLocation, to);
 +            event.callEvent();
 +        }

--- a/paper-server/patches/sources/net/minecraft/world/entity/vehicle/minecart/AbstractMinecart.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/vehicle/minecart/AbstractMinecart.java.patch
@@ -18,7 +18,7 @@
  
      protected AbstractMinecart(final EntityType<?> type, final Level level) {
          super(type, level);
-@@ -161,11 +_,19 @@
+@@ -161,11 +_,21 @@
  
      @Override
      public boolean canCollideWith(final Entity entity) {
@@ -29,8 +29,10 @@
 +            return false;
 +        }
 +
-+        org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent((org.bukkit.entity.Vehicle) this.getBukkitEntity(), entity.getBukkitEntity());
-+        return collisionEvent.callEvent();
++        // Paper start - Guard VehicleEntityCollisionEvent when no plugins listen
++        return org.bukkit.event.vehicle.VehicleEntityCollisionEvent.getHandlerList().getRegisteredListeners().length == 0
++            || new org.bukkit.event.vehicle.VehicleEntityCollisionEvent((org.bukkit.entity.Vehicle) this.getBukkitEntity(), entity.getBukkitEntity()).callEvent();
++        // Paper end - Guard VehicleEntityCollisionEvent when no plugins listen
 +        // Paper end - fix VehicleEntityCollisionEvent not called when colliding with player
      }
  
@@ -55,7 +57,7 @@
          if (this.getHurtTime() > 0) {
              this.setHurtTime(this.getHurtTime() - 1);
          }
-@@ -280,8 +_,20 @@
+@@ -280,8 +_,22 @@
  
          this.checkBelowWorld();
          this.computeSpeed();
@@ -68,9 +70,11 @@
 +        org.bukkit.Location to = org.bukkit.craftbukkit.util.CraftLocation.toBukkit(this.position(), this.level(), this.getYRot(), this.getXRot());
 +        org.bukkit.entity.Vehicle vehicle = (org.bukkit.entity.Vehicle) this.getBukkitEntity();
 +
-+        new org.bukkit.event.vehicle.VehicleUpdateEvent(vehicle).callEvent();
++        if (org.bukkit.event.vehicle.VehicleUpdateEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard VehicleUpdateEvent when no plugins listen
++            new org.bukkit.event.vehicle.VehicleUpdateEvent(vehicle).callEvent();
++        }
 +
-+        if (!from.equals(to)) {
++        if (!from.equals(to) && org.bukkit.event.vehicle.VehicleMoveEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard VehicleMoveEvent when no plugins listen
 +            new org.bukkit.event.vehicle.VehicleMoveEvent(vehicle, from, to).callEvent();
 +        }
 +        // CraftBukkit end
@@ -112,7 +116,7 @@
      }
  
      @Override
-@@ -495,13 +_,29 @@
+@@ -495,13 +_,31 @@
  
          output.putBoolean("FlippedRotation", this.flipped);
          output.putBoolean("HasTicked", this.firstTick);
@@ -133,11 +137,13 @@
 +                    if (io.papermc.paper.event.entity.EntityCollideWithEntityEvent.getHandlerList().getRegisteredListeners().length != 0 &&
 +                            !new io.papermc.paper.event.entity.EntityCollideWithEntityEvent(this.getBukkitEntity(), entity.getBukkitEntity()).callEvent()) return;
 +
-+                    org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
-+                        (org.bukkit.entity.Vehicle) this.getBukkitEntity(),
-+                        entity.getBukkitEntity()
-+                    );
-+                    if (!collisionEvent.callEvent()) return;
++                    if (org.bukkit.event.vehicle.VehicleEntityCollisionEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard VehicleEntityCollisionEvent when no plugins listen
++                        org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
++                            (org.bukkit.entity.Vehicle) this.getBukkitEntity(),
++                            entity.getBukkitEntity()
++                        );
++                        if (!collisionEvent.callEvent()) return;
++                    }
 +                    // Paper end - Collision Events
                      double xa = entity.getX() - this.getX();
                      double za = entity.getZ() - this.getZ();

--- a/paper-server/patches/sources/net/minecraft/world/entity/vehicle/minecart/NewMinecartBehavior.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/vehicle/minecart/NewMinecartBehavior.java.patch
@@ -23,49 +23,55 @@
      }
  
      @Override
-@@ -523,6 +_,13 @@
+@@ -523,6 +_,15 @@
                          && !(entity instanceof AbstractMinecart)
                          && !this.minecart.isVehicle()
                          && !entity.isPassenger()) {
 +                        // CraftBukkit start
-+                        org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
-+                            (org.bukkit.entity.Vehicle) this.minecart.getBukkitEntity(),
-+                            entity.getBukkitEntity()
-+                        );
-+                        if (!collisionEvent.callEvent()) continue;
++                        if (org.bukkit.event.vehicle.VehicleEntityCollisionEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard VehicleEntityCollisionEvent when no plugins listen
++                            org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
++                                (org.bukkit.entity.Vehicle) this.minecart.getBukkitEntity(),
++                                entity.getBukkitEntity()
++                            );
++                            if (!collisionEvent.callEvent()) continue;
++                        }
 +                        // CraftBukkit end
                          boolean pickedUp = entity.startRiding(this.minecart);
                          if (pickedUp) {
                              return true;
-@@ -546,6 +_,17 @@
+@@ -546,6 +_,19 @@
                          || entity instanceof AbstractMinecart
                          || this.minecart.isVehicle()
                          || entity.isPassenger()) {
 +                        // CraftBukkit start
 +                        if (!this.minecart.isPassengerOfSameVehicle(entity)) {
-+                            org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
-+                                (org.bukkit.entity.Vehicle) this.minecart.getBukkitEntity(),
-+                                entity.getBukkitEntity()
-+                            );
-+                            if (!collisionEvent.callEvent()) {
-+                                continue;
++                            if (org.bukkit.event.vehicle.VehicleEntityCollisionEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard VehicleEntityCollisionEvent when no plugins listen
++                                org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
++                                    (org.bukkit.entity.Vehicle) this.minecart.getBukkitEntity(),
++                                    entity.getBukkitEntity()
++                                );
++                                if (!collisionEvent.callEvent()) {
++                                    continue;
++                                }
 +                            }
 +                        }
 +                        // CraftBukkit end
                          entity.push(this.minecart);
                          pushed = true;
                      }
-@@ -554,6 +_,15 @@
+@@ -554,6 +_,17 @@
          } else {
              for (Entity entity : this.level().getEntities(this.minecart, hitbox)) {
                  if (!this.minecart.hasPassenger(entity) && entity.isPushable() && entity instanceof AbstractMinecart) {
 +                    // CraftBukkit start
-+                    org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
-+                        (org.bukkit.entity.Vehicle) this.minecart.getBukkitEntity(),
-+                        entity.getBukkitEntity()
-+                    );
-+                    if (!collisionEvent.callEvent()) {
-+                        continue;
++                    if (org.bukkit.event.vehicle.VehicleEntityCollisionEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard VehicleEntityCollisionEvent when no plugins listen
++                        org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
++                            (org.bukkit.entity.Vehicle) this.minecart.getBukkitEntity(),
++                            entity.getBukkitEntity()
++                        );
++                        if (!collisionEvent.callEvent()) {
++                            continue;
++                        }
 +                    }
 +                    // CraftBukkit end
                      entity.push(this.minecart);

--- a/paper-server/patches/sources/net/minecraft/world/entity/vehicle/minecart/OldMinecartBehavior.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/vehicle/minecart/OldMinecartBehavior.java.patch
@@ -1,37 +1,43 @@
 --- a/net/minecraft/world/entity/vehicle/minecart/OldMinecartBehavior.java
 +++ b/net/minecraft/world/entity/vehicle/minecart/OldMinecartBehavior.java
-@@ -375,8 +_,22 @@
+@@ -375,8 +_,26 @@
                          && !(entity instanceof AbstractMinecart)
                          && !this.minecart.isVehicle()
                          && !entity.isPassenger()) {
 +                        // CraftBukkit start
-+                        org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
-+                            (org.bukkit.entity.Vehicle) this.minecart.getBukkitEntity(), entity.getBukkitEntity()
-+                        );
-+                        if (!collisionEvent.callEvent()) continue;
-+                        // CraftBukkit end
-                         entity.startRiding(this.minecart);
-                     } else {
-+                        // CraftBukkit start
-+                        if (!this.minecart.isPassengerOfSameVehicle(entity)) {
++                        if (org.bukkit.event.vehicle.VehicleEntityCollisionEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard VehicleEntityCollisionEvent when no plugins listen
 +                            org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
 +                                (org.bukkit.entity.Vehicle) this.minecart.getBukkitEntity(), entity.getBukkitEntity()
 +                            );
 +                            if (!collisionEvent.callEvent()) continue;
 +                        }
 +                        // CraftBukkit end
+                         entity.startRiding(this.minecart);
+                     } else {
++                        // CraftBukkit start
++                        if (!this.minecart.isPassengerOfSameVehicle(entity)) {
++                            if (org.bukkit.event.vehicle.VehicleEntityCollisionEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard VehicleEntityCollisionEvent when no plugins listen
++                                org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
++                                    (org.bukkit.entity.Vehicle) this.minecart.getBukkitEntity(), entity.getBukkitEntity()
++                                );
++                                if (!collisionEvent.callEvent()) continue;
++                            }
++                        }
++                        // CraftBukkit end
                          entity.push(this.minecart);
                      }
                  }
-@@ -384,6 +_,12 @@
+@@ -384,6 +_,14 @@
          } else {
              for (Entity entity : this.level().getEntities(this.minecart, hitbox)) {
                  if (!this.minecart.hasPassenger(entity) && entity.isPushable() && entity instanceof AbstractMinecart) {
 +                    // CraftBukkit start
-+                    org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
-+                        (org.bukkit.entity.Vehicle) this.minecart.getBukkitEntity(), entity.getBukkitEntity()
-+                    );
-+                    if (!collisionEvent.callEvent()) continue;
++                    if (org.bukkit.event.vehicle.VehicleEntityCollisionEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard VehicleEntityCollisionEvent when no plugins listen
++                        org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent(
++                            (org.bukkit.entity.Vehicle) this.minecart.getBukkitEntity(), entity.getBukkitEntity()
++                        );
++                        if (!collisionEvent.callEvent()) continue;
++                    }
 +                    // CraftBukkit end
                      entity.push(this.minecart);
                  }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/BaseFireBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/BaseFireBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          effectApplier.apply(InsideBlockEffectType.CLEAR_FREEZE);
          effectApplier.apply(InsideBlockEffectType.FIRE_IGNITE);
          effectApplier.runAfter(InsideBlockEffectType.FIRE_IGNITE, e -> e.hurt(e.level().damageSources().inFire(), this.fireDamage));

--- a/paper-server/patches/sources/net/minecraft/world/level/block/BasePressurePlateBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/BasePressurePlateBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (!level.isClientSide()) {
              int signal = this.getSignalForState(state);
              if (signal == 0) {

--- a/paper-server/patches/sources/net/minecraft/world/level/block/BigDripleafBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/BigDripleafBlock.java.patch
@@ -13,7 +13,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (!level.isClientSide()) {
              if (state.getValue(TILT) == Tilt.NONE && canEntityTilt(pos, entity) && !level.hasNeighborSignal(pos)) {
 -                this.setTiltAndScheduleTick(state, level, pos, Tilt.UNSTABLE, null);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/BubbleColumnBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/BubbleColumnBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (isPrecise) {
              BlockState stateAbove = level.getBlockState(pos.above());
              boolean nothingAbove = stateAbove.getCollisionShape(level, pos).isEmpty() && stateAbove.getFluidState().isEmpty();

--- a/paper-server/patches/sources/net/minecraft/world/level/block/ButtonBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/ButtonBlock.java.patch
@@ -26,7 +26,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (!level.isClientSide() && this.type.canButtonBeActivatedByArrows() && !state.getValue(POWERED)) {
              this.checkPressed(state, level, pos);
          }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/CactusBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/CactusBlock.java.patch
@@ -29,7 +29,7 @@
          final boolean isPrecise
      ) {
 -        entity.hurt(level.damageSources().cactus(), 1.0F);
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
 +        entity.hurt(level.damageSources().cactus().eventBlockDamager(level, pos), 1.0F); // CraftBukkit
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/level/block/CampfireBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/CampfireBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (state.getValue(LIT) && entity instanceof LivingEntity) {
 -            entity.hurt(level.damageSources().campfire(), this.fireDamage);
 +            entity.hurt(level.damageSources().campfire().eventBlockDamager(level, pos), this.fireDamage); // CraftBukkit

--- a/paper-server/patches/sources/net/minecraft/world/level/block/CropBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/CropBlock.java.patch
@@ -42,7 +42,7 @@
          final boolean isPrecise
      ) {
 -        if (level instanceof ServerLevel serverLevel && entity instanceof Ravager && serverLevel.getGameRules().get(GameRules.MOB_GRIEFING)) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
 +        if (level instanceof ServerLevel serverLevel && entity instanceof Ravager && org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(entity, pos, Blocks.AIR.defaultBlockState(), !serverLevel.getGameRules().get(GameRules.MOB_GRIEFING))) { // CraftBukkit
              serverLevel.destroyBlock(pos, true, entity);
          }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/DetectorRailBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/DetectorRailBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (!level.isClientSide()) {
              if (!state.getValue(POWERED)) {
                  this.checkPressed(level, pos, state);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/EndGatewayBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/EndGatewayBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (entity.canUsePortal(false)
              && !level.isClientSide()
              && level.getBlockEntity(pos) instanceof TheEndGatewayBlockEntity endGatewayBlockEntity

--- a/paper-server/patches/sources/net/minecraft/world/level/block/EndPortalBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/EndPortalBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (entity.canUsePortal(false)) {
 +            // CraftBukkit start - Entity in portal
 +            org.bukkit.event.entity.EntityPortalEnterEvent event = new org.bukkit.event.entity.EntityPortalEnterEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.util.CraftLocation.toBukkit(pos, level), org.bukkit.PortalType.ENDER); // Paper - add portal type

--- a/paper-server/patches/sources/net/minecraft/world/level/block/EyeblossomBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/EyeblossomBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (!level.isClientSide()
              && level.getDifficulty() != Difficulty.PEACEFUL
              && entity instanceof Bee bee

--- a/paper-server/patches/sources/net/minecraft/world/level/block/FrogspawnBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/FrogspawnBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (entity.is(EntityTypes.FALLING_BLOCK)) {
              this.destroyBlock(level, pos);
          }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/HoneyBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/HoneyBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (this.isSlidingDown(pos, entity)) {
              this.maybeDoSlideAchievement(entity, pos);
              this.doSlideMovement(entity);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/HopperBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/HopperBlock.java.patch
@@ -14,7 +14,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (level.getBlockEntity(pos) instanceof HopperBlockEntity hopperBlockEntity) {
              HopperBlockEntity.entityInside(level, pos, state, entity, hopperBlockEntity);
          }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/LavaCauldronBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/LavaCauldronBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
 +        BlockPos savedPos = pos.immutable(); // Paper - track lava contact
          effectApplier.apply(InsideBlockEffectType.CLEAR_FREEZE);
          effectApplier.apply(InsideBlockEffectType.LAVA_IGNITE);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/LayeredCauldronBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/LayeredCauldronBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (level instanceof ServerLevel serverLevel) {
              BlockPos blockPos = pos.immutable();
              effectApplier.runBefore(InsideBlockEffectType.EXTINGUISH, e -> {

--- a/paper-server/patches/sources/net/minecraft/world/level/block/LilyPadBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/LilyPadBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          super.entityInside(state, level, pos, entity, effectApplier, isPrecise);
          if (level instanceof ServerLevel && entity instanceof AbstractBoat) {
 +            // CraftBukkit start

--- a/paper-server/patches/sources/net/minecraft/world/level/block/NetherPortalBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/NetherPortalBlock.java.patch
@@ -28,7 +28,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (entity.canUsePortal(false)) {
 +            // CraftBukkit start - Entity in portal
 +            org.bukkit.event.entity.EntityPortalEnterEvent event = new org.bukkit.event.entity.EntityPortalEnterEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.util.CraftLocation.toBukkit(pos, level), org.bukkit.PortalType.NETHER); // Paper - add portal type

--- a/paper-server/patches/sources/net/minecraft/world/level/block/PitcherCropBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/PitcherCropBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (level instanceof ServerLevel serverLevel && entity instanceof Ravager && serverLevel.getGameRules().get(GameRules.MOB_GRIEFING)) {
              serverLevel.destroyBlock(pos, true, entity);
          }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/PowderSnowBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/PowderSnowBlock.java.patch
@@ -5,7 +5,7 @@
          final boolean isPrecise
      ) {
 +        // Paper start - Add EntityInsideBlockEvent
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) {
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { // Paper - Guard when no plugins listen
 +            if (entity instanceof net.minecraft.server.level.ServerPlayer player) {
 +                player.resendPossiblyDesyncedDataValues(java.util.List.of(net.minecraft.world.entity.Entity.DATA_TICKS_FROZEN), player); // prevent desync on cancelled event
 +            }

--- a/paper-server/patches/sources/net/minecraft/world/level/block/SweetBerryBushBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/SweetBerryBushBlock.java.patch
@@ -16,7 +16,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (entity instanceof LivingEntity && !entity.is(EntityTypes.FOX) && !entity.is(EntityTypes.BEE)) {
              entity.makeStuckInBlock(state, new Vec3(0.8F, 0.75, 0.8F));
              if (level instanceof ServerLevel serverLevel && state.getValue(AGE) != 0) {

--- a/paper-server/patches/sources/net/minecraft/world/level/block/TripWireBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/TripWireBlock.java.patch
@@ -53,7 +53,7 @@
          final boolean isPrecise
      ) {
 +        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent tripwires from detecting collision
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (!level.isClientSide()) {
              if (!state.getValue(POWERED) && !level.getBlockTicks().hasScheduledTick(pos, this)) {
                  this.checkPressed(level, pos, List.of(entity));

--- a/paper-server/patches/sources/net/minecraft/world/level/block/WebBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/WebBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          Vec3 speedMultiplier = new Vec3(0.25, 0.05F, 0.25);
          if (entity instanceof LivingEntity livingEntity && livingEntity.hasEffect(MobEffects.WEAVING)) {
              speedMultiplier = new Vec3(0.5, 0.25, 0.5);

--- a/paper-server/patches/sources/net/minecraft/world/level/block/WitherRoseBlock.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/block/WitherRoseBlock.java.patch
@@ -4,7 +4,7 @@
          final InsideBlockEffectApplier effectApplier,
          final boolean isPrecise
      ) {
-+        if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
++        if (io.papermc.paper.event.entity.EntityInsideBlockEvent.getHandlerList().getRegisteredListeners().length != 0 && !new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent; Guard when no plugins listen
          if (level instanceof ServerLevel serverLevel
              && level.getDifficulty() != Difficulty.PEACEFUL
              && entity instanceof LivingEntity livingEntity

--- a/paper-server/patches/sources/net/minecraft/world/level/material/FlowingFluid.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/material/FlowingFluid.java.patch
@@ -1,22 +1,24 @@
 --- a/net/minecraft/world/level/material/FlowingFluid.java
 +++ b/net/minecraft/world/level/material/FlowingFluid.java
-@@ -120,6 +_,15 @@
+@@ -120,6 +_,17 @@
                  Fluid newBelowFluidType = newBelowFluid.getType();
                  if (belowFluid.canBeReplacedWith(level, belowPos, newBelowFluidType, Direction.DOWN)
                      && canHoldSpecificFluid(level, belowPos, belowState, newBelowFluidType)) {
 +                    // CraftBukkit start
 +                    org.bukkit.block.Block source = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
-+                    org.bukkit.event.block.BlockFromToEvent event = new org.bukkit.event.block.BlockFromToEvent(source, org.bukkit.block.BlockFace.DOWN);
-+                    level.getCraftServer().getPluginManager().callEvent(event);
++                    if (org.bukkit.event.block.BlockFromToEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard BlockFromToEvent when no plugins listen
++                        org.bukkit.event.block.BlockFromToEvent event = new org.bukkit.event.block.BlockFromToEvent(source, org.bukkit.block.BlockFace.DOWN);
++                        level.getCraftServer().getPluginManager().callEvent(event);
 +
-+                    if (event.isCancelled()) {
-+                        return;
++                        if (event.isCancelled()) {
++                            return;
++                        }
 +                    }
 +                    // CraftBukkit end
                      this.spreadTo(level, belowPos, belowState, Direction.DOWN, newBelowFluid);
                      if (this.sourceNeighborCount(level, pos) >= 3) {
                          this.spreadToSides(level, pos, fluidState, state);
-@@ -148,7 +_,18 @@
+@@ -148,7 +_,20 @@
                  Direction spread = entry.getKey();
                  FluidState newNeighborFluid = entry.getValue();
                  BlockPos neighborPos = pos.relative(spread);
@@ -25,11 +27,13 @@
 +                if (neighborState == null) continue; // Paper - Prevent chunk loading from fluid flowing
 +                // CraftBukkit start
 +                org.bukkit.block.Block source = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos);
-+                org.bukkit.event.block.BlockFromToEvent event = new org.bukkit.event.block.BlockFromToEvent(source, org.bukkit.craftbukkit.block.CraftBlock.notchToBlockFace(spread));
-+                level.getCraftServer().getPluginManager().callEvent(event);
++                if (org.bukkit.event.block.BlockFromToEvent.getHandlerList().getRegisteredListeners().length != 0) { // Paper - Guard BlockFromToEvent when no plugins listen
++                    org.bukkit.event.block.BlockFromToEvent event = new org.bukkit.event.block.BlockFromToEvent(source, org.bukkit.craftbukkit.block.CraftBlock.notchToBlockFace(spread));
++                    level.getCraftServer().getPluginManager().callEvent(event);
 +
-+                if (event.isCancelled()) {
-+                    continue;
++                    if (event.isCancelled()) {
++                        continue;
++                    }
 +                }
 +                // CraftBukkit end
 +                this.spreadTo(level, neighborPos, neighborState, spread, newNeighborFluid); // Paper - Prevent chunk loading from fluid flowing

--- a/paper-server/patches/sources/net/minecraft/world/level/redstone/NeighborUpdater.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/redstone/NeighborUpdater.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/redstone/NeighborUpdater.java
 +++ b/net/minecraft/world/level/redstone/NeighborUpdater.java
-@@ -66,8 +_,26 @@
+@@ -66,8 +_,28 @@
          final @Nullable Orientation orientation,
          final boolean movedByPiston
      ) {
@@ -12,11 +12,13 @@
 +        // Paper end - Add source block to BlockPhysicsEvent
          try {
 +            // CraftBukkit start
-+            org.bukkit.event.block.BlockPhysicsEvent event = new org.bukkit.event.block.BlockPhysicsEvent(org.bukkit.craftbukkit.block.CraftBlock.at(level, pos), state.asBlockData(), org.bukkit.craftbukkit.block.CraftBlock.at(level, sourcePos)); // Paper - Add source block to BlockPhysicsEvent
-+            level.getCraftServer().getPluginManager().callEvent(event);
++            if (level instanceof net.minecraft.server.level.ServerLevel serverLevel && serverLevel.hasPhysicsEvent) { // Paper - Guard BlockPhysicsEvent when no plugins listen
++                org.bukkit.event.block.BlockPhysicsEvent event = new org.bukkit.event.block.BlockPhysicsEvent(org.bukkit.craftbukkit.block.CraftBlock.at(level, pos), state.asBlockData(), org.bukkit.craftbukkit.block.CraftBlock.at(level, sourcePos)); // Paper - Add source block to BlockPhysicsEvent
++                level.getCraftServer().getPluginManager().callEvent(event);
 +
-+            if (event.isCancelled()) {
-+                return;
++                if (event.isCancelled()) {
++                    return;
++                }
 +            }
 +            // CraftBukkit end
              state.handleNeighborChanged(level, pos, changedBlock, orientation, movedByPiston);


### PR DESCRIPTION
Fixes #14153

## What does this PR do?

Optimizes Bukkit event handling in frequently executed paths by checking for registered listeners before creating and dispatching events.

Affected areas:
- Entity and vehicle collisions/movement.
- Fluid flow.
- Block physics.
- `EntityInsideBlockEvent`.

When listeners exist, the guarded event paths remain unchanged:
- Events are still created and dispatched.
- Event modifications still work.
- Cancellation still works.

No public API or listener registration behavior was changed.

When no listeners are registered, event dispatch is skipped while normal vanilla behavior remains.

## Testing

Validated with:

- `:paper-server:compileJava`
- `fixupSourcePatches`
- `rebuildPatches`
- Full `build`
- `git diff --cached --check`

Listener-enabled test:

```text
EntityInsideBlockEvent handlers: 1
Calls: 40,200
Dispatches: 40,200

Cactus health:
10.0 -> 10.0
````

Listener-disabled test:

```text
EntityInsideBlockEvent handlers: 0
Calls: 40,200
Dispatches: 0

BlockPhysicsEvent dispatches: 0

Cactus health:
10.0 -> 9.0
```

Java Flight Recorder was used with a synthetic workload as allocation evidence:

```text
Patched: 0 EntityInsideBlockEvent allocation samples
Baseline: 4 EntityInsideBlockEvent allocation samples
```

This is targeted validation evidence only and is not a production benchmark or a percentage performance measurement.

The synthetic vehicle workload did not successfully trigger the vanilla vehicle event paths, so those paths were not runtime validated.

## AI Assistance Disclosure

AI assistance was used for repository inspection and implementation assistance.

I reviewed the changes, understand the implementation, and verified the results before submission.