### PR TITLE
Recover missing worldgen settings from server.properties

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/Main.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/Main.java.patch
@@ -140,7 +140,7 @@
  
              WorldStem worldStem;
              try {
-@@ -169,17 +_,31 @@
+@@ -169,17 +_,39 @@
                          executor -> WorldLoader.load(
                              worldLoadConfig,
                              context -> {
@@ -163,6 +163,14 @@
                                      LevelDataAndDimensions worldData = LevelStorageSource.getLevelDataAndDimensions(
 -                                        access, levelDataTag, context.dataConfiguration(), datapackDimensions, context.datapackWorldgen()
 +                                        access, levelDataTag, context.dataConfiguration(), datapackDimensions, context.datapackWorldgen(), net.minecraft.world.level.Level.OVERWORLD // Paper
++                                        // Paper start - Recover missing world gen settings
++                                        ,() -> {
++                                            final DedicatedServerProperties properties = settings.getProperties();
++                                            return new WorldGenSettings(
++                                                properties.worldOptions, properties.createDimensions(context.datapackWorldgen())
++                                            );
++                                        }
++                                        // Paper end - Recover missing world gen settings
                                      );
                                      return new WorldLoader.DataLoadOutput<>(
                                          worldData.worldDataAndGenSettings(), worldData.dimensions().dimensionsRegistryAccess()

--- a/paper-server/patches/sources/net/minecraft/world/level/storage/LevelStorageSource.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/storage/LevelStorageSource.java.patch
@@ -46,7 +46,7 @@
 +                        throw new IllegalStateException("Unable to read or access the world gen settings file " + dataLocation + ". " + error.message());
 +                    }
 +                    LOGGER.warn(
-+                        "World gen settings file is missing! Recreating settings from server.properties. {}",
++                        "World gen settings file is missing! Recreating settings from server.properties: {}",
 +                        dataLocation
                      );
 -                    return new WorldGenSettings(WorldOptions.defaultWithRandomSeed(), new WorldDimensions(datapackDimensions));

--- a/paper-server/patches/sources/net/minecraft/world/level/storage/LevelStorageSource.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/storage/LevelStorageSource.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/storage/LevelStorageSource.java
 +++ b/net/minecraft/world/level/storage/LevelStorageSource.java
-@@ -145,13 +_,14 @@
+@@ -145,21 +_,28 @@
          final WorldDataConfiguration dataConfiguration,
          final Registry<LevelStem> datapackDimensions,
          final HolderLookup.Provider registryAccess
@@ -16,6 +16,24 @@
              .mapOrElse(
                  Function.identity(),
                  error -> {
+-                    LOGGER.error(
+-                        "Unable to read or access the world gen settings file! Falling back to the default settings with a random world seed. {}",
+-                        error.message()
++                    // Paper start - Recover missing overworld world gen settings
++                    Path dataLocation = WorldGenSettings.TYPE.id().withSuffix(".dat").resolveAgainst(worldAccess.getDimensionPath(dimension).resolve(LevelResource.DATA.id()));
++                    if (!Files.notExists(dataLocation, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
++                        throw new IllegalStateException("Unable to read or access the world gen settings file " + dataLocation + ". " + error.message());
++                    }
++                    LOGGER.warn(
++                        "World gen settings file is missing! Falling back to the default settings with a random world seed. {}",
++                        dataLocation
+                     );
+-                    return new WorldGenSettings(WorldOptions.defaultWithRandomSeed(), new WorldDimensions(datapackDimensions));
++                    return new WorldGenSettings(WorldOptions.defaultWithRandomSeed(), net.minecraft.world.level.levelgen.presets.WorldPresets.createNormalWorldDimensions(registryAccess));
++                    // Paper end - Recover missing overworld world gen settings
+                 }
+             );
+         LevelSettings settings = LevelSettings.parse(dataTag, dataConfiguration);
 @@ -170,9 +_,9 @@
      }
  

--- a/paper-server/patches/sources/net/minecraft/world/level/storage/LevelStorageSource.java.patch
+++ b/paper-server/patches/sources/net/minecraft/world/level/storage/LevelStorageSource.java.patch
@@ -1,11 +1,32 @@
 --- a/net/minecraft/world/level/storage/LevelStorageSource.java
 +++ b/net/minecraft/world/level/storage/LevelStorageSource.java
-@@ -145,21 +_,28 @@
+@@ -145,21 +_,48 @@
          final WorldDataConfiguration dataConfiguration,
          final Registry<LevelStem> datapackDimensions,
          final HolderLookup.Provider registryAccess
+-    ) {
 +        , final ResourceKey<Level> dimension // Paper - pass dimension
-     ) {
++    ) {
++        // Paper start - Recover missing overworld world gen settings
++        return getLevelDataAndDimensions(worldAccess, levelDataTag, dataConfiguration, datapackDimensions, registryAccess, dimension, () -> {
++            // Preserve dimension settings if we got them from the datapack
++            WorldDimensions defaultDimensions = datapackDimensions.containsKey(LevelStem.OVERWORLD)
++                ? new WorldDimensions(datapackDimensions)
++                : net.minecraft.world.level.levelgen.presets.WorldPresets.createNormalWorldDimensions(registryAccess);
++            return new WorldGenSettings(WorldOptions.defaultWithRandomSeed(), defaultDimensions);
++        });
++    }
++
++    public static LevelDataAndDimensions getLevelDataAndDimensions(
++        final LevelStorageSource.LevelStorageAccess worldAccess,
++        final Dynamic<?> levelDataTag,
++        final WorldDataConfiguration dataConfiguration,
++        final Registry<LevelStem> datapackDimensions,
++        final HolderLookup.Provider registryAccess,
++        final ResourceKey<Level> dimension,
++        final java.util.function.Supplier<WorldGenSettings> worldGenSettingsFactory
++    ) {
++        // Paper end - Recover missing overworld world gen settings
          if (DataFixers.getFileFixer().requiresFileFixing(NbtUtils.getDataVersion(levelDataTag))) {
              throw new IllegalStateException("Cannot get level data without file fixing first");
          }
@@ -25,11 +46,11 @@
 +                        throw new IllegalStateException("Unable to read or access the world gen settings file " + dataLocation + ". " + error.message());
 +                    }
 +                    LOGGER.warn(
-+                        "World gen settings file is missing! Falling back to the default settings with a random world seed. {}",
++                        "World gen settings file is missing! Recreating settings from server.properties. {}",
 +                        dataLocation
                      );
 -                    return new WorldGenSettings(WorldOptions.defaultWithRandomSeed(), new WorldDimensions(datapackDimensions));
-+                    return new WorldGenSettings(WorldOptions.defaultWithRandomSeed(), net.minecraft.world.level.levelgen.presets.WorldPresets.createNormalWorldDimensions(registryAccess));
++                    return worldGenSettingsFactory.get();
 +                    // Paper end - Recover missing overworld world gen settings
                  }
              );

--- a/paper-server/src/main/java/io/papermc/paper/world/PaperWorldLoader.java
+++ b/paper-server/src/main/java/io/papermc/paper/world/PaperWorldLoader.java
@@ -144,7 +144,7 @@ public record PaperWorldLoader(MinecraftServer server, String levelId) {
             return;
         }
 
-        final WorldGenSettings worldGenSettings = !hasWorldData
+        final WorldGenSettings worldGenSettings = loading.info().dimensionKey() == Level.OVERWORLD || !hasWorldData
             ? this.server.getWorldGenSettings()
             : loadWorldGenSettings(
             this.server.storageSource,


### PR DESCRIPTION
Closes #14066.

This PR fixes crash when the overworld `world_gen_settings.dat` is missing.

## Changes

Changed the recovery behavior, now will recover worldgen settings from server.properties instead of randomly picking seeds.

Tested these cases:

- Completely deleting the `dimensions/data/overworld` directory
- Only deleting `world_gen_settings.dat` in overworld data

Datapack settings will be merged in through `bake()` below so worldgen datapacks still work