### PR TITLE
Add PlayerPrepareTeleportEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPrepareTeleportEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPrepareTeleportEvent.java
@@ -1,6 +1,5 @@
 package io.papermc.paper.event.player;
 
-import com.google.common.collect.ImmutableSet;
 import io.papermc.paper.entity.TeleportFlag;
 import java.util.Collections;
 import java.util.Set;
@@ -48,7 +47,7 @@ public class PlayerPrepareTeleportEvent extends PlayerEvent {
         super(player);
         this.to = to;
         this.cause = cause;
-        this.teleportFlags = ImmutableSet.copyOf(teleportFlags);
+        this.teleportFlags = Set.copyOf(teleportFlags);
     }
 
     /**

--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPrepareTeleportEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPrepareTeleportEvent.java
@@ -1,0 +1,81 @@
+package io.papermc.paper.event.player;
+
+import io.papermc.paper.entity.TeleportFlag;
+import java.util.Set;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Event that is fired before attempting to teleport a player (Allows for pre-teleport handling, such as dismounting passengers if teleporting cross-worlds etc.)
+ * <p>
+ * After the handling of this event, the player will attempt to teleport to the given location.
+ */
+@NullMarked
+public class PlayerPrepareTeleportEvent extends PlayerEvent {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final Location to;
+    private final PlayerTeleportEvent.TeleportCause cause;
+    private final Set<TeleportFlag> teleportFlags;
+
+    @ApiStatus.Internal
+    public PlayerPrepareTeleportEvent(final Player player, Location to, PlayerTeleportEvent.TeleportCause cause, Set<TeleportFlag> teleportFlags) {
+        super(player);
+        this.to = to;
+        this.cause = cause;
+        this.teleportFlags = teleportFlags;
+    }
+
+    /**
+     * Gets the location this player is teleporting to
+     *
+     * @return A copy of the Location the player is teleporting to
+     */
+    public Location getTo() {
+        return this.to.clone();
+    }
+
+    /**
+     * Gets the location this player is teleporting from
+     *
+     * @return A copy of the Location the player is moving from
+     */
+    public Location getFrom() {
+        return this.getPlayer().getLocation();
+    }
+
+    /**
+     * Returns the relative teleportation flags used in this teleportation.
+     * This determines which axis the player will not lose their velocity in.
+     *
+     * @return an immutable set of relative teleportation flags
+     */
+    public @Unmodifiable Set<TeleportFlag> getRelativeTeleportationFlags() {
+        return this.teleportFlags;
+    }
+
+    /**
+     * Gets the cause of this teleportation event
+     *
+     * @return Cause of the event
+     */
+    public PlayerTeleportEvent.TeleportCause getCause() {
+        return this.cause;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPrepareTeleportEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPrepareTeleportEvent.java
@@ -1,6 +1,7 @@
 package io.papermc.paper.event.player;
 
 import io.papermc.paper.entity.TeleportFlag;
+import java.util.Collections;
 import java.util.Set;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -24,6 +25,22 @@ public class PlayerPrepareTeleportEvent extends PlayerEvent {
     private final Location to;
     private final PlayerTeleportEvent.TeleportCause cause;
     private final Set<TeleportFlag> teleportFlags;
+
+    @ApiStatus.Internal
+    public PlayerPrepareTeleportEvent(final Player player, Location to) {
+        super(player);
+        this.to = to;
+        this.cause = PlayerTeleportEvent.TeleportCause.PLUGIN;
+        this.teleportFlags = Collections.emptySet();
+    }
+
+    @ApiStatus.Internal
+    public PlayerPrepareTeleportEvent(final Player player, Location to, PlayerTeleportEvent.TeleportCause cause) {
+        super(player);
+        this.to = to;
+        this.cause = cause;
+        this.teleportFlags = Collections.emptySet();
+    }
 
     @ApiStatus.Internal
     public PlayerPrepareTeleportEvent(final Player player, Location to, PlayerTeleportEvent.TeleportCause cause, Set<TeleportFlag> teleportFlags) {

--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPrepareTeleportEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerPrepareTeleportEvent.java
@@ -1,5 +1,6 @@
 package io.papermc.paper.event.player;
 
+import com.google.common.collect.ImmutableSet;
 import io.papermc.paper.entity.TeleportFlag;
 import java.util.Collections;
 import java.util.Set;
@@ -47,7 +48,7 @@ public class PlayerPrepareTeleportEvent extends PlayerEvent {
         super(player);
         this.to = to;
         this.cause = cause;
-        this.teleportFlags = teleportFlags;
+        this.teleportFlags = ImmutableSet.copyOf(teleportFlags);
     }
 
     /**

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -18,6 +18,7 @@ import io.papermc.paper.dialog.PaperDialog;
 import io.papermc.paper.entity.LookAnchor;
 import io.papermc.paper.entity.PaperPlayerGiveResult;
 import io.papermc.paper.entity.PlayerGiveResult;
+import io.papermc.paper.event.player.PlayerPrepareTeleportEvent;
 import io.papermc.paper.math.Angle;
 import io.papermc.paper.math.Position;
 import io.papermc.paper.util.MCUtil;
@@ -1316,6 +1317,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         if (this.getHandle().connection == null) {
             return false;
         }
+
+        // Paper start - Add PlayerPrepareTeleportEvent
+        final PlayerPrepareTeleportEvent playerPrepareTeleportEvent = new PlayerPrepareTeleportEvent(this, location, cause, Set.of(flags));
+        this.server.getPluginManager().callEvent(playerPrepareTeleportEvent);
+        // Paper end - Add PlayerPrepareTeleportEvent
+
         // Minecraft does not currently support teleporting players between worlds with passengers.
         // It causes them to be dismounted, and causes weird behavior.
         if (location.getWorld() != this.getWorld() && this.getHandle().isVehicle()) {


### PR DESCRIPTION
Continuing off of #12879, Adding `PlayerPrepareTeleportEvent` would allow plugin developers to better handle the case of disallowed cross-world teleports when the player has passengers.

There seems to be a need for some kind of a solution, even if a temporary one, since there's no way to handle this case as `PlayerTeleportEvent` doesn't fire at all if the player has passengers.

Relevant issues: #12093, #10168 & #10173.

Let me know if this PR is missing anything and I'll make any necessary changes!