### PR TITLE
feat: remove name field in Event class

### DIFF
--- a/paper-api/src/main/java/org/bukkit/event/Event.java
+++ b/paper-api/src/main/java/org/bukkit/event/Event.java
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.NotNull;
  */
 public abstract class Event {
 
-    private String name;
     private final boolean isAsync;
 
     /**
@@ -60,10 +59,7 @@ public abstract class Event {
      */
     @NotNull
     public String getEventName() {
-        if (this.name == null) {
-            this.name = this.getClass().getSimpleName();
-        }
-        return this.name;
+        return this.getClass().getSimpleName();
     }
 
     @NotNull


### PR DESCRIPTION
Initially discovered by @SirYwell, the `Event` class currently holds a `String name` field that is only used to cache the output of `getClass().getSimpleName()`.

However, that `getSimpleName()` method itself is already cached as part of the class' reflection data, making this manual cache mostly a waste of 4/8 bytes of memory.

Additionally, in server code, the `getEventName()` method is only called once in error messages, and thus the cache may not even live to see any effect.

For a class as frequently constructed, the memory save here can be seen as significant.