### PR TITLE
Bump spark integration to version 1.10.180

### DIFF
--- a/paper-server/build.gradle.kts
+++ b/paper-server/build.gradle.kts
@@ -156,7 +156,7 @@ dependencies {
 
     // Spark
     implementation("me.lucko:spark-api:0.1-20240720.200737-2")
-    implementation("me.lucko:spark-paper:1.10.177")
+    implementation("me.lucko:spark-paper:1.10.180")
 }
 
 tasks.jar {


### PR DESCRIPTION
Like https://github.com/PaperMC/Paper/pull/14205 this PR bump the spark version with the latest changes.

The most interest feature is the metrics in reports: https://github.com/lucko/spark/pull/581
example (in local)
<img width="1920" height="911" alt="image" src="https://github.com/user-attachments/assets/fb1de489-4b8e-4ff9-9c07-e764344fd415" />
