### PR TITLE
Per world chunk rates config

### DIFF
--- a/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
+++ b/paper-server/patches/features/0001-Moonrise-optimisation-patches.patch
@@ -297,7 +297,7 @@ index 0000000000000000000000000000000000000000..fff7a796a61542213bdaa417d44e25cd
 +    }
 +}
 diff --git a/ca/spottedleaf/moonrise/paper/PaperHooks.java b/ca/spottedleaf/moonrise/paper/PaperHooks.java
-index 292898e3f7563949288fcafb8893e80cb4191828..d69358d60146e47b7f4669c43afc6c97cbde276f 100644
+index 428c8330562af0298cfa9c31af17f08b8966bb8a..7f7fc8fb3ee0bb3f5c21b18bc30fb09c3eb4c440 100644
 --- a/ca/spottedleaf/moonrise/paper/PaperHooks.java
 +++ b/ca/spottedleaf/moonrise/paper/PaperHooks.java
 @@ -13,6 +13,7 @@ import net.minecraft.server.level.ChunkHolder;
@@ -5399,7 +5399,7 @@ index 0000000000000000000000000000000000000000..003a857e70ead858e8437e3c1bfaf22f
 +}
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/player/RegionizedPlayerChunkLoader.java b/ca/spottedleaf/moonrise/patches/chunk_system/player/RegionizedPlayerChunkLoader.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..45c927417d34ddd48c92116efd9b5777bfc52e35
+index 0000000000000000000000000000000000000000..c9ada25ba18fb2b5e23e30653b2eea4b638a9a65
 --- /dev/null
 +++ b/ca/spottedleaf/moonrise/patches/chunk_system/player/RegionizedPlayerChunkLoader.java
 @@ -0,0 +1,1104 @@
@@ -5986,19 +5986,19 @@ index 0000000000000000000000000000000000000000..45c927417d34ddd48c92116efd9b5777
 +        }
 +
 +        private double getMaxChunkLoadRate() {
-+            final double configRate = PlatformHooks.get().configPlayerMaxLoadRate();
++            final double configRate = PlatformHooks.get().configPlayerMaxLoadRate(this.world);
 +
 +            return configRate <= 0.0 || configRate > (double)MAX_RATE ? (double)MAX_RATE : Math.max(1.0, configRate);
 +        }
 +
 +        private double getMaxChunkGenRate() {
-+            final double configRate = PlatformHooks.get().configPlayerMaxGenRate();
++            final double configRate = PlatformHooks.get().configPlayerMaxGenRate(this.world);
 +
 +            return configRate <= 0.0 || configRate > (double)MAX_RATE ? (double)MAX_RATE : Math.max(1.0, configRate);
 +        }
 +
 +        private double getMaxChunkSendRate() {
-+            final double configRate = PlatformHooks.get().configPlayerMaxSendRate();
++            final double configRate = PlatformHooks.get().configPlayerMaxSendRate(this.world);
 +
 +            return configRate <= 0.0 || configRate > (double)MAX_RATE ? (double)MAX_RATE : Math.max(1.0, configRate);
 +        }

--- a/paper-server/patches/sources/ca/spottedleaf/moonrise/paper/PaperHooks.java.patch
+++ b/paper-server/patches/sources/ca/spottedleaf/moonrise/paper/PaperHooks.java.patch
@@ -167,18 +167,18 @@
 +    }
 +
 +    @Override
