### PR TITLE
fix startup crash when auto-enabling plugin-provided datapacks

### DIFF
--- a/paper-server/patches/sources/net/minecraft/server/packs/repository/PackRepository.java.patch
+++ b/paper-server/patches/sources/net/minecraft/server/packs/repository/PackRepository.java.patch
@@ -58,7 +58,7 @@
      }
  
      public boolean addPack(final String packId) {
-@@ -79,11 +_,11 @@
+@@ -79,11 +_,12 @@
          }
      }
  
@@ -68,7 +68,8 @@
  
          for (Pack pack : this.available.values()) {
 -            if (pack.isRequired() && !selectedAndPresent.contains(pack)) {
-+            if (pack.isRequired() && !selectedAndPresent.contains(pack) && pendingReload) { // Paper - add pendingReload flag to determine required pack loading
++            // Paper - compare IDs without converting plugin pack titles before registries are loaded
++            if (pack.isRequired() && !selectedNames.contains(pack.getId()) && pendingReload) { // Paper - add pendingReload flag to determine required pack loading
                  pack.getDefaultPosition().insert(selectedAndPresent, pack, Pack::selectionConfig, false);
              }
          }


### PR DESCRIPTION
It checks the identifiers of the selected packs, rather than comparing the pack objects when selecting them again.

This allows you to avoid converting Adventure pack names before the Minecraft registries become available, which could lead to a NullPointerException when starting the server.

[crash log](https://github.com/user-attachments/files/31965773/latest.log)

Local testing:
1. Paper 26.2
2. One Paper plugin with Bootstrap and a built-in datapack.
3. Register it twice in DATAPACK_DISCOVERY under different identifiers and specify autoEnableOnServerStart(true) for both.
4. Start the server in an existing world.
Result: NPE in AdventureComponent.equals() -> PackRepository.rebuildSelected(), the server does not start.
The error was not reproduced when autoEnableOnServerStart(false).
