### PR TITLE
Add API for operator permission levels and bypassesPlayerLimit

### DIFF
--- a/paper-api/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/paper-api/src/main/java/org/bukkit/OfflinePlayer.java
@@ -591,4 +591,44 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
     default void applySkinToPlayerHeadContents(final PlayerHeadObjectContents.Builder builder) {
         builder.skin(this.getPlayerProfile());
     }
+
+    /**
+     * Checks if this player bypasses the server player limit when connecting.
+     * <p>
+     * Note: A player must be an operator for this privilege to take effect.
+     * </p>
+     *
+     * @return true if the player bypasses the player limit, false otherwise
+     */
+    boolean bypassesPlayerLimit();
+
+    /**
+     * Sets whether this player bypasses the server player limit when connecting.
+     * <p>
+     * Note: The player must already be an operator for this to update their entry in ops.json.
+     * </p>
+     *
+     * @param bypass true if the player should bypass the player limit
+     * @return true if the status was successfully updated, false if the player is not an operator
+     */
+    boolean setBypassesPlayerLimit(boolean bypass);
+
+    /**
+     * Gets the operator permission level for this player (0 through 4).
+     *
+     * @return the permission level, or 0 if the player is not an operator or entry is missing
+     */
+    int getOpLevel();
+
+    /**
+     * Sets the operator permission level for this player.
+     * <p>
+     * If setting a level greater than 0, the player will be added to ops.json if not present.
+     * If set to 0, the player's level will be cleared (or removed from ops depending on server logic).
+     * </p>
+     *
+     * @param level the level to set (must be between 0 and 4)
+     * @throws IllegalArgumentException if level is outside the 0–4 range
+     */
+    void setOpLevel(int level);
 }

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
@@ -579,4 +579,79 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
             manager.save();
         }
     }
+
+    @Override
+    public boolean bypassesPlayerLimit() {
+        ServerOpList opList = MinecraftServer.getServer().getPlayerList().getOps();
+        NameAndId nameAndId = new NameAndId(this.getUniqueId(), this.getName() != null ? this.getName() : "");
+        ServerOpListEntry entry = opList.get(nameAndId);
+
+        return entry != null && entry.getBypassesPlayerLimit();
+    }
+
+    @Override
+    public boolean setBypassesPlayerLimit(boolean bypass) {
+        MinecraftServer server = MinecraftServer.getServer();
+        ServerOpList opList = server.getPlayerList().getOps();
+
+        NameAndId nameAndId = new NameAndId(this.getUniqueId(), this.getName() != null ? this.getName() : "");
+        ServerOpListEntry existingEntry = opList.get(nameAndId);
+
+        if (existingEntry == null) {
+            return false;
+        }
+
+        ServerOpListEntry newEntry = new ServerOpListEntry(
+            nameAndId,
+            existingEntry.permissions(),
+            bypass
+        );
+
+        opList.add(newEntry);
+        return true;
+    }
+
+    @Override
+    public int getOpLevel() {
+        ServerOpList opList = MinecraftServer.getServer().getPlayerList().getOps();
+        NameAndId nameAndId = new NameAndId(this.getUniqueId(), this.getName() != null ? this.getName() : "");
+        ServerOpListEntry entry = opList.get(nameAndId);
+
+        if (entry == null) {
+            return 0;
+        }
+
+        LevelBasedPermissionSet levelSet = entry.permissions();
+        return levelSet.level().id();
+
+    }
+
+    @Override
+    public void setOpLevel(int level) {
+        if (level < 0 || level > 4) {
+            throw new IllegalArgumentException("Operator permission level must be between 0 and 4.");
+        }
+
+        MinecraftServer server = MinecraftServer.getServer();
+        ServerOpList opList = server.getPlayerList().getOps();
+
+        NameAndId nameAndId = new NameAndId(this.getUniqueId(), this.getName() != null ? this.getName() : "");
+        ServerOpListEntry existingEntry = opList.get(nameAndId);
+
+        boolean bypassesLimit = existingEntry != null && existingEntry.getBypassesPlayerLimit();
+
+        PermissionLevel permLevel = PermissionLevel.byId(level);
+        ServerOpListEntry newEntry = new ServerOpListEntry(
+            nameAndId,
+            LevelBasedPermissionSet.forLevel(permLevel),
+            bypassesLimit
+        );
+
+        opList.add(newEntry);
+
+        ServerPlayer serverPlayer = server.getPlayerList().getPlayer(this.getUniqueId());
+        if (serverPlayer != null) {
+            server.getPlayerList().sendPlayerPermissionLevel(serverPlayer);
+        }
+    }
 }


### PR DESCRIPTION
In light of the response I received to my pull request which adds the more advanced operator management commands, I've been working on converting the code to the plugin API.

This is what I have so far. Is this version of the code what Paper is looking for, or are more changes needed?

I apologise in advance if there are any errors/oversights. I am very new at contributing to the API instead of the server. I've also been having seizures again.