-+    public double configPlayerMaxLoadRate() {
-+        return io.papermc.paper.configuration.GlobalConfiguration.get().chunkLoadingBasic.playerMaxChunkLoadRate;
++    public double configPlayerMaxLoadRate(final ServerLevel world) {
++        return world.paperConfig().chunkLoadingBasic.playerMaxChunkLoadRate;
 +    }
 +
 +    @Override
-+    public double configPlayerMaxGenRate() {
-+        return io.papermc.paper.configuration.GlobalConfiguration.get().chunkLoadingBasic.playerMaxChunkGenerateRate;
++    public double configPlayerMaxGenRate(final ServerLevel world) {
++        return world.paperConfig().chunkLoadingBasic.playerMaxChunkGenerateRate;
 +    }
 +
 +    @Override
-+    public double configPlayerMaxSendRate() {
-+        return io.papermc.paper.configuration.GlobalConfiguration.get().chunkLoadingBasic.playerMaxChunkSendRate;
++    public double configPlayerMaxSendRate(final ServerLevel world) {
++        return world.paperConfig().chunkLoadingBasic.playerMaxChunkSendRate;
 +    }
 +
 +    @Override

--- a/paper-server/src/main/java/ca/spottedleaf/moonrise/common/PlatformHooks.java
+++ b/paper-server/src/main/java/ca/spottedleaf/moonrise/common/PlatformHooks.java
@@ -72,11 +72,11 @@ public interface PlatformHooks extends ChunkSystemHooks {
 
     public boolean configAutoConfigSendDistance();
 
-    public double configPlayerMaxLoadRate();
+    public double configPlayerMaxLoadRate(final ServerLevel world);
 
-    public double configPlayerMaxGenRate();
+    public double configPlayerMaxGenRate(final ServerLevel world);
 
-    public double configPlayerMaxSendRate();
+    public double configPlayerMaxSendRate(final ServerLevel world);
 
     public int configPlayerMaxConcurrentLoads();
 

--- a/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -29,28 +29,11 @@ import java.util.Set;
 @SuppressWarnings({"CanBeFinal", "FieldCanBeLocal", "FieldMayBeFinal", "NotNullFieldNotInitialized", "InnerClassMayBeStatic"})
 public class GlobalConfiguration extends ConfigurationPart {
     private static final Logger LOGGER = LogUtils.getLogger();
-    static final int CURRENT_VERSION = 31; // (when you change the version, change the comment, so it conflicts on rebases): allow-nether property to config
+    static final int CURRENT_VERSION = 32; // (when you change the version, change the comment, so it conflicts on rebases): move basic chunk loading limits to world config
     private static GlobalConfiguration instance;
     public static boolean isFirstStart = false;
     public static GlobalConfiguration get() {
         return instance;
-    }
-
-    public ChunkLoadingBasic chunkLoadingBasic;
-
-    public class ChunkLoadingBasic extends ConfigurationPart {
-        @Comment("The maximum rate in chunks per second that the server will send to any individual player. Set to -1 to disable this limit.")
-        public double playerMaxChunkSendRate = 75.0;
-
-        @Comment(
-            "The maximum rate at which chunks will load for any individual player. " +
-            "Note that this setting also affects chunk generations, since a chunk load is always first issued to test if a" +
-            "chunk is already generated. Set to -1 to disable this limit."
-        )
-        public double playerMaxChunkLoadRate = 100.0;
-
-        @Comment("The maximum rate at which chunks will generate for any individual player. Set to -1 to disable this limit.")
-        public double playerMaxChunkGenerateRate = -1.0;
     }
 
     public ChunkLoadingAdvanced chunkLoadingAdvanced;

--- a/paper-server/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
@@ -133,9 +133,9 @@ public class PaperConfigurations extends Configurations<GlobalConfiguration, Wor
     private static final Function<ContextMap, String> WORLD_HEADER = map -> String.format("""
         This is a world configuration file for Paper.
         This file may start empty but can be filled with settings to override ones in the %s/%s
-
+        
         For more information, see https://docs.papermc.io/paper/reference/configuration/#per-world-configuration
-
+        
         World: %s""",
         PaperConfigurations.CONFIG_DIR,
         PaperConfigurations.WORLD_DEFAULTS_CONFIG_FILE_NAME,
@@ -146,7 +146,7 @@ public class PaperConfigurations extends Configurations<GlobalConfiguration, Wor
         The global and world default configuration files have moved to %s
         and the world-specific configuration file has been moved inside
         the respective world folder.
-
+        
         See https://docs.papermc.io/paper/configuration for more information.
         """;
 

--- a/paper-server/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
@@ -25,6 +25,7 @@ import io.papermc.paper.configuration.transformation.global.LegacyPaperConfig;
 import io.papermc.paper.configuration.transformation.global.versioned.V29_LogIPs;
 import io.papermc.paper.configuration.transformation.global.versioned.V30_PacketIds;
 import io.papermc.paper.configuration.transformation.global.versioned.V31_AllowNetherPropertiesToConfig;
+import io.papermc.paper.configuration.transformation.global.versioned.V32_ChunkLoadingBasicToWorld;
 import io.papermc.paper.configuration.transformation.world.FeatureSeedsGeneration;
 import io.papermc.paper.configuration.transformation.world.LegacyPaperWorldConfig;
 import io.papermc.paper.configuration.transformation.world.versioned.V29_ZeroWorldHeight;
@@ -132,9 +133,9 @@ public class PaperConfigurations extends Configurations<GlobalConfiguration, Wor
     private static final Function<ContextMap, String> WORLD_HEADER = map -> String.format("""
         This is a world configuration file for Paper.
         This file may start empty but can be filled with settings to override ones in the %s/%s
-        
+
         For more information, see https://docs.papermc.io/paper/reference/configuration/#per-world-configuration
-        
+
         World: %s""",
         PaperConfigurations.CONFIG_DIR,
         PaperConfigurations.WORLD_DEFAULTS_CONFIG_FILE_NAME,
@@ -145,7 +146,7 @@ public class PaperConfigurations extends Configurations<GlobalConfiguration, Wor
         The global and world default configuration files have moved to %s
         and the world-specific configuration file has been moved inside
         the respective world folder.
-        
+
         See https://docs.papermc.io/paper/configuration for more information.
         """;
 
@@ -298,6 +299,10 @@ public class PaperConfigurations extends Configurations<GlobalConfiguration, Wor
         V29_LogIPs.apply(versionedBuilder);
         V30_PacketIds.apply(versionedBuilder);
         V31_AllowNetherPropertiesToConfig.apply(versionedBuilder);
+        V32_ChunkLoadingBasicToWorld.apply(versionedBuilder, this.createLoaderBuilder()
+            .defaultOptions(options -> options.header(WORLD_DEFAULTS_HEADER))
+            .path(this.globalFolder.resolve(this.defaultWorldConfigFileName))
+            .build(), this.worldConfigVersion());
         // ADD FUTURE VERSIONED TRANSFORMS TO versionedBuilder HERE
         versionedBuilder.build().apply(node);
     }

--- a/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
@@ -88,6 +88,23 @@ public class WorldConfiguration extends ConfigurationPart {
     @Setting(Configuration.VERSION_FIELD)
     public int version = CURRENT_VERSION;
 
+    public ChunkLoadingBasic chunkLoadingBasic;
+
+    public class ChunkLoadingBasic extends ConfigurationPart {
+        @Comment("The maximum rate in chunks per second that the server will send to any individual player. Set to -1 to disable this limit.")
+        public double playerMaxChunkSendRate = 75.0;
+
+        @Comment(
+            "The maximum rate at which chunks will load for any individual player. " +
+            "Note that this setting also affects chunk generations, since a chunk load is always first issued to test if a" +
+            "chunk is already generated. Set to -1 to disable this limit."
+        )
+        public double playerMaxChunkLoadRate = 100.0;
+
+        @Comment("The maximum rate at which chunks will generate for any individual player. Set to -1 to disable this limit.")
+        public double playerMaxChunkGenerateRate = -1.0;
+    }
+
     public Anticheat anticheat;
 
     public class Anticheat extends ConfigurationPart {

--- a/paper-server/src/main/java/io/papermc/paper/configuration/transformation/global/versioned/V32_ChunkLoadingBasicToWorld.java
+++ b/paper-server/src/main/java/io/papermc/paper/configuration/transformation/global/versioned/V32_ChunkLoadingBasicToWorld.java
@@ -1,0 +1,27 @@
+package io.papermc.paper.configuration.transformation.global.versioned;
+
+import io.papermc.paper.configuration.Configuration;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.transformation.ConfigurationTransformation;
+import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
+
+public final class V32_ChunkLoadingBasicToWorld {
+    private static final int VERSION = 32;
+    private static final String CHUNK_LOADING_BASIC = "chunk-loading-basic";
+
+    public static void apply(final ConfigurationTransformation.VersionedBuilder builder, final YamlConfigurationLoader worldDefaultsLoader, final int worldConfigVersion) {
+        builder.addVersion(VERSION, root -> {
+            final ConfigurationNode chunkLoadingBasic = root.node(CHUNK_LOADING_BASIC);
+            if (chunkLoadingBasic.virtual()) {
+                return;
+            }
+            final ConfigurationNode worldDefaults = worldDefaultsLoader.load();
+            if (worldDefaults.node(Configuration.VERSION_FIELD).virtual()) {
+                worldDefaults.node(Configuration.VERSION_FIELD).set(worldConfigVersion);
+            }
+            worldDefaults.node(CHUNK_LOADING_BASIC).mergeFrom(chunkLoadingBasic);
+            worldDefaultsLoader.save(worldDefaults);
+            chunkLoadingBasic.raw(null);
+        });
+    }
+}


### PR DESCRIPTION
The overworld, end and nether chunks vary drastically in their generation cost, disk size and bandwidth cost, having to share the same rate between them sucks, this PR fixes that, it also migrates the existing global config to default worlds config cleanly.