### PR TITLE
Fix loadChunksAsync ignoring ChunkStatus passed in

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -27403,7 +27403,7 @@ index f11c5ea1ee9381e7bf65305b959bd7da67423ece..26822e1211194b411dd8ea75ce523133
          List<Entity> passengers = this.entity.getPassengers();
          if (!passengers.equals(this.lastPassengers)) {
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 473feb1aa6ccf0f03ce0bc895de367b3e554e1bc..e5328f08d6a323aa1307ed791a88916b4588939c 100644
+index 473feb1aa6ccf0f03ce0bc895de367b3e554e1bc..4fce291cb7cd6eb2f4e47237fe247a5d666da0ad 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -182,7 +182,7 @@ import net.minecraft.world.waypoints.WaypointTransmitter;
@@ -27626,7 +27626,13 @@ index 473feb1aa6ccf0f03ce0bc895de367b3e554e1bc..e5328f08d6a323aa1307ed791a88916b
                      }
                  }
              }
-@@ -340,16 +476,135 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -335,21 +471,140 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+         for (int cx = minChunkX; cx <= maxChunkX; ++cx) {
+             for (int cz = minChunkZ; cz <= maxChunkZ; ++cz) {
+                 ca.spottedleaf.moonrise.common.PlatformHooks.get().scheduleChunkLoad(
+-                    this, cx, cz, net.minecraft.world.level.chunk.status.ChunkStatus.FULL, true, priority, consumer
++                    this, cx, cz, chunkStatus, true, priority, consumer
+                 );
              }
          }
      }


### PR DESCRIPTION
Discovered this while implementing a feature in my fork that uses `moonrise$loadChunksAsync` with `ChunkStatus.EMPTY`.

The method above didn't honor the chunk status I've passed in and always load chunks as `FULL` level.

This PR passes the requested chunk status to `scheduleChunkLoad` instead of the hard-coding `ChunkStatus.FULL`.

Currently Paper doesn't have callers that are passing levels lower than `FULL`, so it looks more likely a future-proof fix. 