### PR TITLE
[ci skip] Correct MOB_GRIEFING javadoc on explode events

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
@@ -15,9 +15,6 @@ import org.jetbrains.annotations.NotNull;
  * Note that due to the nature of explosions, {@link #getBlock()} will always be
  * an air block. {@link #getExplodedBlockState()} should be used to get
  * information about the block state that exploded.
- * <p>
- * The event isn't called if the {@link org.bukkit.GameRules#MOB_GRIEFING}
- * is disabled as no block interaction will occur.
  */
 public class BlockExplodeEvent extends BlockEvent implements Cancellable {
 

--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
@@ -11,9 +11,13 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Called when an entity explodes interacting with blocks. The
- * event isn't called if the {@link org.bukkit.GameRules#MOB_GRIEFING}
- * is disabled as no block interaction will occur.
+ * Called when an entity explodes interacting with blocks.
+ * <p>
+ * Explosions caused by mobs do no tinteract with blocks
+ * while {@link org.bukkit.GameRules#MOB_GRIEFING} is disabled
+ * as no block interaction will occur. That game rule does not
+ * affect other explosions. For example, a wind charge still calls this event
+ * with an {@link ExplosionResult#TRIGGER_BLOCK} result.
  */
 public class EntityExplodeEvent extends EntityEvent implements Cancellable {
 

--- a/paper-api/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
+++ b/paper-api/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when an entity explodes interacting with blocks.
  * <p>
- * Explosions caused by mobs do no tinteract with blocks
+ * Explosions caused by mobs do not interact with blocks
  * while {@link org.bukkit.GameRules#MOB_GRIEFING} is disabled
  * as no block interaction will occur. That game rule does not
  * affect other explosions. For example, a wind charge still calls this event


### PR DESCRIPTION
Small change to javadoc clarifying wind charge cases in `EntityExplodeEvent`. 
Also removed the MOB_GRIEFING comment from `BlockExplodeEvent` as it was misleading

Closes #13428