### PR TITLE
ChunkPostSaveEvent

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/event/world/ChunkPostSaveEvent.java
+++ b/paper-api/src/main/java/io/papermc/paper/event/world/ChunkPostSaveEvent.java
@@ -1,0 +1,29 @@
+package io.papermc.paper.event.world;
+
+import org.bukkit.Chunk;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.world.ChunkEvent;
+import org.jetbrains.annotations.ApiStatus.Internal;
+import org.jspecify.annotations.NullMarked;
+
+/// Called during/after a chunk is saved, allowing plugins which store data separate but relating to a chunk to keep
+/// that data in lockstep with the chunk's state, saving whenever the chunk itself is saved. Any modifications to the
+/// chunk during this event are not guaranteed to be saved to the filesystem.
+@NullMarked
+public class ChunkPostSaveEvent extends ChunkEvent {
+	private static final HandlerList HANDLER_LIST = new HandlerList();
+
+	@Internal
+	public ChunkPostSaveEvent(final Chunk chunk) {
+		super(chunk);
+	}
+
+	public static HandlerList getHandlerList() {
+		return HANDLER_LIST;
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return HANDLER_LIST;
+	}
+}

--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -297,10 +297,10 @@ index 0000000000000000000000000000000000000000..fff7a796a61542213bdaa417d44e25cd
 +    }
 +}
 diff --git a/ca/spottedleaf/moonrise/paper/PaperHooks.java b/ca/spottedleaf/moonrise/paper/PaperHooks.java
-index 292898e3f7563949288fcafb8893e80cb4191828..d69358d60146e47b7f4669c43afc6c97cbde276f 100644
+index 70f4f03fddf79e9704a22717579c4962b22a2e14..0c9c634b7ffa4db3d96648ba2c7c00d2288c655d 100644
 --- a/ca/spottedleaf/moonrise/paper/PaperHooks.java
 +++ b/ca/spottedleaf/moonrise/paper/PaperHooks.java
-@@ -13,6 +13,7 @@ import net.minecraft.server.level.ChunkHolder;
+@@ -14,6 +14,7 @@ import net.minecraft.server.level.ChunkHolder;
  import net.minecraft.server.level.GenerationChunkHolder;
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
@@ -308,7 +308,7 @@ index 292898e3f7563949288fcafb8893e80cb4191828..d69358d60146e47b7f4669c43afc6c97
  import net.minecraft.world.entity.Entity;
  import net.minecraft.world.entity.boss.enderdragon.EnderDragonPart;
  import net.minecraft.world.level.BlockGetter;
-@@ -150,7 +151,15 @@ public final class PaperHooks extends BaseChunkSystemHooks implements PlatformHo
+@@ -158,7 +159,15 @@ public final class PaperHooks extends BaseChunkSystemHooks implements PlatformHo
  
      @Override
      public long[] getCounterTypesUncached(final net.minecraft.server.level.TicketType type) {
@@ -325,7 +325,7 @@ index 292898e3f7563949288fcafb8893e80cb4191828..d69358d60146e47b7f4669c43afc6c97
      }
  
      @Override
-@@ -249,7 +258,7 @@ public final class PaperHooks extends BaseChunkSystemHooks implements PlatformHo
+@@ -257,7 +266,7 @@ public final class PaperHooks extends BaseChunkSystemHooks implements PlatformHo
      @Override
      public void postLoadProtoChunk(final ServerLevel world, final ProtoChunk chunk) {
          try (final net.minecraft.util.ProblemReporter.ScopedCollector scopedCollector = new net.minecraft.util.ProblemReporter.ScopedCollector(chunk.problemPath(), LOGGER)) {

--- a/paper-server/patches/features/0002-Rewrite-dataconverter-system.patch
+++ b/paper-server/patches/features/0002-Rewrite-dataconverter-system.patch
@@ -33136,10 +33136,10 @@ index 0000000000000000000000000000000000000000..863a9785c84af6e0c961ae32f0102b5d
 +    }
 +}
 diff --git a/ca/spottedleaf/moonrise/paper/PaperHooks.java b/ca/spottedleaf/moonrise/paper/PaperHooks.java
