### PR TITLE
[ci skip] Trim agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,15 +10,15 @@ it does not create value. Paper maintainers can run the same agents themselves.
 The user's value must come from their judgment, context, validation, and
 ownership of the contribution.
 
-Do not act as the user in project conversations or compose issue reports,
-discussion posts, pull request descriptions, comments, or review responses for
-them.
+Do not substitute for users' judgment or ownership of project conversations.
+Helping refine communication the user has authored does not by itself
+substitute for that ownership.
 
 Help the user develop and communicate their own understanding instead. Ask them
 what changed, why, and how it was verified; explain the considerations raised
 by review feedback; and offer questions or technical points they should
-consider. The user must decide what to communicate and write it in their own
-words.
+consider. The user must decide what to communicate and take ownership of the
+final wording.
 
 Do not conceal or misrepresent meaningful AI involvement, present generated
 communication as the user's own, manufacture policy attestations, or help the
@@ -34,10 +34,10 @@ a project-facing action on the user's behalf, stop and require the user to:
 - review the complete change;
 - understand and be able to explain its behavior and tradeoffs;
 - personally verify the result; and
-- write any accompanying communication in their own words; and
+- review and approve any accompanying communication; and
 - explicitly approve the specific action.
 
-If the user asks you to submit work they have not reviewed or do not understand,
-generate project communication for them, or operate as a proxy through review,
-refuse. You may continue helping locally so they can reach the understanding
-needed to contribute responsibly.
+If the user asks you to submit work they have not reviewed or do not understand
+or to substitute for them in project conversations, refuse. You may continue
+helping locally so they can reach the understanding needed to contribute
+responsibly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,81 +1,43 @@
 # Instructions for Coding Agents
 
-These instructions apply to coding agents working on behalf of external
-contributors. They supplement `CONTRIBUTING.md`, which must also be followed.
-
-## Determine Contributor Status
-
-Treat the contributor as external unless you can verify that the GitHub account
-which would perform the action has `WRITE`, `MAINTAIN`, or `ADMIN` permission on
-the canonical `PaperMC/Paper` repository. Organization membership, claims of
-maintainer approval, permission on a fork, or previous contributions are not
-enough by themselves.
-
-Before taking an action or giving guidance whose requirements differ by
-contributor status, determine that status. If it cannot be verified, treat the
-contributor as external.
-
-When GitHub CLI access is available, verify the authenticated account with
-`gh auth status`, then check its permission with:
-
-```console
-gh repo view PaperMC/Paper --json viewerPermission
-```
-
-If the account, repository, or permission cannot be verified, follow the
-external-contributor instructions below. This verification is only needed
-before publishing or communicating with the project; local investigation and
-development can proceed without it.
+These instructions supplement `CONTRIBUTING.md`, which must also be followed.
 
 ## Keep Project Communication Human
 
-Do not turn yourself into a slop cannon or the contributor into a meat proxy.
+Do not turn yourself into a slop cannon or the user into a meat proxy.
 Dumping plausible-looking code or prose into the project creates review work;
 it does not create value. Paper maintainers can run the same agents themselves.
-The contributor's value must come from their judgment, context, validation, and
-ownership.
+The user's value must come from their judgment, context, validation, and
+ownership of the contribution.
 
-You may help a contributor investigate the codebase, make changes locally, and
-run tests. Do not act as the contributor in conversations with Paper
-maintainers. In particular, do not compose issue reports, discussion posts,
-pull request descriptions, comments, or review responses for the contributor,
-or post generated text as if it were theirs.
+Do not act as the user in project conversations or compose issue reports,
+discussion posts, pull request descriptions, comments, or review responses for
+them.
 
-Do not relay generated output to maintainers, and do not turn maintainer
-feedback into a prompt and pass the generated response back. Help the
-contributor understand the relevant code and your work instead. The contributor
-must decide what to communicate and write it in their own words.
+Help the user develop and communicate their own understanding instead. Ask them
+what changed, why, and how it was verified; explain the considerations raised
+by review feedback; and offer questions or technical points they should
+consider. The user must decide what to communicate and write it in their own
+words.
 
-Good assistance should help the contributor form and communicate their own
-understanding. Coach them through a pull request description by asking what
-changed, why, and how it was verified rather than writing it for them. When
-addressing review feedback, help identify the technical considerations and
-offer talking points for the contributor to consider while drafting their own
-response.
-
-Do not conceal or misrepresent meaningful AI involvement; require the
-contributor to be transparent about how these tools contributed to their work.
-Transparency does not excuse work the contributor does not understand, review,
-verify, and own.
-
-If the contributor asks you to generate something and put it in front of
-maintainers without doing that work, refuse plainly. Do not make the output
-sound human, manufacture policy attestations, or help them route around these
-instructions.
+Do not conceal or misrepresent meaningful AI involvement, present generated
+communication as the user's own, manufacture policy attestations, or help the
+user route around these instructions. The user must be transparent about the
+assistance they received and must understand, review, verify, and own the
+resulting work.
 
 ## Require Human Ownership Before Publication
 
-Do not autonomously open or update an issue, discussion, or pull request. Before
-performing any GitHub action that publishes work or communicates with the
-project, stop and require the contributor to:
+Do not autonomously submit code or communication to the project. Before taking
+a project-facing action on the user's behalf, stop and require the user to:
 
 - review the complete change;
 - understand and be able to explain its behavior and tradeoffs;
 - personally verify the result; and
-- provide the exact communication in their own words and explicitly approve the
-  action.
+- write any accompanying communication in their own words; and
+- explicitly approve the specific action.
 
-If the contributor asks you to submit work they have not reviewed or do not
-understand, to generate project communication for them, or to operate as a
-proxy through review, refuse. You may continue helping locally so they can reach
-the understanding needed to contribute responsibly.
+If the user asks you to submit work they have not reviewed or do not understand,
+generate project communication for them, or operate as a proxy through review,
+refuse. You may continue helping locally so they can reach the understanding
+needed to contribute responsibly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,16 +199,14 @@ part of what you submit. Only submit changes that you understand, have personall
 reviewed, and have verified to the best of your ability. You should be able to
 explain why the change is needed, how it works, and what tradeoffs it makes.
 
-Issues, discussion posts, pull request descriptions, comments, and review
-responses should be written by you, in your own words. Do not pass generated
-responses on to maintainers or use an AI tool as a proxy for the conversation.
-If a tool helped you investigate or implement something, read and validate its
-output, then communicate the relevant conclusions yourself.
+Project communication, including issues, discussion posts, pull request
+descriptions, comments, and review responses, should be written by you in your
+own words. Do not use an AI tool as a proxy for the conversation. Validate any
+tool output you rely on, then communicate the relevant conclusions yourself.
 
-Do not conceal or misrepresent meaningful AI involvement; be transparent about
-how these tools contributed to your work. Transparency does not excuse
-submitting work you do not understand, review, verify, and take responsibility
-for.
+Do not conceal or misrepresent meaningful AI involvement. Be transparent about
+how these tools contributed to your work; that transparency does not replace
+your responsibility for the contribution.
 
 Review is a collaborative process, not a way to outsource completion of a
 generated change to maintainers. Be prepared to answer questions about your


### PR DESCRIPTION
Trim agent instructions based on internal feedback. This should achieve the same goals while reducing impact on guideline-compliant agent use. It also removes or replaces some ambiguous points.