### PR TITLE
Fix repeated cookie requests for the same key

### DIFF
--- a/paper-server/src/main/java/io/papermc/paper/connection/ReadablePlayerCookieConnectionImpl.java
+++ b/paper-server/src/main/java/io/papermc/paper/connection/ReadablePlayerCookieConnectionImpl.java
@@ -1,7 +1,9 @@
 package io.papermc.paper.connection;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayDeque;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import net.minecraft.network.Connection;
@@ -16,7 +18,8 @@ import org.jspecify.annotations.NullMarked;
 public abstract class ReadablePlayerCookieConnectionImpl implements ReadablePlayerCookieConnection {
 
     // Because we support async cookies, order is not promised.
-    private final Map<Identifier, CookieFuture> requestedCookies = new ConcurrentHashMap<>();
+    // Requests for the same key are queued, the client answers them in the order they were sent.
+    private final Map<Identifier, Queue<CookieFuture>> requestedCookies = new ConcurrentHashMap<>();
     private final Connection connection;
 
     public ReadablePlayerCookieConnectionImpl(final Connection connection) {
@@ -29,7 +32,13 @@ public abstract class ReadablePlayerCookieConnectionImpl implements ReadablePlay
 
         CompletableFuture<byte[]> future = new CompletableFuture<>();
         Identifier id = CraftNamespacedKey.toMinecraft(key);
-        this.requestedCookies.put(id, new CookieFuture(id, future));
+        this.requestedCookies.compute(id, (ignored, queue) -> {
+            if (queue == null) {
+                queue = new ArrayDeque<>();
+            }
+            queue.add(new CookieFuture(id, future));
+            return queue;
+        });
 
         this.connection.send(new ClientboundCookieRequestPacket(id));
 
@@ -37,14 +46,19 @@ public abstract class ReadablePlayerCookieConnectionImpl implements ReadablePlay
     }
 
     public boolean handleCookieResponse(ServerboundCookieResponsePacket packet) {
-        CookieFuture future = this.requestedCookies.get(packet.key());
-        if (future != null) {
-            future.future().complete(packet.payload());
-            this.requestedCookies.remove(packet.key());
-            return true;
+        final CookieFuture[] next = new CookieFuture[1];
+        this.requestedCookies.computeIfPresent(packet.key(), (ignored, queue) -> {
+            next[0] = queue.poll();
+            return queue.isEmpty() ? null : queue;
+        });
+
+        if (next[0] == null) {
+            return false;
         }
 
-        return false;
+        // Complete outside of the map operation, a callback may request the same cookie again
+        next[0].future().complete(packet.payload());
+        return true;
     }
 
     public boolean isAwaitingCookies() {

--- a/paper-server/src/test/java/io/papermc/paper/connection/ReadablePlayerCookieConnectionImplTest.java
+++ b/paper-server/src/test/java/io/papermc/paper/connection/ReadablePlayerCookieConnectionImplTest.java
@@ -1,0 +1,83 @@
+package io.papermc.paper.connection;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.cookie.ServerboundCookieResponsePacket;
+import net.minecraft.resources.Identifier;
+import org.bukkit.NamespacedKey;
+import org.bukkit.support.environment.Normal;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@Normal
+public class ReadablePlayerCookieConnectionImplTest {
+
+    private static final NamespacedKey KEY = new NamespacedKey("test", "cookie");
+    private static final Identifier ID = Identifier.fromNamespaceAndPath("test", "cookie");
+
+    private ReadablePlayerCookieConnectionImpl cookieConnection;
+
+    @BeforeEach
+    public void setup() {
+        this.cookieConnection = Mockito.mock(
+            ReadablePlayerCookieConnectionImpl.class,
+            Mockito.withSettings()
+                .useConstructor(Mockito.mock(Connection.class))
+                .defaultAnswer(Mockito.CALLS_REAL_METHODS)
+        );
+    }
+
+    private static ServerboundCookieResponsePacket response(final String payload) {
+        return new ServerboundCookieResponsePacket(ID, payload.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testSingleRequest() {
+        final CompletableFuture<byte[]> future = this.cookieConnection.retrieveCookie(KEY);
+        Assertions.assertTrue(this.cookieConnection.isAwaitingCookies());
+
+        Assertions.assertTrue(this.cookieConnection.handleCookieResponse(response("a")));
+        Assertions.assertArrayEquals("a".getBytes(StandardCharsets.UTF_8), future.getNow(null));
+        Assertions.assertFalse(this.cookieConnection.isAwaitingCookies());
+    }
+
+    @Test
+    public void testSameKeyRequestedTwice() {
+        final CompletableFuture<byte[]> first = this.cookieConnection.retrieveCookie(KEY);
+        final CompletableFuture<byte[]> second = this.cookieConnection.retrieveCookie(KEY);
+
+        Assertions.assertTrue(this.cookieConnection.handleCookieResponse(response("a")));
+        Assertions.assertArrayEquals("a".getBytes(StandardCharsets.UTF_8), first.getNow(null));
+        Assertions.assertFalse(second.isDone());
+        Assertions.assertTrue(this.cookieConnection.isAwaitingCookies());
+
+        Assertions.assertTrue(this.cookieConnection.handleCookieResponse(response("b")));
+        Assertions.assertArrayEquals("b".getBytes(StandardCharsets.UTF_8), second.getNow(null));
+        Assertions.assertFalse(this.cookieConnection.isAwaitingCookies());
+    }
+
+    @Test
+    public void testUnexpectedResponse() {
+        Assertions.assertFalse(this.cookieConnection.handleCookieResponse(response("a")));
+
+        this.cookieConnection.retrieveCookie(KEY);
+        Assertions.assertTrue(this.cookieConnection.handleCookieResponse(response("a")));
+        Assertions.assertFalse(this.cookieConnection.handleCookieResponse(response("a")));
+    }
+
+    @Test
+    public void testRequestFromCallback() {
+        final CompletableFuture<byte[]>[] fromCallback = new CompletableFuture[1];
+        this.cookieConnection.retrieveCookie(KEY).thenRun(() -> fromCallback[0] = this.cookieConnection.retrieveCookie(KEY));
+
+        Assertions.assertTrue(this.cookieConnection.handleCookieResponse(response("a")));
+        Assertions.assertNotNull(fromCallback[0]);
+        Assertions.assertTrue(this.cookieConnection.isAwaitingCookies());
+
+        Assertions.assertTrue(this.cookieConnection.handleCookieResponse(response("b")));
+        Assertions.assertArrayEquals("b".getBytes(StandardCharsets.UTF_8), fromCallback[0].getNow(null));
+    }
+}


### PR DESCRIPTION
Bug

Calling `retrieveCookie()` for the same key multiple times before the client responds caused the pending request to be overwritten. Because the map only stored one request per key, the first future never completed, and the player was kicked with `unexpected query response`.

Changed

Each cookie key now stores a queue of pending requests, so responses are matched in the same order as the requests were sent. This approach was suggested by electronicboy on the issue.

Adding and removing requests from the queue are done as a single map operation. The future is also removed from the queue before being completed, so requesting the same cookie again from a callback works correctly.

Testing

Added `ReadablePlayerCookieConnectionImplTest` with 4 test cases. The tests for requesting the same key twice and requesting it again from a callback fail on the old code and pass with this fix.

I also tested it manually on a 26.2 client with a test command that requests the same cookie 3 times. Before the fix, only the last request completed and the player got kicked. After the fix, all 3 requests completed and the player stayed connected.

Fixes #14211

I used Claude to help write the fix and tests, and I reviewed and tested the changes myself.
