### PR TITLE
Fix zombie fly when trampling after cancelling EntityInteractEvent

### DIFF
--- a/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java.patch
@@ -1,11 +1,12 @@
 --- a/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java
 +++ b/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java
-@@ -101,6 +_,11 @@
+@@ -101,6 +_,12 @@
              }
  
              if (this.ticksSinceReachedGoal > 60) {
 +                // CraftBukkit start - Step on eggs
 +                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityInteractEvent(this.removerMob, org.bukkit.craftbukkit.block.CraftBlock.at(level, eatPos))) {
++                    this.ticksSinceReachedGoal++;
 +                    return;
 +                }
 +                // CraftBukkit end


### PR DESCRIPTION
When cancelling `EntityInteractEvent`, `ticksSinceReachedGoal` doesn't get updated, making the zombie just hop upwards and never step down (since it doesn't trigger the step down code).

The fix is to ensure `ticksSinceReachedGoal` gets incremented even after cancelling the event.

Fixes #14224 