### PR TITLE
Fire PrePlayerAttackEntityEvent for entities hit by sweep attacks

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -334,9 +334,21 @@
          }
      }
  
-@@ -1161,9 +_,12 @@
+@@ -1160,10 +_,24 @@
+                     && !this.isAlliedTo(nearby)
                      && !(nearby instanceof ArmorStand armorStand && armorStand.isMarker())
                      && this.distanceToSqr(nearby) < 9.0) {
++
++                    if(damageSource.getDirectEntity() instanceof Player player) {
++                        io.papermc.paper.event.player.PrePlayerAttackEntityEvent playerAttackEntityEvent = new io.papermc.paper.event.player.PrePlayerAttackEntityEvent(
++                            (org.bukkit.entity.Player) player.getBukkitEntity(),
++                            nearby.getBukkitEntity(),
++                            true
++                        );
++                        if(!playerAttackEntityEvent.callEvent())
++                            continue;
++                    }
++
                      float enchantedDamage = this.getEnchantedDamage(nearby, var12, damageSource) * attackStrengthScale;
 -                    if (nearby.hurtServer(serverLevel, damageSource, enchantedDamage)) {
 +                    // Paper start - Only apply knockback if the event is not canceled


### PR DESCRIPTION
Currently, `PrePlayerAttackEntityEvent` is only fired for the entity that is directly attacked by a player. Entities subsequently hit by a sword sweep attack do not receive the event.

This PR adds `PrePlayerAttackEntityEvent` calls for entities affected by a sweep attack when the direct damage source is a player.

For each nearby entity affected by the sweep attack, the event is created with the attacking player and the entity being hit. If the event is cancelled, the entity is skipped and does not receive the sweep attack damage.