### PR TITLE
Add get entity by id

### DIFF
--- a/paper-api/src/main/java/org/bukkit/Bukkit.java
+++ b/paper-api/src/main/java/org/bukkit/Bukkit.java
@@ -2431,6 +2431,17 @@ public final class Bukkit {
         return server.getEntity(uuid);
     }
 
+    /**
+     * Gets an entity on the server by its entity id
+     *
+     * @param id the id of the entity
+     * @return the entity with the given id, or null if it isn't found
+     */
+    @Nullable
+    public static Entity getEntity(int id) {
+        return server.getEntity(id);
+    }
+
     // Paper start
     /**
      * Gets the current server TPS

--- a/paper-api/src/main/java/org/bukkit/Server.java
+++ b/paper-api/src/main/java/org/bukkit/Server.java
@@ -2179,6 +2179,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
     @Nullable
     Entity getEntity(@NotNull UUID uuid);
 
+    /**
+     * Gets an entity on the server by its entity id
+     *
+     * @param id the id of the entity
+     * @return the entity with the given id, or null if it isn't found
+     */
+    @Nullable
+    Entity getEntity(int id);
+
     // Paper start
     /**
      * Gets the current server TPS

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -2496,6 +2496,18 @@ public final class CraftServer implements Server {
     }
 
     @Override
+    public @Nullable Entity getEntity(int id) {
+        for (ServerLevel world : this.getServer().getAllLevels()) {
+            net.minecraft.world.entity.Entity entity = world.getEntity(id);
+            if (entity != null) {
+                return entity.getBukkitEntity();
+            }
+        }
+
+        return null;
+    }
+
+    @Override
     public org.bukkit.advancement.Advancement getAdvancement(NamespacedKey key) {
         Preconditions.checkArgument(key != null, "key cannot be null");
 


### PR DESCRIPTION
At the moment, the only way to get an entity by ID is to use the `ServerLevel` and call `getEntity(id)`.

This adds `Bukkit#getEntity(int id)` as a public equivalent. Vanilla supports this lookup natively and I recently implemented a server feature that needed it. Having it in the API removes one more reason to use internal methods.

Let me know what you think.