### PR TITLE
Bump spark-paper to the latest version

### DIFF
--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -156,7 +156,7 @@ dependencies {
 
     // Spark
     implementation("me.lucko:spark-api:0.1-20240720.200737-2")
-    implementation("me.lucko:spark-paper:1.10.172")
+    implementation("me.lucko:spark-paper:1.10.177")
 }
 
 tasks.jar {


### PR DESCRIPTION
Bumps spark-paper to 1.10.177, this will fix issues with /spark activity not working since the adventure 5 update