### PR TITLE
chore: deprecate Bukkit commands

### DIFF
--- a/paper-api/src/main/java/org/bukkit/Bukkit.java
+++ b/paper-api/src/main/java/org/bukkit/Bukkit.java
@@ -1079,7 +1079,10 @@ public final class Bukkit {
      *
      * @param name the name of the command to retrieve
      * @return a plugin command if found, null otherwise
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
      */
+    @Deprecated(since = "26.3")
     @Nullable
     public static PluginCommand getPluginCommand(@NotNull String name) {
         return server.getPluginCommand(name);
@@ -1348,7 +1351,10 @@ public final class Bukkit {
      * Gets a list of command aliases defined in the server properties.
      *
      * @return a map of aliases to command names
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
      */
+    @Deprecated(since = "26.3")
     @NotNull
     public static Map<String, String[]> getCommandAliases() {
         return server.getCommandAliases();
@@ -2658,7 +2664,10 @@ public final class Bukkit {
      * Gets the active {@link org.bukkit.command.CommandMap}
      *
      * @return the active command map
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
      */
+    @Deprecated(since = "26.3")
     @NotNull
     public static org.bukkit.command.CommandMap getCommandMap() {
         return server.getCommandMap();
@@ -2675,7 +2684,10 @@ public final class Bukkit {
      * Reload the Command Aliases in commands.yml
      *
      * @return Whether the reload was successful
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
      */
+    @Deprecated(since = "26.3")
     public static boolean reloadCommandAliases() {
         return server.reloadCommandAliases();
     }

--- a/paper-api/src/main/java/org/bukkit/Server.java
+++ b/paper-api/src/main/java/org/bukkit/Server.java
@@ -995,7 +995,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      *
      * @param name the name of the command to retrieve
      * @return a plugin command if found, null otherwise
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
      */
+    @Deprecated(since = "26.3")
     @Nullable
     public PluginCommand getPluginCommand(@NotNull String name);
 
@@ -1239,7 +1242,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      * Gets a list of command aliases defined in the server properties.
      *
      * @return a map of aliases to command names
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
      */
+    @Deprecated(since = "26.3")
     @NotNull
     public Map<String, String[]> getCommandAliases();
 
@@ -2207,7 +2213,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      * Gets the active {@link org.bukkit.command.CommandMap}
      *
      * @return the active command map
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
      */
+    @Deprecated(since = "26.3")
     @NotNull
     org.bukkit.command.CommandMap getCommandMap();
 
@@ -2486,6 +2495,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
 
     void reloadPermissions(); // Paper
 
+    /**
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
+     */
+    @Deprecated(since = "26.3")
     boolean reloadCommandAliases(); // Paper
 
     // Paper start - allow preventing player name suggestions by default

--- a/paper-api/src/main/java/org/bukkit/command/Command.java
+++ b/paper-api/src/main/java/org/bukkit/command/Command.java
@@ -20,7 +20,11 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a Command, which executes various tasks upon user input
+ *
+ * @deprecated plugin developers should prefer to use the
+ *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
  */
+@Deprecated(since = "26.3")
 public abstract class Command {
     private String name;
     private String nextLabel;

--- a/paper-api/src/main/java/org/bukkit/command/CommandExecutor.java
+++ b/paper-api/src/main/java/org/bukkit/command/CommandExecutor.java
@@ -4,7 +4,11 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a class which contains a single method for executing commands
+ *
+ * @deprecated plugin developers should prefer to use the
+ *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
  */
+@Deprecated(since = "26.3")
 public interface CommandExecutor {
 
     /**
@@ -18,6 +22,9 @@ public interface CommandExecutor {
      * @param label Alias of the command which was used
      * @param args Passed command arguments
      * @return true if a valid command, otherwise false
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
      */
+    @Deprecated(since = "26.3")
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args);
 }

--- a/paper-api/src/main/java/org/bukkit/command/CommandMap.java
+++ b/paper-api/src/main/java/org/bukkit/command/CommandMap.java
@@ -5,6 +5,11 @@ import org.bukkit.Location;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * @deprecated plugin developers should prefer to use the
+ *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
+ */
+@Deprecated(since = "26.3")
 public interface CommandMap {
 
     /**

--- a/paper-api/src/main/java/org/bukkit/command/FormattedCommandAlias.java
+++ b/paper-api/src/main/java/org/bukkit/command/FormattedCommandAlias.java
@@ -9,6 +9,11 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * @deprecated plugin developers should prefer to use the
+ *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
+ */
+@Deprecated(since = "26.3")
 public class FormattedCommandAlias extends Command {
     private final String[] formatStrings;
 

--- a/paper-api/src/main/java/org/bukkit/command/MultipleCommandAlias.java
+++ b/paper-api/src/main/java/org/bukkit/command/MultipleCommandAlias.java
@@ -4,7 +4,11 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a command that delegates to one or more other commands
+ *
+ * @deprecated plugin developers should prefer to use the
+ *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
  */
+@Deprecated(since = "26.3")
 public class MultipleCommandAlias extends Command {
     private Command[] commands;
 

--- a/paper-api/src/main/java/org/bukkit/command/PluginCommand.java
+++ b/paper-api/src/main/java/org/bukkit/command/PluginCommand.java
@@ -8,7 +8,11 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a {@link Command} belonging to a plugin
+ *
+ * @deprecated plugin developers should prefer to use the
+ *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
  */
+@Deprecated(since = "26.3")
 public final class PluginCommand extends Command implements PluginIdentifiableCommand {
     private final Plugin owningPlugin;
     private CommandExecutor executor;

--- a/paper-api/src/main/java/org/bukkit/command/PluginCommandYamlParser.java
+++ b/paper-api/src/main/java/org/bukkit/command/PluginCommandYamlParser.java
@@ -8,6 +8,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * @deprecated plugin developers should prefer to use the
+ *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
+ */
+@Deprecated(since = "26.3")
 public class PluginCommandYamlParser {
 
     @NotNull

--- a/paper-api/src/main/java/org/bukkit/command/PluginIdentifiableCommand.java
+++ b/paper-api/src/main/java/org/bukkit/command/PluginIdentifiableCommand.java
@@ -8,7 +8,11 @@ import org.jetbrains.annotations.NotNull;
  * sub-indexes based on the {@link Plugin} they are a part of. Custom command
  * implementations will need to implement this interface to have a sub-index
  * automatically generated on the plugin's behalf.
+ *
+ * @deprecated plugin developers should prefer to use the
+ *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
  */
+@Deprecated(since = "26.3")
 public interface PluginIdentifiableCommand {
 
     /**

--- a/paper-api/src/main/java/org/bukkit/command/SimpleCommandMap.java
+++ b/paper-api/src/main/java/org/bukkit/command/SimpleCommandMap.java
@@ -19,6 +19,11 @@ import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * @deprecated plugin developers should prefer to use the
+ *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
+ */
+@Deprecated(since = "26.3")
 public class SimpleCommandMap implements CommandMap {
     protected final Map<String, Command> knownCommands;
     private final Server server;

--- a/paper-api/src/main/java/org/bukkit/command/TabCompleter.java
+++ b/paper-api/src/main/java/org/bukkit/command/TabCompleter.java
@@ -6,7 +6,11 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a class which can suggest tab completions for commands.
+ *
+ * @deprecated plugin developers should prefer to use the
+ *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
  */
+@Deprecated(since = "26.3")
 public interface TabCompleter {
 
     /**
@@ -21,7 +25,10 @@ public interface TabCompleter {
      *     partial argument to be completed
      * @return A List of possible completions for the final argument, or null
      *     to default to the command executor
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
      */
+    @Deprecated(since = "26.3")
     @Nullable
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args);
 }

--- a/paper-api/src/main/java/org/bukkit/command/TabExecutor.java
+++ b/paper-api/src/main/java/org/bukkit/command/TabExecutor.java
@@ -3,6 +3,10 @@ package org.bukkit.command;
 /**
  * This class is provided as a convenience to implement both TabCompleter and
  * CommandExecutor.
+ *
+ * @deprecated plugin developers should prefer to use the
+ *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
  */
+@Deprecated(since = "26.3")
 public interface TabExecutor extends TabCompleter, CommandExecutor {
 }

--- a/paper-api/src/main/java/org/bukkit/command/defaults/BukkitCommand.java
+++ b/paper-api/src/main/java/org/bukkit/command/defaults/BukkitCommand.java
@@ -4,6 +4,11 @@ import java.util.List;
 import org.bukkit.command.Command;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * @deprecated plugin developers should prefer to use the
+ *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
+ */
+@Deprecated(since = "26.3")
 public abstract class BukkitCommand extends Command {
     protected BukkitCommand(@NotNull String name) {
         super(name);

--- a/paper-api/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/paper-api/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -309,16 +309,24 @@ public abstract class JavaPlugin extends PluginBase {
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
      */
     @Override
+    @Deprecated(since = "26.3")
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         return false;
     }
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
      */
     @Override
+    @Deprecated(since = "26.3")
     public @Nullable List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         return null;
     }
@@ -332,7 +340,10 @@ public abstract class JavaPlugin extends PluginBase {
      * @return the plugin command if found, otherwise null
      * @throws UnsupportedOperationException if this plugin is a paper plugin and the method is called in {@link #onEnable()}
      * @see #registerCommand(String, String, Collection, BasicCommand)
+     * @deprecated plugin developers should prefer to use the
+     *     <a href="https://docs.papermc.io/paper/dev/command-api/basics/introduction/">Brigadier command API</a>
      */
+    @Deprecated(since = "26.3")
     public @Nullable PluginCommand getCommand(String name) {
         if (this.isBeingEnabled && !(pluginMeta instanceof PluginDescriptionFile)) {
             throw new UnsupportedOperationException("""

--- a/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/paper-server/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -1424,6 +1424,7 @@ public final class CraftServer implements Server {
     }
 
     @Override
+    @Deprecated
     public PluginCommand getPluginCommand(String name) {
         Command command = this.commandMap.getCommand(name);
 
@@ -1664,6 +1665,7 @@ public final class CraftServer implements Server {
     }
 
     @Override
+    @Deprecated
     public Map<String, String[]> getCommandAliases() {
         ConfigurationSection section = this.commandsConfiguration.getConfigurationSection("aliases");
         Map<String, String[]> result = new LinkedHashMap<>();
@@ -2290,6 +2292,7 @@ public final class CraftServer implements Server {
     }
 
     @Override
+    @Deprecated
     public SimpleCommandMap getCommandMap() {
         return this.commandMap;
     }
@@ -2858,6 +2861,7 @@ public final class CraftServer implements Server {
     }
 
     @Override
+    @Deprecated
     public boolean reloadCommandAliases() {
         Set<String> removals = getCommandAliases().keySet().stream()
                 .map(key -> key.toLowerCase(java.util.Locale.ENGLISH))


### PR DESCRIPTION
The command docs nowadays only recommends Paper's Brigadier command API. Alongside with users in the Discord's `#paper-dev` channel typically being pointed towards Brigadier instead of Bukkit commands as well. However, many users may still, unaware of the new system, default to the decade-old system. The deprecations in this PR aim to aid plugin developers to be made aware of the no longer relevant Bukkit command system and point towards the recommended alternative through Javadoc comments.

I chose the `since` parameter on the `@Deprecated` to be `"26.3"` because of the near zero chance of this being merged before `26.3` properly releases.