### PR TITLE
Assign BlockProjectileSource before dispenser projectiles spawn

### DIFF
--- a/paper-server/patches/sources/net/minecraft/core/dispenser/ProjectileDispenseBehavior.java.patch
+++ b/paper-server/patches/sources/net/minecraft/core/dispenser/ProjectileDispenseBehavior.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/core/dispenser/ProjectileDispenseBehavior.java
 +++ b/net/minecraft/core/dispenser/ProjectileDispenseBehavior.java
-@@ -27,17 +_,36 @@
+@@ -27,17 +_,38 @@
          ServerLevel level = source.level();
          Direction direction = source.state().getValue(DispenserBlock.FACING);
          Position position = this.dispenseConfig.positionFunction().getDispensePosition(source, direction);
@@ -40,8 +40,10 @@
 +
 +        // SPIGOT-7923: Avoid create projectiles with empty item
 +        if (!singleItemStack.isEmpty()) {
-+            Projectile projectile = Projectile.spawnProjectileUsingShoot(this.projectileItem.asProjectile(level, position, org.bukkit.craftbukkit.inventory.CraftItemStack.unwrap(event.getItem()), direction), level, singleItemStack, event.getVelocity().getX(), event.getVelocity().getY(), event.getVelocity().getZ(), this.dispenseConfig.power(), this.dispenseConfig.uncertainty()); // Paper - track changed items in the dispense event; unwrap is safe here because all uses of the stack make their own copies
++            Projectile projectile = this.projectileItem.asProjectile(level, position, org.bukkit.craftbukkit.inventory.CraftItemStack.unwrap(event.getItem()), direction); // Paper - track changed items in the dispense event; unwrap is safe here because all uses of the stack make their own copies
++            Projectile.Delayed<Projectile> delayedProjectile = Projectile.spawnProjectileUsingShootDelayed(projectile, level, singleItemStack, event.getVelocity().getX(), event.getVelocity().getY(), event.getVelocity().getZ(), this.dispenseConfig.power(), this.dispenseConfig.uncertainty());
 +            projectile.projectileSource = new org.bukkit.craftbukkit.projectiles.CraftBlockProjectileSource(source.blockEntity());
++            delayedProjectile.spawn();
 +        }
 +        if (shrink) dispensed.shrink(1);
 +        // CraftBukkit end


### PR DESCRIPTION
Fixes #14194.

## Problem

`ProjectileLaunchEvent#getEntity().getShooter()` returned `null` for projectiles fired from a dispenser, even though the expected shooter is a `BlockProjectileSource`. This PR addresses the dispenser path specifically, in `ProjectileDispenseBehavior`.

## Root cause

`ProjectileDispenseBehavior` used `Projectile.spawnProjectileUsingShoot(...)`, which delegates to the delayed implementation and then immediately calls `.spawn()`. That spawn call goes through `addFreshEntity(...)`, the point at which the projectile enters the world and `ProjectileLaunchEvent` fires.

Only once that call returned did the dispenser behavior assign:

```java
projectile.projectileSource = new CraftBlockProjectileSource(...);
```

So the effective ordering was:

```text
create/configure projectile
  -> spawn projectile
  -> ProjectileLaunchEvent fires
  -> projectileSource is assigned
```

The event therefore observed a shooter that had not been set yet.

## Changes

Creation/configuration is now split from the actual spawn. The projectile is created via `asProjectile(...)`, configured with `Projectile.spawnProjectileUsingShootDelayed(...)` (which sets it up without inserting it into the world), assigned its `CraftBlockProjectileSource` while still unspawned, and only then spawned via `delayedProjectile.spawn()`.

New ordering:

```text
create projectile
  -> configure launch velocity
  -> assign CraftBlockProjectileSource
  -> spawn projectile
  -> ProjectileLaunchEvent fires
```

This reuses Paper's existing delayed-projectile mechanism rather than introducing new API or a new spawning path. Launch velocity calculation is unchanged; `spawnProjectileUsingShootDelayed` runs the same `shoot(...)` setup; it just postpones the final world insertion until after the source has been attached.

Scope is one source patch against `ProjectileDispenseBehavior`. No API changes and no persistent `test-plugin` changes.

## Testing

Manually verified the change against a dev server: temporarily enabled Paper's local `test-plugin`, registered a `ProjectileLaunchEvent` listener, started `:paper-server:runDevServer`, connected with Minecraft 26.2, and fired a snowball from a placed dispenser. During the event, the listener logged:

```text
ProjectileLaunchEvent: projectile=SNOWBALL, shooter=org.bukkit.craftbukkit.projectiles.CraftBlockProjectileSource
```

That confirms the source is available *during* the event rather than only after the projectile has spawned. The dispenser also continued to launch the snowball normally during the test. The temporary listener was removed and `test-plugin` disabled again afterward.

Source patches rebuild and reapply cleanly, and a full `./gradlew build` passes.