-index d69358d60146e47b7f4669c43afc6c97cbde276f..c34b3c1c0e4fe6503a5702e544a192d2bb11d263 100644
+index 0c9c634b7ffa4db3d96648ba2c7c00d2288c655d..25f9196ed986fcf3413f8f59ea707a26a8e7cbda 100644
 --- a/ca/spottedleaf/moonrise/paper/PaperHooks.java
 +++ b/ca/spottedleaf/moonrise/paper/PaperHooks.java
-@@ -230,6 +230,11 @@ public final class PaperHooks extends BaseChunkSystemHooks implements PlatformHo
+@@ -238,6 +238,11 @@ public final class PaperHooks extends BaseChunkSystemHooks implements PlatformHo
      @Override
      public CompoundTag convertNBT(final DSL.TypeReference type, final DataFixer dataFixer, final CompoundTag nbt,
                                    final int fromVersion, final int toVersion) {
@@ -33151,7 +33151,7 @@ index d69358d60146e47b7f4669c43afc6c97cbde276f..c34b3c1c0e4fe6503a5702e544a192d2
          return (CompoundTag)dataFixer.update(
              type, new Dynamic<>(NbtOps.INSTANCE, nbt), fromVersion, toVersion
          ).getValue();
-@@ -271,4 +276,4 @@ public final class PaperHooks extends BaseChunkSystemHooks implements PlatformHo
+@@ -279,4 +284,4 @@ public final class PaperHooks extends BaseChunkSystemHooks implements PlatformHo
      public boolean addTicketForEnderPearls(final ServerLevel world) {
          return !world.paperConfig().misc.legacyEnderPearlBehavior;
      }

--- a/paper-server/patches/sources/ca/spottedleaf/moonrise/paper/PaperHooks.java.patch
+++ b/paper-server/patches/sources/ca/spottedleaf/moonrise/paper/PaperHooks.java.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/ca/spottedleaf/moonrise/paper/PaperHooks.java
-@@ -1,0 +_,265 @@
+@@ -1,0 +_,273 @@
 +package ca.spottedleaf.moonrise.paper;
 +
 +import ca.spottedleaf.moonrise.common.PlatformHooks;
@@ -8,6 +8,7 @@
 +import com.mojang.datafixers.DSL;
 +import com.mojang.datafixers.DataFixer;
 +import com.mojang.serialization.Dynamic;
++import io.papermc.paper.event.world.ChunkPostSaveEvent;
 +import java.util.Collection;
 +import net.minecraft.core.BlockPos;
 +import net.minecraft.nbt.CompoundTag;
@@ -30,6 +31,9 @@
 +import net.minecraft.world.phys.AABB;
 +import java.util.List;
 +import java.util.function.Predicate;
++import org.bukkit.Chunk;
++import org.bukkit.Server;
++import org.bukkit.craftbukkit.CraftChunk;
 +
 +public final class PaperHooks extends BaseChunkSystemHooks implements PlatformHooks {
 +
@@ -89,7 +93,11 @@
 +
 +    @Override
 +    public void chunkSyncSave(final ServerLevel world, final ChunkAccess chunk, final SerializableChunkData data) {
++        if (!(chunk instanceof LevelChunk)) return;
 +
++        final Server server = world.getCraftServer();
++        final ChunkPostSaveEvent event = new ChunkPostSaveEvent(new CraftChunk((LevelChunk) chunk));
++        server.getPluginManager().callEvent(event);
 +    }
 +
 +    @Override


### PR DESCRIPTION
Adds a ChunkPostSaveEvent which is called during/after a chunk is saved, allowing plugins which store data separate but relating to a chunk to keep that data in lockstep with the chunk's state, saving whenever the chunk itself is saved.