### PR TITLE
Run DataFix WorldGenSettingsFix as LEVEL instead of WORLD_GEN_SETTINGS

### DIFF
--- a/paper-server/patches/sources/net/minecraft/util/datafix/fixes/WorldGenSettingsFix.java.patch
+++ b/paper-server/patches/sources/net/minecraft/util/datafix/fixes/WorldGenSettingsFix.java.patch
@@ -1,0 +1,32 @@
+--- a/net/minecraft/util/datafix/fixes/WorldGenSettingsFix.java
++++ b/net/minecraft/util/datafix/fixes/WorldGenSettingsFix.java
+@@ -46,15 +_,26 @@
+         .build();
+ 
+     public WorldGenSettingsFix(final Schema parent) {
+-        super(parent, true);
++        super(parent, false); // Paper - operate on LEVEL instead of WORLD_GEN_SETTINGS; see makeRule
+     }
+ 
+     @Override
+     protected TypeRewriteRule makeRule() {
+         return this.fixTypeEverywhereTyped(
+             "WorldGenSettings building",
+-            this.getInputSchema().getType(References.WORLD_GEN_SETTINGS),
+-            settings -> settings.update(DSL.remainderFinder(), WorldGenSettingsFix::fix)
++            // Paper start - run this as part of the LEVEL walk instead of the standalone WORLD_GEN_SETTINGS type;
++            // WORLD_GEN_SETTINGS is never reached while walking LEVEL (it is only wired in via
++            // SAVED_DATA_WORLD_GEN_SETTINGS), so this fix must complete here for LevelDatToSavedDataPreparationFix's
++            // later generate_features -> generate_structures rename (v4771) to see the correct field name
++            this.getInputSchema().getType(References.LEVEL),
++            level -> level.update(DSL.remainderFinder(), dataTag -> {
++                Dynamic<?> worldGenSettings = dataTag.get("WorldGenSettings").orElseEmptyMap();
++
++                worldGenSettings = fix(worldGenSettings);
++
++                return dataTag.set("WorldGenSettings", worldGenSettings);
++            })
++            // Paper end
+         );
+     }
+ 


### PR DESCRIPTION
I've run into a problem with an old format level.dat, that the MapFeatures level.dat value did not get properly migrated on Paper. It turned into generate_features, instead of generate_structures. This causes structures to be generated in the world when that was not intended.

I narrowed the problem down to the datafixer running out-of-order. The versioning made it appear this should not happen.

My hypothesis was that this was because these fixes run on the WORLD_GEN_SETTINGS schema, which is something that only exists after the world_gen_settings.dat split even exists. So as a result, it would only run late, after the generate_features > generate_structures rename already occurred.

I've tried rewriting it to use LEVEL, like the other fix, inspired by `LevelLegacyWorldGenSettingsFix`. And that has fixed this problem for me.

I do not know what other impacts this has, because I have limited understanding of datafixers.

In my_void_world_bu.zip is an empty world file with just level.dat, that when loaded, is transformed into the incorrect syntax.
[my_void_world_bu.zip](https://github.com/user-attachments/files/31104949/my_void_world_bu.zip)
