### PR TITLE
Reset client world load status on respawn/cross-dimension teleport

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -28184,7 +28184,7 @@ index 473feb1aa6ccf0f03ce0bc895de367b3e554e1bc..e5328f08d6a323aa1307ed791a88916b
              "Server weather",
              () -> String.format(
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index b569df775fcc9885b7cfee1b8280b68f33f4cd71..220409fd6335e17445e1acdbfac8d83ae36a99b4 100644
+index e3d600eb0de2699387fee86a9fec64b5e92218ad..438d350b5d51d07ee444501fdb28b6ec7b37cd72 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -206,7 +206,7 @@ import net.minecraft.world.scores.criteria.ObjectiveCriteria;
@@ -28885,10 +28885,10 @@ index 3271c83bd103bea9b9ffcd6882b52896ea4da770..f6601bc30fa37a309923ea9883b04233
                  PrepareSpawnTask.this.loadListener.updateFocus(this.spawnLevel.dimension(), spawnChunk);
              }
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index b4845731ba1eaae582afece7e09e2af427b29d6a..1dbb1d49c797be89f3739c2fa226aef25f68ee87 100644
+index 102fff4a33d75746fffe3319165161c200124393..c09ed983e13777f4ab2612efef4dfd071f99b287 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
-@@ -982,8 +982,8 @@ public abstract class PlayerList {
+@@ -983,8 +983,8 @@ public abstract class PlayerList {
          player.connection.send(level.clockManager().createFullSyncPacket(player)); // Paper - per-world time; per-player time
          player.connection.send(new ClientboundSetDefaultSpawnPositionPacket(level.getRespawnData()));
          // Paper start - view distances
@@ -28899,7 +28899,7 @@ index b4845731ba1eaae582afece7e09e2af427b29d6a..1dbb1d49c797be89f3739c2fa226aef2
          // Paper end - view distances
          if (level.isRaining()) {
              // CraftBukkit start - handle player weather
-@@ -1200,7 +1200,7 @@ public abstract class PlayerList {
+@@ -1201,7 +1201,7 @@ public abstract class PlayerList {
  
      public void setViewDistance(final int viewDistance) {
          this.viewDistance = viewDistance;
@@ -28908,7 +28908,7 @@ index b4845731ba1eaae582afece7e09e2af427b29d6a..1dbb1d49c797be89f3739c2fa226aef2
  
          for (ServerLevel level : this.server.getAllLevels()) {
              level.getChunkSource().setViewDistance(viewDistance);
-@@ -1209,7 +1209,7 @@ public abstract class PlayerList {
+@@ -1210,7 +1210,7 @@ public abstract class PlayerList {
  
      public void setSimulationDistance(final int simulationDistance) {
          this.simulationDistance = simulationDistance;

--- a/paper-server/patches/features/0014-Incremental-chunk-and-player-saving.patch
+++ b/paper-server/patches/features/0014-Incremental-chunk-and-player-saving.patch
@@ -113,7 +113,7 @@ index df2c346996204003dbc99c0f33adaeb0e5293d01..762e3b71a8df572234b03dec60d2b6e1
      public void save(final @Nullable ProgressListener progressListener, final boolean flush, final boolean noSave) {
          // Paper start - add close param
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 220409fd6335e17445e1acdbfac8d83ae36a99b4..0099e02d61e26bd6262457f99c6f9f06f90bf9f9 100644
+index 438d350b5d51d07ee444501fdb28b6ec7b37cd72..d0670d44603c748e62a7f6ba3447a76fa1e8e00b 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -208,6 +208,7 @@ import org.slf4j.Logger;
@@ -125,7 +125,7 @@ index 220409fd6335e17445e1acdbfac8d83ae36a99b4..0099e02d61e26bd6262457f99c6f9f06
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      private static final int FLY_STAT_RECORDING_SPEED = 25;
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 1dbb1d49c797be89f3739c2fa226aef25f68ee87..779686f3d0c330b0c9ce4f37168503f3668b1f13 100644
+index c09ed983e13777f4ab2612efef4dfd071f99b287..de67bc621f904d668761c80c31b3445641ea9beb 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -414,6 +414,7 @@ public abstract class PlayerList {
@@ -136,7 +136,7 @@ index 1dbb1d49c797be89f3739c2fa226aef25f68ee87..779686f3d0c330b0c9ce4f37168503f3
          this.playerIo.save(player);
          ServerStatsCounter stats = player.getStats(); // CraftBukkit
          if (stats != null) {
-@@ -950,10 +951,24 @@ public abstract class PlayerList {
+@@ -951,10 +952,24 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {

--- a/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -767,11 +767,16 @@
  
          if (newLevel.dimension() == lastDimension) {
 -            this.connection.teleport(PositionMoveRotation.of(transition), transition.relatives());
-+            this.connection.internalTeleport(PositionMoveRotation.of(transition), transition.relatives()); // CraftBukkit  
++            this.connection.internalTeleport(PositionMoveRotation.of(transition), transition.relatives()); // CraftBukkit
              this.connection.resetPosition();
              transition.postTeleportTransition().onTransition(this);
              return this;
-@@ -1120,18 +_,19 @@
+@@ -1116,22 +_,24 @@
+ 
+         this.isChangingDimension = true;
+         LevelData levelData = newLevel.getLevelData();
++        this.connection.restartClientLoadTimerAfterRespawn(); // Paper - reset client world load status on cross-dimension teleport
+         this.connection.send(new ClientboundRespawnPacket(this.createCommonSpawnInfo(newLevel), ClientboundRespawnPacket.KEEP_ALL_DATA));
          this.connection.send(new ClientboundChangeDifficultyPacket(levelData.getDifficulty(), levelData.isDifficultyLocked()));
          PlayerList playerList = this.server.getPlayerList();
          playerList.sendPlayerPermissionLevel(this);

--- a/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -495,7 +495,7 @@
              player.copyRespawnPosition(serverPlayer);
          }
  
-@@ -408,17 +_,26 @@
+@@ -408,17 +_,27 @@
              player.addTag(tag);
          }
  
@@ -504,6 +504,7 @@
 +        player.setServerLevel(level);
 +        player.unsetRemoved();
 +        player.setShiftKeyDown(false);
++        player.connection.restartClientLoadTimerAfterRespawn();
 +        // Paper end
          Vec3 pos = respawnInfo.position();
          player.snapTo(pos.x, pos.y, pos.z, respawnInfo.yRot(), respawnInfo.xRot());

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -3045,7 +3045,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
         public void respawn() {
             if (CraftPlayer.this.getHealth() <= 0 && CraftPlayer.this.isOnline()) {
                 CraftPlayer.this.server.getServer().getPlayerList().respawn(CraftPlayer.this.getHandle(), false, Entity.RemovalReason.KILLED, org.bukkit.event.player.PlayerRespawnEvent.RespawnReason.PLUGIN);
-                CraftPlayer.this.getHandle().connection.restartClientLoadTimerAfterRespawn();
             }
         }
 


### PR DESCRIPTION
Fixes client world load status not being reset:
- on respawn due to Paper reusing ServerPlayer instance.
- on cross-dimension teleport - while this isn't even done by vanilla, the client always sends the packet on each world load, and it definitely benefits plugins to do that since it's possible.

Tested both cases, works fine.