### PR TITLE
Add fixed range support for consumable sounds

### DIFF
--- a/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Consumable.java
+++ b/paper-api/src/main/java/io/papermc/paper/datacomponent/item/Consumable.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Holds the properties for this item for when it is consumed.
@@ -30,6 +31,14 @@ public interface Consumable extends BuildableDataComponent<Consumable, Consumabl
 
     @Contract(pure = true)
     ItemUseAnimation animation();
+
+    /**
+     * Gets the fixed range of the sound played when consuming this item, if present.
+     *
+     * @return the fixed sound range, or {@code null} if the sound uses a variable range
+     */
+    @Contract(pure = true)
+    @Nullable Float soundRange();
 
     @Contract(pure = true)
     Key sound();
@@ -72,6 +81,16 @@ public interface Consumable extends BuildableDataComponent<Consumable, Consumabl
          */
         @Contract(value = "_ -> this", mutates = "this")
         Builder sound(Key sound);
+
+        /**
+         * Sets the sound played when consuming the item with an optional fixed range.
+         *
+         * @param sound the {@link Key} representing the sound to be used
+         * @param range the fixed range of the sound, or {@code null} to use a variable range
+         * @return the builder for chaining
+         */
+        @Contract(value = "_, _ -> this", mutates = "this")
+        Builder sound(Key sound, @Nullable Float range);
 
         /**
          * Sets whether consuming the item results in particle effects.

--- a/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperConsumable.java
+++ b/paper-server/src/main/java/io/papermc/paper/datacomponent/item/PaperConsumable.java
@@ -7,6 +7,7 @@ import io.papermc.paper.datacomponent.item.consumable.PaperConsumableEffect;
 import io.papermc.paper.util.MCUtil;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.util.List;
+import java.util.Optional;
 import net.kyori.adventure.key.Key;
 import net.minecraft.core.Holder;
 import net.minecraft.sounds.SoundEvent;
@@ -14,6 +15,7 @@ import net.minecraft.sounds.SoundEvents;
 import org.bukkit.craftbukkit.util.Handleable;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.Nullable;
 
 import static io.papermc.paper.util.BoundChecker.requireNonNegative;
 
@@ -44,6 +46,11 @@ public record PaperConsumable(
     }
 
     @Override
+    public @Nullable Float soundRange() {
+        return this.impl.sound().value().fixedRange().orElse(null);
+    }
+
+    @Override
     public boolean hasConsumeParticles() {
         return this.impl.hasConsumeParticles();
     }
@@ -58,7 +65,7 @@ public record PaperConsumable(
         return new BuilderImpl()
             .consumeSeconds(this.consumeSeconds())
             .animation(this.animation())
-            .sound(this.sound())
+            .sound(this.sound(), this.soundRange())
             .addEffects(this.consumeEffects());
     }
 
@@ -87,6 +94,12 @@ public record PaperConsumable(
         @Override
         public Builder sound(final Key sound) {
             this.eatSound = PaperAdventure.resolveSound(sound);
+            return this;
+        }
+
+        @Override
+        public Builder sound(final Key sound, final @Nullable Float range) {
+            this.eatSound = Holder.direct(new SoundEvent(PaperAdventure.asVanilla(sound), Optional.ofNullable(range)));
             return this;
         }
 

--- a/paper-server/src/test/java/io/papermc/paper/item/ItemStackDataComponentTest.java
+++ b/paper-server/src/test/java/io/papermc/paper/item/ItemStackDataComponentTest.java
@@ -3,6 +3,7 @@ package io.papermc.paper.item;
 import io.papermc.paper.datacomponent.DataComponentType;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.datacomponent.item.ChargedProjectiles;
+import io.papermc.paper.datacomponent.item.Consumable;
 import io.papermc.paper.datacomponent.item.CustomModelData;
 import io.papermc.paper.datacomponent.item.DyedItemColor;
 import io.papermc.paper.datacomponent.item.Fireworks;
@@ -250,6 +251,21 @@ class ItemStackDataComponentTest {
         stack.unsetData(DataComponentTypes.TOOL);
         meta = stack.getItemMeta();
         Assertions.assertFalse(meta.hasTool());
+    }
+
+    @Test
+    void testConsumableFixedSoundRange() {
+        final Key sound = Key.key("minecraft:item.apple.eat");
+        final Consumable consumable = Consumable.consumable()
+            .sound(sound, 12.0F)
+            .build();
+
+        Assertions.assertEquals(sound, consumable.sound());
+        Assertions.assertEquals(12.0F, consumable.soundRange());
+
+        final Consumable rebuilt = consumable.toBuilder().build();
+        Assertions.assertEquals(sound, rebuilt.sound());
+        Assertions.assertEquals(12.0F, rebuilt.soundRange());
     }
 
     @Test


### PR DESCRIPTION
Adds support for fixed-range inline sounds in the Consumable data component.

Fixes #14171