### PR TITLE
Extend Jigsaw TileState

### DIFF
--- a/paper-api/src/main/java/org/bukkit/block/Jigsaw.java
+++ b/paper-api/src/main/java/org/bukkit/block/Jigsaw.java
@@ -1,6 +1,56 @@
 package org.bukkit.block;
 
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents a captured state of a jigsaw.
  */
-public interface Jigsaw extends TileState { }
+public interface Jigsaw extends TileState {
+
+    /**
+     * Gets the Target Pool Structure key
+     *
+     * @return The NamespacedKey of the Jigsaw's Target Pool
+     */
+    @NotNull
+    NamespacedKey getTargetPool();
+
+    /**
+     * Sets the Target Pool Structure key
+     *
+     * @param targetPool the key of target Pool
+     */
+    void setTargetPool(@NotNull NamespacedKey targetPool);
+
+    /**
+     * Gets the Name of the Jigsaw Block
+     *
+     * @return The NamespacedKey of the Jigsaw Block
+     */
+    @NotNull
+    NamespacedKey getName();
+
+    /**
+     * Sets the Name of the Jigsaw Block
+     *
+     * @param name the name of the Jigsaw Block
+     */
+    void setName(@NotNull NamespacedKey name);
+
+    /**
+     * Gets the Target Name of the Jigsaw Block
+     *
+     * @return The NamespacedKey of the Jigsaw's Target Name
+     */
+    @NotNull
+    NamespacedKey getTargetName();
+
+    /**
+     * Sets the Target Name of the Jigsaw Block
+     *
+     * @param targetName the target name of the Jigsaw Block
+     */
+    void setTargetName(@NotNull NamespacedKey targetName);
+
+}

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftJigsaw.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/block/CraftJigsaw.java
@@ -1,9 +1,17 @@
 package org.bukkit.craftbukkit.block;
 
+import com.google.common.base.Preconditions;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.entity.JigsawBlockEntity;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Jigsaw;
+import org.bukkit.craftbukkit.util.CraftNamespacedKey;
+import org.jetbrains.annotations.NotNull;
+import java.util.Objects;
+
+import static net.minecraft.core.registries.Registries.TEMPLATE_POOL;
 
 public class CraftJigsaw extends CraftBlockEntityState<JigsawBlockEntity> implements Jigsaw {
 
@@ -13,6 +21,45 @@ public class CraftJigsaw extends CraftBlockEntityState<JigsawBlockEntity> implem
 
     protected CraftJigsaw(CraftJigsaw state, Location location) {
         super(state, location);
+    }
+
+    @Override
+    @NotNull
+    public NamespacedKey getTargetPool() {
+        final Identifier targetPoolKey = getSnapshot().getPool().identifier();
+        return CraftNamespacedKey.fromMinecraft(targetPoolKey);
+    }
+
+    @Override
+    public void setTargetPool(final @NotNull NamespacedKey targetPool) {
+        Preconditions.checkArgument(Objects.nonNull(targetPool), "targetPool cannot be null");
+        getSnapshot().setPool(CraftNamespacedKey.toResourceKey(TEMPLATE_POOL, targetPool));
+    }
+
+    @Override
+    @NotNull
+    public NamespacedKey getName() {
+        final Identifier targetPoolKey = this.getSnapshot().getName();
+        return CraftNamespacedKey.fromMinecraft(targetPoolKey);
+    }
+
+    @Override
+    public void setName(final @NotNull NamespacedKey name) {
+        Preconditions.checkArgument(Objects.nonNull(name), "name cannot be null");
+        getSnapshot().setName(CraftNamespacedKey.toMinecraft(name));
+    }
+
+    @Override
+    @NotNull
+    public NamespacedKey getTargetName() {
+        final Identifier targetPoolKey = this.getSnapshot().getTarget();
+        return CraftNamespacedKey.fromMinecraft(targetPoolKey);
+    }
+
+    @Override
+    public void setTargetName(final @NotNull NamespacedKey targetName) {
+        Preconditions.checkArgument(Objects.nonNull(targetName), "targetName cannot be null");
+        getSnapshot().setTarget(CraftNamespacedKey.toMinecraft(targetName));
     }
 
     @Override


### PR DESCRIPTION
Currently there is no way to fetch information from the tilestate from jigsaw blocks. This PR extends the functionality of the Jigsaw tile state to allow fetching and changing of the `target pool`, `target name` and `name`. This allows Developers to use the jigsaw block to place own structures in a more profound way.

Arguably one could make the methods (`setTargetPool(final @NotNull NamespacedKey targetPool)`, `setName(final @NotNull NamespacedKey name)` and `void setTargetName(final @NotNull NamespacedKey targetName)`) `@Nullable`, and change the default Identifier in case of null to `minecraft:empty` (default value when placing a jigsaw). However this might be counterintuitive as developers default namespace is not `minecraft`, so I dont see any reason to change this. Also I haven't implemented the remaining options from the tilestate (`joint`, `finalState`, ...), this can be done using a different PR.


I've verified the changes using a small sample plugin. The Plugin intercepts the BlockPlacesEvent of an Jigsaw Block and prints the `target pool`, `target name` and `name`. Then it changes the `target pool`, `target name` and `name` using the setters and updates the tilestates. Afterwards it prints out the `target pool`, `target name` and `name` again. The output is plausible.