### PR TITLE
Document undefined tracker behavior in track/untrack events.

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerTrackEntityEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerTrackEntityEvent.java
@@ -15,6 +15,8 @@ import org.jspecify.annotations.NullMarked;
  * <p>
  * Adding or removing entities from the world at the point in time this event is called is completely
  * unsupported and should be avoided.
+ * Teleporting entities in the world at the point in time this event is called yields an undefined tracker
+ * behavior and should be avoided.
  */
 @NullMarked
 public class PlayerTrackEntityEvent extends PlayerEvent implements Cancellable {

--- a/paper-api/src/main/java/io/papermc/paper/event/player/PlayerUntrackEntityEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/player/PlayerUntrackEntityEvent.java
@@ -12,6 +12,8 @@ import org.jspecify.annotations.NullMarked;
  * <p>
  * Adding or removing entities from the world at the point in time this event is called is completely
  * unsupported and should be avoided.
+ * Teleporting entities in the world at the point in time this event is called yields an undefined tracker
+ * behavior and should be avoided.
  */
 @NullMarked
 public class PlayerUntrackEntityEvent extends PlayerEvent {


### PR DESCRIPTION
If a player is teleported during this event, the entity tracker sometimes tracks the entities immediately and sometimes only in the next tick (depending on their order in player list). So if a plugin teleported me into a group of players inside this event, I would statistically see about half of them right away and the rest in the next tick.

This PR adds a javadoc note to PlayerTrackEntityEvent and PlayerUntrackEntityEvent warning that teleporting entities druing these events yields undefined tracker behavior